### PR TITLE
Add AVR-Ex devices

### DIFF
--- a/crt1/iosym/avr16ea28.S
+++ b/crt1/iosym/avr16ea28.S
@@ -1,0 +1,26945 @@
+/* This file is part of avr-libc.
+
+   Automatically created by devtools/ioreg.pl
+   DO NOT EDIT!
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in
+     the documentation and/or other materials provided with the
+     distribution.
+
+   * Neither the name of the copyright holders nor the names of
+     contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE. */
+
+/* $Id$ */
+
+#include <avr/version.h>
+
+#define DW_TAG_array_type               0x01
+#define DW_TAG_compile_unit             0x11
+#define DW_TAG_typedef                  0x16
+#define DW_TAG_subrange_type            0x21
+#define DW_TAG_base_type                0x24
+#define DW_TAG_variable                 0x34
+
+#define DW_FORM_addr                    0x01
+#define DW_FORM_block1                  0x0a
+#define DW_FORM_block2                  0x03
+#define DW_FORM_block4                  0x04
+#define DW_FORM_data1                   0x0b
+#define DW_FORM_data2                   0x05
+#define DW_FORM_data4                   0x06
+#define DW_FORM_data8                   0x07
+#define DW_FORM_string                  0x08
+#define DW_FORM_flag                    0x0c
+#define DW_FORM_strp                    0x0e
+#define DW_FORM_ref1                    0x11
+#define DW_FORM_ref2                    0x12
+#define DW_FORM_ref4                    0x13
+#define DW_FORM_ref8                    0x14
+
+#define DW_AT_location                  0x02
+#define DW_AT_name                      0x03
+#define DW_AT_byte_size                 0x0b
+#define DW_AT_stmt_list                 0x10
+#define DW_AT_language                  0x13
+#define DW_AT_producer                  0x25
+#define DW_AT_upper_bound               0x2f
+#define DW_AT_decl_file                 0x3a
+#define DW_AT_decl_line                 0x3b
+#define DW_AT_encoding                  0x3e
+#define DW_AT_external                  0x3f
+#define DW_AT_type                      0x49
+
+#define DW_LANG_C89                     0x0001
+
+#define DW_CHILDREN_no                  0x00
+#define DW_CHILDREN_yes                 0x01
+
+#define DW_ATE_unsigned                 0x7
+#define DW_ATE_unsigned_char            0x8
+
+#define DW_OP_addr                      0x03
+.eject
+	.section	.debug_abbrev, "", @progbits
+.Ldebug_abbrev0:
+	.section	.debug_info, "", @progbits
+	.section	.debug_line, "", @progbits
+.Ldebug_line0:
+	.section	.debug_str, "", @progbits
+
+	.section	.debug_info, "", @progbits
+	;; compilation unit header
+.Lssinfo:
+	.long	.Leinfo - .Lsinfo
+.Lsinfo:
+	.word	2		; DWARF-2
+	.long	.Ldebug_abbrev0
+	.byte	4		; sizeof(address)
+
+
+	;; DIE #1: compilation unit
+	.section	.debug_info
+	.uleb128	1	; ref to abbrev 1
+	.section	.debug_abbrev
+	.uleb128	1
+	.uleb128	DW_TAG_compile_unit
+	.byte		DW_CHILDREN_yes
+
+	.uleb128	DW_AT_producer
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lproducer:
+	.ascii		"avr-libc "
+	.asciz		__AVR_LIBC_VERSION_STRING__
+	.section	.debug_info
+	.long		.Lproducer
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_stmt_list
+	.uleb128	DW_FORM_data4
+	.section	.debug_info
+	.long		.Ldebug_line0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+	;; DIE #2: base type uint8_t
+	.section	.debug_info
+.Luint8_t:
+	.uleb128	2	; ref to abbrev 2
+	.section	.debug_abbrev
+	.uleb128	2
+	.uleb128	DW_TAG_base_type
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Luint8_t_name:
+	.string		"uint8_t"
+	.section	.debug_info
+	.long		.Luint8_t_name
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_byte_size
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_encoding
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		DW_ATE_unsigned_char
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+	;; DIE #3: base type uint16_t
+	.section	.debug_info
+.Luint16_t:
+	.uleb128	3	; ref to abbrev 3
+	.section	.debug_abbrev
+	.uleb128	3
+	.uleb128	DW_TAG_base_type
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Luint16_t_name:
+	.string		"uint16_t"
+	.section	.debug_info
+	.long		.Luint16_t_name
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_byte_size
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		2
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_encoding
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		DW_ATE_unsigned
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #4: variable CTRLA
+	.section	.debug_info
+	.uleb128	4	; ref to abbrev 4
+	.section	.debug_abbrev
+	.uleb128	4
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname4:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname4
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #5: variable CTRLB
+	.section	.debug_info
+	.uleb128	5	; ref to abbrev 5
+	.section	.debug_abbrev
+	.uleb128	5
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname5:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname5
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #6: variable MUXCTRL
+	.section	.debug_info
+	.uleb128	6	; ref to abbrev 6
+	.section	.debug_abbrev
+	.uleb128	6
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname6:
+	.string		"MUXCTRL"
+	.section	.debug_info
+	.long		.Lname6
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #7: variable DACREF
+	.section	.debug_info
+	.uleb128	7	; ref to abbrev 7
+	.section	.debug_abbrev
+	.uleb128	7
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname7:
+	.string		"DACREF"
+	.section	.debug_info
+	.long		.Lname7
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #8: variable INTCTRL
+	.section	.debug_info
+	.uleb128	8	; ref to abbrev 8
+	.section	.debug_abbrev
+	.uleb128	8
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname8:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname8
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #9: variable STATUS
+	.section	.debug_info
+	.uleb128	9	; ref to abbrev 9
+	.section	.debug_abbrev
+	.uleb128	9
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname9:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname9
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #10: variable CTRLA
+	.section	.debug_info
+	.uleb128	10	; ref to abbrev 10
+	.section	.debug_abbrev
+	.uleb128	10
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname10:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname10
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #11: variable CTRLB
+	.section	.debug_info
+	.uleb128	11	; ref to abbrev 11
+	.section	.debug_abbrev
+	.uleb128	11
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname11:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname11
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #12: variable MUXCTRL
+	.section	.debug_info
+	.uleb128	12	; ref to abbrev 12
+	.section	.debug_abbrev
+	.uleb128	12
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname12:
+	.string		"MUXCTRL"
+	.section	.debug_info
+	.long		.Lname12
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #13: variable DACREF
+	.section	.debug_info
+	.uleb128	13	; ref to abbrev 13
+	.section	.debug_abbrev
+	.uleb128	13
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname13:
+	.string		"DACREF"
+	.section	.debug_info
+	.long		.Lname13
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #14: variable INTCTRL
+	.section	.debug_info
+	.uleb128	14	; ref to abbrev 14
+	.section	.debug_abbrev
+	.uleb128	14
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname14:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname14
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #15: variable STATUS
+	.section	.debug_info
+	.uleb128	15	; ref to abbrev 15
+	.section	.debug_abbrev
+	.uleb128	15
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname15:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname15
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #16: variable CTRLA
+	.section	.debug_info
+	.uleb128	16	; ref to abbrev 16
+	.section	.debug_abbrev
+	.uleb128	16
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname16:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname16
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #17: variable CTRLB
+	.section	.debug_info
+	.uleb128	17	; ref to abbrev 17
+	.section	.debug_abbrev
+	.uleb128	17
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname17:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname17
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #18: variable CTRLC
+	.section	.debug_info
+	.uleb128	18	; ref to abbrev 18
+	.section	.debug_abbrev
+	.uleb128	18
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname18:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname18
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #19: variable CTRLD
+	.section	.debug_info
+	.uleb128	19	; ref to abbrev 19
+	.section	.debug_abbrev
+	.uleb128	19
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname19:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname19
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #20: variable INTCTRL
+	.section	.debug_info
+	.uleb128	20	; ref to abbrev 20
+	.section	.debug_abbrev
+	.uleb128	20
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname20:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname20
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #21: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	21	; ref to abbrev 21
+	.section	.debug_abbrev
+	.uleb128	21
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname21:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname21
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #22: variable STATUS
+	.section	.debug_info
+	.uleb128	22	; ref to abbrev 22
+	.section	.debug_abbrev
+	.uleb128	22
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname22:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname22
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #23: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	23	; ref to abbrev 23
+	.section	.debug_abbrev
+	.uleb128	23
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname23:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname23
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #24: variable CTRLE
+	.section	.debug_info
+	.uleb128	24	; ref to abbrev 24
+	.section	.debug_abbrev
+	.uleb128	24
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname24:
+	.string		"CTRLE"
+	.section	.debug_info
+	.long		.Lname24
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #25: variable CTRLF
+	.section	.debug_info
+	.uleb128	25	; ref to abbrev 25
+	.section	.debug_abbrev
+	.uleb128	25
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname25:
+	.string		"CTRLF"
+	.section	.debug_info
+	.long		.Lname25
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #26: variable COMMAND
+	.section	.debug_info
+	.uleb128	26	; ref to abbrev 26
+	.section	.debug_abbrev
+	.uleb128	26
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname26:
+	.string		"COMMAND"
+	.section	.debug_info
+	.long		.Lname26
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #27: variable PGACTRL
+	.section	.debug_info
+	.uleb128	27	; ref to abbrev 27
+	.section	.debug_abbrev
+	.uleb128	27
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname27:
+	.string		"PGACTRL"
+	.section	.debug_info
+	.long		.Lname27
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #28: variable MUXPOS
+	.section	.debug_info
+	.uleb128	28	; ref to abbrev 28
+	.section	.debug_abbrev
+	.uleb128	28
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname28:
+	.string		"MUXPOS"
+	.section	.debug_info
+	.long		.Lname28
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #29: variable MUXNEG
+	.section	.debug_info
+	.uleb128	29	; ref to abbrev 29
+	.section	.debug_abbrev
+	.uleb128	29
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname29:
+	.string		"MUXNEG"
+	.section	.debug_info
+	.long		.Lname29
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #30: base type uint32_t
+	.section	.debug_info
+.Luint32_t:
+	.uleb128	30	; ref to abbrev 30
+	.section	.debug_abbrev
+	.uleb128	30
+	.uleb128	DW_TAG_base_type
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Luint32_t_name:
+	.string		"uint32_t"
+	.section	.debug_info
+	.long		.Luint32_t_name
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_byte_size
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		4
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_encoding
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		DW_ATE_unsigned
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #31: variable RESULT
+	.section	.debug_info
+	.uleb128	31	; ref to abbrev 31
+	.section	.debug_abbrev
+	.uleb128	31
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname31:
+	.string		"RESULT"
+	.section	.debug_info
+	.long		.Lname31
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint32_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #32: variable SAMPLE
+	.section	.debug_info
+	.uleb128	32	; ref to abbrev 32
+	.section	.debug_abbrev
+	.uleb128	32
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname32:
+	.string		"SAMPLE"
+	.section	.debug_info
+	.long		.Lname32
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #33: variable TEMP0
+	.section	.debug_info
+	.uleb128	33	; ref to abbrev 33
+	.section	.debug_abbrev
+	.uleb128	33
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname33:
+	.string		"TEMP0"
+	.section	.debug_info
+	.long		.Lname33
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #34: variable TEMP1
+	.section	.debug_info
+	.uleb128	34	; ref to abbrev 34
+	.section	.debug_abbrev
+	.uleb128	34
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname34:
+	.string		"TEMP1"
+	.section	.debug_info
+	.long		.Lname34
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x19
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #35: variable TEMP2
+	.section	.debug_info
+	.uleb128	35	; ref to abbrev 35
+	.section	.debug_abbrev
+	.uleb128	35
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname35:
+	.string		"TEMP2"
+	.section	.debug_info
+	.long		.Lname35
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x1A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #36: variable WINLT
+	.section	.debug_info
+	.uleb128	36	; ref to abbrev 36
+	.section	.debug_abbrev
+	.uleb128	36
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname36:
+	.string		"WINLT"
+	.section	.debug_info
+	.long		.Lname36
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x1C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #37: variable WINHT
+	.section	.debug_info
+	.uleb128	37	; ref to abbrev 37
+	.section	.debug_abbrev
+	.uleb128	37
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname37:
+	.string		"WINHT"
+	.section	.debug_info
+	.long		.Lname37
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x1E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #38: variable CTRLA
+	.section	.debug_info
+	.uleb128	38	; ref to abbrev 38
+	.section	.debug_abbrev
+	.uleb128	38
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname38:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname38
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #39: variable CTRLB
+	.section	.debug_info
+	.uleb128	39	; ref to abbrev 39
+	.section	.debug_abbrev
+	.uleb128	39
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname39:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname39
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #40: variable VLMCTRLA
+	.section	.debug_info
+	.uleb128	40	; ref to abbrev 40
+	.section	.debug_abbrev
+	.uleb128	40
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname40:
+	.string		"VLMCTRLA"
+	.section	.debug_info
+	.long		.Lname40
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #41: variable INTCTRL
+	.section	.debug_info
+	.uleb128	41	; ref to abbrev 41
+	.section	.debug_abbrev
+	.uleb128	41
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname41:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname41
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #42: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	42	; ref to abbrev 42
+	.section	.debug_abbrev
+	.uleb128	42
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname42:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname42
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #43: variable STATUS
+	.section	.debug_info
+	.uleb128	43	; ref to abbrev 43
+	.section	.debug_abbrev
+	.uleb128	43
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname43:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname43
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #44: variable CTRLA
+	.section	.debug_info
+	.uleb128	44	; ref to abbrev 44
+	.section	.debug_abbrev
+	.uleb128	44
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname44:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname44
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #45: variable SEQCTRL0
+	.section	.debug_info
+	.uleb128	45	; ref to abbrev 45
+	.section	.debug_abbrev
+	.uleb128	45
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname45:
+	.string		"SEQCTRL0"
+	.section	.debug_info
+	.long		.Lname45
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #46: variable SEQCTRL1
+	.section	.debug_info
+	.uleb128	46	; ref to abbrev 46
+	.section	.debug_abbrev
+	.uleb128	46
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname46:
+	.string		"SEQCTRL1"
+	.section	.debug_info
+	.long		.Lname46
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #47: variable INTCTRL0
+	.section	.debug_info
+	.uleb128	47	; ref to abbrev 47
+	.section	.debug_abbrev
+	.uleb128	47
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname47:
+	.string		"INTCTRL0"
+	.section	.debug_info
+	.long		.Lname47
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #48: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	48	; ref to abbrev 48
+	.section	.debug_abbrev
+	.uleb128	48
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname48:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname48
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #49: variable LUT0CTRLA
+	.section	.debug_info
+	.uleb128	49	; ref to abbrev 49
+	.section	.debug_abbrev
+	.uleb128	49
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname49:
+	.string		"LUT0CTRLA"
+	.section	.debug_info
+	.long		.Lname49
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #50: variable LUT0CTRLB
+	.section	.debug_info
+	.uleb128	50	; ref to abbrev 50
+	.section	.debug_abbrev
+	.uleb128	50
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname50:
+	.string		"LUT0CTRLB"
+	.section	.debug_info
+	.long		.Lname50
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #51: variable LUT0CTRLC
+	.section	.debug_info
+	.uleb128	51	; ref to abbrev 51
+	.section	.debug_abbrev
+	.uleb128	51
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname51:
+	.string		"LUT0CTRLC"
+	.section	.debug_info
+	.long		.Lname51
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #52: variable TRUTH0
+	.section	.debug_info
+	.uleb128	52	; ref to abbrev 52
+	.section	.debug_abbrev
+	.uleb128	52
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname52:
+	.string		"TRUTH0"
+	.section	.debug_info
+	.long		.Lname52
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #53: variable LUT1CTRLA
+	.section	.debug_info
+	.uleb128	53	; ref to abbrev 53
+	.section	.debug_abbrev
+	.uleb128	53
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname53:
+	.string		"LUT1CTRLA"
+	.section	.debug_info
+	.long		.Lname53
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #54: variable LUT1CTRLB
+	.section	.debug_info
+	.uleb128	54	; ref to abbrev 54
+	.section	.debug_abbrev
+	.uleb128	54
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname54:
+	.string		"LUT1CTRLB"
+	.section	.debug_info
+	.long		.Lname54
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #55: variable LUT1CTRLC
+	.section	.debug_info
+	.uleb128	55	; ref to abbrev 55
+	.section	.debug_abbrev
+	.uleb128	55
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname55:
+	.string		"LUT1CTRLC"
+	.section	.debug_info
+	.long		.Lname55
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #56: variable TRUTH1
+	.section	.debug_info
+	.uleb128	56	; ref to abbrev 56
+	.section	.debug_abbrev
+	.uleb128	56
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname56:
+	.string		"TRUTH1"
+	.section	.debug_info
+	.long		.Lname56
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #57: variable LUT2CTRLA
+	.section	.debug_info
+	.uleb128	57	; ref to abbrev 57
+	.section	.debug_abbrev
+	.uleb128	57
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname57:
+	.string		"LUT2CTRLA"
+	.section	.debug_info
+	.long		.Lname57
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #58: variable LUT2CTRLB
+	.section	.debug_info
+	.uleb128	58	; ref to abbrev 58
+	.section	.debug_abbrev
+	.uleb128	58
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname58:
+	.string		"LUT2CTRLB"
+	.section	.debug_info
+	.long		.Lname58
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #59: variable LUT2CTRLC
+	.section	.debug_info
+	.uleb128	59	; ref to abbrev 59
+	.section	.debug_abbrev
+	.uleb128	59
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname59:
+	.string		"LUT2CTRLC"
+	.section	.debug_info
+	.long		.Lname59
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #60: variable TRUTH2
+	.section	.debug_info
+	.uleb128	60	; ref to abbrev 60
+	.section	.debug_abbrev
+	.uleb128	60
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname60:
+	.string		"TRUTH2"
+	.section	.debug_info
+	.long		.Lname60
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #61: variable LUT3CTRLA
+	.section	.debug_info
+	.uleb128	61	; ref to abbrev 61
+	.section	.debug_abbrev
+	.uleb128	61
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname61:
+	.string		"LUT3CTRLA"
+	.section	.debug_info
+	.long		.Lname61
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #62: variable LUT3CTRLB
+	.section	.debug_info
+	.uleb128	62	; ref to abbrev 62
+	.section	.debug_abbrev
+	.uleb128	62
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname62:
+	.string		"LUT3CTRLB"
+	.section	.debug_info
+	.long		.Lname62
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #63: variable LUT3CTRLC
+	.section	.debug_info
+	.uleb128	63	; ref to abbrev 63
+	.section	.debug_abbrev
+	.uleb128	63
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname63:
+	.string		"LUT3CTRLC"
+	.section	.debug_info
+	.long		.Lname63
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #64: variable TRUTH3
+	.section	.debug_info
+	.uleb128	64	; ref to abbrev 64
+	.section	.debug_abbrev
+	.uleb128	64
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname64:
+	.string		"TRUTH3"
+	.section	.debug_info
+	.long		.Lname64
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #65: variable MCLKCTRLA
+	.section	.debug_info
+	.uleb128	65	; ref to abbrev 65
+	.section	.debug_abbrev
+	.uleb128	65
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname65:
+	.string		"MCLKCTRLA"
+	.section	.debug_info
+	.long		.Lname65
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #66: variable MCLKCTRLB
+	.section	.debug_info
+	.uleb128	66	; ref to abbrev 66
+	.section	.debug_abbrev
+	.uleb128	66
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname66:
+	.string		"MCLKCTRLB"
+	.section	.debug_info
+	.long		.Lname66
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #67: variable MCLKCTRLC
+	.section	.debug_info
+	.uleb128	67	; ref to abbrev 67
+	.section	.debug_abbrev
+	.uleb128	67
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname67:
+	.string		"MCLKCTRLC"
+	.section	.debug_info
+	.long		.Lname67
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #68: variable MCLKINTCTRL
+	.section	.debug_info
+	.uleb128	68	; ref to abbrev 68
+	.section	.debug_abbrev
+	.uleb128	68
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname68:
+	.string		"MCLKINTCTRL"
+	.section	.debug_info
+	.long		.Lname68
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #69: variable MCLKINTFLAGS
+	.section	.debug_info
+	.uleb128	69	; ref to abbrev 69
+	.section	.debug_abbrev
+	.uleb128	69
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname69:
+	.string		"MCLKINTFLAGS"
+	.section	.debug_info
+	.long		.Lname69
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #70: variable MCLKSTATUS
+	.section	.debug_info
+	.uleb128	70	; ref to abbrev 70
+	.section	.debug_abbrev
+	.uleb128	70
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname70:
+	.string		"MCLKSTATUS"
+	.section	.debug_info
+	.long		.Lname70
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #71: variable MCLKTIMEBASE
+	.section	.debug_info
+	.uleb128	71	; ref to abbrev 71
+	.section	.debug_abbrev
+	.uleb128	71
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname71:
+	.string		"MCLKTIMEBASE"
+	.section	.debug_info
+	.long		.Lname71
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #72: variable OSCHFCTRLA
+	.section	.debug_info
+	.uleb128	72	; ref to abbrev 72
+	.section	.debug_abbrev
+	.uleb128	72
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname72:
+	.string		"OSCHFCTRLA"
+	.section	.debug_info
+	.long		.Lname72
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #73: variable OSCHFTUNE
+	.section	.debug_info
+	.uleb128	73	; ref to abbrev 73
+	.section	.debug_abbrev
+	.uleb128	73
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname73:
+	.string		"OSCHFTUNE"
+	.section	.debug_info
+	.long		.Lname73
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #74: variable OSC32KCTRLA
+	.section	.debug_info
+	.uleb128	74	; ref to abbrev 74
+	.section	.debug_abbrev
+	.uleb128	74
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname74:
+	.string		"OSC32KCTRLA"
+	.section	.debug_info
+	.long		.Lname74
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #75: variable XOSC32KCTRLA
+	.section	.debug_info
+	.uleb128	75	; ref to abbrev 75
+	.section	.debug_abbrev
+	.uleb128	75
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname75:
+	.string		"XOSC32KCTRLA"
+	.section	.debug_info
+	.long		.Lname75
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x1C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #76: variable XOSCHFCTRLA
+	.section	.debug_info
+	.uleb128	76	; ref to abbrev 76
+	.section	.debug_abbrev
+	.uleb128	76
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname76:
+	.string		"XOSCHFCTRLA"
+	.section	.debug_info
+	.long		.Lname76
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #77: variable CCP
+	.section	.debug_info
+	.uleb128	77	; ref to abbrev 77
+	.section	.debug_abbrev
+	.uleb128	77
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname77:
+	.string		"CCP"
+	.section	.debug_info
+	.long		.Lname77
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0030 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #78: variable SP
+	.section	.debug_info
+	.uleb128	78	; ref to abbrev 78
+	.section	.debug_abbrev
+	.uleb128	78
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname78:
+	.string		"SP"
+	.section	.debug_info
+	.long		.Lname78
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0030 + 0xD
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #79: variable SREG
+	.section	.debug_info
+	.uleb128	79	; ref to abbrev 79
+	.section	.debug_abbrev
+	.uleb128	79
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname79:
+	.string		"SREG"
+	.section	.debug_info
+	.long		.Lname79
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0030 + 0xF
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #80: variable CTRLA
+	.section	.debug_info
+	.uleb128	80	; ref to abbrev 80
+	.section	.debug_abbrev
+	.uleb128	80
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname80:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname80
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0110 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #81: variable STATUS
+	.section	.debug_info
+	.uleb128	81	; ref to abbrev 81
+	.section	.debug_abbrev
+	.uleb128	81
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname81:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname81
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0110 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #82: variable LVL0PRI
+	.section	.debug_info
+	.uleb128	82	; ref to abbrev 82
+	.section	.debug_abbrev
+	.uleb128	82
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname82:
+	.string		"LVL0PRI"
+	.section	.debug_info
+	.long		.Lname82
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0110 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #83: variable LVL1VEC
+	.section	.debug_info
+	.uleb128	83	; ref to abbrev 83
+	.section	.debug_abbrev
+	.uleb128	83
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname83:
+	.string		"LVL1VEC"
+	.section	.debug_info
+	.long		.Lname83
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0110 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #84: variable CTRLA
+	.section	.debug_info
+	.uleb128	84	; ref to abbrev 84
+	.section	.debug_abbrev
+	.uleb128	84
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname84:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname84
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0120 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #85: variable CTRLB
+	.section	.debug_info
+	.uleb128	85	; ref to abbrev 85
+	.section	.debug_abbrev
+	.uleb128	85
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname85:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname85
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0120 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #86: variable STATUS
+	.section	.debug_info
+	.uleb128	86	; ref to abbrev 86
+	.section	.debug_abbrev
+	.uleb128	86
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname86:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname86
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0120 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #87: variable CTRLA
+	.section	.debug_info
+	.uleb128	87	; ref to abbrev 87
+	.section	.debug_abbrev
+	.uleb128	87
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname87:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname87
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x06A0 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #88: variable DATA
+	.section	.debug_info
+	.uleb128	88	; ref to abbrev 88
+	.section	.debug_abbrev
+	.uleb128	88
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname88:
+	.string		"DATA"
+	.section	.debug_info
+	.long		.Lname88
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x06A0 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #89: variable SWEVENTA
+	.section	.debug_info
+	.uleb128	89	; ref to abbrev 89
+	.section	.debug_abbrev
+	.uleb128	89
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname89:
+	.string		"SWEVENTA"
+	.section	.debug_info
+	.long		.Lname89
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #90: variable CHANNEL0
+	.section	.debug_info
+	.uleb128	90	; ref to abbrev 90
+	.section	.debug_abbrev
+	.uleb128	90
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname90:
+	.string		"CHANNEL0"
+	.section	.debug_info
+	.long		.Lname90
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #91: variable CHANNEL1
+	.section	.debug_info
+	.uleb128	91	; ref to abbrev 91
+	.section	.debug_abbrev
+	.uleb128	91
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname91:
+	.string		"CHANNEL1"
+	.section	.debug_info
+	.long		.Lname91
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #92: variable CHANNEL2
+	.section	.debug_info
+	.uleb128	92	; ref to abbrev 92
+	.section	.debug_abbrev
+	.uleb128	92
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname92:
+	.string		"CHANNEL2"
+	.section	.debug_info
+	.long		.Lname92
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #93: variable CHANNEL3
+	.section	.debug_info
+	.uleb128	93	; ref to abbrev 93
+	.section	.debug_abbrev
+	.uleb128	93
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname93:
+	.string		"CHANNEL3"
+	.section	.debug_info
+	.long		.Lname93
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #94: variable CHANNEL4
+	.section	.debug_info
+	.uleb128	94	; ref to abbrev 94
+	.section	.debug_abbrev
+	.uleb128	94
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname94:
+	.string		"CHANNEL4"
+	.section	.debug_info
+	.long		.Lname94
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #95: variable CHANNEL5
+	.section	.debug_info
+	.uleb128	95	; ref to abbrev 95
+	.section	.debug_abbrev
+	.uleb128	95
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname95:
+	.string		"CHANNEL5"
+	.section	.debug_info
+	.long		.Lname95
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #96: variable USERCCLLUT0A
+	.section	.debug_info
+	.uleb128	96	; ref to abbrev 96
+	.section	.debug_abbrev
+	.uleb128	96
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname96:
+	.string		"USERCCLLUT0A"
+	.section	.debug_info
+	.long		.Lname96
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #97: variable USERCCLLUT0B
+	.section	.debug_info
+	.uleb128	97	; ref to abbrev 97
+	.section	.debug_abbrev
+	.uleb128	97
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname97:
+	.string		"USERCCLLUT0B"
+	.section	.debug_info
+	.long		.Lname97
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x21
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #98: variable USERCCLLUT1A
+	.section	.debug_info
+	.uleb128	98	; ref to abbrev 98
+	.section	.debug_abbrev
+	.uleb128	98
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname98:
+	.string		"USERCCLLUT1A"
+	.section	.debug_info
+	.long		.Lname98
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x22
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #99: variable USERCCLLUT1B
+	.section	.debug_info
+	.uleb128	99	; ref to abbrev 99
+	.section	.debug_abbrev
+	.uleb128	99
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname99:
+	.string		"USERCCLLUT1B"
+	.section	.debug_info
+	.long		.Lname99
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x23
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #100: variable USERCCLLUT2A
+	.section	.debug_info
+	.uleb128	100	; ref to abbrev 100
+	.section	.debug_abbrev
+	.uleb128	100
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname100:
+	.string		"USERCCLLUT2A"
+	.section	.debug_info
+	.long		.Lname100
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x24
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #101: variable USERCCLLUT2B
+	.section	.debug_info
+	.uleb128	101	; ref to abbrev 101
+	.section	.debug_abbrev
+	.uleb128	101
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname101:
+	.string		"USERCCLLUT2B"
+	.section	.debug_info
+	.long		.Lname101
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x25
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #102: variable USERCCLLUT3A
+	.section	.debug_info
+	.uleb128	102	; ref to abbrev 102
+	.section	.debug_abbrev
+	.uleb128	102
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname102:
+	.string		"USERCCLLUT3A"
+	.section	.debug_info
+	.long		.Lname102
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x26
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #103: variable USERCCLLUT3B
+	.section	.debug_info
+	.uleb128	103	; ref to abbrev 103
+	.section	.debug_abbrev
+	.uleb128	103
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname103:
+	.string		"USERCCLLUT3B"
+	.section	.debug_info
+	.long		.Lname103
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x27
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #104: variable USERADC0START
+	.section	.debug_info
+	.uleb128	104	; ref to abbrev 104
+	.section	.debug_abbrev
+	.uleb128	104
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname104:
+	.string		"USERADC0START"
+	.section	.debug_info
+	.long		.Lname104
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x28
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #105: variable USEREVSYSEVOUTA
+	.section	.debug_info
+	.uleb128	105	; ref to abbrev 105
+	.section	.debug_abbrev
+	.uleb128	105
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname105:
+	.string		"USEREVSYSEVOUTA"
+	.section	.debug_info
+	.long		.Lname105
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x29
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #106: variable USEREVSYSEVOUTC
+	.section	.debug_info
+	.uleb128	106	; ref to abbrev 106
+	.section	.debug_abbrev
+	.uleb128	106
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname106:
+	.string		"USEREVSYSEVOUTC"
+	.section	.debug_info
+	.long		.Lname106
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #107: variable USEREVSYSEVOUTD
+	.section	.debug_info
+	.uleb128	107	; ref to abbrev 107
+	.section	.debug_abbrev
+	.uleb128	107
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname107:
+	.string		"USEREVSYSEVOUTD"
+	.section	.debug_info
+	.long		.Lname107
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #108: variable USEREVSYSEVOUTF
+	.section	.debug_info
+	.uleb128	108	; ref to abbrev 108
+	.section	.debug_abbrev
+	.uleb128	108
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname108:
+	.string		"USEREVSYSEVOUTF"
+	.section	.debug_info
+	.long		.Lname108
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #109: variable USERUSART0IRDA
+	.section	.debug_info
+	.uleb128	109	; ref to abbrev 109
+	.section	.debug_abbrev
+	.uleb128	109
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname109:
+	.string		"USERUSART0IRDA"
+	.section	.debug_info
+	.long		.Lname109
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #110: variable USERUSART1IRDA
+	.section	.debug_info
+	.uleb128	110	; ref to abbrev 110
+	.section	.debug_abbrev
+	.uleb128	110
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname110:
+	.string		"USERUSART1IRDA"
+	.section	.debug_info
+	.long		.Lname110
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x30
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #111: variable USERUSART2IRDA
+	.section	.debug_info
+	.uleb128	111	; ref to abbrev 111
+	.section	.debug_abbrev
+	.uleb128	111
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname111:
+	.string		"USERUSART2IRDA"
+	.section	.debug_info
+	.long		.Lname111
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x31
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #112: variable USERTCA0CNTA
+	.section	.debug_info
+	.uleb128	112	; ref to abbrev 112
+	.section	.debug_abbrev
+	.uleb128	112
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname112:
+	.string		"USERTCA0CNTA"
+	.section	.debug_info
+	.long		.Lname112
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x32
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #113: variable USERTCA0CNTB
+	.section	.debug_info
+	.uleb128	113	; ref to abbrev 113
+	.section	.debug_abbrev
+	.uleb128	113
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname113:
+	.string		"USERTCA0CNTB"
+	.section	.debug_info
+	.long		.Lname113
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x33
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #114: variable USERTCA1CNTA
+	.section	.debug_info
+	.uleb128	114	; ref to abbrev 114
+	.section	.debug_abbrev
+	.uleb128	114
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname114:
+	.string		"USERTCA1CNTA"
+	.section	.debug_info
+	.long		.Lname114
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x34
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #115: variable USERTCA1CNTB
+	.section	.debug_info
+	.uleb128	115	; ref to abbrev 115
+	.section	.debug_abbrev
+	.uleb128	115
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname115:
+	.string		"USERTCA1CNTB"
+	.section	.debug_info
+	.long		.Lname115
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x35
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #116: variable USERTCB0CAPT
+	.section	.debug_info
+	.uleb128	116	; ref to abbrev 116
+	.section	.debug_abbrev
+	.uleb128	116
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname116:
+	.string		"USERTCB0CAPT"
+	.section	.debug_info
+	.long		.Lname116
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x36
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #117: variable USERTCB0COUNT
+	.section	.debug_info
+	.uleb128	117	; ref to abbrev 117
+	.section	.debug_abbrev
+	.uleb128	117
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname117:
+	.string		"USERTCB0COUNT"
+	.section	.debug_info
+	.long		.Lname117
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x37
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #118: variable USERTCB1CAPT
+	.section	.debug_info
+	.uleb128	118	; ref to abbrev 118
+	.section	.debug_abbrev
+	.uleb128	118
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname118:
+	.string		"USERTCB1CAPT"
+	.section	.debug_info
+	.long		.Lname118
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x38
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #119: variable USERTCB1COUNT
+	.section	.debug_info
+	.uleb128	119	; ref to abbrev 119
+	.section	.debug_abbrev
+	.uleb128	119
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname119:
+	.string		"USERTCB1COUNT"
+	.section	.debug_info
+	.long		.Lname119
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x39
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #120: variable USERTCB2CAPT
+	.section	.debug_info
+	.uleb128	120	; ref to abbrev 120
+	.section	.debug_abbrev
+	.uleb128	120
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname120:
+	.string		"USERTCB2CAPT"
+	.section	.debug_info
+	.long		.Lname120
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x3A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #121: variable USERTCB2COUNT
+	.section	.debug_info
+	.uleb128	121	; ref to abbrev 121
+	.section	.debug_abbrev
+	.uleb128	121
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname121:
+	.string		"USERTCB2COUNT"
+	.section	.debug_info
+	.long		.Lname121
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x3B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #122: variable USERTCB3CAPT
+	.section	.debug_info
+	.uleb128	122	; ref to abbrev 122
+	.section	.debug_abbrev
+	.uleb128	122
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname122:
+	.string		"USERTCB3CAPT"
+	.section	.debug_info
+	.long		.Lname122
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x3C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #123: variable USERTCB3COUNT
+	.section	.debug_info
+	.uleb128	123	; ref to abbrev 123
+	.section	.debug_abbrev
+	.uleb128	123
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname123:
+	.string		"USERTCB3COUNT"
+	.section	.debug_info
+	.long		.Lname123
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x3D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #124: variable WDTCFG
+	.section	.debug_info
+	.uleb128	124	; ref to abbrev 124
+	.section	.debug_abbrev
+	.uleb128	124
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname124:
+	.string		"WDTCFG"
+	.section	.debug_info
+	.long		.Lname124
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #125: variable BODCFG
+	.section	.debug_info
+	.uleb128	125	; ref to abbrev 125
+	.section	.debug_abbrev
+	.uleb128	125
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname125:
+	.string		"BODCFG"
+	.section	.debug_info
+	.long		.Lname125
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #126: variable OSCCFG
+	.section	.debug_info
+	.uleb128	126	; ref to abbrev 126
+	.section	.debug_abbrev
+	.uleb128	126
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname126:
+	.string		"OSCCFG"
+	.section	.debug_info
+	.long		.Lname126
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #127: variable SYSCFG0
+	.section	.debug_info
+	.uleb128	127	; ref to abbrev 127
+	.section	.debug_abbrev
+	.uleb128	127
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname127:
+	.string		"SYSCFG0"
+	.section	.debug_info
+	.long		.Lname127
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #128: variable SYSCFG1
+	.section	.debug_info
+	.uleb128	128	; ref to abbrev 128
+	.section	.debug_abbrev
+	.uleb128	128
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname128:
+	.string		"SYSCFG1"
+	.section	.debug_info
+	.long		.Lname128
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #129: variable CODESIZE
+	.section	.debug_info
+	.uleb128	129	; ref to abbrev 129
+	.section	.debug_abbrev
+	.uleb128	129
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname129:
+	.string		"CODESIZE"
+	.section	.debug_info
+	.long		.Lname129
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #130: variable BOOTSIZE
+	.section	.debug_info
+	.uleb128	130	; ref to abbrev 130
+	.section	.debug_abbrev
+	.uleb128	130
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname130:
+	.string		"BOOTSIZE"
+	.section	.debug_info
+	.long		.Lname130
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #131: variable GPR0
+	.section	.debug_info
+	.uleb128	131	; ref to abbrev 131
+	.section	.debug_abbrev
+	.uleb128	131
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname131:
+	.string		"GPR0"
+	.section	.debug_info
+	.long		.Lname131
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x001C + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #132: variable GPR1
+	.section	.debug_info
+	.uleb128	132	; ref to abbrev 132
+	.section	.debug_abbrev
+	.uleb128	132
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname132:
+	.string		"GPR1"
+	.section	.debug_info
+	.long		.Lname132
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x001C + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #133: variable GPR2
+	.section	.debug_info
+	.uleb128	133	; ref to abbrev 133
+	.section	.debug_abbrev
+	.uleb128	133
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname133:
+	.string		"GPR2"
+	.section	.debug_info
+	.long		.Lname133
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x001C + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #134: variable GPR3
+	.section	.debug_info
+	.uleb128	134	; ref to abbrev 134
+	.section	.debug_abbrev
+	.uleb128	134
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname134:
+	.string		"GPR3"
+	.section	.debug_info
+	.long		.Lname134
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x001C + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #135: variable KEY
+	.section	.debug_info
+	.uleb128	135	; ref to abbrev 135
+	.section	.debug_abbrev
+	.uleb128	135
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname135:
+	.string		"KEY"
+	.section	.debug_info
+	.long		.Lname135
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint32_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1040 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #136: variable CTRLA
+	.section	.debug_info
+	.uleb128	136	; ref to abbrev 136
+	.section	.debug_abbrev
+	.uleb128	136
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname136:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname136
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #137: variable CTRLB
+	.section	.debug_info
+	.uleb128	137	; ref to abbrev 137
+	.section	.debug_abbrev
+	.uleb128	137
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname137:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname137
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #138: variable INTCTRL
+	.section	.debug_info
+	.uleb128	138	; ref to abbrev 138
+	.section	.debug_abbrev
+	.uleb128	138
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname138:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname138
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #139: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	139	; ref to abbrev 139
+	.section	.debug_abbrev
+	.uleb128	139
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname139:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname139
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #140: variable STATUS
+	.section	.debug_info
+	.uleb128	140	; ref to abbrev 140
+	.section	.debug_abbrev
+	.uleb128	140
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname140:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname140
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #141: variable DATA
+	.section	.debug_info
+	.uleb128	141	; ref to abbrev 141
+	.section	.debug_abbrev
+	.uleb128	141
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname141:
+	.string		"DATA"
+	.section	.debug_info
+	.long		.Lname141
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #142: variable ADDR
+	.section	.debug_info
+	.uleb128	142	; ref to abbrev 142
+	.section	.debug_abbrev
+	.uleb128	142
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname142:
+	.string		"ADDR"
+	.section	.debug_info
+	.long		.Lname142
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint32_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #143: variable DIR
+	.section	.debug_info
+	.uleb128	143	; ref to abbrev 143
+	.section	.debug_abbrev
+	.uleb128	143
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname143:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname143
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #144: variable DIRSET
+	.section	.debug_info
+	.uleb128	144	; ref to abbrev 144
+	.section	.debug_abbrev
+	.uleb128	144
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname144:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname144
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #145: variable DIRCLR
+	.section	.debug_info
+	.uleb128	145	; ref to abbrev 145
+	.section	.debug_abbrev
+	.uleb128	145
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname145:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname145
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #146: variable DIRTGL
+	.section	.debug_info
+	.uleb128	146	; ref to abbrev 146
+	.section	.debug_abbrev
+	.uleb128	146
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname146:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname146
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #147: variable OUT
+	.section	.debug_info
+	.uleb128	147	; ref to abbrev 147
+	.section	.debug_abbrev
+	.uleb128	147
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname147:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname147
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #148: variable OUTSET
+	.section	.debug_info
+	.uleb128	148	; ref to abbrev 148
+	.section	.debug_abbrev
+	.uleb128	148
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname148:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname148
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #149: variable OUTCLR
+	.section	.debug_info
+	.uleb128	149	; ref to abbrev 149
+	.section	.debug_abbrev
+	.uleb128	149
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname149:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname149
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #150: variable OUTTGL
+	.section	.debug_info
+	.uleb128	150	; ref to abbrev 150
+	.section	.debug_abbrev
+	.uleb128	150
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname150:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname150
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #151: variable IN
+	.section	.debug_info
+	.uleb128	151	; ref to abbrev 151
+	.section	.debug_abbrev
+	.uleb128	151
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname151:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname151
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #152: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	152	; ref to abbrev 152
+	.section	.debug_abbrev
+	.uleb128	152
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname152:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname152
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #153: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	153	; ref to abbrev 153
+	.section	.debug_abbrev
+	.uleb128	153
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname153:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname153
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #154: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	154	; ref to abbrev 154
+	.section	.debug_abbrev
+	.uleb128	154
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname154:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname154
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #155: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	155	; ref to abbrev 155
+	.section	.debug_abbrev
+	.uleb128	155
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname155:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname155
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #156: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	156	; ref to abbrev 156
+	.section	.debug_abbrev
+	.uleb128	156
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname156:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname156
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #157: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	157	; ref to abbrev 157
+	.section	.debug_abbrev
+	.uleb128	157
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname157:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname157
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #158: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	158	; ref to abbrev 158
+	.section	.debug_abbrev
+	.uleb128	158
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname158:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname158
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #159: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	159	; ref to abbrev 159
+	.section	.debug_abbrev
+	.uleb128	159
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname159:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname159
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #160: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	160	; ref to abbrev 160
+	.section	.debug_abbrev
+	.uleb128	160
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname160:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname160
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #161: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	161	; ref to abbrev 161
+	.section	.debug_abbrev
+	.uleb128	161
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname161:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname161
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #162: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	162	; ref to abbrev 162
+	.section	.debug_abbrev
+	.uleb128	162
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname162:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname162
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #163: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	163	; ref to abbrev 163
+	.section	.debug_abbrev
+	.uleb128	163
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname163:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname163
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #164: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	164	; ref to abbrev 164
+	.section	.debug_abbrev
+	.uleb128	164
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname164:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname164
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #165: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	165	; ref to abbrev 165
+	.section	.debug_abbrev
+	.uleb128	165
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname165:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname165
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #166: variable EVGENCTRL
+	.section	.debug_info
+	.uleb128	166	; ref to abbrev 166
+	.section	.debug_abbrev
+	.uleb128	166
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname166:
+	.string		"EVGENCTRL"
+	.section	.debug_info
+	.long		.Lname166
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #167: variable DIR
+	.section	.debug_info
+	.uleb128	167	; ref to abbrev 167
+	.section	.debug_abbrev
+	.uleb128	167
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname167:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname167
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #168: variable DIRSET
+	.section	.debug_info
+	.uleb128	168	; ref to abbrev 168
+	.section	.debug_abbrev
+	.uleb128	168
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname168:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname168
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #169: variable DIRCLR
+	.section	.debug_info
+	.uleb128	169	; ref to abbrev 169
+	.section	.debug_abbrev
+	.uleb128	169
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname169:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname169
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #170: variable DIRTGL
+	.section	.debug_info
+	.uleb128	170	; ref to abbrev 170
+	.section	.debug_abbrev
+	.uleb128	170
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname170:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname170
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #171: variable OUT
+	.section	.debug_info
+	.uleb128	171	; ref to abbrev 171
+	.section	.debug_abbrev
+	.uleb128	171
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname171:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname171
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #172: variable OUTSET
+	.section	.debug_info
+	.uleb128	172	; ref to abbrev 172
+	.section	.debug_abbrev
+	.uleb128	172
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname172:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname172
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #173: variable OUTCLR
+	.section	.debug_info
+	.uleb128	173	; ref to abbrev 173
+	.section	.debug_abbrev
+	.uleb128	173
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname173:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname173
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #174: variable OUTTGL
+	.section	.debug_info
+	.uleb128	174	; ref to abbrev 174
+	.section	.debug_abbrev
+	.uleb128	174
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname174:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname174
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #175: variable IN
+	.section	.debug_info
+	.uleb128	175	; ref to abbrev 175
+	.section	.debug_abbrev
+	.uleb128	175
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname175:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname175
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #176: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	176	; ref to abbrev 176
+	.section	.debug_abbrev
+	.uleb128	176
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname176:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname176
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #177: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	177	; ref to abbrev 177
+	.section	.debug_abbrev
+	.uleb128	177
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname177:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname177
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #178: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	178	; ref to abbrev 178
+	.section	.debug_abbrev
+	.uleb128	178
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname178:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname178
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #179: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	179	; ref to abbrev 179
+	.section	.debug_abbrev
+	.uleb128	179
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname179:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname179
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #180: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	180	; ref to abbrev 180
+	.section	.debug_abbrev
+	.uleb128	180
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname180:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname180
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #181: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	181	; ref to abbrev 181
+	.section	.debug_abbrev
+	.uleb128	181
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname181:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname181
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #182: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	182	; ref to abbrev 182
+	.section	.debug_abbrev
+	.uleb128	182
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname182:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname182
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #183: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	183	; ref to abbrev 183
+	.section	.debug_abbrev
+	.uleb128	183
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname183:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname183
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #184: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	184	; ref to abbrev 184
+	.section	.debug_abbrev
+	.uleb128	184
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname184:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname184
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #185: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	185	; ref to abbrev 185
+	.section	.debug_abbrev
+	.uleb128	185
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname185:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname185
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #186: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	186	; ref to abbrev 186
+	.section	.debug_abbrev
+	.uleb128	186
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname186:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname186
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #187: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	187	; ref to abbrev 187
+	.section	.debug_abbrev
+	.uleb128	187
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname187:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname187
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #188: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	188	; ref to abbrev 188
+	.section	.debug_abbrev
+	.uleb128	188
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname188:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname188
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #189: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	189	; ref to abbrev 189
+	.section	.debug_abbrev
+	.uleb128	189
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname189:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname189
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #190: variable EVGENCTRL
+	.section	.debug_info
+	.uleb128	190	; ref to abbrev 190
+	.section	.debug_abbrev
+	.uleb128	190
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname190:
+	.string		"EVGENCTRL"
+	.section	.debug_info
+	.long		.Lname190
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #191: variable DIR
+	.section	.debug_info
+	.uleb128	191	; ref to abbrev 191
+	.section	.debug_abbrev
+	.uleb128	191
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname191:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname191
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #192: variable DIRSET
+	.section	.debug_info
+	.uleb128	192	; ref to abbrev 192
+	.section	.debug_abbrev
+	.uleb128	192
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname192:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname192
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #193: variable DIRCLR
+	.section	.debug_info
+	.uleb128	193	; ref to abbrev 193
+	.section	.debug_abbrev
+	.uleb128	193
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname193:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname193
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #194: variable DIRTGL
+	.section	.debug_info
+	.uleb128	194	; ref to abbrev 194
+	.section	.debug_abbrev
+	.uleb128	194
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname194:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname194
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #195: variable OUT
+	.section	.debug_info
+	.uleb128	195	; ref to abbrev 195
+	.section	.debug_abbrev
+	.uleb128	195
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname195:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname195
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #196: variable OUTSET
+	.section	.debug_info
+	.uleb128	196	; ref to abbrev 196
+	.section	.debug_abbrev
+	.uleb128	196
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname196:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname196
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #197: variable OUTCLR
+	.section	.debug_info
+	.uleb128	197	; ref to abbrev 197
+	.section	.debug_abbrev
+	.uleb128	197
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname197:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname197
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #198: variable OUTTGL
+	.section	.debug_info
+	.uleb128	198	; ref to abbrev 198
+	.section	.debug_abbrev
+	.uleb128	198
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname198:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname198
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #199: variable IN
+	.section	.debug_info
+	.uleb128	199	; ref to abbrev 199
+	.section	.debug_abbrev
+	.uleb128	199
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname199:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname199
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #200: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	200	; ref to abbrev 200
+	.section	.debug_abbrev
+	.uleb128	200
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname200:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname200
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #201: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	201	; ref to abbrev 201
+	.section	.debug_abbrev
+	.uleb128	201
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname201:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname201
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #202: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	202	; ref to abbrev 202
+	.section	.debug_abbrev
+	.uleb128	202
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname202:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname202
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #203: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	203	; ref to abbrev 203
+	.section	.debug_abbrev
+	.uleb128	203
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname203:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname203
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #204: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	204	; ref to abbrev 204
+	.section	.debug_abbrev
+	.uleb128	204
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname204:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname204
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #205: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	205	; ref to abbrev 205
+	.section	.debug_abbrev
+	.uleb128	205
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname205:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname205
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #206: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	206	; ref to abbrev 206
+	.section	.debug_abbrev
+	.uleb128	206
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname206:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname206
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #207: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	207	; ref to abbrev 207
+	.section	.debug_abbrev
+	.uleb128	207
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname207:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname207
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #208: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	208	; ref to abbrev 208
+	.section	.debug_abbrev
+	.uleb128	208
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname208:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname208
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #209: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	209	; ref to abbrev 209
+	.section	.debug_abbrev
+	.uleb128	209
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname209:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname209
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #210: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	210	; ref to abbrev 210
+	.section	.debug_abbrev
+	.uleb128	210
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname210:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname210
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #211: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	211	; ref to abbrev 211
+	.section	.debug_abbrev
+	.uleb128	211
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname211:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname211
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #212: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	212	; ref to abbrev 212
+	.section	.debug_abbrev
+	.uleb128	212
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname212:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname212
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #213: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	213	; ref to abbrev 213
+	.section	.debug_abbrev
+	.uleb128	213
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname213:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname213
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #214: variable EVGENCTRL
+	.section	.debug_info
+	.uleb128	214	; ref to abbrev 214
+	.section	.debug_abbrev
+	.uleb128	214
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname214:
+	.string		"EVGENCTRL"
+	.section	.debug_info
+	.long		.Lname214
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #215: variable DIR
+	.section	.debug_info
+	.uleb128	215	; ref to abbrev 215
+	.section	.debug_abbrev
+	.uleb128	215
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname215:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname215
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #216: variable DIRSET
+	.section	.debug_info
+	.uleb128	216	; ref to abbrev 216
+	.section	.debug_abbrev
+	.uleb128	216
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname216:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname216
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #217: variable DIRCLR
+	.section	.debug_info
+	.uleb128	217	; ref to abbrev 217
+	.section	.debug_abbrev
+	.uleb128	217
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname217:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname217
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #218: variable DIRTGL
+	.section	.debug_info
+	.uleb128	218	; ref to abbrev 218
+	.section	.debug_abbrev
+	.uleb128	218
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname218:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname218
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #219: variable OUT
+	.section	.debug_info
+	.uleb128	219	; ref to abbrev 219
+	.section	.debug_abbrev
+	.uleb128	219
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname219:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname219
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #220: variable OUTSET
+	.section	.debug_info
+	.uleb128	220	; ref to abbrev 220
+	.section	.debug_abbrev
+	.uleb128	220
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname220:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname220
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #221: variable OUTCLR
+	.section	.debug_info
+	.uleb128	221	; ref to abbrev 221
+	.section	.debug_abbrev
+	.uleb128	221
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname221:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname221
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #222: variable OUTTGL
+	.section	.debug_info
+	.uleb128	222	; ref to abbrev 222
+	.section	.debug_abbrev
+	.uleb128	222
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname222:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname222
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #223: variable IN
+	.section	.debug_info
+	.uleb128	223	; ref to abbrev 223
+	.section	.debug_abbrev
+	.uleb128	223
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname223:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname223
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #224: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	224	; ref to abbrev 224
+	.section	.debug_abbrev
+	.uleb128	224
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname224:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname224
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #225: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	225	; ref to abbrev 225
+	.section	.debug_abbrev
+	.uleb128	225
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname225:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname225
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #226: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	226	; ref to abbrev 226
+	.section	.debug_abbrev
+	.uleb128	226
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname226:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname226
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #227: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	227	; ref to abbrev 227
+	.section	.debug_abbrev
+	.uleb128	227
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname227:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname227
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #228: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	228	; ref to abbrev 228
+	.section	.debug_abbrev
+	.uleb128	228
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname228:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname228
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #229: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	229	; ref to abbrev 229
+	.section	.debug_abbrev
+	.uleb128	229
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname229:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname229
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #230: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	230	; ref to abbrev 230
+	.section	.debug_abbrev
+	.uleb128	230
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname230:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname230
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #231: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	231	; ref to abbrev 231
+	.section	.debug_abbrev
+	.uleb128	231
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname231:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname231
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #232: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	232	; ref to abbrev 232
+	.section	.debug_abbrev
+	.uleb128	232
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname232:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname232
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #233: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	233	; ref to abbrev 233
+	.section	.debug_abbrev
+	.uleb128	233
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname233:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname233
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #234: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	234	; ref to abbrev 234
+	.section	.debug_abbrev
+	.uleb128	234
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname234:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname234
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #235: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	235	; ref to abbrev 235
+	.section	.debug_abbrev
+	.uleb128	235
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname235:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname235
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #236: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	236	; ref to abbrev 236
+	.section	.debug_abbrev
+	.uleb128	236
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname236:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname236
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #237: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	237	; ref to abbrev 237
+	.section	.debug_abbrev
+	.uleb128	237
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname237:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname237
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #238: variable EVGENCTRL
+	.section	.debug_info
+	.uleb128	238	; ref to abbrev 238
+	.section	.debug_abbrev
+	.uleb128	238
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname238:
+	.string		"EVGENCTRL"
+	.section	.debug_info
+	.long		.Lname238
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #239: variable EVSYSROUTEA
+	.section	.debug_info
+	.uleb128	239	; ref to abbrev 239
+	.section	.debug_abbrev
+	.uleb128	239
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname239:
+	.string		"EVSYSROUTEA"
+	.section	.debug_info
+	.long		.Lname239
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #240: variable CCLROUTEA
+	.section	.debug_info
+	.uleb128	240	; ref to abbrev 240
+	.section	.debug_abbrev
+	.uleb128	240
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname240:
+	.string		"CCLROUTEA"
+	.section	.debug_info
+	.long		.Lname240
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #241: variable USARTROUTEA
+	.section	.debug_info
+	.uleb128	241	; ref to abbrev 241
+	.section	.debug_abbrev
+	.uleb128	241
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname241:
+	.string		"USARTROUTEA"
+	.section	.debug_info
+	.long		.Lname241
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #242: variable USARTROUTEB
+	.section	.debug_info
+	.uleb128	242	; ref to abbrev 242
+	.section	.debug_abbrev
+	.uleb128	242
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname242:
+	.string		"USARTROUTEB"
+	.section	.debug_info
+	.long		.Lname242
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #243: variable SPIROUTEA
+	.section	.debug_info
+	.uleb128	243	; ref to abbrev 243
+	.section	.debug_abbrev
+	.uleb128	243
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname243:
+	.string		"SPIROUTEA"
+	.section	.debug_info
+	.long		.Lname243
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #244: variable TWIROUTEA
+	.section	.debug_info
+	.uleb128	244	; ref to abbrev 244
+	.section	.debug_abbrev
+	.uleb128	244
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname244:
+	.string		"TWIROUTEA"
+	.section	.debug_info
+	.long		.Lname244
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #245: variable TCAROUTEA
+	.section	.debug_info
+	.uleb128	245	; ref to abbrev 245
+	.section	.debug_abbrev
+	.uleb128	245
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname245:
+	.string		"TCAROUTEA"
+	.section	.debug_info
+	.long		.Lname245
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #246: variable TCBROUTEA
+	.section	.debug_info
+	.uleb128	246	; ref to abbrev 246
+	.section	.debug_abbrev
+	.uleb128	246
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname246:
+	.string		"TCBROUTEA"
+	.section	.debug_info
+	.long		.Lname246
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #247: variable ACROUTEA
+	.section	.debug_info
+	.uleb128	247	; ref to abbrev 247
+	.section	.debug_abbrev
+	.uleb128	247
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname247:
+	.string		"ACROUTEA"
+	.section	.debug_info
+	.long		.Lname247
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #248: variable RSTFR
+	.section	.debug_info
+	.uleb128	248	; ref to abbrev 248
+	.section	.debug_abbrev
+	.uleb128	248
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname248:
+	.string		"RSTFR"
+	.section	.debug_info
+	.long		.Lname248
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0040 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #249: variable SWRR
+	.section	.debug_info
+	.uleb128	249	; ref to abbrev 249
+	.section	.debug_abbrev
+	.uleb128	249
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname249:
+	.string		"SWRR"
+	.section	.debug_info
+	.long		.Lname249
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0040 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #250: variable CTRLA
+	.section	.debug_info
+	.uleb128	250	; ref to abbrev 250
+	.section	.debug_abbrev
+	.uleb128	250
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname250:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname250
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #251: variable STATUS
+	.section	.debug_info
+	.uleb128	251	; ref to abbrev 251
+	.section	.debug_abbrev
+	.uleb128	251
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname251:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname251
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #252: variable INTCTRL
+	.section	.debug_info
+	.uleb128	252	; ref to abbrev 252
+	.section	.debug_abbrev
+	.uleb128	252
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname252:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname252
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #253: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	253	; ref to abbrev 253
+	.section	.debug_abbrev
+	.uleb128	253
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname253:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname253
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #254: variable TEMP
+	.section	.debug_info
+	.uleb128	254	; ref to abbrev 254
+	.section	.debug_abbrev
+	.uleb128	254
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname254:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname254
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #255: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	255	; ref to abbrev 255
+	.section	.debug_abbrev
+	.uleb128	255
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname255:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname255
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #256: variable CALIB
+	.section	.debug_info
+	.uleb128	256	; ref to abbrev 256
+	.section	.debug_abbrev
+	.uleb128	256
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname256:
+	.string		"CALIB"
+	.section	.debug_info
+	.long		.Lname256
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #257: variable CLKSEL
+	.section	.debug_info
+	.uleb128	257	; ref to abbrev 257
+	.section	.debug_abbrev
+	.uleb128	257
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname257:
+	.string		"CLKSEL"
+	.section	.debug_info
+	.long		.Lname257
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #258: variable CNT
+	.section	.debug_info
+	.uleb128	258	; ref to abbrev 258
+	.section	.debug_abbrev
+	.uleb128	258
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname258:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname258
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #259: variable PER
+	.section	.debug_info
+	.uleb128	259	; ref to abbrev 259
+	.section	.debug_abbrev
+	.uleb128	259
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname259:
+	.string		"PER"
+	.section	.debug_info
+	.long		.Lname259
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #260: variable CMP
+	.section	.debug_info
+	.uleb128	260	; ref to abbrev 260
+	.section	.debug_abbrev
+	.uleb128	260
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname260:
+	.string		"CMP"
+	.section	.debug_info
+	.long		.Lname260
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #261: variable PITCTRLA
+	.section	.debug_info
+	.uleb128	261	; ref to abbrev 261
+	.section	.debug_abbrev
+	.uleb128	261
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname261:
+	.string		"PITCTRLA"
+	.section	.debug_info
+	.long		.Lname261
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #262: variable PITSTATUS
+	.section	.debug_info
+	.uleb128	262	; ref to abbrev 262
+	.section	.debug_abbrev
+	.uleb128	262
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname262:
+	.string		"PITSTATUS"
+	.section	.debug_info
+	.long		.Lname262
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #263: variable PITINTCTRL
+	.section	.debug_info
+	.uleb128	263	; ref to abbrev 263
+	.section	.debug_abbrev
+	.uleb128	263
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname263:
+	.string		"PITINTCTRL"
+	.section	.debug_info
+	.long		.Lname263
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #264: variable PITINTFLAGS
+	.section	.debug_info
+	.uleb128	264	; ref to abbrev 264
+	.section	.debug_abbrev
+	.uleb128	264
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname264:
+	.string		"PITINTFLAGS"
+	.section	.debug_info
+	.long		.Lname264
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #265: variable PITDBGCTRL
+	.section	.debug_info
+	.uleb128	265	; ref to abbrev 265
+	.section	.debug_abbrev
+	.uleb128	265
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname265:
+	.string		"PITDBGCTRL"
+	.section	.debug_info
+	.long		.Lname265
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #266: variable PITEVGENCTRLA
+	.section	.debug_info
+	.uleb128	266	; ref to abbrev 266
+	.section	.debug_abbrev
+	.uleb128	266
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname266:
+	.string		"PITEVGENCTRLA"
+	.section	.debug_info
+	.long		.Lname266
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #267: variable DEVICEID0
+	.section	.debug_info
+	.uleb128	267	; ref to abbrev 267
+	.section	.debug_abbrev
+	.uleb128	267
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname267:
+	.string		"DEVICEID0"
+	.section	.debug_info
+	.long		.Lname267
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #268: variable DEVICEID1
+	.section	.debug_info
+	.uleb128	268	; ref to abbrev 268
+	.section	.debug_abbrev
+	.uleb128	268
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname268:
+	.string		"DEVICEID1"
+	.section	.debug_info
+	.long		.Lname268
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #269: variable DEVICEID2
+	.section	.debug_info
+	.uleb128	269	; ref to abbrev 269
+	.section	.debug_abbrev
+	.uleb128	269
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname269:
+	.string		"DEVICEID2"
+	.section	.debug_info
+	.long		.Lname269
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #270: variable TEMPSENSE0
+	.section	.debug_info
+	.uleb128	270	; ref to abbrev 270
+	.section	.debug_abbrev
+	.uleb128	270
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname270:
+	.string		"TEMPSENSE0"
+	.section	.debug_info
+	.long		.Lname270
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #271: variable TEMPSENSE1
+	.section	.debug_info
+	.uleb128	271	; ref to abbrev 271
+	.section	.debug_abbrev
+	.uleb128	271
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname271:
+	.string		"TEMPSENSE1"
+	.section	.debug_info
+	.long		.Lname271
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #272: variable SERNUM0
+	.section	.debug_info
+	.uleb128	272	; ref to abbrev 272
+	.section	.debug_abbrev
+	.uleb128	272
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname272:
+	.string		"SERNUM0"
+	.section	.debug_info
+	.long		.Lname272
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #273: variable SERNUM1
+	.section	.debug_info
+	.uleb128	273	; ref to abbrev 273
+	.section	.debug_abbrev
+	.uleb128	273
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname273:
+	.string		"SERNUM1"
+	.section	.debug_info
+	.long		.Lname273
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #274: variable SERNUM2
+	.section	.debug_info
+	.uleb128	274	; ref to abbrev 274
+	.section	.debug_abbrev
+	.uleb128	274
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname274:
+	.string		"SERNUM2"
+	.section	.debug_info
+	.long		.Lname274
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #275: variable SERNUM3
+	.section	.debug_info
+	.uleb128	275	; ref to abbrev 275
+	.section	.debug_abbrev
+	.uleb128	275
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname275:
+	.string		"SERNUM3"
+	.section	.debug_info
+	.long		.Lname275
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #276: variable SERNUM4
+	.section	.debug_info
+	.uleb128	276	; ref to abbrev 276
+	.section	.debug_abbrev
+	.uleb128	276
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname276:
+	.string		"SERNUM4"
+	.section	.debug_info
+	.long		.Lname276
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #277: variable SERNUM5
+	.section	.debug_info
+	.uleb128	277	; ref to abbrev 277
+	.section	.debug_abbrev
+	.uleb128	277
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname277:
+	.string		"SERNUM5"
+	.section	.debug_info
+	.long		.Lname277
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #278: variable SERNUM6
+	.section	.debug_info
+	.uleb128	278	; ref to abbrev 278
+	.section	.debug_abbrev
+	.uleb128	278
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname278:
+	.string		"SERNUM6"
+	.section	.debug_info
+	.long		.Lname278
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #279: variable SERNUM7
+	.section	.debug_info
+	.uleb128	279	; ref to abbrev 279
+	.section	.debug_abbrev
+	.uleb128	279
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname279:
+	.string		"SERNUM7"
+	.section	.debug_info
+	.long		.Lname279
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #280: variable SERNUM8
+	.section	.debug_info
+	.uleb128	280	; ref to abbrev 280
+	.section	.debug_abbrev
+	.uleb128	280
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname280:
+	.string		"SERNUM8"
+	.section	.debug_info
+	.long		.Lname280
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #281: variable SERNUM9
+	.section	.debug_info
+	.uleb128	281	; ref to abbrev 281
+	.section	.debug_abbrev
+	.uleb128	281
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname281:
+	.string		"SERNUM9"
+	.section	.debug_info
+	.long		.Lname281
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x19
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #282: variable SERNUM10
+	.section	.debug_info
+	.uleb128	282	; ref to abbrev 282
+	.section	.debug_abbrev
+	.uleb128	282
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname282:
+	.string		"SERNUM10"
+	.section	.debug_info
+	.long		.Lname282
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x1A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #283: variable SERNUM11
+	.section	.debug_info
+	.uleb128	283	; ref to abbrev 283
+	.section	.debug_abbrev
+	.uleb128	283
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname283:
+	.string		"SERNUM11"
+	.section	.debug_info
+	.long		.Lname283
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x1B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #284: variable SERNUM12
+	.section	.debug_info
+	.uleb128	284	; ref to abbrev 284
+	.section	.debug_abbrev
+	.uleb128	284
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname284:
+	.string		"SERNUM12"
+	.section	.debug_info
+	.long		.Lname284
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x1C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #285: variable SERNUM13
+	.section	.debug_info
+	.uleb128	285	; ref to abbrev 285
+	.section	.debug_abbrev
+	.uleb128	285
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname285:
+	.string		"SERNUM13"
+	.section	.debug_info
+	.long		.Lname285
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x1D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #286: variable SERNUM14
+	.section	.debug_info
+	.uleb128	286	; ref to abbrev 286
+	.section	.debug_abbrev
+	.uleb128	286
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname286:
+	.string		"SERNUM14"
+	.section	.debug_info
+	.long		.Lname286
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x1E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #287: variable SERNUM15
+	.section	.debug_info
+	.uleb128	287	; ref to abbrev 287
+	.section	.debug_abbrev
+	.uleb128	287
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname287:
+	.string		"SERNUM15"
+	.section	.debug_info
+	.long		.Lname287
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x1F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #288: variable CTRLA
+	.section	.debug_info
+	.uleb128	288	; ref to abbrev 288
+	.section	.debug_abbrev
+	.uleb128	288
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname288:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname288
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0050 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #289: variable CTRLA
+	.section	.debug_info
+	.uleb128	289	; ref to abbrev 289
+	.section	.debug_abbrev
+	.uleb128	289
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname289:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname289
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #290: variable CTRLB
+	.section	.debug_info
+	.uleb128	290	; ref to abbrev 290
+	.section	.debug_abbrev
+	.uleb128	290
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname290:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname290
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #291: variable INTCTRL
+	.section	.debug_info
+	.uleb128	291	; ref to abbrev 291
+	.section	.debug_abbrev
+	.uleb128	291
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname291:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname291
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #292: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	292	; ref to abbrev 292
+	.section	.debug_abbrev
+	.uleb128	292
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname292:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname292
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #293: variable DATA
+	.section	.debug_info
+	.uleb128	293	; ref to abbrev 293
+	.section	.debug_abbrev
+	.uleb128	293
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname293:
+	.string		"DATA"
+	.section	.debug_info
+	.long		.Lname293
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #294: variable REVID
+	.section	.debug_info
+	.uleb128	294	; ref to abbrev 294
+	.section	.debug_abbrev
+	.uleb128	294
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname294:
+	.string		"REVID"
+	.section	.debug_info
+	.long		.Lname294
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0F00 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #295: variable OCDMCTRL
+	.section	.debug_info
+	.uleb128	295	; ref to abbrev 295
+	.section	.debug_abbrev
+	.uleb128	295
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname295:
+	.string		"OCDMCTRL"
+	.section	.debug_info
+	.long		.Lname295
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0F00 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #296: variable OCDMSTATUS
+	.section	.debug_info
+	.uleb128	296	; ref to abbrev 296
+	.section	.debug_abbrev
+	.uleb128	296
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname296:
+	.string		"OCDMSTATUS"
+	.section	.debug_info
+	.long		.Lname296
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0F00 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #297: variable CTRLA
+	.section	.debug_info
+	.uleb128	297	; ref to abbrev 297
+	.section	.debug_abbrev
+	.uleb128	297
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname297:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname297
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #298: variable CTRLB
+	.section	.debug_info
+	.uleb128	298	; ref to abbrev 298
+	.section	.debug_abbrev
+	.uleb128	298
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname298:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname298
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #299: variable CTRLC
+	.section	.debug_info
+	.uleb128	299	; ref to abbrev 299
+	.section	.debug_abbrev
+	.uleb128	299
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname299:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname299
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #300: variable CTRLD
+	.section	.debug_info
+	.uleb128	300	; ref to abbrev 300
+	.section	.debug_abbrev
+	.uleb128	300
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname300:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname300
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #301: variable CTRLECLR
+	.section	.debug_info
+	.uleb128	301	; ref to abbrev 301
+	.section	.debug_abbrev
+	.uleb128	301
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname301:
+	.string		"CTRLECLR"
+	.section	.debug_info
+	.long		.Lname301
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #302: variable CTRLESET
+	.section	.debug_info
+	.uleb128	302	; ref to abbrev 302
+	.section	.debug_abbrev
+	.uleb128	302
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname302:
+	.string		"CTRLESET"
+	.section	.debug_info
+	.long		.Lname302
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #303: variable CTRLFCLR
+	.section	.debug_info
+	.uleb128	303	; ref to abbrev 303
+	.section	.debug_abbrev
+	.uleb128	303
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname303:
+	.string		"CTRLFCLR"
+	.section	.debug_info
+	.long		.Lname303
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #304: variable CTRLFSET
+	.section	.debug_info
+	.uleb128	304	; ref to abbrev 304
+	.section	.debug_abbrev
+	.uleb128	304
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname304:
+	.string		"CTRLFSET"
+	.section	.debug_info
+	.long		.Lname304
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #305: variable EVCTRL
+	.section	.debug_info
+	.uleb128	305	; ref to abbrev 305
+	.section	.debug_abbrev
+	.uleb128	305
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname305:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname305
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #306: variable INTCTRL
+	.section	.debug_info
+	.uleb128	306	; ref to abbrev 306
+	.section	.debug_abbrev
+	.uleb128	306
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname306:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname306
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #307: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	307	; ref to abbrev 307
+	.section	.debug_abbrev
+	.uleb128	307
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname307:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname307
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #308: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	308	; ref to abbrev 308
+	.section	.debug_abbrev
+	.uleb128	308
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname308:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname308
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #309: variable TEMP
+	.section	.debug_info
+	.uleb128	309	; ref to abbrev 309
+	.section	.debug_abbrev
+	.uleb128	309
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname309:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname309
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #310: variable CNT
+	.section	.debug_info
+	.uleb128	310	; ref to abbrev 310
+	.section	.debug_abbrev
+	.uleb128	310
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname310:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname310
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #311: variable PER
+	.section	.debug_info
+	.uleb128	311	; ref to abbrev 311
+	.section	.debug_abbrev
+	.uleb128	311
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname311:
+	.string		"PER"
+	.section	.debug_info
+	.long		.Lname311
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x26
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #312: variable CMP0
+	.section	.debug_info
+	.uleb128	312	; ref to abbrev 312
+	.section	.debug_abbrev
+	.uleb128	312
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname312:
+	.string		"CMP0"
+	.section	.debug_info
+	.long		.Lname312
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x28
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #313: variable CMP1
+	.section	.debug_info
+	.uleb128	313	; ref to abbrev 313
+	.section	.debug_abbrev
+	.uleb128	313
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname313:
+	.string		"CMP1"
+	.section	.debug_info
+	.long		.Lname313
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #314: variable CMP2
+	.section	.debug_info
+	.uleb128	314	; ref to abbrev 314
+	.section	.debug_abbrev
+	.uleb128	314
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname314:
+	.string		"CMP2"
+	.section	.debug_info
+	.long		.Lname314
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #315: variable PERBUF
+	.section	.debug_info
+	.uleb128	315	; ref to abbrev 315
+	.section	.debug_abbrev
+	.uleb128	315
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname315:
+	.string		"PERBUF"
+	.section	.debug_info
+	.long		.Lname315
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x36
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #316: variable CMP0BUF
+	.section	.debug_info
+	.uleb128	316	; ref to abbrev 316
+	.section	.debug_abbrev
+	.uleb128	316
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname316:
+	.string		"CMP0BUF"
+	.section	.debug_info
+	.long		.Lname316
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x38
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #317: variable CMP1BUF
+	.section	.debug_info
+	.uleb128	317	; ref to abbrev 317
+	.section	.debug_abbrev
+	.uleb128	317
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname317:
+	.string		"CMP1BUF"
+	.section	.debug_info
+	.long		.Lname317
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x3A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #318: variable CMP2BUF
+	.section	.debug_info
+	.uleb128	318	; ref to abbrev 318
+	.section	.debug_abbrev
+	.uleb128	318
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname318:
+	.string		"CMP2BUF"
+	.section	.debug_info
+	.long		.Lname318
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x3C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #319: variable CTRLA
+	.section	.debug_info
+	.uleb128	319	; ref to abbrev 319
+	.section	.debug_abbrev
+	.uleb128	319
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname319:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname319
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #320: variable CTRLB
+	.section	.debug_info
+	.uleb128	320	; ref to abbrev 320
+	.section	.debug_abbrev
+	.uleb128	320
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname320:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname320
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #321: variable CTRLC
+	.section	.debug_info
+	.uleb128	321	; ref to abbrev 321
+	.section	.debug_abbrev
+	.uleb128	321
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname321:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname321
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #322: variable CTRLD
+	.section	.debug_info
+	.uleb128	322	; ref to abbrev 322
+	.section	.debug_abbrev
+	.uleb128	322
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname322:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname322
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #323: variable CTRLECLR
+	.section	.debug_info
+	.uleb128	323	; ref to abbrev 323
+	.section	.debug_abbrev
+	.uleb128	323
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname323:
+	.string		"CTRLECLR"
+	.section	.debug_info
+	.long		.Lname323
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #324: variable CTRLESET
+	.section	.debug_info
+	.uleb128	324	; ref to abbrev 324
+	.section	.debug_abbrev
+	.uleb128	324
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname324:
+	.string		"CTRLESET"
+	.section	.debug_info
+	.long		.Lname324
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #325: variable INTCTRL
+	.section	.debug_info
+	.uleb128	325	; ref to abbrev 325
+	.section	.debug_abbrev
+	.uleb128	325
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname325:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname325
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #326: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	326	; ref to abbrev 326
+	.section	.debug_abbrev
+	.uleb128	326
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname326:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname326
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #327: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	327	; ref to abbrev 327
+	.section	.debug_abbrev
+	.uleb128	327
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname327:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname327
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #328: variable LCNT
+	.section	.debug_info
+	.uleb128	328	; ref to abbrev 328
+	.section	.debug_abbrev
+	.uleb128	328
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname328:
+	.string		"LCNT"
+	.section	.debug_info
+	.long		.Lname328
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #329: variable HCNT
+	.section	.debug_info
+	.uleb128	329	; ref to abbrev 329
+	.section	.debug_abbrev
+	.uleb128	329
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname329:
+	.string		"HCNT"
+	.section	.debug_info
+	.long		.Lname329
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x21
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #330: variable LPER
+	.section	.debug_info
+	.uleb128	330	; ref to abbrev 330
+	.section	.debug_abbrev
+	.uleb128	330
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname330:
+	.string		"LPER"
+	.section	.debug_info
+	.long		.Lname330
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x26
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #331: variable HPER
+	.section	.debug_info
+	.uleb128	331	; ref to abbrev 331
+	.section	.debug_abbrev
+	.uleb128	331
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname331:
+	.string		"HPER"
+	.section	.debug_info
+	.long		.Lname331
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x27
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #332: variable LCMP0
+	.section	.debug_info
+	.uleb128	332	; ref to abbrev 332
+	.section	.debug_abbrev
+	.uleb128	332
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname332:
+	.string		"LCMP0"
+	.section	.debug_info
+	.long		.Lname332
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x28
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #333: variable HCMP0
+	.section	.debug_info
+	.uleb128	333	; ref to abbrev 333
+	.section	.debug_abbrev
+	.uleb128	333
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname333:
+	.string		"HCMP0"
+	.section	.debug_info
+	.long		.Lname333
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x29
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #334: variable LCMP1
+	.section	.debug_info
+	.uleb128	334	; ref to abbrev 334
+	.section	.debug_abbrev
+	.uleb128	334
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname334:
+	.string		"LCMP1"
+	.section	.debug_info
+	.long		.Lname334
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #335: variable HCMP1
+	.section	.debug_info
+	.uleb128	335	; ref to abbrev 335
+	.section	.debug_abbrev
+	.uleb128	335
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname335:
+	.string		"HCMP1"
+	.section	.debug_info
+	.long		.Lname335
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #336: variable LCMP2
+	.section	.debug_info
+	.uleb128	336	; ref to abbrev 336
+	.section	.debug_abbrev
+	.uleb128	336
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname336:
+	.string		"LCMP2"
+	.section	.debug_info
+	.long		.Lname336
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #337: variable HCMP2
+	.section	.debug_info
+	.uleb128	337	; ref to abbrev 337
+	.section	.debug_abbrev
+	.uleb128	337
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname337:
+	.string		"HCMP2"
+	.section	.debug_info
+	.long		.Lname337
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #338: variable CTRLA
+	.section	.debug_info
+	.uleb128	338	; ref to abbrev 338
+	.section	.debug_abbrev
+	.uleb128	338
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname338:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname338
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #339: variable CTRLB
+	.section	.debug_info
+	.uleb128	339	; ref to abbrev 339
+	.section	.debug_abbrev
+	.uleb128	339
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname339:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname339
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #340: variable EVCTRL
+	.section	.debug_info
+	.uleb128	340	; ref to abbrev 340
+	.section	.debug_abbrev
+	.uleb128	340
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname340:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname340
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #341: variable INTCTRL
+	.section	.debug_info
+	.uleb128	341	; ref to abbrev 341
+	.section	.debug_abbrev
+	.uleb128	341
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname341:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname341
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #342: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	342	; ref to abbrev 342
+	.section	.debug_abbrev
+	.uleb128	342
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname342:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname342
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #343: variable STATUS
+	.section	.debug_info
+	.uleb128	343	; ref to abbrev 343
+	.section	.debug_abbrev
+	.uleb128	343
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname343:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname343
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #344: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	344	; ref to abbrev 344
+	.section	.debug_abbrev
+	.uleb128	344
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname344:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname344
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #345: variable TEMP
+	.section	.debug_info
+	.uleb128	345	; ref to abbrev 345
+	.section	.debug_abbrev
+	.uleb128	345
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname345:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname345
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #346: variable CNT
+	.section	.debug_info
+	.uleb128	346	; ref to abbrev 346
+	.section	.debug_abbrev
+	.uleb128	346
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname346:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname346
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #347: variable CCMP
+	.section	.debug_info
+	.uleb128	347	; ref to abbrev 347
+	.section	.debug_abbrev
+	.uleb128	347
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname347:
+	.string		"CCMP"
+	.section	.debug_info
+	.long		.Lname347
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #348: variable CTRLA
+	.section	.debug_info
+	.uleb128	348	; ref to abbrev 348
+	.section	.debug_abbrev
+	.uleb128	348
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname348:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname348
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #349: variable CTRLB
+	.section	.debug_info
+	.uleb128	349	; ref to abbrev 349
+	.section	.debug_abbrev
+	.uleb128	349
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname349:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname349
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #350: variable EVCTRL
+	.section	.debug_info
+	.uleb128	350	; ref to abbrev 350
+	.section	.debug_abbrev
+	.uleb128	350
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname350:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname350
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #351: variable INTCTRL
+	.section	.debug_info
+	.uleb128	351	; ref to abbrev 351
+	.section	.debug_abbrev
+	.uleb128	351
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname351:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname351
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #352: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	352	; ref to abbrev 352
+	.section	.debug_abbrev
+	.uleb128	352
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname352:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname352
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #353: variable STATUS
+	.section	.debug_info
+	.uleb128	353	; ref to abbrev 353
+	.section	.debug_abbrev
+	.uleb128	353
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname353:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname353
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #354: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	354	; ref to abbrev 354
+	.section	.debug_abbrev
+	.uleb128	354
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname354:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname354
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #355: variable TEMP
+	.section	.debug_info
+	.uleb128	355	; ref to abbrev 355
+	.section	.debug_abbrev
+	.uleb128	355
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname355:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname355
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #356: variable CNT
+	.section	.debug_info
+	.uleb128	356	; ref to abbrev 356
+	.section	.debug_abbrev
+	.uleb128	356
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname356:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname356
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #357: variable CCMP
+	.section	.debug_info
+	.uleb128	357	; ref to abbrev 357
+	.section	.debug_abbrev
+	.uleb128	357
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname357:
+	.string		"CCMP"
+	.section	.debug_info
+	.long		.Lname357
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #358: variable CTRLA
+	.section	.debug_info
+	.uleb128	358	; ref to abbrev 358
+	.section	.debug_abbrev
+	.uleb128	358
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname358:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname358
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #359: variable CTRLB
+	.section	.debug_info
+	.uleb128	359	; ref to abbrev 359
+	.section	.debug_abbrev
+	.uleb128	359
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname359:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname359
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #360: variable EVCTRL
+	.section	.debug_info
+	.uleb128	360	; ref to abbrev 360
+	.section	.debug_abbrev
+	.uleb128	360
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname360:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname360
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #361: variable INTCTRL
+	.section	.debug_info
+	.uleb128	361	; ref to abbrev 361
+	.section	.debug_abbrev
+	.uleb128	361
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname361:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname361
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #362: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	362	; ref to abbrev 362
+	.section	.debug_abbrev
+	.uleb128	362
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname362:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname362
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #363: variable STATUS
+	.section	.debug_info
+	.uleb128	363	; ref to abbrev 363
+	.section	.debug_abbrev
+	.uleb128	363
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname363:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname363
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #364: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	364	; ref to abbrev 364
+	.section	.debug_abbrev
+	.uleb128	364
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname364:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname364
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #365: variable TEMP
+	.section	.debug_info
+	.uleb128	365	; ref to abbrev 365
+	.section	.debug_abbrev
+	.uleb128	365
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname365:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname365
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #366: variable CNT
+	.section	.debug_info
+	.uleb128	366	; ref to abbrev 366
+	.section	.debug_abbrev
+	.uleb128	366
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname366:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname366
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #367: variable CCMP
+	.section	.debug_info
+	.uleb128	367	; ref to abbrev 367
+	.section	.debug_abbrev
+	.uleb128	367
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname367:
+	.string		"CCMP"
+	.section	.debug_info
+	.long		.Lname367
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #368: variable CTRLA
+	.section	.debug_info
+	.uleb128	368	; ref to abbrev 368
+	.section	.debug_abbrev
+	.uleb128	368
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname368:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname368
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #369: variable DUALCTRL
+	.section	.debug_info
+	.uleb128	369	; ref to abbrev 369
+	.section	.debug_abbrev
+	.uleb128	369
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname369:
+	.string		"DUALCTRL"
+	.section	.debug_info
+	.long		.Lname369
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #370: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	370	; ref to abbrev 370
+	.section	.debug_abbrev
+	.uleb128	370
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname370:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname370
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #371: variable MCTRLA
+	.section	.debug_info
+	.uleb128	371	; ref to abbrev 371
+	.section	.debug_abbrev
+	.uleb128	371
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname371:
+	.string		"MCTRLA"
+	.section	.debug_info
+	.long		.Lname371
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #372: variable MCTRLB
+	.section	.debug_info
+	.uleb128	372	; ref to abbrev 372
+	.section	.debug_abbrev
+	.uleb128	372
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname372:
+	.string		"MCTRLB"
+	.section	.debug_info
+	.long		.Lname372
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #373: variable MSTATUS
+	.section	.debug_info
+	.uleb128	373	; ref to abbrev 373
+	.section	.debug_abbrev
+	.uleb128	373
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname373:
+	.string		"MSTATUS"
+	.section	.debug_info
+	.long		.Lname373
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #374: variable MBAUD
+	.section	.debug_info
+	.uleb128	374	; ref to abbrev 374
+	.section	.debug_abbrev
+	.uleb128	374
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname374:
+	.string		"MBAUD"
+	.section	.debug_info
+	.long		.Lname374
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #375: variable MADDR
+	.section	.debug_info
+	.uleb128	375	; ref to abbrev 375
+	.section	.debug_abbrev
+	.uleb128	375
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname375:
+	.string		"MADDR"
+	.section	.debug_info
+	.long		.Lname375
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #376: variable MDATA
+	.section	.debug_info
+	.uleb128	376	; ref to abbrev 376
+	.section	.debug_abbrev
+	.uleb128	376
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname376:
+	.string		"MDATA"
+	.section	.debug_info
+	.long		.Lname376
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #377: variable SCTRLA
+	.section	.debug_info
+	.uleb128	377	; ref to abbrev 377
+	.section	.debug_abbrev
+	.uleb128	377
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname377:
+	.string		"SCTRLA"
+	.section	.debug_info
+	.long		.Lname377
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #378: variable SCTRLB
+	.section	.debug_info
+	.uleb128	378	; ref to abbrev 378
+	.section	.debug_abbrev
+	.uleb128	378
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname378:
+	.string		"SCTRLB"
+	.section	.debug_info
+	.long		.Lname378
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #379: variable SSTATUS
+	.section	.debug_info
+	.uleb128	379	; ref to abbrev 379
+	.section	.debug_abbrev
+	.uleb128	379
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname379:
+	.string		"SSTATUS"
+	.section	.debug_info
+	.long		.Lname379
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #380: variable SADDR
+	.section	.debug_info
+	.uleb128	380	; ref to abbrev 380
+	.section	.debug_abbrev
+	.uleb128	380
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname380:
+	.string		"SADDR"
+	.section	.debug_info
+	.long		.Lname380
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #381: variable SDATA
+	.section	.debug_info
+	.uleb128	381	; ref to abbrev 381
+	.section	.debug_abbrev
+	.uleb128	381
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname381:
+	.string		"SDATA"
+	.section	.debug_info
+	.long		.Lname381
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xD
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #382: variable SADDRMASK
+	.section	.debug_info
+	.uleb128	382	; ref to abbrev 382
+	.section	.debug_abbrev
+	.uleb128	382
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname382:
+	.string		"SADDRMASK"
+	.section	.debug_info
+	.long		.Lname382
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xE
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #383: variable RXDATAL
+	.section	.debug_info
+	.uleb128	383	; ref to abbrev 383
+	.section	.debug_abbrev
+	.uleb128	383
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname383:
+	.string		"RXDATAL"
+	.section	.debug_info
+	.long		.Lname383
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #384: variable RXDATAH
+	.section	.debug_info
+	.uleb128	384	; ref to abbrev 384
+	.section	.debug_abbrev
+	.uleb128	384
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname384:
+	.string		"RXDATAH"
+	.section	.debug_info
+	.long		.Lname384
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #385: variable TXDATAL
+	.section	.debug_info
+	.uleb128	385	; ref to abbrev 385
+	.section	.debug_abbrev
+	.uleb128	385
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname385:
+	.string		"TXDATAL"
+	.section	.debug_info
+	.long		.Lname385
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #386: variable TXDATAH
+	.section	.debug_info
+	.uleb128	386	; ref to abbrev 386
+	.section	.debug_abbrev
+	.uleb128	386
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname386:
+	.string		"TXDATAH"
+	.section	.debug_info
+	.long		.Lname386
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #387: variable STATUS
+	.section	.debug_info
+	.uleb128	387	; ref to abbrev 387
+	.section	.debug_abbrev
+	.uleb128	387
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname387:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname387
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #388: variable CTRLA
+	.section	.debug_info
+	.uleb128	388	; ref to abbrev 388
+	.section	.debug_abbrev
+	.uleb128	388
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname388:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname388
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #389: variable CTRLB
+	.section	.debug_info
+	.uleb128	389	; ref to abbrev 389
+	.section	.debug_abbrev
+	.uleb128	389
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname389:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname389
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #390: variable CTRLC
+	.section	.debug_info
+	.uleb128	390	; ref to abbrev 390
+	.section	.debug_abbrev
+	.uleb128	390
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname390:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname390
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #391: variable BAUD
+	.section	.debug_info
+	.uleb128	391	; ref to abbrev 391
+	.section	.debug_abbrev
+	.uleb128	391
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname391:
+	.string		"BAUD"
+	.section	.debug_info
+	.long		.Lname391
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #392: variable CTRLD
+	.section	.debug_info
+	.uleb128	392	; ref to abbrev 392
+	.section	.debug_abbrev
+	.uleb128	392
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname392:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname392
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #393: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	393	; ref to abbrev 393
+	.section	.debug_abbrev
+	.uleb128	393
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname393:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname393
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #394: variable EVCTRL
+	.section	.debug_info
+	.uleb128	394	; ref to abbrev 394
+	.section	.debug_abbrev
+	.uleb128	394
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname394:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname394
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #395: variable TXPLCTRL
+	.section	.debug_info
+	.uleb128	395	; ref to abbrev 395
+	.section	.debug_abbrev
+	.uleb128	395
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname395:
+	.string		"TXPLCTRL"
+	.section	.debug_info
+	.long		.Lname395
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xD
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #396: variable RXPLCTRL
+	.section	.debug_info
+	.uleb128	396	; ref to abbrev 396
+	.section	.debug_abbrev
+	.uleb128	396
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname396:
+	.string		"RXPLCTRL"
+	.section	.debug_info
+	.long		.Lname396
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xE
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #397: variable RXDATAL
+	.section	.debug_info
+	.uleb128	397	; ref to abbrev 397
+	.section	.debug_abbrev
+	.uleb128	397
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname397:
+	.string		"RXDATAL"
+	.section	.debug_info
+	.long		.Lname397
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #398: variable RXDATAH
+	.section	.debug_info
+	.uleb128	398	; ref to abbrev 398
+	.section	.debug_abbrev
+	.uleb128	398
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname398:
+	.string		"RXDATAH"
+	.section	.debug_info
+	.long		.Lname398
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #399: variable TXDATAL
+	.section	.debug_info
+	.uleb128	399	; ref to abbrev 399
+	.section	.debug_abbrev
+	.uleb128	399
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname399:
+	.string		"TXDATAL"
+	.section	.debug_info
+	.long		.Lname399
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #400: variable TXDATAH
+	.section	.debug_info
+	.uleb128	400	; ref to abbrev 400
+	.section	.debug_abbrev
+	.uleb128	400
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname400:
+	.string		"TXDATAH"
+	.section	.debug_info
+	.long		.Lname400
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #401: variable STATUS
+	.section	.debug_info
+	.uleb128	401	; ref to abbrev 401
+	.section	.debug_abbrev
+	.uleb128	401
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname401:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname401
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #402: variable CTRLA
+	.section	.debug_info
+	.uleb128	402	; ref to abbrev 402
+	.section	.debug_abbrev
+	.uleb128	402
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname402:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname402
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #403: variable CTRLB
+	.section	.debug_info
+	.uleb128	403	; ref to abbrev 403
+	.section	.debug_abbrev
+	.uleb128	403
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname403:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname403
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #404: variable CTRLC
+	.section	.debug_info
+	.uleb128	404	; ref to abbrev 404
+	.section	.debug_abbrev
+	.uleb128	404
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname404:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname404
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #405: variable BAUD
+	.section	.debug_info
+	.uleb128	405	; ref to abbrev 405
+	.section	.debug_abbrev
+	.uleb128	405
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname405:
+	.string		"BAUD"
+	.section	.debug_info
+	.long		.Lname405
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #406: variable CTRLD
+	.section	.debug_info
+	.uleb128	406	; ref to abbrev 406
+	.section	.debug_abbrev
+	.uleb128	406
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname406:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname406
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #407: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	407	; ref to abbrev 407
+	.section	.debug_abbrev
+	.uleb128	407
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname407:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname407
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #408: variable EVCTRL
+	.section	.debug_info
+	.uleb128	408	; ref to abbrev 408
+	.section	.debug_abbrev
+	.uleb128	408
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname408:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname408
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #409: variable TXPLCTRL
+	.section	.debug_info
+	.uleb128	409	; ref to abbrev 409
+	.section	.debug_abbrev
+	.uleb128	409
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname409:
+	.string		"TXPLCTRL"
+	.section	.debug_info
+	.long		.Lname409
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0xD
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #410: variable RXPLCTRL
+	.section	.debug_info
+	.uleb128	410	; ref to abbrev 410
+	.section	.debug_abbrev
+	.uleb128	410
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname410:
+	.string		"RXPLCTRL"
+	.section	.debug_info
+	.long		.Lname410
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0xE
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #411: variable RXDATAL
+	.section	.debug_info
+	.uleb128	411	; ref to abbrev 411
+	.section	.debug_abbrev
+	.uleb128	411
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname411:
+	.string		"RXDATAL"
+	.section	.debug_info
+	.long		.Lname411
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #412: variable RXDATAH
+	.section	.debug_info
+	.uleb128	412	; ref to abbrev 412
+	.section	.debug_abbrev
+	.uleb128	412
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname412:
+	.string		"RXDATAH"
+	.section	.debug_info
+	.long		.Lname412
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #413: variable TXDATAL
+	.section	.debug_info
+	.uleb128	413	; ref to abbrev 413
+	.section	.debug_abbrev
+	.uleb128	413
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname413:
+	.string		"TXDATAL"
+	.section	.debug_info
+	.long		.Lname413
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #414: variable TXDATAH
+	.section	.debug_info
+	.uleb128	414	; ref to abbrev 414
+	.section	.debug_abbrev
+	.uleb128	414
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname414:
+	.string		"TXDATAH"
+	.section	.debug_info
+	.long		.Lname414
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #415: variable STATUS
+	.section	.debug_info
+	.uleb128	415	; ref to abbrev 415
+	.section	.debug_abbrev
+	.uleb128	415
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname415:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname415
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #416: variable CTRLA
+	.section	.debug_info
+	.uleb128	416	; ref to abbrev 416
+	.section	.debug_abbrev
+	.uleb128	416
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname416:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname416
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #417: variable CTRLB
+	.section	.debug_info
+	.uleb128	417	; ref to abbrev 417
+	.section	.debug_abbrev
+	.uleb128	417
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname417:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname417
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #418: variable CTRLC
+	.section	.debug_info
+	.uleb128	418	; ref to abbrev 418
+	.section	.debug_abbrev
+	.uleb128	418
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname418:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname418
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #419: variable BAUD
+	.section	.debug_info
+	.uleb128	419	; ref to abbrev 419
+	.section	.debug_abbrev
+	.uleb128	419
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname419:
+	.string		"BAUD"
+	.section	.debug_info
+	.long		.Lname419
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #420: variable CTRLD
+	.section	.debug_info
+	.uleb128	420	; ref to abbrev 420
+	.section	.debug_abbrev
+	.uleb128	420
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname420:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname420
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #421: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	421	; ref to abbrev 421
+	.section	.debug_abbrev
+	.uleb128	421
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname421:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname421
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #422: variable EVCTRL
+	.section	.debug_info
+	.uleb128	422	; ref to abbrev 422
+	.section	.debug_abbrev
+	.uleb128	422
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname422:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname422
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #423: variable TXPLCTRL
+	.section	.debug_info
+	.uleb128	423	; ref to abbrev 423
+	.section	.debug_abbrev
+	.uleb128	423
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname423:
+	.string		"TXPLCTRL"
+	.section	.debug_info
+	.long		.Lname423
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0xD
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #424: variable RXPLCTRL
+	.section	.debug_info
+	.uleb128	424	; ref to abbrev 424
+	.section	.debug_abbrev
+	.uleb128	424
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname424:
+	.string		"RXPLCTRL"
+	.section	.debug_info
+	.long		.Lname424
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0xE
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #425: variable USERROW0
+	.section	.debug_info
+	.uleb128	425	; ref to abbrev 425
+	.section	.debug_abbrev
+	.uleb128	425
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname425:
+	.string		"USERROW0"
+	.section	.debug_info
+	.long		.Lname425
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #426: variable USERROW1
+	.section	.debug_info
+	.uleb128	426	; ref to abbrev 426
+	.section	.debug_abbrev
+	.uleb128	426
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname426:
+	.string		"USERROW1"
+	.section	.debug_info
+	.long		.Lname426
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #427: variable USERROW2
+	.section	.debug_info
+	.uleb128	427	; ref to abbrev 427
+	.section	.debug_abbrev
+	.uleb128	427
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname427:
+	.string		"USERROW2"
+	.section	.debug_info
+	.long		.Lname427
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #428: variable USERROW3
+	.section	.debug_info
+	.uleb128	428	; ref to abbrev 428
+	.section	.debug_abbrev
+	.uleb128	428
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname428:
+	.string		"USERROW3"
+	.section	.debug_info
+	.long		.Lname428
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #429: variable USERROW4
+	.section	.debug_info
+	.uleb128	429	; ref to abbrev 429
+	.section	.debug_abbrev
+	.uleb128	429
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname429:
+	.string		"USERROW4"
+	.section	.debug_info
+	.long		.Lname429
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #430: variable USERROW5
+	.section	.debug_info
+	.uleb128	430	; ref to abbrev 430
+	.section	.debug_abbrev
+	.uleb128	430
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname430:
+	.string		"USERROW5"
+	.section	.debug_info
+	.long		.Lname430
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #431: variable USERROW6
+	.section	.debug_info
+	.uleb128	431	; ref to abbrev 431
+	.section	.debug_abbrev
+	.uleb128	431
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname431:
+	.string		"USERROW6"
+	.section	.debug_info
+	.long		.Lname431
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #432: variable USERROW7
+	.section	.debug_info
+	.uleb128	432	; ref to abbrev 432
+	.section	.debug_abbrev
+	.uleb128	432
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname432:
+	.string		"USERROW7"
+	.section	.debug_info
+	.long		.Lname432
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #433: variable USERROW8
+	.section	.debug_info
+	.uleb128	433	; ref to abbrev 433
+	.section	.debug_abbrev
+	.uleb128	433
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname433:
+	.string		"USERROW8"
+	.section	.debug_info
+	.long		.Lname433
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #434: variable USERROW9
+	.section	.debug_info
+	.uleb128	434	; ref to abbrev 434
+	.section	.debug_abbrev
+	.uleb128	434
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname434:
+	.string		"USERROW9"
+	.section	.debug_info
+	.long		.Lname434
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #435: variable USERROW10
+	.section	.debug_info
+	.uleb128	435	; ref to abbrev 435
+	.section	.debug_abbrev
+	.uleb128	435
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname435:
+	.string		"USERROW10"
+	.section	.debug_info
+	.long		.Lname435
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #436: variable USERROW11
+	.section	.debug_info
+	.uleb128	436	; ref to abbrev 436
+	.section	.debug_abbrev
+	.uleb128	436
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname436:
+	.string		"USERROW11"
+	.section	.debug_info
+	.long		.Lname436
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #437: variable USERROW12
+	.section	.debug_info
+	.uleb128	437	; ref to abbrev 437
+	.section	.debug_abbrev
+	.uleb128	437
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname437:
+	.string		"USERROW12"
+	.section	.debug_info
+	.long		.Lname437
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #438: variable USERROW13
+	.section	.debug_info
+	.uleb128	438	; ref to abbrev 438
+	.section	.debug_abbrev
+	.uleb128	438
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname438:
+	.string		"USERROW13"
+	.section	.debug_info
+	.long		.Lname438
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #439: variable USERROW14
+	.section	.debug_info
+	.uleb128	439	; ref to abbrev 439
+	.section	.debug_abbrev
+	.uleb128	439
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname439:
+	.string		"USERROW14"
+	.section	.debug_info
+	.long		.Lname439
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #440: variable USERROW15
+	.section	.debug_info
+	.uleb128	440	; ref to abbrev 440
+	.section	.debug_abbrev
+	.uleb128	440
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname440:
+	.string		"USERROW15"
+	.section	.debug_info
+	.long		.Lname440
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x0F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #441: variable USERROW16
+	.section	.debug_info
+	.uleb128	441	; ref to abbrev 441
+	.section	.debug_abbrev
+	.uleb128	441
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname441:
+	.string		"USERROW16"
+	.section	.debug_info
+	.long		.Lname441
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #442: variable USERROW17
+	.section	.debug_info
+	.uleb128	442	; ref to abbrev 442
+	.section	.debug_abbrev
+	.uleb128	442
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname442:
+	.string		"USERROW17"
+	.section	.debug_info
+	.long		.Lname442
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #443: variable USERROW18
+	.section	.debug_info
+	.uleb128	443	; ref to abbrev 443
+	.section	.debug_abbrev
+	.uleb128	443
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname443:
+	.string		"USERROW18"
+	.section	.debug_info
+	.long		.Lname443
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #444: variable USERROW19
+	.section	.debug_info
+	.uleb128	444	; ref to abbrev 444
+	.section	.debug_abbrev
+	.uleb128	444
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname444:
+	.string		"USERROW19"
+	.section	.debug_info
+	.long		.Lname444
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #445: variable USERROW20
+	.section	.debug_info
+	.uleb128	445	; ref to abbrev 445
+	.section	.debug_abbrev
+	.uleb128	445
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname445:
+	.string		"USERROW20"
+	.section	.debug_info
+	.long		.Lname445
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #446: variable USERROW21
+	.section	.debug_info
+	.uleb128	446	; ref to abbrev 446
+	.section	.debug_abbrev
+	.uleb128	446
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname446:
+	.string		"USERROW21"
+	.section	.debug_info
+	.long		.Lname446
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #447: variable USERROW22
+	.section	.debug_info
+	.uleb128	447	; ref to abbrev 447
+	.section	.debug_abbrev
+	.uleb128	447
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname447:
+	.string		"USERROW22"
+	.section	.debug_info
+	.long		.Lname447
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #448: variable USERROW23
+	.section	.debug_info
+	.uleb128	448	; ref to abbrev 448
+	.section	.debug_abbrev
+	.uleb128	448
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname448:
+	.string		"USERROW23"
+	.section	.debug_info
+	.long		.Lname448
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #449: variable USERROW24
+	.section	.debug_info
+	.uleb128	449	; ref to abbrev 449
+	.section	.debug_abbrev
+	.uleb128	449
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname449:
+	.string		"USERROW24"
+	.section	.debug_info
+	.long		.Lname449
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #450: variable USERROW25
+	.section	.debug_info
+	.uleb128	450	; ref to abbrev 450
+	.section	.debug_abbrev
+	.uleb128	450
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname450:
+	.string		"USERROW25"
+	.section	.debug_info
+	.long		.Lname450
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x19
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #451: variable USERROW26
+	.section	.debug_info
+	.uleb128	451	; ref to abbrev 451
+	.section	.debug_abbrev
+	.uleb128	451
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname451:
+	.string		"USERROW26"
+	.section	.debug_info
+	.long		.Lname451
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #452: variable USERROW27
+	.section	.debug_info
+	.uleb128	452	; ref to abbrev 452
+	.section	.debug_abbrev
+	.uleb128	452
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname452:
+	.string		"USERROW27"
+	.section	.debug_info
+	.long		.Lname452
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #453: variable USERROW28
+	.section	.debug_info
+	.uleb128	453	; ref to abbrev 453
+	.section	.debug_abbrev
+	.uleb128	453
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname453:
+	.string		"USERROW28"
+	.section	.debug_info
+	.long		.Lname453
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #454: variable USERROW29
+	.section	.debug_info
+	.uleb128	454	; ref to abbrev 454
+	.section	.debug_abbrev
+	.uleb128	454
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname454:
+	.string		"USERROW29"
+	.section	.debug_info
+	.long		.Lname454
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #455: variable USERROW30
+	.section	.debug_info
+	.uleb128	455	; ref to abbrev 455
+	.section	.debug_abbrev
+	.uleb128	455
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname455:
+	.string		"USERROW30"
+	.section	.debug_info
+	.long		.Lname455
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #456: variable USERROW31
+	.section	.debug_info
+	.uleb128	456	; ref to abbrev 456
+	.section	.debug_abbrev
+	.uleb128	456
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname456:
+	.string		"USERROW31"
+	.section	.debug_info
+	.long		.Lname456
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #457: variable USERROW32
+	.section	.debug_info
+	.uleb128	457	; ref to abbrev 457
+	.section	.debug_abbrev
+	.uleb128	457
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname457:
+	.string		"USERROW32"
+	.section	.debug_info
+	.long		.Lname457
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #458: variable USERROW33
+	.section	.debug_info
+	.uleb128	458	; ref to abbrev 458
+	.section	.debug_abbrev
+	.uleb128	458
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname458:
+	.string		"USERROW33"
+	.section	.debug_info
+	.long		.Lname458
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x21
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #459: variable USERROW34
+	.section	.debug_info
+	.uleb128	459	; ref to abbrev 459
+	.section	.debug_abbrev
+	.uleb128	459
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname459:
+	.string		"USERROW34"
+	.section	.debug_info
+	.long		.Lname459
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x22
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #460: variable USERROW35
+	.section	.debug_info
+	.uleb128	460	; ref to abbrev 460
+	.section	.debug_abbrev
+	.uleb128	460
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname460:
+	.string		"USERROW35"
+	.section	.debug_info
+	.long		.Lname460
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x23
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #461: variable USERROW36
+	.section	.debug_info
+	.uleb128	461	; ref to abbrev 461
+	.section	.debug_abbrev
+	.uleb128	461
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname461:
+	.string		"USERROW36"
+	.section	.debug_info
+	.long		.Lname461
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x24
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #462: variable USERROW37
+	.section	.debug_info
+	.uleb128	462	; ref to abbrev 462
+	.section	.debug_abbrev
+	.uleb128	462
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname462:
+	.string		"USERROW37"
+	.section	.debug_info
+	.long		.Lname462
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x25
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #463: variable USERROW38
+	.section	.debug_info
+	.uleb128	463	; ref to abbrev 463
+	.section	.debug_abbrev
+	.uleb128	463
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname463:
+	.string		"USERROW38"
+	.section	.debug_info
+	.long		.Lname463
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x26
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #464: variable USERROW39
+	.section	.debug_info
+	.uleb128	464	; ref to abbrev 464
+	.section	.debug_abbrev
+	.uleb128	464
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname464:
+	.string		"USERROW39"
+	.section	.debug_info
+	.long		.Lname464
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x27
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #465: variable USERROW40
+	.section	.debug_info
+	.uleb128	465	; ref to abbrev 465
+	.section	.debug_abbrev
+	.uleb128	465
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname465:
+	.string		"USERROW40"
+	.section	.debug_info
+	.long		.Lname465
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x28
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #466: variable USERROW41
+	.section	.debug_info
+	.uleb128	466	; ref to abbrev 466
+	.section	.debug_abbrev
+	.uleb128	466
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname466:
+	.string		"USERROW41"
+	.section	.debug_info
+	.long		.Lname466
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x29
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #467: variable USERROW42
+	.section	.debug_info
+	.uleb128	467	; ref to abbrev 467
+	.section	.debug_abbrev
+	.uleb128	467
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname467:
+	.string		"USERROW42"
+	.section	.debug_info
+	.long		.Lname467
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x2A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #468: variable USERROW43
+	.section	.debug_info
+	.uleb128	468	; ref to abbrev 468
+	.section	.debug_abbrev
+	.uleb128	468
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname468:
+	.string		"USERROW43"
+	.section	.debug_info
+	.long		.Lname468
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x2B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #469: variable USERROW44
+	.section	.debug_info
+	.uleb128	469	; ref to abbrev 469
+	.section	.debug_abbrev
+	.uleb128	469
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname469:
+	.string		"USERROW44"
+	.section	.debug_info
+	.long		.Lname469
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x2C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #470: variable USERROW45
+	.section	.debug_info
+	.uleb128	470	; ref to abbrev 470
+	.section	.debug_abbrev
+	.uleb128	470
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname470:
+	.string		"USERROW45"
+	.section	.debug_info
+	.long		.Lname470
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x2D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #471: variable USERROW46
+	.section	.debug_info
+	.uleb128	471	; ref to abbrev 471
+	.section	.debug_abbrev
+	.uleb128	471
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname471:
+	.string		"USERROW46"
+	.section	.debug_info
+	.long		.Lname471
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x2E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #472: variable USERROW47
+	.section	.debug_info
+	.uleb128	472	; ref to abbrev 472
+	.section	.debug_abbrev
+	.uleb128	472
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname472:
+	.string		"USERROW47"
+	.section	.debug_info
+	.long		.Lname472
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x2F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #473: variable USERROW48
+	.section	.debug_info
+	.uleb128	473	; ref to abbrev 473
+	.section	.debug_abbrev
+	.uleb128	473
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname473:
+	.string		"USERROW48"
+	.section	.debug_info
+	.long		.Lname473
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x30
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #474: variable USERROW49
+	.section	.debug_info
+	.uleb128	474	; ref to abbrev 474
+	.section	.debug_abbrev
+	.uleb128	474
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname474:
+	.string		"USERROW49"
+	.section	.debug_info
+	.long		.Lname474
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x31
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #475: variable USERROW50
+	.section	.debug_info
+	.uleb128	475	; ref to abbrev 475
+	.section	.debug_abbrev
+	.uleb128	475
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname475:
+	.string		"USERROW50"
+	.section	.debug_info
+	.long		.Lname475
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x32
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #476: variable USERROW51
+	.section	.debug_info
+	.uleb128	476	; ref to abbrev 476
+	.section	.debug_abbrev
+	.uleb128	476
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname476:
+	.string		"USERROW51"
+	.section	.debug_info
+	.long		.Lname476
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x33
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #477: variable USERROW52
+	.section	.debug_info
+	.uleb128	477	; ref to abbrev 477
+	.section	.debug_abbrev
+	.uleb128	477
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname477:
+	.string		"USERROW52"
+	.section	.debug_info
+	.long		.Lname477
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x34
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #478: variable USERROW53
+	.section	.debug_info
+	.uleb128	478	; ref to abbrev 478
+	.section	.debug_abbrev
+	.uleb128	478
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname478:
+	.string		"USERROW53"
+	.section	.debug_info
+	.long		.Lname478
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x35
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #479: variable USERROW54
+	.section	.debug_info
+	.uleb128	479	; ref to abbrev 479
+	.section	.debug_abbrev
+	.uleb128	479
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname479:
+	.string		"USERROW54"
+	.section	.debug_info
+	.long		.Lname479
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x36
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #480: variable USERROW55
+	.section	.debug_info
+	.uleb128	480	; ref to abbrev 480
+	.section	.debug_abbrev
+	.uleb128	480
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname480:
+	.string		"USERROW55"
+	.section	.debug_info
+	.long		.Lname480
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x37
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #481: variable USERROW56
+	.section	.debug_info
+	.uleb128	481	; ref to abbrev 481
+	.section	.debug_abbrev
+	.uleb128	481
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname481:
+	.string		"USERROW56"
+	.section	.debug_info
+	.long		.Lname481
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x38
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #482: variable USERROW57
+	.section	.debug_info
+	.uleb128	482	; ref to abbrev 482
+	.section	.debug_abbrev
+	.uleb128	482
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname482:
+	.string		"USERROW57"
+	.section	.debug_info
+	.long		.Lname482
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x39
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #483: variable USERROW58
+	.section	.debug_info
+	.uleb128	483	; ref to abbrev 483
+	.section	.debug_abbrev
+	.uleb128	483
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname483:
+	.string		"USERROW58"
+	.section	.debug_info
+	.long		.Lname483
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x3A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #484: variable USERROW59
+	.section	.debug_info
+	.uleb128	484	; ref to abbrev 484
+	.section	.debug_abbrev
+	.uleb128	484
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname484:
+	.string		"USERROW59"
+	.section	.debug_info
+	.long		.Lname484
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x3B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #485: variable USERROW60
+	.section	.debug_info
+	.uleb128	485	; ref to abbrev 485
+	.section	.debug_abbrev
+	.uleb128	485
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname485:
+	.string		"USERROW60"
+	.section	.debug_info
+	.long		.Lname485
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x3C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #486: variable USERROW61
+	.section	.debug_info
+	.uleb128	486	; ref to abbrev 486
+	.section	.debug_abbrev
+	.uleb128	486
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname486:
+	.string		"USERROW61"
+	.section	.debug_info
+	.long		.Lname486
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x3D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #487: variable USERROW62
+	.section	.debug_info
+	.uleb128	487	; ref to abbrev 487
+	.section	.debug_abbrev
+	.uleb128	487
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname487:
+	.string		"USERROW62"
+	.section	.debug_info
+	.long		.Lname487
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x3E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #488: variable USERROW63
+	.section	.debug_info
+	.uleb128	488	; ref to abbrev 488
+	.section	.debug_abbrev
+	.uleb128	488
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname488:
+	.string		"USERROW63"
+	.section	.debug_info
+	.long		.Lname488
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x3F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #489: variable DIR
+	.section	.debug_info
+	.uleb128	489	; ref to abbrev 489
+	.section	.debug_abbrev
+	.uleb128	489
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname489:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname489
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0000 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #490: variable OUT
+	.section	.debug_info
+	.uleb128	490	; ref to abbrev 490
+	.section	.debug_abbrev
+	.uleb128	490
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname490:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname490
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0000 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #491: variable IN
+	.section	.debug_info
+	.uleb128	491	; ref to abbrev 491
+	.section	.debug_abbrev
+	.uleb128	491
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname491:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname491
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0000 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #492: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	492	; ref to abbrev 492
+	.section	.debug_abbrev
+	.uleb128	492
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname492:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname492
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0000 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #493: variable DIR
+	.section	.debug_info
+	.uleb128	493	; ref to abbrev 493
+	.section	.debug_abbrev
+	.uleb128	493
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname493:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname493
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0008 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #494: variable OUT
+	.section	.debug_info
+	.uleb128	494	; ref to abbrev 494
+	.section	.debug_abbrev
+	.uleb128	494
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname494:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname494
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0008 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #495: variable IN
+	.section	.debug_info
+	.uleb128	495	; ref to abbrev 495
+	.section	.debug_abbrev
+	.uleb128	495
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname495:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname495
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0008 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #496: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	496	; ref to abbrev 496
+	.section	.debug_abbrev
+	.uleb128	496
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname496:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname496
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0008 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #497: variable DIR
+	.section	.debug_info
+	.uleb128	497	; ref to abbrev 497
+	.section	.debug_abbrev
+	.uleb128	497
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname497:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname497
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x000C + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #498: variable OUT
+	.section	.debug_info
+	.uleb128	498	; ref to abbrev 498
+	.section	.debug_abbrev
+	.uleb128	498
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname498:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname498
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x000C + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #499: variable IN
+	.section	.debug_info
+	.uleb128	499	; ref to abbrev 499
+	.section	.debug_abbrev
+	.uleb128	499
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname499:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname499
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x000C + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #500: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	500	; ref to abbrev 500
+	.section	.debug_abbrev
+	.uleb128	500
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname500:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname500
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x000C + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #501: variable DIR
+	.section	.debug_info
+	.uleb128	501	; ref to abbrev 501
+	.section	.debug_abbrev
+	.uleb128	501
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname501:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname501
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0014 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #502: variable OUT
+	.section	.debug_info
+	.uleb128	502	; ref to abbrev 502
+	.section	.debug_abbrev
+	.uleb128	502
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname502:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname502
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0014 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #503: variable IN
+	.section	.debug_info
+	.uleb128	503	; ref to abbrev 503
+	.section	.debug_abbrev
+	.uleb128	503
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname503:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname503
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0014 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #504: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	504	; ref to abbrev 504
+	.section	.debug_abbrev
+	.uleb128	504
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname504:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname504
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0014 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #505: variable DAC0REF
+	.section	.debug_info
+	.uleb128	505	; ref to abbrev 505
+	.section	.debug_abbrev
+	.uleb128	505
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname505:
+	.string		"DAC0REF"
+	.section	.debug_info
+	.long		.Lname505
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00B0 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #506: variable ACREF
+	.section	.debug_info
+	.uleb128	506	; ref to abbrev 506
+	.section	.debug_abbrev
+	.uleb128	506
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname506:
+	.string		"ACREF"
+	.section	.debug_info
+	.long		.Lname506
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00B0 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #507: variable CTRLA
+	.section	.debug_info
+	.uleb128	507	; ref to abbrev 507
+	.section	.debug_abbrev
+	.uleb128	507
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname507:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname507
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0100 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #508: variable STATUS
+	.section	.debug_info
+	.uleb128	508	; ref to abbrev 508
+	.section	.debug_abbrev
+	.uleb128	508
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname508:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname508
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0100 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+	;; trailer
+	.section	.debug_abbrev
+	.uleb128	0
+
+	.section	.debug_info
+	.uleb128	0
+.Leinfo:

--- a/crt1/iosym/avr16ea32.S
+++ b/crt1/iosym/avr16ea32.S
@@ -1,0 +1,26945 @@
+/* This file is part of avr-libc.
+
+   Automatically created by devtools/ioreg.pl
+   DO NOT EDIT!
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in
+     the documentation and/or other materials provided with the
+     distribution.
+
+   * Neither the name of the copyright holders nor the names of
+     contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE. */
+
+/* $Id$ */
+
+#include <avr/version.h>
+
+#define DW_TAG_array_type               0x01
+#define DW_TAG_compile_unit             0x11
+#define DW_TAG_typedef                  0x16
+#define DW_TAG_subrange_type            0x21
+#define DW_TAG_base_type                0x24
+#define DW_TAG_variable                 0x34
+
+#define DW_FORM_addr                    0x01
+#define DW_FORM_block1                  0x0a
+#define DW_FORM_block2                  0x03
+#define DW_FORM_block4                  0x04
+#define DW_FORM_data1                   0x0b
+#define DW_FORM_data2                   0x05
+#define DW_FORM_data4                   0x06
+#define DW_FORM_data8                   0x07
+#define DW_FORM_string                  0x08
+#define DW_FORM_flag                    0x0c
+#define DW_FORM_strp                    0x0e
+#define DW_FORM_ref1                    0x11
+#define DW_FORM_ref2                    0x12
+#define DW_FORM_ref4                    0x13
+#define DW_FORM_ref8                    0x14
+
+#define DW_AT_location                  0x02
+#define DW_AT_name                      0x03
+#define DW_AT_byte_size                 0x0b
+#define DW_AT_stmt_list                 0x10
+#define DW_AT_language                  0x13
+#define DW_AT_producer                  0x25
+#define DW_AT_upper_bound               0x2f
+#define DW_AT_decl_file                 0x3a
+#define DW_AT_decl_line                 0x3b
+#define DW_AT_encoding                  0x3e
+#define DW_AT_external                  0x3f
+#define DW_AT_type                      0x49
+
+#define DW_LANG_C89                     0x0001
+
+#define DW_CHILDREN_no                  0x00
+#define DW_CHILDREN_yes                 0x01
+
+#define DW_ATE_unsigned                 0x7
+#define DW_ATE_unsigned_char            0x8
+
+#define DW_OP_addr                      0x03
+.eject
+	.section	.debug_abbrev, "", @progbits
+.Ldebug_abbrev0:
+	.section	.debug_info, "", @progbits
+	.section	.debug_line, "", @progbits
+.Ldebug_line0:
+	.section	.debug_str, "", @progbits
+
+	.section	.debug_info, "", @progbits
+	;; compilation unit header
+.Lssinfo:
+	.long	.Leinfo - .Lsinfo
+.Lsinfo:
+	.word	2		; DWARF-2
+	.long	.Ldebug_abbrev0
+	.byte	4		; sizeof(address)
+
+
+	;; DIE #1: compilation unit
+	.section	.debug_info
+	.uleb128	1	; ref to abbrev 1
+	.section	.debug_abbrev
+	.uleb128	1
+	.uleb128	DW_TAG_compile_unit
+	.byte		DW_CHILDREN_yes
+
+	.uleb128	DW_AT_producer
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lproducer:
+	.ascii		"avr-libc "
+	.asciz		__AVR_LIBC_VERSION_STRING__
+	.section	.debug_info
+	.long		.Lproducer
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_stmt_list
+	.uleb128	DW_FORM_data4
+	.section	.debug_info
+	.long		.Ldebug_line0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+	;; DIE #2: base type uint8_t
+	.section	.debug_info
+.Luint8_t:
+	.uleb128	2	; ref to abbrev 2
+	.section	.debug_abbrev
+	.uleb128	2
+	.uleb128	DW_TAG_base_type
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Luint8_t_name:
+	.string		"uint8_t"
+	.section	.debug_info
+	.long		.Luint8_t_name
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_byte_size
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_encoding
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		DW_ATE_unsigned_char
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+	;; DIE #3: base type uint16_t
+	.section	.debug_info
+.Luint16_t:
+	.uleb128	3	; ref to abbrev 3
+	.section	.debug_abbrev
+	.uleb128	3
+	.uleb128	DW_TAG_base_type
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Luint16_t_name:
+	.string		"uint16_t"
+	.section	.debug_info
+	.long		.Luint16_t_name
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_byte_size
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		2
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_encoding
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		DW_ATE_unsigned
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #4: variable CTRLA
+	.section	.debug_info
+	.uleb128	4	; ref to abbrev 4
+	.section	.debug_abbrev
+	.uleb128	4
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname4:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname4
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #5: variable CTRLB
+	.section	.debug_info
+	.uleb128	5	; ref to abbrev 5
+	.section	.debug_abbrev
+	.uleb128	5
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname5:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname5
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #6: variable MUXCTRL
+	.section	.debug_info
+	.uleb128	6	; ref to abbrev 6
+	.section	.debug_abbrev
+	.uleb128	6
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname6:
+	.string		"MUXCTRL"
+	.section	.debug_info
+	.long		.Lname6
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #7: variable DACREF
+	.section	.debug_info
+	.uleb128	7	; ref to abbrev 7
+	.section	.debug_abbrev
+	.uleb128	7
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname7:
+	.string		"DACREF"
+	.section	.debug_info
+	.long		.Lname7
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #8: variable INTCTRL
+	.section	.debug_info
+	.uleb128	8	; ref to abbrev 8
+	.section	.debug_abbrev
+	.uleb128	8
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname8:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname8
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #9: variable STATUS
+	.section	.debug_info
+	.uleb128	9	; ref to abbrev 9
+	.section	.debug_abbrev
+	.uleb128	9
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname9:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname9
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #10: variable CTRLA
+	.section	.debug_info
+	.uleb128	10	; ref to abbrev 10
+	.section	.debug_abbrev
+	.uleb128	10
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname10:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname10
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #11: variable CTRLB
+	.section	.debug_info
+	.uleb128	11	; ref to abbrev 11
+	.section	.debug_abbrev
+	.uleb128	11
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname11:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname11
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #12: variable MUXCTRL
+	.section	.debug_info
+	.uleb128	12	; ref to abbrev 12
+	.section	.debug_abbrev
+	.uleb128	12
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname12:
+	.string		"MUXCTRL"
+	.section	.debug_info
+	.long		.Lname12
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #13: variable DACREF
+	.section	.debug_info
+	.uleb128	13	; ref to abbrev 13
+	.section	.debug_abbrev
+	.uleb128	13
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname13:
+	.string		"DACREF"
+	.section	.debug_info
+	.long		.Lname13
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #14: variable INTCTRL
+	.section	.debug_info
+	.uleb128	14	; ref to abbrev 14
+	.section	.debug_abbrev
+	.uleb128	14
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname14:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname14
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #15: variable STATUS
+	.section	.debug_info
+	.uleb128	15	; ref to abbrev 15
+	.section	.debug_abbrev
+	.uleb128	15
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname15:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname15
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #16: variable CTRLA
+	.section	.debug_info
+	.uleb128	16	; ref to abbrev 16
+	.section	.debug_abbrev
+	.uleb128	16
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname16:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname16
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #17: variable CTRLB
+	.section	.debug_info
+	.uleb128	17	; ref to abbrev 17
+	.section	.debug_abbrev
+	.uleb128	17
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname17:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname17
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #18: variable CTRLC
+	.section	.debug_info
+	.uleb128	18	; ref to abbrev 18
+	.section	.debug_abbrev
+	.uleb128	18
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname18:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname18
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #19: variable CTRLD
+	.section	.debug_info
+	.uleb128	19	; ref to abbrev 19
+	.section	.debug_abbrev
+	.uleb128	19
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname19:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname19
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #20: variable INTCTRL
+	.section	.debug_info
+	.uleb128	20	; ref to abbrev 20
+	.section	.debug_abbrev
+	.uleb128	20
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname20:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname20
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #21: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	21	; ref to abbrev 21
+	.section	.debug_abbrev
+	.uleb128	21
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname21:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname21
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #22: variable STATUS
+	.section	.debug_info
+	.uleb128	22	; ref to abbrev 22
+	.section	.debug_abbrev
+	.uleb128	22
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname22:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname22
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #23: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	23	; ref to abbrev 23
+	.section	.debug_abbrev
+	.uleb128	23
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname23:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname23
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #24: variable CTRLE
+	.section	.debug_info
+	.uleb128	24	; ref to abbrev 24
+	.section	.debug_abbrev
+	.uleb128	24
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname24:
+	.string		"CTRLE"
+	.section	.debug_info
+	.long		.Lname24
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #25: variable CTRLF
+	.section	.debug_info
+	.uleb128	25	; ref to abbrev 25
+	.section	.debug_abbrev
+	.uleb128	25
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname25:
+	.string		"CTRLF"
+	.section	.debug_info
+	.long		.Lname25
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #26: variable COMMAND
+	.section	.debug_info
+	.uleb128	26	; ref to abbrev 26
+	.section	.debug_abbrev
+	.uleb128	26
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname26:
+	.string		"COMMAND"
+	.section	.debug_info
+	.long		.Lname26
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #27: variable PGACTRL
+	.section	.debug_info
+	.uleb128	27	; ref to abbrev 27
+	.section	.debug_abbrev
+	.uleb128	27
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname27:
+	.string		"PGACTRL"
+	.section	.debug_info
+	.long		.Lname27
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #28: variable MUXPOS
+	.section	.debug_info
+	.uleb128	28	; ref to abbrev 28
+	.section	.debug_abbrev
+	.uleb128	28
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname28:
+	.string		"MUXPOS"
+	.section	.debug_info
+	.long		.Lname28
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #29: variable MUXNEG
+	.section	.debug_info
+	.uleb128	29	; ref to abbrev 29
+	.section	.debug_abbrev
+	.uleb128	29
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname29:
+	.string		"MUXNEG"
+	.section	.debug_info
+	.long		.Lname29
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #30: base type uint32_t
+	.section	.debug_info
+.Luint32_t:
+	.uleb128	30	; ref to abbrev 30
+	.section	.debug_abbrev
+	.uleb128	30
+	.uleb128	DW_TAG_base_type
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Luint32_t_name:
+	.string		"uint32_t"
+	.section	.debug_info
+	.long		.Luint32_t_name
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_byte_size
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		4
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_encoding
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		DW_ATE_unsigned
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #31: variable RESULT
+	.section	.debug_info
+	.uleb128	31	; ref to abbrev 31
+	.section	.debug_abbrev
+	.uleb128	31
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname31:
+	.string		"RESULT"
+	.section	.debug_info
+	.long		.Lname31
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint32_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #32: variable SAMPLE
+	.section	.debug_info
+	.uleb128	32	; ref to abbrev 32
+	.section	.debug_abbrev
+	.uleb128	32
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname32:
+	.string		"SAMPLE"
+	.section	.debug_info
+	.long		.Lname32
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #33: variable TEMP0
+	.section	.debug_info
+	.uleb128	33	; ref to abbrev 33
+	.section	.debug_abbrev
+	.uleb128	33
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname33:
+	.string		"TEMP0"
+	.section	.debug_info
+	.long		.Lname33
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #34: variable TEMP1
+	.section	.debug_info
+	.uleb128	34	; ref to abbrev 34
+	.section	.debug_abbrev
+	.uleb128	34
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname34:
+	.string		"TEMP1"
+	.section	.debug_info
+	.long		.Lname34
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x19
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #35: variable TEMP2
+	.section	.debug_info
+	.uleb128	35	; ref to abbrev 35
+	.section	.debug_abbrev
+	.uleb128	35
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname35:
+	.string		"TEMP2"
+	.section	.debug_info
+	.long		.Lname35
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x1A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #36: variable WINLT
+	.section	.debug_info
+	.uleb128	36	; ref to abbrev 36
+	.section	.debug_abbrev
+	.uleb128	36
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname36:
+	.string		"WINLT"
+	.section	.debug_info
+	.long		.Lname36
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x1C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #37: variable WINHT
+	.section	.debug_info
+	.uleb128	37	; ref to abbrev 37
+	.section	.debug_abbrev
+	.uleb128	37
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname37:
+	.string		"WINHT"
+	.section	.debug_info
+	.long		.Lname37
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x1E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #38: variable CTRLA
+	.section	.debug_info
+	.uleb128	38	; ref to abbrev 38
+	.section	.debug_abbrev
+	.uleb128	38
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname38:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname38
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #39: variable CTRLB
+	.section	.debug_info
+	.uleb128	39	; ref to abbrev 39
+	.section	.debug_abbrev
+	.uleb128	39
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname39:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname39
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #40: variable VLMCTRLA
+	.section	.debug_info
+	.uleb128	40	; ref to abbrev 40
+	.section	.debug_abbrev
+	.uleb128	40
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname40:
+	.string		"VLMCTRLA"
+	.section	.debug_info
+	.long		.Lname40
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #41: variable INTCTRL
+	.section	.debug_info
+	.uleb128	41	; ref to abbrev 41
+	.section	.debug_abbrev
+	.uleb128	41
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname41:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname41
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #42: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	42	; ref to abbrev 42
+	.section	.debug_abbrev
+	.uleb128	42
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname42:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname42
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #43: variable STATUS
+	.section	.debug_info
+	.uleb128	43	; ref to abbrev 43
+	.section	.debug_abbrev
+	.uleb128	43
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname43:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname43
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #44: variable CTRLA
+	.section	.debug_info
+	.uleb128	44	; ref to abbrev 44
+	.section	.debug_abbrev
+	.uleb128	44
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname44:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname44
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #45: variable SEQCTRL0
+	.section	.debug_info
+	.uleb128	45	; ref to abbrev 45
+	.section	.debug_abbrev
+	.uleb128	45
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname45:
+	.string		"SEQCTRL0"
+	.section	.debug_info
+	.long		.Lname45
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #46: variable SEQCTRL1
+	.section	.debug_info
+	.uleb128	46	; ref to abbrev 46
+	.section	.debug_abbrev
+	.uleb128	46
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname46:
+	.string		"SEQCTRL1"
+	.section	.debug_info
+	.long		.Lname46
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #47: variable INTCTRL0
+	.section	.debug_info
+	.uleb128	47	; ref to abbrev 47
+	.section	.debug_abbrev
+	.uleb128	47
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname47:
+	.string		"INTCTRL0"
+	.section	.debug_info
+	.long		.Lname47
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #48: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	48	; ref to abbrev 48
+	.section	.debug_abbrev
+	.uleb128	48
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname48:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname48
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #49: variable LUT0CTRLA
+	.section	.debug_info
+	.uleb128	49	; ref to abbrev 49
+	.section	.debug_abbrev
+	.uleb128	49
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname49:
+	.string		"LUT0CTRLA"
+	.section	.debug_info
+	.long		.Lname49
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #50: variable LUT0CTRLB
+	.section	.debug_info
+	.uleb128	50	; ref to abbrev 50
+	.section	.debug_abbrev
+	.uleb128	50
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname50:
+	.string		"LUT0CTRLB"
+	.section	.debug_info
+	.long		.Lname50
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #51: variable LUT0CTRLC
+	.section	.debug_info
+	.uleb128	51	; ref to abbrev 51
+	.section	.debug_abbrev
+	.uleb128	51
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname51:
+	.string		"LUT0CTRLC"
+	.section	.debug_info
+	.long		.Lname51
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #52: variable TRUTH0
+	.section	.debug_info
+	.uleb128	52	; ref to abbrev 52
+	.section	.debug_abbrev
+	.uleb128	52
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname52:
+	.string		"TRUTH0"
+	.section	.debug_info
+	.long		.Lname52
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #53: variable LUT1CTRLA
+	.section	.debug_info
+	.uleb128	53	; ref to abbrev 53
+	.section	.debug_abbrev
+	.uleb128	53
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname53:
+	.string		"LUT1CTRLA"
+	.section	.debug_info
+	.long		.Lname53
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #54: variable LUT1CTRLB
+	.section	.debug_info
+	.uleb128	54	; ref to abbrev 54
+	.section	.debug_abbrev
+	.uleb128	54
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname54:
+	.string		"LUT1CTRLB"
+	.section	.debug_info
+	.long		.Lname54
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #55: variable LUT1CTRLC
+	.section	.debug_info
+	.uleb128	55	; ref to abbrev 55
+	.section	.debug_abbrev
+	.uleb128	55
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname55:
+	.string		"LUT1CTRLC"
+	.section	.debug_info
+	.long		.Lname55
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #56: variable TRUTH1
+	.section	.debug_info
+	.uleb128	56	; ref to abbrev 56
+	.section	.debug_abbrev
+	.uleb128	56
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname56:
+	.string		"TRUTH1"
+	.section	.debug_info
+	.long		.Lname56
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #57: variable LUT2CTRLA
+	.section	.debug_info
+	.uleb128	57	; ref to abbrev 57
+	.section	.debug_abbrev
+	.uleb128	57
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname57:
+	.string		"LUT2CTRLA"
+	.section	.debug_info
+	.long		.Lname57
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #58: variable LUT2CTRLB
+	.section	.debug_info
+	.uleb128	58	; ref to abbrev 58
+	.section	.debug_abbrev
+	.uleb128	58
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname58:
+	.string		"LUT2CTRLB"
+	.section	.debug_info
+	.long		.Lname58
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #59: variable LUT2CTRLC
+	.section	.debug_info
+	.uleb128	59	; ref to abbrev 59
+	.section	.debug_abbrev
+	.uleb128	59
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname59:
+	.string		"LUT2CTRLC"
+	.section	.debug_info
+	.long		.Lname59
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #60: variable TRUTH2
+	.section	.debug_info
+	.uleb128	60	; ref to abbrev 60
+	.section	.debug_abbrev
+	.uleb128	60
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname60:
+	.string		"TRUTH2"
+	.section	.debug_info
+	.long		.Lname60
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #61: variable LUT3CTRLA
+	.section	.debug_info
+	.uleb128	61	; ref to abbrev 61
+	.section	.debug_abbrev
+	.uleb128	61
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname61:
+	.string		"LUT3CTRLA"
+	.section	.debug_info
+	.long		.Lname61
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #62: variable LUT3CTRLB
+	.section	.debug_info
+	.uleb128	62	; ref to abbrev 62
+	.section	.debug_abbrev
+	.uleb128	62
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname62:
+	.string		"LUT3CTRLB"
+	.section	.debug_info
+	.long		.Lname62
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #63: variable LUT3CTRLC
+	.section	.debug_info
+	.uleb128	63	; ref to abbrev 63
+	.section	.debug_abbrev
+	.uleb128	63
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname63:
+	.string		"LUT3CTRLC"
+	.section	.debug_info
+	.long		.Lname63
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #64: variable TRUTH3
+	.section	.debug_info
+	.uleb128	64	; ref to abbrev 64
+	.section	.debug_abbrev
+	.uleb128	64
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname64:
+	.string		"TRUTH3"
+	.section	.debug_info
+	.long		.Lname64
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #65: variable MCLKCTRLA
+	.section	.debug_info
+	.uleb128	65	; ref to abbrev 65
+	.section	.debug_abbrev
+	.uleb128	65
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname65:
+	.string		"MCLKCTRLA"
+	.section	.debug_info
+	.long		.Lname65
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #66: variable MCLKCTRLB
+	.section	.debug_info
+	.uleb128	66	; ref to abbrev 66
+	.section	.debug_abbrev
+	.uleb128	66
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname66:
+	.string		"MCLKCTRLB"
+	.section	.debug_info
+	.long		.Lname66
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #67: variable MCLKCTRLC
+	.section	.debug_info
+	.uleb128	67	; ref to abbrev 67
+	.section	.debug_abbrev
+	.uleb128	67
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname67:
+	.string		"MCLKCTRLC"
+	.section	.debug_info
+	.long		.Lname67
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #68: variable MCLKINTCTRL
+	.section	.debug_info
+	.uleb128	68	; ref to abbrev 68
+	.section	.debug_abbrev
+	.uleb128	68
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname68:
+	.string		"MCLKINTCTRL"
+	.section	.debug_info
+	.long		.Lname68
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #69: variable MCLKINTFLAGS
+	.section	.debug_info
+	.uleb128	69	; ref to abbrev 69
+	.section	.debug_abbrev
+	.uleb128	69
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname69:
+	.string		"MCLKINTFLAGS"
+	.section	.debug_info
+	.long		.Lname69
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #70: variable MCLKSTATUS
+	.section	.debug_info
+	.uleb128	70	; ref to abbrev 70
+	.section	.debug_abbrev
+	.uleb128	70
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname70:
+	.string		"MCLKSTATUS"
+	.section	.debug_info
+	.long		.Lname70
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #71: variable MCLKTIMEBASE
+	.section	.debug_info
+	.uleb128	71	; ref to abbrev 71
+	.section	.debug_abbrev
+	.uleb128	71
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname71:
+	.string		"MCLKTIMEBASE"
+	.section	.debug_info
+	.long		.Lname71
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #72: variable OSCHFCTRLA
+	.section	.debug_info
+	.uleb128	72	; ref to abbrev 72
+	.section	.debug_abbrev
+	.uleb128	72
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname72:
+	.string		"OSCHFCTRLA"
+	.section	.debug_info
+	.long		.Lname72
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #73: variable OSCHFTUNE
+	.section	.debug_info
+	.uleb128	73	; ref to abbrev 73
+	.section	.debug_abbrev
+	.uleb128	73
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname73:
+	.string		"OSCHFTUNE"
+	.section	.debug_info
+	.long		.Lname73
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #74: variable OSC32KCTRLA
+	.section	.debug_info
+	.uleb128	74	; ref to abbrev 74
+	.section	.debug_abbrev
+	.uleb128	74
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname74:
+	.string		"OSC32KCTRLA"
+	.section	.debug_info
+	.long		.Lname74
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #75: variable XOSC32KCTRLA
+	.section	.debug_info
+	.uleb128	75	; ref to abbrev 75
+	.section	.debug_abbrev
+	.uleb128	75
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname75:
+	.string		"XOSC32KCTRLA"
+	.section	.debug_info
+	.long		.Lname75
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x1C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #76: variable XOSCHFCTRLA
+	.section	.debug_info
+	.uleb128	76	; ref to abbrev 76
+	.section	.debug_abbrev
+	.uleb128	76
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname76:
+	.string		"XOSCHFCTRLA"
+	.section	.debug_info
+	.long		.Lname76
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #77: variable CCP
+	.section	.debug_info
+	.uleb128	77	; ref to abbrev 77
+	.section	.debug_abbrev
+	.uleb128	77
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname77:
+	.string		"CCP"
+	.section	.debug_info
+	.long		.Lname77
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0030 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #78: variable SP
+	.section	.debug_info
+	.uleb128	78	; ref to abbrev 78
+	.section	.debug_abbrev
+	.uleb128	78
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname78:
+	.string		"SP"
+	.section	.debug_info
+	.long		.Lname78
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0030 + 0xD
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #79: variable SREG
+	.section	.debug_info
+	.uleb128	79	; ref to abbrev 79
+	.section	.debug_abbrev
+	.uleb128	79
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname79:
+	.string		"SREG"
+	.section	.debug_info
+	.long		.Lname79
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0030 + 0xF
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #80: variable CTRLA
+	.section	.debug_info
+	.uleb128	80	; ref to abbrev 80
+	.section	.debug_abbrev
+	.uleb128	80
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname80:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname80
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0110 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #81: variable STATUS
+	.section	.debug_info
+	.uleb128	81	; ref to abbrev 81
+	.section	.debug_abbrev
+	.uleb128	81
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname81:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname81
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0110 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #82: variable LVL0PRI
+	.section	.debug_info
+	.uleb128	82	; ref to abbrev 82
+	.section	.debug_abbrev
+	.uleb128	82
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname82:
+	.string		"LVL0PRI"
+	.section	.debug_info
+	.long		.Lname82
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0110 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #83: variable LVL1VEC
+	.section	.debug_info
+	.uleb128	83	; ref to abbrev 83
+	.section	.debug_abbrev
+	.uleb128	83
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname83:
+	.string		"LVL1VEC"
+	.section	.debug_info
+	.long		.Lname83
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0110 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #84: variable CTRLA
+	.section	.debug_info
+	.uleb128	84	; ref to abbrev 84
+	.section	.debug_abbrev
+	.uleb128	84
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname84:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname84
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0120 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #85: variable CTRLB
+	.section	.debug_info
+	.uleb128	85	; ref to abbrev 85
+	.section	.debug_abbrev
+	.uleb128	85
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname85:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname85
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0120 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #86: variable STATUS
+	.section	.debug_info
+	.uleb128	86	; ref to abbrev 86
+	.section	.debug_abbrev
+	.uleb128	86
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname86:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname86
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0120 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #87: variable CTRLA
+	.section	.debug_info
+	.uleb128	87	; ref to abbrev 87
+	.section	.debug_abbrev
+	.uleb128	87
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname87:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname87
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x06A0 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #88: variable DATA
+	.section	.debug_info
+	.uleb128	88	; ref to abbrev 88
+	.section	.debug_abbrev
+	.uleb128	88
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname88:
+	.string		"DATA"
+	.section	.debug_info
+	.long		.Lname88
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x06A0 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #89: variable SWEVENTA
+	.section	.debug_info
+	.uleb128	89	; ref to abbrev 89
+	.section	.debug_abbrev
+	.uleb128	89
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname89:
+	.string		"SWEVENTA"
+	.section	.debug_info
+	.long		.Lname89
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #90: variable CHANNEL0
+	.section	.debug_info
+	.uleb128	90	; ref to abbrev 90
+	.section	.debug_abbrev
+	.uleb128	90
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname90:
+	.string		"CHANNEL0"
+	.section	.debug_info
+	.long		.Lname90
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #91: variable CHANNEL1
+	.section	.debug_info
+	.uleb128	91	; ref to abbrev 91
+	.section	.debug_abbrev
+	.uleb128	91
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname91:
+	.string		"CHANNEL1"
+	.section	.debug_info
+	.long		.Lname91
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #92: variable CHANNEL2
+	.section	.debug_info
+	.uleb128	92	; ref to abbrev 92
+	.section	.debug_abbrev
+	.uleb128	92
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname92:
+	.string		"CHANNEL2"
+	.section	.debug_info
+	.long		.Lname92
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #93: variable CHANNEL3
+	.section	.debug_info
+	.uleb128	93	; ref to abbrev 93
+	.section	.debug_abbrev
+	.uleb128	93
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname93:
+	.string		"CHANNEL3"
+	.section	.debug_info
+	.long		.Lname93
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #94: variable CHANNEL4
+	.section	.debug_info
+	.uleb128	94	; ref to abbrev 94
+	.section	.debug_abbrev
+	.uleb128	94
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname94:
+	.string		"CHANNEL4"
+	.section	.debug_info
+	.long		.Lname94
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #95: variable CHANNEL5
+	.section	.debug_info
+	.uleb128	95	; ref to abbrev 95
+	.section	.debug_abbrev
+	.uleb128	95
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname95:
+	.string		"CHANNEL5"
+	.section	.debug_info
+	.long		.Lname95
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #96: variable USERCCLLUT0A
+	.section	.debug_info
+	.uleb128	96	; ref to abbrev 96
+	.section	.debug_abbrev
+	.uleb128	96
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname96:
+	.string		"USERCCLLUT0A"
+	.section	.debug_info
+	.long		.Lname96
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #97: variable USERCCLLUT0B
+	.section	.debug_info
+	.uleb128	97	; ref to abbrev 97
+	.section	.debug_abbrev
+	.uleb128	97
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname97:
+	.string		"USERCCLLUT0B"
+	.section	.debug_info
+	.long		.Lname97
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x21
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #98: variable USERCCLLUT1A
+	.section	.debug_info
+	.uleb128	98	; ref to abbrev 98
+	.section	.debug_abbrev
+	.uleb128	98
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname98:
+	.string		"USERCCLLUT1A"
+	.section	.debug_info
+	.long		.Lname98
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x22
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #99: variable USERCCLLUT1B
+	.section	.debug_info
+	.uleb128	99	; ref to abbrev 99
+	.section	.debug_abbrev
+	.uleb128	99
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname99:
+	.string		"USERCCLLUT1B"
+	.section	.debug_info
+	.long		.Lname99
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x23
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #100: variable USERCCLLUT2A
+	.section	.debug_info
+	.uleb128	100	; ref to abbrev 100
+	.section	.debug_abbrev
+	.uleb128	100
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname100:
+	.string		"USERCCLLUT2A"
+	.section	.debug_info
+	.long		.Lname100
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x24
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #101: variable USERCCLLUT2B
+	.section	.debug_info
+	.uleb128	101	; ref to abbrev 101
+	.section	.debug_abbrev
+	.uleb128	101
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname101:
+	.string		"USERCCLLUT2B"
+	.section	.debug_info
+	.long		.Lname101
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x25
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #102: variable USERCCLLUT3A
+	.section	.debug_info
+	.uleb128	102	; ref to abbrev 102
+	.section	.debug_abbrev
+	.uleb128	102
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname102:
+	.string		"USERCCLLUT3A"
+	.section	.debug_info
+	.long		.Lname102
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x26
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #103: variable USERCCLLUT3B
+	.section	.debug_info
+	.uleb128	103	; ref to abbrev 103
+	.section	.debug_abbrev
+	.uleb128	103
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname103:
+	.string		"USERCCLLUT3B"
+	.section	.debug_info
+	.long		.Lname103
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x27
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #104: variable USERADC0START
+	.section	.debug_info
+	.uleb128	104	; ref to abbrev 104
+	.section	.debug_abbrev
+	.uleb128	104
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname104:
+	.string		"USERADC0START"
+	.section	.debug_info
+	.long		.Lname104
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x28
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #105: variable USEREVSYSEVOUTA
+	.section	.debug_info
+	.uleb128	105	; ref to abbrev 105
+	.section	.debug_abbrev
+	.uleb128	105
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname105:
+	.string		"USEREVSYSEVOUTA"
+	.section	.debug_info
+	.long		.Lname105
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x29
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #106: variable USEREVSYSEVOUTC
+	.section	.debug_info
+	.uleb128	106	; ref to abbrev 106
+	.section	.debug_abbrev
+	.uleb128	106
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname106:
+	.string		"USEREVSYSEVOUTC"
+	.section	.debug_info
+	.long		.Lname106
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #107: variable USEREVSYSEVOUTD
+	.section	.debug_info
+	.uleb128	107	; ref to abbrev 107
+	.section	.debug_abbrev
+	.uleb128	107
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname107:
+	.string		"USEREVSYSEVOUTD"
+	.section	.debug_info
+	.long		.Lname107
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #108: variable USEREVSYSEVOUTF
+	.section	.debug_info
+	.uleb128	108	; ref to abbrev 108
+	.section	.debug_abbrev
+	.uleb128	108
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname108:
+	.string		"USEREVSYSEVOUTF"
+	.section	.debug_info
+	.long		.Lname108
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #109: variable USERUSART0IRDA
+	.section	.debug_info
+	.uleb128	109	; ref to abbrev 109
+	.section	.debug_abbrev
+	.uleb128	109
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname109:
+	.string		"USERUSART0IRDA"
+	.section	.debug_info
+	.long		.Lname109
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #110: variable USERUSART1IRDA
+	.section	.debug_info
+	.uleb128	110	; ref to abbrev 110
+	.section	.debug_abbrev
+	.uleb128	110
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname110:
+	.string		"USERUSART1IRDA"
+	.section	.debug_info
+	.long		.Lname110
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x30
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #111: variable USERUSART2IRDA
+	.section	.debug_info
+	.uleb128	111	; ref to abbrev 111
+	.section	.debug_abbrev
+	.uleb128	111
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname111:
+	.string		"USERUSART2IRDA"
+	.section	.debug_info
+	.long		.Lname111
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x31
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #112: variable USERTCA0CNTA
+	.section	.debug_info
+	.uleb128	112	; ref to abbrev 112
+	.section	.debug_abbrev
+	.uleb128	112
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname112:
+	.string		"USERTCA0CNTA"
+	.section	.debug_info
+	.long		.Lname112
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x32
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #113: variable USERTCA0CNTB
+	.section	.debug_info
+	.uleb128	113	; ref to abbrev 113
+	.section	.debug_abbrev
+	.uleb128	113
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname113:
+	.string		"USERTCA0CNTB"
+	.section	.debug_info
+	.long		.Lname113
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x33
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #114: variable USERTCA1CNTA
+	.section	.debug_info
+	.uleb128	114	; ref to abbrev 114
+	.section	.debug_abbrev
+	.uleb128	114
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname114:
+	.string		"USERTCA1CNTA"
+	.section	.debug_info
+	.long		.Lname114
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x34
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #115: variable USERTCA1CNTB
+	.section	.debug_info
+	.uleb128	115	; ref to abbrev 115
+	.section	.debug_abbrev
+	.uleb128	115
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname115:
+	.string		"USERTCA1CNTB"
+	.section	.debug_info
+	.long		.Lname115
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x35
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #116: variable USERTCB0CAPT
+	.section	.debug_info
+	.uleb128	116	; ref to abbrev 116
+	.section	.debug_abbrev
+	.uleb128	116
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname116:
+	.string		"USERTCB0CAPT"
+	.section	.debug_info
+	.long		.Lname116
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x36
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #117: variable USERTCB0COUNT
+	.section	.debug_info
+	.uleb128	117	; ref to abbrev 117
+	.section	.debug_abbrev
+	.uleb128	117
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname117:
+	.string		"USERTCB0COUNT"
+	.section	.debug_info
+	.long		.Lname117
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x37
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #118: variable USERTCB1CAPT
+	.section	.debug_info
+	.uleb128	118	; ref to abbrev 118
+	.section	.debug_abbrev
+	.uleb128	118
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname118:
+	.string		"USERTCB1CAPT"
+	.section	.debug_info
+	.long		.Lname118
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x38
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #119: variable USERTCB1COUNT
+	.section	.debug_info
+	.uleb128	119	; ref to abbrev 119
+	.section	.debug_abbrev
+	.uleb128	119
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname119:
+	.string		"USERTCB1COUNT"
+	.section	.debug_info
+	.long		.Lname119
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x39
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #120: variable USERTCB2CAPT
+	.section	.debug_info
+	.uleb128	120	; ref to abbrev 120
+	.section	.debug_abbrev
+	.uleb128	120
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname120:
+	.string		"USERTCB2CAPT"
+	.section	.debug_info
+	.long		.Lname120
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x3A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #121: variable USERTCB2COUNT
+	.section	.debug_info
+	.uleb128	121	; ref to abbrev 121
+	.section	.debug_abbrev
+	.uleb128	121
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname121:
+	.string		"USERTCB2COUNT"
+	.section	.debug_info
+	.long		.Lname121
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x3B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #122: variable USERTCB3CAPT
+	.section	.debug_info
+	.uleb128	122	; ref to abbrev 122
+	.section	.debug_abbrev
+	.uleb128	122
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname122:
+	.string		"USERTCB3CAPT"
+	.section	.debug_info
+	.long		.Lname122
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x3C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #123: variable USERTCB3COUNT
+	.section	.debug_info
+	.uleb128	123	; ref to abbrev 123
+	.section	.debug_abbrev
+	.uleb128	123
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname123:
+	.string		"USERTCB3COUNT"
+	.section	.debug_info
+	.long		.Lname123
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x3D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #124: variable WDTCFG
+	.section	.debug_info
+	.uleb128	124	; ref to abbrev 124
+	.section	.debug_abbrev
+	.uleb128	124
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname124:
+	.string		"WDTCFG"
+	.section	.debug_info
+	.long		.Lname124
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #125: variable BODCFG
+	.section	.debug_info
+	.uleb128	125	; ref to abbrev 125
+	.section	.debug_abbrev
+	.uleb128	125
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname125:
+	.string		"BODCFG"
+	.section	.debug_info
+	.long		.Lname125
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #126: variable OSCCFG
+	.section	.debug_info
+	.uleb128	126	; ref to abbrev 126
+	.section	.debug_abbrev
+	.uleb128	126
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname126:
+	.string		"OSCCFG"
+	.section	.debug_info
+	.long		.Lname126
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #127: variable SYSCFG0
+	.section	.debug_info
+	.uleb128	127	; ref to abbrev 127
+	.section	.debug_abbrev
+	.uleb128	127
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname127:
+	.string		"SYSCFG0"
+	.section	.debug_info
+	.long		.Lname127
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #128: variable SYSCFG1
+	.section	.debug_info
+	.uleb128	128	; ref to abbrev 128
+	.section	.debug_abbrev
+	.uleb128	128
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname128:
+	.string		"SYSCFG1"
+	.section	.debug_info
+	.long		.Lname128
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #129: variable CODESIZE
+	.section	.debug_info
+	.uleb128	129	; ref to abbrev 129
+	.section	.debug_abbrev
+	.uleb128	129
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname129:
+	.string		"CODESIZE"
+	.section	.debug_info
+	.long		.Lname129
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #130: variable BOOTSIZE
+	.section	.debug_info
+	.uleb128	130	; ref to abbrev 130
+	.section	.debug_abbrev
+	.uleb128	130
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname130:
+	.string		"BOOTSIZE"
+	.section	.debug_info
+	.long		.Lname130
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #131: variable GPR0
+	.section	.debug_info
+	.uleb128	131	; ref to abbrev 131
+	.section	.debug_abbrev
+	.uleb128	131
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname131:
+	.string		"GPR0"
+	.section	.debug_info
+	.long		.Lname131
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x001C + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #132: variable GPR1
+	.section	.debug_info
+	.uleb128	132	; ref to abbrev 132
+	.section	.debug_abbrev
+	.uleb128	132
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname132:
+	.string		"GPR1"
+	.section	.debug_info
+	.long		.Lname132
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x001C + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #133: variable GPR2
+	.section	.debug_info
+	.uleb128	133	; ref to abbrev 133
+	.section	.debug_abbrev
+	.uleb128	133
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname133:
+	.string		"GPR2"
+	.section	.debug_info
+	.long		.Lname133
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x001C + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #134: variable GPR3
+	.section	.debug_info
+	.uleb128	134	; ref to abbrev 134
+	.section	.debug_abbrev
+	.uleb128	134
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname134:
+	.string		"GPR3"
+	.section	.debug_info
+	.long		.Lname134
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x001C + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #135: variable KEY
+	.section	.debug_info
+	.uleb128	135	; ref to abbrev 135
+	.section	.debug_abbrev
+	.uleb128	135
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname135:
+	.string		"KEY"
+	.section	.debug_info
+	.long		.Lname135
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint32_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1040 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #136: variable CTRLA
+	.section	.debug_info
+	.uleb128	136	; ref to abbrev 136
+	.section	.debug_abbrev
+	.uleb128	136
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname136:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname136
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #137: variable CTRLB
+	.section	.debug_info
+	.uleb128	137	; ref to abbrev 137
+	.section	.debug_abbrev
+	.uleb128	137
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname137:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname137
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #138: variable INTCTRL
+	.section	.debug_info
+	.uleb128	138	; ref to abbrev 138
+	.section	.debug_abbrev
+	.uleb128	138
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname138:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname138
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #139: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	139	; ref to abbrev 139
+	.section	.debug_abbrev
+	.uleb128	139
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname139:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname139
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #140: variable STATUS
+	.section	.debug_info
+	.uleb128	140	; ref to abbrev 140
+	.section	.debug_abbrev
+	.uleb128	140
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname140:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname140
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #141: variable DATA
+	.section	.debug_info
+	.uleb128	141	; ref to abbrev 141
+	.section	.debug_abbrev
+	.uleb128	141
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname141:
+	.string		"DATA"
+	.section	.debug_info
+	.long		.Lname141
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #142: variable ADDR
+	.section	.debug_info
+	.uleb128	142	; ref to abbrev 142
+	.section	.debug_abbrev
+	.uleb128	142
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname142:
+	.string		"ADDR"
+	.section	.debug_info
+	.long		.Lname142
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint32_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #143: variable DIR
+	.section	.debug_info
+	.uleb128	143	; ref to abbrev 143
+	.section	.debug_abbrev
+	.uleb128	143
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname143:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname143
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #144: variable DIRSET
+	.section	.debug_info
+	.uleb128	144	; ref to abbrev 144
+	.section	.debug_abbrev
+	.uleb128	144
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname144:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname144
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #145: variable DIRCLR
+	.section	.debug_info
+	.uleb128	145	; ref to abbrev 145
+	.section	.debug_abbrev
+	.uleb128	145
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname145:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname145
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #146: variable DIRTGL
+	.section	.debug_info
+	.uleb128	146	; ref to abbrev 146
+	.section	.debug_abbrev
+	.uleb128	146
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname146:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname146
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #147: variable OUT
+	.section	.debug_info
+	.uleb128	147	; ref to abbrev 147
+	.section	.debug_abbrev
+	.uleb128	147
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname147:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname147
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #148: variable OUTSET
+	.section	.debug_info
+	.uleb128	148	; ref to abbrev 148
+	.section	.debug_abbrev
+	.uleb128	148
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname148:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname148
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #149: variable OUTCLR
+	.section	.debug_info
+	.uleb128	149	; ref to abbrev 149
+	.section	.debug_abbrev
+	.uleb128	149
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname149:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname149
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #150: variable OUTTGL
+	.section	.debug_info
+	.uleb128	150	; ref to abbrev 150
+	.section	.debug_abbrev
+	.uleb128	150
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname150:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname150
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #151: variable IN
+	.section	.debug_info
+	.uleb128	151	; ref to abbrev 151
+	.section	.debug_abbrev
+	.uleb128	151
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname151:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname151
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #152: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	152	; ref to abbrev 152
+	.section	.debug_abbrev
+	.uleb128	152
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname152:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname152
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #153: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	153	; ref to abbrev 153
+	.section	.debug_abbrev
+	.uleb128	153
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname153:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname153
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #154: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	154	; ref to abbrev 154
+	.section	.debug_abbrev
+	.uleb128	154
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname154:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname154
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #155: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	155	; ref to abbrev 155
+	.section	.debug_abbrev
+	.uleb128	155
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname155:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname155
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #156: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	156	; ref to abbrev 156
+	.section	.debug_abbrev
+	.uleb128	156
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname156:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname156
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #157: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	157	; ref to abbrev 157
+	.section	.debug_abbrev
+	.uleb128	157
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname157:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname157
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #158: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	158	; ref to abbrev 158
+	.section	.debug_abbrev
+	.uleb128	158
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname158:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname158
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #159: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	159	; ref to abbrev 159
+	.section	.debug_abbrev
+	.uleb128	159
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname159:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname159
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #160: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	160	; ref to abbrev 160
+	.section	.debug_abbrev
+	.uleb128	160
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname160:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname160
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #161: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	161	; ref to abbrev 161
+	.section	.debug_abbrev
+	.uleb128	161
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname161:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname161
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #162: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	162	; ref to abbrev 162
+	.section	.debug_abbrev
+	.uleb128	162
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname162:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname162
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #163: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	163	; ref to abbrev 163
+	.section	.debug_abbrev
+	.uleb128	163
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname163:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname163
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #164: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	164	; ref to abbrev 164
+	.section	.debug_abbrev
+	.uleb128	164
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname164:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname164
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #165: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	165	; ref to abbrev 165
+	.section	.debug_abbrev
+	.uleb128	165
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname165:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname165
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #166: variable EVGENCTRL
+	.section	.debug_info
+	.uleb128	166	; ref to abbrev 166
+	.section	.debug_abbrev
+	.uleb128	166
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname166:
+	.string		"EVGENCTRL"
+	.section	.debug_info
+	.long		.Lname166
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #167: variable DIR
+	.section	.debug_info
+	.uleb128	167	; ref to abbrev 167
+	.section	.debug_abbrev
+	.uleb128	167
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname167:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname167
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #168: variable DIRSET
+	.section	.debug_info
+	.uleb128	168	; ref to abbrev 168
+	.section	.debug_abbrev
+	.uleb128	168
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname168:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname168
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #169: variable DIRCLR
+	.section	.debug_info
+	.uleb128	169	; ref to abbrev 169
+	.section	.debug_abbrev
+	.uleb128	169
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname169:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname169
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #170: variable DIRTGL
+	.section	.debug_info
+	.uleb128	170	; ref to abbrev 170
+	.section	.debug_abbrev
+	.uleb128	170
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname170:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname170
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #171: variable OUT
+	.section	.debug_info
+	.uleb128	171	; ref to abbrev 171
+	.section	.debug_abbrev
+	.uleb128	171
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname171:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname171
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #172: variable OUTSET
+	.section	.debug_info
+	.uleb128	172	; ref to abbrev 172
+	.section	.debug_abbrev
+	.uleb128	172
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname172:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname172
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #173: variable OUTCLR
+	.section	.debug_info
+	.uleb128	173	; ref to abbrev 173
+	.section	.debug_abbrev
+	.uleb128	173
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname173:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname173
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #174: variable OUTTGL
+	.section	.debug_info
+	.uleb128	174	; ref to abbrev 174
+	.section	.debug_abbrev
+	.uleb128	174
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname174:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname174
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #175: variable IN
+	.section	.debug_info
+	.uleb128	175	; ref to abbrev 175
+	.section	.debug_abbrev
+	.uleb128	175
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname175:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname175
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #176: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	176	; ref to abbrev 176
+	.section	.debug_abbrev
+	.uleb128	176
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname176:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname176
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #177: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	177	; ref to abbrev 177
+	.section	.debug_abbrev
+	.uleb128	177
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname177:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname177
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #178: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	178	; ref to abbrev 178
+	.section	.debug_abbrev
+	.uleb128	178
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname178:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname178
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #179: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	179	; ref to abbrev 179
+	.section	.debug_abbrev
+	.uleb128	179
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname179:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname179
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #180: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	180	; ref to abbrev 180
+	.section	.debug_abbrev
+	.uleb128	180
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname180:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname180
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #181: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	181	; ref to abbrev 181
+	.section	.debug_abbrev
+	.uleb128	181
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname181:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname181
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #182: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	182	; ref to abbrev 182
+	.section	.debug_abbrev
+	.uleb128	182
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname182:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname182
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #183: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	183	; ref to abbrev 183
+	.section	.debug_abbrev
+	.uleb128	183
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname183:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname183
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #184: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	184	; ref to abbrev 184
+	.section	.debug_abbrev
+	.uleb128	184
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname184:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname184
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #185: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	185	; ref to abbrev 185
+	.section	.debug_abbrev
+	.uleb128	185
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname185:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname185
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #186: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	186	; ref to abbrev 186
+	.section	.debug_abbrev
+	.uleb128	186
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname186:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname186
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #187: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	187	; ref to abbrev 187
+	.section	.debug_abbrev
+	.uleb128	187
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname187:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname187
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #188: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	188	; ref to abbrev 188
+	.section	.debug_abbrev
+	.uleb128	188
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname188:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname188
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #189: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	189	; ref to abbrev 189
+	.section	.debug_abbrev
+	.uleb128	189
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname189:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname189
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #190: variable EVGENCTRL
+	.section	.debug_info
+	.uleb128	190	; ref to abbrev 190
+	.section	.debug_abbrev
+	.uleb128	190
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname190:
+	.string		"EVGENCTRL"
+	.section	.debug_info
+	.long		.Lname190
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #191: variable DIR
+	.section	.debug_info
+	.uleb128	191	; ref to abbrev 191
+	.section	.debug_abbrev
+	.uleb128	191
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname191:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname191
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #192: variable DIRSET
+	.section	.debug_info
+	.uleb128	192	; ref to abbrev 192
+	.section	.debug_abbrev
+	.uleb128	192
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname192:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname192
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #193: variable DIRCLR
+	.section	.debug_info
+	.uleb128	193	; ref to abbrev 193
+	.section	.debug_abbrev
+	.uleb128	193
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname193:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname193
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #194: variable DIRTGL
+	.section	.debug_info
+	.uleb128	194	; ref to abbrev 194
+	.section	.debug_abbrev
+	.uleb128	194
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname194:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname194
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #195: variable OUT
+	.section	.debug_info
+	.uleb128	195	; ref to abbrev 195
+	.section	.debug_abbrev
+	.uleb128	195
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname195:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname195
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #196: variable OUTSET
+	.section	.debug_info
+	.uleb128	196	; ref to abbrev 196
+	.section	.debug_abbrev
+	.uleb128	196
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname196:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname196
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #197: variable OUTCLR
+	.section	.debug_info
+	.uleb128	197	; ref to abbrev 197
+	.section	.debug_abbrev
+	.uleb128	197
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname197:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname197
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #198: variable OUTTGL
+	.section	.debug_info
+	.uleb128	198	; ref to abbrev 198
+	.section	.debug_abbrev
+	.uleb128	198
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname198:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname198
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #199: variable IN
+	.section	.debug_info
+	.uleb128	199	; ref to abbrev 199
+	.section	.debug_abbrev
+	.uleb128	199
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname199:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname199
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #200: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	200	; ref to abbrev 200
+	.section	.debug_abbrev
+	.uleb128	200
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname200:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname200
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #201: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	201	; ref to abbrev 201
+	.section	.debug_abbrev
+	.uleb128	201
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname201:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname201
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #202: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	202	; ref to abbrev 202
+	.section	.debug_abbrev
+	.uleb128	202
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname202:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname202
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #203: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	203	; ref to abbrev 203
+	.section	.debug_abbrev
+	.uleb128	203
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname203:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname203
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #204: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	204	; ref to abbrev 204
+	.section	.debug_abbrev
+	.uleb128	204
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname204:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname204
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #205: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	205	; ref to abbrev 205
+	.section	.debug_abbrev
+	.uleb128	205
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname205:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname205
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #206: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	206	; ref to abbrev 206
+	.section	.debug_abbrev
+	.uleb128	206
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname206:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname206
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #207: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	207	; ref to abbrev 207
+	.section	.debug_abbrev
+	.uleb128	207
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname207:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname207
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #208: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	208	; ref to abbrev 208
+	.section	.debug_abbrev
+	.uleb128	208
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname208:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname208
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #209: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	209	; ref to abbrev 209
+	.section	.debug_abbrev
+	.uleb128	209
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname209:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname209
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #210: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	210	; ref to abbrev 210
+	.section	.debug_abbrev
+	.uleb128	210
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname210:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname210
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #211: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	211	; ref to abbrev 211
+	.section	.debug_abbrev
+	.uleb128	211
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname211:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname211
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #212: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	212	; ref to abbrev 212
+	.section	.debug_abbrev
+	.uleb128	212
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname212:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname212
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #213: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	213	; ref to abbrev 213
+	.section	.debug_abbrev
+	.uleb128	213
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname213:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname213
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #214: variable EVGENCTRL
+	.section	.debug_info
+	.uleb128	214	; ref to abbrev 214
+	.section	.debug_abbrev
+	.uleb128	214
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname214:
+	.string		"EVGENCTRL"
+	.section	.debug_info
+	.long		.Lname214
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #215: variable DIR
+	.section	.debug_info
+	.uleb128	215	; ref to abbrev 215
+	.section	.debug_abbrev
+	.uleb128	215
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname215:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname215
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #216: variable DIRSET
+	.section	.debug_info
+	.uleb128	216	; ref to abbrev 216
+	.section	.debug_abbrev
+	.uleb128	216
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname216:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname216
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #217: variable DIRCLR
+	.section	.debug_info
+	.uleb128	217	; ref to abbrev 217
+	.section	.debug_abbrev
+	.uleb128	217
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname217:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname217
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #218: variable DIRTGL
+	.section	.debug_info
+	.uleb128	218	; ref to abbrev 218
+	.section	.debug_abbrev
+	.uleb128	218
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname218:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname218
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #219: variable OUT
+	.section	.debug_info
+	.uleb128	219	; ref to abbrev 219
+	.section	.debug_abbrev
+	.uleb128	219
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname219:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname219
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #220: variable OUTSET
+	.section	.debug_info
+	.uleb128	220	; ref to abbrev 220
+	.section	.debug_abbrev
+	.uleb128	220
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname220:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname220
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #221: variable OUTCLR
+	.section	.debug_info
+	.uleb128	221	; ref to abbrev 221
+	.section	.debug_abbrev
+	.uleb128	221
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname221:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname221
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #222: variable OUTTGL
+	.section	.debug_info
+	.uleb128	222	; ref to abbrev 222
+	.section	.debug_abbrev
+	.uleb128	222
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname222:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname222
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #223: variable IN
+	.section	.debug_info
+	.uleb128	223	; ref to abbrev 223
+	.section	.debug_abbrev
+	.uleb128	223
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname223:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname223
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #224: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	224	; ref to abbrev 224
+	.section	.debug_abbrev
+	.uleb128	224
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname224:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname224
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #225: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	225	; ref to abbrev 225
+	.section	.debug_abbrev
+	.uleb128	225
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname225:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname225
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #226: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	226	; ref to abbrev 226
+	.section	.debug_abbrev
+	.uleb128	226
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname226:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname226
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #227: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	227	; ref to abbrev 227
+	.section	.debug_abbrev
+	.uleb128	227
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname227:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname227
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #228: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	228	; ref to abbrev 228
+	.section	.debug_abbrev
+	.uleb128	228
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname228:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname228
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #229: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	229	; ref to abbrev 229
+	.section	.debug_abbrev
+	.uleb128	229
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname229:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname229
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #230: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	230	; ref to abbrev 230
+	.section	.debug_abbrev
+	.uleb128	230
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname230:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname230
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #231: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	231	; ref to abbrev 231
+	.section	.debug_abbrev
+	.uleb128	231
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname231:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname231
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #232: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	232	; ref to abbrev 232
+	.section	.debug_abbrev
+	.uleb128	232
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname232:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname232
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #233: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	233	; ref to abbrev 233
+	.section	.debug_abbrev
+	.uleb128	233
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname233:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname233
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #234: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	234	; ref to abbrev 234
+	.section	.debug_abbrev
+	.uleb128	234
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname234:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname234
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #235: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	235	; ref to abbrev 235
+	.section	.debug_abbrev
+	.uleb128	235
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname235:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname235
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #236: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	236	; ref to abbrev 236
+	.section	.debug_abbrev
+	.uleb128	236
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname236:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname236
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #237: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	237	; ref to abbrev 237
+	.section	.debug_abbrev
+	.uleb128	237
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname237:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname237
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #238: variable EVGENCTRL
+	.section	.debug_info
+	.uleb128	238	; ref to abbrev 238
+	.section	.debug_abbrev
+	.uleb128	238
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname238:
+	.string		"EVGENCTRL"
+	.section	.debug_info
+	.long		.Lname238
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #239: variable EVSYSROUTEA
+	.section	.debug_info
+	.uleb128	239	; ref to abbrev 239
+	.section	.debug_abbrev
+	.uleb128	239
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname239:
+	.string		"EVSYSROUTEA"
+	.section	.debug_info
+	.long		.Lname239
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #240: variable CCLROUTEA
+	.section	.debug_info
+	.uleb128	240	; ref to abbrev 240
+	.section	.debug_abbrev
+	.uleb128	240
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname240:
+	.string		"CCLROUTEA"
+	.section	.debug_info
+	.long		.Lname240
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #241: variable USARTROUTEA
+	.section	.debug_info
+	.uleb128	241	; ref to abbrev 241
+	.section	.debug_abbrev
+	.uleb128	241
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname241:
+	.string		"USARTROUTEA"
+	.section	.debug_info
+	.long		.Lname241
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #242: variable USARTROUTEB
+	.section	.debug_info
+	.uleb128	242	; ref to abbrev 242
+	.section	.debug_abbrev
+	.uleb128	242
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname242:
+	.string		"USARTROUTEB"
+	.section	.debug_info
+	.long		.Lname242
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #243: variable SPIROUTEA
+	.section	.debug_info
+	.uleb128	243	; ref to abbrev 243
+	.section	.debug_abbrev
+	.uleb128	243
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname243:
+	.string		"SPIROUTEA"
+	.section	.debug_info
+	.long		.Lname243
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #244: variable TWIROUTEA
+	.section	.debug_info
+	.uleb128	244	; ref to abbrev 244
+	.section	.debug_abbrev
+	.uleb128	244
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname244:
+	.string		"TWIROUTEA"
+	.section	.debug_info
+	.long		.Lname244
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #245: variable TCAROUTEA
+	.section	.debug_info
+	.uleb128	245	; ref to abbrev 245
+	.section	.debug_abbrev
+	.uleb128	245
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname245:
+	.string		"TCAROUTEA"
+	.section	.debug_info
+	.long		.Lname245
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #246: variable TCBROUTEA
+	.section	.debug_info
+	.uleb128	246	; ref to abbrev 246
+	.section	.debug_abbrev
+	.uleb128	246
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname246:
+	.string		"TCBROUTEA"
+	.section	.debug_info
+	.long		.Lname246
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #247: variable ACROUTEA
+	.section	.debug_info
+	.uleb128	247	; ref to abbrev 247
+	.section	.debug_abbrev
+	.uleb128	247
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname247:
+	.string		"ACROUTEA"
+	.section	.debug_info
+	.long		.Lname247
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #248: variable RSTFR
+	.section	.debug_info
+	.uleb128	248	; ref to abbrev 248
+	.section	.debug_abbrev
+	.uleb128	248
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname248:
+	.string		"RSTFR"
+	.section	.debug_info
+	.long		.Lname248
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0040 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #249: variable SWRR
+	.section	.debug_info
+	.uleb128	249	; ref to abbrev 249
+	.section	.debug_abbrev
+	.uleb128	249
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname249:
+	.string		"SWRR"
+	.section	.debug_info
+	.long		.Lname249
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0040 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #250: variable CTRLA
+	.section	.debug_info
+	.uleb128	250	; ref to abbrev 250
+	.section	.debug_abbrev
+	.uleb128	250
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname250:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname250
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #251: variable STATUS
+	.section	.debug_info
+	.uleb128	251	; ref to abbrev 251
+	.section	.debug_abbrev
+	.uleb128	251
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname251:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname251
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #252: variable INTCTRL
+	.section	.debug_info
+	.uleb128	252	; ref to abbrev 252
+	.section	.debug_abbrev
+	.uleb128	252
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname252:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname252
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #253: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	253	; ref to abbrev 253
+	.section	.debug_abbrev
+	.uleb128	253
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname253:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname253
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #254: variable TEMP
+	.section	.debug_info
+	.uleb128	254	; ref to abbrev 254
+	.section	.debug_abbrev
+	.uleb128	254
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname254:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname254
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #255: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	255	; ref to abbrev 255
+	.section	.debug_abbrev
+	.uleb128	255
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname255:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname255
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #256: variable CALIB
+	.section	.debug_info
+	.uleb128	256	; ref to abbrev 256
+	.section	.debug_abbrev
+	.uleb128	256
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname256:
+	.string		"CALIB"
+	.section	.debug_info
+	.long		.Lname256
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #257: variable CLKSEL
+	.section	.debug_info
+	.uleb128	257	; ref to abbrev 257
+	.section	.debug_abbrev
+	.uleb128	257
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname257:
+	.string		"CLKSEL"
+	.section	.debug_info
+	.long		.Lname257
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #258: variable CNT
+	.section	.debug_info
+	.uleb128	258	; ref to abbrev 258
+	.section	.debug_abbrev
+	.uleb128	258
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname258:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname258
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #259: variable PER
+	.section	.debug_info
+	.uleb128	259	; ref to abbrev 259
+	.section	.debug_abbrev
+	.uleb128	259
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname259:
+	.string		"PER"
+	.section	.debug_info
+	.long		.Lname259
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #260: variable CMP
+	.section	.debug_info
+	.uleb128	260	; ref to abbrev 260
+	.section	.debug_abbrev
+	.uleb128	260
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname260:
+	.string		"CMP"
+	.section	.debug_info
+	.long		.Lname260
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #261: variable PITCTRLA
+	.section	.debug_info
+	.uleb128	261	; ref to abbrev 261
+	.section	.debug_abbrev
+	.uleb128	261
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname261:
+	.string		"PITCTRLA"
+	.section	.debug_info
+	.long		.Lname261
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #262: variable PITSTATUS
+	.section	.debug_info
+	.uleb128	262	; ref to abbrev 262
+	.section	.debug_abbrev
+	.uleb128	262
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname262:
+	.string		"PITSTATUS"
+	.section	.debug_info
+	.long		.Lname262
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #263: variable PITINTCTRL
+	.section	.debug_info
+	.uleb128	263	; ref to abbrev 263
+	.section	.debug_abbrev
+	.uleb128	263
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname263:
+	.string		"PITINTCTRL"
+	.section	.debug_info
+	.long		.Lname263
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #264: variable PITINTFLAGS
+	.section	.debug_info
+	.uleb128	264	; ref to abbrev 264
+	.section	.debug_abbrev
+	.uleb128	264
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname264:
+	.string		"PITINTFLAGS"
+	.section	.debug_info
+	.long		.Lname264
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #265: variable PITDBGCTRL
+	.section	.debug_info
+	.uleb128	265	; ref to abbrev 265
+	.section	.debug_abbrev
+	.uleb128	265
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname265:
+	.string		"PITDBGCTRL"
+	.section	.debug_info
+	.long		.Lname265
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #266: variable PITEVGENCTRLA
+	.section	.debug_info
+	.uleb128	266	; ref to abbrev 266
+	.section	.debug_abbrev
+	.uleb128	266
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname266:
+	.string		"PITEVGENCTRLA"
+	.section	.debug_info
+	.long		.Lname266
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #267: variable DEVICEID0
+	.section	.debug_info
+	.uleb128	267	; ref to abbrev 267
+	.section	.debug_abbrev
+	.uleb128	267
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname267:
+	.string		"DEVICEID0"
+	.section	.debug_info
+	.long		.Lname267
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #268: variable DEVICEID1
+	.section	.debug_info
+	.uleb128	268	; ref to abbrev 268
+	.section	.debug_abbrev
+	.uleb128	268
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname268:
+	.string		"DEVICEID1"
+	.section	.debug_info
+	.long		.Lname268
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #269: variable DEVICEID2
+	.section	.debug_info
+	.uleb128	269	; ref to abbrev 269
+	.section	.debug_abbrev
+	.uleb128	269
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname269:
+	.string		"DEVICEID2"
+	.section	.debug_info
+	.long		.Lname269
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #270: variable TEMPSENSE0
+	.section	.debug_info
+	.uleb128	270	; ref to abbrev 270
+	.section	.debug_abbrev
+	.uleb128	270
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname270:
+	.string		"TEMPSENSE0"
+	.section	.debug_info
+	.long		.Lname270
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #271: variable TEMPSENSE1
+	.section	.debug_info
+	.uleb128	271	; ref to abbrev 271
+	.section	.debug_abbrev
+	.uleb128	271
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname271:
+	.string		"TEMPSENSE1"
+	.section	.debug_info
+	.long		.Lname271
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #272: variable SERNUM0
+	.section	.debug_info
+	.uleb128	272	; ref to abbrev 272
+	.section	.debug_abbrev
+	.uleb128	272
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname272:
+	.string		"SERNUM0"
+	.section	.debug_info
+	.long		.Lname272
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #273: variable SERNUM1
+	.section	.debug_info
+	.uleb128	273	; ref to abbrev 273
+	.section	.debug_abbrev
+	.uleb128	273
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname273:
+	.string		"SERNUM1"
+	.section	.debug_info
+	.long		.Lname273
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #274: variable SERNUM2
+	.section	.debug_info
+	.uleb128	274	; ref to abbrev 274
+	.section	.debug_abbrev
+	.uleb128	274
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname274:
+	.string		"SERNUM2"
+	.section	.debug_info
+	.long		.Lname274
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #275: variable SERNUM3
+	.section	.debug_info
+	.uleb128	275	; ref to abbrev 275
+	.section	.debug_abbrev
+	.uleb128	275
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname275:
+	.string		"SERNUM3"
+	.section	.debug_info
+	.long		.Lname275
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #276: variable SERNUM4
+	.section	.debug_info
+	.uleb128	276	; ref to abbrev 276
+	.section	.debug_abbrev
+	.uleb128	276
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname276:
+	.string		"SERNUM4"
+	.section	.debug_info
+	.long		.Lname276
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #277: variable SERNUM5
+	.section	.debug_info
+	.uleb128	277	; ref to abbrev 277
+	.section	.debug_abbrev
+	.uleb128	277
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname277:
+	.string		"SERNUM5"
+	.section	.debug_info
+	.long		.Lname277
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #278: variable SERNUM6
+	.section	.debug_info
+	.uleb128	278	; ref to abbrev 278
+	.section	.debug_abbrev
+	.uleb128	278
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname278:
+	.string		"SERNUM6"
+	.section	.debug_info
+	.long		.Lname278
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #279: variable SERNUM7
+	.section	.debug_info
+	.uleb128	279	; ref to abbrev 279
+	.section	.debug_abbrev
+	.uleb128	279
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname279:
+	.string		"SERNUM7"
+	.section	.debug_info
+	.long		.Lname279
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #280: variable SERNUM8
+	.section	.debug_info
+	.uleb128	280	; ref to abbrev 280
+	.section	.debug_abbrev
+	.uleb128	280
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname280:
+	.string		"SERNUM8"
+	.section	.debug_info
+	.long		.Lname280
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #281: variable SERNUM9
+	.section	.debug_info
+	.uleb128	281	; ref to abbrev 281
+	.section	.debug_abbrev
+	.uleb128	281
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname281:
+	.string		"SERNUM9"
+	.section	.debug_info
+	.long		.Lname281
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x19
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #282: variable SERNUM10
+	.section	.debug_info
+	.uleb128	282	; ref to abbrev 282
+	.section	.debug_abbrev
+	.uleb128	282
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname282:
+	.string		"SERNUM10"
+	.section	.debug_info
+	.long		.Lname282
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x1A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #283: variable SERNUM11
+	.section	.debug_info
+	.uleb128	283	; ref to abbrev 283
+	.section	.debug_abbrev
+	.uleb128	283
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname283:
+	.string		"SERNUM11"
+	.section	.debug_info
+	.long		.Lname283
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x1B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #284: variable SERNUM12
+	.section	.debug_info
+	.uleb128	284	; ref to abbrev 284
+	.section	.debug_abbrev
+	.uleb128	284
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname284:
+	.string		"SERNUM12"
+	.section	.debug_info
+	.long		.Lname284
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x1C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #285: variable SERNUM13
+	.section	.debug_info
+	.uleb128	285	; ref to abbrev 285
+	.section	.debug_abbrev
+	.uleb128	285
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname285:
+	.string		"SERNUM13"
+	.section	.debug_info
+	.long		.Lname285
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x1D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #286: variable SERNUM14
+	.section	.debug_info
+	.uleb128	286	; ref to abbrev 286
+	.section	.debug_abbrev
+	.uleb128	286
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname286:
+	.string		"SERNUM14"
+	.section	.debug_info
+	.long		.Lname286
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x1E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #287: variable SERNUM15
+	.section	.debug_info
+	.uleb128	287	; ref to abbrev 287
+	.section	.debug_abbrev
+	.uleb128	287
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname287:
+	.string		"SERNUM15"
+	.section	.debug_info
+	.long		.Lname287
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x1F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #288: variable CTRLA
+	.section	.debug_info
+	.uleb128	288	; ref to abbrev 288
+	.section	.debug_abbrev
+	.uleb128	288
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname288:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname288
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0050 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #289: variable CTRLA
+	.section	.debug_info
+	.uleb128	289	; ref to abbrev 289
+	.section	.debug_abbrev
+	.uleb128	289
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname289:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname289
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #290: variable CTRLB
+	.section	.debug_info
+	.uleb128	290	; ref to abbrev 290
+	.section	.debug_abbrev
+	.uleb128	290
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname290:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname290
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #291: variable INTCTRL
+	.section	.debug_info
+	.uleb128	291	; ref to abbrev 291
+	.section	.debug_abbrev
+	.uleb128	291
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname291:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname291
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #292: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	292	; ref to abbrev 292
+	.section	.debug_abbrev
+	.uleb128	292
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname292:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname292
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #293: variable DATA
+	.section	.debug_info
+	.uleb128	293	; ref to abbrev 293
+	.section	.debug_abbrev
+	.uleb128	293
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname293:
+	.string		"DATA"
+	.section	.debug_info
+	.long		.Lname293
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #294: variable REVID
+	.section	.debug_info
+	.uleb128	294	; ref to abbrev 294
+	.section	.debug_abbrev
+	.uleb128	294
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname294:
+	.string		"REVID"
+	.section	.debug_info
+	.long		.Lname294
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0F00 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #295: variable OCDMCTRL
+	.section	.debug_info
+	.uleb128	295	; ref to abbrev 295
+	.section	.debug_abbrev
+	.uleb128	295
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname295:
+	.string		"OCDMCTRL"
+	.section	.debug_info
+	.long		.Lname295
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0F00 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #296: variable OCDMSTATUS
+	.section	.debug_info
+	.uleb128	296	; ref to abbrev 296
+	.section	.debug_abbrev
+	.uleb128	296
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname296:
+	.string		"OCDMSTATUS"
+	.section	.debug_info
+	.long		.Lname296
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0F00 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #297: variable CTRLA
+	.section	.debug_info
+	.uleb128	297	; ref to abbrev 297
+	.section	.debug_abbrev
+	.uleb128	297
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname297:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname297
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #298: variable CTRLB
+	.section	.debug_info
+	.uleb128	298	; ref to abbrev 298
+	.section	.debug_abbrev
+	.uleb128	298
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname298:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname298
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #299: variable CTRLC
+	.section	.debug_info
+	.uleb128	299	; ref to abbrev 299
+	.section	.debug_abbrev
+	.uleb128	299
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname299:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname299
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #300: variable CTRLD
+	.section	.debug_info
+	.uleb128	300	; ref to abbrev 300
+	.section	.debug_abbrev
+	.uleb128	300
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname300:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname300
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #301: variable CTRLECLR
+	.section	.debug_info
+	.uleb128	301	; ref to abbrev 301
+	.section	.debug_abbrev
+	.uleb128	301
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname301:
+	.string		"CTRLECLR"
+	.section	.debug_info
+	.long		.Lname301
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #302: variable CTRLESET
+	.section	.debug_info
+	.uleb128	302	; ref to abbrev 302
+	.section	.debug_abbrev
+	.uleb128	302
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname302:
+	.string		"CTRLESET"
+	.section	.debug_info
+	.long		.Lname302
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #303: variable CTRLFCLR
+	.section	.debug_info
+	.uleb128	303	; ref to abbrev 303
+	.section	.debug_abbrev
+	.uleb128	303
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname303:
+	.string		"CTRLFCLR"
+	.section	.debug_info
+	.long		.Lname303
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #304: variable CTRLFSET
+	.section	.debug_info
+	.uleb128	304	; ref to abbrev 304
+	.section	.debug_abbrev
+	.uleb128	304
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname304:
+	.string		"CTRLFSET"
+	.section	.debug_info
+	.long		.Lname304
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #305: variable EVCTRL
+	.section	.debug_info
+	.uleb128	305	; ref to abbrev 305
+	.section	.debug_abbrev
+	.uleb128	305
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname305:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname305
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #306: variable INTCTRL
+	.section	.debug_info
+	.uleb128	306	; ref to abbrev 306
+	.section	.debug_abbrev
+	.uleb128	306
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname306:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname306
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #307: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	307	; ref to abbrev 307
+	.section	.debug_abbrev
+	.uleb128	307
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname307:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname307
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #308: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	308	; ref to abbrev 308
+	.section	.debug_abbrev
+	.uleb128	308
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname308:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname308
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #309: variable TEMP
+	.section	.debug_info
+	.uleb128	309	; ref to abbrev 309
+	.section	.debug_abbrev
+	.uleb128	309
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname309:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname309
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #310: variable CNT
+	.section	.debug_info
+	.uleb128	310	; ref to abbrev 310
+	.section	.debug_abbrev
+	.uleb128	310
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname310:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname310
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #311: variable PER
+	.section	.debug_info
+	.uleb128	311	; ref to abbrev 311
+	.section	.debug_abbrev
+	.uleb128	311
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname311:
+	.string		"PER"
+	.section	.debug_info
+	.long		.Lname311
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x26
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #312: variable CMP0
+	.section	.debug_info
+	.uleb128	312	; ref to abbrev 312
+	.section	.debug_abbrev
+	.uleb128	312
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname312:
+	.string		"CMP0"
+	.section	.debug_info
+	.long		.Lname312
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x28
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #313: variable CMP1
+	.section	.debug_info
+	.uleb128	313	; ref to abbrev 313
+	.section	.debug_abbrev
+	.uleb128	313
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname313:
+	.string		"CMP1"
+	.section	.debug_info
+	.long		.Lname313
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #314: variable CMP2
+	.section	.debug_info
+	.uleb128	314	; ref to abbrev 314
+	.section	.debug_abbrev
+	.uleb128	314
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname314:
+	.string		"CMP2"
+	.section	.debug_info
+	.long		.Lname314
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #315: variable PERBUF
+	.section	.debug_info
+	.uleb128	315	; ref to abbrev 315
+	.section	.debug_abbrev
+	.uleb128	315
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname315:
+	.string		"PERBUF"
+	.section	.debug_info
+	.long		.Lname315
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x36
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #316: variable CMP0BUF
+	.section	.debug_info
+	.uleb128	316	; ref to abbrev 316
+	.section	.debug_abbrev
+	.uleb128	316
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname316:
+	.string		"CMP0BUF"
+	.section	.debug_info
+	.long		.Lname316
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x38
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #317: variable CMP1BUF
+	.section	.debug_info
+	.uleb128	317	; ref to abbrev 317
+	.section	.debug_abbrev
+	.uleb128	317
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname317:
+	.string		"CMP1BUF"
+	.section	.debug_info
+	.long		.Lname317
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x3A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #318: variable CMP2BUF
+	.section	.debug_info
+	.uleb128	318	; ref to abbrev 318
+	.section	.debug_abbrev
+	.uleb128	318
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname318:
+	.string		"CMP2BUF"
+	.section	.debug_info
+	.long		.Lname318
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x3C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #319: variable CTRLA
+	.section	.debug_info
+	.uleb128	319	; ref to abbrev 319
+	.section	.debug_abbrev
+	.uleb128	319
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname319:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname319
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #320: variable CTRLB
+	.section	.debug_info
+	.uleb128	320	; ref to abbrev 320
+	.section	.debug_abbrev
+	.uleb128	320
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname320:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname320
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #321: variable CTRLC
+	.section	.debug_info
+	.uleb128	321	; ref to abbrev 321
+	.section	.debug_abbrev
+	.uleb128	321
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname321:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname321
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #322: variable CTRLD
+	.section	.debug_info
+	.uleb128	322	; ref to abbrev 322
+	.section	.debug_abbrev
+	.uleb128	322
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname322:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname322
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #323: variable CTRLECLR
+	.section	.debug_info
+	.uleb128	323	; ref to abbrev 323
+	.section	.debug_abbrev
+	.uleb128	323
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname323:
+	.string		"CTRLECLR"
+	.section	.debug_info
+	.long		.Lname323
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #324: variable CTRLESET
+	.section	.debug_info
+	.uleb128	324	; ref to abbrev 324
+	.section	.debug_abbrev
+	.uleb128	324
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname324:
+	.string		"CTRLESET"
+	.section	.debug_info
+	.long		.Lname324
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #325: variable INTCTRL
+	.section	.debug_info
+	.uleb128	325	; ref to abbrev 325
+	.section	.debug_abbrev
+	.uleb128	325
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname325:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname325
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #326: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	326	; ref to abbrev 326
+	.section	.debug_abbrev
+	.uleb128	326
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname326:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname326
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #327: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	327	; ref to abbrev 327
+	.section	.debug_abbrev
+	.uleb128	327
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname327:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname327
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #328: variable LCNT
+	.section	.debug_info
+	.uleb128	328	; ref to abbrev 328
+	.section	.debug_abbrev
+	.uleb128	328
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname328:
+	.string		"LCNT"
+	.section	.debug_info
+	.long		.Lname328
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #329: variable HCNT
+	.section	.debug_info
+	.uleb128	329	; ref to abbrev 329
+	.section	.debug_abbrev
+	.uleb128	329
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname329:
+	.string		"HCNT"
+	.section	.debug_info
+	.long		.Lname329
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x21
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #330: variable LPER
+	.section	.debug_info
+	.uleb128	330	; ref to abbrev 330
+	.section	.debug_abbrev
+	.uleb128	330
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname330:
+	.string		"LPER"
+	.section	.debug_info
+	.long		.Lname330
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x26
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #331: variable HPER
+	.section	.debug_info
+	.uleb128	331	; ref to abbrev 331
+	.section	.debug_abbrev
+	.uleb128	331
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname331:
+	.string		"HPER"
+	.section	.debug_info
+	.long		.Lname331
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x27
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #332: variable LCMP0
+	.section	.debug_info
+	.uleb128	332	; ref to abbrev 332
+	.section	.debug_abbrev
+	.uleb128	332
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname332:
+	.string		"LCMP0"
+	.section	.debug_info
+	.long		.Lname332
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x28
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #333: variable HCMP0
+	.section	.debug_info
+	.uleb128	333	; ref to abbrev 333
+	.section	.debug_abbrev
+	.uleb128	333
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname333:
+	.string		"HCMP0"
+	.section	.debug_info
+	.long		.Lname333
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x29
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #334: variable LCMP1
+	.section	.debug_info
+	.uleb128	334	; ref to abbrev 334
+	.section	.debug_abbrev
+	.uleb128	334
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname334:
+	.string		"LCMP1"
+	.section	.debug_info
+	.long		.Lname334
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #335: variable HCMP1
+	.section	.debug_info
+	.uleb128	335	; ref to abbrev 335
+	.section	.debug_abbrev
+	.uleb128	335
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname335:
+	.string		"HCMP1"
+	.section	.debug_info
+	.long		.Lname335
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #336: variable LCMP2
+	.section	.debug_info
+	.uleb128	336	; ref to abbrev 336
+	.section	.debug_abbrev
+	.uleb128	336
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname336:
+	.string		"LCMP2"
+	.section	.debug_info
+	.long		.Lname336
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #337: variable HCMP2
+	.section	.debug_info
+	.uleb128	337	; ref to abbrev 337
+	.section	.debug_abbrev
+	.uleb128	337
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname337:
+	.string		"HCMP2"
+	.section	.debug_info
+	.long		.Lname337
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #338: variable CTRLA
+	.section	.debug_info
+	.uleb128	338	; ref to abbrev 338
+	.section	.debug_abbrev
+	.uleb128	338
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname338:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname338
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #339: variable CTRLB
+	.section	.debug_info
+	.uleb128	339	; ref to abbrev 339
+	.section	.debug_abbrev
+	.uleb128	339
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname339:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname339
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #340: variable EVCTRL
+	.section	.debug_info
+	.uleb128	340	; ref to abbrev 340
+	.section	.debug_abbrev
+	.uleb128	340
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname340:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname340
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #341: variable INTCTRL
+	.section	.debug_info
+	.uleb128	341	; ref to abbrev 341
+	.section	.debug_abbrev
+	.uleb128	341
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname341:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname341
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #342: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	342	; ref to abbrev 342
+	.section	.debug_abbrev
+	.uleb128	342
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname342:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname342
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #343: variable STATUS
+	.section	.debug_info
+	.uleb128	343	; ref to abbrev 343
+	.section	.debug_abbrev
+	.uleb128	343
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname343:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname343
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #344: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	344	; ref to abbrev 344
+	.section	.debug_abbrev
+	.uleb128	344
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname344:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname344
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #345: variable TEMP
+	.section	.debug_info
+	.uleb128	345	; ref to abbrev 345
+	.section	.debug_abbrev
+	.uleb128	345
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname345:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname345
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #346: variable CNT
+	.section	.debug_info
+	.uleb128	346	; ref to abbrev 346
+	.section	.debug_abbrev
+	.uleb128	346
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname346:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname346
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #347: variable CCMP
+	.section	.debug_info
+	.uleb128	347	; ref to abbrev 347
+	.section	.debug_abbrev
+	.uleb128	347
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname347:
+	.string		"CCMP"
+	.section	.debug_info
+	.long		.Lname347
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #348: variable CTRLA
+	.section	.debug_info
+	.uleb128	348	; ref to abbrev 348
+	.section	.debug_abbrev
+	.uleb128	348
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname348:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname348
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #349: variable CTRLB
+	.section	.debug_info
+	.uleb128	349	; ref to abbrev 349
+	.section	.debug_abbrev
+	.uleb128	349
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname349:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname349
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #350: variable EVCTRL
+	.section	.debug_info
+	.uleb128	350	; ref to abbrev 350
+	.section	.debug_abbrev
+	.uleb128	350
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname350:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname350
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #351: variable INTCTRL
+	.section	.debug_info
+	.uleb128	351	; ref to abbrev 351
+	.section	.debug_abbrev
+	.uleb128	351
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname351:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname351
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #352: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	352	; ref to abbrev 352
+	.section	.debug_abbrev
+	.uleb128	352
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname352:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname352
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #353: variable STATUS
+	.section	.debug_info
+	.uleb128	353	; ref to abbrev 353
+	.section	.debug_abbrev
+	.uleb128	353
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname353:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname353
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #354: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	354	; ref to abbrev 354
+	.section	.debug_abbrev
+	.uleb128	354
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname354:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname354
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #355: variable TEMP
+	.section	.debug_info
+	.uleb128	355	; ref to abbrev 355
+	.section	.debug_abbrev
+	.uleb128	355
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname355:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname355
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #356: variable CNT
+	.section	.debug_info
+	.uleb128	356	; ref to abbrev 356
+	.section	.debug_abbrev
+	.uleb128	356
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname356:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname356
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #357: variable CCMP
+	.section	.debug_info
+	.uleb128	357	; ref to abbrev 357
+	.section	.debug_abbrev
+	.uleb128	357
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname357:
+	.string		"CCMP"
+	.section	.debug_info
+	.long		.Lname357
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #358: variable CTRLA
+	.section	.debug_info
+	.uleb128	358	; ref to abbrev 358
+	.section	.debug_abbrev
+	.uleb128	358
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname358:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname358
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #359: variable CTRLB
+	.section	.debug_info
+	.uleb128	359	; ref to abbrev 359
+	.section	.debug_abbrev
+	.uleb128	359
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname359:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname359
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #360: variable EVCTRL
+	.section	.debug_info
+	.uleb128	360	; ref to abbrev 360
+	.section	.debug_abbrev
+	.uleb128	360
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname360:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname360
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #361: variable INTCTRL
+	.section	.debug_info
+	.uleb128	361	; ref to abbrev 361
+	.section	.debug_abbrev
+	.uleb128	361
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname361:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname361
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #362: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	362	; ref to abbrev 362
+	.section	.debug_abbrev
+	.uleb128	362
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname362:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname362
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #363: variable STATUS
+	.section	.debug_info
+	.uleb128	363	; ref to abbrev 363
+	.section	.debug_abbrev
+	.uleb128	363
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname363:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname363
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #364: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	364	; ref to abbrev 364
+	.section	.debug_abbrev
+	.uleb128	364
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname364:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname364
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #365: variable TEMP
+	.section	.debug_info
+	.uleb128	365	; ref to abbrev 365
+	.section	.debug_abbrev
+	.uleb128	365
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname365:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname365
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #366: variable CNT
+	.section	.debug_info
+	.uleb128	366	; ref to abbrev 366
+	.section	.debug_abbrev
+	.uleb128	366
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname366:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname366
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #367: variable CCMP
+	.section	.debug_info
+	.uleb128	367	; ref to abbrev 367
+	.section	.debug_abbrev
+	.uleb128	367
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname367:
+	.string		"CCMP"
+	.section	.debug_info
+	.long		.Lname367
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #368: variable CTRLA
+	.section	.debug_info
+	.uleb128	368	; ref to abbrev 368
+	.section	.debug_abbrev
+	.uleb128	368
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname368:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname368
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #369: variable DUALCTRL
+	.section	.debug_info
+	.uleb128	369	; ref to abbrev 369
+	.section	.debug_abbrev
+	.uleb128	369
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname369:
+	.string		"DUALCTRL"
+	.section	.debug_info
+	.long		.Lname369
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #370: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	370	; ref to abbrev 370
+	.section	.debug_abbrev
+	.uleb128	370
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname370:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname370
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #371: variable MCTRLA
+	.section	.debug_info
+	.uleb128	371	; ref to abbrev 371
+	.section	.debug_abbrev
+	.uleb128	371
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname371:
+	.string		"MCTRLA"
+	.section	.debug_info
+	.long		.Lname371
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #372: variable MCTRLB
+	.section	.debug_info
+	.uleb128	372	; ref to abbrev 372
+	.section	.debug_abbrev
+	.uleb128	372
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname372:
+	.string		"MCTRLB"
+	.section	.debug_info
+	.long		.Lname372
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #373: variable MSTATUS
+	.section	.debug_info
+	.uleb128	373	; ref to abbrev 373
+	.section	.debug_abbrev
+	.uleb128	373
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname373:
+	.string		"MSTATUS"
+	.section	.debug_info
+	.long		.Lname373
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #374: variable MBAUD
+	.section	.debug_info
+	.uleb128	374	; ref to abbrev 374
+	.section	.debug_abbrev
+	.uleb128	374
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname374:
+	.string		"MBAUD"
+	.section	.debug_info
+	.long		.Lname374
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #375: variable MADDR
+	.section	.debug_info
+	.uleb128	375	; ref to abbrev 375
+	.section	.debug_abbrev
+	.uleb128	375
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname375:
+	.string		"MADDR"
+	.section	.debug_info
+	.long		.Lname375
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #376: variable MDATA
+	.section	.debug_info
+	.uleb128	376	; ref to abbrev 376
+	.section	.debug_abbrev
+	.uleb128	376
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname376:
+	.string		"MDATA"
+	.section	.debug_info
+	.long		.Lname376
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #377: variable SCTRLA
+	.section	.debug_info
+	.uleb128	377	; ref to abbrev 377
+	.section	.debug_abbrev
+	.uleb128	377
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname377:
+	.string		"SCTRLA"
+	.section	.debug_info
+	.long		.Lname377
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #378: variable SCTRLB
+	.section	.debug_info
+	.uleb128	378	; ref to abbrev 378
+	.section	.debug_abbrev
+	.uleb128	378
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname378:
+	.string		"SCTRLB"
+	.section	.debug_info
+	.long		.Lname378
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #379: variable SSTATUS
+	.section	.debug_info
+	.uleb128	379	; ref to abbrev 379
+	.section	.debug_abbrev
+	.uleb128	379
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname379:
+	.string		"SSTATUS"
+	.section	.debug_info
+	.long		.Lname379
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #380: variable SADDR
+	.section	.debug_info
+	.uleb128	380	; ref to abbrev 380
+	.section	.debug_abbrev
+	.uleb128	380
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname380:
+	.string		"SADDR"
+	.section	.debug_info
+	.long		.Lname380
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #381: variable SDATA
+	.section	.debug_info
+	.uleb128	381	; ref to abbrev 381
+	.section	.debug_abbrev
+	.uleb128	381
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname381:
+	.string		"SDATA"
+	.section	.debug_info
+	.long		.Lname381
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xD
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #382: variable SADDRMASK
+	.section	.debug_info
+	.uleb128	382	; ref to abbrev 382
+	.section	.debug_abbrev
+	.uleb128	382
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname382:
+	.string		"SADDRMASK"
+	.section	.debug_info
+	.long		.Lname382
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xE
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #383: variable RXDATAL
+	.section	.debug_info
+	.uleb128	383	; ref to abbrev 383
+	.section	.debug_abbrev
+	.uleb128	383
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname383:
+	.string		"RXDATAL"
+	.section	.debug_info
+	.long		.Lname383
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #384: variable RXDATAH
+	.section	.debug_info
+	.uleb128	384	; ref to abbrev 384
+	.section	.debug_abbrev
+	.uleb128	384
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname384:
+	.string		"RXDATAH"
+	.section	.debug_info
+	.long		.Lname384
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #385: variable TXDATAL
+	.section	.debug_info
+	.uleb128	385	; ref to abbrev 385
+	.section	.debug_abbrev
+	.uleb128	385
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname385:
+	.string		"TXDATAL"
+	.section	.debug_info
+	.long		.Lname385
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #386: variable TXDATAH
+	.section	.debug_info
+	.uleb128	386	; ref to abbrev 386
+	.section	.debug_abbrev
+	.uleb128	386
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname386:
+	.string		"TXDATAH"
+	.section	.debug_info
+	.long		.Lname386
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #387: variable STATUS
+	.section	.debug_info
+	.uleb128	387	; ref to abbrev 387
+	.section	.debug_abbrev
+	.uleb128	387
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname387:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname387
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #388: variable CTRLA
+	.section	.debug_info
+	.uleb128	388	; ref to abbrev 388
+	.section	.debug_abbrev
+	.uleb128	388
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname388:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname388
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #389: variable CTRLB
+	.section	.debug_info
+	.uleb128	389	; ref to abbrev 389
+	.section	.debug_abbrev
+	.uleb128	389
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname389:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname389
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #390: variable CTRLC
+	.section	.debug_info
+	.uleb128	390	; ref to abbrev 390
+	.section	.debug_abbrev
+	.uleb128	390
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname390:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname390
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #391: variable BAUD
+	.section	.debug_info
+	.uleb128	391	; ref to abbrev 391
+	.section	.debug_abbrev
+	.uleb128	391
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname391:
+	.string		"BAUD"
+	.section	.debug_info
+	.long		.Lname391
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #392: variable CTRLD
+	.section	.debug_info
+	.uleb128	392	; ref to abbrev 392
+	.section	.debug_abbrev
+	.uleb128	392
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname392:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname392
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #393: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	393	; ref to abbrev 393
+	.section	.debug_abbrev
+	.uleb128	393
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname393:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname393
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #394: variable EVCTRL
+	.section	.debug_info
+	.uleb128	394	; ref to abbrev 394
+	.section	.debug_abbrev
+	.uleb128	394
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname394:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname394
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #395: variable TXPLCTRL
+	.section	.debug_info
+	.uleb128	395	; ref to abbrev 395
+	.section	.debug_abbrev
+	.uleb128	395
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname395:
+	.string		"TXPLCTRL"
+	.section	.debug_info
+	.long		.Lname395
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xD
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #396: variable RXPLCTRL
+	.section	.debug_info
+	.uleb128	396	; ref to abbrev 396
+	.section	.debug_abbrev
+	.uleb128	396
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname396:
+	.string		"RXPLCTRL"
+	.section	.debug_info
+	.long		.Lname396
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xE
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #397: variable RXDATAL
+	.section	.debug_info
+	.uleb128	397	; ref to abbrev 397
+	.section	.debug_abbrev
+	.uleb128	397
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname397:
+	.string		"RXDATAL"
+	.section	.debug_info
+	.long		.Lname397
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #398: variable RXDATAH
+	.section	.debug_info
+	.uleb128	398	; ref to abbrev 398
+	.section	.debug_abbrev
+	.uleb128	398
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname398:
+	.string		"RXDATAH"
+	.section	.debug_info
+	.long		.Lname398
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #399: variable TXDATAL
+	.section	.debug_info
+	.uleb128	399	; ref to abbrev 399
+	.section	.debug_abbrev
+	.uleb128	399
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname399:
+	.string		"TXDATAL"
+	.section	.debug_info
+	.long		.Lname399
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #400: variable TXDATAH
+	.section	.debug_info
+	.uleb128	400	; ref to abbrev 400
+	.section	.debug_abbrev
+	.uleb128	400
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname400:
+	.string		"TXDATAH"
+	.section	.debug_info
+	.long		.Lname400
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #401: variable STATUS
+	.section	.debug_info
+	.uleb128	401	; ref to abbrev 401
+	.section	.debug_abbrev
+	.uleb128	401
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname401:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname401
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #402: variable CTRLA
+	.section	.debug_info
+	.uleb128	402	; ref to abbrev 402
+	.section	.debug_abbrev
+	.uleb128	402
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname402:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname402
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #403: variable CTRLB
+	.section	.debug_info
+	.uleb128	403	; ref to abbrev 403
+	.section	.debug_abbrev
+	.uleb128	403
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname403:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname403
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #404: variable CTRLC
+	.section	.debug_info
+	.uleb128	404	; ref to abbrev 404
+	.section	.debug_abbrev
+	.uleb128	404
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname404:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname404
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #405: variable BAUD
+	.section	.debug_info
+	.uleb128	405	; ref to abbrev 405
+	.section	.debug_abbrev
+	.uleb128	405
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname405:
+	.string		"BAUD"
+	.section	.debug_info
+	.long		.Lname405
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #406: variable CTRLD
+	.section	.debug_info
+	.uleb128	406	; ref to abbrev 406
+	.section	.debug_abbrev
+	.uleb128	406
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname406:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname406
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #407: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	407	; ref to abbrev 407
+	.section	.debug_abbrev
+	.uleb128	407
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname407:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname407
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #408: variable EVCTRL
+	.section	.debug_info
+	.uleb128	408	; ref to abbrev 408
+	.section	.debug_abbrev
+	.uleb128	408
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname408:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname408
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #409: variable TXPLCTRL
+	.section	.debug_info
+	.uleb128	409	; ref to abbrev 409
+	.section	.debug_abbrev
+	.uleb128	409
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname409:
+	.string		"TXPLCTRL"
+	.section	.debug_info
+	.long		.Lname409
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0xD
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #410: variable RXPLCTRL
+	.section	.debug_info
+	.uleb128	410	; ref to abbrev 410
+	.section	.debug_abbrev
+	.uleb128	410
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname410:
+	.string		"RXPLCTRL"
+	.section	.debug_info
+	.long		.Lname410
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0xE
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #411: variable RXDATAL
+	.section	.debug_info
+	.uleb128	411	; ref to abbrev 411
+	.section	.debug_abbrev
+	.uleb128	411
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname411:
+	.string		"RXDATAL"
+	.section	.debug_info
+	.long		.Lname411
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #412: variable RXDATAH
+	.section	.debug_info
+	.uleb128	412	; ref to abbrev 412
+	.section	.debug_abbrev
+	.uleb128	412
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname412:
+	.string		"RXDATAH"
+	.section	.debug_info
+	.long		.Lname412
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #413: variable TXDATAL
+	.section	.debug_info
+	.uleb128	413	; ref to abbrev 413
+	.section	.debug_abbrev
+	.uleb128	413
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname413:
+	.string		"TXDATAL"
+	.section	.debug_info
+	.long		.Lname413
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #414: variable TXDATAH
+	.section	.debug_info
+	.uleb128	414	; ref to abbrev 414
+	.section	.debug_abbrev
+	.uleb128	414
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname414:
+	.string		"TXDATAH"
+	.section	.debug_info
+	.long		.Lname414
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #415: variable STATUS
+	.section	.debug_info
+	.uleb128	415	; ref to abbrev 415
+	.section	.debug_abbrev
+	.uleb128	415
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname415:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname415
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #416: variable CTRLA
+	.section	.debug_info
+	.uleb128	416	; ref to abbrev 416
+	.section	.debug_abbrev
+	.uleb128	416
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname416:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname416
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #417: variable CTRLB
+	.section	.debug_info
+	.uleb128	417	; ref to abbrev 417
+	.section	.debug_abbrev
+	.uleb128	417
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname417:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname417
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #418: variable CTRLC
+	.section	.debug_info
+	.uleb128	418	; ref to abbrev 418
+	.section	.debug_abbrev
+	.uleb128	418
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname418:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname418
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #419: variable BAUD
+	.section	.debug_info
+	.uleb128	419	; ref to abbrev 419
+	.section	.debug_abbrev
+	.uleb128	419
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname419:
+	.string		"BAUD"
+	.section	.debug_info
+	.long		.Lname419
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #420: variable CTRLD
+	.section	.debug_info
+	.uleb128	420	; ref to abbrev 420
+	.section	.debug_abbrev
+	.uleb128	420
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname420:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname420
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #421: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	421	; ref to abbrev 421
+	.section	.debug_abbrev
+	.uleb128	421
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname421:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname421
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #422: variable EVCTRL
+	.section	.debug_info
+	.uleb128	422	; ref to abbrev 422
+	.section	.debug_abbrev
+	.uleb128	422
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname422:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname422
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #423: variable TXPLCTRL
+	.section	.debug_info
+	.uleb128	423	; ref to abbrev 423
+	.section	.debug_abbrev
+	.uleb128	423
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname423:
+	.string		"TXPLCTRL"
+	.section	.debug_info
+	.long		.Lname423
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0xD
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #424: variable RXPLCTRL
+	.section	.debug_info
+	.uleb128	424	; ref to abbrev 424
+	.section	.debug_abbrev
+	.uleb128	424
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname424:
+	.string		"RXPLCTRL"
+	.section	.debug_info
+	.long		.Lname424
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0xE
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #425: variable USERROW0
+	.section	.debug_info
+	.uleb128	425	; ref to abbrev 425
+	.section	.debug_abbrev
+	.uleb128	425
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname425:
+	.string		"USERROW0"
+	.section	.debug_info
+	.long		.Lname425
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #426: variable USERROW1
+	.section	.debug_info
+	.uleb128	426	; ref to abbrev 426
+	.section	.debug_abbrev
+	.uleb128	426
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname426:
+	.string		"USERROW1"
+	.section	.debug_info
+	.long		.Lname426
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #427: variable USERROW2
+	.section	.debug_info
+	.uleb128	427	; ref to abbrev 427
+	.section	.debug_abbrev
+	.uleb128	427
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname427:
+	.string		"USERROW2"
+	.section	.debug_info
+	.long		.Lname427
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #428: variable USERROW3
+	.section	.debug_info
+	.uleb128	428	; ref to abbrev 428
+	.section	.debug_abbrev
+	.uleb128	428
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname428:
+	.string		"USERROW3"
+	.section	.debug_info
+	.long		.Lname428
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #429: variable USERROW4
+	.section	.debug_info
+	.uleb128	429	; ref to abbrev 429
+	.section	.debug_abbrev
+	.uleb128	429
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname429:
+	.string		"USERROW4"
+	.section	.debug_info
+	.long		.Lname429
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #430: variable USERROW5
+	.section	.debug_info
+	.uleb128	430	; ref to abbrev 430
+	.section	.debug_abbrev
+	.uleb128	430
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname430:
+	.string		"USERROW5"
+	.section	.debug_info
+	.long		.Lname430
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #431: variable USERROW6
+	.section	.debug_info
+	.uleb128	431	; ref to abbrev 431
+	.section	.debug_abbrev
+	.uleb128	431
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname431:
+	.string		"USERROW6"
+	.section	.debug_info
+	.long		.Lname431
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #432: variable USERROW7
+	.section	.debug_info
+	.uleb128	432	; ref to abbrev 432
+	.section	.debug_abbrev
+	.uleb128	432
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname432:
+	.string		"USERROW7"
+	.section	.debug_info
+	.long		.Lname432
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #433: variable USERROW8
+	.section	.debug_info
+	.uleb128	433	; ref to abbrev 433
+	.section	.debug_abbrev
+	.uleb128	433
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname433:
+	.string		"USERROW8"
+	.section	.debug_info
+	.long		.Lname433
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #434: variable USERROW9
+	.section	.debug_info
+	.uleb128	434	; ref to abbrev 434
+	.section	.debug_abbrev
+	.uleb128	434
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname434:
+	.string		"USERROW9"
+	.section	.debug_info
+	.long		.Lname434
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #435: variable USERROW10
+	.section	.debug_info
+	.uleb128	435	; ref to abbrev 435
+	.section	.debug_abbrev
+	.uleb128	435
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname435:
+	.string		"USERROW10"
+	.section	.debug_info
+	.long		.Lname435
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #436: variable USERROW11
+	.section	.debug_info
+	.uleb128	436	; ref to abbrev 436
+	.section	.debug_abbrev
+	.uleb128	436
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname436:
+	.string		"USERROW11"
+	.section	.debug_info
+	.long		.Lname436
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #437: variable USERROW12
+	.section	.debug_info
+	.uleb128	437	; ref to abbrev 437
+	.section	.debug_abbrev
+	.uleb128	437
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname437:
+	.string		"USERROW12"
+	.section	.debug_info
+	.long		.Lname437
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #438: variable USERROW13
+	.section	.debug_info
+	.uleb128	438	; ref to abbrev 438
+	.section	.debug_abbrev
+	.uleb128	438
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname438:
+	.string		"USERROW13"
+	.section	.debug_info
+	.long		.Lname438
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #439: variable USERROW14
+	.section	.debug_info
+	.uleb128	439	; ref to abbrev 439
+	.section	.debug_abbrev
+	.uleb128	439
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname439:
+	.string		"USERROW14"
+	.section	.debug_info
+	.long		.Lname439
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #440: variable USERROW15
+	.section	.debug_info
+	.uleb128	440	; ref to abbrev 440
+	.section	.debug_abbrev
+	.uleb128	440
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname440:
+	.string		"USERROW15"
+	.section	.debug_info
+	.long		.Lname440
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x0F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #441: variable USERROW16
+	.section	.debug_info
+	.uleb128	441	; ref to abbrev 441
+	.section	.debug_abbrev
+	.uleb128	441
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname441:
+	.string		"USERROW16"
+	.section	.debug_info
+	.long		.Lname441
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #442: variable USERROW17
+	.section	.debug_info
+	.uleb128	442	; ref to abbrev 442
+	.section	.debug_abbrev
+	.uleb128	442
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname442:
+	.string		"USERROW17"
+	.section	.debug_info
+	.long		.Lname442
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #443: variable USERROW18
+	.section	.debug_info
+	.uleb128	443	; ref to abbrev 443
+	.section	.debug_abbrev
+	.uleb128	443
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname443:
+	.string		"USERROW18"
+	.section	.debug_info
+	.long		.Lname443
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #444: variable USERROW19
+	.section	.debug_info
+	.uleb128	444	; ref to abbrev 444
+	.section	.debug_abbrev
+	.uleb128	444
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname444:
+	.string		"USERROW19"
+	.section	.debug_info
+	.long		.Lname444
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #445: variable USERROW20
+	.section	.debug_info
+	.uleb128	445	; ref to abbrev 445
+	.section	.debug_abbrev
+	.uleb128	445
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname445:
+	.string		"USERROW20"
+	.section	.debug_info
+	.long		.Lname445
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #446: variable USERROW21
+	.section	.debug_info
+	.uleb128	446	; ref to abbrev 446
+	.section	.debug_abbrev
+	.uleb128	446
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname446:
+	.string		"USERROW21"
+	.section	.debug_info
+	.long		.Lname446
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #447: variable USERROW22
+	.section	.debug_info
+	.uleb128	447	; ref to abbrev 447
+	.section	.debug_abbrev
+	.uleb128	447
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname447:
+	.string		"USERROW22"
+	.section	.debug_info
+	.long		.Lname447
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #448: variable USERROW23
+	.section	.debug_info
+	.uleb128	448	; ref to abbrev 448
+	.section	.debug_abbrev
+	.uleb128	448
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname448:
+	.string		"USERROW23"
+	.section	.debug_info
+	.long		.Lname448
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #449: variable USERROW24
+	.section	.debug_info
+	.uleb128	449	; ref to abbrev 449
+	.section	.debug_abbrev
+	.uleb128	449
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname449:
+	.string		"USERROW24"
+	.section	.debug_info
+	.long		.Lname449
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #450: variable USERROW25
+	.section	.debug_info
+	.uleb128	450	; ref to abbrev 450
+	.section	.debug_abbrev
+	.uleb128	450
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname450:
+	.string		"USERROW25"
+	.section	.debug_info
+	.long		.Lname450
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x19
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #451: variable USERROW26
+	.section	.debug_info
+	.uleb128	451	; ref to abbrev 451
+	.section	.debug_abbrev
+	.uleb128	451
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname451:
+	.string		"USERROW26"
+	.section	.debug_info
+	.long		.Lname451
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #452: variable USERROW27
+	.section	.debug_info
+	.uleb128	452	; ref to abbrev 452
+	.section	.debug_abbrev
+	.uleb128	452
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname452:
+	.string		"USERROW27"
+	.section	.debug_info
+	.long		.Lname452
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #453: variable USERROW28
+	.section	.debug_info
+	.uleb128	453	; ref to abbrev 453
+	.section	.debug_abbrev
+	.uleb128	453
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname453:
+	.string		"USERROW28"
+	.section	.debug_info
+	.long		.Lname453
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #454: variable USERROW29
+	.section	.debug_info
+	.uleb128	454	; ref to abbrev 454
+	.section	.debug_abbrev
+	.uleb128	454
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname454:
+	.string		"USERROW29"
+	.section	.debug_info
+	.long		.Lname454
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #455: variable USERROW30
+	.section	.debug_info
+	.uleb128	455	; ref to abbrev 455
+	.section	.debug_abbrev
+	.uleb128	455
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname455:
+	.string		"USERROW30"
+	.section	.debug_info
+	.long		.Lname455
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #456: variable USERROW31
+	.section	.debug_info
+	.uleb128	456	; ref to abbrev 456
+	.section	.debug_abbrev
+	.uleb128	456
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname456:
+	.string		"USERROW31"
+	.section	.debug_info
+	.long		.Lname456
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #457: variable USERROW32
+	.section	.debug_info
+	.uleb128	457	; ref to abbrev 457
+	.section	.debug_abbrev
+	.uleb128	457
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname457:
+	.string		"USERROW32"
+	.section	.debug_info
+	.long		.Lname457
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #458: variable USERROW33
+	.section	.debug_info
+	.uleb128	458	; ref to abbrev 458
+	.section	.debug_abbrev
+	.uleb128	458
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname458:
+	.string		"USERROW33"
+	.section	.debug_info
+	.long		.Lname458
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x21
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #459: variable USERROW34
+	.section	.debug_info
+	.uleb128	459	; ref to abbrev 459
+	.section	.debug_abbrev
+	.uleb128	459
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname459:
+	.string		"USERROW34"
+	.section	.debug_info
+	.long		.Lname459
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x22
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #460: variable USERROW35
+	.section	.debug_info
+	.uleb128	460	; ref to abbrev 460
+	.section	.debug_abbrev
+	.uleb128	460
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname460:
+	.string		"USERROW35"
+	.section	.debug_info
+	.long		.Lname460
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x23
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #461: variable USERROW36
+	.section	.debug_info
+	.uleb128	461	; ref to abbrev 461
+	.section	.debug_abbrev
+	.uleb128	461
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname461:
+	.string		"USERROW36"
+	.section	.debug_info
+	.long		.Lname461
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x24
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #462: variable USERROW37
+	.section	.debug_info
+	.uleb128	462	; ref to abbrev 462
+	.section	.debug_abbrev
+	.uleb128	462
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname462:
+	.string		"USERROW37"
+	.section	.debug_info
+	.long		.Lname462
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x25
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #463: variable USERROW38
+	.section	.debug_info
+	.uleb128	463	; ref to abbrev 463
+	.section	.debug_abbrev
+	.uleb128	463
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname463:
+	.string		"USERROW38"
+	.section	.debug_info
+	.long		.Lname463
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x26
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #464: variable USERROW39
+	.section	.debug_info
+	.uleb128	464	; ref to abbrev 464
+	.section	.debug_abbrev
+	.uleb128	464
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname464:
+	.string		"USERROW39"
+	.section	.debug_info
+	.long		.Lname464
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x27
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #465: variable USERROW40
+	.section	.debug_info
+	.uleb128	465	; ref to abbrev 465
+	.section	.debug_abbrev
+	.uleb128	465
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname465:
+	.string		"USERROW40"
+	.section	.debug_info
+	.long		.Lname465
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x28
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #466: variable USERROW41
+	.section	.debug_info
+	.uleb128	466	; ref to abbrev 466
+	.section	.debug_abbrev
+	.uleb128	466
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname466:
+	.string		"USERROW41"
+	.section	.debug_info
+	.long		.Lname466
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x29
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #467: variable USERROW42
+	.section	.debug_info
+	.uleb128	467	; ref to abbrev 467
+	.section	.debug_abbrev
+	.uleb128	467
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname467:
+	.string		"USERROW42"
+	.section	.debug_info
+	.long		.Lname467
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x2A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #468: variable USERROW43
+	.section	.debug_info
+	.uleb128	468	; ref to abbrev 468
+	.section	.debug_abbrev
+	.uleb128	468
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname468:
+	.string		"USERROW43"
+	.section	.debug_info
+	.long		.Lname468
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x2B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #469: variable USERROW44
+	.section	.debug_info
+	.uleb128	469	; ref to abbrev 469
+	.section	.debug_abbrev
+	.uleb128	469
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname469:
+	.string		"USERROW44"
+	.section	.debug_info
+	.long		.Lname469
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x2C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #470: variable USERROW45
+	.section	.debug_info
+	.uleb128	470	; ref to abbrev 470
+	.section	.debug_abbrev
+	.uleb128	470
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname470:
+	.string		"USERROW45"
+	.section	.debug_info
+	.long		.Lname470
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x2D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #471: variable USERROW46
+	.section	.debug_info
+	.uleb128	471	; ref to abbrev 471
+	.section	.debug_abbrev
+	.uleb128	471
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname471:
+	.string		"USERROW46"
+	.section	.debug_info
+	.long		.Lname471
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x2E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #472: variable USERROW47
+	.section	.debug_info
+	.uleb128	472	; ref to abbrev 472
+	.section	.debug_abbrev
+	.uleb128	472
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname472:
+	.string		"USERROW47"
+	.section	.debug_info
+	.long		.Lname472
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x2F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #473: variable USERROW48
+	.section	.debug_info
+	.uleb128	473	; ref to abbrev 473
+	.section	.debug_abbrev
+	.uleb128	473
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname473:
+	.string		"USERROW48"
+	.section	.debug_info
+	.long		.Lname473
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x30
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #474: variable USERROW49
+	.section	.debug_info
+	.uleb128	474	; ref to abbrev 474
+	.section	.debug_abbrev
+	.uleb128	474
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname474:
+	.string		"USERROW49"
+	.section	.debug_info
+	.long		.Lname474
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x31
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #475: variable USERROW50
+	.section	.debug_info
+	.uleb128	475	; ref to abbrev 475
+	.section	.debug_abbrev
+	.uleb128	475
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname475:
+	.string		"USERROW50"
+	.section	.debug_info
+	.long		.Lname475
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x32
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #476: variable USERROW51
+	.section	.debug_info
+	.uleb128	476	; ref to abbrev 476
+	.section	.debug_abbrev
+	.uleb128	476
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname476:
+	.string		"USERROW51"
+	.section	.debug_info
+	.long		.Lname476
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x33
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #477: variable USERROW52
+	.section	.debug_info
+	.uleb128	477	; ref to abbrev 477
+	.section	.debug_abbrev
+	.uleb128	477
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname477:
+	.string		"USERROW52"
+	.section	.debug_info
+	.long		.Lname477
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x34
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #478: variable USERROW53
+	.section	.debug_info
+	.uleb128	478	; ref to abbrev 478
+	.section	.debug_abbrev
+	.uleb128	478
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname478:
+	.string		"USERROW53"
+	.section	.debug_info
+	.long		.Lname478
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x35
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #479: variable USERROW54
+	.section	.debug_info
+	.uleb128	479	; ref to abbrev 479
+	.section	.debug_abbrev
+	.uleb128	479
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname479:
+	.string		"USERROW54"
+	.section	.debug_info
+	.long		.Lname479
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x36
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #480: variable USERROW55
+	.section	.debug_info
+	.uleb128	480	; ref to abbrev 480
+	.section	.debug_abbrev
+	.uleb128	480
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname480:
+	.string		"USERROW55"
+	.section	.debug_info
+	.long		.Lname480
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x37
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #481: variable USERROW56
+	.section	.debug_info
+	.uleb128	481	; ref to abbrev 481
+	.section	.debug_abbrev
+	.uleb128	481
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname481:
+	.string		"USERROW56"
+	.section	.debug_info
+	.long		.Lname481
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x38
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #482: variable USERROW57
+	.section	.debug_info
+	.uleb128	482	; ref to abbrev 482
+	.section	.debug_abbrev
+	.uleb128	482
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname482:
+	.string		"USERROW57"
+	.section	.debug_info
+	.long		.Lname482
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x39
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #483: variable USERROW58
+	.section	.debug_info
+	.uleb128	483	; ref to abbrev 483
+	.section	.debug_abbrev
+	.uleb128	483
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname483:
+	.string		"USERROW58"
+	.section	.debug_info
+	.long		.Lname483
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x3A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #484: variable USERROW59
+	.section	.debug_info
+	.uleb128	484	; ref to abbrev 484
+	.section	.debug_abbrev
+	.uleb128	484
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname484:
+	.string		"USERROW59"
+	.section	.debug_info
+	.long		.Lname484
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x3B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #485: variable USERROW60
+	.section	.debug_info
+	.uleb128	485	; ref to abbrev 485
+	.section	.debug_abbrev
+	.uleb128	485
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname485:
+	.string		"USERROW60"
+	.section	.debug_info
+	.long		.Lname485
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x3C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #486: variable USERROW61
+	.section	.debug_info
+	.uleb128	486	; ref to abbrev 486
+	.section	.debug_abbrev
+	.uleb128	486
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname486:
+	.string		"USERROW61"
+	.section	.debug_info
+	.long		.Lname486
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x3D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #487: variable USERROW62
+	.section	.debug_info
+	.uleb128	487	; ref to abbrev 487
+	.section	.debug_abbrev
+	.uleb128	487
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname487:
+	.string		"USERROW62"
+	.section	.debug_info
+	.long		.Lname487
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x3E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #488: variable USERROW63
+	.section	.debug_info
+	.uleb128	488	; ref to abbrev 488
+	.section	.debug_abbrev
+	.uleb128	488
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname488:
+	.string		"USERROW63"
+	.section	.debug_info
+	.long		.Lname488
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x3F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #489: variable DIR
+	.section	.debug_info
+	.uleb128	489	; ref to abbrev 489
+	.section	.debug_abbrev
+	.uleb128	489
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname489:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname489
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0000 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #490: variable OUT
+	.section	.debug_info
+	.uleb128	490	; ref to abbrev 490
+	.section	.debug_abbrev
+	.uleb128	490
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname490:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname490
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0000 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #491: variable IN
+	.section	.debug_info
+	.uleb128	491	; ref to abbrev 491
+	.section	.debug_abbrev
+	.uleb128	491
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname491:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname491
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0000 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #492: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	492	; ref to abbrev 492
+	.section	.debug_abbrev
+	.uleb128	492
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname492:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname492
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0000 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #493: variable DIR
+	.section	.debug_info
+	.uleb128	493	; ref to abbrev 493
+	.section	.debug_abbrev
+	.uleb128	493
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname493:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname493
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0008 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #494: variable OUT
+	.section	.debug_info
+	.uleb128	494	; ref to abbrev 494
+	.section	.debug_abbrev
+	.uleb128	494
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname494:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname494
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0008 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #495: variable IN
+	.section	.debug_info
+	.uleb128	495	; ref to abbrev 495
+	.section	.debug_abbrev
+	.uleb128	495
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname495:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname495
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0008 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #496: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	496	; ref to abbrev 496
+	.section	.debug_abbrev
+	.uleb128	496
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname496:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname496
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0008 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #497: variable DIR
+	.section	.debug_info
+	.uleb128	497	; ref to abbrev 497
+	.section	.debug_abbrev
+	.uleb128	497
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname497:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname497
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x000C + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #498: variable OUT
+	.section	.debug_info
+	.uleb128	498	; ref to abbrev 498
+	.section	.debug_abbrev
+	.uleb128	498
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname498:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname498
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x000C + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #499: variable IN
+	.section	.debug_info
+	.uleb128	499	; ref to abbrev 499
+	.section	.debug_abbrev
+	.uleb128	499
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname499:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname499
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x000C + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #500: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	500	; ref to abbrev 500
+	.section	.debug_abbrev
+	.uleb128	500
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname500:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname500
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x000C + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #501: variable DIR
+	.section	.debug_info
+	.uleb128	501	; ref to abbrev 501
+	.section	.debug_abbrev
+	.uleb128	501
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname501:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname501
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0014 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #502: variable OUT
+	.section	.debug_info
+	.uleb128	502	; ref to abbrev 502
+	.section	.debug_abbrev
+	.uleb128	502
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname502:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname502
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0014 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #503: variable IN
+	.section	.debug_info
+	.uleb128	503	; ref to abbrev 503
+	.section	.debug_abbrev
+	.uleb128	503
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname503:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname503
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0014 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #504: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	504	; ref to abbrev 504
+	.section	.debug_abbrev
+	.uleb128	504
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname504:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname504
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0014 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #505: variable DAC0REF
+	.section	.debug_info
+	.uleb128	505	; ref to abbrev 505
+	.section	.debug_abbrev
+	.uleb128	505
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname505:
+	.string		"DAC0REF"
+	.section	.debug_info
+	.long		.Lname505
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00B0 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #506: variable ACREF
+	.section	.debug_info
+	.uleb128	506	; ref to abbrev 506
+	.section	.debug_abbrev
+	.uleb128	506
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname506:
+	.string		"ACREF"
+	.section	.debug_info
+	.long		.Lname506
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00B0 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #507: variable CTRLA
+	.section	.debug_info
+	.uleb128	507	; ref to abbrev 507
+	.section	.debug_abbrev
+	.uleb128	507
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname507:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname507
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0100 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #508: variable STATUS
+	.section	.debug_info
+	.uleb128	508	; ref to abbrev 508
+	.section	.debug_abbrev
+	.uleb128	508
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname508:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname508
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0100 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+	;; trailer
+	.section	.debug_abbrev
+	.uleb128	0
+
+	.section	.debug_info
+	.uleb128	0
+.Leinfo:

--- a/crt1/iosym/avr16ea48.S
+++ b/crt1/iosym/avr16ea48.S
@@ -1,0 +1,32722 @@
+/* This file is part of avr-libc.
+
+   Automatically created by devtools/ioreg.pl
+   DO NOT EDIT!
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in
+     the documentation and/or other materials provided with the
+     distribution.
+
+   * Neither the name of the copyright holders nor the names of
+     contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE. */
+
+/* $Id$ */
+
+#include <avr/version.h>
+
+#define DW_TAG_array_type               0x01
+#define DW_TAG_compile_unit             0x11
+#define DW_TAG_typedef                  0x16
+#define DW_TAG_subrange_type            0x21
+#define DW_TAG_base_type                0x24
+#define DW_TAG_variable                 0x34
+
+#define DW_FORM_addr                    0x01
+#define DW_FORM_block1                  0x0a
+#define DW_FORM_block2                  0x03
+#define DW_FORM_block4                  0x04
+#define DW_FORM_data1                   0x0b
+#define DW_FORM_data2                   0x05
+#define DW_FORM_data4                   0x06
+#define DW_FORM_data8                   0x07
+#define DW_FORM_string                  0x08
+#define DW_FORM_flag                    0x0c
+#define DW_FORM_strp                    0x0e
+#define DW_FORM_ref1                    0x11
+#define DW_FORM_ref2                    0x12
+#define DW_FORM_ref4                    0x13
+#define DW_FORM_ref8                    0x14
+
+#define DW_AT_location                  0x02
+#define DW_AT_name                      0x03
+#define DW_AT_byte_size                 0x0b
+#define DW_AT_stmt_list                 0x10
+#define DW_AT_language                  0x13
+#define DW_AT_producer                  0x25
+#define DW_AT_upper_bound               0x2f
+#define DW_AT_decl_file                 0x3a
+#define DW_AT_decl_line                 0x3b
+#define DW_AT_encoding                  0x3e
+#define DW_AT_external                  0x3f
+#define DW_AT_type                      0x49
+
+#define DW_LANG_C89                     0x0001
+
+#define DW_CHILDREN_no                  0x00
+#define DW_CHILDREN_yes                 0x01
+
+#define DW_ATE_unsigned                 0x7
+#define DW_ATE_unsigned_char            0x8
+
+#define DW_OP_addr                      0x03
+.eject
+	.section	.debug_abbrev, "", @progbits
+.Ldebug_abbrev0:
+	.section	.debug_info, "", @progbits
+	.section	.debug_line, "", @progbits
+.Ldebug_line0:
+	.section	.debug_str, "", @progbits
+
+	.section	.debug_info, "", @progbits
+	;; compilation unit header
+.Lssinfo:
+	.long	.Leinfo - .Lsinfo
+.Lsinfo:
+	.word	2		; DWARF-2
+	.long	.Ldebug_abbrev0
+	.byte	4		; sizeof(address)
+
+
+	;; DIE #1: compilation unit
+	.section	.debug_info
+	.uleb128	1	; ref to abbrev 1
+	.section	.debug_abbrev
+	.uleb128	1
+	.uleb128	DW_TAG_compile_unit
+	.byte		DW_CHILDREN_yes
+
+	.uleb128	DW_AT_producer
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lproducer:
+	.ascii		"avr-libc "
+	.asciz		__AVR_LIBC_VERSION_STRING__
+	.section	.debug_info
+	.long		.Lproducer
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_stmt_list
+	.uleb128	DW_FORM_data4
+	.section	.debug_info
+	.long		.Ldebug_line0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+	;; DIE #2: base type uint8_t
+	.section	.debug_info
+.Luint8_t:
+	.uleb128	2	; ref to abbrev 2
+	.section	.debug_abbrev
+	.uleb128	2
+	.uleb128	DW_TAG_base_type
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Luint8_t_name:
+	.string		"uint8_t"
+	.section	.debug_info
+	.long		.Luint8_t_name
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_byte_size
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_encoding
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		DW_ATE_unsigned_char
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+	;; DIE #3: base type uint16_t
+	.section	.debug_info
+.Luint16_t:
+	.uleb128	3	; ref to abbrev 3
+	.section	.debug_abbrev
+	.uleb128	3
+	.uleb128	DW_TAG_base_type
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Luint16_t_name:
+	.string		"uint16_t"
+	.section	.debug_info
+	.long		.Luint16_t_name
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_byte_size
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		2
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_encoding
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		DW_ATE_unsigned
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #4: variable CTRLA
+	.section	.debug_info
+	.uleb128	4	; ref to abbrev 4
+	.section	.debug_abbrev
+	.uleb128	4
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname4:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname4
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #5: variable CTRLB
+	.section	.debug_info
+	.uleb128	5	; ref to abbrev 5
+	.section	.debug_abbrev
+	.uleb128	5
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname5:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname5
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #6: variable MUXCTRL
+	.section	.debug_info
+	.uleb128	6	; ref to abbrev 6
+	.section	.debug_abbrev
+	.uleb128	6
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname6:
+	.string		"MUXCTRL"
+	.section	.debug_info
+	.long		.Lname6
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #7: variable DACREF
+	.section	.debug_info
+	.uleb128	7	; ref to abbrev 7
+	.section	.debug_abbrev
+	.uleb128	7
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname7:
+	.string		"DACREF"
+	.section	.debug_info
+	.long		.Lname7
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #8: variable INTCTRL
+	.section	.debug_info
+	.uleb128	8	; ref to abbrev 8
+	.section	.debug_abbrev
+	.uleb128	8
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname8:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname8
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #9: variable STATUS
+	.section	.debug_info
+	.uleb128	9	; ref to abbrev 9
+	.section	.debug_abbrev
+	.uleb128	9
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname9:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname9
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #10: variable CTRLA
+	.section	.debug_info
+	.uleb128	10	; ref to abbrev 10
+	.section	.debug_abbrev
+	.uleb128	10
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname10:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname10
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #11: variable CTRLB
+	.section	.debug_info
+	.uleb128	11	; ref to abbrev 11
+	.section	.debug_abbrev
+	.uleb128	11
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname11:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname11
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #12: variable MUXCTRL
+	.section	.debug_info
+	.uleb128	12	; ref to abbrev 12
+	.section	.debug_abbrev
+	.uleb128	12
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname12:
+	.string		"MUXCTRL"
+	.section	.debug_info
+	.long		.Lname12
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #13: variable DACREF
+	.section	.debug_info
+	.uleb128	13	; ref to abbrev 13
+	.section	.debug_abbrev
+	.uleb128	13
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname13:
+	.string		"DACREF"
+	.section	.debug_info
+	.long		.Lname13
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #14: variable INTCTRL
+	.section	.debug_info
+	.uleb128	14	; ref to abbrev 14
+	.section	.debug_abbrev
+	.uleb128	14
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname14:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname14
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #15: variable STATUS
+	.section	.debug_info
+	.uleb128	15	; ref to abbrev 15
+	.section	.debug_abbrev
+	.uleb128	15
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname15:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname15
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #16: variable CTRLA
+	.section	.debug_info
+	.uleb128	16	; ref to abbrev 16
+	.section	.debug_abbrev
+	.uleb128	16
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname16:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname16
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #17: variable CTRLB
+	.section	.debug_info
+	.uleb128	17	; ref to abbrev 17
+	.section	.debug_abbrev
+	.uleb128	17
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname17:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname17
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #18: variable CTRLC
+	.section	.debug_info
+	.uleb128	18	; ref to abbrev 18
+	.section	.debug_abbrev
+	.uleb128	18
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname18:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname18
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #19: variable CTRLD
+	.section	.debug_info
+	.uleb128	19	; ref to abbrev 19
+	.section	.debug_abbrev
+	.uleb128	19
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname19:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname19
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #20: variable INTCTRL
+	.section	.debug_info
+	.uleb128	20	; ref to abbrev 20
+	.section	.debug_abbrev
+	.uleb128	20
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname20:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname20
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #21: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	21	; ref to abbrev 21
+	.section	.debug_abbrev
+	.uleb128	21
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname21:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname21
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #22: variable STATUS
+	.section	.debug_info
+	.uleb128	22	; ref to abbrev 22
+	.section	.debug_abbrev
+	.uleb128	22
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname22:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname22
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #23: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	23	; ref to abbrev 23
+	.section	.debug_abbrev
+	.uleb128	23
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname23:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname23
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #24: variable CTRLE
+	.section	.debug_info
+	.uleb128	24	; ref to abbrev 24
+	.section	.debug_abbrev
+	.uleb128	24
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname24:
+	.string		"CTRLE"
+	.section	.debug_info
+	.long		.Lname24
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #25: variable CTRLF
+	.section	.debug_info
+	.uleb128	25	; ref to abbrev 25
+	.section	.debug_abbrev
+	.uleb128	25
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname25:
+	.string		"CTRLF"
+	.section	.debug_info
+	.long		.Lname25
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #26: variable COMMAND
+	.section	.debug_info
+	.uleb128	26	; ref to abbrev 26
+	.section	.debug_abbrev
+	.uleb128	26
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname26:
+	.string		"COMMAND"
+	.section	.debug_info
+	.long		.Lname26
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #27: variable PGACTRL
+	.section	.debug_info
+	.uleb128	27	; ref to abbrev 27
+	.section	.debug_abbrev
+	.uleb128	27
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname27:
+	.string		"PGACTRL"
+	.section	.debug_info
+	.long		.Lname27
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #28: variable MUXPOS
+	.section	.debug_info
+	.uleb128	28	; ref to abbrev 28
+	.section	.debug_abbrev
+	.uleb128	28
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname28:
+	.string		"MUXPOS"
+	.section	.debug_info
+	.long		.Lname28
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #29: variable MUXNEG
+	.section	.debug_info
+	.uleb128	29	; ref to abbrev 29
+	.section	.debug_abbrev
+	.uleb128	29
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname29:
+	.string		"MUXNEG"
+	.section	.debug_info
+	.long		.Lname29
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #30: base type uint32_t
+	.section	.debug_info
+.Luint32_t:
+	.uleb128	30	; ref to abbrev 30
+	.section	.debug_abbrev
+	.uleb128	30
+	.uleb128	DW_TAG_base_type
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Luint32_t_name:
+	.string		"uint32_t"
+	.section	.debug_info
+	.long		.Luint32_t_name
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_byte_size
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		4
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_encoding
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		DW_ATE_unsigned
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #31: variable RESULT
+	.section	.debug_info
+	.uleb128	31	; ref to abbrev 31
+	.section	.debug_abbrev
+	.uleb128	31
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname31:
+	.string		"RESULT"
+	.section	.debug_info
+	.long		.Lname31
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint32_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #32: variable SAMPLE
+	.section	.debug_info
+	.uleb128	32	; ref to abbrev 32
+	.section	.debug_abbrev
+	.uleb128	32
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname32:
+	.string		"SAMPLE"
+	.section	.debug_info
+	.long		.Lname32
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #33: variable TEMP0
+	.section	.debug_info
+	.uleb128	33	; ref to abbrev 33
+	.section	.debug_abbrev
+	.uleb128	33
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname33:
+	.string		"TEMP0"
+	.section	.debug_info
+	.long		.Lname33
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #34: variable TEMP1
+	.section	.debug_info
+	.uleb128	34	; ref to abbrev 34
+	.section	.debug_abbrev
+	.uleb128	34
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname34:
+	.string		"TEMP1"
+	.section	.debug_info
+	.long		.Lname34
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x19
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #35: variable TEMP2
+	.section	.debug_info
+	.uleb128	35	; ref to abbrev 35
+	.section	.debug_abbrev
+	.uleb128	35
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname35:
+	.string		"TEMP2"
+	.section	.debug_info
+	.long		.Lname35
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x1A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #36: variable WINLT
+	.section	.debug_info
+	.uleb128	36	; ref to abbrev 36
+	.section	.debug_abbrev
+	.uleb128	36
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname36:
+	.string		"WINLT"
+	.section	.debug_info
+	.long		.Lname36
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x1C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #37: variable WINHT
+	.section	.debug_info
+	.uleb128	37	; ref to abbrev 37
+	.section	.debug_abbrev
+	.uleb128	37
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname37:
+	.string		"WINHT"
+	.section	.debug_info
+	.long		.Lname37
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x1E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #38: variable CTRLA
+	.section	.debug_info
+	.uleb128	38	; ref to abbrev 38
+	.section	.debug_abbrev
+	.uleb128	38
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname38:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname38
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #39: variable CTRLB
+	.section	.debug_info
+	.uleb128	39	; ref to abbrev 39
+	.section	.debug_abbrev
+	.uleb128	39
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname39:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname39
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #40: variable VLMCTRLA
+	.section	.debug_info
+	.uleb128	40	; ref to abbrev 40
+	.section	.debug_abbrev
+	.uleb128	40
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname40:
+	.string		"VLMCTRLA"
+	.section	.debug_info
+	.long		.Lname40
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #41: variable INTCTRL
+	.section	.debug_info
+	.uleb128	41	; ref to abbrev 41
+	.section	.debug_abbrev
+	.uleb128	41
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname41:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname41
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #42: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	42	; ref to abbrev 42
+	.section	.debug_abbrev
+	.uleb128	42
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname42:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname42
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #43: variable STATUS
+	.section	.debug_info
+	.uleb128	43	; ref to abbrev 43
+	.section	.debug_abbrev
+	.uleb128	43
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname43:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname43
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #44: variable CTRLA
+	.section	.debug_info
+	.uleb128	44	; ref to abbrev 44
+	.section	.debug_abbrev
+	.uleb128	44
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname44:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname44
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #45: variable SEQCTRL0
+	.section	.debug_info
+	.uleb128	45	; ref to abbrev 45
+	.section	.debug_abbrev
+	.uleb128	45
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname45:
+	.string		"SEQCTRL0"
+	.section	.debug_info
+	.long		.Lname45
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #46: variable SEQCTRL1
+	.section	.debug_info
+	.uleb128	46	; ref to abbrev 46
+	.section	.debug_abbrev
+	.uleb128	46
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname46:
+	.string		"SEQCTRL1"
+	.section	.debug_info
+	.long		.Lname46
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #47: variable INTCTRL0
+	.section	.debug_info
+	.uleb128	47	; ref to abbrev 47
+	.section	.debug_abbrev
+	.uleb128	47
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname47:
+	.string		"INTCTRL0"
+	.section	.debug_info
+	.long		.Lname47
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #48: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	48	; ref to abbrev 48
+	.section	.debug_abbrev
+	.uleb128	48
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname48:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname48
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #49: variable LUT0CTRLA
+	.section	.debug_info
+	.uleb128	49	; ref to abbrev 49
+	.section	.debug_abbrev
+	.uleb128	49
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname49:
+	.string		"LUT0CTRLA"
+	.section	.debug_info
+	.long		.Lname49
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #50: variable LUT0CTRLB
+	.section	.debug_info
+	.uleb128	50	; ref to abbrev 50
+	.section	.debug_abbrev
+	.uleb128	50
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname50:
+	.string		"LUT0CTRLB"
+	.section	.debug_info
+	.long		.Lname50
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #51: variable LUT0CTRLC
+	.section	.debug_info
+	.uleb128	51	; ref to abbrev 51
+	.section	.debug_abbrev
+	.uleb128	51
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname51:
+	.string		"LUT0CTRLC"
+	.section	.debug_info
+	.long		.Lname51
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #52: variable TRUTH0
+	.section	.debug_info
+	.uleb128	52	; ref to abbrev 52
+	.section	.debug_abbrev
+	.uleb128	52
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname52:
+	.string		"TRUTH0"
+	.section	.debug_info
+	.long		.Lname52
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #53: variable LUT1CTRLA
+	.section	.debug_info
+	.uleb128	53	; ref to abbrev 53
+	.section	.debug_abbrev
+	.uleb128	53
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname53:
+	.string		"LUT1CTRLA"
+	.section	.debug_info
+	.long		.Lname53
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #54: variable LUT1CTRLB
+	.section	.debug_info
+	.uleb128	54	; ref to abbrev 54
+	.section	.debug_abbrev
+	.uleb128	54
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname54:
+	.string		"LUT1CTRLB"
+	.section	.debug_info
+	.long		.Lname54
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #55: variable LUT1CTRLC
+	.section	.debug_info
+	.uleb128	55	; ref to abbrev 55
+	.section	.debug_abbrev
+	.uleb128	55
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname55:
+	.string		"LUT1CTRLC"
+	.section	.debug_info
+	.long		.Lname55
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #56: variable TRUTH1
+	.section	.debug_info
+	.uleb128	56	; ref to abbrev 56
+	.section	.debug_abbrev
+	.uleb128	56
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname56:
+	.string		"TRUTH1"
+	.section	.debug_info
+	.long		.Lname56
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #57: variable LUT2CTRLA
+	.section	.debug_info
+	.uleb128	57	; ref to abbrev 57
+	.section	.debug_abbrev
+	.uleb128	57
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname57:
+	.string		"LUT2CTRLA"
+	.section	.debug_info
+	.long		.Lname57
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #58: variable LUT2CTRLB
+	.section	.debug_info
+	.uleb128	58	; ref to abbrev 58
+	.section	.debug_abbrev
+	.uleb128	58
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname58:
+	.string		"LUT2CTRLB"
+	.section	.debug_info
+	.long		.Lname58
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #59: variable LUT2CTRLC
+	.section	.debug_info
+	.uleb128	59	; ref to abbrev 59
+	.section	.debug_abbrev
+	.uleb128	59
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname59:
+	.string		"LUT2CTRLC"
+	.section	.debug_info
+	.long		.Lname59
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #60: variable TRUTH2
+	.section	.debug_info
+	.uleb128	60	; ref to abbrev 60
+	.section	.debug_abbrev
+	.uleb128	60
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname60:
+	.string		"TRUTH2"
+	.section	.debug_info
+	.long		.Lname60
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #61: variable LUT3CTRLA
+	.section	.debug_info
+	.uleb128	61	; ref to abbrev 61
+	.section	.debug_abbrev
+	.uleb128	61
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname61:
+	.string		"LUT3CTRLA"
+	.section	.debug_info
+	.long		.Lname61
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #62: variable LUT3CTRLB
+	.section	.debug_info
+	.uleb128	62	; ref to abbrev 62
+	.section	.debug_abbrev
+	.uleb128	62
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname62:
+	.string		"LUT3CTRLB"
+	.section	.debug_info
+	.long		.Lname62
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #63: variable LUT3CTRLC
+	.section	.debug_info
+	.uleb128	63	; ref to abbrev 63
+	.section	.debug_abbrev
+	.uleb128	63
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname63:
+	.string		"LUT3CTRLC"
+	.section	.debug_info
+	.long		.Lname63
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #64: variable TRUTH3
+	.section	.debug_info
+	.uleb128	64	; ref to abbrev 64
+	.section	.debug_abbrev
+	.uleb128	64
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname64:
+	.string		"TRUTH3"
+	.section	.debug_info
+	.long		.Lname64
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #65: variable MCLKCTRLA
+	.section	.debug_info
+	.uleb128	65	; ref to abbrev 65
+	.section	.debug_abbrev
+	.uleb128	65
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname65:
+	.string		"MCLKCTRLA"
+	.section	.debug_info
+	.long		.Lname65
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #66: variable MCLKCTRLB
+	.section	.debug_info
+	.uleb128	66	; ref to abbrev 66
+	.section	.debug_abbrev
+	.uleb128	66
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname66:
+	.string		"MCLKCTRLB"
+	.section	.debug_info
+	.long		.Lname66
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #67: variable MCLKCTRLC
+	.section	.debug_info
+	.uleb128	67	; ref to abbrev 67
+	.section	.debug_abbrev
+	.uleb128	67
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname67:
+	.string		"MCLKCTRLC"
+	.section	.debug_info
+	.long		.Lname67
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #68: variable MCLKINTCTRL
+	.section	.debug_info
+	.uleb128	68	; ref to abbrev 68
+	.section	.debug_abbrev
+	.uleb128	68
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname68:
+	.string		"MCLKINTCTRL"
+	.section	.debug_info
+	.long		.Lname68
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #69: variable MCLKINTFLAGS
+	.section	.debug_info
+	.uleb128	69	; ref to abbrev 69
+	.section	.debug_abbrev
+	.uleb128	69
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname69:
+	.string		"MCLKINTFLAGS"
+	.section	.debug_info
+	.long		.Lname69
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #70: variable MCLKSTATUS
+	.section	.debug_info
+	.uleb128	70	; ref to abbrev 70
+	.section	.debug_abbrev
+	.uleb128	70
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname70:
+	.string		"MCLKSTATUS"
+	.section	.debug_info
+	.long		.Lname70
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #71: variable MCLKTIMEBASE
+	.section	.debug_info
+	.uleb128	71	; ref to abbrev 71
+	.section	.debug_abbrev
+	.uleb128	71
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname71:
+	.string		"MCLKTIMEBASE"
+	.section	.debug_info
+	.long		.Lname71
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #72: variable OSCHFCTRLA
+	.section	.debug_info
+	.uleb128	72	; ref to abbrev 72
+	.section	.debug_abbrev
+	.uleb128	72
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname72:
+	.string		"OSCHFCTRLA"
+	.section	.debug_info
+	.long		.Lname72
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #73: variable OSCHFTUNE
+	.section	.debug_info
+	.uleb128	73	; ref to abbrev 73
+	.section	.debug_abbrev
+	.uleb128	73
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname73:
+	.string		"OSCHFTUNE"
+	.section	.debug_info
+	.long		.Lname73
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #74: variable OSC32KCTRLA
+	.section	.debug_info
+	.uleb128	74	; ref to abbrev 74
+	.section	.debug_abbrev
+	.uleb128	74
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname74:
+	.string		"OSC32KCTRLA"
+	.section	.debug_info
+	.long		.Lname74
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #75: variable XOSC32KCTRLA
+	.section	.debug_info
+	.uleb128	75	; ref to abbrev 75
+	.section	.debug_abbrev
+	.uleb128	75
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname75:
+	.string		"XOSC32KCTRLA"
+	.section	.debug_info
+	.long		.Lname75
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x1C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #76: variable XOSCHFCTRLA
+	.section	.debug_info
+	.uleb128	76	; ref to abbrev 76
+	.section	.debug_abbrev
+	.uleb128	76
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname76:
+	.string		"XOSCHFCTRLA"
+	.section	.debug_info
+	.long		.Lname76
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #77: variable CCP
+	.section	.debug_info
+	.uleb128	77	; ref to abbrev 77
+	.section	.debug_abbrev
+	.uleb128	77
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname77:
+	.string		"CCP"
+	.section	.debug_info
+	.long		.Lname77
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0030 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #78: variable SP
+	.section	.debug_info
+	.uleb128	78	; ref to abbrev 78
+	.section	.debug_abbrev
+	.uleb128	78
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname78:
+	.string		"SP"
+	.section	.debug_info
+	.long		.Lname78
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0030 + 0xD
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #79: variable SREG
+	.section	.debug_info
+	.uleb128	79	; ref to abbrev 79
+	.section	.debug_abbrev
+	.uleb128	79
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname79:
+	.string		"SREG"
+	.section	.debug_info
+	.long		.Lname79
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0030 + 0xF
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #80: variable CTRLA
+	.section	.debug_info
+	.uleb128	80	; ref to abbrev 80
+	.section	.debug_abbrev
+	.uleb128	80
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname80:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname80
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0110 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #81: variable STATUS
+	.section	.debug_info
+	.uleb128	81	; ref to abbrev 81
+	.section	.debug_abbrev
+	.uleb128	81
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname81:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname81
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0110 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #82: variable LVL0PRI
+	.section	.debug_info
+	.uleb128	82	; ref to abbrev 82
+	.section	.debug_abbrev
+	.uleb128	82
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname82:
+	.string		"LVL0PRI"
+	.section	.debug_info
+	.long		.Lname82
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0110 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #83: variable LVL1VEC
+	.section	.debug_info
+	.uleb128	83	; ref to abbrev 83
+	.section	.debug_abbrev
+	.uleb128	83
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname83:
+	.string		"LVL1VEC"
+	.section	.debug_info
+	.long		.Lname83
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0110 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #84: variable CTRLA
+	.section	.debug_info
+	.uleb128	84	; ref to abbrev 84
+	.section	.debug_abbrev
+	.uleb128	84
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname84:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname84
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0120 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #85: variable CTRLB
+	.section	.debug_info
+	.uleb128	85	; ref to abbrev 85
+	.section	.debug_abbrev
+	.uleb128	85
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname85:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname85
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0120 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #86: variable STATUS
+	.section	.debug_info
+	.uleb128	86	; ref to abbrev 86
+	.section	.debug_abbrev
+	.uleb128	86
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname86:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname86
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0120 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #87: variable CTRLA
+	.section	.debug_info
+	.uleb128	87	; ref to abbrev 87
+	.section	.debug_abbrev
+	.uleb128	87
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname87:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname87
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x06A0 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #88: variable DATA
+	.section	.debug_info
+	.uleb128	88	; ref to abbrev 88
+	.section	.debug_abbrev
+	.uleb128	88
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname88:
+	.string		"DATA"
+	.section	.debug_info
+	.long		.Lname88
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x06A0 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #89: variable SWEVENTA
+	.section	.debug_info
+	.uleb128	89	; ref to abbrev 89
+	.section	.debug_abbrev
+	.uleb128	89
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname89:
+	.string		"SWEVENTA"
+	.section	.debug_info
+	.long		.Lname89
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #90: variable CHANNEL0
+	.section	.debug_info
+	.uleb128	90	; ref to abbrev 90
+	.section	.debug_abbrev
+	.uleb128	90
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname90:
+	.string		"CHANNEL0"
+	.section	.debug_info
+	.long		.Lname90
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #91: variable CHANNEL1
+	.section	.debug_info
+	.uleb128	91	; ref to abbrev 91
+	.section	.debug_abbrev
+	.uleb128	91
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname91:
+	.string		"CHANNEL1"
+	.section	.debug_info
+	.long		.Lname91
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #92: variable CHANNEL2
+	.section	.debug_info
+	.uleb128	92	; ref to abbrev 92
+	.section	.debug_abbrev
+	.uleb128	92
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname92:
+	.string		"CHANNEL2"
+	.section	.debug_info
+	.long		.Lname92
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #93: variable CHANNEL3
+	.section	.debug_info
+	.uleb128	93	; ref to abbrev 93
+	.section	.debug_abbrev
+	.uleb128	93
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname93:
+	.string		"CHANNEL3"
+	.section	.debug_info
+	.long		.Lname93
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #94: variable CHANNEL4
+	.section	.debug_info
+	.uleb128	94	; ref to abbrev 94
+	.section	.debug_abbrev
+	.uleb128	94
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname94:
+	.string		"CHANNEL4"
+	.section	.debug_info
+	.long		.Lname94
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #95: variable CHANNEL5
+	.section	.debug_info
+	.uleb128	95	; ref to abbrev 95
+	.section	.debug_abbrev
+	.uleb128	95
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname95:
+	.string		"CHANNEL5"
+	.section	.debug_info
+	.long		.Lname95
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #96: variable USERCCLLUT0A
+	.section	.debug_info
+	.uleb128	96	; ref to abbrev 96
+	.section	.debug_abbrev
+	.uleb128	96
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname96:
+	.string		"USERCCLLUT0A"
+	.section	.debug_info
+	.long		.Lname96
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #97: variable USERCCLLUT0B
+	.section	.debug_info
+	.uleb128	97	; ref to abbrev 97
+	.section	.debug_abbrev
+	.uleb128	97
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname97:
+	.string		"USERCCLLUT0B"
+	.section	.debug_info
+	.long		.Lname97
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x21
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #98: variable USERCCLLUT1A
+	.section	.debug_info
+	.uleb128	98	; ref to abbrev 98
+	.section	.debug_abbrev
+	.uleb128	98
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname98:
+	.string		"USERCCLLUT1A"
+	.section	.debug_info
+	.long		.Lname98
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x22
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #99: variable USERCCLLUT1B
+	.section	.debug_info
+	.uleb128	99	; ref to abbrev 99
+	.section	.debug_abbrev
+	.uleb128	99
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname99:
+	.string		"USERCCLLUT1B"
+	.section	.debug_info
+	.long		.Lname99
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x23
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #100: variable USERCCLLUT2A
+	.section	.debug_info
+	.uleb128	100	; ref to abbrev 100
+	.section	.debug_abbrev
+	.uleb128	100
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname100:
+	.string		"USERCCLLUT2A"
+	.section	.debug_info
+	.long		.Lname100
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x24
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #101: variable USERCCLLUT2B
+	.section	.debug_info
+	.uleb128	101	; ref to abbrev 101
+	.section	.debug_abbrev
+	.uleb128	101
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname101:
+	.string		"USERCCLLUT2B"
+	.section	.debug_info
+	.long		.Lname101
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x25
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #102: variable USERCCLLUT3A
+	.section	.debug_info
+	.uleb128	102	; ref to abbrev 102
+	.section	.debug_abbrev
+	.uleb128	102
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname102:
+	.string		"USERCCLLUT3A"
+	.section	.debug_info
+	.long		.Lname102
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x26
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #103: variable USERCCLLUT3B
+	.section	.debug_info
+	.uleb128	103	; ref to abbrev 103
+	.section	.debug_abbrev
+	.uleb128	103
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname103:
+	.string		"USERCCLLUT3B"
+	.section	.debug_info
+	.long		.Lname103
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x27
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #104: variable USERADC0START
+	.section	.debug_info
+	.uleb128	104	; ref to abbrev 104
+	.section	.debug_abbrev
+	.uleb128	104
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname104:
+	.string		"USERADC0START"
+	.section	.debug_info
+	.long		.Lname104
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x28
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #105: variable USEREVSYSEVOUTA
+	.section	.debug_info
+	.uleb128	105	; ref to abbrev 105
+	.section	.debug_abbrev
+	.uleb128	105
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname105:
+	.string		"USEREVSYSEVOUTA"
+	.section	.debug_info
+	.long		.Lname105
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x29
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #106: variable USEREVSYSEVOUTB
+	.section	.debug_info
+	.uleb128	106	; ref to abbrev 106
+	.section	.debug_abbrev
+	.uleb128	106
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname106:
+	.string		"USEREVSYSEVOUTB"
+	.section	.debug_info
+	.long		.Lname106
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #107: variable USEREVSYSEVOUTC
+	.section	.debug_info
+	.uleb128	107	; ref to abbrev 107
+	.section	.debug_abbrev
+	.uleb128	107
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname107:
+	.string		"USEREVSYSEVOUTC"
+	.section	.debug_info
+	.long		.Lname107
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #108: variable USEREVSYSEVOUTD
+	.section	.debug_info
+	.uleb128	108	; ref to abbrev 108
+	.section	.debug_abbrev
+	.uleb128	108
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname108:
+	.string		"USEREVSYSEVOUTD"
+	.section	.debug_info
+	.long		.Lname108
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #109: variable USEREVSYSEVOUTE
+	.section	.debug_info
+	.uleb128	109	; ref to abbrev 109
+	.section	.debug_abbrev
+	.uleb128	109
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname109:
+	.string		"USEREVSYSEVOUTE"
+	.section	.debug_info
+	.long		.Lname109
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #110: variable USEREVSYSEVOUTF
+	.section	.debug_info
+	.uleb128	110	; ref to abbrev 110
+	.section	.debug_abbrev
+	.uleb128	110
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname110:
+	.string		"USEREVSYSEVOUTF"
+	.section	.debug_info
+	.long		.Lname110
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #111: variable USERUSART0IRDA
+	.section	.debug_info
+	.uleb128	111	; ref to abbrev 111
+	.section	.debug_abbrev
+	.uleb128	111
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname111:
+	.string		"USERUSART0IRDA"
+	.section	.debug_info
+	.long		.Lname111
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #112: variable USERUSART1IRDA
+	.section	.debug_info
+	.uleb128	112	; ref to abbrev 112
+	.section	.debug_abbrev
+	.uleb128	112
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname112:
+	.string		"USERUSART1IRDA"
+	.section	.debug_info
+	.long		.Lname112
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x30
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #113: variable USERUSART2IRDA
+	.section	.debug_info
+	.uleb128	113	; ref to abbrev 113
+	.section	.debug_abbrev
+	.uleb128	113
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname113:
+	.string		"USERUSART2IRDA"
+	.section	.debug_info
+	.long		.Lname113
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x31
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #114: variable USERTCA0CNTA
+	.section	.debug_info
+	.uleb128	114	; ref to abbrev 114
+	.section	.debug_abbrev
+	.uleb128	114
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname114:
+	.string		"USERTCA0CNTA"
+	.section	.debug_info
+	.long		.Lname114
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x32
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #115: variable USERTCA0CNTB
+	.section	.debug_info
+	.uleb128	115	; ref to abbrev 115
+	.section	.debug_abbrev
+	.uleb128	115
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname115:
+	.string		"USERTCA0CNTB"
+	.section	.debug_info
+	.long		.Lname115
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x33
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #116: variable USERTCA1CNTA
+	.section	.debug_info
+	.uleb128	116	; ref to abbrev 116
+	.section	.debug_abbrev
+	.uleb128	116
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname116:
+	.string		"USERTCA1CNTA"
+	.section	.debug_info
+	.long		.Lname116
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x34
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #117: variable USERTCA1CNTB
+	.section	.debug_info
+	.uleb128	117	; ref to abbrev 117
+	.section	.debug_abbrev
+	.uleb128	117
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname117:
+	.string		"USERTCA1CNTB"
+	.section	.debug_info
+	.long		.Lname117
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x35
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #118: variable USERTCB0CAPT
+	.section	.debug_info
+	.uleb128	118	; ref to abbrev 118
+	.section	.debug_abbrev
+	.uleb128	118
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname118:
+	.string		"USERTCB0CAPT"
+	.section	.debug_info
+	.long		.Lname118
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x36
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #119: variable USERTCB0COUNT
+	.section	.debug_info
+	.uleb128	119	; ref to abbrev 119
+	.section	.debug_abbrev
+	.uleb128	119
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname119:
+	.string		"USERTCB0COUNT"
+	.section	.debug_info
+	.long		.Lname119
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x37
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #120: variable USERTCB1CAPT
+	.section	.debug_info
+	.uleb128	120	; ref to abbrev 120
+	.section	.debug_abbrev
+	.uleb128	120
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname120:
+	.string		"USERTCB1CAPT"
+	.section	.debug_info
+	.long		.Lname120
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x38
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #121: variable USERTCB1COUNT
+	.section	.debug_info
+	.uleb128	121	; ref to abbrev 121
+	.section	.debug_abbrev
+	.uleb128	121
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname121:
+	.string		"USERTCB1COUNT"
+	.section	.debug_info
+	.long		.Lname121
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x39
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #122: variable USERTCB2CAPT
+	.section	.debug_info
+	.uleb128	122	; ref to abbrev 122
+	.section	.debug_abbrev
+	.uleb128	122
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname122:
+	.string		"USERTCB2CAPT"
+	.section	.debug_info
+	.long		.Lname122
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x3A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #123: variable USERTCB2COUNT
+	.section	.debug_info
+	.uleb128	123	; ref to abbrev 123
+	.section	.debug_abbrev
+	.uleb128	123
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname123:
+	.string		"USERTCB2COUNT"
+	.section	.debug_info
+	.long		.Lname123
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x3B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #124: variable USERTCB3CAPT
+	.section	.debug_info
+	.uleb128	124	; ref to abbrev 124
+	.section	.debug_abbrev
+	.uleb128	124
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname124:
+	.string		"USERTCB3CAPT"
+	.section	.debug_info
+	.long		.Lname124
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x3C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #125: variable USERTCB3COUNT
+	.section	.debug_info
+	.uleb128	125	; ref to abbrev 125
+	.section	.debug_abbrev
+	.uleb128	125
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname125:
+	.string		"USERTCB3COUNT"
+	.section	.debug_info
+	.long		.Lname125
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x3D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #126: variable WDTCFG
+	.section	.debug_info
+	.uleb128	126	; ref to abbrev 126
+	.section	.debug_abbrev
+	.uleb128	126
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname126:
+	.string		"WDTCFG"
+	.section	.debug_info
+	.long		.Lname126
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #127: variable BODCFG
+	.section	.debug_info
+	.uleb128	127	; ref to abbrev 127
+	.section	.debug_abbrev
+	.uleb128	127
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname127:
+	.string		"BODCFG"
+	.section	.debug_info
+	.long		.Lname127
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #128: variable OSCCFG
+	.section	.debug_info
+	.uleb128	128	; ref to abbrev 128
+	.section	.debug_abbrev
+	.uleb128	128
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname128:
+	.string		"OSCCFG"
+	.section	.debug_info
+	.long		.Lname128
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #129: variable SYSCFG0
+	.section	.debug_info
+	.uleb128	129	; ref to abbrev 129
+	.section	.debug_abbrev
+	.uleb128	129
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname129:
+	.string		"SYSCFG0"
+	.section	.debug_info
+	.long		.Lname129
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #130: variable SYSCFG1
+	.section	.debug_info
+	.uleb128	130	; ref to abbrev 130
+	.section	.debug_abbrev
+	.uleb128	130
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname130:
+	.string		"SYSCFG1"
+	.section	.debug_info
+	.long		.Lname130
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #131: variable CODESIZE
+	.section	.debug_info
+	.uleb128	131	; ref to abbrev 131
+	.section	.debug_abbrev
+	.uleb128	131
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname131:
+	.string		"CODESIZE"
+	.section	.debug_info
+	.long		.Lname131
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #132: variable BOOTSIZE
+	.section	.debug_info
+	.uleb128	132	; ref to abbrev 132
+	.section	.debug_abbrev
+	.uleb128	132
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname132:
+	.string		"BOOTSIZE"
+	.section	.debug_info
+	.long		.Lname132
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #133: variable GPR0
+	.section	.debug_info
+	.uleb128	133	; ref to abbrev 133
+	.section	.debug_abbrev
+	.uleb128	133
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname133:
+	.string		"GPR0"
+	.section	.debug_info
+	.long		.Lname133
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x001C + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #134: variable GPR1
+	.section	.debug_info
+	.uleb128	134	; ref to abbrev 134
+	.section	.debug_abbrev
+	.uleb128	134
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname134:
+	.string		"GPR1"
+	.section	.debug_info
+	.long		.Lname134
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x001C + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #135: variable GPR2
+	.section	.debug_info
+	.uleb128	135	; ref to abbrev 135
+	.section	.debug_abbrev
+	.uleb128	135
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname135:
+	.string		"GPR2"
+	.section	.debug_info
+	.long		.Lname135
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x001C + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #136: variable GPR3
+	.section	.debug_info
+	.uleb128	136	; ref to abbrev 136
+	.section	.debug_abbrev
+	.uleb128	136
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname136:
+	.string		"GPR3"
+	.section	.debug_info
+	.long		.Lname136
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x001C + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #137: variable KEY
+	.section	.debug_info
+	.uleb128	137	; ref to abbrev 137
+	.section	.debug_abbrev
+	.uleb128	137
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname137:
+	.string		"KEY"
+	.section	.debug_info
+	.long		.Lname137
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint32_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1040 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #138: variable CTRLA
+	.section	.debug_info
+	.uleb128	138	; ref to abbrev 138
+	.section	.debug_abbrev
+	.uleb128	138
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname138:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname138
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #139: variable CTRLB
+	.section	.debug_info
+	.uleb128	139	; ref to abbrev 139
+	.section	.debug_abbrev
+	.uleb128	139
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname139:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname139
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #140: variable INTCTRL
+	.section	.debug_info
+	.uleb128	140	; ref to abbrev 140
+	.section	.debug_abbrev
+	.uleb128	140
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname140:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname140
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #141: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	141	; ref to abbrev 141
+	.section	.debug_abbrev
+	.uleb128	141
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname141:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname141
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #142: variable STATUS
+	.section	.debug_info
+	.uleb128	142	; ref to abbrev 142
+	.section	.debug_abbrev
+	.uleb128	142
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname142:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname142
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #143: variable DATA
+	.section	.debug_info
+	.uleb128	143	; ref to abbrev 143
+	.section	.debug_abbrev
+	.uleb128	143
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname143:
+	.string		"DATA"
+	.section	.debug_info
+	.long		.Lname143
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #144: variable ADDR
+	.section	.debug_info
+	.uleb128	144	; ref to abbrev 144
+	.section	.debug_abbrev
+	.uleb128	144
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname144:
+	.string		"ADDR"
+	.section	.debug_info
+	.long		.Lname144
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint32_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #145: variable DIR
+	.section	.debug_info
+	.uleb128	145	; ref to abbrev 145
+	.section	.debug_abbrev
+	.uleb128	145
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname145:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname145
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #146: variable DIRSET
+	.section	.debug_info
+	.uleb128	146	; ref to abbrev 146
+	.section	.debug_abbrev
+	.uleb128	146
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname146:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname146
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #147: variable DIRCLR
+	.section	.debug_info
+	.uleb128	147	; ref to abbrev 147
+	.section	.debug_abbrev
+	.uleb128	147
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname147:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname147
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #148: variable DIRTGL
+	.section	.debug_info
+	.uleb128	148	; ref to abbrev 148
+	.section	.debug_abbrev
+	.uleb128	148
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname148:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname148
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #149: variable OUT
+	.section	.debug_info
+	.uleb128	149	; ref to abbrev 149
+	.section	.debug_abbrev
+	.uleb128	149
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname149:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname149
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #150: variable OUTSET
+	.section	.debug_info
+	.uleb128	150	; ref to abbrev 150
+	.section	.debug_abbrev
+	.uleb128	150
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname150:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname150
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #151: variable OUTCLR
+	.section	.debug_info
+	.uleb128	151	; ref to abbrev 151
+	.section	.debug_abbrev
+	.uleb128	151
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname151:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname151
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #152: variable OUTTGL
+	.section	.debug_info
+	.uleb128	152	; ref to abbrev 152
+	.section	.debug_abbrev
+	.uleb128	152
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname152:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname152
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #153: variable IN
+	.section	.debug_info
+	.uleb128	153	; ref to abbrev 153
+	.section	.debug_abbrev
+	.uleb128	153
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname153:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname153
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #154: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	154	; ref to abbrev 154
+	.section	.debug_abbrev
+	.uleb128	154
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname154:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname154
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #155: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	155	; ref to abbrev 155
+	.section	.debug_abbrev
+	.uleb128	155
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname155:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname155
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #156: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	156	; ref to abbrev 156
+	.section	.debug_abbrev
+	.uleb128	156
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname156:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname156
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #157: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	157	; ref to abbrev 157
+	.section	.debug_abbrev
+	.uleb128	157
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname157:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname157
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #158: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	158	; ref to abbrev 158
+	.section	.debug_abbrev
+	.uleb128	158
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname158:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname158
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #159: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	159	; ref to abbrev 159
+	.section	.debug_abbrev
+	.uleb128	159
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname159:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname159
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #160: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	160	; ref to abbrev 160
+	.section	.debug_abbrev
+	.uleb128	160
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname160:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname160
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #161: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	161	; ref to abbrev 161
+	.section	.debug_abbrev
+	.uleb128	161
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname161:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname161
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #162: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	162	; ref to abbrev 162
+	.section	.debug_abbrev
+	.uleb128	162
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname162:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname162
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #163: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	163	; ref to abbrev 163
+	.section	.debug_abbrev
+	.uleb128	163
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname163:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname163
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #164: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	164	; ref to abbrev 164
+	.section	.debug_abbrev
+	.uleb128	164
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname164:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname164
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #165: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	165	; ref to abbrev 165
+	.section	.debug_abbrev
+	.uleb128	165
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname165:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname165
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #166: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	166	; ref to abbrev 166
+	.section	.debug_abbrev
+	.uleb128	166
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname166:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname166
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #167: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	167	; ref to abbrev 167
+	.section	.debug_abbrev
+	.uleb128	167
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname167:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname167
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #168: variable EVGENCTRL
+	.section	.debug_info
+	.uleb128	168	; ref to abbrev 168
+	.section	.debug_abbrev
+	.uleb128	168
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname168:
+	.string		"EVGENCTRL"
+	.section	.debug_info
+	.long		.Lname168
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #169: variable DIR
+	.section	.debug_info
+	.uleb128	169	; ref to abbrev 169
+	.section	.debug_abbrev
+	.uleb128	169
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname169:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname169
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #170: variable DIRSET
+	.section	.debug_info
+	.uleb128	170	; ref to abbrev 170
+	.section	.debug_abbrev
+	.uleb128	170
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname170:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname170
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #171: variable DIRCLR
+	.section	.debug_info
+	.uleb128	171	; ref to abbrev 171
+	.section	.debug_abbrev
+	.uleb128	171
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname171:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname171
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #172: variable DIRTGL
+	.section	.debug_info
+	.uleb128	172	; ref to abbrev 172
+	.section	.debug_abbrev
+	.uleb128	172
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname172:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname172
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #173: variable OUT
+	.section	.debug_info
+	.uleb128	173	; ref to abbrev 173
+	.section	.debug_abbrev
+	.uleb128	173
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname173:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname173
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #174: variable OUTSET
+	.section	.debug_info
+	.uleb128	174	; ref to abbrev 174
+	.section	.debug_abbrev
+	.uleb128	174
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname174:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname174
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #175: variable OUTCLR
+	.section	.debug_info
+	.uleb128	175	; ref to abbrev 175
+	.section	.debug_abbrev
+	.uleb128	175
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname175:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname175
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #176: variable OUTTGL
+	.section	.debug_info
+	.uleb128	176	; ref to abbrev 176
+	.section	.debug_abbrev
+	.uleb128	176
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname176:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname176
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #177: variable IN
+	.section	.debug_info
+	.uleb128	177	; ref to abbrev 177
+	.section	.debug_abbrev
+	.uleb128	177
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname177:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname177
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #178: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	178	; ref to abbrev 178
+	.section	.debug_abbrev
+	.uleb128	178
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname178:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname178
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #179: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	179	; ref to abbrev 179
+	.section	.debug_abbrev
+	.uleb128	179
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname179:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname179
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #180: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	180	; ref to abbrev 180
+	.section	.debug_abbrev
+	.uleb128	180
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname180:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname180
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #181: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	181	; ref to abbrev 181
+	.section	.debug_abbrev
+	.uleb128	181
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname181:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname181
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #182: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	182	; ref to abbrev 182
+	.section	.debug_abbrev
+	.uleb128	182
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname182:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname182
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #183: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	183	; ref to abbrev 183
+	.section	.debug_abbrev
+	.uleb128	183
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname183:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname183
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #184: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	184	; ref to abbrev 184
+	.section	.debug_abbrev
+	.uleb128	184
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname184:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname184
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #185: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	185	; ref to abbrev 185
+	.section	.debug_abbrev
+	.uleb128	185
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname185:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname185
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #186: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	186	; ref to abbrev 186
+	.section	.debug_abbrev
+	.uleb128	186
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname186:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname186
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #187: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	187	; ref to abbrev 187
+	.section	.debug_abbrev
+	.uleb128	187
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname187:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname187
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #188: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	188	; ref to abbrev 188
+	.section	.debug_abbrev
+	.uleb128	188
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname188:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname188
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #189: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	189	; ref to abbrev 189
+	.section	.debug_abbrev
+	.uleb128	189
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname189:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname189
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #190: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	190	; ref to abbrev 190
+	.section	.debug_abbrev
+	.uleb128	190
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname190:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname190
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #191: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	191	; ref to abbrev 191
+	.section	.debug_abbrev
+	.uleb128	191
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname191:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname191
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #192: variable EVGENCTRL
+	.section	.debug_info
+	.uleb128	192	; ref to abbrev 192
+	.section	.debug_abbrev
+	.uleb128	192
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname192:
+	.string		"EVGENCTRL"
+	.section	.debug_info
+	.long		.Lname192
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #193: variable DIR
+	.section	.debug_info
+	.uleb128	193	; ref to abbrev 193
+	.section	.debug_abbrev
+	.uleb128	193
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname193:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname193
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #194: variable DIRSET
+	.section	.debug_info
+	.uleb128	194	; ref to abbrev 194
+	.section	.debug_abbrev
+	.uleb128	194
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname194:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname194
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #195: variable DIRCLR
+	.section	.debug_info
+	.uleb128	195	; ref to abbrev 195
+	.section	.debug_abbrev
+	.uleb128	195
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname195:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname195
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #196: variable DIRTGL
+	.section	.debug_info
+	.uleb128	196	; ref to abbrev 196
+	.section	.debug_abbrev
+	.uleb128	196
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname196:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname196
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #197: variable OUT
+	.section	.debug_info
+	.uleb128	197	; ref to abbrev 197
+	.section	.debug_abbrev
+	.uleb128	197
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname197:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname197
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #198: variable OUTSET
+	.section	.debug_info
+	.uleb128	198	; ref to abbrev 198
+	.section	.debug_abbrev
+	.uleb128	198
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname198:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname198
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #199: variable OUTCLR
+	.section	.debug_info
+	.uleb128	199	; ref to abbrev 199
+	.section	.debug_abbrev
+	.uleb128	199
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname199:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname199
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #200: variable OUTTGL
+	.section	.debug_info
+	.uleb128	200	; ref to abbrev 200
+	.section	.debug_abbrev
+	.uleb128	200
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname200:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname200
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #201: variable IN
+	.section	.debug_info
+	.uleb128	201	; ref to abbrev 201
+	.section	.debug_abbrev
+	.uleb128	201
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname201:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname201
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #202: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	202	; ref to abbrev 202
+	.section	.debug_abbrev
+	.uleb128	202
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname202:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname202
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #203: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	203	; ref to abbrev 203
+	.section	.debug_abbrev
+	.uleb128	203
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname203:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname203
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #204: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	204	; ref to abbrev 204
+	.section	.debug_abbrev
+	.uleb128	204
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname204:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname204
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #205: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	205	; ref to abbrev 205
+	.section	.debug_abbrev
+	.uleb128	205
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname205:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname205
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #206: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	206	; ref to abbrev 206
+	.section	.debug_abbrev
+	.uleb128	206
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname206:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname206
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #207: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	207	; ref to abbrev 207
+	.section	.debug_abbrev
+	.uleb128	207
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname207:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname207
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #208: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	208	; ref to abbrev 208
+	.section	.debug_abbrev
+	.uleb128	208
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname208:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname208
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #209: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	209	; ref to abbrev 209
+	.section	.debug_abbrev
+	.uleb128	209
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname209:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname209
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #210: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	210	; ref to abbrev 210
+	.section	.debug_abbrev
+	.uleb128	210
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname210:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname210
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #211: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	211	; ref to abbrev 211
+	.section	.debug_abbrev
+	.uleb128	211
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname211:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname211
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #212: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	212	; ref to abbrev 212
+	.section	.debug_abbrev
+	.uleb128	212
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname212:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname212
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #213: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	213	; ref to abbrev 213
+	.section	.debug_abbrev
+	.uleb128	213
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname213:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname213
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #214: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	214	; ref to abbrev 214
+	.section	.debug_abbrev
+	.uleb128	214
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname214:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname214
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #215: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	215	; ref to abbrev 215
+	.section	.debug_abbrev
+	.uleb128	215
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname215:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname215
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #216: variable EVGENCTRL
+	.section	.debug_info
+	.uleb128	216	; ref to abbrev 216
+	.section	.debug_abbrev
+	.uleb128	216
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname216:
+	.string		"EVGENCTRL"
+	.section	.debug_info
+	.long		.Lname216
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #217: variable DIR
+	.section	.debug_info
+	.uleb128	217	; ref to abbrev 217
+	.section	.debug_abbrev
+	.uleb128	217
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname217:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname217
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #218: variable DIRSET
+	.section	.debug_info
+	.uleb128	218	; ref to abbrev 218
+	.section	.debug_abbrev
+	.uleb128	218
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname218:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname218
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #219: variable DIRCLR
+	.section	.debug_info
+	.uleb128	219	; ref to abbrev 219
+	.section	.debug_abbrev
+	.uleb128	219
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname219:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname219
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #220: variable DIRTGL
+	.section	.debug_info
+	.uleb128	220	; ref to abbrev 220
+	.section	.debug_abbrev
+	.uleb128	220
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname220:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname220
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #221: variable OUT
+	.section	.debug_info
+	.uleb128	221	; ref to abbrev 221
+	.section	.debug_abbrev
+	.uleb128	221
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname221:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname221
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #222: variable OUTSET
+	.section	.debug_info
+	.uleb128	222	; ref to abbrev 222
+	.section	.debug_abbrev
+	.uleb128	222
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname222:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname222
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #223: variable OUTCLR
+	.section	.debug_info
+	.uleb128	223	; ref to abbrev 223
+	.section	.debug_abbrev
+	.uleb128	223
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname223:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname223
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #224: variable OUTTGL
+	.section	.debug_info
+	.uleb128	224	; ref to abbrev 224
+	.section	.debug_abbrev
+	.uleb128	224
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname224:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname224
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #225: variable IN
+	.section	.debug_info
+	.uleb128	225	; ref to abbrev 225
+	.section	.debug_abbrev
+	.uleb128	225
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname225:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname225
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #226: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	226	; ref to abbrev 226
+	.section	.debug_abbrev
+	.uleb128	226
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname226:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname226
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #227: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	227	; ref to abbrev 227
+	.section	.debug_abbrev
+	.uleb128	227
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname227:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname227
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #228: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	228	; ref to abbrev 228
+	.section	.debug_abbrev
+	.uleb128	228
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname228:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname228
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #229: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	229	; ref to abbrev 229
+	.section	.debug_abbrev
+	.uleb128	229
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname229:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname229
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #230: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	230	; ref to abbrev 230
+	.section	.debug_abbrev
+	.uleb128	230
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname230:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname230
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #231: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	231	; ref to abbrev 231
+	.section	.debug_abbrev
+	.uleb128	231
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname231:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname231
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #232: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	232	; ref to abbrev 232
+	.section	.debug_abbrev
+	.uleb128	232
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname232:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname232
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #233: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	233	; ref to abbrev 233
+	.section	.debug_abbrev
+	.uleb128	233
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname233:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname233
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #234: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	234	; ref to abbrev 234
+	.section	.debug_abbrev
+	.uleb128	234
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname234:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname234
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #235: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	235	; ref to abbrev 235
+	.section	.debug_abbrev
+	.uleb128	235
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname235:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname235
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #236: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	236	; ref to abbrev 236
+	.section	.debug_abbrev
+	.uleb128	236
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname236:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname236
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #237: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	237	; ref to abbrev 237
+	.section	.debug_abbrev
+	.uleb128	237
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname237:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname237
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #238: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	238	; ref to abbrev 238
+	.section	.debug_abbrev
+	.uleb128	238
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname238:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname238
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #239: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	239	; ref to abbrev 239
+	.section	.debug_abbrev
+	.uleb128	239
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname239:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname239
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #240: variable EVGENCTRL
+	.section	.debug_info
+	.uleb128	240	; ref to abbrev 240
+	.section	.debug_abbrev
+	.uleb128	240
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname240:
+	.string		"EVGENCTRL"
+	.section	.debug_info
+	.long		.Lname240
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #241: variable DIR
+	.section	.debug_info
+	.uleb128	241	; ref to abbrev 241
+	.section	.debug_abbrev
+	.uleb128	241
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname241:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname241
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #242: variable DIRSET
+	.section	.debug_info
+	.uleb128	242	; ref to abbrev 242
+	.section	.debug_abbrev
+	.uleb128	242
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname242:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname242
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #243: variable DIRCLR
+	.section	.debug_info
+	.uleb128	243	; ref to abbrev 243
+	.section	.debug_abbrev
+	.uleb128	243
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname243:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname243
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #244: variable DIRTGL
+	.section	.debug_info
+	.uleb128	244	; ref to abbrev 244
+	.section	.debug_abbrev
+	.uleb128	244
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname244:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname244
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #245: variable OUT
+	.section	.debug_info
+	.uleb128	245	; ref to abbrev 245
+	.section	.debug_abbrev
+	.uleb128	245
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname245:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname245
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #246: variable OUTSET
+	.section	.debug_info
+	.uleb128	246	; ref to abbrev 246
+	.section	.debug_abbrev
+	.uleb128	246
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname246:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname246
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #247: variable OUTCLR
+	.section	.debug_info
+	.uleb128	247	; ref to abbrev 247
+	.section	.debug_abbrev
+	.uleb128	247
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname247:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname247
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #248: variable OUTTGL
+	.section	.debug_info
+	.uleb128	248	; ref to abbrev 248
+	.section	.debug_abbrev
+	.uleb128	248
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname248:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname248
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #249: variable IN
+	.section	.debug_info
+	.uleb128	249	; ref to abbrev 249
+	.section	.debug_abbrev
+	.uleb128	249
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname249:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname249
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #250: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	250	; ref to abbrev 250
+	.section	.debug_abbrev
+	.uleb128	250
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname250:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname250
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #251: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	251	; ref to abbrev 251
+	.section	.debug_abbrev
+	.uleb128	251
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname251:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname251
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #252: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	252	; ref to abbrev 252
+	.section	.debug_abbrev
+	.uleb128	252
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname252:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname252
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #253: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	253	; ref to abbrev 253
+	.section	.debug_abbrev
+	.uleb128	253
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname253:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname253
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #254: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	254	; ref to abbrev 254
+	.section	.debug_abbrev
+	.uleb128	254
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname254:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname254
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #255: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	255	; ref to abbrev 255
+	.section	.debug_abbrev
+	.uleb128	255
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname255:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname255
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #256: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	256	; ref to abbrev 256
+	.section	.debug_abbrev
+	.uleb128	256
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname256:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname256
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #257: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	257	; ref to abbrev 257
+	.section	.debug_abbrev
+	.uleb128	257
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname257:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname257
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #258: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	258	; ref to abbrev 258
+	.section	.debug_abbrev
+	.uleb128	258
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname258:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname258
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #259: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	259	; ref to abbrev 259
+	.section	.debug_abbrev
+	.uleb128	259
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname259:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname259
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #260: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	260	; ref to abbrev 260
+	.section	.debug_abbrev
+	.uleb128	260
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname260:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname260
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #261: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	261	; ref to abbrev 261
+	.section	.debug_abbrev
+	.uleb128	261
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname261:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname261
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #262: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	262	; ref to abbrev 262
+	.section	.debug_abbrev
+	.uleb128	262
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname262:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname262
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #263: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	263	; ref to abbrev 263
+	.section	.debug_abbrev
+	.uleb128	263
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname263:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname263
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #264: variable EVGENCTRL
+	.section	.debug_info
+	.uleb128	264	; ref to abbrev 264
+	.section	.debug_abbrev
+	.uleb128	264
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname264:
+	.string		"EVGENCTRL"
+	.section	.debug_info
+	.long		.Lname264
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #265: variable DIR
+	.section	.debug_info
+	.uleb128	265	; ref to abbrev 265
+	.section	.debug_abbrev
+	.uleb128	265
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname265:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname265
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #266: variable DIRSET
+	.section	.debug_info
+	.uleb128	266	; ref to abbrev 266
+	.section	.debug_abbrev
+	.uleb128	266
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname266:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname266
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #267: variable DIRCLR
+	.section	.debug_info
+	.uleb128	267	; ref to abbrev 267
+	.section	.debug_abbrev
+	.uleb128	267
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname267:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname267
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #268: variable DIRTGL
+	.section	.debug_info
+	.uleb128	268	; ref to abbrev 268
+	.section	.debug_abbrev
+	.uleb128	268
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname268:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname268
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #269: variable OUT
+	.section	.debug_info
+	.uleb128	269	; ref to abbrev 269
+	.section	.debug_abbrev
+	.uleb128	269
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname269:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname269
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #270: variable OUTSET
+	.section	.debug_info
+	.uleb128	270	; ref to abbrev 270
+	.section	.debug_abbrev
+	.uleb128	270
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname270:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname270
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #271: variable OUTCLR
+	.section	.debug_info
+	.uleb128	271	; ref to abbrev 271
+	.section	.debug_abbrev
+	.uleb128	271
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname271:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname271
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #272: variable OUTTGL
+	.section	.debug_info
+	.uleb128	272	; ref to abbrev 272
+	.section	.debug_abbrev
+	.uleb128	272
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname272:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname272
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #273: variable IN
+	.section	.debug_info
+	.uleb128	273	; ref to abbrev 273
+	.section	.debug_abbrev
+	.uleb128	273
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname273:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname273
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #274: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	274	; ref to abbrev 274
+	.section	.debug_abbrev
+	.uleb128	274
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname274:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname274
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #275: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	275	; ref to abbrev 275
+	.section	.debug_abbrev
+	.uleb128	275
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname275:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname275
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #276: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	276	; ref to abbrev 276
+	.section	.debug_abbrev
+	.uleb128	276
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname276:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname276
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #277: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	277	; ref to abbrev 277
+	.section	.debug_abbrev
+	.uleb128	277
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname277:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname277
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #278: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	278	; ref to abbrev 278
+	.section	.debug_abbrev
+	.uleb128	278
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname278:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname278
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #279: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	279	; ref to abbrev 279
+	.section	.debug_abbrev
+	.uleb128	279
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname279:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname279
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #280: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	280	; ref to abbrev 280
+	.section	.debug_abbrev
+	.uleb128	280
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname280:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname280
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #281: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	281	; ref to abbrev 281
+	.section	.debug_abbrev
+	.uleb128	281
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname281:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname281
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #282: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	282	; ref to abbrev 282
+	.section	.debug_abbrev
+	.uleb128	282
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname282:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname282
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #283: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	283	; ref to abbrev 283
+	.section	.debug_abbrev
+	.uleb128	283
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname283:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname283
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #284: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	284	; ref to abbrev 284
+	.section	.debug_abbrev
+	.uleb128	284
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname284:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname284
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #285: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	285	; ref to abbrev 285
+	.section	.debug_abbrev
+	.uleb128	285
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname285:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname285
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #286: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	286	; ref to abbrev 286
+	.section	.debug_abbrev
+	.uleb128	286
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname286:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname286
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #287: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	287	; ref to abbrev 287
+	.section	.debug_abbrev
+	.uleb128	287
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname287:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname287
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #288: variable EVGENCTRL
+	.section	.debug_info
+	.uleb128	288	; ref to abbrev 288
+	.section	.debug_abbrev
+	.uleb128	288
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname288:
+	.string		"EVGENCTRL"
+	.section	.debug_info
+	.long		.Lname288
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #289: variable EVSYSROUTEA
+	.section	.debug_info
+	.uleb128	289	; ref to abbrev 289
+	.section	.debug_abbrev
+	.uleb128	289
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname289:
+	.string		"EVSYSROUTEA"
+	.section	.debug_info
+	.long		.Lname289
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #290: variable CCLROUTEA
+	.section	.debug_info
+	.uleb128	290	; ref to abbrev 290
+	.section	.debug_abbrev
+	.uleb128	290
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname290:
+	.string		"CCLROUTEA"
+	.section	.debug_info
+	.long		.Lname290
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #291: variable USARTROUTEA
+	.section	.debug_info
+	.uleb128	291	; ref to abbrev 291
+	.section	.debug_abbrev
+	.uleb128	291
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname291:
+	.string		"USARTROUTEA"
+	.section	.debug_info
+	.long		.Lname291
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #292: variable USARTROUTEB
+	.section	.debug_info
+	.uleb128	292	; ref to abbrev 292
+	.section	.debug_abbrev
+	.uleb128	292
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname292:
+	.string		"USARTROUTEB"
+	.section	.debug_info
+	.long		.Lname292
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #293: variable SPIROUTEA
+	.section	.debug_info
+	.uleb128	293	; ref to abbrev 293
+	.section	.debug_abbrev
+	.uleb128	293
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname293:
+	.string		"SPIROUTEA"
+	.section	.debug_info
+	.long		.Lname293
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #294: variable TWIROUTEA
+	.section	.debug_info
+	.uleb128	294	; ref to abbrev 294
+	.section	.debug_abbrev
+	.uleb128	294
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname294:
+	.string		"TWIROUTEA"
+	.section	.debug_info
+	.long		.Lname294
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #295: variable TCAROUTEA
+	.section	.debug_info
+	.uleb128	295	; ref to abbrev 295
+	.section	.debug_abbrev
+	.uleb128	295
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname295:
+	.string		"TCAROUTEA"
+	.section	.debug_info
+	.long		.Lname295
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #296: variable TCBROUTEA
+	.section	.debug_info
+	.uleb128	296	; ref to abbrev 296
+	.section	.debug_abbrev
+	.uleb128	296
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname296:
+	.string		"TCBROUTEA"
+	.section	.debug_info
+	.long		.Lname296
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #297: variable ACROUTEA
+	.section	.debug_info
+	.uleb128	297	; ref to abbrev 297
+	.section	.debug_abbrev
+	.uleb128	297
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname297:
+	.string		"ACROUTEA"
+	.section	.debug_info
+	.long		.Lname297
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #298: variable RSTFR
+	.section	.debug_info
+	.uleb128	298	; ref to abbrev 298
+	.section	.debug_abbrev
+	.uleb128	298
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname298:
+	.string		"RSTFR"
+	.section	.debug_info
+	.long		.Lname298
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0040 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #299: variable SWRR
+	.section	.debug_info
+	.uleb128	299	; ref to abbrev 299
+	.section	.debug_abbrev
+	.uleb128	299
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname299:
+	.string		"SWRR"
+	.section	.debug_info
+	.long		.Lname299
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0040 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #300: variable CTRLA
+	.section	.debug_info
+	.uleb128	300	; ref to abbrev 300
+	.section	.debug_abbrev
+	.uleb128	300
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname300:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname300
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #301: variable STATUS
+	.section	.debug_info
+	.uleb128	301	; ref to abbrev 301
+	.section	.debug_abbrev
+	.uleb128	301
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname301:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname301
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #302: variable INTCTRL
+	.section	.debug_info
+	.uleb128	302	; ref to abbrev 302
+	.section	.debug_abbrev
+	.uleb128	302
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname302:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname302
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #303: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	303	; ref to abbrev 303
+	.section	.debug_abbrev
+	.uleb128	303
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname303:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname303
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #304: variable TEMP
+	.section	.debug_info
+	.uleb128	304	; ref to abbrev 304
+	.section	.debug_abbrev
+	.uleb128	304
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname304:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname304
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #305: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	305	; ref to abbrev 305
+	.section	.debug_abbrev
+	.uleb128	305
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname305:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname305
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #306: variable CALIB
+	.section	.debug_info
+	.uleb128	306	; ref to abbrev 306
+	.section	.debug_abbrev
+	.uleb128	306
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname306:
+	.string		"CALIB"
+	.section	.debug_info
+	.long		.Lname306
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #307: variable CLKSEL
+	.section	.debug_info
+	.uleb128	307	; ref to abbrev 307
+	.section	.debug_abbrev
+	.uleb128	307
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname307:
+	.string		"CLKSEL"
+	.section	.debug_info
+	.long		.Lname307
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #308: variable CNT
+	.section	.debug_info
+	.uleb128	308	; ref to abbrev 308
+	.section	.debug_abbrev
+	.uleb128	308
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname308:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname308
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #309: variable PER
+	.section	.debug_info
+	.uleb128	309	; ref to abbrev 309
+	.section	.debug_abbrev
+	.uleb128	309
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname309:
+	.string		"PER"
+	.section	.debug_info
+	.long		.Lname309
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #310: variable CMP
+	.section	.debug_info
+	.uleb128	310	; ref to abbrev 310
+	.section	.debug_abbrev
+	.uleb128	310
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname310:
+	.string		"CMP"
+	.section	.debug_info
+	.long		.Lname310
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #311: variable PITCTRLA
+	.section	.debug_info
+	.uleb128	311	; ref to abbrev 311
+	.section	.debug_abbrev
+	.uleb128	311
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname311:
+	.string		"PITCTRLA"
+	.section	.debug_info
+	.long		.Lname311
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #312: variable PITSTATUS
+	.section	.debug_info
+	.uleb128	312	; ref to abbrev 312
+	.section	.debug_abbrev
+	.uleb128	312
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname312:
+	.string		"PITSTATUS"
+	.section	.debug_info
+	.long		.Lname312
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #313: variable PITINTCTRL
+	.section	.debug_info
+	.uleb128	313	; ref to abbrev 313
+	.section	.debug_abbrev
+	.uleb128	313
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname313:
+	.string		"PITINTCTRL"
+	.section	.debug_info
+	.long		.Lname313
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #314: variable PITINTFLAGS
+	.section	.debug_info
+	.uleb128	314	; ref to abbrev 314
+	.section	.debug_abbrev
+	.uleb128	314
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname314:
+	.string		"PITINTFLAGS"
+	.section	.debug_info
+	.long		.Lname314
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #315: variable PITDBGCTRL
+	.section	.debug_info
+	.uleb128	315	; ref to abbrev 315
+	.section	.debug_abbrev
+	.uleb128	315
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname315:
+	.string		"PITDBGCTRL"
+	.section	.debug_info
+	.long		.Lname315
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #316: variable PITEVGENCTRLA
+	.section	.debug_info
+	.uleb128	316	; ref to abbrev 316
+	.section	.debug_abbrev
+	.uleb128	316
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname316:
+	.string		"PITEVGENCTRLA"
+	.section	.debug_info
+	.long		.Lname316
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #317: variable DEVICEID0
+	.section	.debug_info
+	.uleb128	317	; ref to abbrev 317
+	.section	.debug_abbrev
+	.uleb128	317
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname317:
+	.string		"DEVICEID0"
+	.section	.debug_info
+	.long		.Lname317
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #318: variable DEVICEID1
+	.section	.debug_info
+	.uleb128	318	; ref to abbrev 318
+	.section	.debug_abbrev
+	.uleb128	318
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname318:
+	.string		"DEVICEID1"
+	.section	.debug_info
+	.long		.Lname318
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #319: variable DEVICEID2
+	.section	.debug_info
+	.uleb128	319	; ref to abbrev 319
+	.section	.debug_abbrev
+	.uleb128	319
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname319:
+	.string		"DEVICEID2"
+	.section	.debug_info
+	.long		.Lname319
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #320: variable TEMPSENSE0
+	.section	.debug_info
+	.uleb128	320	; ref to abbrev 320
+	.section	.debug_abbrev
+	.uleb128	320
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname320:
+	.string		"TEMPSENSE0"
+	.section	.debug_info
+	.long		.Lname320
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #321: variable TEMPSENSE1
+	.section	.debug_info
+	.uleb128	321	; ref to abbrev 321
+	.section	.debug_abbrev
+	.uleb128	321
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname321:
+	.string		"TEMPSENSE1"
+	.section	.debug_info
+	.long		.Lname321
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #322: variable SERNUM0
+	.section	.debug_info
+	.uleb128	322	; ref to abbrev 322
+	.section	.debug_abbrev
+	.uleb128	322
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname322:
+	.string		"SERNUM0"
+	.section	.debug_info
+	.long		.Lname322
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #323: variable SERNUM1
+	.section	.debug_info
+	.uleb128	323	; ref to abbrev 323
+	.section	.debug_abbrev
+	.uleb128	323
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname323:
+	.string		"SERNUM1"
+	.section	.debug_info
+	.long		.Lname323
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #324: variable SERNUM2
+	.section	.debug_info
+	.uleb128	324	; ref to abbrev 324
+	.section	.debug_abbrev
+	.uleb128	324
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname324:
+	.string		"SERNUM2"
+	.section	.debug_info
+	.long		.Lname324
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #325: variable SERNUM3
+	.section	.debug_info
+	.uleb128	325	; ref to abbrev 325
+	.section	.debug_abbrev
+	.uleb128	325
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname325:
+	.string		"SERNUM3"
+	.section	.debug_info
+	.long		.Lname325
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #326: variable SERNUM4
+	.section	.debug_info
+	.uleb128	326	; ref to abbrev 326
+	.section	.debug_abbrev
+	.uleb128	326
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname326:
+	.string		"SERNUM4"
+	.section	.debug_info
+	.long		.Lname326
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #327: variable SERNUM5
+	.section	.debug_info
+	.uleb128	327	; ref to abbrev 327
+	.section	.debug_abbrev
+	.uleb128	327
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname327:
+	.string		"SERNUM5"
+	.section	.debug_info
+	.long		.Lname327
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #328: variable SERNUM6
+	.section	.debug_info
+	.uleb128	328	; ref to abbrev 328
+	.section	.debug_abbrev
+	.uleb128	328
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname328:
+	.string		"SERNUM6"
+	.section	.debug_info
+	.long		.Lname328
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #329: variable SERNUM7
+	.section	.debug_info
+	.uleb128	329	; ref to abbrev 329
+	.section	.debug_abbrev
+	.uleb128	329
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname329:
+	.string		"SERNUM7"
+	.section	.debug_info
+	.long		.Lname329
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #330: variable SERNUM8
+	.section	.debug_info
+	.uleb128	330	; ref to abbrev 330
+	.section	.debug_abbrev
+	.uleb128	330
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname330:
+	.string		"SERNUM8"
+	.section	.debug_info
+	.long		.Lname330
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #331: variable SERNUM9
+	.section	.debug_info
+	.uleb128	331	; ref to abbrev 331
+	.section	.debug_abbrev
+	.uleb128	331
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname331:
+	.string		"SERNUM9"
+	.section	.debug_info
+	.long		.Lname331
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x19
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #332: variable SERNUM10
+	.section	.debug_info
+	.uleb128	332	; ref to abbrev 332
+	.section	.debug_abbrev
+	.uleb128	332
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname332:
+	.string		"SERNUM10"
+	.section	.debug_info
+	.long		.Lname332
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x1A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #333: variable SERNUM11
+	.section	.debug_info
+	.uleb128	333	; ref to abbrev 333
+	.section	.debug_abbrev
+	.uleb128	333
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname333:
+	.string		"SERNUM11"
+	.section	.debug_info
+	.long		.Lname333
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x1B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #334: variable SERNUM12
+	.section	.debug_info
+	.uleb128	334	; ref to abbrev 334
+	.section	.debug_abbrev
+	.uleb128	334
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname334:
+	.string		"SERNUM12"
+	.section	.debug_info
+	.long		.Lname334
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x1C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #335: variable SERNUM13
+	.section	.debug_info
+	.uleb128	335	; ref to abbrev 335
+	.section	.debug_abbrev
+	.uleb128	335
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname335:
+	.string		"SERNUM13"
+	.section	.debug_info
+	.long		.Lname335
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x1D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #336: variable SERNUM14
+	.section	.debug_info
+	.uleb128	336	; ref to abbrev 336
+	.section	.debug_abbrev
+	.uleb128	336
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname336:
+	.string		"SERNUM14"
+	.section	.debug_info
+	.long		.Lname336
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x1E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #337: variable SERNUM15
+	.section	.debug_info
+	.uleb128	337	; ref to abbrev 337
+	.section	.debug_abbrev
+	.uleb128	337
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname337:
+	.string		"SERNUM15"
+	.section	.debug_info
+	.long		.Lname337
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x1F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #338: variable CTRLA
+	.section	.debug_info
+	.uleb128	338	; ref to abbrev 338
+	.section	.debug_abbrev
+	.uleb128	338
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname338:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname338
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0050 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #339: variable CTRLA
+	.section	.debug_info
+	.uleb128	339	; ref to abbrev 339
+	.section	.debug_abbrev
+	.uleb128	339
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname339:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname339
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #340: variable CTRLB
+	.section	.debug_info
+	.uleb128	340	; ref to abbrev 340
+	.section	.debug_abbrev
+	.uleb128	340
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname340:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname340
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #341: variable INTCTRL
+	.section	.debug_info
+	.uleb128	341	; ref to abbrev 341
+	.section	.debug_abbrev
+	.uleb128	341
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname341:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname341
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #342: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	342	; ref to abbrev 342
+	.section	.debug_abbrev
+	.uleb128	342
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname342:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname342
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #343: variable DATA
+	.section	.debug_info
+	.uleb128	343	; ref to abbrev 343
+	.section	.debug_abbrev
+	.uleb128	343
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname343:
+	.string		"DATA"
+	.section	.debug_info
+	.long		.Lname343
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #344: variable REVID
+	.section	.debug_info
+	.uleb128	344	; ref to abbrev 344
+	.section	.debug_abbrev
+	.uleb128	344
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname344:
+	.string		"REVID"
+	.section	.debug_info
+	.long		.Lname344
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0F00 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #345: variable OCDMCTRL
+	.section	.debug_info
+	.uleb128	345	; ref to abbrev 345
+	.section	.debug_abbrev
+	.uleb128	345
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname345:
+	.string		"OCDMCTRL"
+	.section	.debug_info
+	.long		.Lname345
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0F00 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #346: variable OCDMSTATUS
+	.section	.debug_info
+	.uleb128	346	; ref to abbrev 346
+	.section	.debug_abbrev
+	.uleb128	346
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname346:
+	.string		"OCDMSTATUS"
+	.section	.debug_info
+	.long		.Lname346
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0F00 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #347: variable CTRLA
+	.section	.debug_info
+	.uleb128	347	; ref to abbrev 347
+	.section	.debug_abbrev
+	.uleb128	347
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname347:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname347
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #348: variable CTRLB
+	.section	.debug_info
+	.uleb128	348	; ref to abbrev 348
+	.section	.debug_abbrev
+	.uleb128	348
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname348:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname348
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #349: variable CTRLC
+	.section	.debug_info
+	.uleb128	349	; ref to abbrev 349
+	.section	.debug_abbrev
+	.uleb128	349
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname349:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname349
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #350: variable CTRLD
+	.section	.debug_info
+	.uleb128	350	; ref to abbrev 350
+	.section	.debug_abbrev
+	.uleb128	350
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname350:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname350
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #351: variable CTRLECLR
+	.section	.debug_info
+	.uleb128	351	; ref to abbrev 351
+	.section	.debug_abbrev
+	.uleb128	351
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname351:
+	.string		"CTRLECLR"
+	.section	.debug_info
+	.long		.Lname351
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #352: variable CTRLESET
+	.section	.debug_info
+	.uleb128	352	; ref to abbrev 352
+	.section	.debug_abbrev
+	.uleb128	352
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname352:
+	.string		"CTRLESET"
+	.section	.debug_info
+	.long		.Lname352
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #353: variable CTRLFCLR
+	.section	.debug_info
+	.uleb128	353	; ref to abbrev 353
+	.section	.debug_abbrev
+	.uleb128	353
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname353:
+	.string		"CTRLFCLR"
+	.section	.debug_info
+	.long		.Lname353
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #354: variable CTRLFSET
+	.section	.debug_info
+	.uleb128	354	; ref to abbrev 354
+	.section	.debug_abbrev
+	.uleb128	354
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname354:
+	.string		"CTRLFSET"
+	.section	.debug_info
+	.long		.Lname354
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #355: variable EVCTRL
+	.section	.debug_info
+	.uleb128	355	; ref to abbrev 355
+	.section	.debug_abbrev
+	.uleb128	355
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname355:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname355
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #356: variable INTCTRL
+	.section	.debug_info
+	.uleb128	356	; ref to abbrev 356
+	.section	.debug_abbrev
+	.uleb128	356
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname356:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname356
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #357: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	357	; ref to abbrev 357
+	.section	.debug_abbrev
+	.uleb128	357
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname357:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname357
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #358: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	358	; ref to abbrev 358
+	.section	.debug_abbrev
+	.uleb128	358
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname358:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname358
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #359: variable TEMP
+	.section	.debug_info
+	.uleb128	359	; ref to abbrev 359
+	.section	.debug_abbrev
+	.uleb128	359
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname359:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname359
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #360: variable CNT
+	.section	.debug_info
+	.uleb128	360	; ref to abbrev 360
+	.section	.debug_abbrev
+	.uleb128	360
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname360:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname360
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #361: variable PER
+	.section	.debug_info
+	.uleb128	361	; ref to abbrev 361
+	.section	.debug_abbrev
+	.uleb128	361
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname361:
+	.string		"PER"
+	.section	.debug_info
+	.long		.Lname361
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x26
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #362: variable CMP0
+	.section	.debug_info
+	.uleb128	362	; ref to abbrev 362
+	.section	.debug_abbrev
+	.uleb128	362
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname362:
+	.string		"CMP0"
+	.section	.debug_info
+	.long		.Lname362
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x28
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #363: variable CMP1
+	.section	.debug_info
+	.uleb128	363	; ref to abbrev 363
+	.section	.debug_abbrev
+	.uleb128	363
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname363:
+	.string		"CMP1"
+	.section	.debug_info
+	.long		.Lname363
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #364: variable CMP2
+	.section	.debug_info
+	.uleb128	364	; ref to abbrev 364
+	.section	.debug_abbrev
+	.uleb128	364
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname364:
+	.string		"CMP2"
+	.section	.debug_info
+	.long		.Lname364
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #365: variable PERBUF
+	.section	.debug_info
+	.uleb128	365	; ref to abbrev 365
+	.section	.debug_abbrev
+	.uleb128	365
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname365:
+	.string		"PERBUF"
+	.section	.debug_info
+	.long		.Lname365
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x36
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #366: variable CMP0BUF
+	.section	.debug_info
+	.uleb128	366	; ref to abbrev 366
+	.section	.debug_abbrev
+	.uleb128	366
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname366:
+	.string		"CMP0BUF"
+	.section	.debug_info
+	.long		.Lname366
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x38
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #367: variable CMP1BUF
+	.section	.debug_info
+	.uleb128	367	; ref to abbrev 367
+	.section	.debug_abbrev
+	.uleb128	367
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname367:
+	.string		"CMP1BUF"
+	.section	.debug_info
+	.long		.Lname367
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x3A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #368: variable CMP2BUF
+	.section	.debug_info
+	.uleb128	368	; ref to abbrev 368
+	.section	.debug_abbrev
+	.uleb128	368
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname368:
+	.string		"CMP2BUF"
+	.section	.debug_info
+	.long		.Lname368
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x3C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #369: variable CTRLA
+	.section	.debug_info
+	.uleb128	369	; ref to abbrev 369
+	.section	.debug_abbrev
+	.uleb128	369
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname369:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname369
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #370: variable CTRLB
+	.section	.debug_info
+	.uleb128	370	; ref to abbrev 370
+	.section	.debug_abbrev
+	.uleb128	370
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname370:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname370
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #371: variable CTRLC
+	.section	.debug_info
+	.uleb128	371	; ref to abbrev 371
+	.section	.debug_abbrev
+	.uleb128	371
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname371:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname371
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #372: variable CTRLD
+	.section	.debug_info
+	.uleb128	372	; ref to abbrev 372
+	.section	.debug_abbrev
+	.uleb128	372
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname372:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname372
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #373: variable CTRLECLR
+	.section	.debug_info
+	.uleb128	373	; ref to abbrev 373
+	.section	.debug_abbrev
+	.uleb128	373
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname373:
+	.string		"CTRLECLR"
+	.section	.debug_info
+	.long		.Lname373
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #374: variable CTRLESET
+	.section	.debug_info
+	.uleb128	374	; ref to abbrev 374
+	.section	.debug_abbrev
+	.uleb128	374
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname374:
+	.string		"CTRLESET"
+	.section	.debug_info
+	.long		.Lname374
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #375: variable INTCTRL
+	.section	.debug_info
+	.uleb128	375	; ref to abbrev 375
+	.section	.debug_abbrev
+	.uleb128	375
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname375:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname375
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #376: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	376	; ref to abbrev 376
+	.section	.debug_abbrev
+	.uleb128	376
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname376:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname376
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #377: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	377	; ref to abbrev 377
+	.section	.debug_abbrev
+	.uleb128	377
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname377:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname377
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #378: variable LCNT
+	.section	.debug_info
+	.uleb128	378	; ref to abbrev 378
+	.section	.debug_abbrev
+	.uleb128	378
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname378:
+	.string		"LCNT"
+	.section	.debug_info
+	.long		.Lname378
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #379: variable HCNT
+	.section	.debug_info
+	.uleb128	379	; ref to abbrev 379
+	.section	.debug_abbrev
+	.uleb128	379
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname379:
+	.string		"HCNT"
+	.section	.debug_info
+	.long		.Lname379
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x21
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #380: variable LPER
+	.section	.debug_info
+	.uleb128	380	; ref to abbrev 380
+	.section	.debug_abbrev
+	.uleb128	380
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname380:
+	.string		"LPER"
+	.section	.debug_info
+	.long		.Lname380
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x26
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #381: variable HPER
+	.section	.debug_info
+	.uleb128	381	; ref to abbrev 381
+	.section	.debug_abbrev
+	.uleb128	381
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname381:
+	.string		"HPER"
+	.section	.debug_info
+	.long		.Lname381
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x27
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #382: variable LCMP0
+	.section	.debug_info
+	.uleb128	382	; ref to abbrev 382
+	.section	.debug_abbrev
+	.uleb128	382
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname382:
+	.string		"LCMP0"
+	.section	.debug_info
+	.long		.Lname382
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x28
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #383: variable HCMP0
+	.section	.debug_info
+	.uleb128	383	; ref to abbrev 383
+	.section	.debug_abbrev
+	.uleb128	383
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname383:
+	.string		"HCMP0"
+	.section	.debug_info
+	.long		.Lname383
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x29
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #384: variable LCMP1
+	.section	.debug_info
+	.uleb128	384	; ref to abbrev 384
+	.section	.debug_abbrev
+	.uleb128	384
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname384:
+	.string		"LCMP1"
+	.section	.debug_info
+	.long		.Lname384
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #385: variable HCMP1
+	.section	.debug_info
+	.uleb128	385	; ref to abbrev 385
+	.section	.debug_abbrev
+	.uleb128	385
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname385:
+	.string		"HCMP1"
+	.section	.debug_info
+	.long		.Lname385
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #386: variable LCMP2
+	.section	.debug_info
+	.uleb128	386	; ref to abbrev 386
+	.section	.debug_abbrev
+	.uleb128	386
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname386:
+	.string		"LCMP2"
+	.section	.debug_info
+	.long		.Lname386
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #387: variable HCMP2
+	.section	.debug_info
+	.uleb128	387	; ref to abbrev 387
+	.section	.debug_abbrev
+	.uleb128	387
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname387:
+	.string		"HCMP2"
+	.section	.debug_info
+	.long		.Lname387
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #388: variable CTRLA
+	.section	.debug_info
+	.uleb128	388	; ref to abbrev 388
+	.section	.debug_abbrev
+	.uleb128	388
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname388:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname388
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #389: variable CTRLB
+	.section	.debug_info
+	.uleb128	389	; ref to abbrev 389
+	.section	.debug_abbrev
+	.uleb128	389
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname389:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname389
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #390: variable CTRLC
+	.section	.debug_info
+	.uleb128	390	; ref to abbrev 390
+	.section	.debug_abbrev
+	.uleb128	390
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname390:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname390
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #391: variable CTRLD
+	.section	.debug_info
+	.uleb128	391	; ref to abbrev 391
+	.section	.debug_abbrev
+	.uleb128	391
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname391:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname391
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #392: variable CTRLECLR
+	.section	.debug_info
+	.uleb128	392	; ref to abbrev 392
+	.section	.debug_abbrev
+	.uleb128	392
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname392:
+	.string		"CTRLECLR"
+	.section	.debug_info
+	.long		.Lname392
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #393: variable CTRLESET
+	.section	.debug_info
+	.uleb128	393	; ref to abbrev 393
+	.section	.debug_abbrev
+	.uleb128	393
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname393:
+	.string		"CTRLESET"
+	.section	.debug_info
+	.long		.Lname393
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #394: variable CTRLFCLR
+	.section	.debug_info
+	.uleb128	394	; ref to abbrev 394
+	.section	.debug_abbrev
+	.uleb128	394
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname394:
+	.string		"CTRLFCLR"
+	.section	.debug_info
+	.long		.Lname394
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #395: variable CTRLFSET
+	.section	.debug_info
+	.uleb128	395	; ref to abbrev 395
+	.section	.debug_abbrev
+	.uleb128	395
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname395:
+	.string		"CTRLFSET"
+	.section	.debug_info
+	.long		.Lname395
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #396: variable EVCTRL
+	.section	.debug_info
+	.uleb128	396	; ref to abbrev 396
+	.section	.debug_abbrev
+	.uleb128	396
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname396:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname396
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #397: variable INTCTRL
+	.section	.debug_info
+	.uleb128	397	; ref to abbrev 397
+	.section	.debug_abbrev
+	.uleb128	397
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname397:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname397
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #398: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	398	; ref to abbrev 398
+	.section	.debug_abbrev
+	.uleb128	398
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname398:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname398
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #399: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	399	; ref to abbrev 399
+	.section	.debug_abbrev
+	.uleb128	399
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname399:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname399
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #400: variable TEMP
+	.section	.debug_info
+	.uleb128	400	; ref to abbrev 400
+	.section	.debug_abbrev
+	.uleb128	400
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname400:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname400
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x0F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #401: variable CNT
+	.section	.debug_info
+	.uleb128	401	; ref to abbrev 401
+	.section	.debug_abbrev
+	.uleb128	401
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname401:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname401
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #402: variable PER
+	.section	.debug_info
+	.uleb128	402	; ref to abbrev 402
+	.section	.debug_abbrev
+	.uleb128	402
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname402:
+	.string		"PER"
+	.section	.debug_info
+	.long		.Lname402
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x26
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #403: variable CMP0
+	.section	.debug_info
+	.uleb128	403	; ref to abbrev 403
+	.section	.debug_abbrev
+	.uleb128	403
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname403:
+	.string		"CMP0"
+	.section	.debug_info
+	.long		.Lname403
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x28
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #404: variable CMP1
+	.section	.debug_info
+	.uleb128	404	; ref to abbrev 404
+	.section	.debug_abbrev
+	.uleb128	404
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname404:
+	.string		"CMP1"
+	.section	.debug_info
+	.long		.Lname404
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x2A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #405: variable CMP2
+	.section	.debug_info
+	.uleb128	405	; ref to abbrev 405
+	.section	.debug_abbrev
+	.uleb128	405
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname405:
+	.string		"CMP2"
+	.section	.debug_info
+	.long		.Lname405
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x2C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #406: variable PERBUF
+	.section	.debug_info
+	.uleb128	406	; ref to abbrev 406
+	.section	.debug_abbrev
+	.uleb128	406
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname406:
+	.string		"PERBUF"
+	.section	.debug_info
+	.long		.Lname406
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x36
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #407: variable CMP0BUF
+	.section	.debug_info
+	.uleb128	407	; ref to abbrev 407
+	.section	.debug_abbrev
+	.uleb128	407
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname407:
+	.string		"CMP0BUF"
+	.section	.debug_info
+	.long		.Lname407
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x38
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #408: variable CMP1BUF
+	.section	.debug_info
+	.uleb128	408	; ref to abbrev 408
+	.section	.debug_abbrev
+	.uleb128	408
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname408:
+	.string		"CMP1BUF"
+	.section	.debug_info
+	.long		.Lname408
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x3A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #409: variable CMP2BUF
+	.section	.debug_info
+	.uleb128	409	; ref to abbrev 409
+	.section	.debug_abbrev
+	.uleb128	409
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname409:
+	.string		"CMP2BUF"
+	.section	.debug_info
+	.long		.Lname409
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x3C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #410: variable CTRLA
+	.section	.debug_info
+	.uleb128	410	; ref to abbrev 410
+	.section	.debug_abbrev
+	.uleb128	410
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname410:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname410
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #411: variable CTRLB
+	.section	.debug_info
+	.uleb128	411	; ref to abbrev 411
+	.section	.debug_abbrev
+	.uleb128	411
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname411:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname411
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #412: variable CTRLC
+	.section	.debug_info
+	.uleb128	412	; ref to abbrev 412
+	.section	.debug_abbrev
+	.uleb128	412
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname412:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname412
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #413: variable CTRLD
+	.section	.debug_info
+	.uleb128	413	; ref to abbrev 413
+	.section	.debug_abbrev
+	.uleb128	413
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname413:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname413
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #414: variable CTRLECLR
+	.section	.debug_info
+	.uleb128	414	; ref to abbrev 414
+	.section	.debug_abbrev
+	.uleb128	414
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname414:
+	.string		"CTRLECLR"
+	.section	.debug_info
+	.long		.Lname414
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #415: variable CTRLESET
+	.section	.debug_info
+	.uleb128	415	; ref to abbrev 415
+	.section	.debug_abbrev
+	.uleb128	415
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname415:
+	.string		"CTRLESET"
+	.section	.debug_info
+	.long		.Lname415
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #416: variable INTCTRL
+	.section	.debug_info
+	.uleb128	416	; ref to abbrev 416
+	.section	.debug_abbrev
+	.uleb128	416
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname416:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname416
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #417: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	417	; ref to abbrev 417
+	.section	.debug_abbrev
+	.uleb128	417
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname417:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname417
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #418: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	418	; ref to abbrev 418
+	.section	.debug_abbrev
+	.uleb128	418
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname418:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname418
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #419: variable LCNT
+	.section	.debug_info
+	.uleb128	419	; ref to abbrev 419
+	.section	.debug_abbrev
+	.uleb128	419
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname419:
+	.string		"LCNT"
+	.section	.debug_info
+	.long		.Lname419
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #420: variable HCNT
+	.section	.debug_info
+	.uleb128	420	; ref to abbrev 420
+	.section	.debug_abbrev
+	.uleb128	420
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname420:
+	.string		"HCNT"
+	.section	.debug_info
+	.long		.Lname420
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x21
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #421: variable LPER
+	.section	.debug_info
+	.uleb128	421	; ref to abbrev 421
+	.section	.debug_abbrev
+	.uleb128	421
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname421:
+	.string		"LPER"
+	.section	.debug_info
+	.long		.Lname421
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x26
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #422: variable HPER
+	.section	.debug_info
+	.uleb128	422	; ref to abbrev 422
+	.section	.debug_abbrev
+	.uleb128	422
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname422:
+	.string		"HPER"
+	.section	.debug_info
+	.long		.Lname422
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x27
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #423: variable LCMP0
+	.section	.debug_info
+	.uleb128	423	; ref to abbrev 423
+	.section	.debug_abbrev
+	.uleb128	423
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname423:
+	.string		"LCMP0"
+	.section	.debug_info
+	.long		.Lname423
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x28
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #424: variable HCMP0
+	.section	.debug_info
+	.uleb128	424	; ref to abbrev 424
+	.section	.debug_abbrev
+	.uleb128	424
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname424:
+	.string		"HCMP0"
+	.section	.debug_info
+	.long		.Lname424
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x29
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #425: variable LCMP1
+	.section	.debug_info
+	.uleb128	425	; ref to abbrev 425
+	.section	.debug_abbrev
+	.uleb128	425
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname425:
+	.string		"LCMP1"
+	.section	.debug_info
+	.long		.Lname425
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x2A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #426: variable HCMP1
+	.section	.debug_info
+	.uleb128	426	; ref to abbrev 426
+	.section	.debug_abbrev
+	.uleb128	426
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname426:
+	.string		"HCMP1"
+	.section	.debug_info
+	.long		.Lname426
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x2B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #427: variable LCMP2
+	.section	.debug_info
+	.uleb128	427	; ref to abbrev 427
+	.section	.debug_abbrev
+	.uleb128	427
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname427:
+	.string		"LCMP2"
+	.section	.debug_info
+	.long		.Lname427
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x2C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #428: variable HCMP2
+	.section	.debug_info
+	.uleb128	428	; ref to abbrev 428
+	.section	.debug_abbrev
+	.uleb128	428
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname428:
+	.string		"HCMP2"
+	.section	.debug_info
+	.long		.Lname428
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x2D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #429: variable CTRLA
+	.section	.debug_info
+	.uleb128	429	; ref to abbrev 429
+	.section	.debug_abbrev
+	.uleb128	429
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname429:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname429
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #430: variable CTRLB
+	.section	.debug_info
+	.uleb128	430	; ref to abbrev 430
+	.section	.debug_abbrev
+	.uleb128	430
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname430:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname430
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #431: variable EVCTRL
+	.section	.debug_info
+	.uleb128	431	; ref to abbrev 431
+	.section	.debug_abbrev
+	.uleb128	431
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname431:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname431
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #432: variable INTCTRL
+	.section	.debug_info
+	.uleb128	432	; ref to abbrev 432
+	.section	.debug_abbrev
+	.uleb128	432
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname432:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname432
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #433: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	433	; ref to abbrev 433
+	.section	.debug_abbrev
+	.uleb128	433
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname433:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname433
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #434: variable STATUS
+	.section	.debug_info
+	.uleb128	434	; ref to abbrev 434
+	.section	.debug_abbrev
+	.uleb128	434
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname434:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname434
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #435: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	435	; ref to abbrev 435
+	.section	.debug_abbrev
+	.uleb128	435
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname435:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname435
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #436: variable TEMP
+	.section	.debug_info
+	.uleb128	436	; ref to abbrev 436
+	.section	.debug_abbrev
+	.uleb128	436
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname436:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname436
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #437: variable CNT
+	.section	.debug_info
+	.uleb128	437	; ref to abbrev 437
+	.section	.debug_abbrev
+	.uleb128	437
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname437:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname437
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #438: variable CCMP
+	.section	.debug_info
+	.uleb128	438	; ref to abbrev 438
+	.section	.debug_abbrev
+	.uleb128	438
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname438:
+	.string		"CCMP"
+	.section	.debug_info
+	.long		.Lname438
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #439: variable CTRLA
+	.section	.debug_info
+	.uleb128	439	; ref to abbrev 439
+	.section	.debug_abbrev
+	.uleb128	439
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname439:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname439
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #440: variable CTRLB
+	.section	.debug_info
+	.uleb128	440	; ref to abbrev 440
+	.section	.debug_abbrev
+	.uleb128	440
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname440:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname440
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #441: variable EVCTRL
+	.section	.debug_info
+	.uleb128	441	; ref to abbrev 441
+	.section	.debug_abbrev
+	.uleb128	441
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname441:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname441
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #442: variable INTCTRL
+	.section	.debug_info
+	.uleb128	442	; ref to abbrev 442
+	.section	.debug_abbrev
+	.uleb128	442
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname442:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname442
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #443: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	443	; ref to abbrev 443
+	.section	.debug_abbrev
+	.uleb128	443
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname443:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname443
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #444: variable STATUS
+	.section	.debug_info
+	.uleb128	444	; ref to abbrev 444
+	.section	.debug_abbrev
+	.uleb128	444
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname444:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname444
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #445: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	445	; ref to abbrev 445
+	.section	.debug_abbrev
+	.uleb128	445
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname445:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname445
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #446: variable TEMP
+	.section	.debug_info
+	.uleb128	446	; ref to abbrev 446
+	.section	.debug_abbrev
+	.uleb128	446
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname446:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname446
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #447: variable CNT
+	.section	.debug_info
+	.uleb128	447	; ref to abbrev 447
+	.section	.debug_abbrev
+	.uleb128	447
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname447:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname447
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #448: variable CCMP
+	.section	.debug_info
+	.uleb128	448	; ref to abbrev 448
+	.section	.debug_abbrev
+	.uleb128	448
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname448:
+	.string		"CCMP"
+	.section	.debug_info
+	.long		.Lname448
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #449: variable CTRLA
+	.section	.debug_info
+	.uleb128	449	; ref to abbrev 449
+	.section	.debug_abbrev
+	.uleb128	449
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname449:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname449
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #450: variable CTRLB
+	.section	.debug_info
+	.uleb128	450	; ref to abbrev 450
+	.section	.debug_abbrev
+	.uleb128	450
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname450:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname450
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #451: variable EVCTRL
+	.section	.debug_info
+	.uleb128	451	; ref to abbrev 451
+	.section	.debug_abbrev
+	.uleb128	451
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname451:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname451
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #452: variable INTCTRL
+	.section	.debug_info
+	.uleb128	452	; ref to abbrev 452
+	.section	.debug_abbrev
+	.uleb128	452
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname452:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname452
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #453: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	453	; ref to abbrev 453
+	.section	.debug_abbrev
+	.uleb128	453
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname453:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname453
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #454: variable STATUS
+	.section	.debug_info
+	.uleb128	454	; ref to abbrev 454
+	.section	.debug_abbrev
+	.uleb128	454
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname454:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname454
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #455: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	455	; ref to abbrev 455
+	.section	.debug_abbrev
+	.uleb128	455
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname455:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname455
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #456: variable TEMP
+	.section	.debug_info
+	.uleb128	456	; ref to abbrev 456
+	.section	.debug_abbrev
+	.uleb128	456
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname456:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname456
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #457: variable CNT
+	.section	.debug_info
+	.uleb128	457	; ref to abbrev 457
+	.section	.debug_abbrev
+	.uleb128	457
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname457:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname457
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #458: variable CCMP
+	.section	.debug_info
+	.uleb128	458	; ref to abbrev 458
+	.section	.debug_abbrev
+	.uleb128	458
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname458:
+	.string		"CCMP"
+	.section	.debug_info
+	.long		.Lname458
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #459: variable CTRLA
+	.section	.debug_info
+	.uleb128	459	; ref to abbrev 459
+	.section	.debug_abbrev
+	.uleb128	459
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname459:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname459
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B30 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #460: variable CTRLB
+	.section	.debug_info
+	.uleb128	460	; ref to abbrev 460
+	.section	.debug_abbrev
+	.uleb128	460
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname460:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname460
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B30 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #461: variable EVCTRL
+	.section	.debug_info
+	.uleb128	461	; ref to abbrev 461
+	.section	.debug_abbrev
+	.uleb128	461
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname461:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname461
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B30 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #462: variable INTCTRL
+	.section	.debug_info
+	.uleb128	462	; ref to abbrev 462
+	.section	.debug_abbrev
+	.uleb128	462
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname462:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname462
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B30 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #463: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	463	; ref to abbrev 463
+	.section	.debug_abbrev
+	.uleb128	463
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname463:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname463
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B30 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #464: variable STATUS
+	.section	.debug_info
+	.uleb128	464	; ref to abbrev 464
+	.section	.debug_abbrev
+	.uleb128	464
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname464:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname464
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B30 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #465: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	465	; ref to abbrev 465
+	.section	.debug_abbrev
+	.uleb128	465
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname465:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname465
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B30 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #466: variable TEMP
+	.section	.debug_info
+	.uleb128	466	; ref to abbrev 466
+	.section	.debug_abbrev
+	.uleb128	466
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname466:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname466
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B30 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #467: variable CNT
+	.section	.debug_info
+	.uleb128	467	; ref to abbrev 467
+	.section	.debug_abbrev
+	.uleb128	467
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname467:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname467
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B30 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #468: variable CCMP
+	.section	.debug_info
+	.uleb128	468	; ref to abbrev 468
+	.section	.debug_abbrev
+	.uleb128	468
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname468:
+	.string		"CCMP"
+	.section	.debug_info
+	.long		.Lname468
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B30 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #469: variable CTRLA
+	.section	.debug_info
+	.uleb128	469	; ref to abbrev 469
+	.section	.debug_abbrev
+	.uleb128	469
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname469:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname469
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #470: variable DUALCTRL
+	.section	.debug_info
+	.uleb128	470	; ref to abbrev 470
+	.section	.debug_abbrev
+	.uleb128	470
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname470:
+	.string		"DUALCTRL"
+	.section	.debug_info
+	.long		.Lname470
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #471: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	471	; ref to abbrev 471
+	.section	.debug_abbrev
+	.uleb128	471
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname471:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname471
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #472: variable MCTRLA
+	.section	.debug_info
+	.uleb128	472	; ref to abbrev 472
+	.section	.debug_abbrev
+	.uleb128	472
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname472:
+	.string		"MCTRLA"
+	.section	.debug_info
+	.long		.Lname472
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #473: variable MCTRLB
+	.section	.debug_info
+	.uleb128	473	; ref to abbrev 473
+	.section	.debug_abbrev
+	.uleb128	473
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname473:
+	.string		"MCTRLB"
+	.section	.debug_info
+	.long		.Lname473
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #474: variable MSTATUS
+	.section	.debug_info
+	.uleb128	474	; ref to abbrev 474
+	.section	.debug_abbrev
+	.uleb128	474
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname474:
+	.string		"MSTATUS"
+	.section	.debug_info
+	.long		.Lname474
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #475: variable MBAUD
+	.section	.debug_info
+	.uleb128	475	; ref to abbrev 475
+	.section	.debug_abbrev
+	.uleb128	475
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname475:
+	.string		"MBAUD"
+	.section	.debug_info
+	.long		.Lname475
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #476: variable MADDR
+	.section	.debug_info
+	.uleb128	476	; ref to abbrev 476
+	.section	.debug_abbrev
+	.uleb128	476
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname476:
+	.string		"MADDR"
+	.section	.debug_info
+	.long		.Lname476
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #477: variable MDATA
+	.section	.debug_info
+	.uleb128	477	; ref to abbrev 477
+	.section	.debug_abbrev
+	.uleb128	477
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname477:
+	.string		"MDATA"
+	.section	.debug_info
+	.long		.Lname477
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #478: variable SCTRLA
+	.section	.debug_info
+	.uleb128	478	; ref to abbrev 478
+	.section	.debug_abbrev
+	.uleb128	478
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname478:
+	.string		"SCTRLA"
+	.section	.debug_info
+	.long		.Lname478
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #479: variable SCTRLB
+	.section	.debug_info
+	.uleb128	479	; ref to abbrev 479
+	.section	.debug_abbrev
+	.uleb128	479
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname479:
+	.string		"SCTRLB"
+	.section	.debug_info
+	.long		.Lname479
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #480: variable SSTATUS
+	.section	.debug_info
+	.uleb128	480	; ref to abbrev 480
+	.section	.debug_abbrev
+	.uleb128	480
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname480:
+	.string		"SSTATUS"
+	.section	.debug_info
+	.long		.Lname480
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #481: variable SADDR
+	.section	.debug_info
+	.uleb128	481	; ref to abbrev 481
+	.section	.debug_abbrev
+	.uleb128	481
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname481:
+	.string		"SADDR"
+	.section	.debug_info
+	.long		.Lname481
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #482: variable SDATA
+	.section	.debug_info
+	.uleb128	482	; ref to abbrev 482
+	.section	.debug_abbrev
+	.uleb128	482
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname482:
+	.string		"SDATA"
+	.section	.debug_info
+	.long		.Lname482
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xD
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #483: variable SADDRMASK
+	.section	.debug_info
+	.uleb128	483	; ref to abbrev 483
+	.section	.debug_abbrev
+	.uleb128	483
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname483:
+	.string		"SADDRMASK"
+	.section	.debug_info
+	.long		.Lname483
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xE
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #484: variable RXDATAL
+	.section	.debug_info
+	.uleb128	484	; ref to abbrev 484
+	.section	.debug_abbrev
+	.uleb128	484
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname484:
+	.string		"RXDATAL"
+	.section	.debug_info
+	.long		.Lname484
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #485: variable RXDATAH
+	.section	.debug_info
+	.uleb128	485	; ref to abbrev 485
+	.section	.debug_abbrev
+	.uleb128	485
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname485:
+	.string		"RXDATAH"
+	.section	.debug_info
+	.long		.Lname485
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #486: variable TXDATAL
+	.section	.debug_info
+	.uleb128	486	; ref to abbrev 486
+	.section	.debug_abbrev
+	.uleb128	486
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname486:
+	.string		"TXDATAL"
+	.section	.debug_info
+	.long		.Lname486
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #487: variable TXDATAH
+	.section	.debug_info
+	.uleb128	487	; ref to abbrev 487
+	.section	.debug_abbrev
+	.uleb128	487
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname487:
+	.string		"TXDATAH"
+	.section	.debug_info
+	.long		.Lname487
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #488: variable STATUS
+	.section	.debug_info
+	.uleb128	488	; ref to abbrev 488
+	.section	.debug_abbrev
+	.uleb128	488
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname488:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname488
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #489: variable CTRLA
+	.section	.debug_info
+	.uleb128	489	; ref to abbrev 489
+	.section	.debug_abbrev
+	.uleb128	489
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname489:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname489
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #490: variable CTRLB
+	.section	.debug_info
+	.uleb128	490	; ref to abbrev 490
+	.section	.debug_abbrev
+	.uleb128	490
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname490:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname490
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #491: variable CTRLC
+	.section	.debug_info
+	.uleb128	491	; ref to abbrev 491
+	.section	.debug_abbrev
+	.uleb128	491
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname491:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname491
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #492: variable BAUD
+	.section	.debug_info
+	.uleb128	492	; ref to abbrev 492
+	.section	.debug_abbrev
+	.uleb128	492
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname492:
+	.string		"BAUD"
+	.section	.debug_info
+	.long		.Lname492
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #493: variable CTRLD
+	.section	.debug_info
+	.uleb128	493	; ref to abbrev 493
+	.section	.debug_abbrev
+	.uleb128	493
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname493:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname493
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #494: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	494	; ref to abbrev 494
+	.section	.debug_abbrev
+	.uleb128	494
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname494:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname494
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #495: variable EVCTRL
+	.section	.debug_info
+	.uleb128	495	; ref to abbrev 495
+	.section	.debug_abbrev
+	.uleb128	495
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname495:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname495
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #496: variable TXPLCTRL
+	.section	.debug_info
+	.uleb128	496	; ref to abbrev 496
+	.section	.debug_abbrev
+	.uleb128	496
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname496:
+	.string		"TXPLCTRL"
+	.section	.debug_info
+	.long		.Lname496
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xD
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #497: variable RXPLCTRL
+	.section	.debug_info
+	.uleb128	497	; ref to abbrev 497
+	.section	.debug_abbrev
+	.uleb128	497
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname497:
+	.string		"RXPLCTRL"
+	.section	.debug_info
+	.long		.Lname497
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xE
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #498: variable RXDATAL
+	.section	.debug_info
+	.uleb128	498	; ref to abbrev 498
+	.section	.debug_abbrev
+	.uleb128	498
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname498:
+	.string		"RXDATAL"
+	.section	.debug_info
+	.long		.Lname498
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #499: variable RXDATAH
+	.section	.debug_info
+	.uleb128	499	; ref to abbrev 499
+	.section	.debug_abbrev
+	.uleb128	499
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname499:
+	.string		"RXDATAH"
+	.section	.debug_info
+	.long		.Lname499
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #500: variable TXDATAL
+	.section	.debug_info
+	.uleb128	500	; ref to abbrev 500
+	.section	.debug_abbrev
+	.uleb128	500
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname500:
+	.string		"TXDATAL"
+	.section	.debug_info
+	.long		.Lname500
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #501: variable TXDATAH
+	.section	.debug_info
+	.uleb128	501	; ref to abbrev 501
+	.section	.debug_abbrev
+	.uleb128	501
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname501:
+	.string		"TXDATAH"
+	.section	.debug_info
+	.long		.Lname501
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #502: variable STATUS
+	.section	.debug_info
+	.uleb128	502	; ref to abbrev 502
+	.section	.debug_abbrev
+	.uleb128	502
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname502:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname502
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #503: variable CTRLA
+	.section	.debug_info
+	.uleb128	503	; ref to abbrev 503
+	.section	.debug_abbrev
+	.uleb128	503
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname503:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname503
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #504: variable CTRLB
+	.section	.debug_info
+	.uleb128	504	; ref to abbrev 504
+	.section	.debug_abbrev
+	.uleb128	504
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname504:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname504
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #505: variable CTRLC
+	.section	.debug_info
+	.uleb128	505	; ref to abbrev 505
+	.section	.debug_abbrev
+	.uleb128	505
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname505:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname505
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #506: variable BAUD
+	.section	.debug_info
+	.uleb128	506	; ref to abbrev 506
+	.section	.debug_abbrev
+	.uleb128	506
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname506:
+	.string		"BAUD"
+	.section	.debug_info
+	.long		.Lname506
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #507: variable CTRLD
+	.section	.debug_info
+	.uleb128	507	; ref to abbrev 507
+	.section	.debug_abbrev
+	.uleb128	507
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname507:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname507
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #508: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	508	; ref to abbrev 508
+	.section	.debug_abbrev
+	.uleb128	508
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname508:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname508
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #509: variable EVCTRL
+	.section	.debug_info
+	.uleb128	509	; ref to abbrev 509
+	.section	.debug_abbrev
+	.uleb128	509
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname509:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname509
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #510: variable TXPLCTRL
+	.section	.debug_info
+	.uleb128	510	; ref to abbrev 510
+	.section	.debug_abbrev
+	.uleb128	510
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname510:
+	.string		"TXPLCTRL"
+	.section	.debug_info
+	.long		.Lname510
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0xD
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #511: variable RXPLCTRL
+	.section	.debug_info
+	.uleb128	511	; ref to abbrev 511
+	.section	.debug_abbrev
+	.uleb128	511
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname511:
+	.string		"RXPLCTRL"
+	.section	.debug_info
+	.long		.Lname511
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0xE
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #512: variable RXDATAL
+	.section	.debug_info
+	.uleb128	512	; ref to abbrev 512
+	.section	.debug_abbrev
+	.uleb128	512
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname512:
+	.string		"RXDATAL"
+	.section	.debug_info
+	.long		.Lname512
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #513: variable RXDATAH
+	.section	.debug_info
+	.uleb128	513	; ref to abbrev 513
+	.section	.debug_abbrev
+	.uleb128	513
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname513:
+	.string		"RXDATAH"
+	.section	.debug_info
+	.long		.Lname513
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #514: variable TXDATAL
+	.section	.debug_info
+	.uleb128	514	; ref to abbrev 514
+	.section	.debug_abbrev
+	.uleb128	514
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname514:
+	.string		"TXDATAL"
+	.section	.debug_info
+	.long		.Lname514
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #515: variable TXDATAH
+	.section	.debug_info
+	.uleb128	515	; ref to abbrev 515
+	.section	.debug_abbrev
+	.uleb128	515
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname515:
+	.string		"TXDATAH"
+	.section	.debug_info
+	.long		.Lname515
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #516: variable STATUS
+	.section	.debug_info
+	.uleb128	516	; ref to abbrev 516
+	.section	.debug_abbrev
+	.uleb128	516
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname516:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname516
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #517: variable CTRLA
+	.section	.debug_info
+	.uleb128	517	; ref to abbrev 517
+	.section	.debug_abbrev
+	.uleb128	517
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname517:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname517
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #518: variable CTRLB
+	.section	.debug_info
+	.uleb128	518	; ref to abbrev 518
+	.section	.debug_abbrev
+	.uleb128	518
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname518:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname518
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #519: variable CTRLC
+	.section	.debug_info
+	.uleb128	519	; ref to abbrev 519
+	.section	.debug_abbrev
+	.uleb128	519
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname519:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname519
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #520: variable BAUD
+	.section	.debug_info
+	.uleb128	520	; ref to abbrev 520
+	.section	.debug_abbrev
+	.uleb128	520
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname520:
+	.string		"BAUD"
+	.section	.debug_info
+	.long		.Lname520
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #521: variable CTRLD
+	.section	.debug_info
+	.uleb128	521	; ref to abbrev 521
+	.section	.debug_abbrev
+	.uleb128	521
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname521:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname521
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #522: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	522	; ref to abbrev 522
+	.section	.debug_abbrev
+	.uleb128	522
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname522:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname522
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #523: variable EVCTRL
+	.section	.debug_info
+	.uleb128	523	; ref to abbrev 523
+	.section	.debug_abbrev
+	.uleb128	523
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname523:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname523
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #524: variable TXPLCTRL
+	.section	.debug_info
+	.uleb128	524	; ref to abbrev 524
+	.section	.debug_abbrev
+	.uleb128	524
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname524:
+	.string		"TXPLCTRL"
+	.section	.debug_info
+	.long		.Lname524
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0xD
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #525: variable RXPLCTRL
+	.section	.debug_info
+	.uleb128	525	; ref to abbrev 525
+	.section	.debug_abbrev
+	.uleb128	525
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname525:
+	.string		"RXPLCTRL"
+	.section	.debug_info
+	.long		.Lname525
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0xE
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #526: variable USERROW0
+	.section	.debug_info
+	.uleb128	526	; ref to abbrev 526
+	.section	.debug_abbrev
+	.uleb128	526
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname526:
+	.string		"USERROW0"
+	.section	.debug_info
+	.long		.Lname526
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #527: variable USERROW1
+	.section	.debug_info
+	.uleb128	527	; ref to abbrev 527
+	.section	.debug_abbrev
+	.uleb128	527
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname527:
+	.string		"USERROW1"
+	.section	.debug_info
+	.long		.Lname527
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #528: variable USERROW2
+	.section	.debug_info
+	.uleb128	528	; ref to abbrev 528
+	.section	.debug_abbrev
+	.uleb128	528
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname528:
+	.string		"USERROW2"
+	.section	.debug_info
+	.long		.Lname528
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #529: variable USERROW3
+	.section	.debug_info
+	.uleb128	529	; ref to abbrev 529
+	.section	.debug_abbrev
+	.uleb128	529
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname529:
+	.string		"USERROW3"
+	.section	.debug_info
+	.long		.Lname529
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #530: variable USERROW4
+	.section	.debug_info
+	.uleb128	530	; ref to abbrev 530
+	.section	.debug_abbrev
+	.uleb128	530
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname530:
+	.string		"USERROW4"
+	.section	.debug_info
+	.long		.Lname530
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #531: variable USERROW5
+	.section	.debug_info
+	.uleb128	531	; ref to abbrev 531
+	.section	.debug_abbrev
+	.uleb128	531
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname531:
+	.string		"USERROW5"
+	.section	.debug_info
+	.long		.Lname531
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #532: variable USERROW6
+	.section	.debug_info
+	.uleb128	532	; ref to abbrev 532
+	.section	.debug_abbrev
+	.uleb128	532
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname532:
+	.string		"USERROW6"
+	.section	.debug_info
+	.long		.Lname532
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #533: variable USERROW7
+	.section	.debug_info
+	.uleb128	533	; ref to abbrev 533
+	.section	.debug_abbrev
+	.uleb128	533
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname533:
+	.string		"USERROW7"
+	.section	.debug_info
+	.long		.Lname533
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #534: variable USERROW8
+	.section	.debug_info
+	.uleb128	534	; ref to abbrev 534
+	.section	.debug_abbrev
+	.uleb128	534
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname534:
+	.string		"USERROW8"
+	.section	.debug_info
+	.long		.Lname534
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #535: variable USERROW9
+	.section	.debug_info
+	.uleb128	535	; ref to abbrev 535
+	.section	.debug_abbrev
+	.uleb128	535
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname535:
+	.string		"USERROW9"
+	.section	.debug_info
+	.long		.Lname535
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #536: variable USERROW10
+	.section	.debug_info
+	.uleb128	536	; ref to abbrev 536
+	.section	.debug_abbrev
+	.uleb128	536
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname536:
+	.string		"USERROW10"
+	.section	.debug_info
+	.long		.Lname536
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #537: variable USERROW11
+	.section	.debug_info
+	.uleb128	537	; ref to abbrev 537
+	.section	.debug_abbrev
+	.uleb128	537
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname537:
+	.string		"USERROW11"
+	.section	.debug_info
+	.long		.Lname537
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #538: variable USERROW12
+	.section	.debug_info
+	.uleb128	538	; ref to abbrev 538
+	.section	.debug_abbrev
+	.uleb128	538
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname538:
+	.string		"USERROW12"
+	.section	.debug_info
+	.long		.Lname538
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #539: variable USERROW13
+	.section	.debug_info
+	.uleb128	539	; ref to abbrev 539
+	.section	.debug_abbrev
+	.uleb128	539
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname539:
+	.string		"USERROW13"
+	.section	.debug_info
+	.long		.Lname539
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #540: variable USERROW14
+	.section	.debug_info
+	.uleb128	540	; ref to abbrev 540
+	.section	.debug_abbrev
+	.uleb128	540
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname540:
+	.string		"USERROW14"
+	.section	.debug_info
+	.long		.Lname540
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #541: variable USERROW15
+	.section	.debug_info
+	.uleb128	541	; ref to abbrev 541
+	.section	.debug_abbrev
+	.uleb128	541
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname541:
+	.string		"USERROW15"
+	.section	.debug_info
+	.long		.Lname541
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x0F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #542: variable USERROW16
+	.section	.debug_info
+	.uleb128	542	; ref to abbrev 542
+	.section	.debug_abbrev
+	.uleb128	542
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname542:
+	.string		"USERROW16"
+	.section	.debug_info
+	.long		.Lname542
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #543: variable USERROW17
+	.section	.debug_info
+	.uleb128	543	; ref to abbrev 543
+	.section	.debug_abbrev
+	.uleb128	543
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname543:
+	.string		"USERROW17"
+	.section	.debug_info
+	.long		.Lname543
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #544: variable USERROW18
+	.section	.debug_info
+	.uleb128	544	; ref to abbrev 544
+	.section	.debug_abbrev
+	.uleb128	544
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname544:
+	.string		"USERROW18"
+	.section	.debug_info
+	.long		.Lname544
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #545: variable USERROW19
+	.section	.debug_info
+	.uleb128	545	; ref to abbrev 545
+	.section	.debug_abbrev
+	.uleb128	545
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname545:
+	.string		"USERROW19"
+	.section	.debug_info
+	.long		.Lname545
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #546: variable USERROW20
+	.section	.debug_info
+	.uleb128	546	; ref to abbrev 546
+	.section	.debug_abbrev
+	.uleb128	546
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname546:
+	.string		"USERROW20"
+	.section	.debug_info
+	.long		.Lname546
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #547: variable USERROW21
+	.section	.debug_info
+	.uleb128	547	; ref to abbrev 547
+	.section	.debug_abbrev
+	.uleb128	547
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname547:
+	.string		"USERROW21"
+	.section	.debug_info
+	.long		.Lname547
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #548: variable USERROW22
+	.section	.debug_info
+	.uleb128	548	; ref to abbrev 548
+	.section	.debug_abbrev
+	.uleb128	548
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname548:
+	.string		"USERROW22"
+	.section	.debug_info
+	.long		.Lname548
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #549: variable USERROW23
+	.section	.debug_info
+	.uleb128	549	; ref to abbrev 549
+	.section	.debug_abbrev
+	.uleb128	549
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname549:
+	.string		"USERROW23"
+	.section	.debug_info
+	.long		.Lname549
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #550: variable USERROW24
+	.section	.debug_info
+	.uleb128	550	; ref to abbrev 550
+	.section	.debug_abbrev
+	.uleb128	550
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname550:
+	.string		"USERROW24"
+	.section	.debug_info
+	.long		.Lname550
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #551: variable USERROW25
+	.section	.debug_info
+	.uleb128	551	; ref to abbrev 551
+	.section	.debug_abbrev
+	.uleb128	551
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname551:
+	.string		"USERROW25"
+	.section	.debug_info
+	.long		.Lname551
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x19
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #552: variable USERROW26
+	.section	.debug_info
+	.uleb128	552	; ref to abbrev 552
+	.section	.debug_abbrev
+	.uleb128	552
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname552:
+	.string		"USERROW26"
+	.section	.debug_info
+	.long		.Lname552
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #553: variable USERROW27
+	.section	.debug_info
+	.uleb128	553	; ref to abbrev 553
+	.section	.debug_abbrev
+	.uleb128	553
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname553:
+	.string		"USERROW27"
+	.section	.debug_info
+	.long		.Lname553
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #554: variable USERROW28
+	.section	.debug_info
+	.uleb128	554	; ref to abbrev 554
+	.section	.debug_abbrev
+	.uleb128	554
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname554:
+	.string		"USERROW28"
+	.section	.debug_info
+	.long		.Lname554
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #555: variable USERROW29
+	.section	.debug_info
+	.uleb128	555	; ref to abbrev 555
+	.section	.debug_abbrev
+	.uleb128	555
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname555:
+	.string		"USERROW29"
+	.section	.debug_info
+	.long		.Lname555
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #556: variable USERROW30
+	.section	.debug_info
+	.uleb128	556	; ref to abbrev 556
+	.section	.debug_abbrev
+	.uleb128	556
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname556:
+	.string		"USERROW30"
+	.section	.debug_info
+	.long		.Lname556
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #557: variable USERROW31
+	.section	.debug_info
+	.uleb128	557	; ref to abbrev 557
+	.section	.debug_abbrev
+	.uleb128	557
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname557:
+	.string		"USERROW31"
+	.section	.debug_info
+	.long		.Lname557
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #558: variable USERROW32
+	.section	.debug_info
+	.uleb128	558	; ref to abbrev 558
+	.section	.debug_abbrev
+	.uleb128	558
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname558:
+	.string		"USERROW32"
+	.section	.debug_info
+	.long		.Lname558
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #559: variable USERROW33
+	.section	.debug_info
+	.uleb128	559	; ref to abbrev 559
+	.section	.debug_abbrev
+	.uleb128	559
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname559:
+	.string		"USERROW33"
+	.section	.debug_info
+	.long		.Lname559
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x21
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #560: variable USERROW34
+	.section	.debug_info
+	.uleb128	560	; ref to abbrev 560
+	.section	.debug_abbrev
+	.uleb128	560
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname560:
+	.string		"USERROW34"
+	.section	.debug_info
+	.long		.Lname560
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x22
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #561: variable USERROW35
+	.section	.debug_info
+	.uleb128	561	; ref to abbrev 561
+	.section	.debug_abbrev
+	.uleb128	561
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname561:
+	.string		"USERROW35"
+	.section	.debug_info
+	.long		.Lname561
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x23
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #562: variable USERROW36
+	.section	.debug_info
+	.uleb128	562	; ref to abbrev 562
+	.section	.debug_abbrev
+	.uleb128	562
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname562:
+	.string		"USERROW36"
+	.section	.debug_info
+	.long		.Lname562
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x24
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #563: variable USERROW37
+	.section	.debug_info
+	.uleb128	563	; ref to abbrev 563
+	.section	.debug_abbrev
+	.uleb128	563
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname563:
+	.string		"USERROW37"
+	.section	.debug_info
+	.long		.Lname563
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x25
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #564: variable USERROW38
+	.section	.debug_info
+	.uleb128	564	; ref to abbrev 564
+	.section	.debug_abbrev
+	.uleb128	564
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname564:
+	.string		"USERROW38"
+	.section	.debug_info
+	.long		.Lname564
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x26
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #565: variable USERROW39
+	.section	.debug_info
+	.uleb128	565	; ref to abbrev 565
+	.section	.debug_abbrev
+	.uleb128	565
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname565:
+	.string		"USERROW39"
+	.section	.debug_info
+	.long		.Lname565
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x27
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #566: variable USERROW40
+	.section	.debug_info
+	.uleb128	566	; ref to abbrev 566
+	.section	.debug_abbrev
+	.uleb128	566
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname566:
+	.string		"USERROW40"
+	.section	.debug_info
+	.long		.Lname566
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x28
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #567: variable USERROW41
+	.section	.debug_info
+	.uleb128	567	; ref to abbrev 567
+	.section	.debug_abbrev
+	.uleb128	567
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname567:
+	.string		"USERROW41"
+	.section	.debug_info
+	.long		.Lname567
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x29
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #568: variable USERROW42
+	.section	.debug_info
+	.uleb128	568	; ref to abbrev 568
+	.section	.debug_abbrev
+	.uleb128	568
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname568:
+	.string		"USERROW42"
+	.section	.debug_info
+	.long		.Lname568
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x2A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #569: variable USERROW43
+	.section	.debug_info
+	.uleb128	569	; ref to abbrev 569
+	.section	.debug_abbrev
+	.uleb128	569
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname569:
+	.string		"USERROW43"
+	.section	.debug_info
+	.long		.Lname569
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x2B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #570: variable USERROW44
+	.section	.debug_info
+	.uleb128	570	; ref to abbrev 570
+	.section	.debug_abbrev
+	.uleb128	570
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname570:
+	.string		"USERROW44"
+	.section	.debug_info
+	.long		.Lname570
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x2C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #571: variable USERROW45
+	.section	.debug_info
+	.uleb128	571	; ref to abbrev 571
+	.section	.debug_abbrev
+	.uleb128	571
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname571:
+	.string		"USERROW45"
+	.section	.debug_info
+	.long		.Lname571
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x2D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #572: variable USERROW46
+	.section	.debug_info
+	.uleb128	572	; ref to abbrev 572
+	.section	.debug_abbrev
+	.uleb128	572
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname572:
+	.string		"USERROW46"
+	.section	.debug_info
+	.long		.Lname572
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x2E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #573: variable USERROW47
+	.section	.debug_info
+	.uleb128	573	; ref to abbrev 573
+	.section	.debug_abbrev
+	.uleb128	573
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname573:
+	.string		"USERROW47"
+	.section	.debug_info
+	.long		.Lname573
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x2F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #574: variable USERROW48
+	.section	.debug_info
+	.uleb128	574	; ref to abbrev 574
+	.section	.debug_abbrev
+	.uleb128	574
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname574:
+	.string		"USERROW48"
+	.section	.debug_info
+	.long		.Lname574
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x30
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #575: variable USERROW49
+	.section	.debug_info
+	.uleb128	575	; ref to abbrev 575
+	.section	.debug_abbrev
+	.uleb128	575
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname575:
+	.string		"USERROW49"
+	.section	.debug_info
+	.long		.Lname575
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x31
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #576: variable USERROW50
+	.section	.debug_info
+	.uleb128	576	; ref to abbrev 576
+	.section	.debug_abbrev
+	.uleb128	576
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname576:
+	.string		"USERROW50"
+	.section	.debug_info
+	.long		.Lname576
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x32
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #577: variable USERROW51
+	.section	.debug_info
+	.uleb128	577	; ref to abbrev 577
+	.section	.debug_abbrev
+	.uleb128	577
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname577:
+	.string		"USERROW51"
+	.section	.debug_info
+	.long		.Lname577
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x33
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #578: variable USERROW52
+	.section	.debug_info
+	.uleb128	578	; ref to abbrev 578
+	.section	.debug_abbrev
+	.uleb128	578
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname578:
+	.string		"USERROW52"
+	.section	.debug_info
+	.long		.Lname578
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x34
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #579: variable USERROW53
+	.section	.debug_info
+	.uleb128	579	; ref to abbrev 579
+	.section	.debug_abbrev
+	.uleb128	579
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname579:
+	.string		"USERROW53"
+	.section	.debug_info
+	.long		.Lname579
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x35
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #580: variable USERROW54
+	.section	.debug_info
+	.uleb128	580	; ref to abbrev 580
+	.section	.debug_abbrev
+	.uleb128	580
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname580:
+	.string		"USERROW54"
+	.section	.debug_info
+	.long		.Lname580
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x36
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #581: variable USERROW55
+	.section	.debug_info
+	.uleb128	581	; ref to abbrev 581
+	.section	.debug_abbrev
+	.uleb128	581
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname581:
+	.string		"USERROW55"
+	.section	.debug_info
+	.long		.Lname581
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x37
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #582: variable USERROW56
+	.section	.debug_info
+	.uleb128	582	; ref to abbrev 582
+	.section	.debug_abbrev
+	.uleb128	582
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname582:
+	.string		"USERROW56"
+	.section	.debug_info
+	.long		.Lname582
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x38
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #583: variable USERROW57
+	.section	.debug_info
+	.uleb128	583	; ref to abbrev 583
+	.section	.debug_abbrev
+	.uleb128	583
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname583:
+	.string		"USERROW57"
+	.section	.debug_info
+	.long		.Lname583
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x39
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #584: variable USERROW58
+	.section	.debug_info
+	.uleb128	584	; ref to abbrev 584
+	.section	.debug_abbrev
+	.uleb128	584
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname584:
+	.string		"USERROW58"
+	.section	.debug_info
+	.long		.Lname584
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x3A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #585: variable USERROW59
+	.section	.debug_info
+	.uleb128	585	; ref to abbrev 585
+	.section	.debug_abbrev
+	.uleb128	585
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname585:
+	.string		"USERROW59"
+	.section	.debug_info
+	.long		.Lname585
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x3B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #586: variable USERROW60
+	.section	.debug_info
+	.uleb128	586	; ref to abbrev 586
+	.section	.debug_abbrev
+	.uleb128	586
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname586:
+	.string		"USERROW60"
+	.section	.debug_info
+	.long		.Lname586
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x3C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #587: variable USERROW61
+	.section	.debug_info
+	.uleb128	587	; ref to abbrev 587
+	.section	.debug_abbrev
+	.uleb128	587
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname587:
+	.string		"USERROW61"
+	.section	.debug_info
+	.long		.Lname587
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x3D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #588: variable USERROW62
+	.section	.debug_info
+	.uleb128	588	; ref to abbrev 588
+	.section	.debug_abbrev
+	.uleb128	588
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname588:
+	.string		"USERROW62"
+	.section	.debug_info
+	.long		.Lname588
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x3E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #589: variable USERROW63
+	.section	.debug_info
+	.uleb128	589	; ref to abbrev 589
+	.section	.debug_abbrev
+	.uleb128	589
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname589:
+	.string		"USERROW63"
+	.section	.debug_info
+	.long		.Lname589
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x3F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #590: variable DIR
+	.section	.debug_info
+	.uleb128	590	; ref to abbrev 590
+	.section	.debug_abbrev
+	.uleb128	590
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname590:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname590
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0000 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #591: variable OUT
+	.section	.debug_info
+	.uleb128	591	; ref to abbrev 591
+	.section	.debug_abbrev
+	.uleb128	591
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname591:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname591
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0000 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #592: variable IN
+	.section	.debug_info
+	.uleb128	592	; ref to abbrev 592
+	.section	.debug_abbrev
+	.uleb128	592
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname592:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname592
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0000 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #593: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	593	; ref to abbrev 593
+	.section	.debug_abbrev
+	.uleb128	593
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname593:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname593
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0000 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #594: variable DIR
+	.section	.debug_info
+	.uleb128	594	; ref to abbrev 594
+	.section	.debug_abbrev
+	.uleb128	594
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname594:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname594
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0004 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #595: variable OUT
+	.section	.debug_info
+	.uleb128	595	; ref to abbrev 595
+	.section	.debug_abbrev
+	.uleb128	595
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname595:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname595
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0004 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #596: variable IN
+	.section	.debug_info
+	.uleb128	596	; ref to abbrev 596
+	.section	.debug_abbrev
+	.uleb128	596
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname596:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname596
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0004 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #597: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	597	; ref to abbrev 597
+	.section	.debug_abbrev
+	.uleb128	597
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname597:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname597
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0004 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #598: variable DIR
+	.section	.debug_info
+	.uleb128	598	; ref to abbrev 598
+	.section	.debug_abbrev
+	.uleb128	598
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname598:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname598
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0008 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #599: variable OUT
+	.section	.debug_info
+	.uleb128	599	; ref to abbrev 599
+	.section	.debug_abbrev
+	.uleb128	599
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname599:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname599
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0008 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #600: variable IN
+	.section	.debug_info
+	.uleb128	600	; ref to abbrev 600
+	.section	.debug_abbrev
+	.uleb128	600
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname600:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname600
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0008 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #601: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	601	; ref to abbrev 601
+	.section	.debug_abbrev
+	.uleb128	601
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname601:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname601
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0008 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #602: variable DIR
+	.section	.debug_info
+	.uleb128	602	; ref to abbrev 602
+	.section	.debug_abbrev
+	.uleb128	602
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname602:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname602
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x000C + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #603: variable OUT
+	.section	.debug_info
+	.uleb128	603	; ref to abbrev 603
+	.section	.debug_abbrev
+	.uleb128	603
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname603:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname603
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x000C + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #604: variable IN
+	.section	.debug_info
+	.uleb128	604	; ref to abbrev 604
+	.section	.debug_abbrev
+	.uleb128	604
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname604:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname604
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x000C + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #605: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	605	; ref to abbrev 605
+	.section	.debug_abbrev
+	.uleb128	605
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname605:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname605
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x000C + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #606: variable DIR
+	.section	.debug_info
+	.uleb128	606	; ref to abbrev 606
+	.section	.debug_abbrev
+	.uleb128	606
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname606:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname606
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0010 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #607: variable OUT
+	.section	.debug_info
+	.uleb128	607	; ref to abbrev 607
+	.section	.debug_abbrev
+	.uleb128	607
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname607:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname607
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0010 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #608: variable IN
+	.section	.debug_info
+	.uleb128	608	; ref to abbrev 608
+	.section	.debug_abbrev
+	.uleb128	608
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname608:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname608
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0010 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #609: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	609	; ref to abbrev 609
+	.section	.debug_abbrev
+	.uleb128	609
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname609:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname609
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0010 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #610: variable DIR
+	.section	.debug_info
+	.uleb128	610	; ref to abbrev 610
+	.section	.debug_abbrev
+	.uleb128	610
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname610:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname610
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0014 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #611: variable OUT
+	.section	.debug_info
+	.uleb128	611	; ref to abbrev 611
+	.section	.debug_abbrev
+	.uleb128	611
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname611:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname611
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0014 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #612: variable IN
+	.section	.debug_info
+	.uleb128	612	; ref to abbrev 612
+	.section	.debug_abbrev
+	.uleb128	612
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname612:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname612
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0014 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #613: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	613	; ref to abbrev 613
+	.section	.debug_abbrev
+	.uleb128	613
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname613:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname613
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0014 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #614: variable DAC0REF
+	.section	.debug_info
+	.uleb128	614	; ref to abbrev 614
+	.section	.debug_abbrev
+	.uleb128	614
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname614:
+	.string		"DAC0REF"
+	.section	.debug_info
+	.long		.Lname614
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00B0 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #615: variable ACREF
+	.section	.debug_info
+	.uleb128	615	; ref to abbrev 615
+	.section	.debug_abbrev
+	.uleb128	615
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname615:
+	.string		"ACREF"
+	.section	.debug_info
+	.long		.Lname615
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00B0 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #616: variable CTRLA
+	.section	.debug_info
+	.uleb128	616	; ref to abbrev 616
+	.section	.debug_abbrev
+	.uleb128	616
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname616:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname616
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0100 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #617: variable STATUS
+	.section	.debug_info
+	.uleb128	617	; ref to abbrev 617
+	.section	.debug_abbrev
+	.uleb128	617
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname617:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname617
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0100 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+	;; trailer
+	.section	.debug_abbrev
+	.uleb128	0
+
+	.section	.debug_info
+	.uleb128	0
+.Leinfo:

--- a/crt1/iosym/avr16eb14.S
+++ b/crt1/iosym/avr16eb14.S
@@ -1,0 +1,25991 @@
+/* This file is part of avr-libc.
+
+   Automatically created by devtools/ioreg.pl
+   DO NOT EDIT!
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in
+     the documentation and/or other materials provided with the
+     distribution.
+
+   * Neither the name of the copyright holders nor the names of
+     contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE. */
+
+/* $Id$ */
+
+#include <avr/version.h>
+
+#define DW_TAG_array_type               0x01
+#define DW_TAG_compile_unit             0x11
+#define DW_TAG_typedef                  0x16
+#define DW_TAG_subrange_type            0x21
+#define DW_TAG_base_type                0x24
+#define DW_TAG_variable                 0x34
+
+#define DW_FORM_addr                    0x01
+#define DW_FORM_block1                  0x0a
+#define DW_FORM_block2                  0x03
+#define DW_FORM_block4                  0x04
+#define DW_FORM_data1                   0x0b
+#define DW_FORM_data2                   0x05
+#define DW_FORM_data4                   0x06
+#define DW_FORM_data8                   0x07
+#define DW_FORM_string                  0x08
+#define DW_FORM_flag                    0x0c
+#define DW_FORM_strp                    0x0e
+#define DW_FORM_ref1                    0x11
+#define DW_FORM_ref2                    0x12
+#define DW_FORM_ref4                    0x13
+#define DW_FORM_ref8                    0x14
+
+#define DW_AT_location                  0x02
+#define DW_AT_name                      0x03
+#define DW_AT_byte_size                 0x0b
+#define DW_AT_stmt_list                 0x10
+#define DW_AT_language                  0x13
+#define DW_AT_producer                  0x25
+#define DW_AT_upper_bound               0x2f
+#define DW_AT_decl_file                 0x3a
+#define DW_AT_decl_line                 0x3b
+#define DW_AT_encoding                  0x3e
+#define DW_AT_external                  0x3f
+#define DW_AT_type                      0x49
+
+#define DW_LANG_C89                     0x0001
+
+#define DW_CHILDREN_no                  0x00
+#define DW_CHILDREN_yes                 0x01
+
+#define DW_ATE_unsigned                 0x7
+#define DW_ATE_unsigned_char            0x8
+
+#define DW_OP_addr                      0x03
+.eject
+	.section	.debug_abbrev, "", @progbits
+.Ldebug_abbrev0:
+	.section	.debug_info, "", @progbits
+	.section	.debug_line, "", @progbits
+.Ldebug_line0:
+	.section	.debug_str, "", @progbits
+
+	.section	.debug_info, "", @progbits
+	;; compilation unit header
+.Lssinfo:
+	.long	.Leinfo - .Lsinfo
+.Lsinfo:
+	.word	2		; DWARF-2
+	.long	.Ldebug_abbrev0
+	.byte	4		; sizeof(address)
+
+
+	;; DIE #1: compilation unit
+	.section	.debug_info
+	.uleb128	1	; ref to abbrev 1
+	.section	.debug_abbrev
+	.uleb128	1
+	.uleb128	DW_TAG_compile_unit
+	.byte		DW_CHILDREN_yes
+
+	.uleb128	DW_AT_producer
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lproducer:
+	.ascii		"avr-libc "
+	.asciz		__AVR_LIBC_VERSION_STRING__
+	.section	.debug_info
+	.long		.Lproducer
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_stmt_list
+	.uleb128	DW_FORM_data4
+	.section	.debug_info
+	.long		.Ldebug_line0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+	;; DIE #2: base type uint8_t
+	.section	.debug_info
+.Luint8_t:
+	.uleb128	2	; ref to abbrev 2
+	.section	.debug_abbrev
+	.uleb128	2
+	.uleb128	DW_TAG_base_type
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Luint8_t_name:
+	.string		"uint8_t"
+	.section	.debug_info
+	.long		.Luint8_t_name
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_byte_size
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_encoding
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		DW_ATE_unsigned_char
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+	;; DIE #3: base type uint16_t
+	.section	.debug_info
+.Luint16_t:
+	.uleb128	3	; ref to abbrev 3
+	.section	.debug_abbrev
+	.uleb128	3
+	.uleb128	DW_TAG_base_type
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Luint16_t_name:
+	.string		"uint16_t"
+	.section	.debug_info
+	.long		.Luint16_t_name
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_byte_size
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		2
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_encoding
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		DW_ATE_unsigned
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #4: variable CTRLA
+	.section	.debug_info
+	.uleb128	4	; ref to abbrev 4
+	.section	.debug_abbrev
+	.uleb128	4
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname4:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname4
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #5: variable CTRLB
+	.section	.debug_info
+	.uleb128	5	; ref to abbrev 5
+	.section	.debug_abbrev
+	.uleb128	5
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname5:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname5
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #6: variable MUXCTRL
+	.section	.debug_info
+	.uleb128	6	; ref to abbrev 6
+	.section	.debug_abbrev
+	.uleb128	6
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname6:
+	.string		"MUXCTRL"
+	.section	.debug_info
+	.long		.Lname6
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #7: variable DACREF
+	.section	.debug_info
+	.uleb128	7	; ref to abbrev 7
+	.section	.debug_abbrev
+	.uleb128	7
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname7:
+	.string		"DACREF"
+	.section	.debug_info
+	.long		.Lname7
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #8: variable INTCTRL
+	.section	.debug_info
+	.uleb128	8	; ref to abbrev 8
+	.section	.debug_abbrev
+	.uleb128	8
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname8:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname8
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #9: variable STATUS
+	.section	.debug_info
+	.uleb128	9	; ref to abbrev 9
+	.section	.debug_abbrev
+	.uleb128	9
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname9:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname9
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #10: variable CTRLA
+	.section	.debug_info
+	.uleb128	10	; ref to abbrev 10
+	.section	.debug_abbrev
+	.uleb128	10
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname10:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname10
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #11: variable CTRLB
+	.section	.debug_info
+	.uleb128	11	; ref to abbrev 11
+	.section	.debug_abbrev
+	.uleb128	11
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname11:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname11
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #12: variable MUXCTRL
+	.section	.debug_info
+	.uleb128	12	; ref to abbrev 12
+	.section	.debug_abbrev
+	.uleb128	12
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname12:
+	.string		"MUXCTRL"
+	.section	.debug_info
+	.long		.Lname12
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #13: variable DACREF
+	.section	.debug_info
+	.uleb128	13	; ref to abbrev 13
+	.section	.debug_abbrev
+	.uleb128	13
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname13:
+	.string		"DACREF"
+	.section	.debug_info
+	.long		.Lname13
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #14: variable INTCTRL
+	.section	.debug_info
+	.uleb128	14	; ref to abbrev 14
+	.section	.debug_abbrev
+	.uleb128	14
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname14:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname14
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #15: variable STATUS
+	.section	.debug_info
+	.uleb128	15	; ref to abbrev 15
+	.section	.debug_abbrev
+	.uleb128	15
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname15:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname15
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #16: variable CTRLA
+	.section	.debug_info
+	.uleb128	16	; ref to abbrev 16
+	.section	.debug_abbrev
+	.uleb128	16
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname16:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname16
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #17: variable CTRLB
+	.section	.debug_info
+	.uleb128	17	; ref to abbrev 17
+	.section	.debug_abbrev
+	.uleb128	17
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname17:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname17
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #18: variable CTRLC
+	.section	.debug_info
+	.uleb128	18	; ref to abbrev 18
+	.section	.debug_abbrev
+	.uleb128	18
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname18:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname18
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #19: variable CTRLD
+	.section	.debug_info
+	.uleb128	19	; ref to abbrev 19
+	.section	.debug_abbrev
+	.uleb128	19
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname19:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname19
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #20: variable INTCTRL
+	.section	.debug_info
+	.uleb128	20	; ref to abbrev 20
+	.section	.debug_abbrev
+	.uleb128	20
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname20:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname20
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #21: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	21	; ref to abbrev 21
+	.section	.debug_abbrev
+	.uleb128	21
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname21:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname21
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #22: variable STATUS
+	.section	.debug_info
+	.uleb128	22	; ref to abbrev 22
+	.section	.debug_abbrev
+	.uleb128	22
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname22:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname22
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #23: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	23	; ref to abbrev 23
+	.section	.debug_abbrev
+	.uleb128	23
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname23:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname23
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #24: variable CTRLE
+	.section	.debug_info
+	.uleb128	24	; ref to abbrev 24
+	.section	.debug_abbrev
+	.uleb128	24
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname24:
+	.string		"CTRLE"
+	.section	.debug_info
+	.long		.Lname24
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #25: variable CTRLF
+	.section	.debug_info
+	.uleb128	25	; ref to abbrev 25
+	.section	.debug_abbrev
+	.uleb128	25
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname25:
+	.string		"CTRLF"
+	.section	.debug_info
+	.long		.Lname25
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #26: variable COMMAND
+	.section	.debug_info
+	.uleb128	26	; ref to abbrev 26
+	.section	.debug_abbrev
+	.uleb128	26
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname26:
+	.string		"COMMAND"
+	.section	.debug_info
+	.long		.Lname26
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #27: variable PGACTRL
+	.section	.debug_info
+	.uleb128	27	; ref to abbrev 27
+	.section	.debug_abbrev
+	.uleb128	27
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname27:
+	.string		"PGACTRL"
+	.section	.debug_info
+	.long		.Lname27
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #28: variable MUXPOS
+	.section	.debug_info
+	.uleb128	28	; ref to abbrev 28
+	.section	.debug_abbrev
+	.uleb128	28
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname28:
+	.string		"MUXPOS"
+	.section	.debug_info
+	.long		.Lname28
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #29: variable MUXNEG
+	.section	.debug_info
+	.uleb128	29	; ref to abbrev 29
+	.section	.debug_abbrev
+	.uleb128	29
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname29:
+	.string		"MUXNEG"
+	.section	.debug_info
+	.long		.Lname29
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #30: base type uint32_t
+	.section	.debug_info
+.Luint32_t:
+	.uleb128	30	; ref to abbrev 30
+	.section	.debug_abbrev
+	.uleb128	30
+	.uleb128	DW_TAG_base_type
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Luint32_t_name:
+	.string		"uint32_t"
+	.section	.debug_info
+	.long		.Luint32_t_name
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_byte_size
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		4
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_encoding
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		DW_ATE_unsigned
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #31: variable RESULT
+	.section	.debug_info
+	.uleb128	31	; ref to abbrev 31
+	.section	.debug_abbrev
+	.uleb128	31
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname31:
+	.string		"RESULT"
+	.section	.debug_info
+	.long		.Lname31
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint32_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #32: variable SAMPLE
+	.section	.debug_info
+	.uleb128	32	; ref to abbrev 32
+	.section	.debug_abbrev
+	.uleb128	32
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname32:
+	.string		"SAMPLE"
+	.section	.debug_info
+	.long		.Lname32
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #33: variable TEMP0
+	.section	.debug_info
+	.uleb128	33	; ref to abbrev 33
+	.section	.debug_abbrev
+	.uleb128	33
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname33:
+	.string		"TEMP0"
+	.section	.debug_info
+	.long		.Lname33
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #34: variable TEMP1
+	.section	.debug_info
+	.uleb128	34	; ref to abbrev 34
+	.section	.debug_abbrev
+	.uleb128	34
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname34:
+	.string		"TEMP1"
+	.section	.debug_info
+	.long		.Lname34
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x19
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #35: variable TEMP2
+	.section	.debug_info
+	.uleb128	35	; ref to abbrev 35
+	.section	.debug_abbrev
+	.uleb128	35
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname35:
+	.string		"TEMP2"
+	.section	.debug_info
+	.long		.Lname35
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x1A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #36: variable WINLT
+	.section	.debug_info
+	.uleb128	36	; ref to abbrev 36
+	.section	.debug_abbrev
+	.uleb128	36
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname36:
+	.string		"WINLT"
+	.section	.debug_info
+	.long		.Lname36
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x1C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #37: variable WINHT
+	.section	.debug_info
+	.uleb128	37	; ref to abbrev 37
+	.section	.debug_abbrev
+	.uleb128	37
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname37:
+	.string		"WINHT"
+	.section	.debug_info
+	.long		.Lname37
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x1E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #38: variable CTRLA
+	.section	.debug_info
+	.uleb128	38	; ref to abbrev 38
+	.section	.debug_abbrev
+	.uleb128	38
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname38:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname38
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #39: variable CTRLB
+	.section	.debug_info
+	.uleb128	39	; ref to abbrev 39
+	.section	.debug_abbrev
+	.uleb128	39
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname39:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname39
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #40: variable VLMCTRLA
+	.section	.debug_info
+	.uleb128	40	; ref to abbrev 40
+	.section	.debug_abbrev
+	.uleb128	40
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname40:
+	.string		"VLMCTRLA"
+	.section	.debug_info
+	.long		.Lname40
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #41: variable INTCTRL
+	.section	.debug_info
+	.uleb128	41	; ref to abbrev 41
+	.section	.debug_abbrev
+	.uleb128	41
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname41:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname41
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #42: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	42	; ref to abbrev 42
+	.section	.debug_abbrev
+	.uleb128	42
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname42:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname42
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #43: variable STATUS
+	.section	.debug_info
+	.uleb128	43	; ref to abbrev 43
+	.section	.debug_abbrev
+	.uleb128	43
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname43:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname43
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #44: variable BOOTROW
+	.section	.debug_info
+	.uleb128	44	; ref to abbrev 44
+	.section	.debug_abbrev
+	.uleb128	44
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname44:
+	.string		"BOOTROW"
+	.section	.debug_info
+	.long		.Lname44
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #45: variable CTRLA
+	.section	.debug_info
+	.uleb128	45	; ref to abbrev 45
+	.section	.debug_abbrev
+	.uleb128	45
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname45:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname45
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #46: variable SEQCTRL0
+	.section	.debug_info
+	.uleb128	46	; ref to abbrev 46
+	.section	.debug_abbrev
+	.uleb128	46
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname46:
+	.string		"SEQCTRL0"
+	.section	.debug_info
+	.long		.Lname46
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #47: variable SEQCTRL1
+	.section	.debug_info
+	.uleb128	47	; ref to abbrev 47
+	.section	.debug_abbrev
+	.uleb128	47
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname47:
+	.string		"SEQCTRL1"
+	.section	.debug_info
+	.long		.Lname47
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #48: variable INTCTRL0
+	.section	.debug_info
+	.uleb128	48	; ref to abbrev 48
+	.section	.debug_abbrev
+	.uleb128	48
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname48:
+	.string		"INTCTRL0"
+	.section	.debug_info
+	.long		.Lname48
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #49: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	49	; ref to abbrev 49
+	.section	.debug_abbrev
+	.uleb128	49
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname49:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname49
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #50: variable LUT0CTRLA
+	.section	.debug_info
+	.uleb128	50	; ref to abbrev 50
+	.section	.debug_abbrev
+	.uleb128	50
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname50:
+	.string		"LUT0CTRLA"
+	.section	.debug_info
+	.long		.Lname50
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #51: variable LUT0CTRLB
+	.section	.debug_info
+	.uleb128	51	; ref to abbrev 51
+	.section	.debug_abbrev
+	.uleb128	51
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname51:
+	.string		"LUT0CTRLB"
+	.section	.debug_info
+	.long		.Lname51
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #52: variable LUT0CTRLC
+	.section	.debug_info
+	.uleb128	52	; ref to abbrev 52
+	.section	.debug_abbrev
+	.uleb128	52
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname52:
+	.string		"LUT0CTRLC"
+	.section	.debug_info
+	.long		.Lname52
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #53: variable TRUTH0
+	.section	.debug_info
+	.uleb128	53	; ref to abbrev 53
+	.section	.debug_abbrev
+	.uleb128	53
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname53:
+	.string		"TRUTH0"
+	.section	.debug_info
+	.long		.Lname53
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #54: variable LUT1CTRLA
+	.section	.debug_info
+	.uleb128	54	; ref to abbrev 54
+	.section	.debug_abbrev
+	.uleb128	54
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname54:
+	.string		"LUT1CTRLA"
+	.section	.debug_info
+	.long		.Lname54
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #55: variable LUT1CTRLB
+	.section	.debug_info
+	.uleb128	55	; ref to abbrev 55
+	.section	.debug_abbrev
+	.uleb128	55
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname55:
+	.string		"LUT1CTRLB"
+	.section	.debug_info
+	.long		.Lname55
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #56: variable LUT1CTRLC
+	.section	.debug_info
+	.uleb128	56	; ref to abbrev 56
+	.section	.debug_abbrev
+	.uleb128	56
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname56:
+	.string		"LUT1CTRLC"
+	.section	.debug_info
+	.long		.Lname56
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #57: variable TRUTH1
+	.section	.debug_info
+	.uleb128	57	; ref to abbrev 57
+	.section	.debug_abbrev
+	.uleb128	57
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname57:
+	.string		"TRUTH1"
+	.section	.debug_info
+	.long		.Lname57
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #58: variable LUT2CTRLA
+	.section	.debug_info
+	.uleb128	58	; ref to abbrev 58
+	.section	.debug_abbrev
+	.uleb128	58
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname58:
+	.string		"LUT2CTRLA"
+	.section	.debug_info
+	.long		.Lname58
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #59: variable LUT2CTRLB
+	.section	.debug_info
+	.uleb128	59	; ref to abbrev 59
+	.section	.debug_abbrev
+	.uleb128	59
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname59:
+	.string		"LUT2CTRLB"
+	.section	.debug_info
+	.long		.Lname59
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #60: variable LUT2CTRLC
+	.section	.debug_info
+	.uleb128	60	; ref to abbrev 60
+	.section	.debug_abbrev
+	.uleb128	60
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname60:
+	.string		"LUT2CTRLC"
+	.section	.debug_info
+	.long		.Lname60
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #61: variable TRUTH2
+	.section	.debug_info
+	.uleb128	61	; ref to abbrev 61
+	.section	.debug_abbrev
+	.uleb128	61
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname61:
+	.string		"TRUTH2"
+	.section	.debug_info
+	.long		.Lname61
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #62: variable LUT3CTRLA
+	.section	.debug_info
+	.uleb128	62	; ref to abbrev 62
+	.section	.debug_abbrev
+	.uleb128	62
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname62:
+	.string		"LUT3CTRLA"
+	.section	.debug_info
+	.long		.Lname62
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #63: variable LUT3CTRLB
+	.section	.debug_info
+	.uleb128	63	; ref to abbrev 63
+	.section	.debug_abbrev
+	.uleb128	63
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname63:
+	.string		"LUT3CTRLB"
+	.section	.debug_info
+	.long		.Lname63
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #64: variable LUT3CTRLC
+	.section	.debug_info
+	.uleb128	64	; ref to abbrev 64
+	.section	.debug_abbrev
+	.uleb128	64
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname64:
+	.string		"LUT3CTRLC"
+	.section	.debug_info
+	.long		.Lname64
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #65: variable TRUTH3
+	.section	.debug_info
+	.uleb128	65	; ref to abbrev 65
+	.section	.debug_abbrev
+	.uleb128	65
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname65:
+	.string		"TRUTH3"
+	.section	.debug_info
+	.long		.Lname65
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #66: variable MCLKCTRLA
+	.section	.debug_info
+	.uleb128	66	; ref to abbrev 66
+	.section	.debug_abbrev
+	.uleb128	66
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname66:
+	.string		"MCLKCTRLA"
+	.section	.debug_info
+	.long		.Lname66
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #67: variable MCLKCTRLB
+	.section	.debug_info
+	.uleb128	67	; ref to abbrev 67
+	.section	.debug_abbrev
+	.uleb128	67
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname67:
+	.string		"MCLKCTRLB"
+	.section	.debug_info
+	.long		.Lname67
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #68: variable MCLKSTATUS
+	.section	.debug_info
+	.uleb128	68	; ref to abbrev 68
+	.section	.debug_abbrev
+	.uleb128	68
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname68:
+	.string		"MCLKSTATUS"
+	.section	.debug_info
+	.long		.Lname68
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #69: variable MCLKTIMEBASE
+	.section	.debug_info
+	.uleb128	69	; ref to abbrev 69
+	.section	.debug_abbrev
+	.uleb128	69
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname69:
+	.string		"MCLKTIMEBASE"
+	.section	.debug_info
+	.long		.Lname69
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #70: variable OSCHFCTRLA
+	.section	.debug_info
+	.uleb128	70	; ref to abbrev 70
+	.section	.debug_abbrev
+	.uleb128	70
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname70:
+	.string		"OSCHFCTRLA"
+	.section	.debug_info
+	.long		.Lname70
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #71: variable OSCHFTUNE
+	.section	.debug_info
+	.uleb128	71	; ref to abbrev 71
+	.section	.debug_abbrev
+	.uleb128	71
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname71:
+	.string		"OSCHFTUNE"
+	.section	.debug_info
+	.long		.Lname71
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #72: variable PLLCTRLA
+	.section	.debug_info
+	.uleb128	72	; ref to abbrev 72
+	.section	.debug_abbrev
+	.uleb128	72
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname72:
+	.string		"PLLCTRLA"
+	.section	.debug_info
+	.long		.Lname72
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #73: variable PLLCTRLB
+	.section	.debug_info
+	.uleb128	73	; ref to abbrev 73
+	.section	.debug_abbrev
+	.uleb128	73
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname73:
+	.string		"PLLCTRLB"
+	.section	.debug_info
+	.long		.Lname73
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #74: variable OSC32KCTRLA
+	.section	.debug_info
+	.uleb128	74	; ref to abbrev 74
+	.section	.debug_abbrev
+	.uleb128	74
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname74:
+	.string		"OSC32KCTRLA"
+	.section	.debug_info
+	.long		.Lname74
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #75: variable XOSC32KCTRLA
+	.section	.debug_info
+	.uleb128	75	; ref to abbrev 75
+	.section	.debug_abbrev
+	.uleb128	75
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname75:
+	.string		"XOSC32KCTRLA"
+	.section	.debug_info
+	.long		.Lname75
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x1C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #76: variable CCP
+	.section	.debug_info
+	.uleb128	76	; ref to abbrev 76
+	.section	.debug_abbrev
+	.uleb128	76
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname76:
+	.string		"CCP"
+	.section	.debug_info
+	.long		.Lname76
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0030 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #77: variable RAMPZ
+	.section	.debug_info
+	.uleb128	77	; ref to abbrev 77
+	.section	.debug_abbrev
+	.uleb128	77
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname77:
+	.string		"RAMPZ"
+	.section	.debug_info
+	.long		.Lname77
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0030 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #78: variable SP
+	.section	.debug_info
+	.uleb128	78	; ref to abbrev 78
+	.section	.debug_abbrev
+	.uleb128	78
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname78:
+	.string		"SP"
+	.section	.debug_info
+	.long		.Lname78
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0030 + 0xD
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #79: variable SREG
+	.section	.debug_info
+	.uleb128	79	; ref to abbrev 79
+	.section	.debug_abbrev
+	.uleb128	79
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname79:
+	.string		"SREG"
+	.section	.debug_info
+	.long		.Lname79
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0030 + 0xF
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #80: variable CTRLA
+	.section	.debug_info
+	.uleb128	80	; ref to abbrev 80
+	.section	.debug_abbrev
+	.uleb128	80
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname80:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname80
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0110 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #81: variable STATUS
+	.section	.debug_info
+	.uleb128	81	; ref to abbrev 81
+	.section	.debug_abbrev
+	.uleb128	81
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname81:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname81
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0110 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #82: variable LVL0PRI
+	.section	.debug_info
+	.uleb128	82	; ref to abbrev 82
+	.section	.debug_abbrev
+	.uleb128	82
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname82:
+	.string		"LVL0PRI"
+	.section	.debug_info
+	.long		.Lname82
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0110 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #83: variable LVL1VEC
+	.section	.debug_info
+	.uleb128	83	; ref to abbrev 83
+	.section	.debug_abbrev
+	.uleb128	83
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname83:
+	.string		"LVL1VEC"
+	.section	.debug_info
+	.long		.Lname83
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0110 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #84: variable CTRLA
+	.section	.debug_info
+	.uleb128	84	; ref to abbrev 84
+	.section	.debug_abbrev
+	.uleb128	84
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname84:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname84
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0120 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #85: variable CTRLB
+	.section	.debug_info
+	.uleb128	85	; ref to abbrev 85
+	.section	.debug_abbrev
+	.uleb128	85
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname85:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname85
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0120 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #86: variable STATUS
+	.section	.debug_info
+	.uleb128	86	; ref to abbrev 86
+	.section	.debug_abbrev
+	.uleb128	86
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname86:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname86
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0120 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #87: variable SWEVENTA
+	.section	.debug_info
+	.uleb128	87	; ref to abbrev 87
+	.section	.debug_abbrev
+	.uleb128	87
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname87:
+	.string		"SWEVENTA"
+	.section	.debug_info
+	.long		.Lname87
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #88: variable CHANNEL0
+	.section	.debug_info
+	.uleb128	88	; ref to abbrev 88
+	.section	.debug_abbrev
+	.uleb128	88
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname88:
+	.string		"CHANNEL0"
+	.section	.debug_info
+	.long		.Lname88
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #89: variable CHANNEL1
+	.section	.debug_info
+	.uleb128	89	; ref to abbrev 89
+	.section	.debug_abbrev
+	.uleb128	89
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname89:
+	.string		"CHANNEL1"
+	.section	.debug_info
+	.long		.Lname89
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #90: variable CHANNEL2
+	.section	.debug_info
+	.uleb128	90	; ref to abbrev 90
+	.section	.debug_abbrev
+	.uleb128	90
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname90:
+	.string		"CHANNEL2"
+	.section	.debug_info
+	.long		.Lname90
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #91: variable CHANNEL3
+	.section	.debug_info
+	.uleb128	91	; ref to abbrev 91
+	.section	.debug_abbrev
+	.uleb128	91
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname91:
+	.string		"CHANNEL3"
+	.section	.debug_info
+	.long		.Lname91
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #92: variable CHANNEL4
+	.section	.debug_info
+	.uleb128	92	; ref to abbrev 92
+	.section	.debug_abbrev
+	.uleb128	92
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname92:
+	.string		"CHANNEL4"
+	.section	.debug_info
+	.long		.Lname92
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #93: variable CHANNEL5
+	.section	.debug_info
+	.uleb128	93	; ref to abbrev 93
+	.section	.debug_abbrev
+	.uleb128	93
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname93:
+	.string		"CHANNEL5"
+	.section	.debug_info
+	.long		.Lname93
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #94: variable USERCCLLUT0A
+	.section	.debug_info
+	.uleb128	94	; ref to abbrev 94
+	.section	.debug_abbrev
+	.uleb128	94
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname94:
+	.string		"USERCCLLUT0A"
+	.section	.debug_info
+	.long		.Lname94
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #95: variable USERCCLLUT0B
+	.section	.debug_info
+	.uleb128	95	; ref to abbrev 95
+	.section	.debug_abbrev
+	.uleb128	95
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname95:
+	.string		"USERCCLLUT0B"
+	.section	.debug_info
+	.long		.Lname95
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x21
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #96: variable USERCCLLUT1A
+	.section	.debug_info
+	.uleb128	96	; ref to abbrev 96
+	.section	.debug_abbrev
+	.uleb128	96
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname96:
+	.string		"USERCCLLUT1A"
+	.section	.debug_info
+	.long		.Lname96
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x22
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #97: variable USERCCLLUT1B
+	.section	.debug_info
+	.uleb128	97	; ref to abbrev 97
+	.section	.debug_abbrev
+	.uleb128	97
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname97:
+	.string		"USERCCLLUT1B"
+	.section	.debug_info
+	.long		.Lname97
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x23
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #98: variable USERCCLLUT2A
+	.section	.debug_info
+	.uleb128	98	; ref to abbrev 98
+	.section	.debug_abbrev
+	.uleb128	98
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname98:
+	.string		"USERCCLLUT2A"
+	.section	.debug_info
+	.long		.Lname98
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x24
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #99: variable USERCCLLUT2B
+	.section	.debug_info
+	.uleb128	99	; ref to abbrev 99
+	.section	.debug_abbrev
+	.uleb128	99
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname99:
+	.string		"USERCCLLUT2B"
+	.section	.debug_info
+	.long		.Lname99
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x25
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #100: variable USERCCLLUT3A
+	.section	.debug_info
+	.uleb128	100	; ref to abbrev 100
+	.section	.debug_abbrev
+	.uleb128	100
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname100:
+	.string		"USERCCLLUT3A"
+	.section	.debug_info
+	.long		.Lname100
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x26
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #101: variable USERCCLLUT3B
+	.section	.debug_info
+	.uleb128	101	; ref to abbrev 101
+	.section	.debug_abbrev
+	.uleb128	101
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname101:
+	.string		"USERCCLLUT3B"
+	.section	.debug_info
+	.long		.Lname101
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x27
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #102: variable USERADC0START
+	.section	.debug_info
+	.uleb128	102	; ref to abbrev 102
+	.section	.debug_abbrev
+	.uleb128	102
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname102:
+	.string		"USERADC0START"
+	.section	.debug_info
+	.long		.Lname102
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x28
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #103: variable USEREVSYSEVOUTA
+	.section	.debug_info
+	.uleb128	103	; ref to abbrev 103
+	.section	.debug_abbrev
+	.uleb128	103
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname103:
+	.string		"USEREVSYSEVOUTA"
+	.section	.debug_info
+	.long		.Lname103
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x29
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #104: variable USEREVSYSEVOUTC
+	.section	.debug_info
+	.uleb128	104	; ref to abbrev 104
+	.section	.debug_abbrev
+	.uleb128	104
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname104:
+	.string		"USEREVSYSEVOUTC"
+	.section	.debug_info
+	.long		.Lname104
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #105: variable USEREVSYSEVOUTD
+	.section	.debug_info
+	.uleb128	105	; ref to abbrev 105
+	.section	.debug_abbrev
+	.uleb128	105
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname105:
+	.string		"USEREVSYSEVOUTD"
+	.section	.debug_info
+	.long		.Lname105
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #106: variable USEREVSYSEVOUTF
+	.section	.debug_info
+	.uleb128	106	; ref to abbrev 106
+	.section	.debug_abbrev
+	.uleb128	106
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname106:
+	.string		"USEREVSYSEVOUTF"
+	.section	.debug_info
+	.long		.Lname106
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #107: variable USERUSART0IRDA
+	.section	.debug_info
+	.uleb128	107	; ref to abbrev 107
+	.section	.debug_abbrev
+	.uleb128	107
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname107:
+	.string		"USERUSART0IRDA"
+	.section	.debug_info
+	.long		.Lname107
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #108: variable USERTCE0CNTA
+	.section	.debug_info
+	.uleb128	108	; ref to abbrev 108
+	.section	.debug_abbrev
+	.uleb128	108
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname108:
+	.string		"USERTCE0CNTA"
+	.section	.debug_info
+	.long		.Lname108
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #109: variable USERTCE0CNTB
+	.section	.debug_info
+	.uleb128	109	; ref to abbrev 109
+	.section	.debug_abbrev
+	.uleb128	109
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname109:
+	.string		"USERTCE0CNTB"
+	.section	.debug_info
+	.long		.Lname109
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #110: variable USERTCB0CAPT
+	.section	.debug_info
+	.uleb128	110	; ref to abbrev 110
+	.section	.debug_abbrev
+	.uleb128	110
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname110:
+	.string		"USERTCB0CAPT"
+	.section	.debug_info
+	.long		.Lname110
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x30
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #111: variable USERTCB0COUNT
+	.section	.debug_info
+	.uleb128	111	; ref to abbrev 111
+	.section	.debug_abbrev
+	.uleb128	111
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname111:
+	.string		"USERTCB0COUNT"
+	.section	.debug_info
+	.long		.Lname111
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x31
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #112: variable USERTCB1CAPT
+	.section	.debug_info
+	.uleb128	112	; ref to abbrev 112
+	.section	.debug_abbrev
+	.uleb128	112
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname112:
+	.string		"USERTCB1CAPT"
+	.section	.debug_info
+	.long		.Lname112
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x32
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #113: variable USERTCB1COUNT
+	.section	.debug_info
+	.uleb128	113	; ref to abbrev 113
+	.section	.debug_abbrev
+	.uleb128	113
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname113:
+	.string		"USERTCB1COUNT"
+	.section	.debug_info
+	.long		.Lname113
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x33
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #114: variable USERTCF0CNT
+	.section	.debug_info
+	.uleb128	114	; ref to abbrev 114
+	.section	.debug_abbrev
+	.uleb128	114
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname114:
+	.string		"USERTCF0CNT"
+	.section	.debug_info
+	.long		.Lname114
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x34
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #115: variable USERTCF0ACT
+	.section	.debug_info
+	.uleb128	115	; ref to abbrev 115
+	.section	.debug_abbrev
+	.uleb128	115
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname115:
+	.string		"USERTCF0ACT"
+	.section	.debug_info
+	.long		.Lname115
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x35
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #116: variable USERWEXA
+	.section	.debug_info
+	.uleb128	116	; ref to abbrev 116
+	.section	.debug_abbrev
+	.uleb128	116
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname116:
+	.string		"USERWEXA"
+	.section	.debug_info
+	.long		.Lname116
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x36
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #117: variable USERWEXB
+	.section	.debug_info
+	.uleb128	117	; ref to abbrev 117
+	.section	.debug_abbrev
+	.uleb128	117
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname117:
+	.string		"USERWEXB"
+	.section	.debug_info
+	.long		.Lname117
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x37
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #118: variable USERWEXC
+	.section	.debug_info
+	.uleb128	118	; ref to abbrev 118
+	.section	.debug_abbrev
+	.uleb128	118
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname118:
+	.string		"USERWEXC"
+	.section	.debug_info
+	.long		.Lname118
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x38
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #119: variable WDTCFG
+	.section	.debug_info
+	.uleb128	119	; ref to abbrev 119
+	.section	.debug_abbrev
+	.uleb128	119
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname119:
+	.string		"WDTCFG"
+	.section	.debug_info
+	.long		.Lname119
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #120: variable BODCFG
+	.section	.debug_info
+	.uleb128	120	; ref to abbrev 120
+	.section	.debug_abbrev
+	.uleb128	120
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname120:
+	.string		"BODCFG"
+	.section	.debug_info
+	.long		.Lname120
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #121: variable OSCCFG
+	.section	.debug_info
+	.uleb128	121	; ref to abbrev 121
+	.section	.debug_abbrev
+	.uleb128	121
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname121:
+	.string		"OSCCFG"
+	.section	.debug_info
+	.long		.Lname121
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #122: variable SYSCFG0
+	.section	.debug_info
+	.uleb128	122	; ref to abbrev 122
+	.section	.debug_abbrev
+	.uleb128	122
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname122:
+	.string		"SYSCFG0"
+	.section	.debug_info
+	.long		.Lname122
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #123: variable SYSCFG1
+	.section	.debug_info
+	.uleb128	123	; ref to abbrev 123
+	.section	.debug_abbrev
+	.uleb128	123
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname123:
+	.string		"SYSCFG1"
+	.section	.debug_info
+	.long		.Lname123
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #124: variable CODESIZE
+	.section	.debug_info
+	.uleb128	124	; ref to abbrev 124
+	.section	.debug_abbrev
+	.uleb128	124
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname124:
+	.string		"CODESIZE"
+	.section	.debug_info
+	.long		.Lname124
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #125: variable BOOTSIZE
+	.section	.debug_info
+	.uleb128	125	; ref to abbrev 125
+	.section	.debug_abbrev
+	.uleb128	125
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname125:
+	.string		"BOOTSIZE"
+	.section	.debug_info
+	.long		.Lname125
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #126: variable PDICFG
+	.section	.debug_info
+	.uleb128	126	; ref to abbrev 126
+	.section	.debug_abbrev
+	.uleb128	126
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname126:
+	.string		"PDICFG"
+	.section	.debug_info
+	.long		.Lname126
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #127: variable GPR0
+	.section	.debug_info
+	.uleb128	127	; ref to abbrev 127
+	.section	.debug_abbrev
+	.uleb128	127
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname127:
+	.string		"GPR0"
+	.section	.debug_info
+	.long		.Lname127
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x001C + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #128: variable GPR1
+	.section	.debug_info
+	.uleb128	128	; ref to abbrev 128
+	.section	.debug_abbrev
+	.uleb128	128
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname128:
+	.string		"GPR1"
+	.section	.debug_info
+	.long		.Lname128
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x001C + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #129: variable GPR2
+	.section	.debug_info
+	.uleb128	129	; ref to abbrev 129
+	.section	.debug_abbrev
+	.uleb128	129
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname129:
+	.string		"GPR2"
+	.section	.debug_info
+	.long		.Lname129
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x001C + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #130: variable GPR3
+	.section	.debug_info
+	.uleb128	130	; ref to abbrev 130
+	.section	.debug_abbrev
+	.uleb128	130
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname130:
+	.string		"GPR3"
+	.section	.debug_info
+	.long		.Lname130
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x001C + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #131: variable KEY
+	.section	.debug_info
+	.uleb128	131	; ref to abbrev 131
+	.section	.debug_abbrev
+	.uleb128	131
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname131:
+	.string		"KEY"
+	.section	.debug_info
+	.long		.Lname131
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint32_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1040 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #132: variable CTRLA
+	.section	.debug_info
+	.uleb128	132	; ref to abbrev 132
+	.section	.debug_abbrev
+	.uleb128	132
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname132:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname132
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #133: variable CTRLB
+	.section	.debug_info
+	.uleb128	133	; ref to abbrev 133
+	.section	.debug_abbrev
+	.uleb128	133
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname133:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname133
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #134: variable CTRLC
+	.section	.debug_info
+	.uleb128	134	; ref to abbrev 134
+	.section	.debug_abbrev
+	.uleb128	134
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname134:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname134
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #135: variable INTCTRL
+	.section	.debug_info
+	.uleb128	135	; ref to abbrev 135
+	.section	.debug_abbrev
+	.uleb128	135
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname135:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname135
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #136: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	136	; ref to abbrev 136
+	.section	.debug_abbrev
+	.uleb128	136
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname136:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname136
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #137: variable STATUS
+	.section	.debug_info
+	.uleb128	137	; ref to abbrev 137
+	.section	.debug_abbrev
+	.uleb128	137
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname137:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname137
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #138: variable DATA
+	.section	.debug_info
+	.uleb128	138	; ref to abbrev 138
+	.section	.debug_abbrev
+	.uleb128	138
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname138:
+	.string		"DATA"
+	.section	.debug_info
+	.long		.Lname138
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #139: variable ADDR
+	.section	.debug_info
+	.uleb128	139	; ref to abbrev 139
+	.section	.debug_abbrev
+	.uleb128	139
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname139:
+	.string		"ADDR"
+	.section	.debug_info
+	.long		.Lname139
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint32_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #140: variable DIR
+	.section	.debug_info
+	.uleb128	140	; ref to abbrev 140
+	.section	.debug_abbrev
+	.uleb128	140
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname140:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname140
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #141: variable DIRSET
+	.section	.debug_info
+	.uleb128	141	; ref to abbrev 141
+	.section	.debug_abbrev
+	.uleb128	141
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname141:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname141
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #142: variable DIRCLR
+	.section	.debug_info
+	.uleb128	142	; ref to abbrev 142
+	.section	.debug_abbrev
+	.uleb128	142
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname142:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname142
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #143: variable DIRTGL
+	.section	.debug_info
+	.uleb128	143	; ref to abbrev 143
+	.section	.debug_abbrev
+	.uleb128	143
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname143:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname143
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #144: variable OUT
+	.section	.debug_info
+	.uleb128	144	; ref to abbrev 144
+	.section	.debug_abbrev
+	.uleb128	144
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname144:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname144
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #145: variable OUTSET
+	.section	.debug_info
+	.uleb128	145	; ref to abbrev 145
+	.section	.debug_abbrev
+	.uleb128	145
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname145:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname145
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #146: variable OUTCLR
+	.section	.debug_info
+	.uleb128	146	; ref to abbrev 146
+	.section	.debug_abbrev
+	.uleb128	146
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname146:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname146
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #147: variable OUTTGL
+	.section	.debug_info
+	.uleb128	147	; ref to abbrev 147
+	.section	.debug_abbrev
+	.uleb128	147
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname147:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname147
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #148: variable IN
+	.section	.debug_info
+	.uleb128	148	; ref to abbrev 148
+	.section	.debug_abbrev
+	.uleb128	148
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname148:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname148
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #149: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	149	; ref to abbrev 149
+	.section	.debug_abbrev
+	.uleb128	149
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname149:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname149
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #150: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	150	; ref to abbrev 150
+	.section	.debug_abbrev
+	.uleb128	150
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname150:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname150
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #151: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	151	; ref to abbrev 151
+	.section	.debug_abbrev
+	.uleb128	151
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname151:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname151
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #152: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	152	; ref to abbrev 152
+	.section	.debug_abbrev
+	.uleb128	152
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname152:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname152
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #153: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	153	; ref to abbrev 153
+	.section	.debug_abbrev
+	.uleb128	153
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname153:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname153
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #154: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	154	; ref to abbrev 154
+	.section	.debug_abbrev
+	.uleb128	154
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname154:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname154
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #155: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	155	; ref to abbrev 155
+	.section	.debug_abbrev
+	.uleb128	155
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname155:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname155
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #156: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	156	; ref to abbrev 156
+	.section	.debug_abbrev
+	.uleb128	156
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname156:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname156
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #157: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	157	; ref to abbrev 157
+	.section	.debug_abbrev
+	.uleb128	157
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname157:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname157
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #158: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	158	; ref to abbrev 158
+	.section	.debug_abbrev
+	.uleb128	158
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname158:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname158
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #159: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	159	; ref to abbrev 159
+	.section	.debug_abbrev
+	.uleb128	159
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname159:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname159
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #160: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	160	; ref to abbrev 160
+	.section	.debug_abbrev
+	.uleb128	160
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname160:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname160
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #161: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	161	; ref to abbrev 161
+	.section	.debug_abbrev
+	.uleb128	161
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname161:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname161
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #162: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	162	; ref to abbrev 162
+	.section	.debug_abbrev
+	.uleb128	162
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname162:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname162
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #163: variable EVGENCTRLA
+	.section	.debug_info
+	.uleb128	163	; ref to abbrev 163
+	.section	.debug_abbrev
+	.uleb128	163
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname163:
+	.string		"EVGENCTRLA"
+	.section	.debug_info
+	.long		.Lname163
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #164: variable DIR
+	.section	.debug_info
+	.uleb128	164	; ref to abbrev 164
+	.section	.debug_abbrev
+	.uleb128	164
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname164:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname164
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #165: variable DIRSET
+	.section	.debug_info
+	.uleb128	165	; ref to abbrev 165
+	.section	.debug_abbrev
+	.uleb128	165
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname165:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname165
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #166: variable DIRCLR
+	.section	.debug_info
+	.uleb128	166	; ref to abbrev 166
+	.section	.debug_abbrev
+	.uleb128	166
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname166:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname166
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #167: variable DIRTGL
+	.section	.debug_info
+	.uleb128	167	; ref to abbrev 167
+	.section	.debug_abbrev
+	.uleb128	167
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname167:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname167
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #168: variable OUT
+	.section	.debug_info
+	.uleb128	168	; ref to abbrev 168
+	.section	.debug_abbrev
+	.uleb128	168
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname168:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname168
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #169: variable OUTSET
+	.section	.debug_info
+	.uleb128	169	; ref to abbrev 169
+	.section	.debug_abbrev
+	.uleb128	169
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname169:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname169
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #170: variable OUTCLR
+	.section	.debug_info
+	.uleb128	170	; ref to abbrev 170
+	.section	.debug_abbrev
+	.uleb128	170
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname170:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname170
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #171: variable OUTTGL
+	.section	.debug_info
+	.uleb128	171	; ref to abbrev 171
+	.section	.debug_abbrev
+	.uleb128	171
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname171:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname171
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #172: variable IN
+	.section	.debug_info
+	.uleb128	172	; ref to abbrev 172
+	.section	.debug_abbrev
+	.uleb128	172
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname172:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname172
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #173: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	173	; ref to abbrev 173
+	.section	.debug_abbrev
+	.uleb128	173
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname173:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname173
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #174: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	174	; ref to abbrev 174
+	.section	.debug_abbrev
+	.uleb128	174
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname174:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname174
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #175: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	175	; ref to abbrev 175
+	.section	.debug_abbrev
+	.uleb128	175
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname175:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname175
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #176: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	176	; ref to abbrev 176
+	.section	.debug_abbrev
+	.uleb128	176
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname176:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname176
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #177: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	177	; ref to abbrev 177
+	.section	.debug_abbrev
+	.uleb128	177
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname177:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname177
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #178: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	178	; ref to abbrev 178
+	.section	.debug_abbrev
+	.uleb128	178
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname178:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname178
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #179: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	179	; ref to abbrev 179
+	.section	.debug_abbrev
+	.uleb128	179
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname179:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname179
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #180: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	180	; ref to abbrev 180
+	.section	.debug_abbrev
+	.uleb128	180
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname180:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname180
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #181: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	181	; ref to abbrev 181
+	.section	.debug_abbrev
+	.uleb128	181
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname181:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname181
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #182: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	182	; ref to abbrev 182
+	.section	.debug_abbrev
+	.uleb128	182
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname182:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname182
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #183: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	183	; ref to abbrev 183
+	.section	.debug_abbrev
+	.uleb128	183
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname183:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname183
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #184: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	184	; ref to abbrev 184
+	.section	.debug_abbrev
+	.uleb128	184
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname184:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname184
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #185: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	185	; ref to abbrev 185
+	.section	.debug_abbrev
+	.uleb128	185
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname185:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname185
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #186: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	186	; ref to abbrev 186
+	.section	.debug_abbrev
+	.uleb128	186
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname186:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname186
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #187: variable EVGENCTRLA
+	.section	.debug_info
+	.uleb128	187	; ref to abbrev 187
+	.section	.debug_abbrev
+	.uleb128	187
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname187:
+	.string		"EVGENCTRLA"
+	.section	.debug_info
+	.long		.Lname187
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #188: variable DIR
+	.section	.debug_info
+	.uleb128	188	; ref to abbrev 188
+	.section	.debug_abbrev
+	.uleb128	188
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname188:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname188
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #189: variable DIRSET
+	.section	.debug_info
+	.uleb128	189	; ref to abbrev 189
+	.section	.debug_abbrev
+	.uleb128	189
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname189:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname189
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #190: variable DIRCLR
+	.section	.debug_info
+	.uleb128	190	; ref to abbrev 190
+	.section	.debug_abbrev
+	.uleb128	190
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname190:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname190
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #191: variable DIRTGL
+	.section	.debug_info
+	.uleb128	191	; ref to abbrev 191
+	.section	.debug_abbrev
+	.uleb128	191
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname191:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname191
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #192: variable OUT
+	.section	.debug_info
+	.uleb128	192	; ref to abbrev 192
+	.section	.debug_abbrev
+	.uleb128	192
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname192:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname192
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #193: variable OUTSET
+	.section	.debug_info
+	.uleb128	193	; ref to abbrev 193
+	.section	.debug_abbrev
+	.uleb128	193
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname193:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname193
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #194: variable OUTCLR
+	.section	.debug_info
+	.uleb128	194	; ref to abbrev 194
+	.section	.debug_abbrev
+	.uleb128	194
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname194:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname194
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #195: variable OUTTGL
+	.section	.debug_info
+	.uleb128	195	; ref to abbrev 195
+	.section	.debug_abbrev
+	.uleb128	195
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname195:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname195
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #196: variable IN
+	.section	.debug_info
+	.uleb128	196	; ref to abbrev 196
+	.section	.debug_abbrev
+	.uleb128	196
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname196:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname196
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #197: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	197	; ref to abbrev 197
+	.section	.debug_abbrev
+	.uleb128	197
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname197:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname197
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #198: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	198	; ref to abbrev 198
+	.section	.debug_abbrev
+	.uleb128	198
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname198:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname198
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #199: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	199	; ref to abbrev 199
+	.section	.debug_abbrev
+	.uleb128	199
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname199:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname199
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #200: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	200	; ref to abbrev 200
+	.section	.debug_abbrev
+	.uleb128	200
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname200:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname200
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #201: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	201	; ref to abbrev 201
+	.section	.debug_abbrev
+	.uleb128	201
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname201:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname201
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #202: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	202	; ref to abbrev 202
+	.section	.debug_abbrev
+	.uleb128	202
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname202:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname202
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #203: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	203	; ref to abbrev 203
+	.section	.debug_abbrev
+	.uleb128	203
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname203:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname203
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #204: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	204	; ref to abbrev 204
+	.section	.debug_abbrev
+	.uleb128	204
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname204:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname204
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #205: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	205	; ref to abbrev 205
+	.section	.debug_abbrev
+	.uleb128	205
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname205:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname205
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #206: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	206	; ref to abbrev 206
+	.section	.debug_abbrev
+	.uleb128	206
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname206:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname206
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #207: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	207	; ref to abbrev 207
+	.section	.debug_abbrev
+	.uleb128	207
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname207:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname207
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #208: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	208	; ref to abbrev 208
+	.section	.debug_abbrev
+	.uleb128	208
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname208:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname208
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #209: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	209	; ref to abbrev 209
+	.section	.debug_abbrev
+	.uleb128	209
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname209:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname209
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #210: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	210	; ref to abbrev 210
+	.section	.debug_abbrev
+	.uleb128	210
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname210:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname210
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #211: variable EVGENCTRLA
+	.section	.debug_info
+	.uleb128	211	; ref to abbrev 211
+	.section	.debug_abbrev
+	.uleb128	211
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname211:
+	.string		"EVGENCTRLA"
+	.section	.debug_info
+	.long		.Lname211
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #212: variable DIR
+	.section	.debug_info
+	.uleb128	212	; ref to abbrev 212
+	.section	.debug_abbrev
+	.uleb128	212
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname212:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname212
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #213: variable DIRSET
+	.section	.debug_info
+	.uleb128	213	; ref to abbrev 213
+	.section	.debug_abbrev
+	.uleb128	213
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname213:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname213
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #214: variable DIRCLR
+	.section	.debug_info
+	.uleb128	214	; ref to abbrev 214
+	.section	.debug_abbrev
+	.uleb128	214
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname214:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname214
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #215: variable DIRTGL
+	.section	.debug_info
+	.uleb128	215	; ref to abbrev 215
+	.section	.debug_abbrev
+	.uleb128	215
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname215:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname215
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #216: variable OUT
+	.section	.debug_info
+	.uleb128	216	; ref to abbrev 216
+	.section	.debug_abbrev
+	.uleb128	216
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname216:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname216
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #217: variable OUTSET
+	.section	.debug_info
+	.uleb128	217	; ref to abbrev 217
+	.section	.debug_abbrev
+	.uleb128	217
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname217:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname217
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #218: variable OUTCLR
+	.section	.debug_info
+	.uleb128	218	; ref to abbrev 218
+	.section	.debug_abbrev
+	.uleb128	218
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname218:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname218
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #219: variable OUTTGL
+	.section	.debug_info
+	.uleb128	219	; ref to abbrev 219
+	.section	.debug_abbrev
+	.uleb128	219
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname219:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname219
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #220: variable IN
+	.section	.debug_info
+	.uleb128	220	; ref to abbrev 220
+	.section	.debug_abbrev
+	.uleb128	220
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname220:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname220
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #221: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	221	; ref to abbrev 221
+	.section	.debug_abbrev
+	.uleb128	221
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname221:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname221
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #222: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	222	; ref to abbrev 222
+	.section	.debug_abbrev
+	.uleb128	222
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname222:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname222
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #223: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	223	; ref to abbrev 223
+	.section	.debug_abbrev
+	.uleb128	223
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname223:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname223
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #224: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	224	; ref to abbrev 224
+	.section	.debug_abbrev
+	.uleb128	224
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname224:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname224
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #225: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	225	; ref to abbrev 225
+	.section	.debug_abbrev
+	.uleb128	225
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname225:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname225
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #226: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	226	; ref to abbrev 226
+	.section	.debug_abbrev
+	.uleb128	226
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname226:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname226
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #227: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	227	; ref to abbrev 227
+	.section	.debug_abbrev
+	.uleb128	227
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname227:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname227
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #228: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	228	; ref to abbrev 228
+	.section	.debug_abbrev
+	.uleb128	228
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname228:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname228
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #229: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	229	; ref to abbrev 229
+	.section	.debug_abbrev
+	.uleb128	229
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname229:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname229
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #230: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	230	; ref to abbrev 230
+	.section	.debug_abbrev
+	.uleb128	230
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname230:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname230
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #231: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	231	; ref to abbrev 231
+	.section	.debug_abbrev
+	.uleb128	231
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname231:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname231
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #232: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	232	; ref to abbrev 232
+	.section	.debug_abbrev
+	.uleb128	232
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname232:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname232
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #233: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	233	; ref to abbrev 233
+	.section	.debug_abbrev
+	.uleb128	233
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname233:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname233
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #234: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	234	; ref to abbrev 234
+	.section	.debug_abbrev
+	.uleb128	234
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname234:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname234
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #235: variable EVGENCTRLA
+	.section	.debug_info
+	.uleb128	235	; ref to abbrev 235
+	.section	.debug_abbrev
+	.uleb128	235
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname235:
+	.string		"EVGENCTRLA"
+	.section	.debug_info
+	.long		.Lname235
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #236: variable EVSYSROUTEA
+	.section	.debug_info
+	.uleb128	236	; ref to abbrev 236
+	.section	.debug_abbrev
+	.uleb128	236
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname236:
+	.string		"EVSYSROUTEA"
+	.section	.debug_info
+	.long		.Lname236
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #237: variable CCLROUTEA
+	.section	.debug_info
+	.uleb128	237	; ref to abbrev 237
+	.section	.debug_abbrev
+	.uleb128	237
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname237:
+	.string		"CCLROUTEA"
+	.section	.debug_info
+	.long		.Lname237
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #238: variable USARTROUTEA
+	.section	.debug_info
+	.uleb128	238	; ref to abbrev 238
+	.section	.debug_abbrev
+	.uleb128	238
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname238:
+	.string		"USARTROUTEA"
+	.section	.debug_info
+	.long		.Lname238
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #239: variable SPIROUTEA
+	.section	.debug_info
+	.uleb128	239	; ref to abbrev 239
+	.section	.debug_abbrev
+	.uleb128	239
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname239:
+	.string		"SPIROUTEA"
+	.section	.debug_info
+	.long		.Lname239
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #240: variable TWIROUTEA
+	.section	.debug_info
+	.uleb128	240	; ref to abbrev 240
+	.section	.debug_abbrev
+	.uleb128	240
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname240:
+	.string		"TWIROUTEA"
+	.section	.debug_info
+	.long		.Lname240
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #241: variable TCEROUTEA
+	.section	.debug_info
+	.uleb128	241	; ref to abbrev 241
+	.section	.debug_abbrev
+	.uleb128	241
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname241:
+	.string		"TCEROUTEA"
+	.section	.debug_info
+	.long		.Lname241
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #242: variable TCFROUTEA
+	.section	.debug_info
+	.uleb128	242	; ref to abbrev 242
+	.section	.debug_abbrev
+	.uleb128	242
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname242:
+	.string		"TCFROUTEA"
+	.section	.debug_info
+	.long		.Lname242
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #243: variable RSTFR
+	.section	.debug_info
+	.uleb128	243	; ref to abbrev 243
+	.section	.debug_abbrev
+	.uleb128	243
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname243:
+	.string		"RSTFR"
+	.section	.debug_info
+	.long		.Lname243
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0040 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #244: variable SWRR
+	.section	.debug_info
+	.uleb128	244	; ref to abbrev 244
+	.section	.debug_abbrev
+	.uleb128	244
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname244:
+	.string		"SWRR"
+	.section	.debug_info
+	.long		.Lname244
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0040 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #245: variable CTRLA
+	.section	.debug_info
+	.uleb128	245	; ref to abbrev 245
+	.section	.debug_abbrev
+	.uleb128	245
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname245:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname245
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #246: variable STATUS
+	.section	.debug_info
+	.uleb128	246	; ref to abbrev 246
+	.section	.debug_abbrev
+	.uleb128	246
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname246:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname246
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #247: variable INTCTRL
+	.section	.debug_info
+	.uleb128	247	; ref to abbrev 247
+	.section	.debug_abbrev
+	.uleb128	247
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname247:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname247
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #248: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	248	; ref to abbrev 248
+	.section	.debug_abbrev
+	.uleb128	248
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname248:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname248
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #249: variable TEMP
+	.section	.debug_info
+	.uleb128	249	; ref to abbrev 249
+	.section	.debug_abbrev
+	.uleb128	249
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname249:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname249
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #250: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	250	; ref to abbrev 250
+	.section	.debug_abbrev
+	.uleb128	250
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname250:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname250
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #251: variable CALIB
+	.section	.debug_info
+	.uleb128	251	; ref to abbrev 251
+	.section	.debug_abbrev
+	.uleb128	251
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname251:
+	.string		"CALIB"
+	.section	.debug_info
+	.long		.Lname251
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #252: variable CLKSEL
+	.section	.debug_info
+	.uleb128	252	; ref to abbrev 252
+	.section	.debug_abbrev
+	.uleb128	252
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname252:
+	.string		"CLKSEL"
+	.section	.debug_info
+	.long		.Lname252
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #253: variable CNT
+	.section	.debug_info
+	.uleb128	253	; ref to abbrev 253
+	.section	.debug_abbrev
+	.uleb128	253
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname253:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname253
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #254: variable PER
+	.section	.debug_info
+	.uleb128	254	; ref to abbrev 254
+	.section	.debug_abbrev
+	.uleb128	254
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname254:
+	.string		"PER"
+	.section	.debug_info
+	.long		.Lname254
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #255: variable CMP
+	.section	.debug_info
+	.uleb128	255	; ref to abbrev 255
+	.section	.debug_abbrev
+	.uleb128	255
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname255:
+	.string		"CMP"
+	.section	.debug_info
+	.long		.Lname255
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #256: variable PITCTRLA
+	.section	.debug_info
+	.uleb128	256	; ref to abbrev 256
+	.section	.debug_abbrev
+	.uleb128	256
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname256:
+	.string		"PITCTRLA"
+	.section	.debug_info
+	.long		.Lname256
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #257: variable PITSTATUS
+	.section	.debug_info
+	.uleb128	257	; ref to abbrev 257
+	.section	.debug_abbrev
+	.uleb128	257
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname257:
+	.string		"PITSTATUS"
+	.section	.debug_info
+	.long		.Lname257
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #258: variable PITINTCTRL
+	.section	.debug_info
+	.uleb128	258	; ref to abbrev 258
+	.section	.debug_abbrev
+	.uleb128	258
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname258:
+	.string		"PITINTCTRL"
+	.section	.debug_info
+	.long		.Lname258
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #259: variable PITINTFLAGS
+	.section	.debug_info
+	.uleb128	259	; ref to abbrev 259
+	.section	.debug_abbrev
+	.uleb128	259
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname259:
+	.string		"PITINTFLAGS"
+	.section	.debug_info
+	.long		.Lname259
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #260: variable PITDBGCTRL
+	.section	.debug_info
+	.uleb128	260	; ref to abbrev 260
+	.section	.debug_abbrev
+	.uleb128	260
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname260:
+	.string		"PITDBGCTRL"
+	.section	.debug_info
+	.long		.Lname260
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #261: variable PITEVGENCTRLA
+	.section	.debug_info
+	.uleb128	261	; ref to abbrev 261
+	.section	.debug_abbrev
+	.uleb128	261
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname261:
+	.string		"PITEVGENCTRLA"
+	.section	.debug_info
+	.long		.Lname261
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #262: variable DEVICEID0
+	.section	.debug_info
+	.uleb128	262	; ref to abbrev 262
+	.section	.debug_abbrev
+	.uleb128	262
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname262:
+	.string		"DEVICEID0"
+	.section	.debug_info
+	.long		.Lname262
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #263: variable DEVICEID1
+	.section	.debug_info
+	.uleb128	263	; ref to abbrev 263
+	.section	.debug_abbrev
+	.uleb128	263
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname263:
+	.string		"DEVICEID1"
+	.section	.debug_info
+	.long		.Lname263
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #264: variable DEVICEID2
+	.section	.debug_info
+	.uleb128	264	; ref to abbrev 264
+	.section	.debug_abbrev
+	.uleb128	264
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname264:
+	.string		"DEVICEID2"
+	.section	.debug_info
+	.long		.Lname264
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #265: variable TEMPSENSE0
+	.section	.debug_info
+	.uleb128	265	; ref to abbrev 265
+	.section	.debug_abbrev
+	.uleb128	265
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname265:
+	.string		"TEMPSENSE0"
+	.section	.debug_info
+	.long		.Lname265
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #266: variable TEMPSENSE1
+	.section	.debug_info
+	.uleb128	266	; ref to abbrev 266
+	.section	.debug_abbrev
+	.uleb128	266
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname266:
+	.string		"TEMPSENSE1"
+	.section	.debug_info
+	.long		.Lname266
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #267: variable SERNUM0
+	.section	.debug_info
+	.uleb128	267	; ref to abbrev 267
+	.section	.debug_abbrev
+	.uleb128	267
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname267:
+	.string		"SERNUM0"
+	.section	.debug_info
+	.long		.Lname267
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #268: variable SERNUM1
+	.section	.debug_info
+	.uleb128	268	; ref to abbrev 268
+	.section	.debug_abbrev
+	.uleb128	268
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname268:
+	.string		"SERNUM1"
+	.section	.debug_info
+	.long		.Lname268
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #269: variable SERNUM2
+	.section	.debug_info
+	.uleb128	269	; ref to abbrev 269
+	.section	.debug_abbrev
+	.uleb128	269
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname269:
+	.string		"SERNUM2"
+	.section	.debug_info
+	.long		.Lname269
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #270: variable SERNUM3
+	.section	.debug_info
+	.uleb128	270	; ref to abbrev 270
+	.section	.debug_abbrev
+	.uleb128	270
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname270:
+	.string		"SERNUM3"
+	.section	.debug_info
+	.long		.Lname270
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #271: variable SERNUM4
+	.section	.debug_info
+	.uleb128	271	; ref to abbrev 271
+	.section	.debug_abbrev
+	.uleb128	271
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname271:
+	.string		"SERNUM4"
+	.section	.debug_info
+	.long		.Lname271
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #272: variable SERNUM5
+	.section	.debug_info
+	.uleb128	272	; ref to abbrev 272
+	.section	.debug_abbrev
+	.uleb128	272
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname272:
+	.string		"SERNUM5"
+	.section	.debug_info
+	.long		.Lname272
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #273: variable SERNUM6
+	.section	.debug_info
+	.uleb128	273	; ref to abbrev 273
+	.section	.debug_abbrev
+	.uleb128	273
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname273:
+	.string		"SERNUM6"
+	.section	.debug_info
+	.long		.Lname273
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #274: variable SERNUM7
+	.section	.debug_info
+	.uleb128	274	; ref to abbrev 274
+	.section	.debug_abbrev
+	.uleb128	274
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname274:
+	.string		"SERNUM7"
+	.section	.debug_info
+	.long		.Lname274
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #275: variable SERNUM8
+	.section	.debug_info
+	.uleb128	275	; ref to abbrev 275
+	.section	.debug_abbrev
+	.uleb128	275
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname275:
+	.string		"SERNUM8"
+	.section	.debug_info
+	.long		.Lname275
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #276: variable SERNUM9
+	.section	.debug_info
+	.uleb128	276	; ref to abbrev 276
+	.section	.debug_abbrev
+	.uleb128	276
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname276:
+	.string		"SERNUM9"
+	.section	.debug_info
+	.long		.Lname276
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x19
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #277: variable SERNUM10
+	.section	.debug_info
+	.uleb128	277	; ref to abbrev 277
+	.section	.debug_abbrev
+	.uleb128	277
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname277:
+	.string		"SERNUM10"
+	.section	.debug_info
+	.long		.Lname277
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #278: variable SERNUM11
+	.section	.debug_info
+	.uleb128	278	; ref to abbrev 278
+	.section	.debug_abbrev
+	.uleb128	278
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname278:
+	.string		"SERNUM11"
+	.section	.debug_info
+	.long		.Lname278
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #279: variable SERNUM12
+	.section	.debug_info
+	.uleb128	279	; ref to abbrev 279
+	.section	.debug_abbrev
+	.uleb128	279
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname279:
+	.string		"SERNUM12"
+	.section	.debug_info
+	.long		.Lname279
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #280: variable SERNUM13
+	.section	.debug_info
+	.uleb128	280	; ref to abbrev 280
+	.section	.debug_abbrev
+	.uleb128	280
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname280:
+	.string		"SERNUM13"
+	.section	.debug_info
+	.long		.Lname280
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #281: variable SERNUM14
+	.section	.debug_info
+	.uleb128	281	; ref to abbrev 281
+	.section	.debug_abbrev
+	.uleb128	281
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname281:
+	.string		"SERNUM14"
+	.section	.debug_info
+	.long		.Lname281
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #282: variable SERNUM15
+	.section	.debug_info
+	.uleb128	282	; ref to abbrev 282
+	.section	.debug_abbrev
+	.uleb128	282
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname282:
+	.string		"SERNUM15"
+	.section	.debug_info
+	.long		.Lname282
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #283: variable CTRLA
+	.section	.debug_info
+	.uleb128	283	; ref to abbrev 283
+	.section	.debug_abbrev
+	.uleb128	283
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname283:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname283
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0050 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #284: variable CTRLA
+	.section	.debug_info
+	.uleb128	284	; ref to abbrev 284
+	.section	.debug_abbrev
+	.uleb128	284
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname284:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname284
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #285: variable CTRLB
+	.section	.debug_info
+	.uleb128	285	; ref to abbrev 285
+	.section	.debug_abbrev
+	.uleb128	285
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname285:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname285
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #286: variable INTCTRL
+	.section	.debug_info
+	.uleb128	286	; ref to abbrev 286
+	.section	.debug_abbrev
+	.uleb128	286
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname286:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname286
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #287: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	287	; ref to abbrev 287
+	.section	.debug_abbrev
+	.uleb128	287
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname287:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname287
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #288: variable DATA
+	.section	.debug_info
+	.uleb128	288	; ref to abbrev 288
+	.section	.debug_abbrev
+	.uleb128	288
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname288:
+	.string		"DATA"
+	.section	.debug_info
+	.long		.Lname288
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #289: variable REVID
+	.section	.debug_info
+	.uleb128	289	; ref to abbrev 289
+	.section	.debug_abbrev
+	.uleb128	289
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname289:
+	.string		"REVID"
+	.section	.debug_info
+	.long		.Lname289
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0F00 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #290: variable CTRLA
+	.section	.debug_info
+	.uleb128	290	; ref to abbrev 290
+	.section	.debug_abbrev
+	.uleb128	290
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname290:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname290
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #291: variable CTRLB
+	.section	.debug_info
+	.uleb128	291	; ref to abbrev 291
+	.section	.debug_abbrev
+	.uleb128	291
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname291:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname291
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #292: variable CTRLC
+	.section	.debug_info
+	.uleb128	292	; ref to abbrev 292
+	.section	.debug_abbrev
+	.uleb128	292
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname292:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname292
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #293: variable EVCTRL
+	.section	.debug_info
+	.uleb128	293	; ref to abbrev 293
+	.section	.debug_abbrev
+	.uleb128	293
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname293:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname293
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #294: variable INTCTRL
+	.section	.debug_info
+	.uleb128	294	; ref to abbrev 294
+	.section	.debug_abbrev
+	.uleb128	294
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname294:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname294
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #295: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	295	; ref to abbrev 295
+	.section	.debug_abbrev
+	.uleb128	295
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname295:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname295
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #296: variable STATUS
+	.section	.debug_info
+	.uleb128	296	; ref to abbrev 296
+	.section	.debug_abbrev
+	.uleb128	296
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname296:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname296
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #297: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	297	; ref to abbrev 297
+	.section	.debug_abbrev
+	.uleb128	297
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname297:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname297
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #298: variable TEMP
+	.section	.debug_info
+	.uleb128	298	; ref to abbrev 298
+	.section	.debug_abbrev
+	.uleb128	298
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname298:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname298
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #299: variable CNT
+	.section	.debug_info
+	.uleb128	299	; ref to abbrev 299
+	.section	.debug_abbrev
+	.uleb128	299
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname299:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname299
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #300: variable CCMP
+	.section	.debug_info
+	.uleb128	300	; ref to abbrev 300
+	.section	.debug_abbrev
+	.uleb128	300
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname300:
+	.string		"CCMP"
+	.section	.debug_info
+	.long		.Lname300
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #301: variable CTRLA
+	.section	.debug_info
+	.uleb128	301	; ref to abbrev 301
+	.section	.debug_abbrev
+	.uleb128	301
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname301:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname301
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #302: variable CTRLB
+	.section	.debug_info
+	.uleb128	302	; ref to abbrev 302
+	.section	.debug_abbrev
+	.uleb128	302
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname302:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname302
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #303: variable CTRLC
+	.section	.debug_info
+	.uleb128	303	; ref to abbrev 303
+	.section	.debug_abbrev
+	.uleb128	303
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname303:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname303
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #304: variable EVCTRL
+	.section	.debug_info
+	.uleb128	304	; ref to abbrev 304
+	.section	.debug_abbrev
+	.uleb128	304
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname304:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname304
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #305: variable INTCTRL
+	.section	.debug_info
+	.uleb128	305	; ref to abbrev 305
+	.section	.debug_abbrev
+	.uleb128	305
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname305:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname305
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #306: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	306	; ref to abbrev 306
+	.section	.debug_abbrev
+	.uleb128	306
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname306:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname306
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #307: variable STATUS
+	.section	.debug_info
+	.uleb128	307	; ref to abbrev 307
+	.section	.debug_abbrev
+	.uleb128	307
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname307:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname307
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #308: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	308	; ref to abbrev 308
+	.section	.debug_abbrev
+	.uleb128	308
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname308:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname308
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #309: variable TEMP
+	.section	.debug_info
+	.uleb128	309	; ref to abbrev 309
+	.section	.debug_abbrev
+	.uleb128	309
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname309:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname309
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #310: variable CNT
+	.section	.debug_info
+	.uleb128	310	; ref to abbrev 310
+	.section	.debug_abbrev
+	.uleb128	310
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname310:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname310
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #311: variable CCMP
+	.section	.debug_info
+	.uleb128	311	; ref to abbrev 311
+	.section	.debug_abbrev
+	.uleb128	311
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname311:
+	.string		"CCMP"
+	.section	.debug_info
+	.long		.Lname311
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #312: variable CTRLA
+	.section	.debug_info
+	.uleb128	312	; ref to abbrev 312
+	.section	.debug_abbrev
+	.uleb128	312
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname312:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname312
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #313: variable CTRLB
+	.section	.debug_info
+	.uleb128	313	; ref to abbrev 313
+	.section	.debug_abbrev
+	.uleb128	313
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname313:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname313
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #314: variable CTRLC
+	.section	.debug_info
+	.uleb128	314	; ref to abbrev 314
+	.section	.debug_abbrev
+	.uleb128	314
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname314:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname314
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #315: variable CTRLD
+	.section	.debug_info
+	.uleb128	315	; ref to abbrev 315
+	.section	.debug_abbrev
+	.uleb128	315
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname315:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname315
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #316: variable CTRLECLR
+	.section	.debug_info
+	.uleb128	316	; ref to abbrev 316
+	.section	.debug_abbrev
+	.uleb128	316
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname316:
+	.string		"CTRLECLR"
+	.section	.debug_info
+	.long		.Lname316
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #317: variable CTRLESET
+	.section	.debug_info
+	.uleb128	317	; ref to abbrev 317
+	.section	.debug_abbrev
+	.uleb128	317
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname317:
+	.string		"CTRLESET"
+	.section	.debug_info
+	.long		.Lname317
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #318: variable CTRLFCLR
+	.section	.debug_info
+	.uleb128	318	; ref to abbrev 318
+	.section	.debug_abbrev
+	.uleb128	318
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname318:
+	.string		"CTRLFCLR"
+	.section	.debug_info
+	.long		.Lname318
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #319: variable CTRLFSET
+	.section	.debug_info
+	.uleb128	319	; ref to abbrev 319
+	.section	.debug_abbrev
+	.uleb128	319
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname319:
+	.string		"CTRLFSET"
+	.section	.debug_info
+	.long		.Lname319
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #320: variable EVGENCTRL
+	.section	.debug_info
+	.uleb128	320	; ref to abbrev 320
+	.section	.debug_abbrev
+	.uleb128	320
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname320:
+	.string		"EVGENCTRL"
+	.section	.debug_info
+	.long		.Lname320
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #321: variable EVCTRL
+	.section	.debug_info
+	.uleb128	321	; ref to abbrev 321
+	.section	.debug_abbrev
+	.uleb128	321
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname321:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname321
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #322: variable INTCTRL
+	.section	.debug_info
+	.uleb128	322	; ref to abbrev 322
+	.section	.debug_abbrev
+	.uleb128	322
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname322:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname322
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #323: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	323	; ref to abbrev 323
+	.section	.debug_abbrev
+	.uleb128	323
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname323:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname323
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #324: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	324	; ref to abbrev 324
+	.section	.debug_abbrev
+	.uleb128	324
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname324:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname324
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #325: variable TEMP
+	.section	.debug_info
+	.uleb128	325	; ref to abbrev 325
+	.section	.debug_abbrev
+	.uleb128	325
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname325:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname325
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #326: variable CNT
+	.section	.debug_info
+	.uleb128	326	; ref to abbrev 326
+	.section	.debug_abbrev
+	.uleb128	326
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname326:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname326
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #327: variable AMP
+	.section	.debug_info
+	.uleb128	327	; ref to abbrev 327
+	.section	.debug_abbrev
+	.uleb128	327
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname327:
+	.string		"AMP"
+	.section	.debug_info
+	.long		.Lname327
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x22
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #328: variable OFFSET
+	.section	.debug_info
+	.uleb128	328	; ref to abbrev 328
+	.section	.debug_abbrev
+	.uleb128	328
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname328:
+	.string		"OFFSET"
+	.section	.debug_info
+	.long		.Lname328
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x24
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #329: variable PER
+	.section	.debug_info
+	.uleb128	329	; ref to abbrev 329
+	.section	.debug_abbrev
+	.uleb128	329
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname329:
+	.string		"PER"
+	.section	.debug_info
+	.long		.Lname329
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x26
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #330: variable CMP0
+	.section	.debug_info
+	.uleb128	330	; ref to abbrev 330
+	.section	.debug_abbrev
+	.uleb128	330
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname330:
+	.string		"CMP0"
+	.section	.debug_info
+	.long		.Lname330
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x28
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #331: variable CMP1
+	.section	.debug_info
+	.uleb128	331	; ref to abbrev 331
+	.section	.debug_abbrev
+	.uleb128	331
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname331:
+	.string		"CMP1"
+	.section	.debug_info
+	.long		.Lname331
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #332: variable CMP2
+	.section	.debug_info
+	.uleb128	332	; ref to abbrev 332
+	.section	.debug_abbrev
+	.uleb128	332
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname332:
+	.string		"CMP2"
+	.section	.debug_info
+	.long		.Lname332
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #333: variable CMP3
+	.section	.debug_info
+	.uleb128	333	; ref to abbrev 333
+	.section	.debug_abbrev
+	.uleb128	333
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname333:
+	.string		"CMP3"
+	.section	.debug_info
+	.long		.Lname333
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #334: variable PERBUF
+	.section	.debug_info
+	.uleb128	334	; ref to abbrev 334
+	.section	.debug_abbrev
+	.uleb128	334
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname334:
+	.string		"PERBUF"
+	.section	.debug_info
+	.long		.Lname334
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x36
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #335: variable CMP0BUF
+	.section	.debug_info
+	.uleb128	335	; ref to abbrev 335
+	.section	.debug_abbrev
+	.uleb128	335
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname335:
+	.string		"CMP0BUF"
+	.section	.debug_info
+	.long		.Lname335
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x38
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #336: variable CMP1BUF
+	.section	.debug_info
+	.uleb128	336	; ref to abbrev 336
+	.section	.debug_abbrev
+	.uleb128	336
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname336:
+	.string		"CMP1BUF"
+	.section	.debug_info
+	.long		.Lname336
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x3A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #337: variable CMP2BUF
+	.section	.debug_info
+	.uleb128	337	; ref to abbrev 337
+	.section	.debug_abbrev
+	.uleb128	337
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname337:
+	.string		"CMP2BUF"
+	.section	.debug_info
+	.long		.Lname337
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x3C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #338: variable CMP3BUF
+	.section	.debug_info
+	.uleb128	338	; ref to abbrev 338
+	.section	.debug_abbrev
+	.uleb128	338
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname338:
+	.string		"CMP3BUF"
+	.section	.debug_info
+	.long		.Lname338
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x3E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #339: variable CTRLA
+	.section	.debug_info
+	.uleb128	339	; ref to abbrev 339
+	.section	.debug_abbrev
+	.uleb128	339
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname339:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname339
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C00 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #340: variable CTRLB
+	.section	.debug_info
+	.uleb128	340	; ref to abbrev 340
+	.section	.debug_abbrev
+	.uleb128	340
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname340:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname340
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C00 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #341: variable CTRLC
+	.section	.debug_info
+	.uleb128	341	; ref to abbrev 341
+	.section	.debug_abbrev
+	.uleb128	341
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname341:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname341
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C00 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #342: variable CTRLD
+	.section	.debug_info
+	.uleb128	342	; ref to abbrev 342
+	.section	.debug_abbrev
+	.uleb128	342
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname342:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname342
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C00 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #343: variable EVCTRL
+	.section	.debug_info
+	.uleb128	343	; ref to abbrev 343
+	.section	.debug_abbrev
+	.uleb128	343
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname343:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname343
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C00 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #344: variable INTCTRL
+	.section	.debug_info
+	.uleb128	344	; ref to abbrev 344
+	.section	.debug_abbrev
+	.uleb128	344
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname344:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname344
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C00 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #345: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	345	; ref to abbrev 345
+	.section	.debug_abbrev
+	.uleb128	345
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname345:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname345
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C00 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #346: variable STATUS
+	.section	.debug_info
+	.uleb128	346	; ref to abbrev 346
+	.section	.debug_abbrev
+	.uleb128	346
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname346:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname346
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C00 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #347: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	347	; ref to abbrev 347
+	.section	.debug_abbrev
+	.uleb128	347
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname347:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname347
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C00 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #348: variable CNT
+	.section	.debug_info
+	.uleb128	348	; ref to abbrev 348
+	.section	.debug_abbrev
+	.uleb128	348
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname348:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname348
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint32_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C00 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #349: variable CMP
+	.section	.debug_info
+	.uleb128	349	; ref to abbrev 349
+	.section	.debug_abbrev
+	.uleb128	349
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname349:
+	.string		"CMP"
+	.section	.debug_info
+	.long		.Lname349
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint32_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C00 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #350: variable CTRLA
+	.section	.debug_info
+	.uleb128	350	; ref to abbrev 350
+	.section	.debug_abbrev
+	.uleb128	350
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname350:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname350
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #351: variable DUALCTRL
+	.section	.debug_info
+	.uleb128	351	; ref to abbrev 351
+	.section	.debug_abbrev
+	.uleb128	351
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname351:
+	.string		"DUALCTRL"
+	.section	.debug_info
+	.long		.Lname351
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #352: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	352	; ref to abbrev 352
+	.section	.debug_abbrev
+	.uleb128	352
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname352:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname352
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #353: variable MCTRLA
+	.section	.debug_info
+	.uleb128	353	; ref to abbrev 353
+	.section	.debug_abbrev
+	.uleb128	353
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname353:
+	.string		"MCTRLA"
+	.section	.debug_info
+	.long		.Lname353
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #354: variable MCTRLB
+	.section	.debug_info
+	.uleb128	354	; ref to abbrev 354
+	.section	.debug_abbrev
+	.uleb128	354
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname354:
+	.string		"MCTRLB"
+	.section	.debug_info
+	.long		.Lname354
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #355: variable MSTATUS
+	.section	.debug_info
+	.uleb128	355	; ref to abbrev 355
+	.section	.debug_abbrev
+	.uleb128	355
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname355:
+	.string		"MSTATUS"
+	.section	.debug_info
+	.long		.Lname355
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #356: variable MBAUD
+	.section	.debug_info
+	.uleb128	356	; ref to abbrev 356
+	.section	.debug_abbrev
+	.uleb128	356
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname356:
+	.string		"MBAUD"
+	.section	.debug_info
+	.long		.Lname356
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #357: variable MADDR
+	.section	.debug_info
+	.uleb128	357	; ref to abbrev 357
+	.section	.debug_abbrev
+	.uleb128	357
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname357:
+	.string		"MADDR"
+	.section	.debug_info
+	.long		.Lname357
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #358: variable MDATA
+	.section	.debug_info
+	.uleb128	358	; ref to abbrev 358
+	.section	.debug_abbrev
+	.uleb128	358
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname358:
+	.string		"MDATA"
+	.section	.debug_info
+	.long		.Lname358
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #359: variable SCTRLA
+	.section	.debug_info
+	.uleb128	359	; ref to abbrev 359
+	.section	.debug_abbrev
+	.uleb128	359
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname359:
+	.string		"SCTRLA"
+	.section	.debug_info
+	.long		.Lname359
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #360: variable SCTRLB
+	.section	.debug_info
+	.uleb128	360	; ref to abbrev 360
+	.section	.debug_abbrev
+	.uleb128	360
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname360:
+	.string		"SCTRLB"
+	.section	.debug_info
+	.long		.Lname360
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #361: variable SSTATUS
+	.section	.debug_info
+	.uleb128	361	; ref to abbrev 361
+	.section	.debug_abbrev
+	.uleb128	361
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname361:
+	.string		"SSTATUS"
+	.section	.debug_info
+	.long		.Lname361
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #362: variable SADDR
+	.section	.debug_info
+	.uleb128	362	; ref to abbrev 362
+	.section	.debug_abbrev
+	.uleb128	362
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname362:
+	.string		"SADDR"
+	.section	.debug_info
+	.long		.Lname362
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #363: variable SDATA
+	.section	.debug_info
+	.uleb128	363	; ref to abbrev 363
+	.section	.debug_abbrev
+	.uleb128	363
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname363:
+	.string		"SDATA"
+	.section	.debug_info
+	.long		.Lname363
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xD
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #364: variable SADDRMASK
+	.section	.debug_info
+	.uleb128	364	; ref to abbrev 364
+	.section	.debug_abbrev
+	.uleb128	364
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname364:
+	.string		"SADDRMASK"
+	.section	.debug_info
+	.long		.Lname364
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xE
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #365: variable RXDATAL
+	.section	.debug_info
+	.uleb128	365	; ref to abbrev 365
+	.section	.debug_abbrev
+	.uleb128	365
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname365:
+	.string		"RXDATAL"
+	.section	.debug_info
+	.long		.Lname365
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #366: variable RXDATAH
+	.section	.debug_info
+	.uleb128	366	; ref to abbrev 366
+	.section	.debug_abbrev
+	.uleb128	366
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname366:
+	.string		"RXDATAH"
+	.section	.debug_info
+	.long		.Lname366
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #367: variable TXDATAL
+	.section	.debug_info
+	.uleb128	367	; ref to abbrev 367
+	.section	.debug_abbrev
+	.uleb128	367
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname367:
+	.string		"TXDATAL"
+	.section	.debug_info
+	.long		.Lname367
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #368: variable TXDATAH
+	.section	.debug_info
+	.uleb128	368	; ref to abbrev 368
+	.section	.debug_abbrev
+	.uleb128	368
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname368:
+	.string		"TXDATAH"
+	.section	.debug_info
+	.long		.Lname368
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #369: variable STATUS
+	.section	.debug_info
+	.uleb128	369	; ref to abbrev 369
+	.section	.debug_abbrev
+	.uleb128	369
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname369:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname369
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #370: variable CTRLA
+	.section	.debug_info
+	.uleb128	370	; ref to abbrev 370
+	.section	.debug_abbrev
+	.uleb128	370
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname370:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname370
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #371: variable CTRLB
+	.section	.debug_info
+	.uleb128	371	; ref to abbrev 371
+	.section	.debug_abbrev
+	.uleb128	371
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname371:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname371
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #372: variable CTRLC
+	.section	.debug_info
+	.uleb128	372	; ref to abbrev 372
+	.section	.debug_abbrev
+	.uleb128	372
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname372:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname372
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #373: variable BAUD
+	.section	.debug_info
+	.uleb128	373	; ref to abbrev 373
+	.section	.debug_abbrev
+	.uleb128	373
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname373:
+	.string		"BAUD"
+	.section	.debug_info
+	.long		.Lname373
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #374: variable CTRLD
+	.section	.debug_info
+	.uleb128	374	; ref to abbrev 374
+	.section	.debug_abbrev
+	.uleb128	374
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname374:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname374
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #375: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	375	; ref to abbrev 375
+	.section	.debug_abbrev
+	.uleb128	375
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname375:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname375
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #376: variable EVCTRL
+	.section	.debug_info
+	.uleb128	376	; ref to abbrev 376
+	.section	.debug_abbrev
+	.uleb128	376
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname376:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname376
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #377: variable TXPLCTRL
+	.section	.debug_info
+	.uleb128	377	; ref to abbrev 377
+	.section	.debug_abbrev
+	.uleb128	377
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname377:
+	.string		"TXPLCTRL"
+	.section	.debug_info
+	.long		.Lname377
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xD
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #378: variable RXPLCTRL
+	.section	.debug_info
+	.uleb128	378	; ref to abbrev 378
+	.section	.debug_abbrev
+	.uleb128	378
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname378:
+	.string		"RXPLCTRL"
+	.section	.debug_info
+	.long		.Lname378
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xE
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #379: variable USERROW0
+	.section	.debug_info
+	.uleb128	379	; ref to abbrev 379
+	.section	.debug_abbrev
+	.uleb128	379
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname379:
+	.string		"USERROW0"
+	.section	.debug_info
+	.long		.Lname379
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #380: variable USERROW1
+	.section	.debug_info
+	.uleb128	380	; ref to abbrev 380
+	.section	.debug_abbrev
+	.uleb128	380
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname380:
+	.string		"USERROW1"
+	.section	.debug_info
+	.long		.Lname380
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #381: variable USERROW2
+	.section	.debug_info
+	.uleb128	381	; ref to abbrev 381
+	.section	.debug_abbrev
+	.uleb128	381
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname381:
+	.string		"USERROW2"
+	.section	.debug_info
+	.long		.Lname381
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #382: variable USERROW3
+	.section	.debug_info
+	.uleb128	382	; ref to abbrev 382
+	.section	.debug_abbrev
+	.uleb128	382
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname382:
+	.string		"USERROW3"
+	.section	.debug_info
+	.long		.Lname382
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #383: variable USERROW4
+	.section	.debug_info
+	.uleb128	383	; ref to abbrev 383
+	.section	.debug_abbrev
+	.uleb128	383
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname383:
+	.string		"USERROW4"
+	.section	.debug_info
+	.long		.Lname383
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #384: variable USERROW5
+	.section	.debug_info
+	.uleb128	384	; ref to abbrev 384
+	.section	.debug_abbrev
+	.uleb128	384
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname384:
+	.string		"USERROW5"
+	.section	.debug_info
+	.long		.Lname384
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #385: variable USERROW6
+	.section	.debug_info
+	.uleb128	385	; ref to abbrev 385
+	.section	.debug_abbrev
+	.uleb128	385
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname385:
+	.string		"USERROW6"
+	.section	.debug_info
+	.long		.Lname385
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #386: variable USERROW7
+	.section	.debug_info
+	.uleb128	386	; ref to abbrev 386
+	.section	.debug_abbrev
+	.uleb128	386
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname386:
+	.string		"USERROW7"
+	.section	.debug_info
+	.long		.Lname386
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #387: variable USERROW8
+	.section	.debug_info
+	.uleb128	387	; ref to abbrev 387
+	.section	.debug_abbrev
+	.uleb128	387
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname387:
+	.string		"USERROW8"
+	.section	.debug_info
+	.long		.Lname387
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #388: variable USERROW9
+	.section	.debug_info
+	.uleb128	388	; ref to abbrev 388
+	.section	.debug_abbrev
+	.uleb128	388
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname388:
+	.string		"USERROW9"
+	.section	.debug_info
+	.long		.Lname388
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #389: variable USERROW10
+	.section	.debug_info
+	.uleb128	389	; ref to abbrev 389
+	.section	.debug_abbrev
+	.uleb128	389
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname389:
+	.string		"USERROW10"
+	.section	.debug_info
+	.long		.Lname389
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #390: variable USERROW11
+	.section	.debug_info
+	.uleb128	390	; ref to abbrev 390
+	.section	.debug_abbrev
+	.uleb128	390
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname390:
+	.string		"USERROW11"
+	.section	.debug_info
+	.long		.Lname390
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #391: variable USERROW12
+	.section	.debug_info
+	.uleb128	391	; ref to abbrev 391
+	.section	.debug_abbrev
+	.uleb128	391
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname391:
+	.string		"USERROW12"
+	.section	.debug_info
+	.long		.Lname391
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #392: variable USERROW13
+	.section	.debug_info
+	.uleb128	392	; ref to abbrev 392
+	.section	.debug_abbrev
+	.uleb128	392
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname392:
+	.string		"USERROW13"
+	.section	.debug_info
+	.long		.Lname392
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #393: variable USERROW14
+	.section	.debug_info
+	.uleb128	393	; ref to abbrev 393
+	.section	.debug_abbrev
+	.uleb128	393
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname393:
+	.string		"USERROW14"
+	.section	.debug_info
+	.long		.Lname393
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #394: variable USERROW15
+	.section	.debug_info
+	.uleb128	394	; ref to abbrev 394
+	.section	.debug_abbrev
+	.uleb128	394
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname394:
+	.string		"USERROW15"
+	.section	.debug_info
+	.long		.Lname394
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x0F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #395: variable USERROW16
+	.section	.debug_info
+	.uleb128	395	; ref to abbrev 395
+	.section	.debug_abbrev
+	.uleb128	395
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname395:
+	.string		"USERROW16"
+	.section	.debug_info
+	.long		.Lname395
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #396: variable USERROW17
+	.section	.debug_info
+	.uleb128	396	; ref to abbrev 396
+	.section	.debug_abbrev
+	.uleb128	396
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname396:
+	.string		"USERROW17"
+	.section	.debug_info
+	.long		.Lname396
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #397: variable USERROW18
+	.section	.debug_info
+	.uleb128	397	; ref to abbrev 397
+	.section	.debug_abbrev
+	.uleb128	397
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname397:
+	.string		"USERROW18"
+	.section	.debug_info
+	.long		.Lname397
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #398: variable USERROW19
+	.section	.debug_info
+	.uleb128	398	; ref to abbrev 398
+	.section	.debug_abbrev
+	.uleb128	398
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname398:
+	.string		"USERROW19"
+	.section	.debug_info
+	.long		.Lname398
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #399: variable USERROW20
+	.section	.debug_info
+	.uleb128	399	; ref to abbrev 399
+	.section	.debug_abbrev
+	.uleb128	399
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname399:
+	.string		"USERROW20"
+	.section	.debug_info
+	.long		.Lname399
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #400: variable USERROW21
+	.section	.debug_info
+	.uleb128	400	; ref to abbrev 400
+	.section	.debug_abbrev
+	.uleb128	400
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname400:
+	.string		"USERROW21"
+	.section	.debug_info
+	.long		.Lname400
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #401: variable USERROW22
+	.section	.debug_info
+	.uleb128	401	; ref to abbrev 401
+	.section	.debug_abbrev
+	.uleb128	401
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname401:
+	.string		"USERROW22"
+	.section	.debug_info
+	.long		.Lname401
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #402: variable USERROW23
+	.section	.debug_info
+	.uleb128	402	; ref to abbrev 402
+	.section	.debug_abbrev
+	.uleb128	402
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname402:
+	.string		"USERROW23"
+	.section	.debug_info
+	.long		.Lname402
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #403: variable USERROW24
+	.section	.debug_info
+	.uleb128	403	; ref to abbrev 403
+	.section	.debug_abbrev
+	.uleb128	403
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname403:
+	.string		"USERROW24"
+	.section	.debug_info
+	.long		.Lname403
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #404: variable USERROW25
+	.section	.debug_info
+	.uleb128	404	; ref to abbrev 404
+	.section	.debug_abbrev
+	.uleb128	404
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname404:
+	.string		"USERROW25"
+	.section	.debug_info
+	.long		.Lname404
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x19
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #405: variable USERROW26
+	.section	.debug_info
+	.uleb128	405	; ref to abbrev 405
+	.section	.debug_abbrev
+	.uleb128	405
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname405:
+	.string		"USERROW26"
+	.section	.debug_info
+	.long		.Lname405
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x1A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #406: variable USERROW27
+	.section	.debug_info
+	.uleb128	406	; ref to abbrev 406
+	.section	.debug_abbrev
+	.uleb128	406
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname406:
+	.string		"USERROW27"
+	.section	.debug_info
+	.long		.Lname406
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x1B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #407: variable USERROW28
+	.section	.debug_info
+	.uleb128	407	; ref to abbrev 407
+	.section	.debug_abbrev
+	.uleb128	407
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname407:
+	.string		"USERROW28"
+	.section	.debug_info
+	.long		.Lname407
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x1C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #408: variable USERROW29
+	.section	.debug_info
+	.uleb128	408	; ref to abbrev 408
+	.section	.debug_abbrev
+	.uleb128	408
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname408:
+	.string		"USERROW29"
+	.section	.debug_info
+	.long		.Lname408
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x1D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #409: variable USERROW30
+	.section	.debug_info
+	.uleb128	409	; ref to abbrev 409
+	.section	.debug_abbrev
+	.uleb128	409
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname409:
+	.string		"USERROW30"
+	.section	.debug_info
+	.long		.Lname409
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x1E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #410: variable USERROW31
+	.section	.debug_info
+	.uleb128	410	; ref to abbrev 410
+	.section	.debug_abbrev
+	.uleb128	410
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname410:
+	.string		"USERROW31"
+	.section	.debug_info
+	.long		.Lname410
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x1F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #411: variable USERROW32
+	.section	.debug_info
+	.uleb128	411	; ref to abbrev 411
+	.section	.debug_abbrev
+	.uleb128	411
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname411:
+	.string		"USERROW32"
+	.section	.debug_info
+	.long		.Lname411
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #412: variable USERROW33
+	.section	.debug_info
+	.uleb128	412	; ref to abbrev 412
+	.section	.debug_abbrev
+	.uleb128	412
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname412:
+	.string		"USERROW33"
+	.section	.debug_info
+	.long		.Lname412
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x21
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #413: variable USERROW34
+	.section	.debug_info
+	.uleb128	413	; ref to abbrev 413
+	.section	.debug_abbrev
+	.uleb128	413
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname413:
+	.string		"USERROW34"
+	.section	.debug_info
+	.long		.Lname413
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x22
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #414: variable USERROW35
+	.section	.debug_info
+	.uleb128	414	; ref to abbrev 414
+	.section	.debug_abbrev
+	.uleb128	414
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname414:
+	.string		"USERROW35"
+	.section	.debug_info
+	.long		.Lname414
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x23
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #415: variable USERROW36
+	.section	.debug_info
+	.uleb128	415	; ref to abbrev 415
+	.section	.debug_abbrev
+	.uleb128	415
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname415:
+	.string		"USERROW36"
+	.section	.debug_info
+	.long		.Lname415
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x24
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #416: variable USERROW37
+	.section	.debug_info
+	.uleb128	416	; ref to abbrev 416
+	.section	.debug_abbrev
+	.uleb128	416
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname416:
+	.string		"USERROW37"
+	.section	.debug_info
+	.long		.Lname416
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x25
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #417: variable USERROW38
+	.section	.debug_info
+	.uleb128	417	; ref to abbrev 417
+	.section	.debug_abbrev
+	.uleb128	417
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname417:
+	.string		"USERROW38"
+	.section	.debug_info
+	.long		.Lname417
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x26
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #418: variable USERROW39
+	.section	.debug_info
+	.uleb128	418	; ref to abbrev 418
+	.section	.debug_abbrev
+	.uleb128	418
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname418:
+	.string		"USERROW39"
+	.section	.debug_info
+	.long		.Lname418
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x27
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #419: variable USERROW40
+	.section	.debug_info
+	.uleb128	419	; ref to abbrev 419
+	.section	.debug_abbrev
+	.uleb128	419
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname419:
+	.string		"USERROW40"
+	.section	.debug_info
+	.long		.Lname419
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x28
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #420: variable USERROW41
+	.section	.debug_info
+	.uleb128	420	; ref to abbrev 420
+	.section	.debug_abbrev
+	.uleb128	420
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname420:
+	.string		"USERROW41"
+	.section	.debug_info
+	.long		.Lname420
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x29
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #421: variable USERROW42
+	.section	.debug_info
+	.uleb128	421	; ref to abbrev 421
+	.section	.debug_abbrev
+	.uleb128	421
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname421:
+	.string		"USERROW42"
+	.section	.debug_info
+	.long		.Lname421
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x2A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #422: variable USERROW43
+	.section	.debug_info
+	.uleb128	422	; ref to abbrev 422
+	.section	.debug_abbrev
+	.uleb128	422
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname422:
+	.string		"USERROW43"
+	.section	.debug_info
+	.long		.Lname422
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x2B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #423: variable USERROW44
+	.section	.debug_info
+	.uleb128	423	; ref to abbrev 423
+	.section	.debug_abbrev
+	.uleb128	423
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname423:
+	.string		"USERROW44"
+	.section	.debug_info
+	.long		.Lname423
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x2C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #424: variable USERROW45
+	.section	.debug_info
+	.uleb128	424	; ref to abbrev 424
+	.section	.debug_abbrev
+	.uleb128	424
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname424:
+	.string		"USERROW45"
+	.section	.debug_info
+	.long		.Lname424
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x2D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #425: variable USERROW46
+	.section	.debug_info
+	.uleb128	425	; ref to abbrev 425
+	.section	.debug_abbrev
+	.uleb128	425
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname425:
+	.string		"USERROW46"
+	.section	.debug_info
+	.long		.Lname425
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x2E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #426: variable USERROW47
+	.section	.debug_info
+	.uleb128	426	; ref to abbrev 426
+	.section	.debug_abbrev
+	.uleb128	426
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname426:
+	.string		"USERROW47"
+	.section	.debug_info
+	.long		.Lname426
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x2F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #427: variable USERROW48
+	.section	.debug_info
+	.uleb128	427	; ref to abbrev 427
+	.section	.debug_abbrev
+	.uleb128	427
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname427:
+	.string		"USERROW48"
+	.section	.debug_info
+	.long		.Lname427
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x30
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #428: variable USERROW49
+	.section	.debug_info
+	.uleb128	428	; ref to abbrev 428
+	.section	.debug_abbrev
+	.uleb128	428
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname428:
+	.string		"USERROW49"
+	.section	.debug_info
+	.long		.Lname428
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x31
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #429: variable USERROW50
+	.section	.debug_info
+	.uleb128	429	; ref to abbrev 429
+	.section	.debug_abbrev
+	.uleb128	429
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname429:
+	.string		"USERROW50"
+	.section	.debug_info
+	.long		.Lname429
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x32
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #430: variable USERROW51
+	.section	.debug_info
+	.uleb128	430	; ref to abbrev 430
+	.section	.debug_abbrev
+	.uleb128	430
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname430:
+	.string		"USERROW51"
+	.section	.debug_info
+	.long		.Lname430
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x33
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #431: variable USERROW52
+	.section	.debug_info
+	.uleb128	431	; ref to abbrev 431
+	.section	.debug_abbrev
+	.uleb128	431
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname431:
+	.string		"USERROW52"
+	.section	.debug_info
+	.long		.Lname431
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x34
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #432: variable USERROW53
+	.section	.debug_info
+	.uleb128	432	; ref to abbrev 432
+	.section	.debug_abbrev
+	.uleb128	432
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname432:
+	.string		"USERROW53"
+	.section	.debug_info
+	.long		.Lname432
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x35
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #433: variable USERROW54
+	.section	.debug_info
+	.uleb128	433	; ref to abbrev 433
+	.section	.debug_abbrev
+	.uleb128	433
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname433:
+	.string		"USERROW54"
+	.section	.debug_info
+	.long		.Lname433
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x36
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #434: variable USERROW55
+	.section	.debug_info
+	.uleb128	434	; ref to abbrev 434
+	.section	.debug_abbrev
+	.uleb128	434
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname434:
+	.string		"USERROW55"
+	.section	.debug_info
+	.long		.Lname434
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x37
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #435: variable USERROW56
+	.section	.debug_info
+	.uleb128	435	; ref to abbrev 435
+	.section	.debug_abbrev
+	.uleb128	435
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname435:
+	.string		"USERROW56"
+	.section	.debug_info
+	.long		.Lname435
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x38
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #436: variable USERROW57
+	.section	.debug_info
+	.uleb128	436	; ref to abbrev 436
+	.section	.debug_abbrev
+	.uleb128	436
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname436:
+	.string		"USERROW57"
+	.section	.debug_info
+	.long		.Lname436
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x39
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #437: variable USERROW58
+	.section	.debug_info
+	.uleb128	437	; ref to abbrev 437
+	.section	.debug_abbrev
+	.uleb128	437
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname437:
+	.string		"USERROW58"
+	.section	.debug_info
+	.long		.Lname437
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x3A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #438: variable USERROW59
+	.section	.debug_info
+	.uleb128	438	; ref to abbrev 438
+	.section	.debug_abbrev
+	.uleb128	438
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname438:
+	.string		"USERROW59"
+	.section	.debug_info
+	.long		.Lname438
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x3B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #439: variable USERROW60
+	.section	.debug_info
+	.uleb128	439	; ref to abbrev 439
+	.section	.debug_abbrev
+	.uleb128	439
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname439:
+	.string		"USERROW60"
+	.section	.debug_info
+	.long		.Lname439
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x3C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #440: variable USERROW61
+	.section	.debug_info
+	.uleb128	440	; ref to abbrev 440
+	.section	.debug_abbrev
+	.uleb128	440
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname440:
+	.string		"USERROW61"
+	.section	.debug_info
+	.long		.Lname440
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x3D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #441: variable USERROW62
+	.section	.debug_info
+	.uleb128	441	; ref to abbrev 441
+	.section	.debug_abbrev
+	.uleb128	441
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname441:
+	.string		"USERROW62"
+	.section	.debug_info
+	.long		.Lname441
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x3E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #442: variable USERROW63
+	.section	.debug_info
+	.uleb128	442	; ref to abbrev 442
+	.section	.debug_abbrev
+	.uleb128	442
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname442:
+	.string		"USERROW63"
+	.section	.debug_info
+	.long		.Lname442
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x3F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #443: variable DIR
+	.section	.debug_info
+	.uleb128	443	; ref to abbrev 443
+	.section	.debug_abbrev
+	.uleb128	443
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname443:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname443
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0000 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #444: variable OUT
+	.section	.debug_info
+	.uleb128	444	; ref to abbrev 444
+	.section	.debug_abbrev
+	.uleb128	444
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname444:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname444
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0000 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #445: variable IN
+	.section	.debug_info
+	.uleb128	445	; ref to abbrev 445
+	.section	.debug_abbrev
+	.uleb128	445
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname445:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname445
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0000 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #446: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	446	; ref to abbrev 446
+	.section	.debug_abbrev
+	.uleb128	446
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname446:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname446
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0000 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #447: variable DIR
+	.section	.debug_info
+	.uleb128	447	; ref to abbrev 447
+	.section	.debug_abbrev
+	.uleb128	447
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname447:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname447
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0008 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #448: variable OUT
+	.section	.debug_info
+	.uleb128	448	; ref to abbrev 448
+	.section	.debug_abbrev
+	.uleb128	448
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname448:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname448
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0008 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #449: variable IN
+	.section	.debug_info
+	.uleb128	449	; ref to abbrev 449
+	.section	.debug_abbrev
+	.uleb128	449
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname449:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname449
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0008 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #450: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	450	; ref to abbrev 450
+	.section	.debug_abbrev
+	.uleb128	450
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname450:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname450
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0008 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #451: variable DIR
+	.section	.debug_info
+	.uleb128	451	; ref to abbrev 451
+	.section	.debug_abbrev
+	.uleb128	451
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname451:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname451
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x000C + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #452: variable OUT
+	.section	.debug_info
+	.uleb128	452	; ref to abbrev 452
+	.section	.debug_abbrev
+	.uleb128	452
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname452:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname452
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x000C + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #453: variable IN
+	.section	.debug_info
+	.uleb128	453	; ref to abbrev 453
+	.section	.debug_abbrev
+	.uleb128	453
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname453:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname453
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x000C + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #454: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	454	; ref to abbrev 454
+	.section	.debug_abbrev
+	.uleb128	454
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname454:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname454
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x000C + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #455: variable DIR
+	.section	.debug_info
+	.uleb128	455	; ref to abbrev 455
+	.section	.debug_abbrev
+	.uleb128	455
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname455:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname455
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0014 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #456: variable OUT
+	.section	.debug_info
+	.uleb128	456	; ref to abbrev 456
+	.section	.debug_abbrev
+	.uleb128	456
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname456:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname456
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0014 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #457: variable IN
+	.section	.debug_info
+	.uleb128	457	; ref to abbrev 457
+	.section	.debug_abbrev
+	.uleb128	457
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname457:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname457
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0014 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #458: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	458	; ref to abbrev 458
+	.section	.debug_abbrev
+	.uleb128	458
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname458:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname458
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0014 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #459: variable DAC0REF
+	.section	.debug_info
+	.uleb128	459	; ref to abbrev 459
+	.section	.debug_abbrev
+	.uleb128	459
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname459:
+	.string		"DAC0REF"
+	.section	.debug_info
+	.long		.Lname459
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00B0 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #460: variable ACREF
+	.section	.debug_info
+	.uleb128	460	; ref to abbrev 460
+	.section	.debug_abbrev
+	.uleb128	460
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname460:
+	.string		"ACREF"
+	.section	.debug_info
+	.long		.Lname460
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00B0 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #461: variable CTRLA
+	.section	.debug_info
+	.uleb128	461	; ref to abbrev 461
+	.section	.debug_abbrev
+	.uleb128	461
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname461:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname461
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0100 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #462: variable STATUS
+	.section	.debug_info
+	.uleb128	462	; ref to abbrev 462
+	.section	.debug_abbrev
+	.uleb128	462
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname462:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname462
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0100 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #463: variable CTRLA
+	.section	.debug_info
+	.uleb128	463	; ref to abbrev 463
+	.section	.debug_abbrev
+	.uleb128	463
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname463:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname463
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #464: variable CTRLB
+	.section	.debug_info
+	.uleb128	464	; ref to abbrev 464
+	.section	.debug_abbrev
+	.uleb128	464
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname464:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname464
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #465: variable CTRLC
+	.section	.debug_info
+	.uleb128	465	; ref to abbrev 465
+	.section	.debug_abbrev
+	.uleb128	465
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname465:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname465
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #466: variable EVCTRLA
+	.section	.debug_info
+	.uleb128	466	; ref to abbrev 466
+	.section	.debug_abbrev
+	.uleb128	466
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname466:
+	.string		"EVCTRLA"
+	.section	.debug_info
+	.long		.Lname466
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #467: variable EVCTRLB
+	.section	.debug_info
+	.uleb128	467	; ref to abbrev 467
+	.section	.debug_abbrev
+	.uleb128	467
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname467:
+	.string		"EVCTRLB"
+	.section	.debug_info
+	.long		.Lname467
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #468: variable EVCTRLC
+	.section	.debug_info
+	.uleb128	468	; ref to abbrev 468
+	.section	.debug_abbrev
+	.uleb128	468
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname468:
+	.string		"EVCTRLC"
+	.section	.debug_info
+	.long		.Lname468
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #469: variable BUFCTRL
+	.section	.debug_info
+	.uleb128	469	; ref to abbrev 469
+	.section	.debug_abbrev
+	.uleb128	469
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname469:
+	.string		"BUFCTRL"
+	.section	.debug_info
+	.long		.Lname469
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #470: variable BLANKCTRL
+	.section	.debug_info
+	.uleb128	470	; ref to abbrev 470
+	.section	.debug_abbrev
+	.uleb128	470
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname470:
+	.string		"BLANKCTRL"
+	.section	.debug_info
+	.long		.Lname470
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #471: variable BLANKTIME
+	.section	.debug_info
+	.uleb128	471	; ref to abbrev 471
+	.section	.debug_abbrev
+	.uleb128	471
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname471:
+	.string		"BLANKTIME"
+	.section	.debug_info
+	.long		.Lname471
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #472: variable FAULTCTRL
+	.section	.debug_info
+	.uleb128	472	; ref to abbrev 472
+	.section	.debug_abbrev
+	.uleb128	472
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname472:
+	.string		"FAULTCTRL"
+	.section	.debug_info
+	.long		.Lname472
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #473: variable FAULTDRV
+	.section	.debug_info
+	.uleb128	473	; ref to abbrev 473
+	.section	.debug_abbrev
+	.uleb128	473
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname473:
+	.string		"FAULTDRV"
+	.section	.debug_info
+	.long		.Lname473
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #474: variable FAULTOUT
+	.section	.debug_info
+	.uleb128	474	; ref to abbrev 474
+	.section	.debug_abbrev
+	.uleb128	474
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname474:
+	.string		"FAULTOUT"
+	.section	.debug_info
+	.long		.Lname474
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #475: variable INTCTRL
+	.section	.debug_info
+	.uleb128	475	; ref to abbrev 475
+	.section	.debug_abbrev
+	.uleb128	475
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname475:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname475
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #476: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	476	; ref to abbrev 476
+	.section	.debug_abbrev
+	.uleb128	476
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname476:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname476
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #477: variable STATUS
+	.section	.debug_info
+	.uleb128	477	; ref to abbrev 477
+	.section	.debug_abbrev
+	.uleb128	477
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname477:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname477
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x0F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #478: variable DTLS
+	.section	.debug_info
+	.uleb128	478	; ref to abbrev 478
+	.section	.debug_abbrev
+	.uleb128	478
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname478:
+	.string		"DTLS"
+	.section	.debug_info
+	.long		.Lname478
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #479: variable DTHS
+	.section	.debug_info
+	.uleb128	479	; ref to abbrev 479
+	.section	.debug_abbrev
+	.uleb128	479
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname479:
+	.string		"DTHS"
+	.section	.debug_info
+	.long		.Lname479
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #480: variable DTBOTH
+	.section	.debug_info
+	.uleb128	480	; ref to abbrev 480
+	.section	.debug_abbrev
+	.uleb128	480
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname480:
+	.string		"DTBOTH"
+	.section	.debug_info
+	.long		.Lname480
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #481: variable SWAP
+	.section	.debug_info
+	.uleb128	481	; ref to abbrev 481
+	.section	.debug_abbrev
+	.uleb128	481
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname481:
+	.string		"SWAP"
+	.section	.debug_info
+	.long		.Lname481
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #482: variable PGMOVR
+	.section	.debug_info
+	.uleb128	482	; ref to abbrev 482
+	.section	.debug_abbrev
+	.uleb128	482
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname482:
+	.string		"PGMOVR"
+	.section	.debug_info
+	.long		.Lname482
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #483: variable PGMOUT
+	.section	.debug_info
+	.uleb128	483	; ref to abbrev 483
+	.section	.debug_abbrev
+	.uleb128	483
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname483:
+	.string		"PGMOUT"
+	.section	.debug_info
+	.long		.Lname483
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #484: variable OUTOVEN
+	.section	.debug_info
+	.uleb128	484	; ref to abbrev 484
+	.section	.debug_abbrev
+	.uleb128	484
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname484:
+	.string		"OUTOVEN"
+	.section	.debug_info
+	.long		.Lname484
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #485: variable DTLSBUF
+	.section	.debug_info
+	.uleb128	485	; ref to abbrev 485
+	.section	.debug_abbrev
+	.uleb128	485
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname485:
+	.string		"DTLSBUF"
+	.section	.debug_info
+	.long		.Lname485
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #486: variable DTHSBUF
+	.section	.debug_info
+	.uleb128	486	; ref to abbrev 486
+	.section	.debug_abbrev
+	.uleb128	486
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname486:
+	.string		"DTHSBUF"
+	.section	.debug_info
+	.long		.Lname486
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x19
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #487: variable DTBOTHBUF
+	.section	.debug_info
+	.uleb128	487	; ref to abbrev 487
+	.section	.debug_abbrev
+	.uleb128	487
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname487:
+	.string		"DTBOTHBUF"
+	.section	.debug_info
+	.long		.Lname487
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x1A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #488: variable SWAPBUF
+	.section	.debug_info
+	.uleb128	488	; ref to abbrev 488
+	.section	.debug_abbrev
+	.uleb128	488
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname488:
+	.string		"SWAPBUF"
+	.section	.debug_info
+	.long		.Lname488
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x1B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #489: variable PGMOVRBUF
+	.section	.debug_info
+	.uleb128	489	; ref to abbrev 489
+	.section	.debug_abbrev
+	.uleb128	489
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname489:
+	.string		"PGMOVRBUF"
+	.section	.debug_info
+	.long		.Lname489
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x1C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #490: variable PGMOUTBUF
+	.section	.debug_info
+	.uleb128	490	; ref to abbrev 490
+	.section	.debug_abbrev
+	.uleb128	490
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname490:
+	.string		"PGMOUTBUF"
+	.section	.debug_info
+	.long		.Lname490
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x1D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+	;; trailer
+	.section	.debug_abbrev
+	.uleb128	0
+
+	.section	.debug_info
+	.uleb128	0
+.Leinfo:

--- a/crt1/iosym/avr16eb20.S
+++ b/crt1/iosym/avr16eb20.S
@@ -1,0 +1,26044 @@
+/* This file is part of avr-libc.
+
+   Automatically created by devtools/ioreg.pl
+   DO NOT EDIT!
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in
+     the documentation and/or other materials provided with the
+     distribution.
+
+   * Neither the name of the copyright holders nor the names of
+     contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE. */
+
+/* $Id$ */
+
+#include <avr/version.h>
+
+#define DW_TAG_array_type               0x01
+#define DW_TAG_compile_unit             0x11
+#define DW_TAG_typedef                  0x16
+#define DW_TAG_subrange_type            0x21
+#define DW_TAG_base_type                0x24
+#define DW_TAG_variable                 0x34
+
+#define DW_FORM_addr                    0x01
+#define DW_FORM_block1                  0x0a
+#define DW_FORM_block2                  0x03
+#define DW_FORM_block4                  0x04
+#define DW_FORM_data1                   0x0b
+#define DW_FORM_data2                   0x05
+#define DW_FORM_data4                   0x06
+#define DW_FORM_data8                   0x07
+#define DW_FORM_string                  0x08
+#define DW_FORM_flag                    0x0c
+#define DW_FORM_strp                    0x0e
+#define DW_FORM_ref1                    0x11
+#define DW_FORM_ref2                    0x12
+#define DW_FORM_ref4                    0x13
+#define DW_FORM_ref8                    0x14
+
+#define DW_AT_location                  0x02
+#define DW_AT_name                      0x03
+#define DW_AT_byte_size                 0x0b
+#define DW_AT_stmt_list                 0x10
+#define DW_AT_language                  0x13
+#define DW_AT_producer                  0x25
+#define DW_AT_upper_bound               0x2f
+#define DW_AT_decl_file                 0x3a
+#define DW_AT_decl_line                 0x3b
+#define DW_AT_encoding                  0x3e
+#define DW_AT_external                  0x3f
+#define DW_AT_type                      0x49
+
+#define DW_LANG_C89                     0x0001
+
+#define DW_CHILDREN_no                  0x00
+#define DW_CHILDREN_yes                 0x01
+
+#define DW_ATE_unsigned                 0x7
+#define DW_ATE_unsigned_char            0x8
+
+#define DW_OP_addr                      0x03
+.eject
+	.section	.debug_abbrev, "", @progbits
+.Ldebug_abbrev0:
+	.section	.debug_info, "", @progbits
+	.section	.debug_line, "", @progbits
+.Ldebug_line0:
+	.section	.debug_str, "", @progbits
+
+	.section	.debug_info, "", @progbits
+	;; compilation unit header
+.Lssinfo:
+	.long	.Leinfo - .Lsinfo
+.Lsinfo:
+	.word	2		; DWARF-2
+	.long	.Ldebug_abbrev0
+	.byte	4		; sizeof(address)
+
+
+	;; DIE #1: compilation unit
+	.section	.debug_info
+	.uleb128	1	; ref to abbrev 1
+	.section	.debug_abbrev
+	.uleb128	1
+	.uleb128	DW_TAG_compile_unit
+	.byte		DW_CHILDREN_yes
+
+	.uleb128	DW_AT_producer
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lproducer:
+	.ascii		"avr-libc "
+	.asciz		__AVR_LIBC_VERSION_STRING__
+	.section	.debug_info
+	.long		.Lproducer
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_stmt_list
+	.uleb128	DW_FORM_data4
+	.section	.debug_info
+	.long		.Ldebug_line0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+	;; DIE #2: base type uint8_t
+	.section	.debug_info
+.Luint8_t:
+	.uleb128	2	; ref to abbrev 2
+	.section	.debug_abbrev
+	.uleb128	2
+	.uleb128	DW_TAG_base_type
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Luint8_t_name:
+	.string		"uint8_t"
+	.section	.debug_info
+	.long		.Luint8_t_name
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_byte_size
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_encoding
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		DW_ATE_unsigned_char
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+	;; DIE #3: base type uint16_t
+	.section	.debug_info
+.Luint16_t:
+	.uleb128	3	; ref to abbrev 3
+	.section	.debug_abbrev
+	.uleb128	3
+	.uleb128	DW_TAG_base_type
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Luint16_t_name:
+	.string		"uint16_t"
+	.section	.debug_info
+	.long		.Luint16_t_name
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_byte_size
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		2
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_encoding
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		DW_ATE_unsigned
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #4: variable CTRLA
+	.section	.debug_info
+	.uleb128	4	; ref to abbrev 4
+	.section	.debug_abbrev
+	.uleb128	4
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname4:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname4
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #5: variable CTRLB
+	.section	.debug_info
+	.uleb128	5	; ref to abbrev 5
+	.section	.debug_abbrev
+	.uleb128	5
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname5:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname5
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #6: variable MUXCTRL
+	.section	.debug_info
+	.uleb128	6	; ref to abbrev 6
+	.section	.debug_abbrev
+	.uleb128	6
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname6:
+	.string		"MUXCTRL"
+	.section	.debug_info
+	.long		.Lname6
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #7: variable DACREF
+	.section	.debug_info
+	.uleb128	7	; ref to abbrev 7
+	.section	.debug_abbrev
+	.uleb128	7
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname7:
+	.string		"DACREF"
+	.section	.debug_info
+	.long		.Lname7
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #8: variable INTCTRL
+	.section	.debug_info
+	.uleb128	8	; ref to abbrev 8
+	.section	.debug_abbrev
+	.uleb128	8
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname8:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname8
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #9: variable STATUS
+	.section	.debug_info
+	.uleb128	9	; ref to abbrev 9
+	.section	.debug_abbrev
+	.uleb128	9
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname9:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname9
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #10: variable CTRLA
+	.section	.debug_info
+	.uleb128	10	; ref to abbrev 10
+	.section	.debug_abbrev
+	.uleb128	10
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname10:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname10
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #11: variable CTRLB
+	.section	.debug_info
+	.uleb128	11	; ref to abbrev 11
+	.section	.debug_abbrev
+	.uleb128	11
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname11:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname11
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #12: variable MUXCTRL
+	.section	.debug_info
+	.uleb128	12	; ref to abbrev 12
+	.section	.debug_abbrev
+	.uleb128	12
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname12:
+	.string		"MUXCTRL"
+	.section	.debug_info
+	.long		.Lname12
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #13: variable DACREF
+	.section	.debug_info
+	.uleb128	13	; ref to abbrev 13
+	.section	.debug_abbrev
+	.uleb128	13
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname13:
+	.string		"DACREF"
+	.section	.debug_info
+	.long		.Lname13
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #14: variable INTCTRL
+	.section	.debug_info
+	.uleb128	14	; ref to abbrev 14
+	.section	.debug_abbrev
+	.uleb128	14
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname14:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname14
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #15: variable STATUS
+	.section	.debug_info
+	.uleb128	15	; ref to abbrev 15
+	.section	.debug_abbrev
+	.uleb128	15
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname15:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname15
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #16: variable CTRLA
+	.section	.debug_info
+	.uleb128	16	; ref to abbrev 16
+	.section	.debug_abbrev
+	.uleb128	16
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname16:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname16
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #17: variable CTRLB
+	.section	.debug_info
+	.uleb128	17	; ref to abbrev 17
+	.section	.debug_abbrev
+	.uleb128	17
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname17:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname17
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #18: variable CTRLC
+	.section	.debug_info
+	.uleb128	18	; ref to abbrev 18
+	.section	.debug_abbrev
+	.uleb128	18
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname18:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname18
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #19: variable CTRLD
+	.section	.debug_info
+	.uleb128	19	; ref to abbrev 19
+	.section	.debug_abbrev
+	.uleb128	19
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname19:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname19
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #20: variable INTCTRL
+	.section	.debug_info
+	.uleb128	20	; ref to abbrev 20
+	.section	.debug_abbrev
+	.uleb128	20
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname20:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname20
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #21: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	21	; ref to abbrev 21
+	.section	.debug_abbrev
+	.uleb128	21
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname21:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname21
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #22: variable STATUS
+	.section	.debug_info
+	.uleb128	22	; ref to abbrev 22
+	.section	.debug_abbrev
+	.uleb128	22
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname22:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname22
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #23: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	23	; ref to abbrev 23
+	.section	.debug_abbrev
+	.uleb128	23
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname23:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname23
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #24: variable CTRLE
+	.section	.debug_info
+	.uleb128	24	; ref to abbrev 24
+	.section	.debug_abbrev
+	.uleb128	24
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname24:
+	.string		"CTRLE"
+	.section	.debug_info
+	.long		.Lname24
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #25: variable CTRLF
+	.section	.debug_info
+	.uleb128	25	; ref to abbrev 25
+	.section	.debug_abbrev
+	.uleb128	25
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname25:
+	.string		"CTRLF"
+	.section	.debug_info
+	.long		.Lname25
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #26: variable COMMAND
+	.section	.debug_info
+	.uleb128	26	; ref to abbrev 26
+	.section	.debug_abbrev
+	.uleb128	26
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname26:
+	.string		"COMMAND"
+	.section	.debug_info
+	.long		.Lname26
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #27: variable PGACTRL
+	.section	.debug_info
+	.uleb128	27	; ref to abbrev 27
+	.section	.debug_abbrev
+	.uleb128	27
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname27:
+	.string		"PGACTRL"
+	.section	.debug_info
+	.long		.Lname27
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #28: variable MUXPOS
+	.section	.debug_info
+	.uleb128	28	; ref to abbrev 28
+	.section	.debug_abbrev
+	.uleb128	28
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname28:
+	.string		"MUXPOS"
+	.section	.debug_info
+	.long		.Lname28
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #29: variable MUXNEG
+	.section	.debug_info
+	.uleb128	29	; ref to abbrev 29
+	.section	.debug_abbrev
+	.uleb128	29
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname29:
+	.string		"MUXNEG"
+	.section	.debug_info
+	.long		.Lname29
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #30: base type uint32_t
+	.section	.debug_info
+.Luint32_t:
+	.uleb128	30	; ref to abbrev 30
+	.section	.debug_abbrev
+	.uleb128	30
+	.uleb128	DW_TAG_base_type
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Luint32_t_name:
+	.string		"uint32_t"
+	.section	.debug_info
+	.long		.Luint32_t_name
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_byte_size
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		4
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_encoding
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		DW_ATE_unsigned
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #31: variable RESULT
+	.section	.debug_info
+	.uleb128	31	; ref to abbrev 31
+	.section	.debug_abbrev
+	.uleb128	31
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname31:
+	.string		"RESULT"
+	.section	.debug_info
+	.long		.Lname31
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint32_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #32: variable SAMPLE
+	.section	.debug_info
+	.uleb128	32	; ref to abbrev 32
+	.section	.debug_abbrev
+	.uleb128	32
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname32:
+	.string		"SAMPLE"
+	.section	.debug_info
+	.long		.Lname32
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #33: variable TEMP0
+	.section	.debug_info
+	.uleb128	33	; ref to abbrev 33
+	.section	.debug_abbrev
+	.uleb128	33
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname33:
+	.string		"TEMP0"
+	.section	.debug_info
+	.long		.Lname33
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #34: variable TEMP1
+	.section	.debug_info
+	.uleb128	34	; ref to abbrev 34
+	.section	.debug_abbrev
+	.uleb128	34
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname34:
+	.string		"TEMP1"
+	.section	.debug_info
+	.long		.Lname34
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x19
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #35: variable TEMP2
+	.section	.debug_info
+	.uleb128	35	; ref to abbrev 35
+	.section	.debug_abbrev
+	.uleb128	35
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname35:
+	.string		"TEMP2"
+	.section	.debug_info
+	.long		.Lname35
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x1A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #36: variable WINLT
+	.section	.debug_info
+	.uleb128	36	; ref to abbrev 36
+	.section	.debug_abbrev
+	.uleb128	36
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname36:
+	.string		"WINLT"
+	.section	.debug_info
+	.long		.Lname36
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x1C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #37: variable WINHT
+	.section	.debug_info
+	.uleb128	37	; ref to abbrev 37
+	.section	.debug_abbrev
+	.uleb128	37
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname37:
+	.string		"WINHT"
+	.section	.debug_info
+	.long		.Lname37
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x1E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #38: variable CTRLA
+	.section	.debug_info
+	.uleb128	38	; ref to abbrev 38
+	.section	.debug_abbrev
+	.uleb128	38
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname38:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname38
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #39: variable CTRLB
+	.section	.debug_info
+	.uleb128	39	; ref to abbrev 39
+	.section	.debug_abbrev
+	.uleb128	39
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname39:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname39
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #40: variable VLMCTRLA
+	.section	.debug_info
+	.uleb128	40	; ref to abbrev 40
+	.section	.debug_abbrev
+	.uleb128	40
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname40:
+	.string		"VLMCTRLA"
+	.section	.debug_info
+	.long		.Lname40
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #41: variable INTCTRL
+	.section	.debug_info
+	.uleb128	41	; ref to abbrev 41
+	.section	.debug_abbrev
+	.uleb128	41
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname41:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname41
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #42: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	42	; ref to abbrev 42
+	.section	.debug_abbrev
+	.uleb128	42
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname42:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname42
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #43: variable STATUS
+	.section	.debug_info
+	.uleb128	43	; ref to abbrev 43
+	.section	.debug_abbrev
+	.uleb128	43
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname43:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname43
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #44: variable BOOTROW
+	.section	.debug_info
+	.uleb128	44	; ref to abbrev 44
+	.section	.debug_abbrev
+	.uleb128	44
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname44:
+	.string		"BOOTROW"
+	.section	.debug_info
+	.long		.Lname44
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #45: variable CTRLA
+	.section	.debug_info
+	.uleb128	45	; ref to abbrev 45
+	.section	.debug_abbrev
+	.uleb128	45
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname45:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname45
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #46: variable SEQCTRL0
+	.section	.debug_info
+	.uleb128	46	; ref to abbrev 46
+	.section	.debug_abbrev
+	.uleb128	46
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname46:
+	.string		"SEQCTRL0"
+	.section	.debug_info
+	.long		.Lname46
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #47: variable SEQCTRL1
+	.section	.debug_info
+	.uleb128	47	; ref to abbrev 47
+	.section	.debug_abbrev
+	.uleb128	47
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname47:
+	.string		"SEQCTRL1"
+	.section	.debug_info
+	.long		.Lname47
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #48: variable INTCTRL0
+	.section	.debug_info
+	.uleb128	48	; ref to abbrev 48
+	.section	.debug_abbrev
+	.uleb128	48
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname48:
+	.string		"INTCTRL0"
+	.section	.debug_info
+	.long		.Lname48
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #49: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	49	; ref to abbrev 49
+	.section	.debug_abbrev
+	.uleb128	49
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname49:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname49
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #50: variable LUT0CTRLA
+	.section	.debug_info
+	.uleb128	50	; ref to abbrev 50
+	.section	.debug_abbrev
+	.uleb128	50
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname50:
+	.string		"LUT0CTRLA"
+	.section	.debug_info
+	.long		.Lname50
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #51: variable LUT0CTRLB
+	.section	.debug_info
+	.uleb128	51	; ref to abbrev 51
+	.section	.debug_abbrev
+	.uleb128	51
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname51:
+	.string		"LUT0CTRLB"
+	.section	.debug_info
+	.long		.Lname51
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #52: variable LUT0CTRLC
+	.section	.debug_info
+	.uleb128	52	; ref to abbrev 52
+	.section	.debug_abbrev
+	.uleb128	52
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname52:
+	.string		"LUT0CTRLC"
+	.section	.debug_info
+	.long		.Lname52
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #53: variable TRUTH0
+	.section	.debug_info
+	.uleb128	53	; ref to abbrev 53
+	.section	.debug_abbrev
+	.uleb128	53
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname53:
+	.string		"TRUTH0"
+	.section	.debug_info
+	.long		.Lname53
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #54: variable LUT1CTRLA
+	.section	.debug_info
+	.uleb128	54	; ref to abbrev 54
+	.section	.debug_abbrev
+	.uleb128	54
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname54:
+	.string		"LUT1CTRLA"
+	.section	.debug_info
+	.long		.Lname54
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #55: variable LUT1CTRLB
+	.section	.debug_info
+	.uleb128	55	; ref to abbrev 55
+	.section	.debug_abbrev
+	.uleb128	55
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname55:
+	.string		"LUT1CTRLB"
+	.section	.debug_info
+	.long		.Lname55
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #56: variable LUT1CTRLC
+	.section	.debug_info
+	.uleb128	56	; ref to abbrev 56
+	.section	.debug_abbrev
+	.uleb128	56
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname56:
+	.string		"LUT1CTRLC"
+	.section	.debug_info
+	.long		.Lname56
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #57: variable TRUTH1
+	.section	.debug_info
+	.uleb128	57	; ref to abbrev 57
+	.section	.debug_abbrev
+	.uleb128	57
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname57:
+	.string		"TRUTH1"
+	.section	.debug_info
+	.long		.Lname57
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #58: variable LUT2CTRLA
+	.section	.debug_info
+	.uleb128	58	; ref to abbrev 58
+	.section	.debug_abbrev
+	.uleb128	58
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname58:
+	.string		"LUT2CTRLA"
+	.section	.debug_info
+	.long		.Lname58
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #59: variable LUT2CTRLB
+	.section	.debug_info
+	.uleb128	59	; ref to abbrev 59
+	.section	.debug_abbrev
+	.uleb128	59
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname59:
+	.string		"LUT2CTRLB"
+	.section	.debug_info
+	.long		.Lname59
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #60: variable LUT2CTRLC
+	.section	.debug_info
+	.uleb128	60	; ref to abbrev 60
+	.section	.debug_abbrev
+	.uleb128	60
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname60:
+	.string		"LUT2CTRLC"
+	.section	.debug_info
+	.long		.Lname60
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #61: variable TRUTH2
+	.section	.debug_info
+	.uleb128	61	; ref to abbrev 61
+	.section	.debug_abbrev
+	.uleb128	61
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname61:
+	.string		"TRUTH2"
+	.section	.debug_info
+	.long		.Lname61
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #62: variable LUT3CTRLA
+	.section	.debug_info
+	.uleb128	62	; ref to abbrev 62
+	.section	.debug_abbrev
+	.uleb128	62
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname62:
+	.string		"LUT3CTRLA"
+	.section	.debug_info
+	.long		.Lname62
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #63: variable LUT3CTRLB
+	.section	.debug_info
+	.uleb128	63	; ref to abbrev 63
+	.section	.debug_abbrev
+	.uleb128	63
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname63:
+	.string		"LUT3CTRLB"
+	.section	.debug_info
+	.long		.Lname63
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #64: variable LUT3CTRLC
+	.section	.debug_info
+	.uleb128	64	; ref to abbrev 64
+	.section	.debug_abbrev
+	.uleb128	64
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname64:
+	.string		"LUT3CTRLC"
+	.section	.debug_info
+	.long		.Lname64
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #65: variable TRUTH3
+	.section	.debug_info
+	.uleb128	65	; ref to abbrev 65
+	.section	.debug_abbrev
+	.uleb128	65
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname65:
+	.string		"TRUTH3"
+	.section	.debug_info
+	.long		.Lname65
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #66: variable MCLKCTRLA
+	.section	.debug_info
+	.uleb128	66	; ref to abbrev 66
+	.section	.debug_abbrev
+	.uleb128	66
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname66:
+	.string		"MCLKCTRLA"
+	.section	.debug_info
+	.long		.Lname66
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #67: variable MCLKCTRLB
+	.section	.debug_info
+	.uleb128	67	; ref to abbrev 67
+	.section	.debug_abbrev
+	.uleb128	67
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname67:
+	.string		"MCLKCTRLB"
+	.section	.debug_info
+	.long		.Lname67
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #68: variable MCLKSTATUS
+	.section	.debug_info
+	.uleb128	68	; ref to abbrev 68
+	.section	.debug_abbrev
+	.uleb128	68
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname68:
+	.string		"MCLKSTATUS"
+	.section	.debug_info
+	.long		.Lname68
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #69: variable MCLKTIMEBASE
+	.section	.debug_info
+	.uleb128	69	; ref to abbrev 69
+	.section	.debug_abbrev
+	.uleb128	69
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname69:
+	.string		"MCLKTIMEBASE"
+	.section	.debug_info
+	.long		.Lname69
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #70: variable OSCHFCTRLA
+	.section	.debug_info
+	.uleb128	70	; ref to abbrev 70
+	.section	.debug_abbrev
+	.uleb128	70
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname70:
+	.string		"OSCHFCTRLA"
+	.section	.debug_info
+	.long		.Lname70
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #71: variable OSCHFTUNE
+	.section	.debug_info
+	.uleb128	71	; ref to abbrev 71
+	.section	.debug_abbrev
+	.uleb128	71
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname71:
+	.string		"OSCHFTUNE"
+	.section	.debug_info
+	.long		.Lname71
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #72: variable PLLCTRLA
+	.section	.debug_info
+	.uleb128	72	; ref to abbrev 72
+	.section	.debug_abbrev
+	.uleb128	72
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname72:
+	.string		"PLLCTRLA"
+	.section	.debug_info
+	.long		.Lname72
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #73: variable PLLCTRLB
+	.section	.debug_info
+	.uleb128	73	; ref to abbrev 73
+	.section	.debug_abbrev
+	.uleb128	73
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname73:
+	.string		"PLLCTRLB"
+	.section	.debug_info
+	.long		.Lname73
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #74: variable OSC32KCTRLA
+	.section	.debug_info
+	.uleb128	74	; ref to abbrev 74
+	.section	.debug_abbrev
+	.uleb128	74
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname74:
+	.string		"OSC32KCTRLA"
+	.section	.debug_info
+	.long		.Lname74
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #75: variable XOSC32KCTRLA
+	.section	.debug_info
+	.uleb128	75	; ref to abbrev 75
+	.section	.debug_abbrev
+	.uleb128	75
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname75:
+	.string		"XOSC32KCTRLA"
+	.section	.debug_info
+	.long		.Lname75
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x1C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #76: variable CCP
+	.section	.debug_info
+	.uleb128	76	; ref to abbrev 76
+	.section	.debug_abbrev
+	.uleb128	76
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname76:
+	.string		"CCP"
+	.section	.debug_info
+	.long		.Lname76
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0030 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #77: variable RAMPZ
+	.section	.debug_info
+	.uleb128	77	; ref to abbrev 77
+	.section	.debug_abbrev
+	.uleb128	77
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname77:
+	.string		"RAMPZ"
+	.section	.debug_info
+	.long		.Lname77
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0030 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #78: variable SP
+	.section	.debug_info
+	.uleb128	78	; ref to abbrev 78
+	.section	.debug_abbrev
+	.uleb128	78
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname78:
+	.string		"SP"
+	.section	.debug_info
+	.long		.Lname78
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0030 + 0xD
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #79: variable SREG
+	.section	.debug_info
+	.uleb128	79	; ref to abbrev 79
+	.section	.debug_abbrev
+	.uleb128	79
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname79:
+	.string		"SREG"
+	.section	.debug_info
+	.long		.Lname79
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0030 + 0xF
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #80: variable CTRLA
+	.section	.debug_info
+	.uleb128	80	; ref to abbrev 80
+	.section	.debug_abbrev
+	.uleb128	80
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname80:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname80
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0110 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #81: variable STATUS
+	.section	.debug_info
+	.uleb128	81	; ref to abbrev 81
+	.section	.debug_abbrev
+	.uleb128	81
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname81:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname81
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0110 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #82: variable LVL0PRI
+	.section	.debug_info
+	.uleb128	82	; ref to abbrev 82
+	.section	.debug_abbrev
+	.uleb128	82
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname82:
+	.string		"LVL0PRI"
+	.section	.debug_info
+	.long		.Lname82
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0110 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #83: variable LVL1VEC
+	.section	.debug_info
+	.uleb128	83	; ref to abbrev 83
+	.section	.debug_abbrev
+	.uleb128	83
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname83:
+	.string		"LVL1VEC"
+	.section	.debug_info
+	.long		.Lname83
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0110 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #84: variable CTRLA
+	.section	.debug_info
+	.uleb128	84	; ref to abbrev 84
+	.section	.debug_abbrev
+	.uleb128	84
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname84:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname84
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0120 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #85: variable CTRLB
+	.section	.debug_info
+	.uleb128	85	; ref to abbrev 85
+	.section	.debug_abbrev
+	.uleb128	85
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname85:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname85
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0120 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #86: variable STATUS
+	.section	.debug_info
+	.uleb128	86	; ref to abbrev 86
+	.section	.debug_abbrev
+	.uleb128	86
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname86:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname86
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0120 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #87: variable SWEVENTA
+	.section	.debug_info
+	.uleb128	87	; ref to abbrev 87
+	.section	.debug_abbrev
+	.uleb128	87
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname87:
+	.string		"SWEVENTA"
+	.section	.debug_info
+	.long		.Lname87
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #88: variable CHANNEL0
+	.section	.debug_info
+	.uleb128	88	; ref to abbrev 88
+	.section	.debug_abbrev
+	.uleb128	88
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname88:
+	.string		"CHANNEL0"
+	.section	.debug_info
+	.long		.Lname88
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #89: variable CHANNEL1
+	.section	.debug_info
+	.uleb128	89	; ref to abbrev 89
+	.section	.debug_abbrev
+	.uleb128	89
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname89:
+	.string		"CHANNEL1"
+	.section	.debug_info
+	.long		.Lname89
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #90: variable CHANNEL2
+	.section	.debug_info
+	.uleb128	90	; ref to abbrev 90
+	.section	.debug_abbrev
+	.uleb128	90
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname90:
+	.string		"CHANNEL2"
+	.section	.debug_info
+	.long		.Lname90
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #91: variable CHANNEL3
+	.section	.debug_info
+	.uleb128	91	; ref to abbrev 91
+	.section	.debug_abbrev
+	.uleb128	91
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname91:
+	.string		"CHANNEL3"
+	.section	.debug_info
+	.long		.Lname91
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #92: variable CHANNEL4
+	.section	.debug_info
+	.uleb128	92	; ref to abbrev 92
+	.section	.debug_abbrev
+	.uleb128	92
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname92:
+	.string		"CHANNEL4"
+	.section	.debug_info
+	.long		.Lname92
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #93: variable CHANNEL5
+	.section	.debug_info
+	.uleb128	93	; ref to abbrev 93
+	.section	.debug_abbrev
+	.uleb128	93
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname93:
+	.string		"CHANNEL5"
+	.section	.debug_info
+	.long		.Lname93
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #94: variable USERCCLLUT0A
+	.section	.debug_info
+	.uleb128	94	; ref to abbrev 94
+	.section	.debug_abbrev
+	.uleb128	94
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname94:
+	.string		"USERCCLLUT0A"
+	.section	.debug_info
+	.long		.Lname94
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #95: variable USERCCLLUT0B
+	.section	.debug_info
+	.uleb128	95	; ref to abbrev 95
+	.section	.debug_abbrev
+	.uleb128	95
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname95:
+	.string		"USERCCLLUT0B"
+	.section	.debug_info
+	.long		.Lname95
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x21
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #96: variable USERCCLLUT1A
+	.section	.debug_info
+	.uleb128	96	; ref to abbrev 96
+	.section	.debug_abbrev
+	.uleb128	96
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname96:
+	.string		"USERCCLLUT1A"
+	.section	.debug_info
+	.long		.Lname96
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x22
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #97: variable USERCCLLUT1B
+	.section	.debug_info
+	.uleb128	97	; ref to abbrev 97
+	.section	.debug_abbrev
+	.uleb128	97
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname97:
+	.string		"USERCCLLUT1B"
+	.section	.debug_info
+	.long		.Lname97
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x23
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #98: variable USERCCLLUT2A
+	.section	.debug_info
+	.uleb128	98	; ref to abbrev 98
+	.section	.debug_abbrev
+	.uleb128	98
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname98:
+	.string		"USERCCLLUT2A"
+	.section	.debug_info
+	.long		.Lname98
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x24
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #99: variable USERCCLLUT2B
+	.section	.debug_info
+	.uleb128	99	; ref to abbrev 99
+	.section	.debug_abbrev
+	.uleb128	99
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname99:
+	.string		"USERCCLLUT2B"
+	.section	.debug_info
+	.long		.Lname99
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x25
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #100: variable USERCCLLUT3A
+	.section	.debug_info
+	.uleb128	100	; ref to abbrev 100
+	.section	.debug_abbrev
+	.uleb128	100
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname100:
+	.string		"USERCCLLUT3A"
+	.section	.debug_info
+	.long		.Lname100
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x26
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #101: variable USERCCLLUT3B
+	.section	.debug_info
+	.uleb128	101	; ref to abbrev 101
+	.section	.debug_abbrev
+	.uleb128	101
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname101:
+	.string		"USERCCLLUT3B"
+	.section	.debug_info
+	.long		.Lname101
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x27
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #102: variable USERADC0START
+	.section	.debug_info
+	.uleb128	102	; ref to abbrev 102
+	.section	.debug_abbrev
+	.uleb128	102
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname102:
+	.string		"USERADC0START"
+	.section	.debug_info
+	.long		.Lname102
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x28
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #103: variable USEREVSYSEVOUTA
+	.section	.debug_info
+	.uleb128	103	; ref to abbrev 103
+	.section	.debug_abbrev
+	.uleb128	103
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname103:
+	.string		"USEREVSYSEVOUTA"
+	.section	.debug_info
+	.long		.Lname103
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x29
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #104: variable USEREVSYSEVOUTC
+	.section	.debug_info
+	.uleb128	104	; ref to abbrev 104
+	.section	.debug_abbrev
+	.uleb128	104
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname104:
+	.string		"USEREVSYSEVOUTC"
+	.section	.debug_info
+	.long		.Lname104
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #105: variable USEREVSYSEVOUTD
+	.section	.debug_info
+	.uleb128	105	; ref to abbrev 105
+	.section	.debug_abbrev
+	.uleb128	105
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname105:
+	.string		"USEREVSYSEVOUTD"
+	.section	.debug_info
+	.long		.Lname105
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #106: variable USEREVSYSEVOUTF
+	.section	.debug_info
+	.uleb128	106	; ref to abbrev 106
+	.section	.debug_abbrev
+	.uleb128	106
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname106:
+	.string		"USEREVSYSEVOUTF"
+	.section	.debug_info
+	.long		.Lname106
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #107: variable USERUSART0IRDA
+	.section	.debug_info
+	.uleb128	107	; ref to abbrev 107
+	.section	.debug_abbrev
+	.uleb128	107
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname107:
+	.string		"USERUSART0IRDA"
+	.section	.debug_info
+	.long		.Lname107
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #108: variable USERTCE0CNTA
+	.section	.debug_info
+	.uleb128	108	; ref to abbrev 108
+	.section	.debug_abbrev
+	.uleb128	108
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname108:
+	.string		"USERTCE0CNTA"
+	.section	.debug_info
+	.long		.Lname108
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #109: variable USERTCE0CNTB
+	.section	.debug_info
+	.uleb128	109	; ref to abbrev 109
+	.section	.debug_abbrev
+	.uleb128	109
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname109:
+	.string		"USERTCE0CNTB"
+	.section	.debug_info
+	.long		.Lname109
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #110: variable USERTCB0CAPT
+	.section	.debug_info
+	.uleb128	110	; ref to abbrev 110
+	.section	.debug_abbrev
+	.uleb128	110
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname110:
+	.string		"USERTCB0CAPT"
+	.section	.debug_info
+	.long		.Lname110
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x30
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #111: variable USERTCB0COUNT
+	.section	.debug_info
+	.uleb128	111	; ref to abbrev 111
+	.section	.debug_abbrev
+	.uleb128	111
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname111:
+	.string		"USERTCB0COUNT"
+	.section	.debug_info
+	.long		.Lname111
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x31
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #112: variable USERTCB1CAPT
+	.section	.debug_info
+	.uleb128	112	; ref to abbrev 112
+	.section	.debug_abbrev
+	.uleb128	112
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname112:
+	.string		"USERTCB1CAPT"
+	.section	.debug_info
+	.long		.Lname112
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x32
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #113: variable USERTCB1COUNT
+	.section	.debug_info
+	.uleb128	113	; ref to abbrev 113
+	.section	.debug_abbrev
+	.uleb128	113
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname113:
+	.string		"USERTCB1COUNT"
+	.section	.debug_info
+	.long		.Lname113
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x33
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #114: variable USERTCF0CNT
+	.section	.debug_info
+	.uleb128	114	; ref to abbrev 114
+	.section	.debug_abbrev
+	.uleb128	114
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname114:
+	.string		"USERTCF0CNT"
+	.section	.debug_info
+	.long		.Lname114
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x34
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #115: variable USERTCF0ACT
+	.section	.debug_info
+	.uleb128	115	; ref to abbrev 115
+	.section	.debug_abbrev
+	.uleb128	115
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname115:
+	.string		"USERTCF0ACT"
+	.section	.debug_info
+	.long		.Lname115
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x35
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #116: variable USERWEXA
+	.section	.debug_info
+	.uleb128	116	; ref to abbrev 116
+	.section	.debug_abbrev
+	.uleb128	116
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname116:
+	.string		"USERWEXA"
+	.section	.debug_info
+	.long		.Lname116
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x36
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #117: variable USERWEXB
+	.section	.debug_info
+	.uleb128	117	; ref to abbrev 117
+	.section	.debug_abbrev
+	.uleb128	117
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname117:
+	.string		"USERWEXB"
+	.section	.debug_info
+	.long		.Lname117
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x37
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #118: variable USERWEXC
+	.section	.debug_info
+	.uleb128	118	; ref to abbrev 118
+	.section	.debug_abbrev
+	.uleb128	118
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname118:
+	.string		"USERWEXC"
+	.section	.debug_info
+	.long		.Lname118
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x38
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #119: variable WDTCFG
+	.section	.debug_info
+	.uleb128	119	; ref to abbrev 119
+	.section	.debug_abbrev
+	.uleb128	119
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname119:
+	.string		"WDTCFG"
+	.section	.debug_info
+	.long		.Lname119
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #120: variable BODCFG
+	.section	.debug_info
+	.uleb128	120	; ref to abbrev 120
+	.section	.debug_abbrev
+	.uleb128	120
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname120:
+	.string		"BODCFG"
+	.section	.debug_info
+	.long		.Lname120
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #121: variable OSCCFG
+	.section	.debug_info
+	.uleb128	121	; ref to abbrev 121
+	.section	.debug_abbrev
+	.uleb128	121
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname121:
+	.string		"OSCCFG"
+	.section	.debug_info
+	.long		.Lname121
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #122: variable SYSCFG0
+	.section	.debug_info
+	.uleb128	122	; ref to abbrev 122
+	.section	.debug_abbrev
+	.uleb128	122
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname122:
+	.string		"SYSCFG0"
+	.section	.debug_info
+	.long		.Lname122
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #123: variable SYSCFG1
+	.section	.debug_info
+	.uleb128	123	; ref to abbrev 123
+	.section	.debug_abbrev
+	.uleb128	123
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname123:
+	.string		"SYSCFG1"
+	.section	.debug_info
+	.long		.Lname123
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #124: variable CODESIZE
+	.section	.debug_info
+	.uleb128	124	; ref to abbrev 124
+	.section	.debug_abbrev
+	.uleb128	124
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname124:
+	.string		"CODESIZE"
+	.section	.debug_info
+	.long		.Lname124
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #125: variable BOOTSIZE
+	.section	.debug_info
+	.uleb128	125	; ref to abbrev 125
+	.section	.debug_abbrev
+	.uleb128	125
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname125:
+	.string		"BOOTSIZE"
+	.section	.debug_info
+	.long		.Lname125
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #126: variable PDICFG
+	.section	.debug_info
+	.uleb128	126	; ref to abbrev 126
+	.section	.debug_abbrev
+	.uleb128	126
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname126:
+	.string		"PDICFG"
+	.section	.debug_info
+	.long		.Lname126
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #127: variable GPR0
+	.section	.debug_info
+	.uleb128	127	; ref to abbrev 127
+	.section	.debug_abbrev
+	.uleb128	127
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname127:
+	.string		"GPR0"
+	.section	.debug_info
+	.long		.Lname127
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x001C + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #128: variable GPR1
+	.section	.debug_info
+	.uleb128	128	; ref to abbrev 128
+	.section	.debug_abbrev
+	.uleb128	128
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname128:
+	.string		"GPR1"
+	.section	.debug_info
+	.long		.Lname128
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x001C + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #129: variable GPR2
+	.section	.debug_info
+	.uleb128	129	; ref to abbrev 129
+	.section	.debug_abbrev
+	.uleb128	129
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname129:
+	.string		"GPR2"
+	.section	.debug_info
+	.long		.Lname129
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x001C + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #130: variable GPR3
+	.section	.debug_info
+	.uleb128	130	; ref to abbrev 130
+	.section	.debug_abbrev
+	.uleb128	130
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname130:
+	.string		"GPR3"
+	.section	.debug_info
+	.long		.Lname130
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x001C + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #131: variable KEY
+	.section	.debug_info
+	.uleb128	131	; ref to abbrev 131
+	.section	.debug_abbrev
+	.uleb128	131
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname131:
+	.string		"KEY"
+	.section	.debug_info
+	.long		.Lname131
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint32_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1040 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #132: variable CTRLA
+	.section	.debug_info
+	.uleb128	132	; ref to abbrev 132
+	.section	.debug_abbrev
+	.uleb128	132
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname132:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname132
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #133: variable CTRLB
+	.section	.debug_info
+	.uleb128	133	; ref to abbrev 133
+	.section	.debug_abbrev
+	.uleb128	133
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname133:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname133
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #134: variable CTRLC
+	.section	.debug_info
+	.uleb128	134	; ref to abbrev 134
+	.section	.debug_abbrev
+	.uleb128	134
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname134:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname134
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #135: variable INTCTRL
+	.section	.debug_info
+	.uleb128	135	; ref to abbrev 135
+	.section	.debug_abbrev
+	.uleb128	135
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname135:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname135
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #136: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	136	; ref to abbrev 136
+	.section	.debug_abbrev
+	.uleb128	136
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname136:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname136
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #137: variable STATUS
+	.section	.debug_info
+	.uleb128	137	; ref to abbrev 137
+	.section	.debug_abbrev
+	.uleb128	137
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname137:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname137
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #138: variable DATA
+	.section	.debug_info
+	.uleb128	138	; ref to abbrev 138
+	.section	.debug_abbrev
+	.uleb128	138
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname138:
+	.string		"DATA"
+	.section	.debug_info
+	.long		.Lname138
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #139: variable ADDR
+	.section	.debug_info
+	.uleb128	139	; ref to abbrev 139
+	.section	.debug_abbrev
+	.uleb128	139
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname139:
+	.string		"ADDR"
+	.section	.debug_info
+	.long		.Lname139
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint32_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #140: variable DIR
+	.section	.debug_info
+	.uleb128	140	; ref to abbrev 140
+	.section	.debug_abbrev
+	.uleb128	140
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname140:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname140
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #141: variable DIRSET
+	.section	.debug_info
+	.uleb128	141	; ref to abbrev 141
+	.section	.debug_abbrev
+	.uleb128	141
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname141:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname141
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #142: variable DIRCLR
+	.section	.debug_info
+	.uleb128	142	; ref to abbrev 142
+	.section	.debug_abbrev
+	.uleb128	142
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname142:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname142
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #143: variable DIRTGL
+	.section	.debug_info
+	.uleb128	143	; ref to abbrev 143
+	.section	.debug_abbrev
+	.uleb128	143
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname143:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname143
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #144: variable OUT
+	.section	.debug_info
+	.uleb128	144	; ref to abbrev 144
+	.section	.debug_abbrev
+	.uleb128	144
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname144:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname144
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #145: variable OUTSET
+	.section	.debug_info
+	.uleb128	145	; ref to abbrev 145
+	.section	.debug_abbrev
+	.uleb128	145
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname145:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname145
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #146: variable OUTCLR
+	.section	.debug_info
+	.uleb128	146	; ref to abbrev 146
+	.section	.debug_abbrev
+	.uleb128	146
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname146:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname146
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #147: variable OUTTGL
+	.section	.debug_info
+	.uleb128	147	; ref to abbrev 147
+	.section	.debug_abbrev
+	.uleb128	147
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname147:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname147
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #148: variable IN
+	.section	.debug_info
+	.uleb128	148	; ref to abbrev 148
+	.section	.debug_abbrev
+	.uleb128	148
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname148:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname148
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #149: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	149	; ref to abbrev 149
+	.section	.debug_abbrev
+	.uleb128	149
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname149:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname149
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #150: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	150	; ref to abbrev 150
+	.section	.debug_abbrev
+	.uleb128	150
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname150:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname150
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #151: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	151	; ref to abbrev 151
+	.section	.debug_abbrev
+	.uleb128	151
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname151:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname151
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #152: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	152	; ref to abbrev 152
+	.section	.debug_abbrev
+	.uleb128	152
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname152:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname152
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #153: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	153	; ref to abbrev 153
+	.section	.debug_abbrev
+	.uleb128	153
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname153:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname153
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #154: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	154	; ref to abbrev 154
+	.section	.debug_abbrev
+	.uleb128	154
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname154:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname154
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #155: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	155	; ref to abbrev 155
+	.section	.debug_abbrev
+	.uleb128	155
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname155:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname155
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #156: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	156	; ref to abbrev 156
+	.section	.debug_abbrev
+	.uleb128	156
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname156:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname156
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #157: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	157	; ref to abbrev 157
+	.section	.debug_abbrev
+	.uleb128	157
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname157:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname157
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #158: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	158	; ref to abbrev 158
+	.section	.debug_abbrev
+	.uleb128	158
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname158:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname158
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #159: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	159	; ref to abbrev 159
+	.section	.debug_abbrev
+	.uleb128	159
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname159:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname159
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #160: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	160	; ref to abbrev 160
+	.section	.debug_abbrev
+	.uleb128	160
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname160:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname160
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #161: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	161	; ref to abbrev 161
+	.section	.debug_abbrev
+	.uleb128	161
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname161:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname161
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #162: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	162	; ref to abbrev 162
+	.section	.debug_abbrev
+	.uleb128	162
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname162:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname162
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #163: variable EVGENCTRLA
+	.section	.debug_info
+	.uleb128	163	; ref to abbrev 163
+	.section	.debug_abbrev
+	.uleb128	163
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname163:
+	.string		"EVGENCTRLA"
+	.section	.debug_info
+	.long		.Lname163
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #164: variable DIR
+	.section	.debug_info
+	.uleb128	164	; ref to abbrev 164
+	.section	.debug_abbrev
+	.uleb128	164
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname164:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname164
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #165: variable DIRSET
+	.section	.debug_info
+	.uleb128	165	; ref to abbrev 165
+	.section	.debug_abbrev
+	.uleb128	165
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname165:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname165
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #166: variable DIRCLR
+	.section	.debug_info
+	.uleb128	166	; ref to abbrev 166
+	.section	.debug_abbrev
+	.uleb128	166
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname166:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname166
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #167: variable DIRTGL
+	.section	.debug_info
+	.uleb128	167	; ref to abbrev 167
+	.section	.debug_abbrev
+	.uleb128	167
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname167:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname167
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #168: variable OUT
+	.section	.debug_info
+	.uleb128	168	; ref to abbrev 168
+	.section	.debug_abbrev
+	.uleb128	168
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname168:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname168
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #169: variable OUTSET
+	.section	.debug_info
+	.uleb128	169	; ref to abbrev 169
+	.section	.debug_abbrev
+	.uleb128	169
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname169:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname169
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #170: variable OUTCLR
+	.section	.debug_info
+	.uleb128	170	; ref to abbrev 170
+	.section	.debug_abbrev
+	.uleb128	170
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname170:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname170
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #171: variable OUTTGL
+	.section	.debug_info
+	.uleb128	171	; ref to abbrev 171
+	.section	.debug_abbrev
+	.uleb128	171
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname171:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname171
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #172: variable IN
+	.section	.debug_info
+	.uleb128	172	; ref to abbrev 172
+	.section	.debug_abbrev
+	.uleb128	172
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname172:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname172
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #173: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	173	; ref to abbrev 173
+	.section	.debug_abbrev
+	.uleb128	173
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname173:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname173
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #174: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	174	; ref to abbrev 174
+	.section	.debug_abbrev
+	.uleb128	174
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname174:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname174
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #175: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	175	; ref to abbrev 175
+	.section	.debug_abbrev
+	.uleb128	175
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname175:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname175
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #176: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	176	; ref to abbrev 176
+	.section	.debug_abbrev
+	.uleb128	176
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname176:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname176
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #177: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	177	; ref to abbrev 177
+	.section	.debug_abbrev
+	.uleb128	177
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname177:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname177
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #178: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	178	; ref to abbrev 178
+	.section	.debug_abbrev
+	.uleb128	178
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname178:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname178
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #179: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	179	; ref to abbrev 179
+	.section	.debug_abbrev
+	.uleb128	179
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname179:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname179
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #180: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	180	; ref to abbrev 180
+	.section	.debug_abbrev
+	.uleb128	180
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname180:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname180
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #181: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	181	; ref to abbrev 181
+	.section	.debug_abbrev
+	.uleb128	181
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname181:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname181
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #182: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	182	; ref to abbrev 182
+	.section	.debug_abbrev
+	.uleb128	182
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname182:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname182
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #183: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	183	; ref to abbrev 183
+	.section	.debug_abbrev
+	.uleb128	183
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname183:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname183
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #184: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	184	; ref to abbrev 184
+	.section	.debug_abbrev
+	.uleb128	184
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname184:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname184
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #185: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	185	; ref to abbrev 185
+	.section	.debug_abbrev
+	.uleb128	185
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname185:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname185
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #186: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	186	; ref to abbrev 186
+	.section	.debug_abbrev
+	.uleb128	186
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname186:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname186
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #187: variable EVGENCTRLA
+	.section	.debug_info
+	.uleb128	187	; ref to abbrev 187
+	.section	.debug_abbrev
+	.uleb128	187
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname187:
+	.string		"EVGENCTRLA"
+	.section	.debug_info
+	.long		.Lname187
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #188: variable DIR
+	.section	.debug_info
+	.uleb128	188	; ref to abbrev 188
+	.section	.debug_abbrev
+	.uleb128	188
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname188:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname188
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #189: variable DIRSET
+	.section	.debug_info
+	.uleb128	189	; ref to abbrev 189
+	.section	.debug_abbrev
+	.uleb128	189
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname189:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname189
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #190: variable DIRCLR
+	.section	.debug_info
+	.uleb128	190	; ref to abbrev 190
+	.section	.debug_abbrev
+	.uleb128	190
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname190:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname190
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #191: variable DIRTGL
+	.section	.debug_info
+	.uleb128	191	; ref to abbrev 191
+	.section	.debug_abbrev
+	.uleb128	191
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname191:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname191
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #192: variable OUT
+	.section	.debug_info
+	.uleb128	192	; ref to abbrev 192
+	.section	.debug_abbrev
+	.uleb128	192
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname192:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname192
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #193: variable OUTSET
+	.section	.debug_info
+	.uleb128	193	; ref to abbrev 193
+	.section	.debug_abbrev
+	.uleb128	193
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname193:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname193
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #194: variable OUTCLR
+	.section	.debug_info
+	.uleb128	194	; ref to abbrev 194
+	.section	.debug_abbrev
+	.uleb128	194
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname194:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname194
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #195: variable OUTTGL
+	.section	.debug_info
+	.uleb128	195	; ref to abbrev 195
+	.section	.debug_abbrev
+	.uleb128	195
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname195:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname195
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #196: variable IN
+	.section	.debug_info
+	.uleb128	196	; ref to abbrev 196
+	.section	.debug_abbrev
+	.uleb128	196
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname196:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname196
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #197: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	197	; ref to abbrev 197
+	.section	.debug_abbrev
+	.uleb128	197
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname197:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname197
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #198: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	198	; ref to abbrev 198
+	.section	.debug_abbrev
+	.uleb128	198
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname198:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname198
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #199: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	199	; ref to abbrev 199
+	.section	.debug_abbrev
+	.uleb128	199
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname199:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname199
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #200: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	200	; ref to abbrev 200
+	.section	.debug_abbrev
+	.uleb128	200
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname200:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname200
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #201: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	201	; ref to abbrev 201
+	.section	.debug_abbrev
+	.uleb128	201
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname201:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname201
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #202: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	202	; ref to abbrev 202
+	.section	.debug_abbrev
+	.uleb128	202
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname202:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname202
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #203: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	203	; ref to abbrev 203
+	.section	.debug_abbrev
+	.uleb128	203
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname203:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname203
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #204: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	204	; ref to abbrev 204
+	.section	.debug_abbrev
+	.uleb128	204
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname204:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname204
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #205: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	205	; ref to abbrev 205
+	.section	.debug_abbrev
+	.uleb128	205
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname205:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname205
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #206: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	206	; ref to abbrev 206
+	.section	.debug_abbrev
+	.uleb128	206
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname206:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname206
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #207: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	207	; ref to abbrev 207
+	.section	.debug_abbrev
+	.uleb128	207
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname207:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname207
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #208: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	208	; ref to abbrev 208
+	.section	.debug_abbrev
+	.uleb128	208
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname208:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname208
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #209: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	209	; ref to abbrev 209
+	.section	.debug_abbrev
+	.uleb128	209
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname209:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname209
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #210: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	210	; ref to abbrev 210
+	.section	.debug_abbrev
+	.uleb128	210
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname210:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname210
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #211: variable EVGENCTRLA
+	.section	.debug_info
+	.uleb128	211	; ref to abbrev 211
+	.section	.debug_abbrev
+	.uleb128	211
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname211:
+	.string		"EVGENCTRLA"
+	.section	.debug_info
+	.long		.Lname211
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #212: variable DIR
+	.section	.debug_info
+	.uleb128	212	; ref to abbrev 212
+	.section	.debug_abbrev
+	.uleb128	212
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname212:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname212
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #213: variable DIRSET
+	.section	.debug_info
+	.uleb128	213	; ref to abbrev 213
+	.section	.debug_abbrev
+	.uleb128	213
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname213:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname213
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #214: variable DIRCLR
+	.section	.debug_info
+	.uleb128	214	; ref to abbrev 214
+	.section	.debug_abbrev
+	.uleb128	214
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname214:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname214
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #215: variable DIRTGL
+	.section	.debug_info
+	.uleb128	215	; ref to abbrev 215
+	.section	.debug_abbrev
+	.uleb128	215
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname215:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname215
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #216: variable OUT
+	.section	.debug_info
+	.uleb128	216	; ref to abbrev 216
+	.section	.debug_abbrev
+	.uleb128	216
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname216:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname216
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #217: variable OUTSET
+	.section	.debug_info
+	.uleb128	217	; ref to abbrev 217
+	.section	.debug_abbrev
+	.uleb128	217
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname217:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname217
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #218: variable OUTCLR
+	.section	.debug_info
+	.uleb128	218	; ref to abbrev 218
+	.section	.debug_abbrev
+	.uleb128	218
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname218:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname218
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #219: variable OUTTGL
+	.section	.debug_info
+	.uleb128	219	; ref to abbrev 219
+	.section	.debug_abbrev
+	.uleb128	219
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname219:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname219
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #220: variable IN
+	.section	.debug_info
+	.uleb128	220	; ref to abbrev 220
+	.section	.debug_abbrev
+	.uleb128	220
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname220:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname220
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #221: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	221	; ref to abbrev 221
+	.section	.debug_abbrev
+	.uleb128	221
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname221:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname221
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #222: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	222	; ref to abbrev 222
+	.section	.debug_abbrev
+	.uleb128	222
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname222:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname222
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #223: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	223	; ref to abbrev 223
+	.section	.debug_abbrev
+	.uleb128	223
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname223:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname223
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #224: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	224	; ref to abbrev 224
+	.section	.debug_abbrev
+	.uleb128	224
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname224:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname224
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #225: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	225	; ref to abbrev 225
+	.section	.debug_abbrev
+	.uleb128	225
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname225:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname225
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #226: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	226	; ref to abbrev 226
+	.section	.debug_abbrev
+	.uleb128	226
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname226:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname226
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #227: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	227	; ref to abbrev 227
+	.section	.debug_abbrev
+	.uleb128	227
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname227:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname227
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #228: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	228	; ref to abbrev 228
+	.section	.debug_abbrev
+	.uleb128	228
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname228:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname228
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #229: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	229	; ref to abbrev 229
+	.section	.debug_abbrev
+	.uleb128	229
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname229:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname229
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #230: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	230	; ref to abbrev 230
+	.section	.debug_abbrev
+	.uleb128	230
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname230:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname230
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #231: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	231	; ref to abbrev 231
+	.section	.debug_abbrev
+	.uleb128	231
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname231:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname231
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #232: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	232	; ref to abbrev 232
+	.section	.debug_abbrev
+	.uleb128	232
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname232:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname232
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #233: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	233	; ref to abbrev 233
+	.section	.debug_abbrev
+	.uleb128	233
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname233:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname233
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #234: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	234	; ref to abbrev 234
+	.section	.debug_abbrev
+	.uleb128	234
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname234:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname234
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #235: variable EVGENCTRLA
+	.section	.debug_info
+	.uleb128	235	; ref to abbrev 235
+	.section	.debug_abbrev
+	.uleb128	235
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname235:
+	.string		"EVGENCTRLA"
+	.section	.debug_info
+	.long		.Lname235
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #236: variable EVSYSROUTEA
+	.section	.debug_info
+	.uleb128	236	; ref to abbrev 236
+	.section	.debug_abbrev
+	.uleb128	236
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname236:
+	.string		"EVSYSROUTEA"
+	.section	.debug_info
+	.long		.Lname236
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #237: variable CCLROUTEA
+	.section	.debug_info
+	.uleb128	237	; ref to abbrev 237
+	.section	.debug_abbrev
+	.uleb128	237
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname237:
+	.string		"CCLROUTEA"
+	.section	.debug_info
+	.long		.Lname237
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #238: variable USARTROUTEA
+	.section	.debug_info
+	.uleb128	238	; ref to abbrev 238
+	.section	.debug_abbrev
+	.uleb128	238
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname238:
+	.string		"USARTROUTEA"
+	.section	.debug_info
+	.long		.Lname238
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #239: variable SPIROUTEA
+	.section	.debug_info
+	.uleb128	239	; ref to abbrev 239
+	.section	.debug_abbrev
+	.uleb128	239
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname239:
+	.string		"SPIROUTEA"
+	.section	.debug_info
+	.long		.Lname239
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #240: variable TWIROUTEA
+	.section	.debug_info
+	.uleb128	240	; ref to abbrev 240
+	.section	.debug_abbrev
+	.uleb128	240
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname240:
+	.string		"TWIROUTEA"
+	.section	.debug_info
+	.long		.Lname240
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #241: variable TCEROUTEA
+	.section	.debug_info
+	.uleb128	241	; ref to abbrev 241
+	.section	.debug_abbrev
+	.uleb128	241
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname241:
+	.string		"TCEROUTEA"
+	.section	.debug_info
+	.long		.Lname241
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #242: variable TCBROUTEA
+	.section	.debug_info
+	.uleb128	242	; ref to abbrev 242
+	.section	.debug_abbrev
+	.uleb128	242
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname242:
+	.string		"TCBROUTEA"
+	.section	.debug_info
+	.long		.Lname242
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #243: variable TCFROUTEA
+	.section	.debug_info
+	.uleb128	243	; ref to abbrev 243
+	.section	.debug_abbrev
+	.uleb128	243
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname243:
+	.string		"TCFROUTEA"
+	.section	.debug_info
+	.long		.Lname243
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #244: variable RSTFR
+	.section	.debug_info
+	.uleb128	244	; ref to abbrev 244
+	.section	.debug_abbrev
+	.uleb128	244
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname244:
+	.string		"RSTFR"
+	.section	.debug_info
+	.long		.Lname244
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0040 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #245: variable SWRR
+	.section	.debug_info
+	.uleb128	245	; ref to abbrev 245
+	.section	.debug_abbrev
+	.uleb128	245
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname245:
+	.string		"SWRR"
+	.section	.debug_info
+	.long		.Lname245
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0040 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #246: variable CTRLA
+	.section	.debug_info
+	.uleb128	246	; ref to abbrev 246
+	.section	.debug_abbrev
+	.uleb128	246
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname246:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname246
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #247: variable STATUS
+	.section	.debug_info
+	.uleb128	247	; ref to abbrev 247
+	.section	.debug_abbrev
+	.uleb128	247
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname247:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname247
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #248: variable INTCTRL
+	.section	.debug_info
+	.uleb128	248	; ref to abbrev 248
+	.section	.debug_abbrev
+	.uleb128	248
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname248:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname248
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #249: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	249	; ref to abbrev 249
+	.section	.debug_abbrev
+	.uleb128	249
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname249:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname249
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #250: variable TEMP
+	.section	.debug_info
+	.uleb128	250	; ref to abbrev 250
+	.section	.debug_abbrev
+	.uleb128	250
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname250:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname250
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #251: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	251	; ref to abbrev 251
+	.section	.debug_abbrev
+	.uleb128	251
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname251:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname251
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #252: variable CALIB
+	.section	.debug_info
+	.uleb128	252	; ref to abbrev 252
+	.section	.debug_abbrev
+	.uleb128	252
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname252:
+	.string		"CALIB"
+	.section	.debug_info
+	.long		.Lname252
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #253: variable CLKSEL
+	.section	.debug_info
+	.uleb128	253	; ref to abbrev 253
+	.section	.debug_abbrev
+	.uleb128	253
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname253:
+	.string		"CLKSEL"
+	.section	.debug_info
+	.long		.Lname253
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #254: variable CNT
+	.section	.debug_info
+	.uleb128	254	; ref to abbrev 254
+	.section	.debug_abbrev
+	.uleb128	254
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname254:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname254
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #255: variable PER
+	.section	.debug_info
+	.uleb128	255	; ref to abbrev 255
+	.section	.debug_abbrev
+	.uleb128	255
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname255:
+	.string		"PER"
+	.section	.debug_info
+	.long		.Lname255
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #256: variable CMP
+	.section	.debug_info
+	.uleb128	256	; ref to abbrev 256
+	.section	.debug_abbrev
+	.uleb128	256
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname256:
+	.string		"CMP"
+	.section	.debug_info
+	.long		.Lname256
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #257: variable PITCTRLA
+	.section	.debug_info
+	.uleb128	257	; ref to abbrev 257
+	.section	.debug_abbrev
+	.uleb128	257
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname257:
+	.string		"PITCTRLA"
+	.section	.debug_info
+	.long		.Lname257
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #258: variable PITSTATUS
+	.section	.debug_info
+	.uleb128	258	; ref to abbrev 258
+	.section	.debug_abbrev
+	.uleb128	258
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname258:
+	.string		"PITSTATUS"
+	.section	.debug_info
+	.long		.Lname258
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #259: variable PITINTCTRL
+	.section	.debug_info
+	.uleb128	259	; ref to abbrev 259
+	.section	.debug_abbrev
+	.uleb128	259
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname259:
+	.string		"PITINTCTRL"
+	.section	.debug_info
+	.long		.Lname259
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #260: variable PITINTFLAGS
+	.section	.debug_info
+	.uleb128	260	; ref to abbrev 260
+	.section	.debug_abbrev
+	.uleb128	260
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname260:
+	.string		"PITINTFLAGS"
+	.section	.debug_info
+	.long		.Lname260
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #261: variable PITDBGCTRL
+	.section	.debug_info
+	.uleb128	261	; ref to abbrev 261
+	.section	.debug_abbrev
+	.uleb128	261
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname261:
+	.string		"PITDBGCTRL"
+	.section	.debug_info
+	.long		.Lname261
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #262: variable PITEVGENCTRLA
+	.section	.debug_info
+	.uleb128	262	; ref to abbrev 262
+	.section	.debug_abbrev
+	.uleb128	262
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname262:
+	.string		"PITEVGENCTRLA"
+	.section	.debug_info
+	.long		.Lname262
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #263: variable DEVICEID0
+	.section	.debug_info
+	.uleb128	263	; ref to abbrev 263
+	.section	.debug_abbrev
+	.uleb128	263
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname263:
+	.string		"DEVICEID0"
+	.section	.debug_info
+	.long		.Lname263
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #264: variable DEVICEID1
+	.section	.debug_info
+	.uleb128	264	; ref to abbrev 264
+	.section	.debug_abbrev
+	.uleb128	264
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname264:
+	.string		"DEVICEID1"
+	.section	.debug_info
+	.long		.Lname264
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #265: variable DEVICEID2
+	.section	.debug_info
+	.uleb128	265	; ref to abbrev 265
+	.section	.debug_abbrev
+	.uleb128	265
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname265:
+	.string		"DEVICEID2"
+	.section	.debug_info
+	.long		.Lname265
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #266: variable TEMPSENSE0
+	.section	.debug_info
+	.uleb128	266	; ref to abbrev 266
+	.section	.debug_abbrev
+	.uleb128	266
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname266:
+	.string		"TEMPSENSE0"
+	.section	.debug_info
+	.long		.Lname266
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #267: variable TEMPSENSE1
+	.section	.debug_info
+	.uleb128	267	; ref to abbrev 267
+	.section	.debug_abbrev
+	.uleb128	267
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname267:
+	.string		"TEMPSENSE1"
+	.section	.debug_info
+	.long		.Lname267
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #268: variable SERNUM0
+	.section	.debug_info
+	.uleb128	268	; ref to abbrev 268
+	.section	.debug_abbrev
+	.uleb128	268
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname268:
+	.string		"SERNUM0"
+	.section	.debug_info
+	.long		.Lname268
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #269: variable SERNUM1
+	.section	.debug_info
+	.uleb128	269	; ref to abbrev 269
+	.section	.debug_abbrev
+	.uleb128	269
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname269:
+	.string		"SERNUM1"
+	.section	.debug_info
+	.long		.Lname269
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #270: variable SERNUM2
+	.section	.debug_info
+	.uleb128	270	; ref to abbrev 270
+	.section	.debug_abbrev
+	.uleb128	270
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname270:
+	.string		"SERNUM2"
+	.section	.debug_info
+	.long		.Lname270
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #271: variable SERNUM3
+	.section	.debug_info
+	.uleb128	271	; ref to abbrev 271
+	.section	.debug_abbrev
+	.uleb128	271
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname271:
+	.string		"SERNUM3"
+	.section	.debug_info
+	.long		.Lname271
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #272: variable SERNUM4
+	.section	.debug_info
+	.uleb128	272	; ref to abbrev 272
+	.section	.debug_abbrev
+	.uleb128	272
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname272:
+	.string		"SERNUM4"
+	.section	.debug_info
+	.long		.Lname272
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #273: variable SERNUM5
+	.section	.debug_info
+	.uleb128	273	; ref to abbrev 273
+	.section	.debug_abbrev
+	.uleb128	273
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname273:
+	.string		"SERNUM5"
+	.section	.debug_info
+	.long		.Lname273
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #274: variable SERNUM6
+	.section	.debug_info
+	.uleb128	274	; ref to abbrev 274
+	.section	.debug_abbrev
+	.uleb128	274
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname274:
+	.string		"SERNUM6"
+	.section	.debug_info
+	.long		.Lname274
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #275: variable SERNUM7
+	.section	.debug_info
+	.uleb128	275	; ref to abbrev 275
+	.section	.debug_abbrev
+	.uleb128	275
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname275:
+	.string		"SERNUM7"
+	.section	.debug_info
+	.long		.Lname275
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #276: variable SERNUM8
+	.section	.debug_info
+	.uleb128	276	; ref to abbrev 276
+	.section	.debug_abbrev
+	.uleb128	276
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname276:
+	.string		"SERNUM8"
+	.section	.debug_info
+	.long		.Lname276
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #277: variable SERNUM9
+	.section	.debug_info
+	.uleb128	277	; ref to abbrev 277
+	.section	.debug_abbrev
+	.uleb128	277
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname277:
+	.string		"SERNUM9"
+	.section	.debug_info
+	.long		.Lname277
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x19
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #278: variable SERNUM10
+	.section	.debug_info
+	.uleb128	278	; ref to abbrev 278
+	.section	.debug_abbrev
+	.uleb128	278
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname278:
+	.string		"SERNUM10"
+	.section	.debug_info
+	.long		.Lname278
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #279: variable SERNUM11
+	.section	.debug_info
+	.uleb128	279	; ref to abbrev 279
+	.section	.debug_abbrev
+	.uleb128	279
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname279:
+	.string		"SERNUM11"
+	.section	.debug_info
+	.long		.Lname279
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #280: variable SERNUM12
+	.section	.debug_info
+	.uleb128	280	; ref to abbrev 280
+	.section	.debug_abbrev
+	.uleb128	280
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname280:
+	.string		"SERNUM12"
+	.section	.debug_info
+	.long		.Lname280
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #281: variable SERNUM13
+	.section	.debug_info
+	.uleb128	281	; ref to abbrev 281
+	.section	.debug_abbrev
+	.uleb128	281
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname281:
+	.string		"SERNUM13"
+	.section	.debug_info
+	.long		.Lname281
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #282: variable SERNUM14
+	.section	.debug_info
+	.uleb128	282	; ref to abbrev 282
+	.section	.debug_abbrev
+	.uleb128	282
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname282:
+	.string		"SERNUM14"
+	.section	.debug_info
+	.long		.Lname282
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #283: variable SERNUM15
+	.section	.debug_info
+	.uleb128	283	; ref to abbrev 283
+	.section	.debug_abbrev
+	.uleb128	283
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname283:
+	.string		"SERNUM15"
+	.section	.debug_info
+	.long		.Lname283
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #284: variable CTRLA
+	.section	.debug_info
+	.uleb128	284	; ref to abbrev 284
+	.section	.debug_abbrev
+	.uleb128	284
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname284:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname284
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0050 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #285: variable CTRLA
+	.section	.debug_info
+	.uleb128	285	; ref to abbrev 285
+	.section	.debug_abbrev
+	.uleb128	285
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname285:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname285
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #286: variable CTRLB
+	.section	.debug_info
+	.uleb128	286	; ref to abbrev 286
+	.section	.debug_abbrev
+	.uleb128	286
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname286:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname286
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #287: variable INTCTRL
+	.section	.debug_info
+	.uleb128	287	; ref to abbrev 287
+	.section	.debug_abbrev
+	.uleb128	287
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname287:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname287
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #288: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	288	; ref to abbrev 288
+	.section	.debug_abbrev
+	.uleb128	288
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname288:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname288
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #289: variable DATA
+	.section	.debug_info
+	.uleb128	289	; ref to abbrev 289
+	.section	.debug_abbrev
+	.uleb128	289
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname289:
+	.string		"DATA"
+	.section	.debug_info
+	.long		.Lname289
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #290: variable REVID
+	.section	.debug_info
+	.uleb128	290	; ref to abbrev 290
+	.section	.debug_abbrev
+	.uleb128	290
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname290:
+	.string		"REVID"
+	.section	.debug_info
+	.long		.Lname290
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0F00 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #291: variable CTRLA
+	.section	.debug_info
+	.uleb128	291	; ref to abbrev 291
+	.section	.debug_abbrev
+	.uleb128	291
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname291:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname291
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #292: variable CTRLB
+	.section	.debug_info
+	.uleb128	292	; ref to abbrev 292
+	.section	.debug_abbrev
+	.uleb128	292
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname292:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname292
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #293: variable CTRLC
+	.section	.debug_info
+	.uleb128	293	; ref to abbrev 293
+	.section	.debug_abbrev
+	.uleb128	293
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname293:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname293
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #294: variable EVCTRL
+	.section	.debug_info
+	.uleb128	294	; ref to abbrev 294
+	.section	.debug_abbrev
+	.uleb128	294
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname294:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname294
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #295: variable INTCTRL
+	.section	.debug_info
+	.uleb128	295	; ref to abbrev 295
+	.section	.debug_abbrev
+	.uleb128	295
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname295:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname295
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #296: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	296	; ref to abbrev 296
+	.section	.debug_abbrev
+	.uleb128	296
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname296:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname296
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #297: variable STATUS
+	.section	.debug_info
+	.uleb128	297	; ref to abbrev 297
+	.section	.debug_abbrev
+	.uleb128	297
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname297:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname297
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #298: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	298	; ref to abbrev 298
+	.section	.debug_abbrev
+	.uleb128	298
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname298:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname298
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #299: variable TEMP
+	.section	.debug_info
+	.uleb128	299	; ref to abbrev 299
+	.section	.debug_abbrev
+	.uleb128	299
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname299:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname299
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #300: variable CNT
+	.section	.debug_info
+	.uleb128	300	; ref to abbrev 300
+	.section	.debug_abbrev
+	.uleb128	300
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname300:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname300
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #301: variable CCMP
+	.section	.debug_info
+	.uleb128	301	; ref to abbrev 301
+	.section	.debug_abbrev
+	.uleb128	301
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname301:
+	.string		"CCMP"
+	.section	.debug_info
+	.long		.Lname301
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #302: variable CTRLA
+	.section	.debug_info
+	.uleb128	302	; ref to abbrev 302
+	.section	.debug_abbrev
+	.uleb128	302
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname302:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname302
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #303: variable CTRLB
+	.section	.debug_info
+	.uleb128	303	; ref to abbrev 303
+	.section	.debug_abbrev
+	.uleb128	303
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname303:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname303
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #304: variable CTRLC
+	.section	.debug_info
+	.uleb128	304	; ref to abbrev 304
+	.section	.debug_abbrev
+	.uleb128	304
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname304:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname304
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #305: variable EVCTRL
+	.section	.debug_info
+	.uleb128	305	; ref to abbrev 305
+	.section	.debug_abbrev
+	.uleb128	305
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname305:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname305
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #306: variable INTCTRL
+	.section	.debug_info
+	.uleb128	306	; ref to abbrev 306
+	.section	.debug_abbrev
+	.uleb128	306
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname306:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname306
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #307: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	307	; ref to abbrev 307
+	.section	.debug_abbrev
+	.uleb128	307
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname307:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname307
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #308: variable STATUS
+	.section	.debug_info
+	.uleb128	308	; ref to abbrev 308
+	.section	.debug_abbrev
+	.uleb128	308
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname308:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname308
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #309: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	309	; ref to abbrev 309
+	.section	.debug_abbrev
+	.uleb128	309
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname309:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname309
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #310: variable TEMP
+	.section	.debug_info
+	.uleb128	310	; ref to abbrev 310
+	.section	.debug_abbrev
+	.uleb128	310
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname310:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname310
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #311: variable CNT
+	.section	.debug_info
+	.uleb128	311	; ref to abbrev 311
+	.section	.debug_abbrev
+	.uleb128	311
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname311:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname311
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #312: variable CCMP
+	.section	.debug_info
+	.uleb128	312	; ref to abbrev 312
+	.section	.debug_abbrev
+	.uleb128	312
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname312:
+	.string		"CCMP"
+	.section	.debug_info
+	.long		.Lname312
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #313: variable CTRLA
+	.section	.debug_info
+	.uleb128	313	; ref to abbrev 313
+	.section	.debug_abbrev
+	.uleb128	313
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname313:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname313
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #314: variable CTRLB
+	.section	.debug_info
+	.uleb128	314	; ref to abbrev 314
+	.section	.debug_abbrev
+	.uleb128	314
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname314:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname314
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #315: variable CTRLC
+	.section	.debug_info
+	.uleb128	315	; ref to abbrev 315
+	.section	.debug_abbrev
+	.uleb128	315
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname315:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname315
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #316: variable CTRLD
+	.section	.debug_info
+	.uleb128	316	; ref to abbrev 316
+	.section	.debug_abbrev
+	.uleb128	316
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname316:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname316
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #317: variable CTRLECLR
+	.section	.debug_info
+	.uleb128	317	; ref to abbrev 317
+	.section	.debug_abbrev
+	.uleb128	317
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname317:
+	.string		"CTRLECLR"
+	.section	.debug_info
+	.long		.Lname317
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #318: variable CTRLESET
+	.section	.debug_info
+	.uleb128	318	; ref to abbrev 318
+	.section	.debug_abbrev
+	.uleb128	318
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname318:
+	.string		"CTRLESET"
+	.section	.debug_info
+	.long		.Lname318
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #319: variable CTRLFCLR
+	.section	.debug_info
+	.uleb128	319	; ref to abbrev 319
+	.section	.debug_abbrev
+	.uleb128	319
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname319:
+	.string		"CTRLFCLR"
+	.section	.debug_info
+	.long		.Lname319
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #320: variable CTRLFSET
+	.section	.debug_info
+	.uleb128	320	; ref to abbrev 320
+	.section	.debug_abbrev
+	.uleb128	320
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname320:
+	.string		"CTRLFSET"
+	.section	.debug_info
+	.long		.Lname320
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #321: variable EVGENCTRL
+	.section	.debug_info
+	.uleb128	321	; ref to abbrev 321
+	.section	.debug_abbrev
+	.uleb128	321
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname321:
+	.string		"EVGENCTRL"
+	.section	.debug_info
+	.long		.Lname321
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #322: variable EVCTRL
+	.section	.debug_info
+	.uleb128	322	; ref to abbrev 322
+	.section	.debug_abbrev
+	.uleb128	322
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname322:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname322
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #323: variable INTCTRL
+	.section	.debug_info
+	.uleb128	323	; ref to abbrev 323
+	.section	.debug_abbrev
+	.uleb128	323
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname323:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname323
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #324: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	324	; ref to abbrev 324
+	.section	.debug_abbrev
+	.uleb128	324
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname324:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname324
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #325: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	325	; ref to abbrev 325
+	.section	.debug_abbrev
+	.uleb128	325
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname325:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname325
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #326: variable TEMP
+	.section	.debug_info
+	.uleb128	326	; ref to abbrev 326
+	.section	.debug_abbrev
+	.uleb128	326
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname326:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname326
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #327: variable CNT
+	.section	.debug_info
+	.uleb128	327	; ref to abbrev 327
+	.section	.debug_abbrev
+	.uleb128	327
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname327:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname327
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #328: variable AMP
+	.section	.debug_info
+	.uleb128	328	; ref to abbrev 328
+	.section	.debug_abbrev
+	.uleb128	328
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname328:
+	.string		"AMP"
+	.section	.debug_info
+	.long		.Lname328
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x22
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #329: variable OFFSET
+	.section	.debug_info
+	.uleb128	329	; ref to abbrev 329
+	.section	.debug_abbrev
+	.uleb128	329
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname329:
+	.string		"OFFSET"
+	.section	.debug_info
+	.long		.Lname329
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x24
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #330: variable PER
+	.section	.debug_info
+	.uleb128	330	; ref to abbrev 330
+	.section	.debug_abbrev
+	.uleb128	330
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname330:
+	.string		"PER"
+	.section	.debug_info
+	.long		.Lname330
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x26
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #331: variable CMP0
+	.section	.debug_info
+	.uleb128	331	; ref to abbrev 331
+	.section	.debug_abbrev
+	.uleb128	331
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname331:
+	.string		"CMP0"
+	.section	.debug_info
+	.long		.Lname331
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x28
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #332: variable CMP1
+	.section	.debug_info
+	.uleb128	332	; ref to abbrev 332
+	.section	.debug_abbrev
+	.uleb128	332
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname332:
+	.string		"CMP1"
+	.section	.debug_info
+	.long		.Lname332
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #333: variable CMP2
+	.section	.debug_info
+	.uleb128	333	; ref to abbrev 333
+	.section	.debug_abbrev
+	.uleb128	333
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname333:
+	.string		"CMP2"
+	.section	.debug_info
+	.long		.Lname333
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #334: variable CMP3
+	.section	.debug_info
+	.uleb128	334	; ref to abbrev 334
+	.section	.debug_abbrev
+	.uleb128	334
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname334:
+	.string		"CMP3"
+	.section	.debug_info
+	.long		.Lname334
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #335: variable PERBUF
+	.section	.debug_info
+	.uleb128	335	; ref to abbrev 335
+	.section	.debug_abbrev
+	.uleb128	335
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname335:
+	.string		"PERBUF"
+	.section	.debug_info
+	.long		.Lname335
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x36
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #336: variable CMP0BUF
+	.section	.debug_info
+	.uleb128	336	; ref to abbrev 336
+	.section	.debug_abbrev
+	.uleb128	336
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname336:
+	.string		"CMP0BUF"
+	.section	.debug_info
+	.long		.Lname336
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x38
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #337: variable CMP1BUF
+	.section	.debug_info
+	.uleb128	337	; ref to abbrev 337
+	.section	.debug_abbrev
+	.uleb128	337
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname337:
+	.string		"CMP1BUF"
+	.section	.debug_info
+	.long		.Lname337
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x3A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #338: variable CMP2BUF
+	.section	.debug_info
+	.uleb128	338	; ref to abbrev 338
+	.section	.debug_abbrev
+	.uleb128	338
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname338:
+	.string		"CMP2BUF"
+	.section	.debug_info
+	.long		.Lname338
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x3C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #339: variable CMP3BUF
+	.section	.debug_info
+	.uleb128	339	; ref to abbrev 339
+	.section	.debug_abbrev
+	.uleb128	339
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname339:
+	.string		"CMP3BUF"
+	.section	.debug_info
+	.long		.Lname339
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x3E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #340: variable CTRLA
+	.section	.debug_info
+	.uleb128	340	; ref to abbrev 340
+	.section	.debug_abbrev
+	.uleb128	340
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname340:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname340
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C00 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #341: variable CTRLB
+	.section	.debug_info
+	.uleb128	341	; ref to abbrev 341
+	.section	.debug_abbrev
+	.uleb128	341
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname341:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname341
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C00 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #342: variable CTRLC
+	.section	.debug_info
+	.uleb128	342	; ref to abbrev 342
+	.section	.debug_abbrev
+	.uleb128	342
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname342:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname342
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C00 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #343: variable CTRLD
+	.section	.debug_info
+	.uleb128	343	; ref to abbrev 343
+	.section	.debug_abbrev
+	.uleb128	343
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname343:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname343
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C00 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #344: variable EVCTRL
+	.section	.debug_info
+	.uleb128	344	; ref to abbrev 344
+	.section	.debug_abbrev
+	.uleb128	344
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname344:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname344
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C00 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #345: variable INTCTRL
+	.section	.debug_info
+	.uleb128	345	; ref to abbrev 345
+	.section	.debug_abbrev
+	.uleb128	345
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname345:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname345
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C00 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #346: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	346	; ref to abbrev 346
+	.section	.debug_abbrev
+	.uleb128	346
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname346:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname346
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C00 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #347: variable STATUS
+	.section	.debug_info
+	.uleb128	347	; ref to abbrev 347
+	.section	.debug_abbrev
+	.uleb128	347
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname347:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname347
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C00 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #348: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	348	; ref to abbrev 348
+	.section	.debug_abbrev
+	.uleb128	348
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname348:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname348
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C00 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #349: variable CNT
+	.section	.debug_info
+	.uleb128	349	; ref to abbrev 349
+	.section	.debug_abbrev
+	.uleb128	349
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname349:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname349
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint32_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C00 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #350: variable CMP
+	.section	.debug_info
+	.uleb128	350	; ref to abbrev 350
+	.section	.debug_abbrev
+	.uleb128	350
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname350:
+	.string		"CMP"
+	.section	.debug_info
+	.long		.Lname350
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint32_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C00 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #351: variable CTRLA
+	.section	.debug_info
+	.uleb128	351	; ref to abbrev 351
+	.section	.debug_abbrev
+	.uleb128	351
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname351:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname351
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #352: variable DUALCTRL
+	.section	.debug_info
+	.uleb128	352	; ref to abbrev 352
+	.section	.debug_abbrev
+	.uleb128	352
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname352:
+	.string		"DUALCTRL"
+	.section	.debug_info
+	.long		.Lname352
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #353: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	353	; ref to abbrev 353
+	.section	.debug_abbrev
+	.uleb128	353
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname353:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname353
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #354: variable MCTRLA
+	.section	.debug_info
+	.uleb128	354	; ref to abbrev 354
+	.section	.debug_abbrev
+	.uleb128	354
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname354:
+	.string		"MCTRLA"
+	.section	.debug_info
+	.long		.Lname354
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #355: variable MCTRLB
+	.section	.debug_info
+	.uleb128	355	; ref to abbrev 355
+	.section	.debug_abbrev
+	.uleb128	355
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname355:
+	.string		"MCTRLB"
+	.section	.debug_info
+	.long		.Lname355
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #356: variable MSTATUS
+	.section	.debug_info
+	.uleb128	356	; ref to abbrev 356
+	.section	.debug_abbrev
+	.uleb128	356
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname356:
+	.string		"MSTATUS"
+	.section	.debug_info
+	.long		.Lname356
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #357: variable MBAUD
+	.section	.debug_info
+	.uleb128	357	; ref to abbrev 357
+	.section	.debug_abbrev
+	.uleb128	357
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname357:
+	.string		"MBAUD"
+	.section	.debug_info
+	.long		.Lname357
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #358: variable MADDR
+	.section	.debug_info
+	.uleb128	358	; ref to abbrev 358
+	.section	.debug_abbrev
+	.uleb128	358
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname358:
+	.string		"MADDR"
+	.section	.debug_info
+	.long		.Lname358
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #359: variable MDATA
+	.section	.debug_info
+	.uleb128	359	; ref to abbrev 359
+	.section	.debug_abbrev
+	.uleb128	359
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname359:
+	.string		"MDATA"
+	.section	.debug_info
+	.long		.Lname359
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #360: variable SCTRLA
+	.section	.debug_info
+	.uleb128	360	; ref to abbrev 360
+	.section	.debug_abbrev
+	.uleb128	360
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname360:
+	.string		"SCTRLA"
+	.section	.debug_info
+	.long		.Lname360
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #361: variable SCTRLB
+	.section	.debug_info
+	.uleb128	361	; ref to abbrev 361
+	.section	.debug_abbrev
+	.uleb128	361
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname361:
+	.string		"SCTRLB"
+	.section	.debug_info
+	.long		.Lname361
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #362: variable SSTATUS
+	.section	.debug_info
+	.uleb128	362	; ref to abbrev 362
+	.section	.debug_abbrev
+	.uleb128	362
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname362:
+	.string		"SSTATUS"
+	.section	.debug_info
+	.long		.Lname362
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #363: variable SADDR
+	.section	.debug_info
+	.uleb128	363	; ref to abbrev 363
+	.section	.debug_abbrev
+	.uleb128	363
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname363:
+	.string		"SADDR"
+	.section	.debug_info
+	.long		.Lname363
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #364: variable SDATA
+	.section	.debug_info
+	.uleb128	364	; ref to abbrev 364
+	.section	.debug_abbrev
+	.uleb128	364
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname364:
+	.string		"SDATA"
+	.section	.debug_info
+	.long		.Lname364
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xD
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #365: variable SADDRMASK
+	.section	.debug_info
+	.uleb128	365	; ref to abbrev 365
+	.section	.debug_abbrev
+	.uleb128	365
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname365:
+	.string		"SADDRMASK"
+	.section	.debug_info
+	.long		.Lname365
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xE
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #366: variable RXDATAL
+	.section	.debug_info
+	.uleb128	366	; ref to abbrev 366
+	.section	.debug_abbrev
+	.uleb128	366
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname366:
+	.string		"RXDATAL"
+	.section	.debug_info
+	.long		.Lname366
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #367: variable RXDATAH
+	.section	.debug_info
+	.uleb128	367	; ref to abbrev 367
+	.section	.debug_abbrev
+	.uleb128	367
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname367:
+	.string		"RXDATAH"
+	.section	.debug_info
+	.long		.Lname367
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #368: variable TXDATAL
+	.section	.debug_info
+	.uleb128	368	; ref to abbrev 368
+	.section	.debug_abbrev
+	.uleb128	368
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname368:
+	.string		"TXDATAL"
+	.section	.debug_info
+	.long		.Lname368
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #369: variable TXDATAH
+	.section	.debug_info
+	.uleb128	369	; ref to abbrev 369
+	.section	.debug_abbrev
+	.uleb128	369
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname369:
+	.string		"TXDATAH"
+	.section	.debug_info
+	.long		.Lname369
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #370: variable STATUS
+	.section	.debug_info
+	.uleb128	370	; ref to abbrev 370
+	.section	.debug_abbrev
+	.uleb128	370
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname370:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname370
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #371: variable CTRLA
+	.section	.debug_info
+	.uleb128	371	; ref to abbrev 371
+	.section	.debug_abbrev
+	.uleb128	371
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname371:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname371
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #372: variable CTRLB
+	.section	.debug_info
+	.uleb128	372	; ref to abbrev 372
+	.section	.debug_abbrev
+	.uleb128	372
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname372:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname372
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #373: variable CTRLC
+	.section	.debug_info
+	.uleb128	373	; ref to abbrev 373
+	.section	.debug_abbrev
+	.uleb128	373
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname373:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname373
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #374: variable BAUD
+	.section	.debug_info
+	.uleb128	374	; ref to abbrev 374
+	.section	.debug_abbrev
+	.uleb128	374
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname374:
+	.string		"BAUD"
+	.section	.debug_info
+	.long		.Lname374
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #375: variable CTRLD
+	.section	.debug_info
+	.uleb128	375	; ref to abbrev 375
+	.section	.debug_abbrev
+	.uleb128	375
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname375:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname375
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #376: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	376	; ref to abbrev 376
+	.section	.debug_abbrev
+	.uleb128	376
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname376:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname376
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #377: variable EVCTRL
+	.section	.debug_info
+	.uleb128	377	; ref to abbrev 377
+	.section	.debug_abbrev
+	.uleb128	377
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname377:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname377
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #378: variable TXPLCTRL
+	.section	.debug_info
+	.uleb128	378	; ref to abbrev 378
+	.section	.debug_abbrev
+	.uleb128	378
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname378:
+	.string		"TXPLCTRL"
+	.section	.debug_info
+	.long		.Lname378
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xD
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #379: variable RXPLCTRL
+	.section	.debug_info
+	.uleb128	379	; ref to abbrev 379
+	.section	.debug_abbrev
+	.uleb128	379
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname379:
+	.string		"RXPLCTRL"
+	.section	.debug_info
+	.long		.Lname379
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xE
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #380: variable USERROW0
+	.section	.debug_info
+	.uleb128	380	; ref to abbrev 380
+	.section	.debug_abbrev
+	.uleb128	380
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname380:
+	.string		"USERROW0"
+	.section	.debug_info
+	.long		.Lname380
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #381: variable USERROW1
+	.section	.debug_info
+	.uleb128	381	; ref to abbrev 381
+	.section	.debug_abbrev
+	.uleb128	381
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname381:
+	.string		"USERROW1"
+	.section	.debug_info
+	.long		.Lname381
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #382: variable USERROW2
+	.section	.debug_info
+	.uleb128	382	; ref to abbrev 382
+	.section	.debug_abbrev
+	.uleb128	382
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname382:
+	.string		"USERROW2"
+	.section	.debug_info
+	.long		.Lname382
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #383: variable USERROW3
+	.section	.debug_info
+	.uleb128	383	; ref to abbrev 383
+	.section	.debug_abbrev
+	.uleb128	383
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname383:
+	.string		"USERROW3"
+	.section	.debug_info
+	.long		.Lname383
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #384: variable USERROW4
+	.section	.debug_info
+	.uleb128	384	; ref to abbrev 384
+	.section	.debug_abbrev
+	.uleb128	384
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname384:
+	.string		"USERROW4"
+	.section	.debug_info
+	.long		.Lname384
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #385: variable USERROW5
+	.section	.debug_info
+	.uleb128	385	; ref to abbrev 385
+	.section	.debug_abbrev
+	.uleb128	385
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname385:
+	.string		"USERROW5"
+	.section	.debug_info
+	.long		.Lname385
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #386: variable USERROW6
+	.section	.debug_info
+	.uleb128	386	; ref to abbrev 386
+	.section	.debug_abbrev
+	.uleb128	386
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname386:
+	.string		"USERROW6"
+	.section	.debug_info
+	.long		.Lname386
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #387: variable USERROW7
+	.section	.debug_info
+	.uleb128	387	; ref to abbrev 387
+	.section	.debug_abbrev
+	.uleb128	387
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname387:
+	.string		"USERROW7"
+	.section	.debug_info
+	.long		.Lname387
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #388: variable USERROW8
+	.section	.debug_info
+	.uleb128	388	; ref to abbrev 388
+	.section	.debug_abbrev
+	.uleb128	388
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname388:
+	.string		"USERROW8"
+	.section	.debug_info
+	.long		.Lname388
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #389: variable USERROW9
+	.section	.debug_info
+	.uleb128	389	; ref to abbrev 389
+	.section	.debug_abbrev
+	.uleb128	389
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname389:
+	.string		"USERROW9"
+	.section	.debug_info
+	.long		.Lname389
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #390: variable USERROW10
+	.section	.debug_info
+	.uleb128	390	; ref to abbrev 390
+	.section	.debug_abbrev
+	.uleb128	390
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname390:
+	.string		"USERROW10"
+	.section	.debug_info
+	.long		.Lname390
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #391: variable USERROW11
+	.section	.debug_info
+	.uleb128	391	; ref to abbrev 391
+	.section	.debug_abbrev
+	.uleb128	391
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname391:
+	.string		"USERROW11"
+	.section	.debug_info
+	.long		.Lname391
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #392: variable USERROW12
+	.section	.debug_info
+	.uleb128	392	; ref to abbrev 392
+	.section	.debug_abbrev
+	.uleb128	392
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname392:
+	.string		"USERROW12"
+	.section	.debug_info
+	.long		.Lname392
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #393: variable USERROW13
+	.section	.debug_info
+	.uleb128	393	; ref to abbrev 393
+	.section	.debug_abbrev
+	.uleb128	393
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname393:
+	.string		"USERROW13"
+	.section	.debug_info
+	.long		.Lname393
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #394: variable USERROW14
+	.section	.debug_info
+	.uleb128	394	; ref to abbrev 394
+	.section	.debug_abbrev
+	.uleb128	394
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname394:
+	.string		"USERROW14"
+	.section	.debug_info
+	.long		.Lname394
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #395: variable USERROW15
+	.section	.debug_info
+	.uleb128	395	; ref to abbrev 395
+	.section	.debug_abbrev
+	.uleb128	395
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname395:
+	.string		"USERROW15"
+	.section	.debug_info
+	.long		.Lname395
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x0F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #396: variable USERROW16
+	.section	.debug_info
+	.uleb128	396	; ref to abbrev 396
+	.section	.debug_abbrev
+	.uleb128	396
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname396:
+	.string		"USERROW16"
+	.section	.debug_info
+	.long		.Lname396
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #397: variable USERROW17
+	.section	.debug_info
+	.uleb128	397	; ref to abbrev 397
+	.section	.debug_abbrev
+	.uleb128	397
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname397:
+	.string		"USERROW17"
+	.section	.debug_info
+	.long		.Lname397
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #398: variable USERROW18
+	.section	.debug_info
+	.uleb128	398	; ref to abbrev 398
+	.section	.debug_abbrev
+	.uleb128	398
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname398:
+	.string		"USERROW18"
+	.section	.debug_info
+	.long		.Lname398
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #399: variable USERROW19
+	.section	.debug_info
+	.uleb128	399	; ref to abbrev 399
+	.section	.debug_abbrev
+	.uleb128	399
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname399:
+	.string		"USERROW19"
+	.section	.debug_info
+	.long		.Lname399
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #400: variable USERROW20
+	.section	.debug_info
+	.uleb128	400	; ref to abbrev 400
+	.section	.debug_abbrev
+	.uleb128	400
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname400:
+	.string		"USERROW20"
+	.section	.debug_info
+	.long		.Lname400
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #401: variable USERROW21
+	.section	.debug_info
+	.uleb128	401	; ref to abbrev 401
+	.section	.debug_abbrev
+	.uleb128	401
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname401:
+	.string		"USERROW21"
+	.section	.debug_info
+	.long		.Lname401
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #402: variable USERROW22
+	.section	.debug_info
+	.uleb128	402	; ref to abbrev 402
+	.section	.debug_abbrev
+	.uleb128	402
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname402:
+	.string		"USERROW22"
+	.section	.debug_info
+	.long		.Lname402
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #403: variable USERROW23
+	.section	.debug_info
+	.uleb128	403	; ref to abbrev 403
+	.section	.debug_abbrev
+	.uleb128	403
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname403:
+	.string		"USERROW23"
+	.section	.debug_info
+	.long		.Lname403
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #404: variable USERROW24
+	.section	.debug_info
+	.uleb128	404	; ref to abbrev 404
+	.section	.debug_abbrev
+	.uleb128	404
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname404:
+	.string		"USERROW24"
+	.section	.debug_info
+	.long		.Lname404
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #405: variable USERROW25
+	.section	.debug_info
+	.uleb128	405	; ref to abbrev 405
+	.section	.debug_abbrev
+	.uleb128	405
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname405:
+	.string		"USERROW25"
+	.section	.debug_info
+	.long		.Lname405
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x19
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #406: variable USERROW26
+	.section	.debug_info
+	.uleb128	406	; ref to abbrev 406
+	.section	.debug_abbrev
+	.uleb128	406
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname406:
+	.string		"USERROW26"
+	.section	.debug_info
+	.long		.Lname406
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x1A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #407: variable USERROW27
+	.section	.debug_info
+	.uleb128	407	; ref to abbrev 407
+	.section	.debug_abbrev
+	.uleb128	407
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname407:
+	.string		"USERROW27"
+	.section	.debug_info
+	.long		.Lname407
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x1B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #408: variable USERROW28
+	.section	.debug_info
+	.uleb128	408	; ref to abbrev 408
+	.section	.debug_abbrev
+	.uleb128	408
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname408:
+	.string		"USERROW28"
+	.section	.debug_info
+	.long		.Lname408
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x1C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #409: variable USERROW29
+	.section	.debug_info
+	.uleb128	409	; ref to abbrev 409
+	.section	.debug_abbrev
+	.uleb128	409
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname409:
+	.string		"USERROW29"
+	.section	.debug_info
+	.long		.Lname409
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x1D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #410: variable USERROW30
+	.section	.debug_info
+	.uleb128	410	; ref to abbrev 410
+	.section	.debug_abbrev
+	.uleb128	410
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname410:
+	.string		"USERROW30"
+	.section	.debug_info
+	.long		.Lname410
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x1E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #411: variable USERROW31
+	.section	.debug_info
+	.uleb128	411	; ref to abbrev 411
+	.section	.debug_abbrev
+	.uleb128	411
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname411:
+	.string		"USERROW31"
+	.section	.debug_info
+	.long		.Lname411
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x1F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #412: variable USERROW32
+	.section	.debug_info
+	.uleb128	412	; ref to abbrev 412
+	.section	.debug_abbrev
+	.uleb128	412
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname412:
+	.string		"USERROW32"
+	.section	.debug_info
+	.long		.Lname412
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #413: variable USERROW33
+	.section	.debug_info
+	.uleb128	413	; ref to abbrev 413
+	.section	.debug_abbrev
+	.uleb128	413
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname413:
+	.string		"USERROW33"
+	.section	.debug_info
+	.long		.Lname413
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x21
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #414: variable USERROW34
+	.section	.debug_info
+	.uleb128	414	; ref to abbrev 414
+	.section	.debug_abbrev
+	.uleb128	414
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname414:
+	.string		"USERROW34"
+	.section	.debug_info
+	.long		.Lname414
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x22
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #415: variable USERROW35
+	.section	.debug_info
+	.uleb128	415	; ref to abbrev 415
+	.section	.debug_abbrev
+	.uleb128	415
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname415:
+	.string		"USERROW35"
+	.section	.debug_info
+	.long		.Lname415
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x23
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #416: variable USERROW36
+	.section	.debug_info
+	.uleb128	416	; ref to abbrev 416
+	.section	.debug_abbrev
+	.uleb128	416
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname416:
+	.string		"USERROW36"
+	.section	.debug_info
+	.long		.Lname416
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x24
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #417: variable USERROW37
+	.section	.debug_info
+	.uleb128	417	; ref to abbrev 417
+	.section	.debug_abbrev
+	.uleb128	417
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname417:
+	.string		"USERROW37"
+	.section	.debug_info
+	.long		.Lname417
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x25
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #418: variable USERROW38
+	.section	.debug_info
+	.uleb128	418	; ref to abbrev 418
+	.section	.debug_abbrev
+	.uleb128	418
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname418:
+	.string		"USERROW38"
+	.section	.debug_info
+	.long		.Lname418
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x26
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #419: variable USERROW39
+	.section	.debug_info
+	.uleb128	419	; ref to abbrev 419
+	.section	.debug_abbrev
+	.uleb128	419
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname419:
+	.string		"USERROW39"
+	.section	.debug_info
+	.long		.Lname419
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x27
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #420: variable USERROW40
+	.section	.debug_info
+	.uleb128	420	; ref to abbrev 420
+	.section	.debug_abbrev
+	.uleb128	420
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname420:
+	.string		"USERROW40"
+	.section	.debug_info
+	.long		.Lname420
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x28
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #421: variable USERROW41
+	.section	.debug_info
+	.uleb128	421	; ref to abbrev 421
+	.section	.debug_abbrev
+	.uleb128	421
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname421:
+	.string		"USERROW41"
+	.section	.debug_info
+	.long		.Lname421
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x29
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #422: variable USERROW42
+	.section	.debug_info
+	.uleb128	422	; ref to abbrev 422
+	.section	.debug_abbrev
+	.uleb128	422
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname422:
+	.string		"USERROW42"
+	.section	.debug_info
+	.long		.Lname422
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x2A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #423: variable USERROW43
+	.section	.debug_info
+	.uleb128	423	; ref to abbrev 423
+	.section	.debug_abbrev
+	.uleb128	423
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname423:
+	.string		"USERROW43"
+	.section	.debug_info
+	.long		.Lname423
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x2B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #424: variable USERROW44
+	.section	.debug_info
+	.uleb128	424	; ref to abbrev 424
+	.section	.debug_abbrev
+	.uleb128	424
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname424:
+	.string		"USERROW44"
+	.section	.debug_info
+	.long		.Lname424
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x2C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #425: variable USERROW45
+	.section	.debug_info
+	.uleb128	425	; ref to abbrev 425
+	.section	.debug_abbrev
+	.uleb128	425
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname425:
+	.string		"USERROW45"
+	.section	.debug_info
+	.long		.Lname425
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x2D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #426: variable USERROW46
+	.section	.debug_info
+	.uleb128	426	; ref to abbrev 426
+	.section	.debug_abbrev
+	.uleb128	426
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname426:
+	.string		"USERROW46"
+	.section	.debug_info
+	.long		.Lname426
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x2E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #427: variable USERROW47
+	.section	.debug_info
+	.uleb128	427	; ref to abbrev 427
+	.section	.debug_abbrev
+	.uleb128	427
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname427:
+	.string		"USERROW47"
+	.section	.debug_info
+	.long		.Lname427
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x2F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #428: variable USERROW48
+	.section	.debug_info
+	.uleb128	428	; ref to abbrev 428
+	.section	.debug_abbrev
+	.uleb128	428
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname428:
+	.string		"USERROW48"
+	.section	.debug_info
+	.long		.Lname428
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x30
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #429: variable USERROW49
+	.section	.debug_info
+	.uleb128	429	; ref to abbrev 429
+	.section	.debug_abbrev
+	.uleb128	429
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname429:
+	.string		"USERROW49"
+	.section	.debug_info
+	.long		.Lname429
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x31
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #430: variable USERROW50
+	.section	.debug_info
+	.uleb128	430	; ref to abbrev 430
+	.section	.debug_abbrev
+	.uleb128	430
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname430:
+	.string		"USERROW50"
+	.section	.debug_info
+	.long		.Lname430
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x32
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #431: variable USERROW51
+	.section	.debug_info
+	.uleb128	431	; ref to abbrev 431
+	.section	.debug_abbrev
+	.uleb128	431
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname431:
+	.string		"USERROW51"
+	.section	.debug_info
+	.long		.Lname431
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x33
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #432: variable USERROW52
+	.section	.debug_info
+	.uleb128	432	; ref to abbrev 432
+	.section	.debug_abbrev
+	.uleb128	432
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname432:
+	.string		"USERROW52"
+	.section	.debug_info
+	.long		.Lname432
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x34
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #433: variable USERROW53
+	.section	.debug_info
+	.uleb128	433	; ref to abbrev 433
+	.section	.debug_abbrev
+	.uleb128	433
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname433:
+	.string		"USERROW53"
+	.section	.debug_info
+	.long		.Lname433
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x35
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #434: variable USERROW54
+	.section	.debug_info
+	.uleb128	434	; ref to abbrev 434
+	.section	.debug_abbrev
+	.uleb128	434
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname434:
+	.string		"USERROW54"
+	.section	.debug_info
+	.long		.Lname434
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x36
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #435: variable USERROW55
+	.section	.debug_info
+	.uleb128	435	; ref to abbrev 435
+	.section	.debug_abbrev
+	.uleb128	435
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname435:
+	.string		"USERROW55"
+	.section	.debug_info
+	.long		.Lname435
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x37
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #436: variable USERROW56
+	.section	.debug_info
+	.uleb128	436	; ref to abbrev 436
+	.section	.debug_abbrev
+	.uleb128	436
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname436:
+	.string		"USERROW56"
+	.section	.debug_info
+	.long		.Lname436
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x38
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #437: variable USERROW57
+	.section	.debug_info
+	.uleb128	437	; ref to abbrev 437
+	.section	.debug_abbrev
+	.uleb128	437
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname437:
+	.string		"USERROW57"
+	.section	.debug_info
+	.long		.Lname437
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x39
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #438: variable USERROW58
+	.section	.debug_info
+	.uleb128	438	; ref to abbrev 438
+	.section	.debug_abbrev
+	.uleb128	438
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname438:
+	.string		"USERROW58"
+	.section	.debug_info
+	.long		.Lname438
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x3A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #439: variable USERROW59
+	.section	.debug_info
+	.uleb128	439	; ref to abbrev 439
+	.section	.debug_abbrev
+	.uleb128	439
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname439:
+	.string		"USERROW59"
+	.section	.debug_info
+	.long		.Lname439
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x3B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #440: variable USERROW60
+	.section	.debug_info
+	.uleb128	440	; ref to abbrev 440
+	.section	.debug_abbrev
+	.uleb128	440
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname440:
+	.string		"USERROW60"
+	.section	.debug_info
+	.long		.Lname440
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x3C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #441: variable USERROW61
+	.section	.debug_info
+	.uleb128	441	; ref to abbrev 441
+	.section	.debug_abbrev
+	.uleb128	441
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname441:
+	.string		"USERROW61"
+	.section	.debug_info
+	.long		.Lname441
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x3D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #442: variable USERROW62
+	.section	.debug_info
+	.uleb128	442	; ref to abbrev 442
+	.section	.debug_abbrev
+	.uleb128	442
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname442:
+	.string		"USERROW62"
+	.section	.debug_info
+	.long		.Lname442
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x3E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #443: variable USERROW63
+	.section	.debug_info
+	.uleb128	443	; ref to abbrev 443
+	.section	.debug_abbrev
+	.uleb128	443
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname443:
+	.string		"USERROW63"
+	.section	.debug_info
+	.long		.Lname443
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x3F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #444: variable DIR
+	.section	.debug_info
+	.uleb128	444	; ref to abbrev 444
+	.section	.debug_abbrev
+	.uleb128	444
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname444:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname444
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0000 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #445: variable OUT
+	.section	.debug_info
+	.uleb128	445	; ref to abbrev 445
+	.section	.debug_abbrev
+	.uleb128	445
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname445:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname445
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0000 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #446: variable IN
+	.section	.debug_info
+	.uleb128	446	; ref to abbrev 446
+	.section	.debug_abbrev
+	.uleb128	446
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname446:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname446
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0000 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #447: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	447	; ref to abbrev 447
+	.section	.debug_abbrev
+	.uleb128	447
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname447:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname447
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0000 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #448: variable DIR
+	.section	.debug_info
+	.uleb128	448	; ref to abbrev 448
+	.section	.debug_abbrev
+	.uleb128	448
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname448:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname448
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0008 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #449: variable OUT
+	.section	.debug_info
+	.uleb128	449	; ref to abbrev 449
+	.section	.debug_abbrev
+	.uleb128	449
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname449:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname449
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0008 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #450: variable IN
+	.section	.debug_info
+	.uleb128	450	; ref to abbrev 450
+	.section	.debug_abbrev
+	.uleb128	450
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname450:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname450
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0008 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #451: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	451	; ref to abbrev 451
+	.section	.debug_abbrev
+	.uleb128	451
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname451:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname451
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0008 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #452: variable DIR
+	.section	.debug_info
+	.uleb128	452	; ref to abbrev 452
+	.section	.debug_abbrev
+	.uleb128	452
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname452:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname452
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x000C + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #453: variable OUT
+	.section	.debug_info
+	.uleb128	453	; ref to abbrev 453
+	.section	.debug_abbrev
+	.uleb128	453
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname453:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname453
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x000C + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #454: variable IN
+	.section	.debug_info
+	.uleb128	454	; ref to abbrev 454
+	.section	.debug_abbrev
+	.uleb128	454
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname454:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname454
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x000C + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #455: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	455	; ref to abbrev 455
+	.section	.debug_abbrev
+	.uleb128	455
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname455:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname455
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x000C + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #456: variable DIR
+	.section	.debug_info
+	.uleb128	456	; ref to abbrev 456
+	.section	.debug_abbrev
+	.uleb128	456
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname456:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname456
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0014 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #457: variable OUT
+	.section	.debug_info
+	.uleb128	457	; ref to abbrev 457
+	.section	.debug_abbrev
+	.uleb128	457
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname457:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname457
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0014 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #458: variable IN
+	.section	.debug_info
+	.uleb128	458	; ref to abbrev 458
+	.section	.debug_abbrev
+	.uleb128	458
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname458:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname458
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0014 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #459: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	459	; ref to abbrev 459
+	.section	.debug_abbrev
+	.uleb128	459
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname459:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname459
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0014 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #460: variable DAC0REF
+	.section	.debug_info
+	.uleb128	460	; ref to abbrev 460
+	.section	.debug_abbrev
+	.uleb128	460
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname460:
+	.string		"DAC0REF"
+	.section	.debug_info
+	.long		.Lname460
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00B0 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #461: variable ACREF
+	.section	.debug_info
+	.uleb128	461	; ref to abbrev 461
+	.section	.debug_abbrev
+	.uleb128	461
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname461:
+	.string		"ACREF"
+	.section	.debug_info
+	.long		.Lname461
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00B0 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #462: variable CTRLA
+	.section	.debug_info
+	.uleb128	462	; ref to abbrev 462
+	.section	.debug_abbrev
+	.uleb128	462
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname462:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname462
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0100 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #463: variable STATUS
+	.section	.debug_info
+	.uleb128	463	; ref to abbrev 463
+	.section	.debug_abbrev
+	.uleb128	463
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname463:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname463
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0100 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #464: variable CTRLA
+	.section	.debug_info
+	.uleb128	464	; ref to abbrev 464
+	.section	.debug_abbrev
+	.uleb128	464
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname464:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname464
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #465: variable CTRLB
+	.section	.debug_info
+	.uleb128	465	; ref to abbrev 465
+	.section	.debug_abbrev
+	.uleb128	465
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname465:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname465
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #466: variable CTRLC
+	.section	.debug_info
+	.uleb128	466	; ref to abbrev 466
+	.section	.debug_abbrev
+	.uleb128	466
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname466:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname466
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #467: variable EVCTRLA
+	.section	.debug_info
+	.uleb128	467	; ref to abbrev 467
+	.section	.debug_abbrev
+	.uleb128	467
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname467:
+	.string		"EVCTRLA"
+	.section	.debug_info
+	.long		.Lname467
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #468: variable EVCTRLB
+	.section	.debug_info
+	.uleb128	468	; ref to abbrev 468
+	.section	.debug_abbrev
+	.uleb128	468
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname468:
+	.string		"EVCTRLB"
+	.section	.debug_info
+	.long		.Lname468
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #469: variable EVCTRLC
+	.section	.debug_info
+	.uleb128	469	; ref to abbrev 469
+	.section	.debug_abbrev
+	.uleb128	469
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname469:
+	.string		"EVCTRLC"
+	.section	.debug_info
+	.long		.Lname469
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #470: variable BUFCTRL
+	.section	.debug_info
+	.uleb128	470	; ref to abbrev 470
+	.section	.debug_abbrev
+	.uleb128	470
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname470:
+	.string		"BUFCTRL"
+	.section	.debug_info
+	.long		.Lname470
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #471: variable BLANKCTRL
+	.section	.debug_info
+	.uleb128	471	; ref to abbrev 471
+	.section	.debug_abbrev
+	.uleb128	471
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname471:
+	.string		"BLANKCTRL"
+	.section	.debug_info
+	.long		.Lname471
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #472: variable BLANKTIME
+	.section	.debug_info
+	.uleb128	472	; ref to abbrev 472
+	.section	.debug_abbrev
+	.uleb128	472
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname472:
+	.string		"BLANKTIME"
+	.section	.debug_info
+	.long		.Lname472
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #473: variable FAULTCTRL
+	.section	.debug_info
+	.uleb128	473	; ref to abbrev 473
+	.section	.debug_abbrev
+	.uleb128	473
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname473:
+	.string		"FAULTCTRL"
+	.section	.debug_info
+	.long		.Lname473
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #474: variable FAULTDRV
+	.section	.debug_info
+	.uleb128	474	; ref to abbrev 474
+	.section	.debug_abbrev
+	.uleb128	474
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname474:
+	.string		"FAULTDRV"
+	.section	.debug_info
+	.long		.Lname474
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #475: variable FAULTOUT
+	.section	.debug_info
+	.uleb128	475	; ref to abbrev 475
+	.section	.debug_abbrev
+	.uleb128	475
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname475:
+	.string		"FAULTOUT"
+	.section	.debug_info
+	.long		.Lname475
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #476: variable INTCTRL
+	.section	.debug_info
+	.uleb128	476	; ref to abbrev 476
+	.section	.debug_abbrev
+	.uleb128	476
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname476:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname476
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #477: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	477	; ref to abbrev 477
+	.section	.debug_abbrev
+	.uleb128	477
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname477:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname477
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #478: variable STATUS
+	.section	.debug_info
+	.uleb128	478	; ref to abbrev 478
+	.section	.debug_abbrev
+	.uleb128	478
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname478:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname478
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x0F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #479: variable DTLS
+	.section	.debug_info
+	.uleb128	479	; ref to abbrev 479
+	.section	.debug_abbrev
+	.uleb128	479
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname479:
+	.string		"DTLS"
+	.section	.debug_info
+	.long		.Lname479
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #480: variable DTHS
+	.section	.debug_info
+	.uleb128	480	; ref to abbrev 480
+	.section	.debug_abbrev
+	.uleb128	480
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname480:
+	.string		"DTHS"
+	.section	.debug_info
+	.long		.Lname480
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #481: variable DTBOTH
+	.section	.debug_info
+	.uleb128	481	; ref to abbrev 481
+	.section	.debug_abbrev
+	.uleb128	481
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname481:
+	.string		"DTBOTH"
+	.section	.debug_info
+	.long		.Lname481
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #482: variable SWAP
+	.section	.debug_info
+	.uleb128	482	; ref to abbrev 482
+	.section	.debug_abbrev
+	.uleb128	482
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname482:
+	.string		"SWAP"
+	.section	.debug_info
+	.long		.Lname482
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #483: variable PGMOVR
+	.section	.debug_info
+	.uleb128	483	; ref to abbrev 483
+	.section	.debug_abbrev
+	.uleb128	483
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname483:
+	.string		"PGMOVR"
+	.section	.debug_info
+	.long		.Lname483
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #484: variable PGMOUT
+	.section	.debug_info
+	.uleb128	484	; ref to abbrev 484
+	.section	.debug_abbrev
+	.uleb128	484
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname484:
+	.string		"PGMOUT"
+	.section	.debug_info
+	.long		.Lname484
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #485: variable OUTOVEN
+	.section	.debug_info
+	.uleb128	485	; ref to abbrev 485
+	.section	.debug_abbrev
+	.uleb128	485
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname485:
+	.string		"OUTOVEN"
+	.section	.debug_info
+	.long		.Lname485
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #486: variable DTLSBUF
+	.section	.debug_info
+	.uleb128	486	; ref to abbrev 486
+	.section	.debug_abbrev
+	.uleb128	486
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname486:
+	.string		"DTLSBUF"
+	.section	.debug_info
+	.long		.Lname486
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #487: variable DTHSBUF
+	.section	.debug_info
+	.uleb128	487	; ref to abbrev 487
+	.section	.debug_abbrev
+	.uleb128	487
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname487:
+	.string		"DTHSBUF"
+	.section	.debug_info
+	.long		.Lname487
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x19
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #488: variable DTBOTHBUF
+	.section	.debug_info
+	.uleb128	488	; ref to abbrev 488
+	.section	.debug_abbrev
+	.uleb128	488
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname488:
+	.string		"DTBOTHBUF"
+	.section	.debug_info
+	.long		.Lname488
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x1A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #489: variable SWAPBUF
+	.section	.debug_info
+	.uleb128	489	; ref to abbrev 489
+	.section	.debug_abbrev
+	.uleb128	489
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname489:
+	.string		"SWAPBUF"
+	.section	.debug_info
+	.long		.Lname489
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x1B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #490: variable PGMOVRBUF
+	.section	.debug_info
+	.uleb128	490	; ref to abbrev 490
+	.section	.debug_abbrev
+	.uleb128	490
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname490:
+	.string		"PGMOVRBUF"
+	.section	.debug_info
+	.long		.Lname490
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x1C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #491: variable PGMOUTBUF
+	.section	.debug_info
+	.uleb128	491	; ref to abbrev 491
+	.section	.debug_abbrev
+	.uleb128	491
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname491:
+	.string		"PGMOUTBUF"
+	.section	.debug_info
+	.long		.Lname491
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x1D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+	;; trailer
+	.section	.debug_abbrev
+	.uleb128	0
+
+	.section	.debug_info
+	.uleb128	0
+.Leinfo:

--- a/crt1/iosym/avr16eb28.S
+++ b/crt1/iosym/avr16eb28.S
@@ -1,0 +1,26044 @@
+/* This file is part of avr-libc.
+
+   Automatically created by devtools/ioreg.pl
+   DO NOT EDIT!
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in
+     the documentation and/or other materials provided with the
+     distribution.
+
+   * Neither the name of the copyright holders nor the names of
+     contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE. */
+
+/* $Id$ */
+
+#include <avr/version.h>
+
+#define DW_TAG_array_type               0x01
+#define DW_TAG_compile_unit             0x11
+#define DW_TAG_typedef                  0x16
+#define DW_TAG_subrange_type            0x21
+#define DW_TAG_base_type                0x24
+#define DW_TAG_variable                 0x34
+
+#define DW_FORM_addr                    0x01
+#define DW_FORM_block1                  0x0a
+#define DW_FORM_block2                  0x03
+#define DW_FORM_block4                  0x04
+#define DW_FORM_data1                   0x0b
+#define DW_FORM_data2                   0x05
+#define DW_FORM_data4                   0x06
+#define DW_FORM_data8                   0x07
+#define DW_FORM_string                  0x08
+#define DW_FORM_flag                    0x0c
+#define DW_FORM_strp                    0x0e
+#define DW_FORM_ref1                    0x11
+#define DW_FORM_ref2                    0x12
+#define DW_FORM_ref4                    0x13
+#define DW_FORM_ref8                    0x14
+
+#define DW_AT_location                  0x02
+#define DW_AT_name                      0x03
+#define DW_AT_byte_size                 0x0b
+#define DW_AT_stmt_list                 0x10
+#define DW_AT_language                  0x13
+#define DW_AT_producer                  0x25
+#define DW_AT_upper_bound               0x2f
+#define DW_AT_decl_file                 0x3a
+#define DW_AT_decl_line                 0x3b
+#define DW_AT_encoding                  0x3e
+#define DW_AT_external                  0x3f
+#define DW_AT_type                      0x49
+
+#define DW_LANG_C89                     0x0001
+
+#define DW_CHILDREN_no                  0x00
+#define DW_CHILDREN_yes                 0x01
+
+#define DW_ATE_unsigned                 0x7
+#define DW_ATE_unsigned_char            0x8
+
+#define DW_OP_addr                      0x03
+.eject
+	.section	.debug_abbrev, "", @progbits
+.Ldebug_abbrev0:
+	.section	.debug_info, "", @progbits
+	.section	.debug_line, "", @progbits
+.Ldebug_line0:
+	.section	.debug_str, "", @progbits
+
+	.section	.debug_info, "", @progbits
+	;; compilation unit header
+.Lssinfo:
+	.long	.Leinfo - .Lsinfo
+.Lsinfo:
+	.word	2		; DWARF-2
+	.long	.Ldebug_abbrev0
+	.byte	4		; sizeof(address)
+
+
+	;; DIE #1: compilation unit
+	.section	.debug_info
+	.uleb128	1	; ref to abbrev 1
+	.section	.debug_abbrev
+	.uleb128	1
+	.uleb128	DW_TAG_compile_unit
+	.byte		DW_CHILDREN_yes
+
+	.uleb128	DW_AT_producer
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lproducer:
+	.ascii		"avr-libc "
+	.asciz		__AVR_LIBC_VERSION_STRING__
+	.section	.debug_info
+	.long		.Lproducer
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_stmt_list
+	.uleb128	DW_FORM_data4
+	.section	.debug_info
+	.long		.Ldebug_line0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+	;; DIE #2: base type uint8_t
+	.section	.debug_info
+.Luint8_t:
+	.uleb128	2	; ref to abbrev 2
+	.section	.debug_abbrev
+	.uleb128	2
+	.uleb128	DW_TAG_base_type
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Luint8_t_name:
+	.string		"uint8_t"
+	.section	.debug_info
+	.long		.Luint8_t_name
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_byte_size
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_encoding
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		DW_ATE_unsigned_char
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+	;; DIE #3: base type uint16_t
+	.section	.debug_info
+.Luint16_t:
+	.uleb128	3	; ref to abbrev 3
+	.section	.debug_abbrev
+	.uleb128	3
+	.uleb128	DW_TAG_base_type
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Luint16_t_name:
+	.string		"uint16_t"
+	.section	.debug_info
+	.long		.Luint16_t_name
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_byte_size
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		2
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_encoding
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		DW_ATE_unsigned
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #4: variable CTRLA
+	.section	.debug_info
+	.uleb128	4	; ref to abbrev 4
+	.section	.debug_abbrev
+	.uleb128	4
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname4:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname4
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #5: variable CTRLB
+	.section	.debug_info
+	.uleb128	5	; ref to abbrev 5
+	.section	.debug_abbrev
+	.uleb128	5
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname5:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname5
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #6: variable MUXCTRL
+	.section	.debug_info
+	.uleb128	6	; ref to abbrev 6
+	.section	.debug_abbrev
+	.uleb128	6
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname6:
+	.string		"MUXCTRL"
+	.section	.debug_info
+	.long		.Lname6
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #7: variable DACREF
+	.section	.debug_info
+	.uleb128	7	; ref to abbrev 7
+	.section	.debug_abbrev
+	.uleb128	7
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname7:
+	.string		"DACREF"
+	.section	.debug_info
+	.long		.Lname7
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #8: variable INTCTRL
+	.section	.debug_info
+	.uleb128	8	; ref to abbrev 8
+	.section	.debug_abbrev
+	.uleb128	8
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname8:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname8
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #9: variable STATUS
+	.section	.debug_info
+	.uleb128	9	; ref to abbrev 9
+	.section	.debug_abbrev
+	.uleb128	9
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname9:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname9
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #10: variable CTRLA
+	.section	.debug_info
+	.uleb128	10	; ref to abbrev 10
+	.section	.debug_abbrev
+	.uleb128	10
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname10:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname10
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #11: variable CTRLB
+	.section	.debug_info
+	.uleb128	11	; ref to abbrev 11
+	.section	.debug_abbrev
+	.uleb128	11
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname11:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname11
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #12: variable MUXCTRL
+	.section	.debug_info
+	.uleb128	12	; ref to abbrev 12
+	.section	.debug_abbrev
+	.uleb128	12
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname12:
+	.string		"MUXCTRL"
+	.section	.debug_info
+	.long		.Lname12
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #13: variable DACREF
+	.section	.debug_info
+	.uleb128	13	; ref to abbrev 13
+	.section	.debug_abbrev
+	.uleb128	13
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname13:
+	.string		"DACREF"
+	.section	.debug_info
+	.long		.Lname13
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #14: variable INTCTRL
+	.section	.debug_info
+	.uleb128	14	; ref to abbrev 14
+	.section	.debug_abbrev
+	.uleb128	14
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname14:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname14
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #15: variable STATUS
+	.section	.debug_info
+	.uleb128	15	; ref to abbrev 15
+	.section	.debug_abbrev
+	.uleb128	15
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname15:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname15
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #16: variable CTRLA
+	.section	.debug_info
+	.uleb128	16	; ref to abbrev 16
+	.section	.debug_abbrev
+	.uleb128	16
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname16:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname16
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #17: variable CTRLB
+	.section	.debug_info
+	.uleb128	17	; ref to abbrev 17
+	.section	.debug_abbrev
+	.uleb128	17
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname17:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname17
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #18: variable CTRLC
+	.section	.debug_info
+	.uleb128	18	; ref to abbrev 18
+	.section	.debug_abbrev
+	.uleb128	18
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname18:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname18
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #19: variable CTRLD
+	.section	.debug_info
+	.uleb128	19	; ref to abbrev 19
+	.section	.debug_abbrev
+	.uleb128	19
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname19:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname19
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #20: variable INTCTRL
+	.section	.debug_info
+	.uleb128	20	; ref to abbrev 20
+	.section	.debug_abbrev
+	.uleb128	20
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname20:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname20
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #21: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	21	; ref to abbrev 21
+	.section	.debug_abbrev
+	.uleb128	21
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname21:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname21
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #22: variable STATUS
+	.section	.debug_info
+	.uleb128	22	; ref to abbrev 22
+	.section	.debug_abbrev
+	.uleb128	22
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname22:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname22
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #23: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	23	; ref to abbrev 23
+	.section	.debug_abbrev
+	.uleb128	23
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname23:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname23
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #24: variable CTRLE
+	.section	.debug_info
+	.uleb128	24	; ref to abbrev 24
+	.section	.debug_abbrev
+	.uleb128	24
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname24:
+	.string		"CTRLE"
+	.section	.debug_info
+	.long		.Lname24
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #25: variable CTRLF
+	.section	.debug_info
+	.uleb128	25	; ref to abbrev 25
+	.section	.debug_abbrev
+	.uleb128	25
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname25:
+	.string		"CTRLF"
+	.section	.debug_info
+	.long		.Lname25
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #26: variable COMMAND
+	.section	.debug_info
+	.uleb128	26	; ref to abbrev 26
+	.section	.debug_abbrev
+	.uleb128	26
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname26:
+	.string		"COMMAND"
+	.section	.debug_info
+	.long		.Lname26
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #27: variable PGACTRL
+	.section	.debug_info
+	.uleb128	27	; ref to abbrev 27
+	.section	.debug_abbrev
+	.uleb128	27
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname27:
+	.string		"PGACTRL"
+	.section	.debug_info
+	.long		.Lname27
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #28: variable MUXPOS
+	.section	.debug_info
+	.uleb128	28	; ref to abbrev 28
+	.section	.debug_abbrev
+	.uleb128	28
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname28:
+	.string		"MUXPOS"
+	.section	.debug_info
+	.long		.Lname28
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #29: variable MUXNEG
+	.section	.debug_info
+	.uleb128	29	; ref to abbrev 29
+	.section	.debug_abbrev
+	.uleb128	29
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname29:
+	.string		"MUXNEG"
+	.section	.debug_info
+	.long		.Lname29
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #30: base type uint32_t
+	.section	.debug_info
+.Luint32_t:
+	.uleb128	30	; ref to abbrev 30
+	.section	.debug_abbrev
+	.uleb128	30
+	.uleb128	DW_TAG_base_type
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Luint32_t_name:
+	.string		"uint32_t"
+	.section	.debug_info
+	.long		.Luint32_t_name
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_byte_size
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		4
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_encoding
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		DW_ATE_unsigned
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #31: variable RESULT
+	.section	.debug_info
+	.uleb128	31	; ref to abbrev 31
+	.section	.debug_abbrev
+	.uleb128	31
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname31:
+	.string		"RESULT"
+	.section	.debug_info
+	.long		.Lname31
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint32_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #32: variable SAMPLE
+	.section	.debug_info
+	.uleb128	32	; ref to abbrev 32
+	.section	.debug_abbrev
+	.uleb128	32
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname32:
+	.string		"SAMPLE"
+	.section	.debug_info
+	.long		.Lname32
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #33: variable TEMP0
+	.section	.debug_info
+	.uleb128	33	; ref to abbrev 33
+	.section	.debug_abbrev
+	.uleb128	33
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname33:
+	.string		"TEMP0"
+	.section	.debug_info
+	.long		.Lname33
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #34: variable TEMP1
+	.section	.debug_info
+	.uleb128	34	; ref to abbrev 34
+	.section	.debug_abbrev
+	.uleb128	34
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname34:
+	.string		"TEMP1"
+	.section	.debug_info
+	.long		.Lname34
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x19
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #35: variable TEMP2
+	.section	.debug_info
+	.uleb128	35	; ref to abbrev 35
+	.section	.debug_abbrev
+	.uleb128	35
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname35:
+	.string		"TEMP2"
+	.section	.debug_info
+	.long		.Lname35
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x1A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #36: variable WINLT
+	.section	.debug_info
+	.uleb128	36	; ref to abbrev 36
+	.section	.debug_abbrev
+	.uleb128	36
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname36:
+	.string		"WINLT"
+	.section	.debug_info
+	.long		.Lname36
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x1C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #37: variable WINHT
+	.section	.debug_info
+	.uleb128	37	; ref to abbrev 37
+	.section	.debug_abbrev
+	.uleb128	37
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname37:
+	.string		"WINHT"
+	.section	.debug_info
+	.long		.Lname37
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x1E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #38: variable CTRLA
+	.section	.debug_info
+	.uleb128	38	; ref to abbrev 38
+	.section	.debug_abbrev
+	.uleb128	38
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname38:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname38
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #39: variable CTRLB
+	.section	.debug_info
+	.uleb128	39	; ref to abbrev 39
+	.section	.debug_abbrev
+	.uleb128	39
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname39:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname39
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #40: variable VLMCTRLA
+	.section	.debug_info
+	.uleb128	40	; ref to abbrev 40
+	.section	.debug_abbrev
+	.uleb128	40
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname40:
+	.string		"VLMCTRLA"
+	.section	.debug_info
+	.long		.Lname40
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #41: variable INTCTRL
+	.section	.debug_info
+	.uleb128	41	; ref to abbrev 41
+	.section	.debug_abbrev
+	.uleb128	41
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname41:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname41
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #42: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	42	; ref to abbrev 42
+	.section	.debug_abbrev
+	.uleb128	42
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname42:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname42
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #43: variable STATUS
+	.section	.debug_info
+	.uleb128	43	; ref to abbrev 43
+	.section	.debug_abbrev
+	.uleb128	43
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname43:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname43
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #44: variable BOOTROW
+	.section	.debug_info
+	.uleb128	44	; ref to abbrev 44
+	.section	.debug_abbrev
+	.uleb128	44
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname44:
+	.string		"BOOTROW"
+	.section	.debug_info
+	.long		.Lname44
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #45: variable CTRLA
+	.section	.debug_info
+	.uleb128	45	; ref to abbrev 45
+	.section	.debug_abbrev
+	.uleb128	45
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname45:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname45
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #46: variable SEQCTRL0
+	.section	.debug_info
+	.uleb128	46	; ref to abbrev 46
+	.section	.debug_abbrev
+	.uleb128	46
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname46:
+	.string		"SEQCTRL0"
+	.section	.debug_info
+	.long		.Lname46
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #47: variable SEQCTRL1
+	.section	.debug_info
+	.uleb128	47	; ref to abbrev 47
+	.section	.debug_abbrev
+	.uleb128	47
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname47:
+	.string		"SEQCTRL1"
+	.section	.debug_info
+	.long		.Lname47
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #48: variable INTCTRL0
+	.section	.debug_info
+	.uleb128	48	; ref to abbrev 48
+	.section	.debug_abbrev
+	.uleb128	48
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname48:
+	.string		"INTCTRL0"
+	.section	.debug_info
+	.long		.Lname48
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #49: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	49	; ref to abbrev 49
+	.section	.debug_abbrev
+	.uleb128	49
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname49:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname49
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #50: variable LUT0CTRLA
+	.section	.debug_info
+	.uleb128	50	; ref to abbrev 50
+	.section	.debug_abbrev
+	.uleb128	50
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname50:
+	.string		"LUT0CTRLA"
+	.section	.debug_info
+	.long		.Lname50
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #51: variable LUT0CTRLB
+	.section	.debug_info
+	.uleb128	51	; ref to abbrev 51
+	.section	.debug_abbrev
+	.uleb128	51
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname51:
+	.string		"LUT0CTRLB"
+	.section	.debug_info
+	.long		.Lname51
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #52: variable LUT0CTRLC
+	.section	.debug_info
+	.uleb128	52	; ref to abbrev 52
+	.section	.debug_abbrev
+	.uleb128	52
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname52:
+	.string		"LUT0CTRLC"
+	.section	.debug_info
+	.long		.Lname52
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #53: variable TRUTH0
+	.section	.debug_info
+	.uleb128	53	; ref to abbrev 53
+	.section	.debug_abbrev
+	.uleb128	53
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname53:
+	.string		"TRUTH0"
+	.section	.debug_info
+	.long		.Lname53
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #54: variable LUT1CTRLA
+	.section	.debug_info
+	.uleb128	54	; ref to abbrev 54
+	.section	.debug_abbrev
+	.uleb128	54
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname54:
+	.string		"LUT1CTRLA"
+	.section	.debug_info
+	.long		.Lname54
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #55: variable LUT1CTRLB
+	.section	.debug_info
+	.uleb128	55	; ref to abbrev 55
+	.section	.debug_abbrev
+	.uleb128	55
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname55:
+	.string		"LUT1CTRLB"
+	.section	.debug_info
+	.long		.Lname55
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #56: variable LUT1CTRLC
+	.section	.debug_info
+	.uleb128	56	; ref to abbrev 56
+	.section	.debug_abbrev
+	.uleb128	56
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname56:
+	.string		"LUT1CTRLC"
+	.section	.debug_info
+	.long		.Lname56
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #57: variable TRUTH1
+	.section	.debug_info
+	.uleb128	57	; ref to abbrev 57
+	.section	.debug_abbrev
+	.uleb128	57
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname57:
+	.string		"TRUTH1"
+	.section	.debug_info
+	.long		.Lname57
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #58: variable LUT2CTRLA
+	.section	.debug_info
+	.uleb128	58	; ref to abbrev 58
+	.section	.debug_abbrev
+	.uleb128	58
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname58:
+	.string		"LUT2CTRLA"
+	.section	.debug_info
+	.long		.Lname58
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #59: variable LUT2CTRLB
+	.section	.debug_info
+	.uleb128	59	; ref to abbrev 59
+	.section	.debug_abbrev
+	.uleb128	59
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname59:
+	.string		"LUT2CTRLB"
+	.section	.debug_info
+	.long		.Lname59
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #60: variable LUT2CTRLC
+	.section	.debug_info
+	.uleb128	60	; ref to abbrev 60
+	.section	.debug_abbrev
+	.uleb128	60
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname60:
+	.string		"LUT2CTRLC"
+	.section	.debug_info
+	.long		.Lname60
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #61: variable TRUTH2
+	.section	.debug_info
+	.uleb128	61	; ref to abbrev 61
+	.section	.debug_abbrev
+	.uleb128	61
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname61:
+	.string		"TRUTH2"
+	.section	.debug_info
+	.long		.Lname61
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #62: variable LUT3CTRLA
+	.section	.debug_info
+	.uleb128	62	; ref to abbrev 62
+	.section	.debug_abbrev
+	.uleb128	62
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname62:
+	.string		"LUT3CTRLA"
+	.section	.debug_info
+	.long		.Lname62
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #63: variable LUT3CTRLB
+	.section	.debug_info
+	.uleb128	63	; ref to abbrev 63
+	.section	.debug_abbrev
+	.uleb128	63
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname63:
+	.string		"LUT3CTRLB"
+	.section	.debug_info
+	.long		.Lname63
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #64: variable LUT3CTRLC
+	.section	.debug_info
+	.uleb128	64	; ref to abbrev 64
+	.section	.debug_abbrev
+	.uleb128	64
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname64:
+	.string		"LUT3CTRLC"
+	.section	.debug_info
+	.long		.Lname64
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #65: variable TRUTH3
+	.section	.debug_info
+	.uleb128	65	; ref to abbrev 65
+	.section	.debug_abbrev
+	.uleb128	65
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname65:
+	.string		"TRUTH3"
+	.section	.debug_info
+	.long		.Lname65
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #66: variable MCLKCTRLA
+	.section	.debug_info
+	.uleb128	66	; ref to abbrev 66
+	.section	.debug_abbrev
+	.uleb128	66
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname66:
+	.string		"MCLKCTRLA"
+	.section	.debug_info
+	.long		.Lname66
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #67: variable MCLKCTRLB
+	.section	.debug_info
+	.uleb128	67	; ref to abbrev 67
+	.section	.debug_abbrev
+	.uleb128	67
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname67:
+	.string		"MCLKCTRLB"
+	.section	.debug_info
+	.long		.Lname67
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #68: variable MCLKSTATUS
+	.section	.debug_info
+	.uleb128	68	; ref to abbrev 68
+	.section	.debug_abbrev
+	.uleb128	68
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname68:
+	.string		"MCLKSTATUS"
+	.section	.debug_info
+	.long		.Lname68
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #69: variable MCLKTIMEBASE
+	.section	.debug_info
+	.uleb128	69	; ref to abbrev 69
+	.section	.debug_abbrev
+	.uleb128	69
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname69:
+	.string		"MCLKTIMEBASE"
+	.section	.debug_info
+	.long		.Lname69
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #70: variable OSCHFCTRLA
+	.section	.debug_info
+	.uleb128	70	; ref to abbrev 70
+	.section	.debug_abbrev
+	.uleb128	70
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname70:
+	.string		"OSCHFCTRLA"
+	.section	.debug_info
+	.long		.Lname70
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #71: variable OSCHFTUNE
+	.section	.debug_info
+	.uleb128	71	; ref to abbrev 71
+	.section	.debug_abbrev
+	.uleb128	71
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname71:
+	.string		"OSCHFTUNE"
+	.section	.debug_info
+	.long		.Lname71
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #72: variable PLLCTRLA
+	.section	.debug_info
+	.uleb128	72	; ref to abbrev 72
+	.section	.debug_abbrev
+	.uleb128	72
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname72:
+	.string		"PLLCTRLA"
+	.section	.debug_info
+	.long		.Lname72
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #73: variable PLLCTRLB
+	.section	.debug_info
+	.uleb128	73	; ref to abbrev 73
+	.section	.debug_abbrev
+	.uleb128	73
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname73:
+	.string		"PLLCTRLB"
+	.section	.debug_info
+	.long		.Lname73
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #74: variable OSC32KCTRLA
+	.section	.debug_info
+	.uleb128	74	; ref to abbrev 74
+	.section	.debug_abbrev
+	.uleb128	74
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname74:
+	.string		"OSC32KCTRLA"
+	.section	.debug_info
+	.long		.Lname74
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #75: variable XOSC32KCTRLA
+	.section	.debug_info
+	.uleb128	75	; ref to abbrev 75
+	.section	.debug_abbrev
+	.uleb128	75
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname75:
+	.string		"XOSC32KCTRLA"
+	.section	.debug_info
+	.long		.Lname75
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x1C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #76: variable CCP
+	.section	.debug_info
+	.uleb128	76	; ref to abbrev 76
+	.section	.debug_abbrev
+	.uleb128	76
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname76:
+	.string		"CCP"
+	.section	.debug_info
+	.long		.Lname76
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0030 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #77: variable RAMPZ
+	.section	.debug_info
+	.uleb128	77	; ref to abbrev 77
+	.section	.debug_abbrev
+	.uleb128	77
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname77:
+	.string		"RAMPZ"
+	.section	.debug_info
+	.long		.Lname77
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0030 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #78: variable SP
+	.section	.debug_info
+	.uleb128	78	; ref to abbrev 78
+	.section	.debug_abbrev
+	.uleb128	78
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname78:
+	.string		"SP"
+	.section	.debug_info
+	.long		.Lname78
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0030 + 0xD
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #79: variable SREG
+	.section	.debug_info
+	.uleb128	79	; ref to abbrev 79
+	.section	.debug_abbrev
+	.uleb128	79
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname79:
+	.string		"SREG"
+	.section	.debug_info
+	.long		.Lname79
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0030 + 0xF
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #80: variable CTRLA
+	.section	.debug_info
+	.uleb128	80	; ref to abbrev 80
+	.section	.debug_abbrev
+	.uleb128	80
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname80:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname80
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0110 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #81: variable STATUS
+	.section	.debug_info
+	.uleb128	81	; ref to abbrev 81
+	.section	.debug_abbrev
+	.uleb128	81
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname81:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname81
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0110 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #82: variable LVL0PRI
+	.section	.debug_info
+	.uleb128	82	; ref to abbrev 82
+	.section	.debug_abbrev
+	.uleb128	82
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname82:
+	.string		"LVL0PRI"
+	.section	.debug_info
+	.long		.Lname82
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0110 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #83: variable LVL1VEC
+	.section	.debug_info
+	.uleb128	83	; ref to abbrev 83
+	.section	.debug_abbrev
+	.uleb128	83
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname83:
+	.string		"LVL1VEC"
+	.section	.debug_info
+	.long		.Lname83
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0110 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #84: variable CTRLA
+	.section	.debug_info
+	.uleb128	84	; ref to abbrev 84
+	.section	.debug_abbrev
+	.uleb128	84
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname84:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname84
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0120 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #85: variable CTRLB
+	.section	.debug_info
+	.uleb128	85	; ref to abbrev 85
+	.section	.debug_abbrev
+	.uleb128	85
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname85:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname85
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0120 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #86: variable STATUS
+	.section	.debug_info
+	.uleb128	86	; ref to abbrev 86
+	.section	.debug_abbrev
+	.uleb128	86
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname86:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname86
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0120 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #87: variable SWEVENTA
+	.section	.debug_info
+	.uleb128	87	; ref to abbrev 87
+	.section	.debug_abbrev
+	.uleb128	87
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname87:
+	.string		"SWEVENTA"
+	.section	.debug_info
+	.long		.Lname87
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #88: variable CHANNEL0
+	.section	.debug_info
+	.uleb128	88	; ref to abbrev 88
+	.section	.debug_abbrev
+	.uleb128	88
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname88:
+	.string		"CHANNEL0"
+	.section	.debug_info
+	.long		.Lname88
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #89: variable CHANNEL1
+	.section	.debug_info
+	.uleb128	89	; ref to abbrev 89
+	.section	.debug_abbrev
+	.uleb128	89
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname89:
+	.string		"CHANNEL1"
+	.section	.debug_info
+	.long		.Lname89
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #90: variable CHANNEL2
+	.section	.debug_info
+	.uleb128	90	; ref to abbrev 90
+	.section	.debug_abbrev
+	.uleb128	90
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname90:
+	.string		"CHANNEL2"
+	.section	.debug_info
+	.long		.Lname90
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #91: variable CHANNEL3
+	.section	.debug_info
+	.uleb128	91	; ref to abbrev 91
+	.section	.debug_abbrev
+	.uleb128	91
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname91:
+	.string		"CHANNEL3"
+	.section	.debug_info
+	.long		.Lname91
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #92: variable CHANNEL4
+	.section	.debug_info
+	.uleb128	92	; ref to abbrev 92
+	.section	.debug_abbrev
+	.uleb128	92
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname92:
+	.string		"CHANNEL4"
+	.section	.debug_info
+	.long		.Lname92
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #93: variable CHANNEL5
+	.section	.debug_info
+	.uleb128	93	; ref to abbrev 93
+	.section	.debug_abbrev
+	.uleb128	93
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname93:
+	.string		"CHANNEL5"
+	.section	.debug_info
+	.long		.Lname93
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #94: variable USERCCLLUT0A
+	.section	.debug_info
+	.uleb128	94	; ref to abbrev 94
+	.section	.debug_abbrev
+	.uleb128	94
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname94:
+	.string		"USERCCLLUT0A"
+	.section	.debug_info
+	.long		.Lname94
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #95: variable USERCCLLUT0B
+	.section	.debug_info
+	.uleb128	95	; ref to abbrev 95
+	.section	.debug_abbrev
+	.uleb128	95
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname95:
+	.string		"USERCCLLUT0B"
+	.section	.debug_info
+	.long		.Lname95
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x21
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #96: variable USERCCLLUT1A
+	.section	.debug_info
+	.uleb128	96	; ref to abbrev 96
+	.section	.debug_abbrev
+	.uleb128	96
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname96:
+	.string		"USERCCLLUT1A"
+	.section	.debug_info
+	.long		.Lname96
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x22
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #97: variable USERCCLLUT1B
+	.section	.debug_info
+	.uleb128	97	; ref to abbrev 97
+	.section	.debug_abbrev
+	.uleb128	97
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname97:
+	.string		"USERCCLLUT1B"
+	.section	.debug_info
+	.long		.Lname97
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x23
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #98: variable USERCCLLUT2A
+	.section	.debug_info
+	.uleb128	98	; ref to abbrev 98
+	.section	.debug_abbrev
+	.uleb128	98
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname98:
+	.string		"USERCCLLUT2A"
+	.section	.debug_info
+	.long		.Lname98
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x24
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #99: variable USERCCLLUT2B
+	.section	.debug_info
+	.uleb128	99	; ref to abbrev 99
+	.section	.debug_abbrev
+	.uleb128	99
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname99:
+	.string		"USERCCLLUT2B"
+	.section	.debug_info
+	.long		.Lname99
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x25
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #100: variable USERCCLLUT3A
+	.section	.debug_info
+	.uleb128	100	; ref to abbrev 100
+	.section	.debug_abbrev
+	.uleb128	100
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname100:
+	.string		"USERCCLLUT3A"
+	.section	.debug_info
+	.long		.Lname100
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x26
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #101: variable USERCCLLUT3B
+	.section	.debug_info
+	.uleb128	101	; ref to abbrev 101
+	.section	.debug_abbrev
+	.uleb128	101
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname101:
+	.string		"USERCCLLUT3B"
+	.section	.debug_info
+	.long		.Lname101
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x27
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #102: variable USERADC0START
+	.section	.debug_info
+	.uleb128	102	; ref to abbrev 102
+	.section	.debug_abbrev
+	.uleb128	102
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname102:
+	.string		"USERADC0START"
+	.section	.debug_info
+	.long		.Lname102
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x28
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #103: variable USEREVSYSEVOUTA
+	.section	.debug_info
+	.uleb128	103	; ref to abbrev 103
+	.section	.debug_abbrev
+	.uleb128	103
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname103:
+	.string		"USEREVSYSEVOUTA"
+	.section	.debug_info
+	.long		.Lname103
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x29
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #104: variable USEREVSYSEVOUTC
+	.section	.debug_info
+	.uleb128	104	; ref to abbrev 104
+	.section	.debug_abbrev
+	.uleb128	104
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname104:
+	.string		"USEREVSYSEVOUTC"
+	.section	.debug_info
+	.long		.Lname104
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #105: variable USEREVSYSEVOUTD
+	.section	.debug_info
+	.uleb128	105	; ref to abbrev 105
+	.section	.debug_abbrev
+	.uleb128	105
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname105:
+	.string		"USEREVSYSEVOUTD"
+	.section	.debug_info
+	.long		.Lname105
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #106: variable USEREVSYSEVOUTF
+	.section	.debug_info
+	.uleb128	106	; ref to abbrev 106
+	.section	.debug_abbrev
+	.uleb128	106
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname106:
+	.string		"USEREVSYSEVOUTF"
+	.section	.debug_info
+	.long		.Lname106
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #107: variable USERUSART0IRDA
+	.section	.debug_info
+	.uleb128	107	; ref to abbrev 107
+	.section	.debug_abbrev
+	.uleb128	107
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname107:
+	.string		"USERUSART0IRDA"
+	.section	.debug_info
+	.long		.Lname107
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #108: variable USERTCE0CNTA
+	.section	.debug_info
+	.uleb128	108	; ref to abbrev 108
+	.section	.debug_abbrev
+	.uleb128	108
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname108:
+	.string		"USERTCE0CNTA"
+	.section	.debug_info
+	.long		.Lname108
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #109: variable USERTCE0CNTB
+	.section	.debug_info
+	.uleb128	109	; ref to abbrev 109
+	.section	.debug_abbrev
+	.uleb128	109
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname109:
+	.string		"USERTCE0CNTB"
+	.section	.debug_info
+	.long		.Lname109
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #110: variable USERTCB0CAPT
+	.section	.debug_info
+	.uleb128	110	; ref to abbrev 110
+	.section	.debug_abbrev
+	.uleb128	110
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname110:
+	.string		"USERTCB0CAPT"
+	.section	.debug_info
+	.long		.Lname110
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x30
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #111: variable USERTCB0COUNT
+	.section	.debug_info
+	.uleb128	111	; ref to abbrev 111
+	.section	.debug_abbrev
+	.uleb128	111
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname111:
+	.string		"USERTCB0COUNT"
+	.section	.debug_info
+	.long		.Lname111
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x31
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #112: variable USERTCB1CAPT
+	.section	.debug_info
+	.uleb128	112	; ref to abbrev 112
+	.section	.debug_abbrev
+	.uleb128	112
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname112:
+	.string		"USERTCB1CAPT"
+	.section	.debug_info
+	.long		.Lname112
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x32
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #113: variable USERTCB1COUNT
+	.section	.debug_info
+	.uleb128	113	; ref to abbrev 113
+	.section	.debug_abbrev
+	.uleb128	113
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname113:
+	.string		"USERTCB1COUNT"
+	.section	.debug_info
+	.long		.Lname113
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x33
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #114: variable USERTCF0CNT
+	.section	.debug_info
+	.uleb128	114	; ref to abbrev 114
+	.section	.debug_abbrev
+	.uleb128	114
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname114:
+	.string		"USERTCF0CNT"
+	.section	.debug_info
+	.long		.Lname114
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x34
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #115: variable USERTCF0ACT
+	.section	.debug_info
+	.uleb128	115	; ref to abbrev 115
+	.section	.debug_abbrev
+	.uleb128	115
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname115:
+	.string		"USERTCF0ACT"
+	.section	.debug_info
+	.long		.Lname115
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x35
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #116: variable USERWEXA
+	.section	.debug_info
+	.uleb128	116	; ref to abbrev 116
+	.section	.debug_abbrev
+	.uleb128	116
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname116:
+	.string		"USERWEXA"
+	.section	.debug_info
+	.long		.Lname116
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x36
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #117: variable USERWEXB
+	.section	.debug_info
+	.uleb128	117	; ref to abbrev 117
+	.section	.debug_abbrev
+	.uleb128	117
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname117:
+	.string		"USERWEXB"
+	.section	.debug_info
+	.long		.Lname117
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x37
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #118: variable USERWEXC
+	.section	.debug_info
+	.uleb128	118	; ref to abbrev 118
+	.section	.debug_abbrev
+	.uleb128	118
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname118:
+	.string		"USERWEXC"
+	.section	.debug_info
+	.long		.Lname118
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x38
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #119: variable WDTCFG
+	.section	.debug_info
+	.uleb128	119	; ref to abbrev 119
+	.section	.debug_abbrev
+	.uleb128	119
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname119:
+	.string		"WDTCFG"
+	.section	.debug_info
+	.long		.Lname119
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #120: variable BODCFG
+	.section	.debug_info
+	.uleb128	120	; ref to abbrev 120
+	.section	.debug_abbrev
+	.uleb128	120
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname120:
+	.string		"BODCFG"
+	.section	.debug_info
+	.long		.Lname120
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #121: variable OSCCFG
+	.section	.debug_info
+	.uleb128	121	; ref to abbrev 121
+	.section	.debug_abbrev
+	.uleb128	121
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname121:
+	.string		"OSCCFG"
+	.section	.debug_info
+	.long		.Lname121
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #122: variable SYSCFG0
+	.section	.debug_info
+	.uleb128	122	; ref to abbrev 122
+	.section	.debug_abbrev
+	.uleb128	122
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname122:
+	.string		"SYSCFG0"
+	.section	.debug_info
+	.long		.Lname122
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #123: variable SYSCFG1
+	.section	.debug_info
+	.uleb128	123	; ref to abbrev 123
+	.section	.debug_abbrev
+	.uleb128	123
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname123:
+	.string		"SYSCFG1"
+	.section	.debug_info
+	.long		.Lname123
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #124: variable CODESIZE
+	.section	.debug_info
+	.uleb128	124	; ref to abbrev 124
+	.section	.debug_abbrev
+	.uleb128	124
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname124:
+	.string		"CODESIZE"
+	.section	.debug_info
+	.long		.Lname124
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #125: variable BOOTSIZE
+	.section	.debug_info
+	.uleb128	125	; ref to abbrev 125
+	.section	.debug_abbrev
+	.uleb128	125
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname125:
+	.string		"BOOTSIZE"
+	.section	.debug_info
+	.long		.Lname125
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #126: variable PDICFG
+	.section	.debug_info
+	.uleb128	126	; ref to abbrev 126
+	.section	.debug_abbrev
+	.uleb128	126
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname126:
+	.string		"PDICFG"
+	.section	.debug_info
+	.long		.Lname126
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #127: variable GPR0
+	.section	.debug_info
+	.uleb128	127	; ref to abbrev 127
+	.section	.debug_abbrev
+	.uleb128	127
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname127:
+	.string		"GPR0"
+	.section	.debug_info
+	.long		.Lname127
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x001C + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #128: variable GPR1
+	.section	.debug_info
+	.uleb128	128	; ref to abbrev 128
+	.section	.debug_abbrev
+	.uleb128	128
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname128:
+	.string		"GPR1"
+	.section	.debug_info
+	.long		.Lname128
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x001C + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #129: variable GPR2
+	.section	.debug_info
+	.uleb128	129	; ref to abbrev 129
+	.section	.debug_abbrev
+	.uleb128	129
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname129:
+	.string		"GPR2"
+	.section	.debug_info
+	.long		.Lname129
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x001C + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #130: variable GPR3
+	.section	.debug_info
+	.uleb128	130	; ref to abbrev 130
+	.section	.debug_abbrev
+	.uleb128	130
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname130:
+	.string		"GPR3"
+	.section	.debug_info
+	.long		.Lname130
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x001C + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #131: variable KEY
+	.section	.debug_info
+	.uleb128	131	; ref to abbrev 131
+	.section	.debug_abbrev
+	.uleb128	131
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname131:
+	.string		"KEY"
+	.section	.debug_info
+	.long		.Lname131
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint32_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1040 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #132: variable CTRLA
+	.section	.debug_info
+	.uleb128	132	; ref to abbrev 132
+	.section	.debug_abbrev
+	.uleb128	132
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname132:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname132
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #133: variable CTRLB
+	.section	.debug_info
+	.uleb128	133	; ref to abbrev 133
+	.section	.debug_abbrev
+	.uleb128	133
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname133:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname133
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #134: variable CTRLC
+	.section	.debug_info
+	.uleb128	134	; ref to abbrev 134
+	.section	.debug_abbrev
+	.uleb128	134
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname134:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname134
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #135: variable INTCTRL
+	.section	.debug_info
+	.uleb128	135	; ref to abbrev 135
+	.section	.debug_abbrev
+	.uleb128	135
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname135:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname135
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #136: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	136	; ref to abbrev 136
+	.section	.debug_abbrev
+	.uleb128	136
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname136:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname136
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #137: variable STATUS
+	.section	.debug_info
+	.uleb128	137	; ref to abbrev 137
+	.section	.debug_abbrev
+	.uleb128	137
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname137:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname137
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #138: variable DATA
+	.section	.debug_info
+	.uleb128	138	; ref to abbrev 138
+	.section	.debug_abbrev
+	.uleb128	138
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname138:
+	.string		"DATA"
+	.section	.debug_info
+	.long		.Lname138
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #139: variable ADDR
+	.section	.debug_info
+	.uleb128	139	; ref to abbrev 139
+	.section	.debug_abbrev
+	.uleb128	139
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname139:
+	.string		"ADDR"
+	.section	.debug_info
+	.long		.Lname139
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint32_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #140: variable DIR
+	.section	.debug_info
+	.uleb128	140	; ref to abbrev 140
+	.section	.debug_abbrev
+	.uleb128	140
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname140:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname140
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #141: variable DIRSET
+	.section	.debug_info
+	.uleb128	141	; ref to abbrev 141
+	.section	.debug_abbrev
+	.uleb128	141
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname141:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname141
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #142: variable DIRCLR
+	.section	.debug_info
+	.uleb128	142	; ref to abbrev 142
+	.section	.debug_abbrev
+	.uleb128	142
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname142:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname142
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #143: variable DIRTGL
+	.section	.debug_info
+	.uleb128	143	; ref to abbrev 143
+	.section	.debug_abbrev
+	.uleb128	143
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname143:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname143
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #144: variable OUT
+	.section	.debug_info
+	.uleb128	144	; ref to abbrev 144
+	.section	.debug_abbrev
+	.uleb128	144
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname144:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname144
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #145: variable OUTSET
+	.section	.debug_info
+	.uleb128	145	; ref to abbrev 145
+	.section	.debug_abbrev
+	.uleb128	145
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname145:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname145
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #146: variable OUTCLR
+	.section	.debug_info
+	.uleb128	146	; ref to abbrev 146
+	.section	.debug_abbrev
+	.uleb128	146
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname146:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname146
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #147: variable OUTTGL
+	.section	.debug_info
+	.uleb128	147	; ref to abbrev 147
+	.section	.debug_abbrev
+	.uleb128	147
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname147:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname147
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #148: variable IN
+	.section	.debug_info
+	.uleb128	148	; ref to abbrev 148
+	.section	.debug_abbrev
+	.uleb128	148
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname148:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname148
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #149: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	149	; ref to abbrev 149
+	.section	.debug_abbrev
+	.uleb128	149
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname149:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname149
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #150: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	150	; ref to abbrev 150
+	.section	.debug_abbrev
+	.uleb128	150
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname150:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname150
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #151: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	151	; ref to abbrev 151
+	.section	.debug_abbrev
+	.uleb128	151
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname151:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname151
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #152: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	152	; ref to abbrev 152
+	.section	.debug_abbrev
+	.uleb128	152
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname152:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname152
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #153: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	153	; ref to abbrev 153
+	.section	.debug_abbrev
+	.uleb128	153
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname153:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname153
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #154: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	154	; ref to abbrev 154
+	.section	.debug_abbrev
+	.uleb128	154
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname154:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname154
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #155: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	155	; ref to abbrev 155
+	.section	.debug_abbrev
+	.uleb128	155
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname155:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname155
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #156: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	156	; ref to abbrev 156
+	.section	.debug_abbrev
+	.uleb128	156
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname156:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname156
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #157: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	157	; ref to abbrev 157
+	.section	.debug_abbrev
+	.uleb128	157
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname157:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname157
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #158: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	158	; ref to abbrev 158
+	.section	.debug_abbrev
+	.uleb128	158
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname158:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname158
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #159: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	159	; ref to abbrev 159
+	.section	.debug_abbrev
+	.uleb128	159
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname159:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname159
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #160: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	160	; ref to abbrev 160
+	.section	.debug_abbrev
+	.uleb128	160
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname160:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname160
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #161: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	161	; ref to abbrev 161
+	.section	.debug_abbrev
+	.uleb128	161
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname161:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname161
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #162: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	162	; ref to abbrev 162
+	.section	.debug_abbrev
+	.uleb128	162
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname162:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname162
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #163: variable EVGENCTRLA
+	.section	.debug_info
+	.uleb128	163	; ref to abbrev 163
+	.section	.debug_abbrev
+	.uleb128	163
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname163:
+	.string		"EVGENCTRLA"
+	.section	.debug_info
+	.long		.Lname163
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #164: variable DIR
+	.section	.debug_info
+	.uleb128	164	; ref to abbrev 164
+	.section	.debug_abbrev
+	.uleb128	164
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname164:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname164
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #165: variable DIRSET
+	.section	.debug_info
+	.uleb128	165	; ref to abbrev 165
+	.section	.debug_abbrev
+	.uleb128	165
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname165:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname165
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #166: variable DIRCLR
+	.section	.debug_info
+	.uleb128	166	; ref to abbrev 166
+	.section	.debug_abbrev
+	.uleb128	166
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname166:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname166
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #167: variable DIRTGL
+	.section	.debug_info
+	.uleb128	167	; ref to abbrev 167
+	.section	.debug_abbrev
+	.uleb128	167
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname167:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname167
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #168: variable OUT
+	.section	.debug_info
+	.uleb128	168	; ref to abbrev 168
+	.section	.debug_abbrev
+	.uleb128	168
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname168:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname168
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #169: variable OUTSET
+	.section	.debug_info
+	.uleb128	169	; ref to abbrev 169
+	.section	.debug_abbrev
+	.uleb128	169
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname169:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname169
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #170: variable OUTCLR
+	.section	.debug_info
+	.uleb128	170	; ref to abbrev 170
+	.section	.debug_abbrev
+	.uleb128	170
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname170:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname170
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #171: variable OUTTGL
+	.section	.debug_info
+	.uleb128	171	; ref to abbrev 171
+	.section	.debug_abbrev
+	.uleb128	171
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname171:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname171
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #172: variable IN
+	.section	.debug_info
+	.uleb128	172	; ref to abbrev 172
+	.section	.debug_abbrev
+	.uleb128	172
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname172:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname172
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #173: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	173	; ref to abbrev 173
+	.section	.debug_abbrev
+	.uleb128	173
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname173:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname173
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #174: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	174	; ref to abbrev 174
+	.section	.debug_abbrev
+	.uleb128	174
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname174:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname174
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #175: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	175	; ref to abbrev 175
+	.section	.debug_abbrev
+	.uleb128	175
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname175:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname175
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #176: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	176	; ref to abbrev 176
+	.section	.debug_abbrev
+	.uleb128	176
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname176:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname176
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #177: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	177	; ref to abbrev 177
+	.section	.debug_abbrev
+	.uleb128	177
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname177:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname177
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #178: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	178	; ref to abbrev 178
+	.section	.debug_abbrev
+	.uleb128	178
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname178:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname178
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #179: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	179	; ref to abbrev 179
+	.section	.debug_abbrev
+	.uleb128	179
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname179:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname179
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #180: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	180	; ref to abbrev 180
+	.section	.debug_abbrev
+	.uleb128	180
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname180:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname180
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #181: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	181	; ref to abbrev 181
+	.section	.debug_abbrev
+	.uleb128	181
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname181:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname181
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #182: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	182	; ref to abbrev 182
+	.section	.debug_abbrev
+	.uleb128	182
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname182:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname182
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #183: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	183	; ref to abbrev 183
+	.section	.debug_abbrev
+	.uleb128	183
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname183:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname183
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #184: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	184	; ref to abbrev 184
+	.section	.debug_abbrev
+	.uleb128	184
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname184:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname184
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #185: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	185	; ref to abbrev 185
+	.section	.debug_abbrev
+	.uleb128	185
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname185:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname185
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #186: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	186	; ref to abbrev 186
+	.section	.debug_abbrev
+	.uleb128	186
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname186:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname186
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #187: variable EVGENCTRLA
+	.section	.debug_info
+	.uleb128	187	; ref to abbrev 187
+	.section	.debug_abbrev
+	.uleb128	187
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname187:
+	.string		"EVGENCTRLA"
+	.section	.debug_info
+	.long		.Lname187
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #188: variable DIR
+	.section	.debug_info
+	.uleb128	188	; ref to abbrev 188
+	.section	.debug_abbrev
+	.uleb128	188
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname188:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname188
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #189: variable DIRSET
+	.section	.debug_info
+	.uleb128	189	; ref to abbrev 189
+	.section	.debug_abbrev
+	.uleb128	189
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname189:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname189
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #190: variable DIRCLR
+	.section	.debug_info
+	.uleb128	190	; ref to abbrev 190
+	.section	.debug_abbrev
+	.uleb128	190
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname190:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname190
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #191: variable DIRTGL
+	.section	.debug_info
+	.uleb128	191	; ref to abbrev 191
+	.section	.debug_abbrev
+	.uleb128	191
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname191:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname191
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #192: variable OUT
+	.section	.debug_info
+	.uleb128	192	; ref to abbrev 192
+	.section	.debug_abbrev
+	.uleb128	192
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname192:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname192
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #193: variable OUTSET
+	.section	.debug_info
+	.uleb128	193	; ref to abbrev 193
+	.section	.debug_abbrev
+	.uleb128	193
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname193:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname193
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #194: variable OUTCLR
+	.section	.debug_info
+	.uleb128	194	; ref to abbrev 194
+	.section	.debug_abbrev
+	.uleb128	194
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname194:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname194
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #195: variable OUTTGL
+	.section	.debug_info
+	.uleb128	195	; ref to abbrev 195
+	.section	.debug_abbrev
+	.uleb128	195
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname195:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname195
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #196: variable IN
+	.section	.debug_info
+	.uleb128	196	; ref to abbrev 196
+	.section	.debug_abbrev
+	.uleb128	196
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname196:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname196
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #197: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	197	; ref to abbrev 197
+	.section	.debug_abbrev
+	.uleb128	197
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname197:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname197
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #198: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	198	; ref to abbrev 198
+	.section	.debug_abbrev
+	.uleb128	198
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname198:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname198
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #199: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	199	; ref to abbrev 199
+	.section	.debug_abbrev
+	.uleb128	199
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname199:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname199
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #200: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	200	; ref to abbrev 200
+	.section	.debug_abbrev
+	.uleb128	200
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname200:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname200
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #201: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	201	; ref to abbrev 201
+	.section	.debug_abbrev
+	.uleb128	201
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname201:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname201
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #202: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	202	; ref to abbrev 202
+	.section	.debug_abbrev
+	.uleb128	202
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname202:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname202
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #203: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	203	; ref to abbrev 203
+	.section	.debug_abbrev
+	.uleb128	203
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname203:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname203
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #204: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	204	; ref to abbrev 204
+	.section	.debug_abbrev
+	.uleb128	204
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname204:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname204
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #205: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	205	; ref to abbrev 205
+	.section	.debug_abbrev
+	.uleb128	205
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname205:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname205
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #206: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	206	; ref to abbrev 206
+	.section	.debug_abbrev
+	.uleb128	206
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname206:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname206
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #207: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	207	; ref to abbrev 207
+	.section	.debug_abbrev
+	.uleb128	207
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname207:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname207
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #208: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	208	; ref to abbrev 208
+	.section	.debug_abbrev
+	.uleb128	208
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname208:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname208
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #209: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	209	; ref to abbrev 209
+	.section	.debug_abbrev
+	.uleb128	209
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname209:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname209
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #210: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	210	; ref to abbrev 210
+	.section	.debug_abbrev
+	.uleb128	210
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname210:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname210
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #211: variable EVGENCTRLA
+	.section	.debug_info
+	.uleb128	211	; ref to abbrev 211
+	.section	.debug_abbrev
+	.uleb128	211
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname211:
+	.string		"EVGENCTRLA"
+	.section	.debug_info
+	.long		.Lname211
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #212: variable DIR
+	.section	.debug_info
+	.uleb128	212	; ref to abbrev 212
+	.section	.debug_abbrev
+	.uleb128	212
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname212:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname212
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #213: variable DIRSET
+	.section	.debug_info
+	.uleb128	213	; ref to abbrev 213
+	.section	.debug_abbrev
+	.uleb128	213
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname213:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname213
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #214: variable DIRCLR
+	.section	.debug_info
+	.uleb128	214	; ref to abbrev 214
+	.section	.debug_abbrev
+	.uleb128	214
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname214:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname214
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #215: variable DIRTGL
+	.section	.debug_info
+	.uleb128	215	; ref to abbrev 215
+	.section	.debug_abbrev
+	.uleb128	215
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname215:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname215
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #216: variable OUT
+	.section	.debug_info
+	.uleb128	216	; ref to abbrev 216
+	.section	.debug_abbrev
+	.uleb128	216
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname216:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname216
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #217: variable OUTSET
+	.section	.debug_info
+	.uleb128	217	; ref to abbrev 217
+	.section	.debug_abbrev
+	.uleb128	217
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname217:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname217
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #218: variable OUTCLR
+	.section	.debug_info
+	.uleb128	218	; ref to abbrev 218
+	.section	.debug_abbrev
+	.uleb128	218
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname218:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname218
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #219: variable OUTTGL
+	.section	.debug_info
+	.uleb128	219	; ref to abbrev 219
+	.section	.debug_abbrev
+	.uleb128	219
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname219:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname219
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #220: variable IN
+	.section	.debug_info
+	.uleb128	220	; ref to abbrev 220
+	.section	.debug_abbrev
+	.uleb128	220
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname220:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname220
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #221: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	221	; ref to abbrev 221
+	.section	.debug_abbrev
+	.uleb128	221
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname221:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname221
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #222: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	222	; ref to abbrev 222
+	.section	.debug_abbrev
+	.uleb128	222
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname222:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname222
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #223: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	223	; ref to abbrev 223
+	.section	.debug_abbrev
+	.uleb128	223
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname223:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname223
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #224: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	224	; ref to abbrev 224
+	.section	.debug_abbrev
+	.uleb128	224
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname224:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname224
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #225: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	225	; ref to abbrev 225
+	.section	.debug_abbrev
+	.uleb128	225
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname225:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname225
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #226: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	226	; ref to abbrev 226
+	.section	.debug_abbrev
+	.uleb128	226
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname226:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname226
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #227: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	227	; ref to abbrev 227
+	.section	.debug_abbrev
+	.uleb128	227
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname227:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname227
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #228: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	228	; ref to abbrev 228
+	.section	.debug_abbrev
+	.uleb128	228
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname228:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname228
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #229: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	229	; ref to abbrev 229
+	.section	.debug_abbrev
+	.uleb128	229
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname229:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname229
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #230: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	230	; ref to abbrev 230
+	.section	.debug_abbrev
+	.uleb128	230
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname230:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname230
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #231: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	231	; ref to abbrev 231
+	.section	.debug_abbrev
+	.uleb128	231
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname231:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname231
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #232: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	232	; ref to abbrev 232
+	.section	.debug_abbrev
+	.uleb128	232
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname232:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname232
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #233: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	233	; ref to abbrev 233
+	.section	.debug_abbrev
+	.uleb128	233
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname233:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname233
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #234: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	234	; ref to abbrev 234
+	.section	.debug_abbrev
+	.uleb128	234
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname234:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname234
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #235: variable EVGENCTRLA
+	.section	.debug_info
+	.uleb128	235	; ref to abbrev 235
+	.section	.debug_abbrev
+	.uleb128	235
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname235:
+	.string		"EVGENCTRLA"
+	.section	.debug_info
+	.long		.Lname235
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #236: variable EVSYSROUTEA
+	.section	.debug_info
+	.uleb128	236	; ref to abbrev 236
+	.section	.debug_abbrev
+	.uleb128	236
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname236:
+	.string		"EVSYSROUTEA"
+	.section	.debug_info
+	.long		.Lname236
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #237: variable CCLROUTEA
+	.section	.debug_info
+	.uleb128	237	; ref to abbrev 237
+	.section	.debug_abbrev
+	.uleb128	237
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname237:
+	.string		"CCLROUTEA"
+	.section	.debug_info
+	.long		.Lname237
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #238: variable USARTROUTEA
+	.section	.debug_info
+	.uleb128	238	; ref to abbrev 238
+	.section	.debug_abbrev
+	.uleb128	238
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname238:
+	.string		"USARTROUTEA"
+	.section	.debug_info
+	.long		.Lname238
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #239: variable SPIROUTEA
+	.section	.debug_info
+	.uleb128	239	; ref to abbrev 239
+	.section	.debug_abbrev
+	.uleb128	239
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname239:
+	.string		"SPIROUTEA"
+	.section	.debug_info
+	.long		.Lname239
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #240: variable TWIROUTEA
+	.section	.debug_info
+	.uleb128	240	; ref to abbrev 240
+	.section	.debug_abbrev
+	.uleb128	240
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname240:
+	.string		"TWIROUTEA"
+	.section	.debug_info
+	.long		.Lname240
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #241: variable TCEROUTEA
+	.section	.debug_info
+	.uleb128	241	; ref to abbrev 241
+	.section	.debug_abbrev
+	.uleb128	241
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname241:
+	.string		"TCEROUTEA"
+	.section	.debug_info
+	.long		.Lname241
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #242: variable TCBROUTEA
+	.section	.debug_info
+	.uleb128	242	; ref to abbrev 242
+	.section	.debug_abbrev
+	.uleb128	242
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname242:
+	.string		"TCBROUTEA"
+	.section	.debug_info
+	.long		.Lname242
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #243: variable TCFROUTEA
+	.section	.debug_info
+	.uleb128	243	; ref to abbrev 243
+	.section	.debug_abbrev
+	.uleb128	243
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname243:
+	.string		"TCFROUTEA"
+	.section	.debug_info
+	.long		.Lname243
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #244: variable RSTFR
+	.section	.debug_info
+	.uleb128	244	; ref to abbrev 244
+	.section	.debug_abbrev
+	.uleb128	244
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname244:
+	.string		"RSTFR"
+	.section	.debug_info
+	.long		.Lname244
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0040 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #245: variable SWRR
+	.section	.debug_info
+	.uleb128	245	; ref to abbrev 245
+	.section	.debug_abbrev
+	.uleb128	245
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname245:
+	.string		"SWRR"
+	.section	.debug_info
+	.long		.Lname245
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0040 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #246: variable CTRLA
+	.section	.debug_info
+	.uleb128	246	; ref to abbrev 246
+	.section	.debug_abbrev
+	.uleb128	246
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname246:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname246
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #247: variable STATUS
+	.section	.debug_info
+	.uleb128	247	; ref to abbrev 247
+	.section	.debug_abbrev
+	.uleb128	247
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname247:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname247
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #248: variable INTCTRL
+	.section	.debug_info
+	.uleb128	248	; ref to abbrev 248
+	.section	.debug_abbrev
+	.uleb128	248
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname248:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname248
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #249: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	249	; ref to abbrev 249
+	.section	.debug_abbrev
+	.uleb128	249
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname249:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname249
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #250: variable TEMP
+	.section	.debug_info
+	.uleb128	250	; ref to abbrev 250
+	.section	.debug_abbrev
+	.uleb128	250
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname250:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname250
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #251: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	251	; ref to abbrev 251
+	.section	.debug_abbrev
+	.uleb128	251
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname251:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname251
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #252: variable CALIB
+	.section	.debug_info
+	.uleb128	252	; ref to abbrev 252
+	.section	.debug_abbrev
+	.uleb128	252
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname252:
+	.string		"CALIB"
+	.section	.debug_info
+	.long		.Lname252
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #253: variable CLKSEL
+	.section	.debug_info
+	.uleb128	253	; ref to abbrev 253
+	.section	.debug_abbrev
+	.uleb128	253
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname253:
+	.string		"CLKSEL"
+	.section	.debug_info
+	.long		.Lname253
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #254: variable CNT
+	.section	.debug_info
+	.uleb128	254	; ref to abbrev 254
+	.section	.debug_abbrev
+	.uleb128	254
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname254:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname254
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #255: variable PER
+	.section	.debug_info
+	.uleb128	255	; ref to abbrev 255
+	.section	.debug_abbrev
+	.uleb128	255
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname255:
+	.string		"PER"
+	.section	.debug_info
+	.long		.Lname255
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #256: variable CMP
+	.section	.debug_info
+	.uleb128	256	; ref to abbrev 256
+	.section	.debug_abbrev
+	.uleb128	256
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname256:
+	.string		"CMP"
+	.section	.debug_info
+	.long		.Lname256
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #257: variable PITCTRLA
+	.section	.debug_info
+	.uleb128	257	; ref to abbrev 257
+	.section	.debug_abbrev
+	.uleb128	257
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname257:
+	.string		"PITCTRLA"
+	.section	.debug_info
+	.long		.Lname257
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #258: variable PITSTATUS
+	.section	.debug_info
+	.uleb128	258	; ref to abbrev 258
+	.section	.debug_abbrev
+	.uleb128	258
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname258:
+	.string		"PITSTATUS"
+	.section	.debug_info
+	.long		.Lname258
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #259: variable PITINTCTRL
+	.section	.debug_info
+	.uleb128	259	; ref to abbrev 259
+	.section	.debug_abbrev
+	.uleb128	259
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname259:
+	.string		"PITINTCTRL"
+	.section	.debug_info
+	.long		.Lname259
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #260: variable PITINTFLAGS
+	.section	.debug_info
+	.uleb128	260	; ref to abbrev 260
+	.section	.debug_abbrev
+	.uleb128	260
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname260:
+	.string		"PITINTFLAGS"
+	.section	.debug_info
+	.long		.Lname260
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #261: variable PITDBGCTRL
+	.section	.debug_info
+	.uleb128	261	; ref to abbrev 261
+	.section	.debug_abbrev
+	.uleb128	261
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname261:
+	.string		"PITDBGCTRL"
+	.section	.debug_info
+	.long		.Lname261
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #262: variable PITEVGENCTRLA
+	.section	.debug_info
+	.uleb128	262	; ref to abbrev 262
+	.section	.debug_abbrev
+	.uleb128	262
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname262:
+	.string		"PITEVGENCTRLA"
+	.section	.debug_info
+	.long		.Lname262
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #263: variable DEVICEID0
+	.section	.debug_info
+	.uleb128	263	; ref to abbrev 263
+	.section	.debug_abbrev
+	.uleb128	263
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname263:
+	.string		"DEVICEID0"
+	.section	.debug_info
+	.long		.Lname263
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #264: variable DEVICEID1
+	.section	.debug_info
+	.uleb128	264	; ref to abbrev 264
+	.section	.debug_abbrev
+	.uleb128	264
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname264:
+	.string		"DEVICEID1"
+	.section	.debug_info
+	.long		.Lname264
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #265: variable DEVICEID2
+	.section	.debug_info
+	.uleb128	265	; ref to abbrev 265
+	.section	.debug_abbrev
+	.uleb128	265
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname265:
+	.string		"DEVICEID2"
+	.section	.debug_info
+	.long		.Lname265
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #266: variable TEMPSENSE0
+	.section	.debug_info
+	.uleb128	266	; ref to abbrev 266
+	.section	.debug_abbrev
+	.uleb128	266
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname266:
+	.string		"TEMPSENSE0"
+	.section	.debug_info
+	.long		.Lname266
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #267: variable TEMPSENSE1
+	.section	.debug_info
+	.uleb128	267	; ref to abbrev 267
+	.section	.debug_abbrev
+	.uleb128	267
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname267:
+	.string		"TEMPSENSE1"
+	.section	.debug_info
+	.long		.Lname267
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #268: variable SERNUM0
+	.section	.debug_info
+	.uleb128	268	; ref to abbrev 268
+	.section	.debug_abbrev
+	.uleb128	268
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname268:
+	.string		"SERNUM0"
+	.section	.debug_info
+	.long		.Lname268
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #269: variable SERNUM1
+	.section	.debug_info
+	.uleb128	269	; ref to abbrev 269
+	.section	.debug_abbrev
+	.uleb128	269
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname269:
+	.string		"SERNUM1"
+	.section	.debug_info
+	.long		.Lname269
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #270: variable SERNUM2
+	.section	.debug_info
+	.uleb128	270	; ref to abbrev 270
+	.section	.debug_abbrev
+	.uleb128	270
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname270:
+	.string		"SERNUM2"
+	.section	.debug_info
+	.long		.Lname270
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #271: variable SERNUM3
+	.section	.debug_info
+	.uleb128	271	; ref to abbrev 271
+	.section	.debug_abbrev
+	.uleb128	271
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname271:
+	.string		"SERNUM3"
+	.section	.debug_info
+	.long		.Lname271
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #272: variable SERNUM4
+	.section	.debug_info
+	.uleb128	272	; ref to abbrev 272
+	.section	.debug_abbrev
+	.uleb128	272
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname272:
+	.string		"SERNUM4"
+	.section	.debug_info
+	.long		.Lname272
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #273: variable SERNUM5
+	.section	.debug_info
+	.uleb128	273	; ref to abbrev 273
+	.section	.debug_abbrev
+	.uleb128	273
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname273:
+	.string		"SERNUM5"
+	.section	.debug_info
+	.long		.Lname273
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #274: variable SERNUM6
+	.section	.debug_info
+	.uleb128	274	; ref to abbrev 274
+	.section	.debug_abbrev
+	.uleb128	274
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname274:
+	.string		"SERNUM6"
+	.section	.debug_info
+	.long		.Lname274
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #275: variable SERNUM7
+	.section	.debug_info
+	.uleb128	275	; ref to abbrev 275
+	.section	.debug_abbrev
+	.uleb128	275
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname275:
+	.string		"SERNUM7"
+	.section	.debug_info
+	.long		.Lname275
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #276: variable SERNUM8
+	.section	.debug_info
+	.uleb128	276	; ref to abbrev 276
+	.section	.debug_abbrev
+	.uleb128	276
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname276:
+	.string		"SERNUM8"
+	.section	.debug_info
+	.long		.Lname276
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #277: variable SERNUM9
+	.section	.debug_info
+	.uleb128	277	; ref to abbrev 277
+	.section	.debug_abbrev
+	.uleb128	277
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname277:
+	.string		"SERNUM9"
+	.section	.debug_info
+	.long		.Lname277
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x19
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #278: variable SERNUM10
+	.section	.debug_info
+	.uleb128	278	; ref to abbrev 278
+	.section	.debug_abbrev
+	.uleb128	278
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname278:
+	.string		"SERNUM10"
+	.section	.debug_info
+	.long		.Lname278
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #279: variable SERNUM11
+	.section	.debug_info
+	.uleb128	279	; ref to abbrev 279
+	.section	.debug_abbrev
+	.uleb128	279
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname279:
+	.string		"SERNUM11"
+	.section	.debug_info
+	.long		.Lname279
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #280: variable SERNUM12
+	.section	.debug_info
+	.uleb128	280	; ref to abbrev 280
+	.section	.debug_abbrev
+	.uleb128	280
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname280:
+	.string		"SERNUM12"
+	.section	.debug_info
+	.long		.Lname280
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #281: variable SERNUM13
+	.section	.debug_info
+	.uleb128	281	; ref to abbrev 281
+	.section	.debug_abbrev
+	.uleb128	281
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname281:
+	.string		"SERNUM13"
+	.section	.debug_info
+	.long		.Lname281
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #282: variable SERNUM14
+	.section	.debug_info
+	.uleb128	282	; ref to abbrev 282
+	.section	.debug_abbrev
+	.uleb128	282
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname282:
+	.string		"SERNUM14"
+	.section	.debug_info
+	.long		.Lname282
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #283: variable SERNUM15
+	.section	.debug_info
+	.uleb128	283	; ref to abbrev 283
+	.section	.debug_abbrev
+	.uleb128	283
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname283:
+	.string		"SERNUM15"
+	.section	.debug_info
+	.long		.Lname283
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #284: variable CTRLA
+	.section	.debug_info
+	.uleb128	284	; ref to abbrev 284
+	.section	.debug_abbrev
+	.uleb128	284
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname284:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname284
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0050 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #285: variable CTRLA
+	.section	.debug_info
+	.uleb128	285	; ref to abbrev 285
+	.section	.debug_abbrev
+	.uleb128	285
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname285:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname285
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #286: variable CTRLB
+	.section	.debug_info
+	.uleb128	286	; ref to abbrev 286
+	.section	.debug_abbrev
+	.uleb128	286
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname286:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname286
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #287: variable INTCTRL
+	.section	.debug_info
+	.uleb128	287	; ref to abbrev 287
+	.section	.debug_abbrev
+	.uleb128	287
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname287:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname287
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #288: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	288	; ref to abbrev 288
+	.section	.debug_abbrev
+	.uleb128	288
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname288:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname288
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #289: variable DATA
+	.section	.debug_info
+	.uleb128	289	; ref to abbrev 289
+	.section	.debug_abbrev
+	.uleb128	289
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname289:
+	.string		"DATA"
+	.section	.debug_info
+	.long		.Lname289
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #290: variable REVID
+	.section	.debug_info
+	.uleb128	290	; ref to abbrev 290
+	.section	.debug_abbrev
+	.uleb128	290
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname290:
+	.string		"REVID"
+	.section	.debug_info
+	.long		.Lname290
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0F00 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #291: variable CTRLA
+	.section	.debug_info
+	.uleb128	291	; ref to abbrev 291
+	.section	.debug_abbrev
+	.uleb128	291
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname291:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname291
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #292: variable CTRLB
+	.section	.debug_info
+	.uleb128	292	; ref to abbrev 292
+	.section	.debug_abbrev
+	.uleb128	292
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname292:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname292
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #293: variable CTRLC
+	.section	.debug_info
+	.uleb128	293	; ref to abbrev 293
+	.section	.debug_abbrev
+	.uleb128	293
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname293:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname293
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #294: variable EVCTRL
+	.section	.debug_info
+	.uleb128	294	; ref to abbrev 294
+	.section	.debug_abbrev
+	.uleb128	294
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname294:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname294
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #295: variable INTCTRL
+	.section	.debug_info
+	.uleb128	295	; ref to abbrev 295
+	.section	.debug_abbrev
+	.uleb128	295
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname295:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname295
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #296: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	296	; ref to abbrev 296
+	.section	.debug_abbrev
+	.uleb128	296
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname296:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname296
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #297: variable STATUS
+	.section	.debug_info
+	.uleb128	297	; ref to abbrev 297
+	.section	.debug_abbrev
+	.uleb128	297
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname297:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname297
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #298: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	298	; ref to abbrev 298
+	.section	.debug_abbrev
+	.uleb128	298
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname298:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname298
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #299: variable TEMP
+	.section	.debug_info
+	.uleb128	299	; ref to abbrev 299
+	.section	.debug_abbrev
+	.uleb128	299
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname299:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname299
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #300: variable CNT
+	.section	.debug_info
+	.uleb128	300	; ref to abbrev 300
+	.section	.debug_abbrev
+	.uleb128	300
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname300:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname300
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #301: variable CCMP
+	.section	.debug_info
+	.uleb128	301	; ref to abbrev 301
+	.section	.debug_abbrev
+	.uleb128	301
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname301:
+	.string		"CCMP"
+	.section	.debug_info
+	.long		.Lname301
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #302: variable CTRLA
+	.section	.debug_info
+	.uleb128	302	; ref to abbrev 302
+	.section	.debug_abbrev
+	.uleb128	302
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname302:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname302
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #303: variable CTRLB
+	.section	.debug_info
+	.uleb128	303	; ref to abbrev 303
+	.section	.debug_abbrev
+	.uleb128	303
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname303:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname303
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #304: variable CTRLC
+	.section	.debug_info
+	.uleb128	304	; ref to abbrev 304
+	.section	.debug_abbrev
+	.uleb128	304
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname304:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname304
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #305: variable EVCTRL
+	.section	.debug_info
+	.uleb128	305	; ref to abbrev 305
+	.section	.debug_abbrev
+	.uleb128	305
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname305:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname305
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #306: variable INTCTRL
+	.section	.debug_info
+	.uleb128	306	; ref to abbrev 306
+	.section	.debug_abbrev
+	.uleb128	306
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname306:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname306
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #307: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	307	; ref to abbrev 307
+	.section	.debug_abbrev
+	.uleb128	307
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname307:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname307
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #308: variable STATUS
+	.section	.debug_info
+	.uleb128	308	; ref to abbrev 308
+	.section	.debug_abbrev
+	.uleb128	308
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname308:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname308
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #309: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	309	; ref to abbrev 309
+	.section	.debug_abbrev
+	.uleb128	309
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname309:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname309
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #310: variable TEMP
+	.section	.debug_info
+	.uleb128	310	; ref to abbrev 310
+	.section	.debug_abbrev
+	.uleb128	310
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname310:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname310
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #311: variable CNT
+	.section	.debug_info
+	.uleb128	311	; ref to abbrev 311
+	.section	.debug_abbrev
+	.uleb128	311
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname311:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname311
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #312: variable CCMP
+	.section	.debug_info
+	.uleb128	312	; ref to abbrev 312
+	.section	.debug_abbrev
+	.uleb128	312
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname312:
+	.string		"CCMP"
+	.section	.debug_info
+	.long		.Lname312
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #313: variable CTRLA
+	.section	.debug_info
+	.uleb128	313	; ref to abbrev 313
+	.section	.debug_abbrev
+	.uleb128	313
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname313:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname313
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #314: variable CTRLB
+	.section	.debug_info
+	.uleb128	314	; ref to abbrev 314
+	.section	.debug_abbrev
+	.uleb128	314
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname314:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname314
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #315: variable CTRLC
+	.section	.debug_info
+	.uleb128	315	; ref to abbrev 315
+	.section	.debug_abbrev
+	.uleb128	315
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname315:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname315
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #316: variable CTRLD
+	.section	.debug_info
+	.uleb128	316	; ref to abbrev 316
+	.section	.debug_abbrev
+	.uleb128	316
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname316:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname316
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #317: variable CTRLECLR
+	.section	.debug_info
+	.uleb128	317	; ref to abbrev 317
+	.section	.debug_abbrev
+	.uleb128	317
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname317:
+	.string		"CTRLECLR"
+	.section	.debug_info
+	.long		.Lname317
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #318: variable CTRLESET
+	.section	.debug_info
+	.uleb128	318	; ref to abbrev 318
+	.section	.debug_abbrev
+	.uleb128	318
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname318:
+	.string		"CTRLESET"
+	.section	.debug_info
+	.long		.Lname318
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #319: variable CTRLFCLR
+	.section	.debug_info
+	.uleb128	319	; ref to abbrev 319
+	.section	.debug_abbrev
+	.uleb128	319
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname319:
+	.string		"CTRLFCLR"
+	.section	.debug_info
+	.long		.Lname319
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #320: variable CTRLFSET
+	.section	.debug_info
+	.uleb128	320	; ref to abbrev 320
+	.section	.debug_abbrev
+	.uleb128	320
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname320:
+	.string		"CTRLFSET"
+	.section	.debug_info
+	.long		.Lname320
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #321: variable EVGENCTRL
+	.section	.debug_info
+	.uleb128	321	; ref to abbrev 321
+	.section	.debug_abbrev
+	.uleb128	321
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname321:
+	.string		"EVGENCTRL"
+	.section	.debug_info
+	.long		.Lname321
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #322: variable EVCTRL
+	.section	.debug_info
+	.uleb128	322	; ref to abbrev 322
+	.section	.debug_abbrev
+	.uleb128	322
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname322:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname322
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #323: variable INTCTRL
+	.section	.debug_info
+	.uleb128	323	; ref to abbrev 323
+	.section	.debug_abbrev
+	.uleb128	323
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname323:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname323
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #324: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	324	; ref to abbrev 324
+	.section	.debug_abbrev
+	.uleb128	324
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname324:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname324
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #325: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	325	; ref to abbrev 325
+	.section	.debug_abbrev
+	.uleb128	325
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname325:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname325
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #326: variable TEMP
+	.section	.debug_info
+	.uleb128	326	; ref to abbrev 326
+	.section	.debug_abbrev
+	.uleb128	326
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname326:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname326
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #327: variable CNT
+	.section	.debug_info
+	.uleb128	327	; ref to abbrev 327
+	.section	.debug_abbrev
+	.uleb128	327
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname327:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname327
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #328: variable AMP
+	.section	.debug_info
+	.uleb128	328	; ref to abbrev 328
+	.section	.debug_abbrev
+	.uleb128	328
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname328:
+	.string		"AMP"
+	.section	.debug_info
+	.long		.Lname328
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x22
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #329: variable OFFSET
+	.section	.debug_info
+	.uleb128	329	; ref to abbrev 329
+	.section	.debug_abbrev
+	.uleb128	329
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname329:
+	.string		"OFFSET"
+	.section	.debug_info
+	.long		.Lname329
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x24
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #330: variable PER
+	.section	.debug_info
+	.uleb128	330	; ref to abbrev 330
+	.section	.debug_abbrev
+	.uleb128	330
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname330:
+	.string		"PER"
+	.section	.debug_info
+	.long		.Lname330
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x26
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #331: variable CMP0
+	.section	.debug_info
+	.uleb128	331	; ref to abbrev 331
+	.section	.debug_abbrev
+	.uleb128	331
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname331:
+	.string		"CMP0"
+	.section	.debug_info
+	.long		.Lname331
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x28
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #332: variable CMP1
+	.section	.debug_info
+	.uleb128	332	; ref to abbrev 332
+	.section	.debug_abbrev
+	.uleb128	332
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname332:
+	.string		"CMP1"
+	.section	.debug_info
+	.long		.Lname332
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #333: variable CMP2
+	.section	.debug_info
+	.uleb128	333	; ref to abbrev 333
+	.section	.debug_abbrev
+	.uleb128	333
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname333:
+	.string		"CMP2"
+	.section	.debug_info
+	.long		.Lname333
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #334: variable CMP3
+	.section	.debug_info
+	.uleb128	334	; ref to abbrev 334
+	.section	.debug_abbrev
+	.uleb128	334
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname334:
+	.string		"CMP3"
+	.section	.debug_info
+	.long		.Lname334
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #335: variable PERBUF
+	.section	.debug_info
+	.uleb128	335	; ref to abbrev 335
+	.section	.debug_abbrev
+	.uleb128	335
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname335:
+	.string		"PERBUF"
+	.section	.debug_info
+	.long		.Lname335
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x36
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #336: variable CMP0BUF
+	.section	.debug_info
+	.uleb128	336	; ref to abbrev 336
+	.section	.debug_abbrev
+	.uleb128	336
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname336:
+	.string		"CMP0BUF"
+	.section	.debug_info
+	.long		.Lname336
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x38
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #337: variable CMP1BUF
+	.section	.debug_info
+	.uleb128	337	; ref to abbrev 337
+	.section	.debug_abbrev
+	.uleb128	337
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname337:
+	.string		"CMP1BUF"
+	.section	.debug_info
+	.long		.Lname337
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x3A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #338: variable CMP2BUF
+	.section	.debug_info
+	.uleb128	338	; ref to abbrev 338
+	.section	.debug_abbrev
+	.uleb128	338
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname338:
+	.string		"CMP2BUF"
+	.section	.debug_info
+	.long		.Lname338
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x3C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #339: variable CMP3BUF
+	.section	.debug_info
+	.uleb128	339	; ref to abbrev 339
+	.section	.debug_abbrev
+	.uleb128	339
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname339:
+	.string		"CMP3BUF"
+	.section	.debug_info
+	.long		.Lname339
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x3E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #340: variable CTRLA
+	.section	.debug_info
+	.uleb128	340	; ref to abbrev 340
+	.section	.debug_abbrev
+	.uleb128	340
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname340:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname340
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C00 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #341: variable CTRLB
+	.section	.debug_info
+	.uleb128	341	; ref to abbrev 341
+	.section	.debug_abbrev
+	.uleb128	341
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname341:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname341
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C00 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #342: variable CTRLC
+	.section	.debug_info
+	.uleb128	342	; ref to abbrev 342
+	.section	.debug_abbrev
+	.uleb128	342
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname342:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname342
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C00 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #343: variable CTRLD
+	.section	.debug_info
+	.uleb128	343	; ref to abbrev 343
+	.section	.debug_abbrev
+	.uleb128	343
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname343:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname343
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C00 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #344: variable EVCTRL
+	.section	.debug_info
+	.uleb128	344	; ref to abbrev 344
+	.section	.debug_abbrev
+	.uleb128	344
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname344:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname344
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C00 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #345: variable INTCTRL
+	.section	.debug_info
+	.uleb128	345	; ref to abbrev 345
+	.section	.debug_abbrev
+	.uleb128	345
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname345:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname345
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C00 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #346: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	346	; ref to abbrev 346
+	.section	.debug_abbrev
+	.uleb128	346
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname346:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname346
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C00 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #347: variable STATUS
+	.section	.debug_info
+	.uleb128	347	; ref to abbrev 347
+	.section	.debug_abbrev
+	.uleb128	347
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname347:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname347
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C00 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #348: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	348	; ref to abbrev 348
+	.section	.debug_abbrev
+	.uleb128	348
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname348:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname348
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C00 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #349: variable CNT
+	.section	.debug_info
+	.uleb128	349	; ref to abbrev 349
+	.section	.debug_abbrev
+	.uleb128	349
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname349:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname349
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint32_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C00 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #350: variable CMP
+	.section	.debug_info
+	.uleb128	350	; ref to abbrev 350
+	.section	.debug_abbrev
+	.uleb128	350
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname350:
+	.string		"CMP"
+	.section	.debug_info
+	.long		.Lname350
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint32_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C00 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #351: variable CTRLA
+	.section	.debug_info
+	.uleb128	351	; ref to abbrev 351
+	.section	.debug_abbrev
+	.uleb128	351
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname351:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname351
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #352: variable DUALCTRL
+	.section	.debug_info
+	.uleb128	352	; ref to abbrev 352
+	.section	.debug_abbrev
+	.uleb128	352
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname352:
+	.string		"DUALCTRL"
+	.section	.debug_info
+	.long		.Lname352
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #353: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	353	; ref to abbrev 353
+	.section	.debug_abbrev
+	.uleb128	353
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname353:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname353
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #354: variable MCTRLA
+	.section	.debug_info
+	.uleb128	354	; ref to abbrev 354
+	.section	.debug_abbrev
+	.uleb128	354
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname354:
+	.string		"MCTRLA"
+	.section	.debug_info
+	.long		.Lname354
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #355: variable MCTRLB
+	.section	.debug_info
+	.uleb128	355	; ref to abbrev 355
+	.section	.debug_abbrev
+	.uleb128	355
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname355:
+	.string		"MCTRLB"
+	.section	.debug_info
+	.long		.Lname355
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #356: variable MSTATUS
+	.section	.debug_info
+	.uleb128	356	; ref to abbrev 356
+	.section	.debug_abbrev
+	.uleb128	356
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname356:
+	.string		"MSTATUS"
+	.section	.debug_info
+	.long		.Lname356
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #357: variable MBAUD
+	.section	.debug_info
+	.uleb128	357	; ref to abbrev 357
+	.section	.debug_abbrev
+	.uleb128	357
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname357:
+	.string		"MBAUD"
+	.section	.debug_info
+	.long		.Lname357
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #358: variable MADDR
+	.section	.debug_info
+	.uleb128	358	; ref to abbrev 358
+	.section	.debug_abbrev
+	.uleb128	358
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname358:
+	.string		"MADDR"
+	.section	.debug_info
+	.long		.Lname358
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #359: variable MDATA
+	.section	.debug_info
+	.uleb128	359	; ref to abbrev 359
+	.section	.debug_abbrev
+	.uleb128	359
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname359:
+	.string		"MDATA"
+	.section	.debug_info
+	.long		.Lname359
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #360: variable SCTRLA
+	.section	.debug_info
+	.uleb128	360	; ref to abbrev 360
+	.section	.debug_abbrev
+	.uleb128	360
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname360:
+	.string		"SCTRLA"
+	.section	.debug_info
+	.long		.Lname360
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #361: variable SCTRLB
+	.section	.debug_info
+	.uleb128	361	; ref to abbrev 361
+	.section	.debug_abbrev
+	.uleb128	361
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname361:
+	.string		"SCTRLB"
+	.section	.debug_info
+	.long		.Lname361
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #362: variable SSTATUS
+	.section	.debug_info
+	.uleb128	362	; ref to abbrev 362
+	.section	.debug_abbrev
+	.uleb128	362
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname362:
+	.string		"SSTATUS"
+	.section	.debug_info
+	.long		.Lname362
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #363: variable SADDR
+	.section	.debug_info
+	.uleb128	363	; ref to abbrev 363
+	.section	.debug_abbrev
+	.uleb128	363
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname363:
+	.string		"SADDR"
+	.section	.debug_info
+	.long		.Lname363
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #364: variable SDATA
+	.section	.debug_info
+	.uleb128	364	; ref to abbrev 364
+	.section	.debug_abbrev
+	.uleb128	364
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname364:
+	.string		"SDATA"
+	.section	.debug_info
+	.long		.Lname364
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xD
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #365: variable SADDRMASK
+	.section	.debug_info
+	.uleb128	365	; ref to abbrev 365
+	.section	.debug_abbrev
+	.uleb128	365
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname365:
+	.string		"SADDRMASK"
+	.section	.debug_info
+	.long		.Lname365
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xE
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #366: variable RXDATAL
+	.section	.debug_info
+	.uleb128	366	; ref to abbrev 366
+	.section	.debug_abbrev
+	.uleb128	366
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname366:
+	.string		"RXDATAL"
+	.section	.debug_info
+	.long		.Lname366
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #367: variable RXDATAH
+	.section	.debug_info
+	.uleb128	367	; ref to abbrev 367
+	.section	.debug_abbrev
+	.uleb128	367
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname367:
+	.string		"RXDATAH"
+	.section	.debug_info
+	.long		.Lname367
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #368: variable TXDATAL
+	.section	.debug_info
+	.uleb128	368	; ref to abbrev 368
+	.section	.debug_abbrev
+	.uleb128	368
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname368:
+	.string		"TXDATAL"
+	.section	.debug_info
+	.long		.Lname368
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #369: variable TXDATAH
+	.section	.debug_info
+	.uleb128	369	; ref to abbrev 369
+	.section	.debug_abbrev
+	.uleb128	369
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname369:
+	.string		"TXDATAH"
+	.section	.debug_info
+	.long		.Lname369
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #370: variable STATUS
+	.section	.debug_info
+	.uleb128	370	; ref to abbrev 370
+	.section	.debug_abbrev
+	.uleb128	370
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname370:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname370
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #371: variable CTRLA
+	.section	.debug_info
+	.uleb128	371	; ref to abbrev 371
+	.section	.debug_abbrev
+	.uleb128	371
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname371:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname371
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #372: variable CTRLB
+	.section	.debug_info
+	.uleb128	372	; ref to abbrev 372
+	.section	.debug_abbrev
+	.uleb128	372
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname372:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname372
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #373: variable CTRLC
+	.section	.debug_info
+	.uleb128	373	; ref to abbrev 373
+	.section	.debug_abbrev
+	.uleb128	373
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname373:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname373
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #374: variable BAUD
+	.section	.debug_info
+	.uleb128	374	; ref to abbrev 374
+	.section	.debug_abbrev
+	.uleb128	374
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname374:
+	.string		"BAUD"
+	.section	.debug_info
+	.long		.Lname374
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #375: variable CTRLD
+	.section	.debug_info
+	.uleb128	375	; ref to abbrev 375
+	.section	.debug_abbrev
+	.uleb128	375
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname375:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname375
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #376: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	376	; ref to abbrev 376
+	.section	.debug_abbrev
+	.uleb128	376
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname376:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname376
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #377: variable EVCTRL
+	.section	.debug_info
+	.uleb128	377	; ref to abbrev 377
+	.section	.debug_abbrev
+	.uleb128	377
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname377:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname377
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #378: variable TXPLCTRL
+	.section	.debug_info
+	.uleb128	378	; ref to abbrev 378
+	.section	.debug_abbrev
+	.uleb128	378
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname378:
+	.string		"TXPLCTRL"
+	.section	.debug_info
+	.long		.Lname378
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xD
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #379: variable RXPLCTRL
+	.section	.debug_info
+	.uleb128	379	; ref to abbrev 379
+	.section	.debug_abbrev
+	.uleb128	379
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname379:
+	.string		"RXPLCTRL"
+	.section	.debug_info
+	.long		.Lname379
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xE
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #380: variable USERROW0
+	.section	.debug_info
+	.uleb128	380	; ref to abbrev 380
+	.section	.debug_abbrev
+	.uleb128	380
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname380:
+	.string		"USERROW0"
+	.section	.debug_info
+	.long		.Lname380
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #381: variable USERROW1
+	.section	.debug_info
+	.uleb128	381	; ref to abbrev 381
+	.section	.debug_abbrev
+	.uleb128	381
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname381:
+	.string		"USERROW1"
+	.section	.debug_info
+	.long		.Lname381
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #382: variable USERROW2
+	.section	.debug_info
+	.uleb128	382	; ref to abbrev 382
+	.section	.debug_abbrev
+	.uleb128	382
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname382:
+	.string		"USERROW2"
+	.section	.debug_info
+	.long		.Lname382
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #383: variable USERROW3
+	.section	.debug_info
+	.uleb128	383	; ref to abbrev 383
+	.section	.debug_abbrev
+	.uleb128	383
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname383:
+	.string		"USERROW3"
+	.section	.debug_info
+	.long		.Lname383
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #384: variable USERROW4
+	.section	.debug_info
+	.uleb128	384	; ref to abbrev 384
+	.section	.debug_abbrev
+	.uleb128	384
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname384:
+	.string		"USERROW4"
+	.section	.debug_info
+	.long		.Lname384
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #385: variable USERROW5
+	.section	.debug_info
+	.uleb128	385	; ref to abbrev 385
+	.section	.debug_abbrev
+	.uleb128	385
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname385:
+	.string		"USERROW5"
+	.section	.debug_info
+	.long		.Lname385
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #386: variable USERROW6
+	.section	.debug_info
+	.uleb128	386	; ref to abbrev 386
+	.section	.debug_abbrev
+	.uleb128	386
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname386:
+	.string		"USERROW6"
+	.section	.debug_info
+	.long		.Lname386
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #387: variable USERROW7
+	.section	.debug_info
+	.uleb128	387	; ref to abbrev 387
+	.section	.debug_abbrev
+	.uleb128	387
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname387:
+	.string		"USERROW7"
+	.section	.debug_info
+	.long		.Lname387
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #388: variable USERROW8
+	.section	.debug_info
+	.uleb128	388	; ref to abbrev 388
+	.section	.debug_abbrev
+	.uleb128	388
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname388:
+	.string		"USERROW8"
+	.section	.debug_info
+	.long		.Lname388
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #389: variable USERROW9
+	.section	.debug_info
+	.uleb128	389	; ref to abbrev 389
+	.section	.debug_abbrev
+	.uleb128	389
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname389:
+	.string		"USERROW9"
+	.section	.debug_info
+	.long		.Lname389
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #390: variable USERROW10
+	.section	.debug_info
+	.uleb128	390	; ref to abbrev 390
+	.section	.debug_abbrev
+	.uleb128	390
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname390:
+	.string		"USERROW10"
+	.section	.debug_info
+	.long		.Lname390
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #391: variable USERROW11
+	.section	.debug_info
+	.uleb128	391	; ref to abbrev 391
+	.section	.debug_abbrev
+	.uleb128	391
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname391:
+	.string		"USERROW11"
+	.section	.debug_info
+	.long		.Lname391
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #392: variable USERROW12
+	.section	.debug_info
+	.uleb128	392	; ref to abbrev 392
+	.section	.debug_abbrev
+	.uleb128	392
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname392:
+	.string		"USERROW12"
+	.section	.debug_info
+	.long		.Lname392
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #393: variable USERROW13
+	.section	.debug_info
+	.uleb128	393	; ref to abbrev 393
+	.section	.debug_abbrev
+	.uleb128	393
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname393:
+	.string		"USERROW13"
+	.section	.debug_info
+	.long		.Lname393
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #394: variable USERROW14
+	.section	.debug_info
+	.uleb128	394	; ref to abbrev 394
+	.section	.debug_abbrev
+	.uleb128	394
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname394:
+	.string		"USERROW14"
+	.section	.debug_info
+	.long		.Lname394
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #395: variable USERROW15
+	.section	.debug_info
+	.uleb128	395	; ref to abbrev 395
+	.section	.debug_abbrev
+	.uleb128	395
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname395:
+	.string		"USERROW15"
+	.section	.debug_info
+	.long		.Lname395
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x0F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #396: variable USERROW16
+	.section	.debug_info
+	.uleb128	396	; ref to abbrev 396
+	.section	.debug_abbrev
+	.uleb128	396
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname396:
+	.string		"USERROW16"
+	.section	.debug_info
+	.long		.Lname396
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #397: variable USERROW17
+	.section	.debug_info
+	.uleb128	397	; ref to abbrev 397
+	.section	.debug_abbrev
+	.uleb128	397
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname397:
+	.string		"USERROW17"
+	.section	.debug_info
+	.long		.Lname397
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #398: variable USERROW18
+	.section	.debug_info
+	.uleb128	398	; ref to abbrev 398
+	.section	.debug_abbrev
+	.uleb128	398
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname398:
+	.string		"USERROW18"
+	.section	.debug_info
+	.long		.Lname398
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #399: variable USERROW19
+	.section	.debug_info
+	.uleb128	399	; ref to abbrev 399
+	.section	.debug_abbrev
+	.uleb128	399
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname399:
+	.string		"USERROW19"
+	.section	.debug_info
+	.long		.Lname399
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #400: variable USERROW20
+	.section	.debug_info
+	.uleb128	400	; ref to abbrev 400
+	.section	.debug_abbrev
+	.uleb128	400
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname400:
+	.string		"USERROW20"
+	.section	.debug_info
+	.long		.Lname400
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #401: variable USERROW21
+	.section	.debug_info
+	.uleb128	401	; ref to abbrev 401
+	.section	.debug_abbrev
+	.uleb128	401
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname401:
+	.string		"USERROW21"
+	.section	.debug_info
+	.long		.Lname401
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #402: variable USERROW22
+	.section	.debug_info
+	.uleb128	402	; ref to abbrev 402
+	.section	.debug_abbrev
+	.uleb128	402
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname402:
+	.string		"USERROW22"
+	.section	.debug_info
+	.long		.Lname402
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #403: variable USERROW23
+	.section	.debug_info
+	.uleb128	403	; ref to abbrev 403
+	.section	.debug_abbrev
+	.uleb128	403
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname403:
+	.string		"USERROW23"
+	.section	.debug_info
+	.long		.Lname403
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #404: variable USERROW24
+	.section	.debug_info
+	.uleb128	404	; ref to abbrev 404
+	.section	.debug_abbrev
+	.uleb128	404
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname404:
+	.string		"USERROW24"
+	.section	.debug_info
+	.long		.Lname404
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #405: variable USERROW25
+	.section	.debug_info
+	.uleb128	405	; ref to abbrev 405
+	.section	.debug_abbrev
+	.uleb128	405
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname405:
+	.string		"USERROW25"
+	.section	.debug_info
+	.long		.Lname405
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x19
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #406: variable USERROW26
+	.section	.debug_info
+	.uleb128	406	; ref to abbrev 406
+	.section	.debug_abbrev
+	.uleb128	406
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname406:
+	.string		"USERROW26"
+	.section	.debug_info
+	.long		.Lname406
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x1A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #407: variable USERROW27
+	.section	.debug_info
+	.uleb128	407	; ref to abbrev 407
+	.section	.debug_abbrev
+	.uleb128	407
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname407:
+	.string		"USERROW27"
+	.section	.debug_info
+	.long		.Lname407
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x1B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #408: variable USERROW28
+	.section	.debug_info
+	.uleb128	408	; ref to abbrev 408
+	.section	.debug_abbrev
+	.uleb128	408
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname408:
+	.string		"USERROW28"
+	.section	.debug_info
+	.long		.Lname408
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x1C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #409: variable USERROW29
+	.section	.debug_info
+	.uleb128	409	; ref to abbrev 409
+	.section	.debug_abbrev
+	.uleb128	409
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname409:
+	.string		"USERROW29"
+	.section	.debug_info
+	.long		.Lname409
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x1D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #410: variable USERROW30
+	.section	.debug_info
+	.uleb128	410	; ref to abbrev 410
+	.section	.debug_abbrev
+	.uleb128	410
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname410:
+	.string		"USERROW30"
+	.section	.debug_info
+	.long		.Lname410
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x1E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #411: variable USERROW31
+	.section	.debug_info
+	.uleb128	411	; ref to abbrev 411
+	.section	.debug_abbrev
+	.uleb128	411
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname411:
+	.string		"USERROW31"
+	.section	.debug_info
+	.long		.Lname411
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x1F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #412: variable USERROW32
+	.section	.debug_info
+	.uleb128	412	; ref to abbrev 412
+	.section	.debug_abbrev
+	.uleb128	412
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname412:
+	.string		"USERROW32"
+	.section	.debug_info
+	.long		.Lname412
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #413: variable USERROW33
+	.section	.debug_info
+	.uleb128	413	; ref to abbrev 413
+	.section	.debug_abbrev
+	.uleb128	413
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname413:
+	.string		"USERROW33"
+	.section	.debug_info
+	.long		.Lname413
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x21
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #414: variable USERROW34
+	.section	.debug_info
+	.uleb128	414	; ref to abbrev 414
+	.section	.debug_abbrev
+	.uleb128	414
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname414:
+	.string		"USERROW34"
+	.section	.debug_info
+	.long		.Lname414
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x22
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #415: variable USERROW35
+	.section	.debug_info
+	.uleb128	415	; ref to abbrev 415
+	.section	.debug_abbrev
+	.uleb128	415
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname415:
+	.string		"USERROW35"
+	.section	.debug_info
+	.long		.Lname415
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x23
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #416: variable USERROW36
+	.section	.debug_info
+	.uleb128	416	; ref to abbrev 416
+	.section	.debug_abbrev
+	.uleb128	416
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname416:
+	.string		"USERROW36"
+	.section	.debug_info
+	.long		.Lname416
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x24
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #417: variable USERROW37
+	.section	.debug_info
+	.uleb128	417	; ref to abbrev 417
+	.section	.debug_abbrev
+	.uleb128	417
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname417:
+	.string		"USERROW37"
+	.section	.debug_info
+	.long		.Lname417
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x25
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #418: variable USERROW38
+	.section	.debug_info
+	.uleb128	418	; ref to abbrev 418
+	.section	.debug_abbrev
+	.uleb128	418
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname418:
+	.string		"USERROW38"
+	.section	.debug_info
+	.long		.Lname418
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x26
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #419: variable USERROW39
+	.section	.debug_info
+	.uleb128	419	; ref to abbrev 419
+	.section	.debug_abbrev
+	.uleb128	419
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname419:
+	.string		"USERROW39"
+	.section	.debug_info
+	.long		.Lname419
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x27
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #420: variable USERROW40
+	.section	.debug_info
+	.uleb128	420	; ref to abbrev 420
+	.section	.debug_abbrev
+	.uleb128	420
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname420:
+	.string		"USERROW40"
+	.section	.debug_info
+	.long		.Lname420
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x28
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #421: variable USERROW41
+	.section	.debug_info
+	.uleb128	421	; ref to abbrev 421
+	.section	.debug_abbrev
+	.uleb128	421
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname421:
+	.string		"USERROW41"
+	.section	.debug_info
+	.long		.Lname421
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x29
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #422: variable USERROW42
+	.section	.debug_info
+	.uleb128	422	; ref to abbrev 422
+	.section	.debug_abbrev
+	.uleb128	422
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname422:
+	.string		"USERROW42"
+	.section	.debug_info
+	.long		.Lname422
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x2A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #423: variable USERROW43
+	.section	.debug_info
+	.uleb128	423	; ref to abbrev 423
+	.section	.debug_abbrev
+	.uleb128	423
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname423:
+	.string		"USERROW43"
+	.section	.debug_info
+	.long		.Lname423
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x2B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #424: variable USERROW44
+	.section	.debug_info
+	.uleb128	424	; ref to abbrev 424
+	.section	.debug_abbrev
+	.uleb128	424
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname424:
+	.string		"USERROW44"
+	.section	.debug_info
+	.long		.Lname424
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x2C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #425: variable USERROW45
+	.section	.debug_info
+	.uleb128	425	; ref to abbrev 425
+	.section	.debug_abbrev
+	.uleb128	425
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname425:
+	.string		"USERROW45"
+	.section	.debug_info
+	.long		.Lname425
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x2D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #426: variable USERROW46
+	.section	.debug_info
+	.uleb128	426	; ref to abbrev 426
+	.section	.debug_abbrev
+	.uleb128	426
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname426:
+	.string		"USERROW46"
+	.section	.debug_info
+	.long		.Lname426
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x2E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #427: variable USERROW47
+	.section	.debug_info
+	.uleb128	427	; ref to abbrev 427
+	.section	.debug_abbrev
+	.uleb128	427
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname427:
+	.string		"USERROW47"
+	.section	.debug_info
+	.long		.Lname427
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x2F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #428: variable USERROW48
+	.section	.debug_info
+	.uleb128	428	; ref to abbrev 428
+	.section	.debug_abbrev
+	.uleb128	428
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname428:
+	.string		"USERROW48"
+	.section	.debug_info
+	.long		.Lname428
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x30
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #429: variable USERROW49
+	.section	.debug_info
+	.uleb128	429	; ref to abbrev 429
+	.section	.debug_abbrev
+	.uleb128	429
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname429:
+	.string		"USERROW49"
+	.section	.debug_info
+	.long		.Lname429
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x31
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #430: variable USERROW50
+	.section	.debug_info
+	.uleb128	430	; ref to abbrev 430
+	.section	.debug_abbrev
+	.uleb128	430
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname430:
+	.string		"USERROW50"
+	.section	.debug_info
+	.long		.Lname430
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x32
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #431: variable USERROW51
+	.section	.debug_info
+	.uleb128	431	; ref to abbrev 431
+	.section	.debug_abbrev
+	.uleb128	431
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname431:
+	.string		"USERROW51"
+	.section	.debug_info
+	.long		.Lname431
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x33
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #432: variable USERROW52
+	.section	.debug_info
+	.uleb128	432	; ref to abbrev 432
+	.section	.debug_abbrev
+	.uleb128	432
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname432:
+	.string		"USERROW52"
+	.section	.debug_info
+	.long		.Lname432
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x34
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #433: variable USERROW53
+	.section	.debug_info
+	.uleb128	433	; ref to abbrev 433
+	.section	.debug_abbrev
+	.uleb128	433
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname433:
+	.string		"USERROW53"
+	.section	.debug_info
+	.long		.Lname433
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x35
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #434: variable USERROW54
+	.section	.debug_info
+	.uleb128	434	; ref to abbrev 434
+	.section	.debug_abbrev
+	.uleb128	434
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname434:
+	.string		"USERROW54"
+	.section	.debug_info
+	.long		.Lname434
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x36
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #435: variable USERROW55
+	.section	.debug_info
+	.uleb128	435	; ref to abbrev 435
+	.section	.debug_abbrev
+	.uleb128	435
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname435:
+	.string		"USERROW55"
+	.section	.debug_info
+	.long		.Lname435
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x37
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #436: variable USERROW56
+	.section	.debug_info
+	.uleb128	436	; ref to abbrev 436
+	.section	.debug_abbrev
+	.uleb128	436
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname436:
+	.string		"USERROW56"
+	.section	.debug_info
+	.long		.Lname436
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x38
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #437: variable USERROW57
+	.section	.debug_info
+	.uleb128	437	; ref to abbrev 437
+	.section	.debug_abbrev
+	.uleb128	437
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname437:
+	.string		"USERROW57"
+	.section	.debug_info
+	.long		.Lname437
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x39
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #438: variable USERROW58
+	.section	.debug_info
+	.uleb128	438	; ref to abbrev 438
+	.section	.debug_abbrev
+	.uleb128	438
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname438:
+	.string		"USERROW58"
+	.section	.debug_info
+	.long		.Lname438
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x3A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #439: variable USERROW59
+	.section	.debug_info
+	.uleb128	439	; ref to abbrev 439
+	.section	.debug_abbrev
+	.uleb128	439
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname439:
+	.string		"USERROW59"
+	.section	.debug_info
+	.long		.Lname439
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x3B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #440: variable USERROW60
+	.section	.debug_info
+	.uleb128	440	; ref to abbrev 440
+	.section	.debug_abbrev
+	.uleb128	440
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname440:
+	.string		"USERROW60"
+	.section	.debug_info
+	.long		.Lname440
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x3C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #441: variable USERROW61
+	.section	.debug_info
+	.uleb128	441	; ref to abbrev 441
+	.section	.debug_abbrev
+	.uleb128	441
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname441:
+	.string		"USERROW61"
+	.section	.debug_info
+	.long		.Lname441
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x3D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #442: variable USERROW62
+	.section	.debug_info
+	.uleb128	442	; ref to abbrev 442
+	.section	.debug_abbrev
+	.uleb128	442
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname442:
+	.string		"USERROW62"
+	.section	.debug_info
+	.long		.Lname442
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x3E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #443: variable USERROW63
+	.section	.debug_info
+	.uleb128	443	; ref to abbrev 443
+	.section	.debug_abbrev
+	.uleb128	443
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname443:
+	.string		"USERROW63"
+	.section	.debug_info
+	.long		.Lname443
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x3F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #444: variable DIR
+	.section	.debug_info
+	.uleb128	444	; ref to abbrev 444
+	.section	.debug_abbrev
+	.uleb128	444
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname444:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname444
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0000 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #445: variable OUT
+	.section	.debug_info
+	.uleb128	445	; ref to abbrev 445
+	.section	.debug_abbrev
+	.uleb128	445
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname445:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname445
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0000 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #446: variable IN
+	.section	.debug_info
+	.uleb128	446	; ref to abbrev 446
+	.section	.debug_abbrev
+	.uleb128	446
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname446:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname446
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0000 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #447: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	447	; ref to abbrev 447
+	.section	.debug_abbrev
+	.uleb128	447
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname447:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname447
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0000 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #448: variable DIR
+	.section	.debug_info
+	.uleb128	448	; ref to abbrev 448
+	.section	.debug_abbrev
+	.uleb128	448
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname448:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname448
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0008 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #449: variable OUT
+	.section	.debug_info
+	.uleb128	449	; ref to abbrev 449
+	.section	.debug_abbrev
+	.uleb128	449
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname449:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname449
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0008 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #450: variable IN
+	.section	.debug_info
+	.uleb128	450	; ref to abbrev 450
+	.section	.debug_abbrev
+	.uleb128	450
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname450:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname450
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0008 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #451: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	451	; ref to abbrev 451
+	.section	.debug_abbrev
+	.uleb128	451
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname451:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname451
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0008 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #452: variable DIR
+	.section	.debug_info
+	.uleb128	452	; ref to abbrev 452
+	.section	.debug_abbrev
+	.uleb128	452
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname452:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname452
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x000C + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #453: variable OUT
+	.section	.debug_info
+	.uleb128	453	; ref to abbrev 453
+	.section	.debug_abbrev
+	.uleb128	453
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname453:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname453
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x000C + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #454: variable IN
+	.section	.debug_info
+	.uleb128	454	; ref to abbrev 454
+	.section	.debug_abbrev
+	.uleb128	454
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname454:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname454
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x000C + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #455: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	455	; ref to abbrev 455
+	.section	.debug_abbrev
+	.uleb128	455
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname455:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname455
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x000C + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #456: variable DIR
+	.section	.debug_info
+	.uleb128	456	; ref to abbrev 456
+	.section	.debug_abbrev
+	.uleb128	456
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname456:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname456
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0014 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #457: variable OUT
+	.section	.debug_info
+	.uleb128	457	; ref to abbrev 457
+	.section	.debug_abbrev
+	.uleb128	457
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname457:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname457
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0014 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #458: variable IN
+	.section	.debug_info
+	.uleb128	458	; ref to abbrev 458
+	.section	.debug_abbrev
+	.uleb128	458
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname458:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname458
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0014 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #459: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	459	; ref to abbrev 459
+	.section	.debug_abbrev
+	.uleb128	459
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname459:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname459
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0014 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #460: variable DAC0REF
+	.section	.debug_info
+	.uleb128	460	; ref to abbrev 460
+	.section	.debug_abbrev
+	.uleb128	460
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname460:
+	.string		"DAC0REF"
+	.section	.debug_info
+	.long		.Lname460
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00B0 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #461: variable ACREF
+	.section	.debug_info
+	.uleb128	461	; ref to abbrev 461
+	.section	.debug_abbrev
+	.uleb128	461
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname461:
+	.string		"ACREF"
+	.section	.debug_info
+	.long		.Lname461
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00B0 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #462: variable CTRLA
+	.section	.debug_info
+	.uleb128	462	; ref to abbrev 462
+	.section	.debug_abbrev
+	.uleb128	462
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname462:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname462
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0100 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #463: variable STATUS
+	.section	.debug_info
+	.uleb128	463	; ref to abbrev 463
+	.section	.debug_abbrev
+	.uleb128	463
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname463:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname463
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0100 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #464: variable CTRLA
+	.section	.debug_info
+	.uleb128	464	; ref to abbrev 464
+	.section	.debug_abbrev
+	.uleb128	464
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname464:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname464
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #465: variable CTRLB
+	.section	.debug_info
+	.uleb128	465	; ref to abbrev 465
+	.section	.debug_abbrev
+	.uleb128	465
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname465:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname465
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #466: variable CTRLC
+	.section	.debug_info
+	.uleb128	466	; ref to abbrev 466
+	.section	.debug_abbrev
+	.uleb128	466
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname466:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname466
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #467: variable EVCTRLA
+	.section	.debug_info
+	.uleb128	467	; ref to abbrev 467
+	.section	.debug_abbrev
+	.uleb128	467
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname467:
+	.string		"EVCTRLA"
+	.section	.debug_info
+	.long		.Lname467
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #468: variable EVCTRLB
+	.section	.debug_info
+	.uleb128	468	; ref to abbrev 468
+	.section	.debug_abbrev
+	.uleb128	468
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname468:
+	.string		"EVCTRLB"
+	.section	.debug_info
+	.long		.Lname468
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #469: variable EVCTRLC
+	.section	.debug_info
+	.uleb128	469	; ref to abbrev 469
+	.section	.debug_abbrev
+	.uleb128	469
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname469:
+	.string		"EVCTRLC"
+	.section	.debug_info
+	.long		.Lname469
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #470: variable BUFCTRL
+	.section	.debug_info
+	.uleb128	470	; ref to abbrev 470
+	.section	.debug_abbrev
+	.uleb128	470
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname470:
+	.string		"BUFCTRL"
+	.section	.debug_info
+	.long		.Lname470
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #471: variable BLANKCTRL
+	.section	.debug_info
+	.uleb128	471	; ref to abbrev 471
+	.section	.debug_abbrev
+	.uleb128	471
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname471:
+	.string		"BLANKCTRL"
+	.section	.debug_info
+	.long		.Lname471
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #472: variable BLANKTIME
+	.section	.debug_info
+	.uleb128	472	; ref to abbrev 472
+	.section	.debug_abbrev
+	.uleb128	472
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname472:
+	.string		"BLANKTIME"
+	.section	.debug_info
+	.long		.Lname472
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #473: variable FAULTCTRL
+	.section	.debug_info
+	.uleb128	473	; ref to abbrev 473
+	.section	.debug_abbrev
+	.uleb128	473
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname473:
+	.string		"FAULTCTRL"
+	.section	.debug_info
+	.long		.Lname473
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #474: variable FAULTDRV
+	.section	.debug_info
+	.uleb128	474	; ref to abbrev 474
+	.section	.debug_abbrev
+	.uleb128	474
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname474:
+	.string		"FAULTDRV"
+	.section	.debug_info
+	.long		.Lname474
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #475: variable FAULTOUT
+	.section	.debug_info
+	.uleb128	475	; ref to abbrev 475
+	.section	.debug_abbrev
+	.uleb128	475
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname475:
+	.string		"FAULTOUT"
+	.section	.debug_info
+	.long		.Lname475
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #476: variable INTCTRL
+	.section	.debug_info
+	.uleb128	476	; ref to abbrev 476
+	.section	.debug_abbrev
+	.uleb128	476
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname476:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname476
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #477: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	477	; ref to abbrev 477
+	.section	.debug_abbrev
+	.uleb128	477
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname477:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname477
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #478: variable STATUS
+	.section	.debug_info
+	.uleb128	478	; ref to abbrev 478
+	.section	.debug_abbrev
+	.uleb128	478
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname478:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname478
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x0F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #479: variable DTLS
+	.section	.debug_info
+	.uleb128	479	; ref to abbrev 479
+	.section	.debug_abbrev
+	.uleb128	479
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname479:
+	.string		"DTLS"
+	.section	.debug_info
+	.long		.Lname479
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #480: variable DTHS
+	.section	.debug_info
+	.uleb128	480	; ref to abbrev 480
+	.section	.debug_abbrev
+	.uleb128	480
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname480:
+	.string		"DTHS"
+	.section	.debug_info
+	.long		.Lname480
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #481: variable DTBOTH
+	.section	.debug_info
+	.uleb128	481	; ref to abbrev 481
+	.section	.debug_abbrev
+	.uleb128	481
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname481:
+	.string		"DTBOTH"
+	.section	.debug_info
+	.long		.Lname481
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #482: variable SWAP
+	.section	.debug_info
+	.uleb128	482	; ref to abbrev 482
+	.section	.debug_abbrev
+	.uleb128	482
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname482:
+	.string		"SWAP"
+	.section	.debug_info
+	.long		.Lname482
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #483: variable PGMOVR
+	.section	.debug_info
+	.uleb128	483	; ref to abbrev 483
+	.section	.debug_abbrev
+	.uleb128	483
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname483:
+	.string		"PGMOVR"
+	.section	.debug_info
+	.long		.Lname483
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #484: variable PGMOUT
+	.section	.debug_info
+	.uleb128	484	; ref to abbrev 484
+	.section	.debug_abbrev
+	.uleb128	484
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname484:
+	.string		"PGMOUT"
+	.section	.debug_info
+	.long		.Lname484
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #485: variable OUTOVEN
+	.section	.debug_info
+	.uleb128	485	; ref to abbrev 485
+	.section	.debug_abbrev
+	.uleb128	485
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname485:
+	.string		"OUTOVEN"
+	.section	.debug_info
+	.long		.Lname485
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #486: variable DTLSBUF
+	.section	.debug_info
+	.uleb128	486	; ref to abbrev 486
+	.section	.debug_abbrev
+	.uleb128	486
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname486:
+	.string		"DTLSBUF"
+	.section	.debug_info
+	.long		.Lname486
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #487: variable DTHSBUF
+	.section	.debug_info
+	.uleb128	487	; ref to abbrev 487
+	.section	.debug_abbrev
+	.uleb128	487
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname487:
+	.string		"DTHSBUF"
+	.section	.debug_info
+	.long		.Lname487
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x19
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #488: variable DTBOTHBUF
+	.section	.debug_info
+	.uleb128	488	; ref to abbrev 488
+	.section	.debug_abbrev
+	.uleb128	488
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname488:
+	.string		"DTBOTHBUF"
+	.section	.debug_info
+	.long		.Lname488
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x1A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #489: variable SWAPBUF
+	.section	.debug_info
+	.uleb128	489	; ref to abbrev 489
+	.section	.debug_abbrev
+	.uleb128	489
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname489:
+	.string		"SWAPBUF"
+	.section	.debug_info
+	.long		.Lname489
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x1B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #490: variable PGMOVRBUF
+	.section	.debug_info
+	.uleb128	490	; ref to abbrev 490
+	.section	.debug_abbrev
+	.uleb128	490
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname490:
+	.string		"PGMOVRBUF"
+	.section	.debug_info
+	.long		.Lname490
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x1C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #491: variable PGMOUTBUF
+	.section	.debug_info
+	.uleb128	491	; ref to abbrev 491
+	.section	.debug_abbrev
+	.uleb128	491
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname491:
+	.string		"PGMOUTBUF"
+	.section	.debug_info
+	.long		.Lname491
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x1D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+	;; trailer
+	.section	.debug_abbrev
+	.uleb128	0
+
+	.section	.debug_info
+	.uleb128	0
+.Leinfo:

--- a/crt1/iosym/avr16eb32.S
+++ b/crt1/iosym/avr16eb32.S
@@ -1,0 +1,26044 @@
+/* This file is part of avr-libc.
+
+   Automatically created by devtools/ioreg.pl
+   DO NOT EDIT!
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in
+     the documentation and/or other materials provided with the
+     distribution.
+
+   * Neither the name of the copyright holders nor the names of
+     contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE. */
+
+/* $Id$ */
+
+#include <avr/version.h>
+
+#define DW_TAG_array_type               0x01
+#define DW_TAG_compile_unit             0x11
+#define DW_TAG_typedef                  0x16
+#define DW_TAG_subrange_type            0x21
+#define DW_TAG_base_type                0x24
+#define DW_TAG_variable                 0x34
+
+#define DW_FORM_addr                    0x01
+#define DW_FORM_block1                  0x0a
+#define DW_FORM_block2                  0x03
+#define DW_FORM_block4                  0x04
+#define DW_FORM_data1                   0x0b
+#define DW_FORM_data2                   0x05
+#define DW_FORM_data4                   0x06
+#define DW_FORM_data8                   0x07
+#define DW_FORM_string                  0x08
+#define DW_FORM_flag                    0x0c
+#define DW_FORM_strp                    0x0e
+#define DW_FORM_ref1                    0x11
+#define DW_FORM_ref2                    0x12
+#define DW_FORM_ref4                    0x13
+#define DW_FORM_ref8                    0x14
+
+#define DW_AT_location                  0x02
+#define DW_AT_name                      0x03
+#define DW_AT_byte_size                 0x0b
+#define DW_AT_stmt_list                 0x10
+#define DW_AT_language                  0x13
+#define DW_AT_producer                  0x25
+#define DW_AT_upper_bound               0x2f
+#define DW_AT_decl_file                 0x3a
+#define DW_AT_decl_line                 0x3b
+#define DW_AT_encoding                  0x3e
+#define DW_AT_external                  0x3f
+#define DW_AT_type                      0x49
+
+#define DW_LANG_C89                     0x0001
+
+#define DW_CHILDREN_no                  0x00
+#define DW_CHILDREN_yes                 0x01
+
+#define DW_ATE_unsigned                 0x7
+#define DW_ATE_unsigned_char            0x8
+
+#define DW_OP_addr                      0x03
+.eject
+	.section	.debug_abbrev, "", @progbits
+.Ldebug_abbrev0:
+	.section	.debug_info, "", @progbits
+	.section	.debug_line, "", @progbits
+.Ldebug_line0:
+	.section	.debug_str, "", @progbits
+
+	.section	.debug_info, "", @progbits
+	;; compilation unit header
+.Lssinfo:
+	.long	.Leinfo - .Lsinfo
+.Lsinfo:
+	.word	2		; DWARF-2
+	.long	.Ldebug_abbrev0
+	.byte	4		; sizeof(address)
+
+
+	;; DIE #1: compilation unit
+	.section	.debug_info
+	.uleb128	1	; ref to abbrev 1
+	.section	.debug_abbrev
+	.uleb128	1
+	.uleb128	DW_TAG_compile_unit
+	.byte		DW_CHILDREN_yes
+
+	.uleb128	DW_AT_producer
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lproducer:
+	.ascii		"avr-libc "
+	.asciz		__AVR_LIBC_VERSION_STRING__
+	.section	.debug_info
+	.long		.Lproducer
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_stmt_list
+	.uleb128	DW_FORM_data4
+	.section	.debug_info
+	.long		.Ldebug_line0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+	;; DIE #2: base type uint8_t
+	.section	.debug_info
+.Luint8_t:
+	.uleb128	2	; ref to abbrev 2
+	.section	.debug_abbrev
+	.uleb128	2
+	.uleb128	DW_TAG_base_type
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Luint8_t_name:
+	.string		"uint8_t"
+	.section	.debug_info
+	.long		.Luint8_t_name
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_byte_size
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_encoding
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		DW_ATE_unsigned_char
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+	;; DIE #3: base type uint16_t
+	.section	.debug_info
+.Luint16_t:
+	.uleb128	3	; ref to abbrev 3
+	.section	.debug_abbrev
+	.uleb128	3
+	.uleb128	DW_TAG_base_type
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Luint16_t_name:
+	.string		"uint16_t"
+	.section	.debug_info
+	.long		.Luint16_t_name
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_byte_size
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		2
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_encoding
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		DW_ATE_unsigned
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #4: variable CTRLA
+	.section	.debug_info
+	.uleb128	4	; ref to abbrev 4
+	.section	.debug_abbrev
+	.uleb128	4
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname4:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname4
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #5: variable CTRLB
+	.section	.debug_info
+	.uleb128	5	; ref to abbrev 5
+	.section	.debug_abbrev
+	.uleb128	5
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname5:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname5
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #6: variable MUXCTRL
+	.section	.debug_info
+	.uleb128	6	; ref to abbrev 6
+	.section	.debug_abbrev
+	.uleb128	6
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname6:
+	.string		"MUXCTRL"
+	.section	.debug_info
+	.long		.Lname6
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #7: variable DACREF
+	.section	.debug_info
+	.uleb128	7	; ref to abbrev 7
+	.section	.debug_abbrev
+	.uleb128	7
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname7:
+	.string		"DACREF"
+	.section	.debug_info
+	.long		.Lname7
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #8: variable INTCTRL
+	.section	.debug_info
+	.uleb128	8	; ref to abbrev 8
+	.section	.debug_abbrev
+	.uleb128	8
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname8:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname8
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #9: variable STATUS
+	.section	.debug_info
+	.uleb128	9	; ref to abbrev 9
+	.section	.debug_abbrev
+	.uleb128	9
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname9:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname9
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #10: variable CTRLA
+	.section	.debug_info
+	.uleb128	10	; ref to abbrev 10
+	.section	.debug_abbrev
+	.uleb128	10
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname10:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname10
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #11: variable CTRLB
+	.section	.debug_info
+	.uleb128	11	; ref to abbrev 11
+	.section	.debug_abbrev
+	.uleb128	11
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname11:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname11
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #12: variable MUXCTRL
+	.section	.debug_info
+	.uleb128	12	; ref to abbrev 12
+	.section	.debug_abbrev
+	.uleb128	12
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname12:
+	.string		"MUXCTRL"
+	.section	.debug_info
+	.long		.Lname12
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #13: variable DACREF
+	.section	.debug_info
+	.uleb128	13	; ref to abbrev 13
+	.section	.debug_abbrev
+	.uleb128	13
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname13:
+	.string		"DACREF"
+	.section	.debug_info
+	.long		.Lname13
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #14: variable INTCTRL
+	.section	.debug_info
+	.uleb128	14	; ref to abbrev 14
+	.section	.debug_abbrev
+	.uleb128	14
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname14:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname14
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #15: variable STATUS
+	.section	.debug_info
+	.uleb128	15	; ref to abbrev 15
+	.section	.debug_abbrev
+	.uleb128	15
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname15:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname15
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #16: variable CTRLA
+	.section	.debug_info
+	.uleb128	16	; ref to abbrev 16
+	.section	.debug_abbrev
+	.uleb128	16
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname16:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname16
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #17: variable CTRLB
+	.section	.debug_info
+	.uleb128	17	; ref to abbrev 17
+	.section	.debug_abbrev
+	.uleb128	17
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname17:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname17
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #18: variable CTRLC
+	.section	.debug_info
+	.uleb128	18	; ref to abbrev 18
+	.section	.debug_abbrev
+	.uleb128	18
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname18:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname18
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #19: variable CTRLD
+	.section	.debug_info
+	.uleb128	19	; ref to abbrev 19
+	.section	.debug_abbrev
+	.uleb128	19
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname19:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname19
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #20: variable INTCTRL
+	.section	.debug_info
+	.uleb128	20	; ref to abbrev 20
+	.section	.debug_abbrev
+	.uleb128	20
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname20:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname20
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #21: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	21	; ref to abbrev 21
+	.section	.debug_abbrev
+	.uleb128	21
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname21:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname21
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #22: variable STATUS
+	.section	.debug_info
+	.uleb128	22	; ref to abbrev 22
+	.section	.debug_abbrev
+	.uleb128	22
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname22:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname22
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #23: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	23	; ref to abbrev 23
+	.section	.debug_abbrev
+	.uleb128	23
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname23:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname23
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #24: variable CTRLE
+	.section	.debug_info
+	.uleb128	24	; ref to abbrev 24
+	.section	.debug_abbrev
+	.uleb128	24
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname24:
+	.string		"CTRLE"
+	.section	.debug_info
+	.long		.Lname24
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #25: variable CTRLF
+	.section	.debug_info
+	.uleb128	25	; ref to abbrev 25
+	.section	.debug_abbrev
+	.uleb128	25
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname25:
+	.string		"CTRLF"
+	.section	.debug_info
+	.long		.Lname25
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #26: variable COMMAND
+	.section	.debug_info
+	.uleb128	26	; ref to abbrev 26
+	.section	.debug_abbrev
+	.uleb128	26
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname26:
+	.string		"COMMAND"
+	.section	.debug_info
+	.long		.Lname26
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #27: variable PGACTRL
+	.section	.debug_info
+	.uleb128	27	; ref to abbrev 27
+	.section	.debug_abbrev
+	.uleb128	27
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname27:
+	.string		"PGACTRL"
+	.section	.debug_info
+	.long		.Lname27
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #28: variable MUXPOS
+	.section	.debug_info
+	.uleb128	28	; ref to abbrev 28
+	.section	.debug_abbrev
+	.uleb128	28
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname28:
+	.string		"MUXPOS"
+	.section	.debug_info
+	.long		.Lname28
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #29: variable MUXNEG
+	.section	.debug_info
+	.uleb128	29	; ref to abbrev 29
+	.section	.debug_abbrev
+	.uleb128	29
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname29:
+	.string		"MUXNEG"
+	.section	.debug_info
+	.long		.Lname29
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #30: base type uint32_t
+	.section	.debug_info
+.Luint32_t:
+	.uleb128	30	; ref to abbrev 30
+	.section	.debug_abbrev
+	.uleb128	30
+	.uleb128	DW_TAG_base_type
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Luint32_t_name:
+	.string		"uint32_t"
+	.section	.debug_info
+	.long		.Luint32_t_name
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_byte_size
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		4
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_encoding
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		DW_ATE_unsigned
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #31: variable RESULT
+	.section	.debug_info
+	.uleb128	31	; ref to abbrev 31
+	.section	.debug_abbrev
+	.uleb128	31
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname31:
+	.string		"RESULT"
+	.section	.debug_info
+	.long		.Lname31
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint32_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #32: variable SAMPLE
+	.section	.debug_info
+	.uleb128	32	; ref to abbrev 32
+	.section	.debug_abbrev
+	.uleb128	32
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname32:
+	.string		"SAMPLE"
+	.section	.debug_info
+	.long		.Lname32
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #33: variable TEMP0
+	.section	.debug_info
+	.uleb128	33	; ref to abbrev 33
+	.section	.debug_abbrev
+	.uleb128	33
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname33:
+	.string		"TEMP0"
+	.section	.debug_info
+	.long		.Lname33
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #34: variable TEMP1
+	.section	.debug_info
+	.uleb128	34	; ref to abbrev 34
+	.section	.debug_abbrev
+	.uleb128	34
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname34:
+	.string		"TEMP1"
+	.section	.debug_info
+	.long		.Lname34
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x19
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #35: variable TEMP2
+	.section	.debug_info
+	.uleb128	35	; ref to abbrev 35
+	.section	.debug_abbrev
+	.uleb128	35
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname35:
+	.string		"TEMP2"
+	.section	.debug_info
+	.long		.Lname35
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x1A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #36: variable WINLT
+	.section	.debug_info
+	.uleb128	36	; ref to abbrev 36
+	.section	.debug_abbrev
+	.uleb128	36
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname36:
+	.string		"WINLT"
+	.section	.debug_info
+	.long		.Lname36
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x1C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #37: variable WINHT
+	.section	.debug_info
+	.uleb128	37	; ref to abbrev 37
+	.section	.debug_abbrev
+	.uleb128	37
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname37:
+	.string		"WINHT"
+	.section	.debug_info
+	.long		.Lname37
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x1E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #38: variable CTRLA
+	.section	.debug_info
+	.uleb128	38	; ref to abbrev 38
+	.section	.debug_abbrev
+	.uleb128	38
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname38:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname38
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #39: variable CTRLB
+	.section	.debug_info
+	.uleb128	39	; ref to abbrev 39
+	.section	.debug_abbrev
+	.uleb128	39
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname39:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname39
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #40: variable VLMCTRLA
+	.section	.debug_info
+	.uleb128	40	; ref to abbrev 40
+	.section	.debug_abbrev
+	.uleb128	40
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname40:
+	.string		"VLMCTRLA"
+	.section	.debug_info
+	.long		.Lname40
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #41: variable INTCTRL
+	.section	.debug_info
+	.uleb128	41	; ref to abbrev 41
+	.section	.debug_abbrev
+	.uleb128	41
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname41:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname41
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #42: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	42	; ref to abbrev 42
+	.section	.debug_abbrev
+	.uleb128	42
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname42:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname42
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #43: variable STATUS
+	.section	.debug_info
+	.uleb128	43	; ref to abbrev 43
+	.section	.debug_abbrev
+	.uleb128	43
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname43:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname43
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #44: variable BOOTROW
+	.section	.debug_info
+	.uleb128	44	; ref to abbrev 44
+	.section	.debug_abbrev
+	.uleb128	44
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname44:
+	.string		"BOOTROW"
+	.section	.debug_info
+	.long		.Lname44
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #45: variable CTRLA
+	.section	.debug_info
+	.uleb128	45	; ref to abbrev 45
+	.section	.debug_abbrev
+	.uleb128	45
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname45:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname45
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #46: variable SEQCTRL0
+	.section	.debug_info
+	.uleb128	46	; ref to abbrev 46
+	.section	.debug_abbrev
+	.uleb128	46
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname46:
+	.string		"SEQCTRL0"
+	.section	.debug_info
+	.long		.Lname46
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #47: variable SEQCTRL1
+	.section	.debug_info
+	.uleb128	47	; ref to abbrev 47
+	.section	.debug_abbrev
+	.uleb128	47
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname47:
+	.string		"SEQCTRL1"
+	.section	.debug_info
+	.long		.Lname47
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #48: variable INTCTRL0
+	.section	.debug_info
+	.uleb128	48	; ref to abbrev 48
+	.section	.debug_abbrev
+	.uleb128	48
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname48:
+	.string		"INTCTRL0"
+	.section	.debug_info
+	.long		.Lname48
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #49: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	49	; ref to abbrev 49
+	.section	.debug_abbrev
+	.uleb128	49
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname49:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname49
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #50: variable LUT0CTRLA
+	.section	.debug_info
+	.uleb128	50	; ref to abbrev 50
+	.section	.debug_abbrev
+	.uleb128	50
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname50:
+	.string		"LUT0CTRLA"
+	.section	.debug_info
+	.long		.Lname50
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #51: variable LUT0CTRLB
+	.section	.debug_info
+	.uleb128	51	; ref to abbrev 51
+	.section	.debug_abbrev
+	.uleb128	51
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname51:
+	.string		"LUT0CTRLB"
+	.section	.debug_info
+	.long		.Lname51
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #52: variable LUT0CTRLC
+	.section	.debug_info
+	.uleb128	52	; ref to abbrev 52
+	.section	.debug_abbrev
+	.uleb128	52
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname52:
+	.string		"LUT0CTRLC"
+	.section	.debug_info
+	.long		.Lname52
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #53: variable TRUTH0
+	.section	.debug_info
+	.uleb128	53	; ref to abbrev 53
+	.section	.debug_abbrev
+	.uleb128	53
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname53:
+	.string		"TRUTH0"
+	.section	.debug_info
+	.long		.Lname53
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #54: variable LUT1CTRLA
+	.section	.debug_info
+	.uleb128	54	; ref to abbrev 54
+	.section	.debug_abbrev
+	.uleb128	54
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname54:
+	.string		"LUT1CTRLA"
+	.section	.debug_info
+	.long		.Lname54
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #55: variable LUT1CTRLB
+	.section	.debug_info
+	.uleb128	55	; ref to abbrev 55
+	.section	.debug_abbrev
+	.uleb128	55
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname55:
+	.string		"LUT1CTRLB"
+	.section	.debug_info
+	.long		.Lname55
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #56: variable LUT1CTRLC
+	.section	.debug_info
+	.uleb128	56	; ref to abbrev 56
+	.section	.debug_abbrev
+	.uleb128	56
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname56:
+	.string		"LUT1CTRLC"
+	.section	.debug_info
+	.long		.Lname56
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #57: variable TRUTH1
+	.section	.debug_info
+	.uleb128	57	; ref to abbrev 57
+	.section	.debug_abbrev
+	.uleb128	57
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname57:
+	.string		"TRUTH1"
+	.section	.debug_info
+	.long		.Lname57
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #58: variable LUT2CTRLA
+	.section	.debug_info
+	.uleb128	58	; ref to abbrev 58
+	.section	.debug_abbrev
+	.uleb128	58
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname58:
+	.string		"LUT2CTRLA"
+	.section	.debug_info
+	.long		.Lname58
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #59: variable LUT2CTRLB
+	.section	.debug_info
+	.uleb128	59	; ref to abbrev 59
+	.section	.debug_abbrev
+	.uleb128	59
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname59:
+	.string		"LUT2CTRLB"
+	.section	.debug_info
+	.long		.Lname59
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #60: variable LUT2CTRLC
+	.section	.debug_info
+	.uleb128	60	; ref to abbrev 60
+	.section	.debug_abbrev
+	.uleb128	60
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname60:
+	.string		"LUT2CTRLC"
+	.section	.debug_info
+	.long		.Lname60
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #61: variable TRUTH2
+	.section	.debug_info
+	.uleb128	61	; ref to abbrev 61
+	.section	.debug_abbrev
+	.uleb128	61
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname61:
+	.string		"TRUTH2"
+	.section	.debug_info
+	.long		.Lname61
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #62: variable LUT3CTRLA
+	.section	.debug_info
+	.uleb128	62	; ref to abbrev 62
+	.section	.debug_abbrev
+	.uleb128	62
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname62:
+	.string		"LUT3CTRLA"
+	.section	.debug_info
+	.long		.Lname62
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #63: variable LUT3CTRLB
+	.section	.debug_info
+	.uleb128	63	; ref to abbrev 63
+	.section	.debug_abbrev
+	.uleb128	63
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname63:
+	.string		"LUT3CTRLB"
+	.section	.debug_info
+	.long		.Lname63
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #64: variable LUT3CTRLC
+	.section	.debug_info
+	.uleb128	64	; ref to abbrev 64
+	.section	.debug_abbrev
+	.uleb128	64
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname64:
+	.string		"LUT3CTRLC"
+	.section	.debug_info
+	.long		.Lname64
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #65: variable TRUTH3
+	.section	.debug_info
+	.uleb128	65	; ref to abbrev 65
+	.section	.debug_abbrev
+	.uleb128	65
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname65:
+	.string		"TRUTH3"
+	.section	.debug_info
+	.long		.Lname65
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #66: variable MCLKCTRLA
+	.section	.debug_info
+	.uleb128	66	; ref to abbrev 66
+	.section	.debug_abbrev
+	.uleb128	66
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname66:
+	.string		"MCLKCTRLA"
+	.section	.debug_info
+	.long		.Lname66
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #67: variable MCLKCTRLB
+	.section	.debug_info
+	.uleb128	67	; ref to abbrev 67
+	.section	.debug_abbrev
+	.uleb128	67
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname67:
+	.string		"MCLKCTRLB"
+	.section	.debug_info
+	.long		.Lname67
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #68: variable MCLKSTATUS
+	.section	.debug_info
+	.uleb128	68	; ref to abbrev 68
+	.section	.debug_abbrev
+	.uleb128	68
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname68:
+	.string		"MCLKSTATUS"
+	.section	.debug_info
+	.long		.Lname68
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #69: variable MCLKTIMEBASE
+	.section	.debug_info
+	.uleb128	69	; ref to abbrev 69
+	.section	.debug_abbrev
+	.uleb128	69
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname69:
+	.string		"MCLKTIMEBASE"
+	.section	.debug_info
+	.long		.Lname69
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #70: variable OSCHFCTRLA
+	.section	.debug_info
+	.uleb128	70	; ref to abbrev 70
+	.section	.debug_abbrev
+	.uleb128	70
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname70:
+	.string		"OSCHFCTRLA"
+	.section	.debug_info
+	.long		.Lname70
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #71: variable OSCHFTUNE
+	.section	.debug_info
+	.uleb128	71	; ref to abbrev 71
+	.section	.debug_abbrev
+	.uleb128	71
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname71:
+	.string		"OSCHFTUNE"
+	.section	.debug_info
+	.long		.Lname71
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #72: variable PLLCTRLA
+	.section	.debug_info
+	.uleb128	72	; ref to abbrev 72
+	.section	.debug_abbrev
+	.uleb128	72
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname72:
+	.string		"PLLCTRLA"
+	.section	.debug_info
+	.long		.Lname72
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #73: variable PLLCTRLB
+	.section	.debug_info
+	.uleb128	73	; ref to abbrev 73
+	.section	.debug_abbrev
+	.uleb128	73
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname73:
+	.string		"PLLCTRLB"
+	.section	.debug_info
+	.long		.Lname73
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #74: variable OSC32KCTRLA
+	.section	.debug_info
+	.uleb128	74	; ref to abbrev 74
+	.section	.debug_abbrev
+	.uleb128	74
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname74:
+	.string		"OSC32KCTRLA"
+	.section	.debug_info
+	.long		.Lname74
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #75: variable XOSC32KCTRLA
+	.section	.debug_info
+	.uleb128	75	; ref to abbrev 75
+	.section	.debug_abbrev
+	.uleb128	75
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname75:
+	.string		"XOSC32KCTRLA"
+	.section	.debug_info
+	.long		.Lname75
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x1C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #76: variable CCP
+	.section	.debug_info
+	.uleb128	76	; ref to abbrev 76
+	.section	.debug_abbrev
+	.uleb128	76
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname76:
+	.string		"CCP"
+	.section	.debug_info
+	.long		.Lname76
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0030 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #77: variable RAMPZ
+	.section	.debug_info
+	.uleb128	77	; ref to abbrev 77
+	.section	.debug_abbrev
+	.uleb128	77
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname77:
+	.string		"RAMPZ"
+	.section	.debug_info
+	.long		.Lname77
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0030 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #78: variable SP
+	.section	.debug_info
+	.uleb128	78	; ref to abbrev 78
+	.section	.debug_abbrev
+	.uleb128	78
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname78:
+	.string		"SP"
+	.section	.debug_info
+	.long		.Lname78
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0030 + 0xD
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #79: variable SREG
+	.section	.debug_info
+	.uleb128	79	; ref to abbrev 79
+	.section	.debug_abbrev
+	.uleb128	79
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname79:
+	.string		"SREG"
+	.section	.debug_info
+	.long		.Lname79
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0030 + 0xF
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #80: variable CTRLA
+	.section	.debug_info
+	.uleb128	80	; ref to abbrev 80
+	.section	.debug_abbrev
+	.uleb128	80
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname80:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname80
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0110 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #81: variable STATUS
+	.section	.debug_info
+	.uleb128	81	; ref to abbrev 81
+	.section	.debug_abbrev
+	.uleb128	81
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname81:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname81
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0110 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #82: variable LVL0PRI
+	.section	.debug_info
+	.uleb128	82	; ref to abbrev 82
+	.section	.debug_abbrev
+	.uleb128	82
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname82:
+	.string		"LVL0PRI"
+	.section	.debug_info
+	.long		.Lname82
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0110 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #83: variable LVL1VEC
+	.section	.debug_info
+	.uleb128	83	; ref to abbrev 83
+	.section	.debug_abbrev
+	.uleb128	83
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname83:
+	.string		"LVL1VEC"
+	.section	.debug_info
+	.long		.Lname83
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0110 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #84: variable CTRLA
+	.section	.debug_info
+	.uleb128	84	; ref to abbrev 84
+	.section	.debug_abbrev
+	.uleb128	84
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname84:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname84
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0120 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #85: variable CTRLB
+	.section	.debug_info
+	.uleb128	85	; ref to abbrev 85
+	.section	.debug_abbrev
+	.uleb128	85
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname85:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname85
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0120 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #86: variable STATUS
+	.section	.debug_info
+	.uleb128	86	; ref to abbrev 86
+	.section	.debug_abbrev
+	.uleb128	86
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname86:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname86
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0120 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #87: variable SWEVENTA
+	.section	.debug_info
+	.uleb128	87	; ref to abbrev 87
+	.section	.debug_abbrev
+	.uleb128	87
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname87:
+	.string		"SWEVENTA"
+	.section	.debug_info
+	.long		.Lname87
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #88: variable CHANNEL0
+	.section	.debug_info
+	.uleb128	88	; ref to abbrev 88
+	.section	.debug_abbrev
+	.uleb128	88
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname88:
+	.string		"CHANNEL0"
+	.section	.debug_info
+	.long		.Lname88
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #89: variable CHANNEL1
+	.section	.debug_info
+	.uleb128	89	; ref to abbrev 89
+	.section	.debug_abbrev
+	.uleb128	89
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname89:
+	.string		"CHANNEL1"
+	.section	.debug_info
+	.long		.Lname89
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #90: variable CHANNEL2
+	.section	.debug_info
+	.uleb128	90	; ref to abbrev 90
+	.section	.debug_abbrev
+	.uleb128	90
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname90:
+	.string		"CHANNEL2"
+	.section	.debug_info
+	.long		.Lname90
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #91: variable CHANNEL3
+	.section	.debug_info
+	.uleb128	91	; ref to abbrev 91
+	.section	.debug_abbrev
+	.uleb128	91
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname91:
+	.string		"CHANNEL3"
+	.section	.debug_info
+	.long		.Lname91
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #92: variable CHANNEL4
+	.section	.debug_info
+	.uleb128	92	; ref to abbrev 92
+	.section	.debug_abbrev
+	.uleb128	92
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname92:
+	.string		"CHANNEL4"
+	.section	.debug_info
+	.long		.Lname92
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #93: variable CHANNEL5
+	.section	.debug_info
+	.uleb128	93	; ref to abbrev 93
+	.section	.debug_abbrev
+	.uleb128	93
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname93:
+	.string		"CHANNEL5"
+	.section	.debug_info
+	.long		.Lname93
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #94: variable USERCCLLUT0A
+	.section	.debug_info
+	.uleb128	94	; ref to abbrev 94
+	.section	.debug_abbrev
+	.uleb128	94
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname94:
+	.string		"USERCCLLUT0A"
+	.section	.debug_info
+	.long		.Lname94
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #95: variable USERCCLLUT0B
+	.section	.debug_info
+	.uleb128	95	; ref to abbrev 95
+	.section	.debug_abbrev
+	.uleb128	95
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname95:
+	.string		"USERCCLLUT0B"
+	.section	.debug_info
+	.long		.Lname95
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x21
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #96: variable USERCCLLUT1A
+	.section	.debug_info
+	.uleb128	96	; ref to abbrev 96
+	.section	.debug_abbrev
+	.uleb128	96
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname96:
+	.string		"USERCCLLUT1A"
+	.section	.debug_info
+	.long		.Lname96
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x22
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #97: variable USERCCLLUT1B
+	.section	.debug_info
+	.uleb128	97	; ref to abbrev 97
+	.section	.debug_abbrev
+	.uleb128	97
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname97:
+	.string		"USERCCLLUT1B"
+	.section	.debug_info
+	.long		.Lname97
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x23
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #98: variable USERCCLLUT2A
+	.section	.debug_info
+	.uleb128	98	; ref to abbrev 98
+	.section	.debug_abbrev
+	.uleb128	98
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname98:
+	.string		"USERCCLLUT2A"
+	.section	.debug_info
+	.long		.Lname98
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x24
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #99: variable USERCCLLUT2B
+	.section	.debug_info
+	.uleb128	99	; ref to abbrev 99
+	.section	.debug_abbrev
+	.uleb128	99
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname99:
+	.string		"USERCCLLUT2B"
+	.section	.debug_info
+	.long		.Lname99
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x25
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #100: variable USERCCLLUT3A
+	.section	.debug_info
+	.uleb128	100	; ref to abbrev 100
+	.section	.debug_abbrev
+	.uleb128	100
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname100:
+	.string		"USERCCLLUT3A"
+	.section	.debug_info
+	.long		.Lname100
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x26
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #101: variable USERCCLLUT3B
+	.section	.debug_info
+	.uleb128	101	; ref to abbrev 101
+	.section	.debug_abbrev
+	.uleb128	101
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname101:
+	.string		"USERCCLLUT3B"
+	.section	.debug_info
+	.long		.Lname101
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x27
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #102: variable USERADC0START
+	.section	.debug_info
+	.uleb128	102	; ref to abbrev 102
+	.section	.debug_abbrev
+	.uleb128	102
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname102:
+	.string		"USERADC0START"
+	.section	.debug_info
+	.long		.Lname102
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x28
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #103: variable USEREVSYSEVOUTA
+	.section	.debug_info
+	.uleb128	103	; ref to abbrev 103
+	.section	.debug_abbrev
+	.uleb128	103
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname103:
+	.string		"USEREVSYSEVOUTA"
+	.section	.debug_info
+	.long		.Lname103
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x29
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #104: variable USEREVSYSEVOUTC
+	.section	.debug_info
+	.uleb128	104	; ref to abbrev 104
+	.section	.debug_abbrev
+	.uleb128	104
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname104:
+	.string		"USEREVSYSEVOUTC"
+	.section	.debug_info
+	.long		.Lname104
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #105: variable USEREVSYSEVOUTD
+	.section	.debug_info
+	.uleb128	105	; ref to abbrev 105
+	.section	.debug_abbrev
+	.uleb128	105
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname105:
+	.string		"USEREVSYSEVOUTD"
+	.section	.debug_info
+	.long		.Lname105
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #106: variable USEREVSYSEVOUTF
+	.section	.debug_info
+	.uleb128	106	; ref to abbrev 106
+	.section	.debug_abbrev
+	.uleb128	106
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname106:
+	.string		"USEREVSYSEVOUTF"
+	.section	.debug_info
+	.long		.Lname106
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #107: variable USERUSART0IRDA
+	.section	.debug_info
+	.uleb128	107	; ref to abbrev 107
+	.section	.debug_abbrev
+	.uleb128	107
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname107:
+	.string		"USERUSART0IRDA"
+	.section	.debug_info
+	.long		.Lname107
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #108: variable USERTCE0CNTA
+	.section	.debug_info
+	.uleb128	108	; ref to abbrev 108
+	.section	.debug_abbrev
+	.uleb128	108
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname108:
+	.string		"USERTCE0CNTA"
+	.section	.debug_info
+	.long		.Lname108
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #109: variable USERTCE0CNTB
+	.section	.debug_info
+	.uleb128	109	; ref to abbrev 109
+	.section	.debug_abbrev
+	.uleb128	109
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname109:
+	.string		"USERTCE0CNTB"
+	.section	.debug_info
+	.long		.Lname109
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #110: variable USERTCB0CAPT
+	.section	.debug_info
+	.uleb128	110	; ref to abbrev 110
+	.section	.debug_abbrev
+	.uleb128	110
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname110:
+	.string		"USERTCB0CAPT"
+	.section	.debug_info
+	.long		.Lname110
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x30
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #111: variable USERTCB0COUNT
+	.section	.debug_info
+	.uleb128	111	; ref to abbrev 111
+	.section	.debug_abbrev
+	.uleb128	111
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname111:
+	.string		"USERTCB0COUNT"
+	.section	.debug_info
+	.long		.Lname111
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x31
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #112: variable USERTCB1CAPT
+	.section	.debug_info
+	.uleb128	112	; ref to abbrev 112
+	.section	.debug_abbrev
+	.uleb128	112
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname112:
+	.string		"USERTCB1CAPT"
+	.section	.debug_info
+	.long		.Lname112
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x32
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #113: variable USERTCB1COUNT
+	.section	.debug_info
+	.uleb128	113	; ref to abbrev 113
+	.section	.debug_abbrev
+	.uleb128	113
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname113:
+	.string		"USERTCB1COUNT"
+	.section	.debug_info
+	.long		.Lname113
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x33
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #114: variable USERTCF0CNT
+	.section	.debug_info
+	.uleb128	114	; ref to abbrev 114
+	.section	.debug_abbrev
+	.uleb128	114
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname114:
+	.string		"USERTCF0CNT"
+	.section	.debug_info
+	.long		.Lname114
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x34
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #115: variable USERTCF0ACT
+	.section	.debug_info
+	.uleb128	115	; ref to abbrev 115
+	.section	.debug_abbrev
+	.uleb128	115
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname115:
+	.string		"USERTCF0ACT"
+	.section	.debug_info
+	.long		.Lname115
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x35
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #116: variable USERWEXA
+	.section	.debug_info
+	.uleb128	116	; ref to abbrev 116
+	.section	.debug_abbrev
+	.uleb128	116
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname116:
+	.string		"USERWEXA"
+	.section	.debug_info
+	.long		.Lname116
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x36
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #117: variable USERWEXB
+	.section	.debug_info
+	.uleb128	117	; ref to abbrev 117
+	.section	.debug_abbrev
+	.uleb128	117
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname117:
+	.string		"USERWEXB"
+	.section	.debug_info
+	.long		.Lname117
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x37
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #118: variable USERWEXC
+	.section	.debug_info
+	.uleb128	118	; ref to abbrev 118
+	.section	.debug_abbrev
+	.uleb128	118
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname118:
+	.string		"USERWEXC"
+	.section	.debug_info
+	.long		.Lname118
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x38
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #119: variable WDTCFG
+	.section	.debug_info
+	.uleb128	119	; ref to abbrev 119
+	.section	.debug_abbrev
+	.uleb128	119
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname119:
+	.string		"WDTCFG"
+	.section	.debug_info
+	.long		.Lname119
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #120: variable BODCFG
+	.section	.debug_info
+	.uleb128	120	; ref to abbrev 120
+	.section	.debug_abbrev
+	.uleb128	120
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname120:
+	.string		"BODCFG"
+	.section	.debug_info
+	.long		.Lname120
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #121: variable OSCCFG
+	.section	.debug_info
+	.uleb128	121	; ref to abbrev 121
+	.section	.debug_abbrev
+	.uleb128	121
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname121:
+	.string		"OSCCFG"
+	.section	.debug_info
+	.long		.Lname121
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #122: variable SYSCFG0
+	.section	.debug_info
+	.uleb128	122	; ref to abbrev 122
+	.section	.debug_abbrev
+	.uleb128	122
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname122:
+	.string		"SYSCFG0"
+	.section	.debug_info
+	.long		.Lname122
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #123: variable SYSCFG1
+	.section	.debug_info
+	.uleb128	123	; ref to abbrev 123
+	.section	.debug_abbrev
+	.uleb128	123
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname123:
+	.string		"SYSCFG1"
+	.section	.debug_info
+	.long		.Lname123
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #124: variable CODESIZE
+	.section	.debug_info
+	.uleb128	124	; ref to abbrev 124
+	.section	.debug_abbrev
+	.uleb128	124
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname124:
+	.string		"CODESIZE"
+	.section	.debug_info
+	.long		.Lname124
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #125: variable BOOTSIZE
+	.section	.debug_info
+	.uleb128	125	; ref to abbrev 125
+	.section	.debug_abbrev
+	.uleb128	125
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname125:
+	.string		"BOOTSIZE"
+	.section	.debug_info
+	.long		.Lname125
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #126: variable PDICFG
+	.section	.debug_info
+	.uleb128	126	; ref to abbrev 126
+	.section	.debug_abbrev
+	.uleb128	126
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname126:
+	.string		"PDICFG"
+	.section	.debug_info
+	.long		.Lname126
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #127: variable GPR0
+	.section	.debug_info
+	.uleb128	127	; ref to abbrev 127
+	.section	.debug_abbrev
+	.uleb128	127
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname127:
+	.string		"GPR0"
+	.section	.debug_info
+	.long		.Lname127
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x001C + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #128: variable GPR1
+	.section	.debug_info
+	.uleb128	128	; ref to abbrev 128
+	.section	.debug_abbrev
+	.uleb128	128
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname128:
+	.string		"GPR1"
+	.section	.debug_info
+	.long		.Lname128
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x001C + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #129: variable GPR2
+	.section	.debug_info
+	.uleb128	129	; ref to abbrev 129
+	.section	.debug_abbrev
+	.uleb128	129
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname129:
+	.string		"GPR2"
+	.section	.debug_info
+	.long		.Lname129
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x001C + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #130: variable GPR3
+	.section	.debug_info
+	.uleb128	130	; ref to abbrev 130
+	.section	.debug_abbrev
+	.uleb128	130
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname130:
+	.string		"GPR3"
+	.section	.debug_info
+	.long		.Lname130
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x001C + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #131: variable KEY
+	.section	.debug_info
+	.uleb128	131	; ref to abbrev 131
+	.section	.debug_abbrev
+	.uleb128	131
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname131:
+	.string		"KEY"
+	.section	.debug_info
+	.long		.Lname131
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint32_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1040 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #132: variable CTRLA
+	.section	.debug_info
+	.uleb128	132	; ref to abbrev 132
+	.section	.debug_abbrev
+	.uleb128	132
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname132:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname132
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #133: variable CTRLB
+	.section	.debug_info
+	.uleb128	133	; ref to abbrev 133
+	.section	.debug_abbrev
+	.uleb128	133
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname133:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname133
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #134: variable CTRLC
+	.section	.debug_info
+	.uleb128	134	; ref to abbrev 134
+	.section	.debug_abbrev
+	.uleb128	134
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname134:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname134
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #135: variable INTCTRL
+	.section	.debug_info
+	.uleb128	135	; ref to abbrev 135
+	.section	.debug_abbrev
+	.uleb128	135
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname135:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname135
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #136: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	136	; ref to abbrev 136
+	.section	.debug_abbrev
+	.uleb128	136
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname136:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname136
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #137: variable STATUS
+	.section	.debug_info
+	.uleb128	137	; ref to abbrev 137
+	.section	.debug_abbrev
+	.uleb128	137
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname137:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname137
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #138: variable DATA
+	.section	.debug_info
+	.uleb128	138	; ref to abbrev 138
+	.section	.debug_abbrev
+	.uleb128	138
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname138:
+	.string		"DATA"
+	.section	.debug_info
+	.long		.Lname138
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #139: variable ADDR
+	.section	.debug_info
+	.uleb128	139	; ref to abbrev 139
+	.section	.debug_abbrev
+	.uleb128	139
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname139:
+	.string		"ADDR"
+	.section	.debug_info
+	.long		.Lname139
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint32_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #140: variable DIR
+	.section	.debug_info
+	.uleb128	140	; ref to abbrev 140
+	.section	.debug_abbrev
+	.uleb128	140
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname140:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname140
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #141: variable DIRSET
+	.section	.debug_info
+	.uleb128	141	; ref to abbrev 141
+	.section	.debug_abbrev
+	.uleb128	141
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname141:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname141
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #142: variable DIRCLR
+	.section	.debug_info
+	.uleb128	142	; ref to abbrev 142
+	.section	.debug_abbrev
+	.uleb128	142
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname142:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname142
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #143: variable DIRTGL
+	.section	.debug_info
+	.uleb128	143	; ref to abbrev 143
+	.section	.debug_abbrev
+	.uleb128	143
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname143:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname143
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #144: variable OUT
+	.section	.debug_info
+	.uleb128	144	; ref to abbrev 144
+	.section	.debug_abbrev
+	.uleb128	144
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname144:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname144
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #145: variable OUTSET
+	.section	.debug_info
+	.uleb128	145	; ref to abbrev 145
+	.section	.debug_abbrev
+	.uleb128	145
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname145:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname145
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #146: variable OUTCLR
+	.section	.debug_info
+	.uleb128	146	; ref to abbrev 146
+	.section	.debug_abbrev
+	.uleb128	146
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname146:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname146
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #147: variable OUTTGL
+	.section	.debug_info
+	.uleb128	147	; ref to abbrev 147
+	.section	.debug_abbrev
+	.uleb128	147
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname147:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname147
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #148: variable IN
+	.section	.debug_info
+	.uleb128	148	; ref to abbrev 148
+	.section	.debug_abbrev
+	.uleb128	148
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname148:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname148
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #149: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	149	; ref to abbrev 149
+	.section	.debug_abbrev
+	.uleb128	149
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname149:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname149
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #150: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	150	; ref to abbrev 150
+	.section	.debug_abbrev
+	.uleb128	150
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname150:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname150
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #151: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	151	; ref to abbrev 151
+	.section	.debug_abbrev
+	.uleb128	151
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname151:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname151
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #152: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	152	; ref to abbrev 152
+	.section	.debug_abbrev
+	.uleb128	152
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname152:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname152
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #153: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	153	; ref to abbrev 153
+	.section	.debug_abbrev
+	.uleb128	153
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname153:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname153
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #154: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	154	; ref to abbrev 154
+	.section	.debug_abbrev
+	.uleb128	154
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname154:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname154
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #155: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	155	; ref to abbrev 155
+	.section	.debug_abbrev
+	.uleb128	155
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname155:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname155
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #156: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	156	; ref to abbrev 156
+	.section	.debug_abbrev
+	.uleb128	156
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname156:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname156
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #157: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	157	; ref to abbrev 157
+	.section	.debug_abbrev
+	.uleb128	157
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname157:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname157
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #158: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	158	; ref to abbrev 158
+	.section	.debug_abbrev
+	.uleb128	158
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname158:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname158
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #159: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	159	; ref to abbrev 159
+	.section	.debug_abbrev
+	.uleb128	159
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname159:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname159
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #160: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	160	; ref to abbrev 160
+	.section	.debug_abbrev
+	.uleb128	160
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname160:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname160
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #161: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	161	; ref to abbrev 161
+	.section	.debug_abbrev
+	.uleb128	161
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname161:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname161
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #162: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	162	; ref to abbrev 162
+	.section	.debug_abbrev
+	.uleb128	162
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname162:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname162
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #163: variable EVGENCTRLA
+	.section	.debug_info
+	.uleb128	163	; ref to abbrev 163
+	.section	.debug_abbrev
+	.uleb128	163
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname163:
+	.string		"EVGENCTRLA"
+	.section	.debug_info
+	.long		.Lname163
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #164: variable DIR
+	.section	.debug_info
+	.uleb128	164	; ref to abbrev 164
+	.section	.debug_abbrev
+	.uleb128	164
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname164:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname164
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #165: variable DIRSET
+	.section	.debug_info
+	.uleb128	165	; ref to abbrev 165
+	.section	.debug_abbrev
+	.uleb128	165
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname165:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname165
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #166: variable DIRCLR
+	.section	.debug_info
+	.uleb128	166	; ref to abbrev 166
+	.section	.debug_abbrev
+	.uleb128	166
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname166:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname166
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #167: variable DIRTGL
+	.section	.debug_info
+	.uleb128	167	; ref to abbrev 167
+	.section	.debug_abbrev
+	.uleb128	167
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname167:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname167
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #168: variable OUT
+	.section	.debug_info
+	.uleb128	168	; ref to abbrev 168
+	.section	.debug_abbrev
+	.uleb128	168
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname168:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname168
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #169: variable OUTSET
+	.section	.debug_info
+	.uleb128	169	; ref to abbrev 169
+	.section	.debug_abbrev
+	.uleb128	169
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname169:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname169
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #170: variable OUTCLR
+	.section	.debug_info
+	.uleb128	170	; ref to abbrev 170
+	.section	.debug_abbrev
+	.uleb128	170
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname170:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname170
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #171: variable OUTTGL
+	.section	.debug_info
+	.uleb128	171	; ref to abbrev 171
+	.section	.debug_abbrev
+	.uleb128	171
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname171:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname171
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #172: variable IN
+	.section	.debug_info
+	.uleb128	172	; ref to abbrev 172
+	.section	.debug_abbrev
+	.uleb128	172
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname172:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname172
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #173: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	173	; ref to abbrev 173
+	.section	.debug_abbrev
+	.uleb128	173
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname173:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname173
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #174: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	174	; ref to abbrev 174
+	.section	.debug_abbrev
+	.uleb128	174
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname174:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname174
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #175: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	175	; ref to abbrev 175
+	.section	.debug_abbrev
+	.uleb128	175
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname175:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname175
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #176: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	176	; ref to abbrev 176
+	.section	.debug_abbrev
+	.uleb128	176
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname176:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname176
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #177: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	177	; ref to abbrev 177
+	.section	.debug_abbrev
+	.uleb128	177
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname177:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname177
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #178: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	178	; ref to abbrev 178
+	.section	.debug_abbrev
+	.uleb128	178
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname178:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname178
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #179: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	179	; ref to abbrev 179
+	.section	.debug_abbrev
+	.uleb128	179
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname179:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname179
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #180: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	180	; ref to abbrev 180
+	.section	.debug_abbrev
+	.uleb128	180
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname180:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname180
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #181: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	181	; ref to abbrev 181
+	.section	.debug_abbrev
+	.uleb128	181
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname181:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname181
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #182: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	182	; ref to abbrev 182
+	.section	.debug_abbrev
+	.uleb128	182
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname182:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname182
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #183: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	183	; ref to abbrev 183
+	.section	.debug_abbrev
+	.uleb128	183
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname183:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname183
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #184: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	184	; ref to abbrev 184
+	.section	.debug_abbrev
+	.uleb128	184
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname184:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname184
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #185: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	185	; ref to abbrev 185
+	.section	.debug_abbrev
+	.uleb128	185
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname185:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname185
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #186: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	186	; ref to abbrev 186
+	.section	.debug_abbrev
+	.uleb128	186
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname186:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname186
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #187: variable EVGENCTRLA
+	.section	.debug_info
+	.uleb128	187	; ref to abbrev 187
+	.section	.debug_abbrev
+	.uleb128	187
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname187:
+	.string		"EVGENCTRLA"
+	.section	.debug_info
+	.long		.Lname187
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #188: variable DIR
+	.section	.debug_info
+	.uleb128	188	; ref to abbrev 188
+	.section	.debug_abbrev
+	.uleb128	188
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname188:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname188
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #189: variable DIRSET
+	.section	.debug_info
+	.uleb128	189	; ref to abbrev 189
+	.section	.debug_abbrev
+	.uleb128	189
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname189:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname189
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #190: variable DIRCLR
+	.section	.debug_info
+	.uleb128	190	; ref to abbrev 190
+	.section	.debug_abbrev
+	.uleb128	190
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname190:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname190
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #191: variable DIRTGL
+	.section	.debug_info
+	.uleb128	191	; ref to abbrev 191
+	.section	.debug_abbrev
+	.uleb128	191
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname191:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname191
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #192: variable OUT
+	.section	.debug_info
+	.uleb128	192	; ref to abbrev 192
+	.section	.debug_abbrev
+	.uleb128	192
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname192:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname192
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #193: variable OUTSET
+	.section	.debug_info
+	.uleb128	193	; ref to abbrev 193
+	.section	.debug_abbrev
+	.uleb128	193
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname193:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname193
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #194: variable OUTCLR
+	.section	.debug_info
+	.uleb128	194	; ref to abbrev 194
+	.section	.debug_abbrev
+	.uleb128	194
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname194:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname194
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #195: variable OUTTGL
+	.section	.debug_info
+	.uleb128	195	; ref to abbrev 195
+	.section	.debug_abbrev
+	.uleb128	195
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname195:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname195
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #196: variable IN
+	.section	.debug_info
+	.uleb128	196	; ref to abbrev 196
+	.section	.debug_abbrev
+	.uleb128	196
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname196:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname196
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #197: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	197	; ref to abbrev 197
+	.section	.debug_abbrev
+	.uleb128	197
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname197:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname197
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #198: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	198	; ref to abbrev 198
+	.section	.debug_abbrev
+	.uleb128	198
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname198:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname198
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #199: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	199	; ref to abbrev 199
+	.section	.debug_abbrev
+	.uleb128	199
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname199:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname199
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #200: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	200	; ref to abbrev 200
+	.section	.debug_abbrev
+	.uleb128	200
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname200:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname200
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #201: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	201	; ref to abbrev 201
+	.section	.debug_abbrev
+	.uleb128	201
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname201:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname201
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #202: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	202	; ref to abbrev 202
+	.section	.debug_abbrev
+	.uleb128	202
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname202:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname202
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #203: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	203	; ref to abbrev 203
+	.section	.debug_abbrev
+	.uleb128	203
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname203:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname203
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #204: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	204	; ref to abbrev 204
+	.section	.debug_abbrev
+	.uleb128	204
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname204:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname204
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #205: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	205	; ref to abbrev 205
+	.section	.debug_abbrev
+	.uleb128	205
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname205:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname205
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #206: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	206	; ref to abbrev 206
+	.section	.debug_abbrev
+	.uleb128	206
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname206:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname206
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #207: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	207	; ref to abbrev 207
+	.section	.debug_abbrev
+	.uleb128	207
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname207:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname207
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #208: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	208	; ref to abbrev 208
+	.section	.debug_abbrev
+	.uleb128	208
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname208:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname208
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #209: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	209	; ref to abbrev 209
+	.section	.debug_abbrev
+	.uleb128	209
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname209:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname209
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #210: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	210	; ref to abbrev 210
+	.section	.debug_abbrev
+	.uleb128	210
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname210:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname210
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #211: variable EVGENCTRLA
+	.section	.debug_info
+	.uleb128	211	; ref to abbrev 211
+	.section	.debug_abbrev
+	.uleb128	211
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname211:
+	.string		"EVGENCTRLA"
+	.section	.debug_info
+	.long		.Lname211
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #212: variable DIR
+	.section	.debug_info
+	.uleb128	212	; ref to abbrev 212
+	.section	.debug_abbrev
+	.uleb128	212
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname212:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname212
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #213: variable DIRSET
+	.section	.debug_info
+	.uleb128	213	; ref to abbrev 213
+	.section	.debug_abbrev
+	.uleb128	213
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname213:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname213
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #214: variable DIRCLR
+	.section	.debug_info
+	.uleb128	214	; ref to abbrev 214
+	.section	.debug_abbrev
+	.uleb128	214
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname214:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname214
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #215: variable DIRTGL
+	.section	.debug_info
+	.uleb128	215	; ref to abbrev 215
+	.section	.debug_abbrev
+	.uleb128	215
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname215:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname215
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #216: variable OUT
+	.section	.debug_info
+	.uleb128	216	; ref to abbrev 216
+	.section	.debug_abbrev
+	.uleb128	216
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname216:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname216
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #217: variable OUTSET
+	.section	.debug_info
+	.uleb128	217	; ref to abbrev 217
+	.section	.debug_abbrev
+	.uleb128	217
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname217:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname217
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #218: variable OUTCLR
+	.section	.debug_info
+	.uleb128	218	; ref to abbrev 218
+	.section	.debug_abbrev
+	.uleb128	218
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname218:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname218
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #219: variable OUTTGL
+	.section	.debug_info
+	.uleb128	219	; ref to abbrev 219
+	.section	.debug_abbrev
+	.uleb128	219
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname219:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname219
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #220: variable IN
+	.section	.debug_info
+	.uleb128	220	; ref to abbrev 220
+	.section	.debug_abbrev
+	.uleb128	220
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname220:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname220
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #221: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	221	; ref to abbrev 221
+	.section	.debug_abbrev
+	.uleb128	221
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname221:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname221
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #222: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	222	; ref to abbrev 222
+	.section	.debug_abbrev
+	.uleb128	222
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname222:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname222
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #223: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	223	; ref to abbrev 223
+	.section	.debug_abbrev
+	.uleb128	223
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname223:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname223
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #224: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	224	; ref to abbrev 224
+	.section	.debug_abbrev
+	.uleb128	224
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname224:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname224
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #225: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	225	; ref to abbrev 225
+	.section	.debug_abbrev
+	.uleb128	225
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname225:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname225
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #226: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	226	; ref to abbrev 226
+	.section	.debug_abbrev
+	.uleb128	226
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname226:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname226
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #227: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	227	; ref to abbrev 227
+	.section	.debug_abbrev
+	.uleb128	227
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname227:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname227
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #228: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	228	; ref to abbrev 228
+	.section	.debug_abbrev
+	.uleb128	228
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname228:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname228
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #229: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	229	; ref to abbrev 229
+	.section	.debug_abbrev
+	.uleb128	229
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname229:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname229
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #230: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	230	; ref to abbrev 230
+	.section	.debug_abbrev
+	.uleb128	230
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname230:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname230
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #231: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	231	; ref to abbrev 231
+	.section	.debug_abbrev
+	.uleb128	231
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname231:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname231
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #232: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	232	; ref to abbrev 232
+	.section	.debug_abbrev
+	.uleb128	232
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname232:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname232
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #233: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	233	; ref to abbrev 233
+	.section	.debug_abbrev
+	.uleb128	233
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname233:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname233
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #234: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	234	; ref to abbrev 234
+	.section	.debug_abbrev
+	.uleb128	234
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname234:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname234
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #235: variable EVGENCTRLA
+	.section	.debug_info
+	.uleb128	235	; ref to abbrev 235
+	.section	.debug_abbrev
+	.uleb128	235
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname235:
+	.string		"EVGENCTRLA"
+	.section	.debug_info
+	.long		.Lname235
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #236: variable EVSYSROUTEA
+	.section	.debug_info
+	.uleb128	236	; ref to abbrev 236
+	.section	.debug_abbrev
+	.uleb128	236
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname236:
+	.string		"EVSYSROUTEA"
+	.section	.debug_info
+	.long		.Lname236
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #237: variable CCLROUTEA
+	.section	.debug_info
+	.uleb128	237	; ref to abbrev 237
+	.section	.debug_abbrev
+	.uleb128	237
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname237:
+	.string		"CCLROUTEA"
+	.section	.debug_info
+	.long		.Lname237
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #238: variable USARTROUTEA
+	.section	.debug_info
+	.uleb128	238	; ref to abbrev 238
+	.section	.debug_abbrev
+	.uleb128	238
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname238:
+	.string		"USARTROUTEA"
+	.section	.debug_info
+	.long		.Lname238
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #239: variable SPIROUTEA
+	.section	.debug_info
+	.uleb128	239	; ref to abbrev 239
+	.section	.debug_abbrev
+	.uleb128	239
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname239:
+	.string		"SPIROUTEA"
+	.section	.debug_info
+	.long		.Lname239
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #240: variable TWIROUTEA
+	.section	.debug_info
+	.uleb128	240	; ref to abbrev 240
+	.section	.debug_abbrev
+	.uleb128	240
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname240:
+	.string		"TWIROUTEA"
+	.section	.debug_info
+	.long		.Lname240
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #241: variable TCEROUTEA
+	.section	.debug_info
+	.uleb128	241	; ref to abbrev 241
+	.section	.debug_abbrev
+	.uleb128	241
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname241:
+	.string		"TCEROUTEA"
+	.section	.debug_info
+	.long		.Lname241
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #242: variable TCBROUTEA
+	.section	.debug_info
+	.uleb128	242	; ref to abbrev 242
+	.section	.debug_abbrev
+	.uleb128	242
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname242:
+	.string		"TCBROUTEA"
+	.section	.debug_info
+	.long		.Lname242
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #243: variable TCFROUTEA
+	.section	.debug_info
+	.uleb128	243	; ref to abbrev 243
+	.section	.debug_abbrev
+	.uleb128	243
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname243:
+	.string		"TCFROUTEA"
+	.section	.debug_info
+	.long		.Lname243
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #244: variable RSTFR
+	.section	.debug_info
+	.uleb128	244	; ref to abbrev 244
+	.section	.debug_abbrev
+	.uleb128	244
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname244:
+	.string		"RSTFR"
+	.section	.debug_info
+	.long		.Lname244
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0040 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #245: variable SWRR
+	.section	.debug_info
+	.uleb128	245	; ref to abbrev 245
+	.section	.debug_abbrev
+	.uleb128	245
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname245:
+	.string		"SWRR"
+	.section	.debug_info
+	.long		.Lname245
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0040 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #246: variable CTRLA
+	.section	.debug_info
+	.uleb128	246	; ref to abbrev 246
+	.section	.debug_abbrev
+	.uleb128	246
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname246:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname246
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #247: variable STATUS
+	.section	.debug_info
+	.uleb128	247	; ref to abbrev 247
+	.section	.debug_abbrev
+	.uleb128	247
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname247:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname247
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #248: variable INTCTRL
+	.section	.debug_info
+	.uleb128	248	; ref to abbrev 248
+	.section	.debug_abbrev
+	.uleb128	248
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname248:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname248
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #249: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	249	; ref to abbrev 249
+	.section	.debug_abbrev
+	.uleb128	249
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname249:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname249
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #250: variable TEMP
+	.section	.debug_info
+	.uleb128	250	; ref to abbrev 250
+	.section	.debug_abbrev
+	.uleb128	250
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname250:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname250
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #251: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	251	; ref to abbrev 251
+	.section	.debug_abbrev
+	.uleb128	251
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname251:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname251
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #252: variable CALIB
+	.section	.debug_info
+	.uleb128	252	; ref to abbrev 252
+	.section	.debug_abbrev
+	.uleb128	252
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname252:
+	.string		"CALIB"
+	.section	.debug_info
+	.long		.Lname252
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #253: variable CLKSEL
+	.section	.debug_info
+	.uleb128	253	; ref to abbrev 253
+	.section	.debug_abbrev
+	.uleb128	253
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname253:
+	.string		"CLKSEL"
+	.section	.debug_info
+	.long		.Lname253
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #254: variable CNT
+	.section	.debug_info
+	.uleb128	254	; ref to abbrev 254
+	.section	.debug_abbrev
+	.uleb128	254
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname254:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname254
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #255: variable PER
+	.section	.debug_info
+	.uleb128	255	; ref to abbrev 255
+	.section	.debug_abbrev
+	.uleb128	255
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname255:
+	.string		"PER"
+	.section	.debug_info
+	.long		.Lname255
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #256: variable CMP
+	.section	.debug_info
+	.uleb128	256	; ref to abbrev 256
+	.section	.debug_abbrev
+	.uleb128	256
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname256:
+	.string		"CMP"
+	.section	.debug_info
+	.long		.Lname256
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #257: variable PITCTRLA
+	.section	.debug_info
+	.uleb128	257	; ref to abbrev 257
+	.section	.debug_abbrev
+	.uleb128	257
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname257:
+	.string		"PITCTRLA"
+	.section	.debug_info
+	.long		.Lname257
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #258: variable PITSTATUS
+	.section	.debug_info
+	.uleb128	258	; ref to abbrev 258
+	.section	.debug_abbrev
+	.uleb128	258
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname258:
+	.string		"PITSTATUS"
+	.section	.debug_info
+	.long		.Lname258
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #259: variable PITINTCTRL
+	.section	.debug_info
+	.uleb128	259	; ref to abbrev 259
+	.section	.debug_abbrev
+	.uleb128	259
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname259:
+	.string		"PITINTCTRL"
+	.section	.debug_info
+	.long		.Lname259
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #260: variable PITINTFLAGS
+	.section	.debug_info
+	.uleb128	260	; ref to abbrev 260
+	.section	.debug_abbrev
+	.uleb128	260
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname260:
+	.string		"PITINTFLAGS"
+	.section	.debug_info
+	.long		.Lname260
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #261: variable PITDBGCTRL
+	.section	.debug_info
+	.uleb128	261	; ref to abbrev 261
+	.section	.debug_abbrev
+	.uleb128	261
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname261:
+	.string		"PITDBGCTRL"
+	.section	.debug_info
+	.long		.Lname261
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #262: variable PITEVGENCTRLA
+	.section	.debug_info
+	.uleb128	262	; ref to abbrev 262
+	.section	.debug_abbrev
+	.uleb128	262
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname262:
+	.string		"PITEVGENCTRLA"
+	.section	.debug_info
+	.long		.Lname262
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #263: variable DEVICEID0
+	.section	.debug_info
+	.uleb128	263	; ref to abbrev 263
+	.section	.debug_abbrev
+	.uleb128	263
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname263:
+	.string		"DEVICEID0"
+	.section	.debug_info
+	.long		.Lname263
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #264: variable DEVICEID1
+	.section	.debug_info
+	.uleb128	264	; ref to abbrev 264
+	.section	.debug_abbrev
+	.uleb128	264
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname264:
+	.string		"DEVICEID1"
+	.section	.debug_info
+	.long		.Lname264
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #265: variable DEVICEID2
+	.section	.debug_info
+	.uleb128	265	; ref to abbrev 265
+	.section	.debug_abbrev
+	.uleb128	265
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname265:
+	.string		"DEVICEID2"
+	.section	.debug_info
+	.long		.Lname265
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #266: variable TEMPSENSE0
+	.section	.debug_info
+	.uleb128	266	; ref to abbrev 266
+	.section	.debug_abbrev
+	.uleb128	266
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname266:
+	.string		"TEMPSENSE0"
+	.section	.debug_info
+	.long		.Lname266
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #267: variable TEMPSENSE1
+	.section	.debug_info
+	.uleb128	267	; ref to abbrev 267
+	.section	.debug_abbrev
+	.uleb128	267
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname267:
+	.string		"TEMPSENSE1"
+	.section	.debug_info
+	.long		.Lname267
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #268: variable SERNUM0
+	.section	.debug_info
+	.uleb128	268	; ref to abbrev 268
+	.section	.debug_abbrev
+	.uleb128	268
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname268:
+	.string		"SERNUM0"
+	.section	.debug_info
+	.long		.Lname268
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #269: variable SERNUM1
+	.section	.debug_info
+	.uleb128	269	; ref to abbrev 269
+	.section	.debug_abbrev
+	.uleb128	269
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname269:
+	.string		"SERNUM1"
+	.section	.debug_info
+	.long		.Lname269
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #270: variable SERNUM2
+	.section	.debug_info
+	.uleb128	270	; ref to abbrev 270
+	.section	.debug_abbrev
+	.uleb128	270
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname270:
+	.string		"SERNUM2"
+	.section	.debug_info
+	.long		.Lname270
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #271: variable SERNUM3
+	.section	.debug_info
+	.uleb128	271	; ref to abbrev 271
+	.section	.debug_abbrev
+	.uleb128	271
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname271:
+	.string		"SERNUM3"
+	.section	.debug_info
+	.long		.Lname271
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #272: variable SERNUM4
+	.section	.debug_info
+	.uleb128	272	; ref to abbrev 272
+	.section	.debug_abbrev
+	.uleb128	272
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname272:
+	.string		"SERNUM4"
+	.section	.debug_info
+	.long		.Lname272
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #273: variable SERNUM5
+	.section	.debug_info
+	.uleb128	273	; ref to abbrev 273
+	.section	.debug_abbrev
+	.uleb128	273
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname273:
+	.string		"SERNUM5"
+	.section	.debug_info
+	.long		.Lname273
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #274: variable SERNUM6
+	.section	.debug_info
+	.uleb128	274	; ref to abbrev 274
+	.section	.debug_abbrev
+	.uleb128	274
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname274:
+	.string		"SERNUM6"
+	.section	.debug_info
+	.long		.Lname274
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #275: variable SERNUM7
+	.section	.debug_info
+	.uleb128	275	; ref to abbrev 275
+	.section	.debug_abbrev
+	.uleb128	275
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname275:
+	.string		"SERNUM7"
+	.section	.debug_info
+	.long		.Lname275
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #276: variable SERNUM8
+	.section	.debug_info
+	.uleb128	276	; ref to abbrev 276
+	.section	.debug_abbrev
+	.uleb128	276
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname276:
+	.string		"SERNUM8"
+	.section	.debug_info
+	.long		.Lname276
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #277: variable SERNUM9
+	.section	.debug_info
+	.uleb128	277	; ref to abbrev 277
+	.section	.debug_abbrev
+	.uleb128	277
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname277:
+	.string		"SERNUM9"
+	.section	.debug_info
+	.long		.Lname277
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x19
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #278: variable SERNUM10
+	.section	.debug_info
+	.uleb128	278	; ref to abbrev 278
+	.section	.debug_abbrev
+	.uleb128	278
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname278:
+	.string		"SERNUM10"
+	.section	.debug_info
+	.long		.Lname278
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #279: variable SERNUM11
+	.section	.debug_info
+	.uleb128	279	; ref to abbrev 279
+	.section	.debug_abbrev
+	.uleb128	279
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname279:
+	.string		"SERNUM11"
+	.section	.debug_info
+	.long		.Lname279
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #280: variable SERNUM12
+	.section	.debug_info
+	.uleb128	280	; ref to abbrev 280
+	.section	.debug_abbrev
+	.uleb128	280
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname280:
+	.string		"SERNUM12"
+	.section	.debug_info
+	.long		.Lname280
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #281: variable SERNUM13
+	.section	.debug_info
+	.uleb128	281	; ref to abbrev 281
+	.section	.debug_abbrev
+	.uleb128	281
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname281:
+	.string		"SERNUM13"
+	.section	.debug_info
+	.long		.Lname281
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #282: variable SERNUM14
+	.section	.debug_info
+	.uleb128	282	; ref to abbrev 282
+	.section	.debug_abbrev
+	.uleb128	282
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname282:
+	.string		"SERNUM14"
+	.section	.debug_info
+	.long		.Lname282
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #283: variable SERNUM15
+	.section	.debug_info
+	.uleb128	283	; ref to abbrev 283
+	.section	.debug_abbrev
+	.uleb128	283
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname283:
+	.string		"SERNUM15"
+	.section	.debug_info
+	.long		.Lname283
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #284: variable CTRLA
+	.section	.debug_info
+	.uleb128	284	; ref to abbrev 284
+	.section	.debug_abbrev
+	.uleb128	284
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname284:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname284
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0050 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #285: variable CTRLA
+	.section	.debug_info
+	.uleb128	285	; ref to abbrev 285
+	.section	.debug_abbrev
+	.uleb128	285
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname285:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname285
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #286: variable CTRLB
+	.section	.debug_info
+	.uleb128	286	; ref to abbrev 286
+	.section	.debug_abbrev
+	.uleb128	286
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname286:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname286
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #287: variable INTCTRL
+	.section	.debug_info
+	.uleb128	287	; ref to abbrev 287
+	.section	.debug_abbrev
+	.uleb128	287
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname287:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname287
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #288: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	288	; ref to abbrev 288
+	.section	.debug_abbrev
+	.uleb128	288
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname288:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname288
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #289: variable DATA
+	.section	.debug_info
+	.uleb128	289	; ref to abbrev 289
+	.section	.debug_abbrev
+	.uleb128	289
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname289:
+	.string		"DATA"
+	.section	.debug_info
+	.long		.Lname289
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #290: variable REVID
+	.section	.debug_info
+	.uleb128	290	; ref to abbrev 290
+	.section	.debug_abbrev
+	.uleb128	290
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname290:
+	.string		"REVID"
+	.section	.debug_info
+	.long		.Lname290
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0F00 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #291: variable CTRLA
+	.section	.debug_info
+	.uleb128	291	; ref to abbrev 291
+	.section	.debug_abbrev
+	.uleb128	291
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname291:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname291
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #292: variable CTRLB
+	.section	.debug_info
+	.uleb128	292	; ref to abbrev 292
+	.section	.debug_abbrev
+	.uleb128	292
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname292:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname292
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #293: variable CTRLC
+	.section	.debug_info
+	.uleb128	293	; ref to abbrev 293
+	.section	.debug_abbrev
+	.uleb128	293
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname293:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname293
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #294: variable EVCTRL
+	.section	.debug_info
+	.uleb128	294	; ref to abbrev 294
+	.section	.debug_abbrev
+	.uleb128	294
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname294:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname294
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #295: variable INTCTRL
+	.section	.debug_info
+	.uleb128	295	; ref to abbrev 295
+	.section	.debug_abbrev
+	.uleb128	295
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname295:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname295
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #296: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	296	; ref to abbrev 296
+	.section	.debug_abbrev
+	.uleb128	296
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname296:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname296
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #297: variable STATUS
+	.section	.debug_info
+	.uleb128	297	; ref to abbrev 297
+	.section	.debug_abbrev
+	.uleb128	297
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname297:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname297
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #298: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	298	; ref to abbrev 298
+	.section	.debug_abbrev
+	.uleb128	298
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname298:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname298
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #299: variable TEMP
+	.section	.debug_info
+	.uleb128	299	; ref to abbrev 299
+	.section	.debug_abbrev
+	.uleb128	299
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname299:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname299
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #300: variable CNT
+	.section	.debug_info
+	.uleb128	300	; ref to abbrev 300
+	.section	.debug_abbrev
+	.uleb128	300
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname300:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname300
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #301: variable CCMP
+	.section	.debug_info
+	.uleb128	301	; ref to abbrev 301
+	.section	.debug_abbrev
+	.uleb128	301
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname301:
+	.string		"CCMP"
+	.section	.debug_info
+	.long		.Lname301
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #302: variable CTRLA
+	.section	.debug_info
+	.uleb128	302	; ref to abbrev 302
+	.section	.debug_abbrev
+	.uleb128	302
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname302:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname302
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #303: variable CTRLB
+	.section	.debug_info
+	.uleb128	303	; ref to abbrev 303
+	.section	.debug_abbrev
+	.uleb128	303
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname303:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname303
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #304: variable CTRLC
+	.section	.debug_info
+	.uleb128	304	; ref to abbrev 304
+	.section	.debug_abbrev
+	.uleb128	304
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname304:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname304
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #305: variable EVCTRL
+	.section	.debug_info
+	.uleb128	305	; ref to abbrev 305
+	.section	.debug_abbrev
+	.uleb128	305
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname305:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname305
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #306: variable INTCTRL
+	.section	.debug_info
+	.uleb128	306	; ref to abbrev 306
+	.section	.debug_abbrev
+	.uleb128	306
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname306:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname306
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #307: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	307	; ref to abbrev 307
+	.section	.debug_abbrev
+	.uleb128	307
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname307:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname307
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #308: variable STATUS
+	.section	.debug_info
+	.uleb128	308	; ref to abbrev 308
+	.section	.debug_abbrev
+	.uleb128	308
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname308:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname308
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #309: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	309	; ref to abbrev 309
+	.section	.debug_abbrev
+	.uleb128	309
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname309:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname309
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #310: variable TEMP
+	.section	.debug_info
+	.uleb128	310	; ref to abbrev 310
+	.section	.debug_abbrev
+	.uleb128	310
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname310:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname310
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #311: variable CNT
+	.section	.debug_info
+	.uleb128	311	; ref to abbrev 311
+	.section	.debug_abbrev
+	.uleb128	311
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname311:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname311
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #312: variable CCMP
+	.section	.debug_info
+	.uleb128	312	; ref to abbrev 312
+	.section	.debug_abbrev
+	.uleb128	312
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname312:
+	.string		"CCMP"
+	.section	.debug_info
+	.long		.Lname312
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #313: variable CTRLA
+	.section	.debug_info
+	.uleb128	313	; ref to abbrev 313
+	.section	.debug_abbrev
+	.uleb128	313
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname313:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname313
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #314: variable CTRLB
+	.section	.debug_info
+	.uleb128	314	; ref to abbrev 314
+	.section	.debug_abbrev
+	.uleb128	314
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname314:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname314
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #315: variable CTRLC
+	.section	.debug_info
+	.uleb128	315	; ref to abbrev 315
+	.section	.debug_abbrev
+	.uleb128	315
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname315:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname315
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #316: variable CTRLD
+	.section	.debug_info
+	.uleb128	316	; ref to abbrev 316
+	.section	.debug_abbrev
+	.uleb128	316
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname316:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname316
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #317: variable CTRLECLR
+	.section	.debug_info
+	.uleb128	317	; ref to abbrev 317
+	.section	.debug_abbrev
+	.uleb128	317
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname317:
+	.string		"CTRLECLR"
+	.section	.debug_info
+	.long		.Lname317
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #318: variable CTRLESET
+	.section	.debug_info
+	.uleb128	318	; ref to abbrev 318
+	.section	.debug_abbrev
+	.uleb128	318
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname318:
+	.string		"CTRLESET"
+	.section	.debug_info
+	.long		.Lname318
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #319: variable CTRLFCLR
+	.section	.debug_info
+	.uleb128	319	; ref to abbrev 319
+	.section	.debug_abbrev
+	.uleb128	319
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname319:
+	.string		"CTRLFCLR"
+	.section	.debug_info
+	.long		.Lname319
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #320: variable CTRLFSET
+	.section	.debug_info
+	.uleb128	320	; ref to abbrev 320
+	.section	.debug_abbrev
+	.uleb128	320
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname320:
+	.string		"CTRLFSET"
+	.section	.debug_info
+	.long		.Lname320
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #321: variable EVGENCTRL
+	.section	.debug_info
+	.uleb128	321	; ref to abbrev 321
+	.section	.debug_abbrev
+	.uleb128	321
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname321:
+	.string		"EVGENCTRL"
+	.section	.debug_info
+	.long		.Lname321
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #322: variable EVCTRL
+	.section	.debug_info
+	.uleb128	322	; ref to abbrev 322
+	.section	.debug_abbrev
+	.uleb128	322
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname322:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname322
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #323: variable INTCTRL
+	.section	.debug_info
+	.uleb128	323	; ref to abbrev 323
+	.section	.debug_abbrev
+	.uleb128	323
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname323:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname323
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #324: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	324	; ref to abbrev 324
+	.section	.debug_abbrev
+	.uleb128	324
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname324:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname324
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #325: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	325	; ref to abbrev 325
+	.section	.debug_abbrev
+	.uleb128	325
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname325:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname325
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #326: variable TEMP
+	.section	.debug_info
+	.uleb128	326	; ref to abbrev 326
+	.section	.debug_abbrev
+	.uleb128	326
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname326:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname326
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #327: variable CNT
+	.section	.debug_info
+	.uleb128	327	; ref to abbrev 327
+	.section	.debug_abbrev
+	.uleb128	327
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname327:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname327
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #328: variable AMP
+	.section	.debug_info
+	.uleb128	328	; ref to abbrev 328
+	.section	.debug_abbrev
+	.uleb128	328
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname328:
+	.string		"AMP"
+	.section	.debug_info
+	.long		.Lname328
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x22
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #329: variable OFFSET
+	.section	.debug_info
+	.uleb128	329	; ref to abbrev 329
+	.section	.debug_abbrev
+	.uleb128	329
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname329:
+	.string		"OFFSET"
+	.section	.debug_info
+	.long		.Lname329
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x24
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #330: variable PER
+	.section	.debug_info
+	.uleb128	330	; ref to abbrev 330
+	.section	.debug_abbrev
+	.uleb128	330
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname330:
+	.string		"PER"
+	.section	.debug_info
+	.long		.Lname330
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x26
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #331: variable CMP0
+	.section	.debug_info
+	.uleb128	331	; ref to abbrev 331
+	.section	.debug_abbrev
+	.uleb128	331
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname331:
+	.string		"CMP0"
+	.section	.debug_info
+	.long		.Lname331
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x28
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #332: variable CMP1
+	.section	.debug_info
+	.uleb128	332	; ref to abbrev 332
+	.section	.debug_abbrev
+	.uleb128	332
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname332:
+	.string		"CMP1"
+	.section	.debug_info
+	.long		.Lname332
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #333: variable CMP2
+	.section	.debug_info
+	.uleb128	333	; ref to abbrev 333
+	.section	.debug_abbrev
+	.uleb128	333
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname333:
+	.string		"CMP2"
+	.section	.debug_info
+	.long		.Lname333
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #334: variable CMP3
+	.section	.debug_info
+	.uleb128	334	; ref to abbrev 334
+	.section	.debug_abbrev
+	.uleb128	334
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname334:
+	.string		"CMP3"
+	.section	.debug_info
+	.long		.Lname334
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #335: variable PERBUF
+	.section	.debug_info
+	.uleb128	335	; ref to abbrev 335
+	.section	.debug_abbrev
+	.uleb128	335
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname335:
+	.string		"PERBUF"
+	.section	.debug_info
+	.long		.Lname335
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x36
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #336: variable CMP0BUF
+	.section	.debug_info
+	.uleb128	336	; ref to abbrev 336
+	.section	.debug_abbrev
+	.uleb128	336
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname336:
+	.string		"CMP0BUF"
+	.section	.debug_info
+	.long		.Lname336
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x38
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #337: variable CMP1BUF
+	.section	.debug_info
+	.uleb128	337	; ref to abbrev 337
+	.section	.debug_abbrev
+	.uleb128	337
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname337:
+	.string		"CMP1BUF"
+	.section	.debug_info
+	.long		.Lname337
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x3A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #338: variable CMP2BUF
+	.section	.debug_info
+	.uleb128	338	; ref to abbrev 338
+	.section	.debug_abbrev
+	.uleb128	338
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname338:
+	.string		"CMP2BUF"
+	.section	.debug_info
+	.long		.Lname338
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x3C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #339: variable CMP3BUF
+	.section	.debug_info
+	.uleb128	339	; ref to abbrev 339
+	.section	.debug_abbrev
+	.uleb128	339
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname339:
+	.string		"CMP3BUF"
+	.section	.debug_info
+	.long		.Lname339
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x3E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #340: variable CTRLA
+	.section	.debug_info
+	.uleb128	340	; ref to abbrev 340
+	.section	.debug_abbrev
+	.uleb128	340
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname340:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname340
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C00 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #341: variable CTRLB
+	.section	.debug_info
+	.uleb128	341	; ref to abbrev 341
+	.section	.debug_abbrev
+	.uleb128	341
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname341:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname341
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C00 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #342: variable CTRLC
+	.section	.debug_info
+	.uleb128	342	; ref to abbrev 342
+	.section	.debug_abbrev
+	.uleb128	342
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname342:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname342
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C00 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #343: variable CTRLD
+	.section	.debug_info
+	.uleb128	343	; ref to abbrev 343
+	.section	.debug_abbrev
+	.uleb128	343
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname343:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname343
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C00 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #344: variable EVCTRL
+	.section	.debug_info
+	.uleb128	344	; ref to abbrev 344
+	.section	.debug_abbrev
+	.uleb128	344
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname344:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname344
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C00 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #345: variable INTCTRL
+	.section	.debug_info
+	.uleb128	345	; ref to abbrev 345
+	.section	.debug_abbrev
+	.uleb128	345
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname345:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname345
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C00 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #346: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	346	; ref to abbrev 346
+	.section	.debug_abbrev
+	.uleb128	346
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname346:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname346
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C00 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #347: variable STATUS
+	.section	.debug_info
+	.uleb128	347	; ref to abbrev 347
+	.section	.debug_abbrev
+	.uleb128	347
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname347:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname347
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C00 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #348: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	348	; ref to abbrev 348
+	.section	.debug_abbrev
+	.uleb128	348
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname348:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname348
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C00 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #349: variable CNT
+	.section	.debug_info
+	.uleb128	349	; ref to abbrev 349
+	.section	.debug_abbrev
+	.uleb128	349
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname349:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname349
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint32_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C00 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #350: variable CMP
+	.section	.debug_info
+	.uleb128	350	; ref to abbrev 350
+	.section	.debug_abbrev
+	.uleb128	350
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname350:
+	.string		"CMP"
+	.section	.debug_info
+	.long		.Lname350
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint32_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C00 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #351: variable CTRLA
+	.section	.debug_info
+	.uleb128	351	; ref to abbrev 351
+	.section	.debug_abbrev
+	.uleb128	351
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname351:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname351
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #352: variable DUALCTRL
+	.section	.debug_info
+	.uleb128	352	; ref to abbrev 352
+	.section	.debug_abbrev
+	.uleb128	352
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname352:
+	.string		"DUALCTRL"
+	.section	.debug_info
+	.long		.Lname352
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #353: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	353	; ref to abbrev 353
+	.section	.debug_abbrev
+	.uleb128	353
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname353:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname353
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #354: variable MCTRLA
+	.section	.debug_info
+	.uleb128	354	; ref to abbrev 354
+	.section	.debug_abbrev
+	.uleb128	354
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname354:
+	.string		"MCTRLA"
+	.section	.debug_info
+	.long		.Lname354
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #355: variable MCTRLB
+	.section	.debug_info
+	.uleb128	355	; ref to abbrev 355
+	.section	.debug_abbrev
+	.uleb128	355
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname355:
+	.string		"MCTRLB"
+	.section	.debug_info
+	.long		.Lname355
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #356: variable MSTATUS
+	.section	.debug_info
+	.uleb128	356	; ref to abbrev 356
+	.section	.debug_abbrev
+	.uleb128	356
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname356:
+	.string		"MSTATUS"
+	.section	.debug_info
+	.long		.Lname356
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #357: variable MBAUD
+	.section	.debug_info
+	.uleb128	357	; ref to abbrev 357
+	.section	.debug_abbrev
+	.uleb128	357
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname357:
+	.string		"MBAUD"
+	.section	.debug_info
+	.long		.Lname357
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #358: variable MADDR
+	.section	.debug_info
+	.uleb128	358	; ref to abbrev 358
+	.section	.debug_abbrev
+	.uleb128	358
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname358:
+	.string		"MADDR"
+	.section	.debug_info
+	.long		.Lname358
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #359: variable MDATA
+	.section	.debug_info
+	.uleb128	359	; ref to abbrev 359
+	.section	.debug_abbrev
+	.uleb128	359
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname359:
+	.string		"MDATA"
+	.section	.debug_info
+	.long		.Lname359
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #360: variable SCTRLA
+	.section	.debug_info
+	.uleb128	360	; ref to abbrev 360
+	.section	.debug_abbrev
+	.uleb128	360
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname360:
+	.string		"SCTRLA"
+	.section	.debug_info
+	.long		.Lname360
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #361: variable SCTRLB
+	.section	.debug_info
+	.uleb128	361	; ref to abbrev 361
+	.section	.debug_abbrev
+	.uleb128	361
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname361:
+	.string		"SCTRLB"
+	.section	.debug_info
+	.long		.Lname361
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #362: variable SSTATUS
+	.section	.debug_info
+	.uleb128	362	; ref to abbrev 362
+	.section	.debug_abbrev
+	.uleb128	362
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname362:
+	.string		"SSTATUS"
+	.section	.debug_info
+	.long		.Lname362
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #363: variable SADDR
+	.section	.debug_info
+	.uleb128	363	; ref to abbrev 363
+	.section	.debug_abbrev
+	.uleb128	363
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname363:
+	.string		"SADDR"
+	.section	.debug_info
+	.long		.Lname363
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #364: variable SDATA
+	.section	.debug_info
+	.uleb128	364	; ref to abbrev 364
+	.section	.debug_abbrev
+	.uleb128	364
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname364:
+	.string		"SDATA"
+	.section	.debug_info
+	.long		.Lname364
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xD
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #365: variable SADDRMASK
+	.section	.debug_info
+	.uleb128	365	; ref to abbrev 365
+	.section	.debug_abbrev
+	.uleb128	365
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname365:
+	.string		"SADDRMASK"
+	.section	.debug_info
+	.long		.Lname365
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xE
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #366: variable RXDATAL
+	.section	.debug_info
+	.uleb128	366	; ref to abbrev 366
+	.section	.debug_abbrev
+	.uleb128	366
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname366:
+	.string		"RXDATAL"
+	.section	.debug_info
+	.long		.Lname366
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #367: variable RXDATAH
+	.section	.debug_info
+	.uleb128	367	; ref to abbrev 367
+	.section	.debug_abbrev
+	.uleb128	367
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname367:
+	.string		"RXDATAH"
+	.section	.debug_info
+	.long		.Lname367
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #368: variable TXDATAL
+	.section	.debug_info
+	.uleb128	368	; ref to abbrev 368
+	.section	.debug_abbrev
+	.uleb128	368
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname368:
+	.string		"TXDATAL"
+	.section	.debug_info
+	.long		.Lname368
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #369: variable TXDATAH
+	.section	.debug_info
+	.uleb128	369	; ref to abbrev 369
+	.section	.debug_abbrev
+	.uleb128	369
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname369:
+	.string		"TXDATAH"
+	.section	.debug_info
+	.long		.Lname369
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #370: variable STATUS
+	.section	.debug_info
+	.uleb128	370	; ref to abbrev 370
+	.section	.debug_abbrev
+	.uleb128	370
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname370:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname370
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #371: variable CTRLA
+	.section	.debug_info
+	.uleb128	371	; ref to abbrev 371
+	.section	.debug_abbrev
+	.uleb128	371
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname371:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname371
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #372: variable CTRLB
+	.section	.debug_info
+	.uleb128	372	; ref to abbrev 372
+	.section	.debug_abbrev
+	.uleb128	372
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname372:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname372
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #373: variable CTRLC
+	.section	.debug_info
+	.uleb128	373	; ref to abbrev 373
+	.section	.debug_abbrev
+	.uleb128	373
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname373:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname373
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #374: variable BAUD
+	.section	.debug_info
+	.uleb128	374	; ref to abbrev 374
+	.section	.debug_abbrev
+	.uleb128	374
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname374:
+	.string		"BAUD"
+	.section	.debug_info
+	.long		.Lname374
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #375: variable CTRLD
+	.section	.debug_info
+	.uleb128	375	; ref to abbrev 375
+	.section	.debug_abbrev
+	.uleb128	375
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname375:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname375
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #376: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	376	; ref to abbrev 376
+	.section	.debug_abbrev
+	.uleb128	376
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname376:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname376
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #377: variable EVCTRL
+	.section	.debug_info
+	.uleb128	377	; ref to abbrev 377
+	.section	.debug_abbrev
+	.uleb128	377
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname377:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname377
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #378: variable TXPLCTRL
+	.section	.debug_info
+	.uleb128	378	; ref to abbrev 378
+	.section	.debug_abbrev
+	.uleb128	378
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname378:
+	.string		"TXPLCTRL"
+	.section	.debug_info
+	.long		.Lname378
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xD
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #379: variable RXPLCTRL
+	.section	.debug_info
+	.uleb128	379	; ref to abbrev 379
+	.section	.debug_abbrev
+	.uleb128	379
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname379:
+	.string		"RXPLCTRL"
+	.section	.debug_info
+	.long		.Lname379
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xE
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #380: variable USERROW0
+	.section	.debug_info
+	.uleb128	380	; ref to abbrev 380
+	.section	.debug_abbrev
+	.uleb128	380
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname380:
+	.string		"USERROW0"
+	.section	.debug_info
+	.long		.Lname380
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #381: variable USERROW1
+	.section	.debug_info
+	.uleb128	381	; ref to abbrev 381
+	.section	.debug_abbrev
+	.uleb128	381
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname381:
+	.string		"USERROW1"
+	.section	.debug_info
+	.long		.Lname381
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #382: variable USERROW2
+	.section	.debug_info
+	.uleb128	382	; ref to abbrev 382
+	.section	.debug_abbrev
+	.uleb128	382
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname382:
+	.string		"USERROW2"
+	.section	.debug_info
+	.long		.Lname382
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #383: variable USERROW3
+	.section	.debug_info
+	.uleb128	383	; ref to abbrev 383
+	.section	.debug_abbrev
+	.uleb128	383
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname383:
+	.string		"USERROW3"
+	.section	.debug_info
+	.long		.Lname383
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #384: variable USERROW4
+	.section	.debug_info
+	.uleb128	384	; ref to abbrev 384
+	.section	.debug_abbrev
+	.uleb128	384
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname384:
+	.string		"USERROW4"
+	.section	.debug_info
+	.long		.Lname384
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #385: variable USERROW5
+	.section	.debug_info
+	.uleb128	385	; ref to abbrev 385
+	.section	.debug_abbrev
+	.uleb128	385
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname385:
+	.string		"USERROW5"
+	.section	.debug_info
+	.long		.Lname385
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #386: variable USERROW6
+	.section	.debug_info
+	.uleb128	386	; ref to abbrev 386
+	.section	.debug_abbrev
+	.uleb128	386
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname386:
+	.string		"USERROW6"
+	.section	.debug_info
+	.long		.Lname386
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #387: variable USERROW7
+	.section	.debug_info
+	.uleb128	387	; ref to abbrev 387
+	.section	.debug_abbrev
+	.uleb128	387
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname387:
+	.string		"USERROW7"
+	.section	.debug_info
+	.long		.Lname387
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #388: variable USERROW8
+	.section	.debug_info
+	.uleb128	388	; ref to abbrev 388
+	.section	.debug_abbrev
+	.uleb128	388
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname388:
+	.string		"USERROW8"
+	.section	.debug_info
+	.long		.Lname388
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #389: variable USERROW9
+	.section	.debug_info
+	.uleb128	389	; ref to abbrev 389
+	.section	.debug_abbrev
+	.uleb128	389
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname389:
+	.string		"USERROW9"
+	.section	.debug_info
+	.long		.Lname389
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #390: variable USERROW10
+	.section	.debug_info
+	.uleb128	390	; ref to abbrev 390
+	.section	.debug_abbrev
+	.uleb128	390
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname390:
+	.string		"USERROW10"
+	.section	.debug_info
+	.long		.Lname390
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #391: variable USERROW11
+	.section	.debug_info
+	.uleb128	391	; ref to abbrev 391
+	.section	.debug_abbrev
+	.uleb128	391
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname391:
+	.string		"USERROW11"
+	.section	.debug_info
+	.long		.Lname391
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #392: variable USERROW12
+	.section	.debug_info
+	.uleb128	392	; ref to abbrev 392
+	.section	.debug_abbrev
+	.uleb128	392
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname392:
+	.string		"USERROW12"
+	.section	.debug_info
+	.long		.Lname392
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #393: variable USERROW13
+	.section	.debug_info
+	.uleb128	393	; ref to abbrev 393
+	.section	.debug_abbrev
+	.uleb128	393
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname393:
+	.string		"USERROW13"
+	.section	.debug_info
+	.long		.Lname393
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #394: variable USERROW14
+	.section	.debug_info
+	.uleb128	394	; ref to abbrev 394
+	.section	.debug_abbrev
+	.uleb128	394
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname394:
+	.string		"USERROW14"
+	.section	.debug_info
+	.long		.Lname394
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #395: variable USERROW15
+	.section	.debug_info
+	.uleb128	395	; ref to abbrev 395
+	.section	.debug_abbrev
+	.uleb128	395
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname395:
+	.string		"USERROW15"
+	.section	.debug_info
+	.long		.Lname395
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x0F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #396: variable USERROW16
+	.section	.debug_info
+	.uleb128	396	; ref to abbrev 396
+	.section	.debug_abbrev
+	.uleb128	396
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname396:
+	.string		"USERROW16"
+	.section	.debug_info
+	.long		.Lname396
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #397: variable USERROW17
+	.section	.debug_info
+	.uleb128	397	; ref to abbrev 397
+	.section	.debug_abbrev
+	.uleb128	397
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname397:
+	.string		"USERROW17"
+	.section	.debug_info
+	.long		.Lname397
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #398: variable USERROW18
+	.section	.debug_info
+	.uleb128	398	; ref to abbrev 398
+	.section	.debug_abbrev
+	.uleb128	398
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname398:
+	.string		"USERROW18"
+	.section	.debug_info
+	.long		.Lname398
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #399: variable USERROW19
+	.section	.debug_info
+	.uleb128	399	; ref to abbrev 399
+	.section	.debug_abbrev
+	.uleb128	399
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname399:
+	.string		"USERROW19"
+	.section	.debug_info
+	.long		.Lname399
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #400: variable USERROW20
+	.section	.debug_info
+	.uleb128	400	; ref to abbrev 400
+	.section	.debug_abbrev
+	.uleb128	400
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname400:
+	.string		"USERROW20"
+	.section	.debug_info
+	.long		.Lname400
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #401: variable USERROW21
+	.section	.debug_info
+	.uleb128	401	; ref to abbrev 401
+	.section	.debug_abbrev
+	.uleb128	401
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname401:
+	.string		"USERROW21"
+	.section	.debug_info
+	.long		.Lname401
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #402: variable USERROW22
+	.section	.debug_info
+	.uleb128	402	; ref to abbrev 402
+	.section	.debug_abbrev
+	.uleb128	402
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname402:
+	.string		"USERROW22"
+	.section	.debug_info
+	.long		.Lname402
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #403: variable USERROW23
+	.section	.debug_info
+	.uleb128	403	; ref to abbrev 403
+	.section	.debug_abbrev
+	.uleb128	403
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname403:
+	.string		"USERROW23"
+	.section	.debug_info
+	.long		.Lname403
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #404: variable USERROW24
+	.section	.debug_info
+	.uleb128	404	; ref to abbrev 404
+	.section	.debug_abbrev
+	.uleb128	404
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname404:
+	.string		"USERROW24"
+	.section	.debug_info
+	.long		.Lname404
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #405: variable USERROW25
+	.section	.debug_info
+	.uleb128	405	; ref to abbrev 405
+	.section	.debug_abbrev
+	.uleb128	405
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname405:
+	.string		"USERROW25"
+	.section	.debug_info
+	.long		.Lname405
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x19
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #406: variable USERROW26
+	.section	.debug_info
+	.uleb128	406	; ref to abbrev 406
+	.section	.debug_abbrev
+	.uleb128	406
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname406:
+	.string		"USERROW26"
+	.section	.debug_info
+	.long		.Lname406
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x1A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #407: variable USERROW27
+	.section	.debug_info
+	.uleb128	407	; ref to abbrev 407
+	.section	.debug_abbrev
+	.uleb128	407
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname407:
+	.string		"USERROW27"
+	.section	.debug_info
+	.long		.Lname407
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x1B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #408: variable USERROW28
+	.section	.debug_info
+	.uleb128	408	; ref to abbrev 408
+	.section	.debug_abbrev
+	.uleb128	408
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname408:
+	.string		"USERROW28"
+	.section	.debug_info
+	.long		.Lname408
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x1C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #409: variable USERROW29
+	.section	.debug_info
+	.uleb128	409	; ref to abbrev 409
+	.section	.debug_abbrev
+	.uleb128	409
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname409:
+	.string		"USERROW29"
+	.section	.debug_info
+	.long		.Lname409
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x1D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #410: variable USERROW30
+	.section	.debug_info
+	.uleb128	410	; ref to abbrev 410
+	.section	.debug_abbrev
+	.uleb128	410
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname410:
+	.string		"USERROW30"
+	.section	.debug_info
+	.long		.Lname410
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x1E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #411: variable USERROW31
+	.section	.debug_info
+	.uleb128	411	; ref to abbrev 411
+	.section	.debug_abbrev
+	.uleb128	411
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname411:
+	.string		"USERROW31"
+	.section	.debug_info
+	.long		.Lname411
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x1F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #412: variable USERROW32
+	.section	.debug_info
+	.uleb128	412	; ref to abbrev 412
+	.section	.debug_abbrev
+	.uleb128	412
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname412:
+	.string		"USERROW32"
+	.section	.debug_info
+	.long		.Lname412
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #413: variable USERROW33
+	.section	.debug_info
+	.uleb128	413	; ref to abbrev 413
+	.section	.debug_abbrev
+	.uleb128	413
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname413:
+	.string		"USERROW33"
+	.section	.debug_info
+	.long		.Lname413
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x21
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #414: variable USERROW34
+	.section	.debug_info
+	.uleb128	414	; ref to abbrev 414
+	.section	.debug_abbrev
+	.uleb128	414
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname414:
+	.string		"USERROW34"
+	.section	.debug_info
+	.long		.Lname414
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x22
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #415: variable USERROW35
+	.section	.debug_info
+	.uleb128	415	; ref to abbrev 415
+	.section	.debug_abbrev
+	.uleb128	415
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname415:
+	.string		"USERROW35"
+	.section	.debug_info
+	.long		.Lname415
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x23
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #416: variable USERROW36
+	.section	.debug_info
+	.uleb128	416	; ref to abbrev 416
+	.section	.debug_abbrev
+	.uleb128	416
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname416:
+	.string		"USERROW36"
+	.section	.debug_info
+	.long		.Lname416
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x24
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #417: variable USERROW37
+	.section	.debug_info
+	.uleb128	417	; ref to abbrev 417
+	.section	.debug_abbrev
+	.uleb128	417
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname417:
+	.string		"USERROW37"
+	.section	.debug_info
+	.long		.Lname417
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x25
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #418: variable USERROW38
+	.section	.debug_info
+	.uleb128	418	; ref to abbrev 418
+	.section	.debug_abbrev
+	.uleb128	418
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname418:
+	.string		"USERROW38"
+	.section	.debug_info
+	.long		.Lname418
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x26
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #419: variable USERROW39
+	.section	.debug_info
+	.uleb128	419	; ref to abbrev 419
+	.section	.debug_abbrev
+	.uleb128	419
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname419:
+	.string		"USERROW39"
+	.section	.debug_info
+	.long		.Lname419
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x27
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #420: variable USERROW40
+	.section	.debug_info
+	.uleb128	420	; ref to abbrev 420
+	.section	.debug_abbrev
+	.uleb128	420
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname420:
+	.string		"USERROW40"
+	.section	.debug_info
+	.long		.Lname420
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x28
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #421: variable USERROW41
+	.section	.debug_info
+	.uleb128	421	; ref to abbrev 421
+	.section	.debug_abbrev
+	.uleb128	421
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname421:
+	.string		"USERROW41"
+	.section	.debug_info
+	.long		.Lname421
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x29
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #422: variable USERROW42
+	.section	.debug_info
+	.uleb128	422	; ref to abbrev 422
+	.section	.debug_abbrev
+	.uleb128	422
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname422:
+	.string		"USERROW42"
+	.section	.debug_info
+	.long		.Lname422
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x2A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #423: variable USERROW43
+	.section	.debug_info
+	.uleb128	423	; ref to abbrev 423
+	.section	.debug_abbrev
+	.uleb128	423
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname423:
+	.string		"USERROW43"
+	.section	.debug_info
+	.long		.Lname423
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x2B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #424: variable USERROW44
+	.section	.debug_info
+	.uleb128	424	; ref to abbrev 424
+	.section	.debug_abbrev
+	.uleb128	424
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname424:
+	.string		"USERROW44"
+	.section	.debug_info
+	.long		.Lname424
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x2C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #425: variable USERROW45
+	.section	.debug_info
+	.uleb128	425	; ref to abbrev 425
+	.section	.debug_abbrev
+	.uleb128	425
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname425:
+	.string		"USERROW45"
+	.section	.debug_info
+	.long		.Lname425
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x2D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #426: variable USERROW46
+	.section	.debug_info
+	.uleb128	426	; ref to abbrev 426
+	.section	.debug_abbrev
+	.uleb128	426
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname426:
+	.string		"USERROW46"
+	.section	.debug_info
+	.long		.Lname426
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x2E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #427: variable USERROW47
+	.section	.debug_info
+	.uleb128	427	; ref to abbrev 427
+	.section	.debug_abbrev
+	.uleb128	427
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname427:
+	.string		"USERROW47"
+	.section	.debug_info
+	.long		.Lname427
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x2F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #428: variable USERROW48
+	.section	.debug_info
+	.uleb128	428	; ref to abbrev 428
+	.section	.debug_abbrev
+	.uleb128	428
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname428:
+	.string		"USERROW48"
+	.section	.debug_info
+	.long		.Lname428
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x30
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #429: variable USERROW49
+	.section	.debug_info
+	.uleb128	429	; ref to abbrev 429
+	.section	.debug_abbrev
+	.uleb128	429
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname429:
+	.string		"USERROW49"
+	.section	.debug_info
+	.long		.Lname429
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x31
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #430: variable USERROW50
+	.section	.debug_info
+	.uleb128	430	; ref to abbrev 430
+	.section	.debug_abbrev
+	.uleb128	430
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname430:
+	.string		"USERROW50"
+	.section	.debug_info
+	.long		.Lname430
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x32
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #431: variable USERROW51
+	.section	.debug_info
+	.uleb128	431	; ref to abbrev 431
+	.section	.debug_abbrev
+	.uleb128	431
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname431:
+	.string		"USERROW51"
+	.section	.debug_info
+	.long		.Lname431
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x33
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #432: variable USERROW52
+	.section	.debug_info
+	.uleb128	432	; ref to abbrev 432
+	.section	.debug_abbrev
+	.uleb128	432
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname432:
+	.string		"USERROW52"
+	.section	.debug_info
+	.long		.Lname432
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x34
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #433: variable USERROW53
+	.section	.debug_info
+	.uleb128	433	; ref to abbrev 433
+	.section	.debug_abbrev
+	.uleb128	433
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname433:
+	.string		"USERROW53"
+	.section	.debug_info
+	.long		.Lname433
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x35
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #434: variable USERROW54
+	.section	.debug_info
+	.uleb128	434	; ref to abbrev 434
+	.section	.debug_abbrev
+	.uleb128	434
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname434:
+	.string		"USERROW54"
+	.section	.debug_info
+	.long		.Lname434
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x36
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #435: variable USERROW55
+	.section	.debug_info
+	.uleb128	435	; ref to abbrev 435
+	.section	.debug_abbrev
+	.uleb128	435
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname435:
+	.string		"USERROW55"
+	.section	.debug_info
+	.long		.Lname435
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x37
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #436: variable USERROW56
+	.section	.debug_info
+	.uleb128	436	; ref to abbrev 436
+	.section	.debug_abbrev
+	.uleb128	436
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname436:
+	.string		"USERROW56"
+	.section	.debug_info
+	.long		.Lname436
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x38
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #437: variable USERROW57
+	.section	.debug_info
+	.uleb128	437	; ref to abbrev 437
+	.section	.debug_abbrev
+	.uleb128	437
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname437:
+	.string		"USERROW57"
+	.section	.debug_info
+	.long		.Lname437
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x39
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #438: variable USERROW58
+	.section	.debug_info
+	.uleb128	438	; ref to abbrev 438
+	.section	.debug_abbrev
+	.uleb128	438
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname438:
+	.string		"USERROW58"
+	.section	.debug_info
+	.long		.Lname438
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x3A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #439: variable USERROW59
+	.section	.debug_info
+	.uleb128	439	; ref to abbrev 439
+	.section	.debug_abbrev
+	.uleb128	439
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname439:
+	.string		"USERROW59"
+	.section	.debug_info
+	.long		.Lname439
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x3B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #440: variable USERROW60
+	.section	.debug_info
+	.uleb128	440	; ref to abbrev 440
+	.section	.debug_abbrev
+	.uleb128	440
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname440:
+	.string		"USERROW60"
+	.section	.debug_info
+	.long		.Lname440
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x3C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #441: variable USERROW61
+	.section	.debug_info
+	.uleb128	441	; ref to abbrev 441
+	.section	.debug_abbrev
+	.uleb128	441
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname441:
+	.string		"USERROW61"
+	.section	.debug_info
+	.long		.Lname441
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x3D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #442: variable USERROW62
+	.section	.debug_info
+	.uleb128	442	; ref to abbrev 442
+	.section	.debug_abbrev
+	.uleb128	442
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname442:
+	.string		"USERROW62"
+	.section	.debug_info
+	.long		.Lname442
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x3E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #443: variable USERROW63
+	.section	.debug_info
+	.uleb128	443	; ref to abbrev 443
+	.section	.debug_abbrev
+	.uleb128	443
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname443:
+	.string		"USERROW63"
+	.section	.debug_info
+	.long		.Lname443
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1200 + 0x3F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #444: variable DIR
+	.section	.debug_info
+	.uleb128	444	; ref to abbrev 444
+	.section	.debug_abbrev
+	.uleb128	444
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname444:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname444
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0000 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #445: variable OUT
+	.section	.debug_info
+	.uleb128	445	; ref to abbrev 445
+	.section	.debug_abbrev
+	.uleb128	445
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname445:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname445
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0000 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #446: variable IN
+	.section	.debug_info
+	.uleb128	446	; ref to abbrev 446
+	.section	.debug_abbrev
+	.uleb128	446
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname446:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname446
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0000 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #447: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	447	; ref to abbrev 447
+	.section	.debug_abbrev
+	.uleb128	447
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname447:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname447
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0000 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #448: variable DIR
+	.section	.debug_info
+	.uleb128	448	; ref to abbrev 448
+	.section	.debug_abbrev
+	.uleb128	448
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname448:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname448
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0008 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #449: variable OUT
+	.section	.debug_info
+	.uleb128	449	; ref to abbrev 449
+	.section	.debug_abbrev
+	.uleb128	449
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname449:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname449
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0008 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #450: variable IN
+	.section	.debug_info
+	.uleb128	450	; ref to abbrev 450
+	.section	.debug_abbrev
+	.uleb128	450
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname450:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname450
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0008 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #451: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	451	; ref to abbrev 451
+	.section	.debug_abbrev
+	.uleb128	451
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname451:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname451
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0008 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #452: variable DIR
+	.section	.debug_info
+	.uleb128	452	; ref to abbrev 452
+	.section	.debug_abbrev
+	.uleb128	452
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname452:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname452
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x000C + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #453: variable OUT
+	.section	.debug_info
+	.uleb128	453	; ref to abbrev 453
+	.section	.debug_abbrev
+	.uleb128	453
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname453:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname453
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x000C + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #454: variable IN
+	.section	.debug_info
+	.uleb128	454	; ref to abbrev 454
+	.section	.debug_abbrev
+	.uleb128	454
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname454:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname454
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x000C + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #455: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	455	; ref to abbrev 455
+	.section	.debug_abbrev
+	.uleb128	455
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname455:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname455
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x000C + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #456: variable DIR
+	.section	.debug_info
+	.uleb128	456	; ref to abbrev 456
+	.section	.debug_abbrev
+	.uleb128	456
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname456:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname456
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0014 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #457: variable OUT
+	.section	.debug_info
+	.uleb128	457	; ref to abbrev 457
+	.section	.debug_abbrev
+	.uleb128	457
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname457:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname457
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0014 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #458: variable IN
+	.section	.debug_info
+	.uleb128	458	; ref to abbrev 458
+	.section	.debug_abbrev
+	.uleb128	458
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname458:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname458
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0014 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #459: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	459	; ref to abbrev 459
+	.section	.debug_abbrev
+	.uleb128	459
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname459:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname459
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0014 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #460: variable DAC0REF
+	.section	.debug_info
+	.uleb128	460	; ref to abbrev 460
+	.section	.debug_abbrev
+	.uleb128	460
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname460:
+	.string		"DAC0REF"
+	.section	.debug_info
+	.long		.Lname460
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00B0 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #461: variable ACREF
+	.section	.debug_info
+	.uleb128	461	; ref to abbrev 461
+	.section	.debug_abbrev
+	.uleb128	461
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname461:
+	.string		"ACREF"
+	.section	.debug_info
+	.long		.Lname461
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00B0 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #462: variable CTRLA
+	.section	.debug_info
+	.uleb128	462	; ref to abbrev 462
+	.section	.debug_abbrev
+	.uleb128	462
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname462:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname462
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0100 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #463: variable STATUS
+	.section	.debug_info
+	.uleb128	463	; ref to abbrev 463
+	.section	.debug_abbrev
+	.uleb128	463
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname463:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname463
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0100 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #464: variable CTRLA
+	.section	.debug_info
+	.uleb128	464	; ref to abbrev 464
+	.section	.debug_abbrev
+	.uleb128	464
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname464:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname464
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #465: variable CTRLB
+	.section	.debug_info
+	.uleb128	465	; ref to abbrev 465
+	.section	.debug_abbrev
+	.uleb128	465
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname465:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname465
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #466: variable CTRLC
+	.section	.debug_info
+	.uleb128	466	; ref to abbrev 466
+	.section	.debug_abbrev
+	.uleb128	466
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname466:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname466
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #467: variable EVCTRLA
+	.section	.debug_info
+	.uleb128	467	; ref to abbrev 467
+	.section	.debug_abbrev
+	.uleb128	467
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname467:
+	.string		"EVCTRLA"
+	.section	.debug_info
+	.long		.Lname467
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #468: variable EVCTRLB
+	.section	.debug_info
+	.uleb128	468	; ref to abbrev 468
+	.section	.debug_abbrev
+	.uleb128	468
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname468:
+	.string		"EVCTRLB"
+	.section	.debug_info
+	.long		.Lname468
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #469: variable EVCTRLC
+	.section	.debug_info
+	.uleb128	469	; ref to abbrev 469
+	.section	.debug_abbrev
+	.uleb128	469
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname469:
+	.string		"EVCTRLC"
+	.section	.debug_info
+	.long		.Lname469
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #470: variable BUFCTRL
+	.section	.debug_info
+	.uleb128	470	; ref to abbrev 470
+	.section	.debug_abbrev
+	.uleb128	470
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname470:
+	.string		"BUFCTRL"
+	.section	.debug_info
+	.long		.Lname470
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #471: variable BLANKCTRL
+	.section	.debug_info
+	.uleb128	471	; ref to abbrev 471
+	.section	.debug_abbrev
+	.uleb128	471
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname471:
+	.string		"BLANKCTRL"
+	.section	.debug_info
+	.long		.Lname471
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #472: variable BLANKTIME
+	.section	.debug_info
+	.uleb128	472	; ref to abbrev 472
+	.section	.debug_abbrev
+	.uleb128	472
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname472:
+	.string		"BLANKTIME"
+	.section	.debug_info
+	.long		.Lname472
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #473: variable FAULTCTRL
+	.section	.debug_info
+	.uleb128	473	; ref to abbrev 473
+	.section	.debug_abbrev
+	.uleb128	473
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname473:
+	.string		"FAULTCTRL"
+	.section	.debug_info
+	.long		.Lname473
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #474: variable FAULTDRV
+	.section	.debug_info
+	.uleb128	474	; ref to abbrev 474
+	.section	.debug_abbrev
+	.uleb128	474
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname474:
+	.string		"FAULTDRV"
+	.section	.debug_info
+	.long		.Lname474
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #475: variable FAULTOUT
+	.section	.debug_info
+	.uleb128	475	; ref to abbrev 475
+	.section	.debug_abbrev
+	.uleb128	475
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname475:
+	.string		"FAULTOUT"
+	.section	.debug_info
+	.long		.Lname475
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #476: variable INTCTRL
+	.section	.debug_info
+	.uleb128	476	; ref to abbrev 476
+	.section	.debug_abbrev
+	.uleb128	476
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname476:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname476
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #477: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	477	; ref to abbrev 477
+	.section	.debug_abbrev
+	.uleb128	477
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname477:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname477
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #478: variable STATUS
+	.section	.debug_info
+	.uleb128	478	; ref to abbrev 478
+	.section	.debug_abbrev
+	.uleb128	478
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname478:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname478
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x0F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #479: variable DTLS
+	.section	.debug_info
+	.uleb128	479	; ref to abbrev 479
+	.section	.debug_abbrev
+	.uleb128	479
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname479:
+	.string		"DTLS"
+	.section	.debug_info
+	.long		.Lname479
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #480: variable DTHS
+	.section	.debug_info
+	.uleb128	480	; ref to abbrev 480
+	.section	.debug_abbrev
+	.uleb128	480
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname480:
+	.string		"DTHS"
+	.section	.debug_info
+	.long		.Lname480
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #481: variable DTBOTH
+	.section	.debug_info
+	.uleb128	481	; ref to abbrev 481
+	.section	.debug_abbrev
+	.uleb128	481
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname481:
+	.string		"DTBOTH"
+	.section	.debug_info
+	.long		.Lname481
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #482: variable SWAP
+	.section	.debug_info
+	.uleb128	482	; ref to abbrev 482
+	.section	.debug_abbrev
+	.uleb128	482
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname482:
+	.string		"SWAP"
+	.section	.debug_info
+	.long		.Lname482
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #483: variable PGMOVR
+	.section	.debug_info
+	.uleb128	483	; ref to abbrev 483
+	.section	.debug_abbrev
+	.uleb128	483
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname483:
+	.string		"PGMOVR"
+	.section	.debug_info
+	.long		.Lname483
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #484: variable PGMOUT
+	.section	.debug_info
+	.uleb128	484	; ref to abbrev 484
+	.section	.debug_abbrev
+	.uleb128	484
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname484:
+	.string		"PGMOUT"
+	.section	.debug_info
+	.long		.Lname484
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #485: variable OUTOVEN
+	.section	.debug_info
+	.uleb128	485	; ref to abbrev 485
+	.section	.debug_abbrev
+	.uleb128	485
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname485:
+	.string		"OUTOVEN"
+	.section	.debug_info
+	.long		.Lname485
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #486: variable DTLSBUF
+	.section	.debug_info
+	.uleb128	486	; ref to abbrev 486
+	.section	.debug_abbrev
+	.uleb128	486
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname486:
+	.string		"DTLSBUF"
+	.section	.debug_info
+	.long		.Lname486
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #487: variable DTHSBUF
+	.section	.debug_info
+	.uleb128	487	; ref to abbrev 487
+	.section	.debug_abbrev
+	.uleb128	487
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname487:
+	.string		"DTHSBUF"
+	.section	.debug_info
+	.long		.Lname487
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x19
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #488: variable DTBOTHBUF
+	.section	.debug_info
+	.uleb128	488	; ref to abbrev 488
+	.section	.debug_abbrev
+	.uleb128	488
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname488:
+	.string		"DTBOTHBUF"
+	.section	.debug_info
+	.long		.Lname488
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x1A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #489: variable SWAPBUF
+	.section	.debug_info
+	.uleb128	489	; ref to abbrev 489
+	.section	.debug_abbrev
+	.uleb128	489
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname489:
+	.string		"SWAPBUF"
+	.section	.debug_info
+	.long		.Lname489
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x1B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #490: variable PGMOVRBUF
+	.section	.debug_info
+	.uleb128	490	; ref to abbrev 490
+	.section	.debug_abbrev
+	.uleb128	490
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname490:
+	.string		"PGMOVRBUF"
+	.section	.debug_info
+	.long		.Lname490
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x1C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #491: variable PGMOUTBUF
+	.section	.debug_info
+	.uleb128	491	; ref to abbrev 491
+	.section	.debug_abbrev
+	.uleb128	491
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname491:
+	.string		"PGMOUTBUF"
+	.section	.debug_info
+	.long		.Lname491
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0C80 + 0x1D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+	;; trailer
+	.section	.debug_abbrev
+	.uleb128	0
+
+	.section	.debug_info
+	.uleb128	0
+.Leinfo:

--- a/crt1/iosym/avr32ea28.S
+++ b/crt1/iosym/avr32ea28.S
@@ -1,0 +1,26945 @@
+/* This file is part of avr-libc.
+
+   Automatically created by devtools/ioreg.pl
+   DO NOT EDIT!
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in
+     the documentation and/or other materials provided with the
+     distribution.
+
+   * Neither the name of the copyright holders nor the names of
+     contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE. */
+
+/* $Id$ */
+
+#include <avr/version.h>
+
+#define DW_TAG_array_type               0x01
+#define DW_TAG_compile_unit             0x11
+#define DW_TAG_typedef                  0x16
+#define DW_TAG_subrange_type            0x21
+#define DW_TAG_base_type                0x24
+#define DW_TAG_variable                 0x34
+
+#define DW_FORM_addr                    0x01
+#define DW_FORM_block1                  0x0a
+#define DW_FORM_block2                  0x03
+#define DW_FORM_block4                  0x04
+#define DW_FORM_data1                   0x0b
+#define DW_FORM_data2                   0x05
+#define DW_FORM_data4                   0x06
+#define DW_FORM_data8                   0x07
+#define DW_FORM_string                  0x08
+#define DW_FORM_flag                    0x0c
+#define DW_FORM_strp                    0x0e
+#define DW_FORM_ref1                    0x11
+#define DW_FORM_ref2                    0x12
+#define DW_FORM_ref4                    0x13
+#define DW_FORM_ref8                    0x14
+
+#define DW_AT_location                  0x02
+#define DW_AT_name                      0x03
+#define DW_AT_byte_size                 0x0b
+#define DW_AT_stmt_list                 0x10
+#define DW_AT_language                  0x13
+#define DW_AT_producer                  0x25
+#define DW_AT_upper_bound               0x2f
+#define DW_AT_decl_file                 0x3a
+#define DW_AT_decl_line                 0x3b
+#define DW_AT_encoding                  0x3e
+#define DW_AT_external                  0x3f
+#define DW_AT_type                      0x49
+
+#define DW_LANG_C89                     0x0001
+
+#define DW_CHILDREN_no                  0x00
+#define DW_CHILDREN_yes                 0x01
+
+#define DW_ATE_unsigned                 0x7
+#define DW_ATE_unsigned_char            0x8
+
+#define DW_OP_addr                      0x03
+.eject
+	.section	.debug_abbrev, "", @progbits
+.Ldebug_abbrev0:
+	.section	.debug_info, "", @progbits
+	.section	.debug_line, "", @progbits
+.Ldebug_line0:
+	.section	.debug_str, "", @progbits
+
+	.section	.debug_info, "", @progbits
+	;; compilation unit header
+.Lssinfo:
+	.long	.Leinfo - .Lsinfo
+.Lsinfo:
+	.word	2		; DWARF-2
+	.long	.Ldebug_abbrev0
+	.byte	4		; sizeof(address)
+
+
+	;; DIE #1: compilation unit
+	.section	.debug_info
+	.uleb128	1	; ref to abbrev 1
+	.section	.debug_abbrev
+	.uleb128	1
+	.uleb128	DW_TAG_compile_unit
+	.byte		DW_CHILDREN_yes
+
+	.uleb128	DW_AT_producer
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lproducer:
+	.ascii		"avr-libc "
+	.asciz		__AVR_LIBC_VERSION_STRING__
+	.section	.debug_info
+	.long		.Lproducer
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_stmt_list
+	.uleb128	DW_FORM_data4
+	.section	.debug_info
+	.long		.Ldebug_line0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+	;; DIE #2: base type uint8_t
+	.section	.debug_info
+.Luint8_t:
+	.uleb128	2	; ref to abbrev 2
+	.section	.debug_abbrev
+	.uleb128	2
+	.uleb128	DW_TAG_base_type
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Luint8_t_name:
+	.string		"uint8_t"
+	.section	.debug_info
+	.long		.Luint8_t_name
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_byte_size
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_encoding
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		DW_ATE_unsigned_char
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+	;; DIE #3: base type uint16_t
+	.section	.debug_info
+.Luint16_t:
+	.uleb128	3	; ref to abbrev 3
+	.section	.debug_abbrev
+	.uleb128	3
+	.uleb128	DW_TAG_base_type
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Luint16_t_name:
+	.string		"uint16_t"
+	.section	.debug_info
+	.long		.Luint16_t_name
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_byte_size
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		2
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_encoding
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		DW_ATE_unsigned
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #4: variable CTRLA
+	.section	.debug_info
+	.uleb128	4	; ref to abbrev 4
+	.section	.debug_abbrev
+	.uleb128	4
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname4:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname4
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #5: variable CTRLB
+	.section	.debug_info
+	.uleb128	5	; ref to abbrev 5
+	.section	.debug_abbrev
+	.uleb128	5
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname5:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname5
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #6: variable MUXCTRL
+	.section	.debug_info
+	.uleb128	6	; ref to abbrev 6
+	.section	.debug_abbrev
+	.uleb128	6
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname6:
+	.string		"MUXCTRL"
+	.section	.debug_info
+	.long		.Lname6
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #7: variable DACREF
+	.section	.debug_info
+	.uleb128	7	; ref to abbrev 7
+	.section	.debug_abbrev
+	.uleb128	7
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname7:
+	.string		"DACREF"
+	.section	.debug_info
+	.long		.Lname7
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #8: variable INTCTRL
+	.section	.debug_info
+	.uleb128	8	; ref to abbrev 8
+	.section	.debug_abbrev
+	.uleb128	8
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname8:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname8
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #9: variable STATUS
+	.section	.debug_info
+	.uleb128	9	; ref to abbrev 9
+	.section	.debug_abbrev
+	.uleb128	9
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname9:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname9
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #10: variable CTRLA
+	.section	.debug_info
+	.uleb128	10	; ref to abbrev 10
+	.section	.debug_abbrev
+	.uleb128	10
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname10:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname10
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #11: variable CTRLB
+	.section	.debug_info
+	.uleb128	11	; ref to abbrev 11
+	.section	.debug_abbrev
+	.uleb128	11
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname11:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname11
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #12: variable MUXCTRL
+	.section	.debug_info
+	.uleb128	12	; ref to abbrev 12
+	.section	.debug_abbrev
+	.uleb128	12
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname12:
+	.string		"MUXCTRL"
+	.section	.debug_info
+	.long		.Lname12
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #13: variable DACREF
+	.section	.debug_info
+	.uleb128	13	; ref to abbrev 13
+	.section	.debug_abbrev
+	.uleb128	13
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname13:
+	.string		"DACREF"
+	.section	.debug_info
+	.long		.Lname13
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #14: variable INTCTRL
+	.section	.debug_info
+	.uleb128	14	; ref to abbrev 14
+	.section	.debug_abbrev
+	.uleb128	14
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname14:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname14
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #15: variable STATUS
+	.section	.debug_info
+	.uleb128	15	; ref to abbrev 15
+	.section	.debug_abbrev
+	.uleb128	15
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname15:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname15
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #16: variable CTRLA
+	.section	.debug_info
+	.uleb128	16	; ref to abbrev 16
+	.section	.debug_abbrev
+	.uleb128	16
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname16:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname16
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #17: variable CTRLB
+	.section	.debug_info
+	.uleb128	17	; ref to abbrev 17
+	.section	.debug_abbrev
+	.uleb128	17
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname17:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname17
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #18: variable CTRLC
+	.section	.debug_info
+	.uleb128	18	; ref to abbrev 18
+	.section	.debug_abbrev
+	.uleb128	18
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname18:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname18
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #19: variable CTRLD
+	.section	.debug_info
+	.uleb128	19	; ref to abbrev 19
+	.section	.debug_abbrev
+	.uleb128	19
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname19:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname19
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #20: variable INTCTRL
+	.section	.debug_info
+	.uleb128	20	; ref to abbrev 20
+	.section	.debug_abbrev
+	.uleb128	20
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname20:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname20
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #21: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	21	; ref to abbrev 21
+	.section	.debug_abbrev
+	.uleb128	21
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname21:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname21
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #22: variable STATUS
+	.section	.debug_info
+	.uleb128	22	; ref to abbrev 22
+	.section	.debug_abbrev
+	.uleb128	22
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname22:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname22
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #23: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	23	; ref to abbrev 23
+	.section	.debug_abbrev
+	.uleb128	23
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname23:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname23
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #24: variable CTRLE
+	.section	.debug_info
+	.uleb128	24	; ref to abbrev 24
+	.section	.debug_abbrev
+	.uleb128	24
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname24:
+	.string		"CTRLE"
+	.section	.debug_info
+	.long		.Lname24
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #25: variable CTRLF
+	.section	.debug_info
+	.uleb128	25	; ref to abbrev 25
+	.section	.debug_abbrev
+	.uleb128	25
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname25:
+	.string		"CTRLF"
+	.section	.debug_info
+	.long		.Lname25
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #26: variable COMMAND
+	.section	.debug_info
+	.uleb128	26	; ref to abbrev 26
+	.section	.debug_abbrev
+	.uleb128	26
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname26:
+	.string		"COMMAND"
+	.section	.debug_info
+	.long		.Lname26
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #27: variable PGACTRL
+	.section	.debug_info
+	.uleb128	27	; ref to abbrev 27
+	.section	.debug_abbrev
+	.uleb128	27
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname27:
+	.string		"PGACTRL"
+	.section	.debug_info
+	.long		.Lname27
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #28: variable MUXPOS
+	.section	.debug_info
+	.uleb128	28	; ref to abbrev 28
+	.section	.debug_abbrev
+	.uleb128	28
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname28:
+	.string		"MUXPOS"
+	.section	.debug_info
+	.long		.Lname28
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #29: variable MUXNEG
+	.section	.debug_info
+	.uleb128	29	; ref to abbrev 29
+	.section	.debug_abbrev
+	.uleb128	29
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname29:
+	.string		"MUXNEG"
+	.section	.debug_info
+	.long		.Lname29
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #30: base type uint32_t
+	.section	.debug_info
+.Luint32_t:
+	.uleb128	30	; ref to abbrev 30
+	.section	.debug_abbrev
+	.uleb128	30
+	.uleb128	DW_TAG_base_type
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Luint32_t_name:
+	.string		"uint32_t"
+	.section	.debug_info
+	.long		.Luint32_t_name
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_byte_size
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		4
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_encoding
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		DW_ATE_unsigned
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #31: variable RESULT
+	.section	.debug_info
+	.uleb128	31	; ref to abbrev 31
+	.section	.debug_abbrev
+	.uleb128	31
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname31:
+	.string		"RESULT"
+	.section	.debug_info
+	.long		.Lname31
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint32_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #32: variable SAMPLE
+	.section	.debug_info
+	.uleb128	32	; ref to abbrev 32
+	.section	.debug_abbrev
+	.uleb128	32
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname32:
+	.string		"SAMPLE"
+	.section	.debug_info
+	.long		.Lname32
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #33: variable TEMP0
+	.section	.debug_info
+	.uleb128	33	; ref to abbrev 33
+	.section	.debug_abbrev
+	.uleb128	33
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname33:
+	.string		"TEMP0"
+	.section	.debug_info
+	.long		.Lname33
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #34: variable TEMP1
+	.section	.debug_info
+	.uleb128	34	; ref to abbrev 34
+	.section	.debug_abbrev
+	.uleb128	34
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname34:
+	.string		"TEMP1"
+	.section	.debug_info
+	.long		.Lname34
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x19
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #35: variable TEMP2
+	.section	.debug_info
+	.uleb128	35	; ref to abbrev 35
+	.section	.debug_abbrev
+	.uleb128	35
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname35:
+	.string		"TEMP2"
+	.section	.debug_info
+	.long		.Lname35
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x1A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #36: variable WINLT
+	.section	.debug_info
+	.uleb128	36	; ref to abbrev 36
+	.section	.debug_abbrev
+	.uleb128	36
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname36:
+	.string		"WINLT"
+	.section	.debug_info
+	.long		.Lname36
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x1C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #37: variable WINHT
+	.section	.debug_info
+	.uleb128	37	; ref to abbrev 37
+	.section	.debug_abbrev
+	.uleb128	37
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname37:
+	.string		"WINHT"
+	.section	.debug_info
+	.long		.Lname37
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x1E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #38: variable CTRLA
+	.section	.debug_info
+	.uleb128	38	; ref to abbrev 38
+	.section	.debug_abbrev
+	.uleb128	38
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname38:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname38
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #39: variable CTRLB
+	.section	.debug_info
+	.uleb128	39	; ref to abbrev 39
+	.section	.debug_abbrev
+	.uleb128	39
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname39:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname39
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #40: variable VLMCTRLA
+	.section	.debug_info
+	.uleb128	40	; ref to abbrev 40
+	.section	.debug_abbrev
+	.uleb128	40
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname40:
+	.string		"VLMCTRLA"
+	.section	.debug_info
+	.long		.Lname40
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #41: variable INTCTRL
+	.section	.debug_info
+	.uleb128	41	; ref to abbrev 41
+	.section	.debug_abbrev
+	.uleb128	41
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname41:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname41
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #42: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	42	; ref to abbrev 42
+	.section	.debug_abbrev
+	.uleb128	42
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname42:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname42
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #43: variable STATUS
+	.section	.debug_info
+	.uleb128	43	; ref to abbrev 43
+	.section	.debug_abbrev
+	.uleb128	43
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname43:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname43
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #44: variable CTRLA
+	.section	.debug_info
+	.uleb128	44	; ref to abbrev 44
+	.section	.debug_abbrev
+	.uleb128	44
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname44:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname44
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #45: variable SEQCTRL0
+	.section	.debug_info
+	.uleb128	45	; ref to abbrev 45
+	.section	.debug_abbrev
+	.uleb128	45
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname45:
+	.string		"SEQCTRL0"
+	.section	.debug_info
+	.long		.Lname45
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #46: variable SEQCTRL1
+	.section	.debug_info
+	.uleb128	46	; ref to abbrev 46
+	.section	.debug_abbrev
+	.uleb128	46
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname46:
+	.string		"SEQCTRL1"
+	.section	.debug_info
+	.long		.Lname46
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #47: variable INTCTRL0
+	.section	.debug_info
+	.uleb128	47	; ref to abbrev 47
+	.section	.debug_abbrev
+	.uleb128	47
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname47:
+	.string		"INTCTRL0"
+	.section	.debug_info
+	.long		.Lname47
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #48: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	48	; ref to abbrev 48
+	.section	.debug_abbrev
+	.uleb128	48
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname48:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname48
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #49: variable LUT0CTRLA
+	.section	.debug_info
+	.uleb128	49	; ref to abbrev 49
+	.section	.debug_abbrev
+	.uleb128	49
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname49:
+	.string		"LUT0CTRLA"
+	.section	.debug_info
+	.long		.Lname49
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #50: variable LUT0CTRLB
+	.section	.debug_info
+	.uleb128	50	; ref to abbrev 50
+	.section	.debug_abbrev
+	.uleb128	50
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname50:
+	.string		"LUT0CTRLB"
+	.section	.debug_info
+	.long		.Lname50
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #51: variable LUT0CTRLC
+	.section	.debug_info
+	.uleb128	51	; ref to abbrev 51
+	.section	.debug_abbrev
+	.uleb128	51
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname51:
+	.string		"LUT0CTRLC"
+	.section	.debug_info
+	.long		.Lname51
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #52: variable TRUTH0
+	.section	.debug_info
+	.uleb128	52	; ref to abbrev 52
+	.section	.debug_abbrev
+	.uleb128	52
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname52:
+	.string		"TRUTH0"
+	.section	.debug_info
+	.long		.Lname52
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #53: variable LUT1CTRLA
+	.section	.debug_info
+	.uleb128	53	; ref to abbrev 53
+	.section	.debug_abbrev
+	.uleb128	53
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname53:
+	.string		"LUT1CTRLA"
+	.section	.debug_info
+	.long		.Lname53
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #54: variable LUT1CTRLB
+	.section	.debug_info
+	.uleb128	54	; ref to abbrev 54
+	.section	.debug_abbrev
+	.uleb128	54
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname54:
+	.string		"LUT1CTRLB"
+	.section	.debug_info
+	.long		.Lname54
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #55: variable LUT1CTRLC
+	.section	.debug_info
+	.uleb128	55	; ref to abbrev 55
+	.section	.debug_abbrev
+	.uleb128	55
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname55:
+	.string		"LUT1CTRLC"
+	.section	.debug_info
+	.long		.Lname55
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #56: variable TRUTH1
+	.section	.debug_info
+	.uleb128	56	; ref to abbrev 56
+	.section	.debug_abbrev
+	.uleb128	56
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname56:
+	.string		"TRUTH1"
+	.section	.debug_info
+	.long		.Lname56
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #57: variable LUT2CTRLA
+	.section	.debug_info
+	.uleb128	57	; ref to abbrev 57
+	.section	.debug_abbrev
+	.uleb128	57
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname57:
+	.string		"LUT2CTRLA"
+	.section	.debug_info
+	.long		.Lname57
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #58: variable LUT2CTRLB
+	.section	.debug_info
+	.uleb128	58	; ref to abbrev 58
+	.section	.debug_abbrev
+	.uleb128	58
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname58:
+	.string		"LUT2CTRLB"
+	.section	.debug_info
+	.long		.Lname58
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #59: variable LUT2CTRLC
+	.section	.debug_info
+	.uleb128	59	; ref to abbrev 59
+	.section	.debug_abbrev
+	.uleb128	59
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname59:
+	.string		"LUT2CTRLC"
+	.section	.debug_info
+	.long		.Lname59
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #60: variable TRUTH2
+	.section	.debug_info
+	.uleb128	60	; ref to abbrev 60
+	.section	.debug_abbrev
+	.uleb128	60
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname60:
+	.string		"TRUTH2"
+	.section	.debug_info
+	.long		.Lname60
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #61: variable LUT3CTRLA
+	.section	.debug_info
+	.uleb128	61	; ref to abbrev 61
+	.section	.debug_abbrev
+	.uleb128	61
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname61:
+	.string		"LUT3CTRLA"
+	.section	.debug_info
+	.long		.Lname61
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #62: variable LUT3CTRLB
+	.section	.debug_info
+	.uleb128	62	; ref to abbrev 62
+	.section	.debug_abbrev
+	.uleb128	62
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname62:
+	.string		"LUT3CTRLB"
+	.section	.debug_info
+	.long		.Lname62
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #63: variable LUT3CTRLC
+	.section	.debug_info
+	.uleb128	63	; ref to abbrev 63
+	.section	.debug_abbrev
+	.uleb128	63
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname63:
+	.string		"LUT3CTRLC"
+	.section	.debug_info
+	.long		.Lname63
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #64: variable TRUTH3
+	.section	.debug_info
+	.uleb128	64	; ref to abbrev 64
+	.section	.debug_abbrev
+	.uleb128	64
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname64:
+	.string		"TRUTH3"
+	.section	.debug_info
+	.long		.Lname64
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #65: variable MCLKCTRLA
+	.section	.debug_info
+	.uleb128	65	; ref to abbrev 65
+	.section	.debug_abbrev
+	.uleb128	65
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname65:
+	.string		"MCLKCTRLA"
+	.section	.debug_info
+	.long		.Lname65
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #66: variable MCLKCTRLB
+	.section	.debug_info
+	.uleb128	66	; ref to abbrev 66
+	.section	.debug_abbrev
+	.uleb128	66
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname66:
+	.string		"MCLKCTRLB"
+	.section	.debug_info
+	.long		.Lname66
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #67: variable MCLKCTRLC
+	.section	.debug_info
+	.uleb128	67	; ref to abbrev 67
+	.section	.debug_abbrev
+	.uleb128	67
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname67:
+	.string		"MCLKCTRLC"
+	.section	.debug_info
+	.long		.Lname67
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #68: variable MCLKINTCTRL
+	.section	.debug_info
+	.uleb128	68	; ref to abbrev 68
+	.section	.debug_abbrev
+	.uleb128	68
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname68:
+	.string		"MCLKINTCTRL"
+	.section	.debug_info
+	.long		.Lname68
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #69: variable MCLKINTFLAGS
+	.section	.debug_info
+	.uleb128	69	; ref to abbrev 69
+	.section	.debug_abbrev
+	.uleb128	69
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname69:
+	.string		"MCLKINTFLAGS"
+	.section	.debug_info
+	.long		.Lname69
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #70: variable MCLKSTATUS
+	.section	.debug_info
+	.uleb128	70	; ref to abbrev 70
+	.section	.debug_abbrev
+	.uleb128	70
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname70:
+	.string		"MCLKSTATUS"
+	.section	.debug_info
+	.long		.Lname70
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #71: variable MCLKTIMEBASE
+	.section	.debug_info
+	.uleb128	71	; ref to abbrev 71
+	.section	.debug_abbrev
+	.uleb128	71
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname71:
+	.string		"MCLKTIMEBASE"
+	.section	.debug_info
+	.long		.Lname71
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #72: variable OSCHFCTRLA
+	.section	.debug_info
+	.uleb128	72	; ref to abbrev 72
+	.section	.debug_abbrev
+	.uleb128	72
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname72:
+	.string		"OSCHFCTRLA"
+	.section	.debug_info
+	.long		.Lname72
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #73: variable OSCHFTUNE
+	.section	.debug_info
+	.uleb128	73	; ref to abbrev 73
+	.section	.debug_abbrev
+	.uleb128	73
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname73:
+	.string		"OSCHFTUNE"
+	.section	.debug_info
+	.long		.Lname73
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #74: variable OSC32KCTRLA
+	.section	.debug_info
+	.uleb128	74	; ref to abbrev 74
+	.section	.debug_abbrev
+	.uleb128	74
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname74:
+	.string		"OSC32KCTRLA"
+	.section	.debug_info
+	.long		.Lname74
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #75: variable XOSC32KCTRLA
+	.section	.debug_info
+	.uleb128	75	; ref to abbrev 75
+	.section	.debug_abbrev
+	.uleb128	75
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname75:
+	.string		"XOSC32KCTRLA"
+	.section	.debug_info
+	.long		.Lname75
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x1C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #76: variable XOSCHFCTRLA
+	.section	.debug_info
+	.uleb128	76	; ref to abbrev 76
+	.section	.debug_abbrev
+	.uleb128	76
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname76:
+	.string		"XOSCHFCTRLA"
+	.section	.debug_info
+	.long		.Lname76
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #77: variable CCP
+	.section	.debug_info
+	.uleb128	77	; ref to abbrev 77
+	.section	.debug_abbrev
+	.uleb128	77
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname77:
+	.string		"CCP"
+	.section	.debug_info
+	.long		.Lname77
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0030 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #78: variable SP
+	.section	.debug_info
+	.uleb128	78	; ref to abbrev 78
+	.section	.debug_abbrev
+	.uleb128	78
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname78:
+	.string		"SP"
+	.section	.debug_info
+	.long		.Lname78
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0030 + 0xD
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #79: variable SREG
+	.section	.debug_info
+	.uleb128	79	; ref to abbrev 79
+	.section	.debug_abbrev
+	.uleb128	79
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname79:
+	.string		"SREG"
+	.section	.debug_info
+	.long		.Lname79
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0030 + 0xF
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #80: variable CTRLA
+	.section	.debug_info
+	.uleb128	80	; ref to abbrev 80
+	.section	.debug_abbrev
+	.uleb128	80
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname80:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname80
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0110 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #81: variable STATUS
+	.section	.debug_info
+	.uleb128	81	; ref to abbrev 81
+	.section	.debug_abbrev
+	.uleb128	81
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname81:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname81
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0110 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #82: variable LVL0PRI
+	.section	.debug_info
+	.uleb128	82	; ref to abbrev 82
+	.section	.debug_abbrev
+	.uleb128	82
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname82:
+	.string		"LVL0PRI"
+	.section	.debug_info
+	.long		.Lname82
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0110 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #83: variable LVL1VEC
+	.section	.debug_info
+	.uleb128	83	; ref to abbrev 83
+	.section	.debug_abbrev
+	.uleb128	83
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname83:
+	.string		"LVL1VEC"
+	.section	.debug_info
+	.long		.Lname83
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0110 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #84: variable CTRLA
+	.section	.debug_info
+	.uleb128	84	; ref to abbrev 84
+	.section	.debug_abbrev
+	.uleb128	84
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname84:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname84
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0120 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #85: variable CTRLB
+	.section	.debug_info
+	.uleb128	85	; ref to abbrev 85
+	.section	.debug_abbrev
+	.uleb128	85
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname85:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname85
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0120 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #86: variable STATUS
+	.section	.debug_info
+	.uleb128	86	; ref to abbrev 86
+	.section	.debug_abbrev
+	.uleb128	86
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname86:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname86
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0120 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #87: variable CTRLA
+	.section	.debug_info
+	.uleb128	87	; ref to abbrev 87
+	.section	.debug_abbrev
+	.uleb128	87
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname87:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname87
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x06A0 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #88: variable DATA
+	.section	.debug_info
+	.uleb128	88	; ref to abbrev 88
+	.section	.debug_abbrev
+	.uleb128	88
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname88:
+	.string		"DATA"
+	.section	.debug_info
+	.long		.Lname88
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x06A0 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #89: variable SWEVENTA
+	.section	.debug_info
+	.uleb128	89	; ref to abbrev 89
+	.section	.debug_abbrev
+	.uleb128	89
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname89:
+	.string		"SWEVENTA"
+	.section	.debug_info
+	.long		.Lname89
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #90: variable CHANNEL0
+	.section	.debug_info
+	.uleb128	90	; ref to abbrev 90
+	.section	.debug_abbrev
+	.uleb128	90
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname90:
+	.string		"CHANNEL0"
+	.section	.debug_info
+	.long		.Lname90
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #91: variable CHANNEL1
+	.section	.debug_info
+	.uleb128	91	; ref to abbrev 91
+	.section	.debug_abbrev
+	.uleb128	91
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname91:
+	.string		"CHANNEL1"
+	.section	.debug_info
+	.long		.Lname91
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #92: variable CHANNEL2
+	.section	.debug_info
+	.uleb128	92	; ref to abbrev 92
+	.section	.debug_abbrev
+	.uleb128	92
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname92:
+	.string		"CHANNEL2"
+	.section	.debug_info
+	.long		.Lname92
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #93: variable CHANNEL3
+	.section	.debug_info
+	.uleb128	93	; ref to abbrev 93
+	.section	.debug_abbrev
+	.uleb128	93
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname93:
+	.string		"CHANNEL3"
+	.section	.debug_info
+	.long		.Lname93
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #94: variable CHANNEL4
+	.section	.debug_info
+	.uleb128	94	; ref to abbrev 94
+	.section	.debug_abbrev
+	.uleb128	94
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname94:
+	.string		"CHANNEL4"
+	.section	.debug_info
+	.long		.Lname94
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #95: variable CHANNEL5
+	.section	.debug_info
+	.uleb128	95	; ref to abbrev 95
+	.section	.debug_abbrev
+	.uleb128	95
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname95:
+	.string		"CHANNEL5"
+	.section	.debug_info
+	.long		.Lname95
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #96: variable USERCCLLUT0A
+	.section	.debug_info
+	.uleb128	96	; ref to abbrev 96
+	.section	.debug_abbrev
+	.uleb128	96
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname96:
+	.string		"USERCCLLUT0A"
+	.section	.debug_info
+	.long		.Lname96
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #97: variable USERCCLLUT0B
+	.section	.debug_info
+	.uleb128	97	; ref to abbrev 97
+	.section	.debug_abbrev
+	.uleb128	97
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname97:
+	.string		"USERCCLLUT0B"
+	.section	.debug_info
+	.long		.Lname97
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x21
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #98: variable USERCCLLUT1A
+	.section	.debug_info
+	.uleb128	98	; ref to abbrev 98
+	.section	.debug_abbrev
+	.uleb128	98
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname98:
+	.string		"USERCCLLUT1A"
+	.section	.debug_info
+	.long		.Lname98
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x22
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #99: variable USERCCLLUT1B
+	.section	.debug_info
+	.uleb128	99	; ref to abbrev 99
+	.section	.debug_abbrev
+	.uleb128	99
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname99:
+	.string		"USERCCLLUT1B"
+	.section	.debug_info
+	.long		.Lname99
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x23
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #100: variable USERCCLLUT2A
+	.section	.debug_info
+	.uleb128	100	; ref to abbrev 100
+	.section	.debug_abbrev
+	.uleb128	100
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname100:
+	.string		"USERCCLLUT2A"
+	.section	.debug_info
+	.long		.Lname100
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x24
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #101: variable USERCCLLUT2B
+	.section	.debug_info
+	.uleb128	101	; ref to abbrev 101
+	.section	.debug_abbrev
+	.uleb128	101
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname101:
+	.string		"USERCCLLUT2B"
+	.section	.debug_info
+	.long		.Lname101
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x25
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #102: variable USERCCLLUT3A
+	.section	.debug_info
+	.uleb128	102	; ref to abbrev 102
+	.section	.debug_abbrev
+	.uleb128	102
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname102:
+	.string		"USERCCLLUT3A"
+	.section	.debug_info
+	.long		.Lname102
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x26
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #103: variable USERCCLLUT3B
+	.section	.debug_info
+	.uleb128	103	; ref to abbrev 103
+	.section	.debug_abbrev
+	.uleb128	103
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname103:
+	.string		"USERCCLLUT3B"
+	.section	.debug_info
+	.long		.Lname103
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x27
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #104: variable USERADC0START
+	.section	.debug_info
+	.uleb128	104	; ref to abbrev 104
+	.section	.debug_abbrev
+	.uleb128	104
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname104:
+	.string		"USERADC0START"
+	.section	.debug_info
+	.long		.Lname104
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x28
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #105: variable USEREVSYSEVOUTA
+	.section	.debug_info
+	.uleb128	105	; ref to abbrev 105
+	.section	.debug_abbrev
+	.uleb128	105
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname105:
+	.string		"USEREVSYSEVOUTA"
+	.section	.debug_info
+	.long		.Lname105
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x29
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #106: variable USEREVSYSEVOUTC
+	.section	.debug_info
+	.uleb128	106	; ref to abbrev 106
+	.section	.debug_abbrev
+	.uleb128	106
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname106:
+	.string		"USEREVSYSEVOUTC"
+	.section	.debug_info
+	.long		.Lname106
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #107: variable USEREVSYSEVOUTD
+	.section	.debug_info
+	.uleb128	107	; ref to abbrev 107
+	.section	.debug_abbrev
+	.uleb128	107
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname107:
+	.string		"USEREVSYSEVOUTD"
+	.section	.debug_info
+	.long		.Lname107
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #108: variable USEREVSYSEVOUTF
+	.section	.debug_info
+	.uleb128	108	; ref to abbrev 108
+	.section	.debug_abbrev
+	.uleb128	108
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname108:
+	.string		"USEREVSYSEVOUTF"
+	.section	.debug_info
+	.long		.Lname108
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #109: variable USERUSART0IRDA
+	.section	.debug_info
+	.uleb128	109	; ref to abbrev 109
+	.section	.debug_abbrev
+	.uleb128	109
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname109:
+	.string		"USERUSART0IRDA"
+	.section	.debug_info
+	.long		.Lname109
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #110: variable USERUSART1IRDA
+	.section	.debug_info
+	.uleb128	110	; ref to abbrev 110
+	.section	.debug_abbrev
+	.uleb128	110
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname110:
+	.string		"USERUSART1IRDA"
+	.section	.debug_info
+	.long		.Lname110
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x30
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #111: variable USERUSART2IRDA
+	.section	.debug_info
+	.uleb128	111	; ref to abbrev 111
+	.section	.debug_abbrev
+	.uleb128	111
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname111:
+	.string		"USERUSART2IRDA"
+	.section	.debug_info
+	.long		.Lname111
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x31
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #112: variable USERTCA0CNTA
+	.section	.debug_info
+	.uleb128	112	; ref to abbrev 112
+	.section	.debug_abbrev
+	.uleb128	112
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname112:
+	.string		"USERTCA0CNTA"
+	.section	.debug_info
+	.long		.Lname112
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x32
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #113: variable USERTCA0CNTB
+	.section	.debug_info
+	.uleb128	113	; ref to abbrev 113
+	.section	.debug_abbrev
+	.uleb128	113
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname113:
+	.string		"USERTCA0CNTB"
+	.section	.debug_info
+	.long		.Lname113
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x33
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #114: variable USERTCA1CNTA
+	.section	.debug_info
+	.uleb128	114	; ref to abbrev 114
+	.section	.debug_abbrev
+	.uleb128	114
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname114:
+	.string		"USERTCA1CNTA"
+	.section	.debug_info
+	.long		.Lname114
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x34
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #115: variable USERTCA1CNTB
+	.section	.debug_info
+	.uleb128	115	; ref to abbrev 115
+	.section	.debug_abbrev
+	.uleb128	115
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname115:
+	.string		"USERTCA1CNTB"
+	.section	.debug_info
+	.long		.Lname115
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x35
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #116: variable USERTCB0CAPT
+	.section	.debug_info
+	.uleb128	116	; ref to abbrev 116
+	.section	.debug_abbrev
+	.uleb128	116
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname116:
+	.string		"USERTCB0CAPT"
+	.section	.debug_info
+	.long		.Lname116
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x36
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #117: variable USERTCB0COUNT
+	.section	.debug_info
+	.uleb128	117	; ref to abbrev 117
+	.section	.debug_abbrev
+	.uleb128	117
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname117:
+	.string		"USERTCB0COUNT"
+	.section	.debug_info
+	.long		.Lname117
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x37
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #118: variable USERTCB1CAPT
+	.section	.debug_info
+	.uleb128	118	; ref to abbrev 118
+	.section	.debug_abbrev
+	.uleb128	118
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname118:
+	.string		"USERTCB1CAPT"
+	.section	.debug_info
+	.long		.Lname118
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x38
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #119: variable USERTCB1COUNT
+	.section	.debug_info
+	.uleb128	119	; ref to abbrev 119
+	.section	.debug_abbrev
+	.uleb128	119
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname119:
+	.string		"USERTCB1COUNT"
+	.section	.debug_info
+	.long		.Lname119
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x39
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #120: variable USERTCB2CAPT
+	.section	.debug_info
+	.uleb128	120	; ref to abbrev 120
+	.section	.debug_abbrev
+	.uleb128	120
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname120:
+	.string		"USERTCB2CAPT"
+	.section	.debug_info
+	.long		.Lname120
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x3A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #121: variable USERTCB2COUNT
+	.section	.debug_info
+	.uleb128	121	; ref to abbrev 121
+	.section	.debug_abbrev
+	.uleb128	121
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname121:
+	.string		"USERTCB2COUNT"
+	.section	.debug_info
+	.long		.Lname121
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x3B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #122: variable USERTCB3CAPT
+	.section	.debug_info
+	.uleb128	122	; ref to abbrev 122
+	.section	.debug_abbrev
+	.uleb128	122
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname122:
+	.string		"USERTCB3CAPT"
+	.section	.debug_info
+	.long		.Lname122
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x3C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #123: variable USERTCB3COUNT
+	.section	.debug_info
+	.uleb128	123	; ref to abbrev 123
+	.section	.debug_abbrev
+	.uleb128	123
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname123:
+	.string		"USERTCB3COUNT"
+	.section	.debug_info
+	.long		.Lname123
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x3D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #124: variable WDTCFG
+	.section	.debug_info
+	.uleb128	124	; ref to abbrev 124
+	.section	.debug_abbrev
+	.uleb128	124
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname124:
+	.string		"WDTCFG"
+	.section	.debug_info
+	.long		.Lname124
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #125: variable BODCFG
+	.section	.debug_info
+	.uleb128	125	; ref to abbrev 125
+	.section	.debug_abbrev
+	.uleb128	125
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname125:
+	.string		"BODCFG"
+	.section	.debug_info
+	.long		.Lname125
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #126: variable OSCCFG
+	.section	.debug_info
+	.uleb128	126	; ref to abbrev 126
+	.section	.debug_abbrev
+	.uleb128	126
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname126:
+	.string		"OSCCFG"
+	.section	.debug_info
+	.long		.Lname126
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #127: variable SYSCFG0
+	.section	.debug_info
+	.uleb128	127	; ref to abbrev 127
+	.section	.debug_abbrev
+	.uleb128	127
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname127:
+	.string		"SYSCFG0"
+	.section	.debug_info
+	.long		.Lname127
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #128: variable SYSCFG1
+	.section	.debug_info
+	.uleb128	128	; ref to abbrev 128
+	.section	.debug_abbrev
+	.uleb128	128
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname128:
+	.string		"SYSCFG1"
+	.section	.debug_info
+	.long		.Lname128
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #129: variable CODESIZE
+	.section	.debug_info
+	.uleb128	129	; ref to abbrev 129
+	.section	.debug_abbrev
+	.uleb128	129
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname129:
+	.string		"CODESIZE"
+	.section	.debug_info
+	.long		.Lname129
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #130: variable BOOTSIZE
+	.section	.debug_info
+	.uleb128	130	; ref to abbrev 130
+	.section	.debug_abbrev
+	.uleb128	130
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname130:
+	.string		"BOOTSIZE"
+	.section	.debug_info
+	.long		.Lname130
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #131: variable GPR0
+	.section	.debug_info
+	.uleb128	131	; ref to abbrev 131
+	.section	.debug_abbrev
+	.uleb128	131
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname131:
+	.string		"GPR0"
+	.section	.debug_info
+	.long		.Lname131
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x001C + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #132: variable GPR1
+	.section	.debug_info
+	.uleb128	132	; ref to abbrev 132
+	.section	.debug_abbrev
+	.uleb128	132
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname132:
+	.string		"GPR1"
+	.section	.debug_info
+	.long		.Lname132
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x001C + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #133: variable GPR2
+	.section	.debug_info
+	.uleb128	133	; ref to abbrev 133
+	.section	.debug_abbrev
+	.uleb128	133
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname133:
+	.string		"GPR2"
+	.section	.debug_info
+	.long		.Lname133
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x001C + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #134: variable GPR3
+	.section	.debug_info
+	.uleb128	134	; ref to abbrev 134
+	.section	.debug_abbrev
+	.uleb128	134
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname134:
+	.string		"GPR3"
+	.section	.debug_info
+	.long		.Lname134
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x001C + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #135: variable KEY
+	.section	.debug_info
+	.uleb128	135	; ref to abbrev 135
+	.section	.debug_abbrev
+	.uleb128	135
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname135:
+	.string		"KEY"
+	.section	.debug_info
+	.long		.Lname135
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint32_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1040 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #136: variable CTRLA
+	.section	.debug_info
+	.uleb128	136	; ref to abbrev 136
+	.section	.debug_abbrev
+	.uleb128	136
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname136:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname136
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #137: variable CTRLB
+	.section	.debug_info
+	.uleb128	137	; ref to abbrev 137
+	.section	.debug_abbrev
+	.uleb128	137
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname137:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname137
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #138: variable INTCTRL
+	.section	.debug_info
+	.uleb128	138	; ref to abbrev 138
+	.section	.debug_abbrev
+	.uleb128	138
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname138:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname138
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #139: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	139	; ref to abbrev 139
+	.section	.debug_abbrev
+	.uleb128	139
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname139:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname139
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #140: variable STATUS
+	.section	.debug_info
+	.uleb128	140	; ref to abbrev 140
+	.section	.debug_abbrev
+	.uleb128	140
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname140:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname140
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #141: variable DATA
+	.section	.debug_info
+	.uleb128	141	; ref to abbrev 141
+	.section	.debug_abbrev
+	.uleb128	141
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname141:
+	.string		"DATA"
+	.section	.debug_info
+	.long		.Lname141
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #142: variable ADDR
+	.section	.debug_info
+	.uleb128	142	; ref to abbrev 142
+	.section	.debug_abbrev
+	.uleb128	142
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname142:
+	.string		"ADDR"
+	.section	.debug_info
+	.long		.Lname142
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint32_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #143: variable DIR
+	.section	.debug_info
+	.uleb128	143	; ref to abbrev 143
+	.section	.debug_abbrev
+	.uleb128	143
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname143:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname143
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #144: variable DIRSET
+	.section	.debug_info
+	.uleb128	144	; ref to abbrev 144
+	.section	.debug_abbrev
+	.uleb128	144
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname144:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname144
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #145: variable DIRCLR
+	.section	.debug_info
+	.uleb128	145	; ref to abbrev 145
+	.section	.debug_abbrev
+	.uleb128	145
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname145:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname145
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #146: variable DIRTGL
+	.section	.debug_info
+	.uleb128	146	; ref to abbrev 146
+	.section	.debug_abbrev
+	.uleb128	146
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname146:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname146
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #147: variable OUT
+	.section	.debug_info
+	.uleb128	147	; ref to abbrev 147
+	.section	.debug_abbrev
+	.uleb128	147
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname147:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname147
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #148: variable OUTSET
+	.section	.debug_info
+	.uleb128	148	; ref to abbrev 148
+	.section	.debug_abbrev
+	.uleb128	148
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname148:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname148
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #149: variable OUTCLR
+	.section	.debug_info
+	.uleb128	149	; ref to abbrev 149
+	.section	.debug_abbrev
+	.uleb128	149
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname149:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname149
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #150: variable OUTTGL
+	.section	.debug_info
+	.uleb128	150	; ref to abbrev 150
+	.section	.debug_abbrev
+	.uleb128	150
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname150:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname150
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #151: variable IN
+	.section	.debug_info
+	.uleb128	151	; ref to abbrev 151
+	.section	.debug_abbrev
+	.uleb128	151
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname151:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname151
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #152: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	152	; ref to abbrev 152
+	.section	.debug_abbrev
+	.uleb128	152
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname152:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname152
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #153: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	153	; ref to abbrev 153
+	.section	.debug_abbrev
+	.uleb128	153
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname153:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname153
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #154: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	154	; ref to abbrev 154
+	.section	.debug_abbrev
+	.uleb128	154
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname154:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname154
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #155: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	155	; ref to abbrev 155
+	.section	.debug_abbrev
+	.uleb128	155
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname155:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname155
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #156: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	156	; ref to abbrev 156
+	.section	.debug_abbrev
+	.uleb128	156
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname156:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname156
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #157: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	157	; ref to abbrev 157
+	.section	.debug_abbrev
+	.uleb128	157
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname157:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname157
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #158: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	158	; ref to abbrev 158
+	.section	.debug_abbrev
+	.uleb128	158
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname158:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname158
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #159: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	159	; ref to abbrev 159
+	.section	.debug_abbrev
+	.uleb128	159
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname159:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname159
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #160: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	160	; ref to abbrev 160
+	.section	.debug_abbrev
+	.uleb128	160
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname160:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname160
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #161: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	161	; ref to abbrev 161
+	.section	.debug_abbrev
+	.uleb128	161
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname161:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname161
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #162: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	162	; ref to abbrev 162
+	.section	.debug_abbrev
+	.uleb128	162
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname162:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname162
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #163: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	163	; ref to abbrev 163
+	.section	.debug_abbrev
+	.uleb128	163
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname163:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname163
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #164: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	164	; ref to abbrev 164
+	.section	.debug_abbrev
+	.uleb128	164
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname164:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname164
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #165: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	165	; ref to abbrev 165
+	.section	.debug_abbrev
+	.uleb128	165
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname165:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname165
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #166: variable EVGENCTRL
+	.section	.debug_info
+	.uleb128	166	; ref to abbrev 166
+	.section	.debug_abbrev
+	.uleb128	166
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname166:
+	.string		"EVGENCTRL"
+	.section	.debug_info
+	.long		.Lname166
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #167: variable DIR
+	.section	.debug_info
+	.uleb128	167	; ref to abbrev 167
+	.section	.debug_abbrev
+	.uleb128	167
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname167:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname167
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #168: variable DIRSET
+	.section	.debug_info
+	.uleb128	168	; ref to abbrev 168
+	.section	.debug_abbrev
+	.uleb128	168
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname168:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname168
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #169: variable DIRCLR
+	.section	.debug_info
+	.uleb128	169	; ref to abbrev 169
+	.section	.debug_abbrev
+	.uleb128	169
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname169:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname169
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #170: variable DIRTGL
+	.section	.debug_info
+	.uleb128	170	; ref to abbrev 170
+	.section	.debug_abbrev
+	.uleb128	170
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname170:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname170
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #171: variable OUT
+	.section	.debug_info
+	.uleb128	171	; ref to abbrev 171
+	.section	.debug_abbrev
+	.uleb128	171
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname171:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname171
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #172: variable OUTSET
+	.section	.debug_info
+	.uleb128	172	; ref to abbrev 172
+	.section	.debug_abbrev
+	.uleb128	172
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname172:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname172
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #173: variable OUTCLR
+	.section	.debug_info
+	.uleb128	173	; ref to abbrev 173
+	.section	.debug_abbrev
+	.uleb128	173
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname173:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname173
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #174: variable OUTTGL
+	.section	.debug_info
+	.uleb128	174	; ref to abbrev 174
+	.section	.debug_abbrev
+	.uleb128	174
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname174:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname174
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #175: variable IN
+	.section	.debug_info
+	.uleb128	175	; ref to abbrev 175
+	.section	.debug_abbrev
+	.uleb128	175
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname175:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname175
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #176: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	176	; ref to abbrev 176
+	.section	.debug_abbrev
+	.uleb128	176
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname176:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname176
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #177: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	177	; ref to abbrev 177
+	.section	.debug_abbrev
+	.uleb128	177
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname177:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname177
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #178: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	178	; ref to abbrev 178
+	.section	.debug_abbrev
+	.uleb128	178
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname178:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname178
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #179: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	179	; ref to abbrev 179
+	.section	.debug_abbrev
+	.uleb128	179
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname179:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname179
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #180: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	180	; ref to abbrev 180
+	.section	.debug_abbrev
+	.uleb128	180
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname180:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname180
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #181: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	181	; ref to abbrev 181
+	.section	.debug_abbrev
+	.uleb128	181
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname181:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname181
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #182: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	182	; ref to abbrev 182
+	.section	.debug_abbrev
+	.uleb128	182
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname182:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname182
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #183: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	183	; ref to abbrev 183
+	.section	.debug_abbrev
+	.uleb128	183
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname183:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname183
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #184: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	184	; ref to abbrev 184
+	.section	.debug_abbrev
+	.uleb128	184
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname184:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname184
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #185: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	185	; ref to abbrev 185
+	.section	.debug_abbrev
+	.uleb128	185
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname185:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname185
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #186: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	186	; ref to abbrev 186
+	.section	.debug_abbrev
+	.uleb128	186
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname186:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname186
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #187: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	187	; ref to abbrev 187
+	.section	.debug_abbrev
+	.uleb128	187
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname187:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname187
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #188: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	188	; ref to abbrev 188
+	.section	.debug_abbrev
+	.uleb128	188
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname188:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname188
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #189: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	189	; ref to abbrev 189
+	.section	.debug_abbrev
+	.uleb128	189
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname189:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname189
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #190: variable EVGENCTRL
+	.section	.debug_info
+	.uleb128	190	; ref to abbrev 190
+	.section	.debug_abbrev
+	.uleb128	190
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname190:
+	.string		"EVGENCTRL"
+	.section	.debug_info
+	.long		.Lname190
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #191: variable DIR
+	.section	.debug_info
+	.uleb128	191	; ref to abbrev 191
+	.section	.debug_abbrev
+	.uleb128	191
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname191:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname191
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #192: variable DIRSET
+	.section	.debug_info
+	.uleb128	192	; ref to abbrev 192
+	.section	.debug_abbrev
+	.uleb128	192
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname192:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname192
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #193: variable DIRCLR
+	.section	.debug_info
+	.uleb128	193	; ref to abbrev 193
+	.section	.debug_abbrev
+	.uleb128	193
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname193:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname193
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #194: variable DIRTGL
+	.section	.debug_info
+	.uleb128	194	; ref to abbrev 194
+	.section	.debug_abbrev
+	.uleb128	194
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname194:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname194
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #195: variable OUT
+	.section	.debug_info
+	.uleb128	195	; ref to abbrev 195
+	.section	.debug_abbrev
+	.uleb128	195
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname195:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname195
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #196: variable OUTSET
+	.section	.debug_info
+	.uleb128	196	; ref to abbrev 196
+	.section	.debug_abbrev
+	.uleb128	196
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname196:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname196
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #197: variable OUTCLR
+	.section	.debug_info
+	.uleb128	197	; ref to abbrev 197
+	.section	.debug_abbrev
+	.uleb128	197
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname197:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname197
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #198: variable OUTTGL
+	.section	.debug_info
+	.uleb128	198	; ref to abbrev 198
+	.section	.debug_abbrev
+	.uleb128	198
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname198:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname198
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #199: variable IN
+	.section	.debug_info
+	.uleb128	199	; ref to abbrev 199
+	.section	.debug_abbrev
+	.uleb128	199
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname199:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname199
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #200: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	200	; ref to abbrev 200
+	.section	.debug_abbrev
+	.uleb128	200
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname200:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname200
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #201: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	201	; ref to abbrev 201
+	.section	.debug_abbrev
+	.uleb128	201
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname201:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname201
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #202: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	202	; ref to abbrev 202
+	.section	.debug_abbrev
+	.uleb128	202
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname202:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname202
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #203: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	203	; ref to abbrev 203
+	.section	.debug_abbrev
+	.uleb128	203
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname203:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname203
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #204: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	204	; ref to abbrev 204
+	.section	.debug_abbrev
+	.uleb128	204
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname204:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname204
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #205: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	205	; ref to abbrev 205
+	.section	.debug_abbrev
+	.uleb128	205
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname205:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname205
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #206: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	206	; ref to abbrev 206
+	.section	.debug_abbrev
+	.uleb128	206
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname206:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname206
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #207: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	207	; ref to abbrev 207
+	.section	.debug_abbrev
+	.uleb128	207
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname207:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname207
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #208: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	208	; ref to abbrev 208
+	.section	.debug_abbrev
+	.uleb128	208
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname208:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname208
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #209: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	209	; ref to abbrev 209
+	.section	.debug_abbrev
+	.uleb128	209
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname209:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname209
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #210: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	210	; ref to abbrev 210
+	.section	.debug_abbrev
+	.uleb128	210
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname210:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname210
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #211: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	211	; ref to abbrev 211
+	.section	.debug_abbrev
+	.uleb128	211
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname211:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname211
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #212: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	212	; ref to abbrev 212
+	.section	.debug_abbrev
+	.uleb128	212
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname212:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname212
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #213: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	213	; ref to abbrev 213
+	.section	.debug_abbrev
+	.uleb128	213
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname213:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname213
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #214: variable EVGENCTRL
+	.section	.debug_info
+	.uleb128	214	; ref to abbrev 214
+	.section	.debug_abbrev
+	.uleb128	214
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname214:
+	.string		"EVGENCTRL"
+	.section	.debug_info
+	.long		.Lname214
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #215: variable DIR
+	.section	.debug_info
+	.uleb128	215	; ref to abbrev 215
+	.section	.debug_abbrev
+	.uleb128	215
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname215:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname215
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #216: variable DIRSET
+	.section	.debug_info
+	.uleb128	216	; ref to abbrev 216
+	.section	.debug_abbrev
+	.uleb128	216
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname216:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname216
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #217: variable DIRCLR
+	.section	.debug_info
+	.uleb128	217	; ref to abbrev 217
+	.section	.debug_abbrev
+	.uleb128	217
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname217:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname217
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #218: variable DIRTGL
+	.section	.debug_info
+	.uleb128	218	; ref to abbrev 218
+	.section	.debug_abbrev
+	.uleb128	218
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname218:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname218
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #219: variable OUT
+	.section	.debug_info
+	.uleb128	219	; ref to abbrev 219
+	.section	.debug_abbrev
+	.uleb128	219
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname219:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname219
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #220: variable OUTSET
+	.section	.debug_info
+	.uleb128	220	; ref to abbrev 220
+	.section	.debug_abbrev
+	.uleb128	220
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname220:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname220
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #221: variable OUTCLR
+	.section	.debug_info
+	.uleb128	221	; ref to abbrev 221
+	.section	.debug_abbrev
+	.uleb128	221
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname221:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname221
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #222: variable OUTTGL
+	.section	.debug_info
+	.uleb128	222	; ref to abbrev 222
+	.section	.debug_abbrev
+	.uleb128	222
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname222:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname222
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #223: variable IN
+	.section	.debug_info
+	.uleb128	223	; ref to abbrev 223
+	.section	.debug_abbrev
+	.uleb128	223
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname223:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname223
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #224: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	224	; ref to abbrev 224
+	.section	.debug_abbrev
+	.uleb128	224
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname224:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname224
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #225: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	225	; ref to abbrev 225
+	.section	.debug_abbrev
+	.uleb128	225
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname225:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname225
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #226: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	226	; ref to abbrev 226
+	.section	.debug_abbrev
+	.uleb128	226
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname226:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname226
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #227: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	227	; ref to abbrev 227
+	.section	.debug_abbrev
+	.uleb128	227
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname227:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname227
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #228: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	228	; ref to abbrev 228
+	.section	.debug_abbrev
+	.uleb128	228
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname228:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname228
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #229: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	229	; ref to abbrev 229
+	.section	.debug_abbrev
+	.uleb128	229
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname229:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname229
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #230: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	230	; ref to abbrev 230
+	.section	.debug_abbrev
+	.uleb128	230
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname230:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname230
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #231: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	231	; ref to abbrev 231
+	.section	.debug_abbrev
+	.uleb128	231
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname231:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname231
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #232: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	232	; ref to abbrev 232
+	.section	.debug_abbrev
+	.uleb128	232
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname232:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname232
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #233: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	233	; ref to abbrev 233
+	.section	.debug_abbrev
+	.uleb128	233
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname233:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname233
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #234: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	234	; ref to abbrev 234
+	.section	.debug_abbrev
+	.uleb128	234
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname234:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname234
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #235: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	235	; ref to abbrev 235
+	.section	.debug_abbrev
+	.uleb128	235
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname235:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname235
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #236: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	236	; ref to abbrev 236
+	.section	.debug_abbrev
+	.uleb128	236
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname236:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname236
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #237: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	237	; ref to abbrev 237
+	.section	.debug_abbrev
+	.uleb128	237
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname237:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname237
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #238: variable EVGENCTRL
+	.section	.debug_info
+	.uleb128	238	; ref to abbrev 238
+	.section	.debug_abbrev
+	.uleb128	238
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname238:
+	.string		"EVGENCTRL"
+	.section	.debug_info
+	.long		.Lname238
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #239: variable EVSYSROUTEA
+	.section	.debug_info
+	.uleb128	239	; ref to abbrev 239
+	.section	.debug_abbrev
+	.uleb128	239
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname239:
+	.string		"EVSYSROUTEA"
+	.section	.debug_info
+	.long		.Lname239
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #240: variable CCLROUTEA
+	.section	.debug_info
+	.uleb128	240	; ref to abbrev 240
+	.section	.debug_abbrev
+	.uleb128	240
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname240:
+	.string		"CCLROUTEA"
+	.section	.debug_info
+	.long		.Lname240
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #241: variable USARTROUTEA
+	.section	.debug_info
+	.uleb128	241	; ref to abbrev 241
+	.section	.debug_abbrev
+	.uleb128	241
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname241:
+	.string		"USARTROUTEA"
+	.section	.debug_info
+	.long		.Lname241
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #242: variable USARTROUTEB
+	.section	.debug_info
+	.uleb128	242	; ref to abbrev 242
+	.section	.debug_abbrev
+	.uleb128	242
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname242:
+	.string		"USARTROUTEB"
+	.section	.debug_info
+	.long		.Lname242
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #243: variable SPIROUTEA
+	.section	.debug_info
+	.uleb128	243	; ref to abbrev 243
+	.section	.debug_abbrev
+	.uleb128	243
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname243:
+	.string		"SPIROUTEA"
+	.section	.debug_info
+	.long		.Lname243
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #244: variable TWIROUTEA
+	.section	.debug_info
+	.uleb128	244	; ref to abbrev 244
+	.section	.debug_abbrev
+	.uleb128	244
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname244:
+	.string		"TWIROUTEA"
+	.section	.debug_info
+	.long		.Lname244
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #245: variable TCAROUTEA
+	.section	.debug_info
+	.uleb128	245	; ref to abbrev 245
+	.section	.debug_abbrev
+	.uleb128	245
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname245:
+	.string		"TCAROUTEA"
+	.section	.debug_info
+	.long		.Lname245
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #246: variable TCBROUTEA
+	.section	.debug_info
+	.uleb128	246	; ref to abbrev 246
+	.section	.debug_abbrev
+	.uleb128	246
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname246:
+	.string		"TCBROUTEA"
+	.section	.debug_info
+	.long		.Lname246
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #247: variable ACROUTEA
+	.section	.debug_info
+	.uleb128	247	; ref to abbrev 247
+	.section	.debug_abbrev
+	.uleb128	247
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname247:
+	.string		"ACROUTEA"
+	.section	.debug_info
+	.long		.Lname247
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #248: variable RSTFR
+	.section	.debug_info
+	.uleb128	248	; ref to abbrev 248
+	.section	.debug_abbrev
+	.uleb128	248
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname248:
+	.string		"RSTFR"
+	.section	.debug_info
+	.long		.Lname248
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0040 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #249: variable SWRR
+	.section	.debug_info
+	.uleb128	249	; ref to abbrev 249
+	.section	.debug_abbrev
+	.uleb128	249
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname249:
+	.string		"SWRR"
+	.section	.debug_info
+	.long		.Lname249
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0040 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #250: variable CTRLA
+	.section	.debug_info
+	.uleb128	250	; ref to abbrev 250
+	.section	.debug_abbrev
+	.uleb128	250
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname250:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname250
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #251: variable STATUS
+	.section	.debug_info
+	.uleb128	251	; ref to abbrev 251
+	.section	.debug_abbrev
+	.uleb128	251
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname251:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname251
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #252: variable INTCTRL
+	.section	.debug_info
+	.uleb128	252	; ref to abbrev 252
+	.section	.debug_abbrev
+	.uleb128	252
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname252:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname252
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #253: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	253	; ref to abbrev 253
+	.section	.debug_abbrev
+	.uleb128	253
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname253:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname253
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #254: variable TEMP
+	.section	.debug_info
+	.uleb128	254	; ref to abbrev 254
+	.section	.debug_abbrev
+	.uleb128	254
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname254:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname254
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #255: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	255	; ref to abbrev 255
+	.section	.debug_abbrev
+	.uleb128	255
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname255:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname255
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #256: variable CALIB
+	.section	.debug_info
+	.uleb128	256	; ref to abbrev 256
+	.section	.debug_abbrev
+	.uleb128	256
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname256:
+	.string		"CALIB"
+	.section	.debug_info
+	.long		.Lname256
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #257: variable CLKSEL
+	.section	.debug_info
+	.uleb128	257	; ref to abbrev 257
+	.section	.debug_abbrev
+	.uleb128	257
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname257:
+	.string		"CLKSEL"
+	.section	.debug_info
+	.long		.Lname257
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #258: variable CNT
+	.section	.debug_info
+	.uleb128	258	; ref to abbrev 258
+	.section	.debug_abbrev
+	.uleb128	258
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname258:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname258
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #259: variable PER
+	.section	.debug_info
+	.uleb128	259	; ref to abbrev 259
+	.section	.debug_abbrev
+	.uleb128	259
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname259:
+	.string		"PER"
+	.section	.debug_info
+	.long		.Lname259
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #260: variable CMP
+	.section	.debug_info
+	.uleb128	260	; ref to abbrev 260
+	.section	.debug_abbrev
+	.uleb128	260
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname260:
+	.string		"CMP"
+	.section	.debug_info
+	.long		.Lname260
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #261: variable PITCTRLA
+	.section	.debug_info
+	.uleb128	261	; ref to abbrev 261
+	.section	.debug_abbrev
+	.uleb128	261
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname261:
+	.string		"PITCTRLA"
+	.section	.debug_info
+	.long		.Lname261
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #262: variable PITSTATUS
+	.section	.debug_info
+	.uleb128	262	; ref to abbrev 262
+	.section	.debug_abbrev
+	.uleb128	262
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname262:
+	.string		"PITSTATUS"
+	.section	.debug_info
+	.long		.Lname262
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #263: variable PITINTCTRL
+	.section	.debug_info
+	.uleb128	263	; ref to abbrev 263
+	.section	.debug_abbrev
+	.uleb128	263
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname263:
+	.string		"PITINTCTRL"
+	.section	.debug_info
+	.long		.Lname263
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #264: variable PITINTFLAGS
+	.section	.debug_info
+	.uleb128	264	; ref to abbrev 264
+	.section	.debug_abbrev
+	.uleb128	264
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname264:
+	.string		"PITINTFLAGS"
+	.section	.debug_info
+	.long		.Lname264
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #265: variable PITDBGCTRL
+	.section	.debug_info
+	.uleb128	265	; ref to abbrev 265
+	.section	.debug_abbrev
+	.uleb128	265
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname265:
+	.string		"PITDBGCTRL"
+	.section	.debug_info
+	.long		.Lname265
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #266: variable PITEVGENCTRLA
+	.section	.debug_info
+	.uleb128	266	; ref to abbrev 266
+	.section	.debug_abbrev
+	.uleb128	266
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname266:
+	.string		"PITEVGENCTRLA"
+	.section	.debug_info
+	.long		.Lname266
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #267: variable DEVICEID0
+	.section	.debug_info
+	.uleb128	267	; ref to abbrev 267
+	.section	.debug_abbrev
+	.uleb128	267
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname267:
+	.string		"DEVICEID0"
+	.section	.debug_info
+	.long		.Lname267
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #268: variable DEVICEID1
+	.section	.debug_info
+	.uleb128	268	; ref to abbrev 268
+	.section	.debug_abbrev
+	.uleb128	268
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname268:
+	.string		"DEVICEID1"
+	.section	.debug_info
+	.long		.Lname268
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #269: variable DEVICEID2
+	.section	.debug_info
+	.uleb128	269	; ref to abbrev 269
+	.section	.debug_abbrev
+	.uleb128	269
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname269:
+	.string		"DEVICEID2"
+	.section	.debug_info
+	.long		.Lname269
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #270: variable TEMPSENSE0
+	.section	.debug_info
+	.uleb128	270	; ref to abbrev 270
+	.section	.debug_abbrev
+	.uleb128	270
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname270:
+	.string		"TEMPSENSE0"
+	.section	.debug_info
+	.long		.Lname270
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #271: variable TEMPSENSE1
+	.section	.debug_info
+	.uleb128	271	; ref to abbrev 271
+	.section	.debug_abbrev
+	.uleb128	271
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname271:
+	.string		"TEMPSENSE1"
+	.section	.debug_info
+	.long		.Lname271
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #272: variable SERNUM0
+	.section	.debug_info
+	.uleb128	272	; ref to abbrev 272
+	.section	.debug_abbrev
+	.uleb128	272
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname272:
+	.string		"SERNUM0"
+	.section	.debug_info
+	.long		.Lname272
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #273: variable SERNUM1
+	.section	.debug_info
+	.uleb128	273	; ref to abbrev 273
+	.section	.debug_abbrev
+	.uleb128	273
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname273:
+	.string		"SERNUM1"
+	.section	.debug_info
+	.long		.Lname273
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #274: variable SERNUM2
+	.section	.debug_info
+	.uleb128	274	; ref to abbrev 274
+	.section	.debug_abbrev
+	.uleb128	274
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname274:
+	.string		"SERNUM2"
+	.section	.debug_info
+	.long		.Lname274
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #275: variable SERNUM3
+	.section	.debug_info
+	.uleb128	275	; ref to abbrev 275
+	.section	.debug_abbrev
+	.uleb128	275
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname275:
+	.string		"SERNUM3"
+	.section	.debug_info
+	.long		.Lname275
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #276: variable SERNUM4
+	.section	.debug_info
+	.uleb128	276	; ref to abbrev 276
+	.section	.debug_abbrev
+	.uleb128	276
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname276:
+	.string		"SERNUM4"
+	.section	.debug_info
+	.long		.Lname276
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #277: variable SERNUM5
+	.section	.debug_info
+	.uleb128	277	; ref to abbrev 277
+	.section	.debug_abbrev
+	.uleb128	277
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname277:
+	.string		"SERNUM5"
+	.section	.debug_info
+	.long		.Lname277
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #278: variable SERNUM6
+	.section	.debug_info
+	.uleb128	278	; ref to abbrev 278
+	.section	.debug_abbrev
+	.uleb128	278
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname278:
+	.string		"SERNUM6"
+	.section	.debug_info
+	.long		.Lname278
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #279: variable SERNUM7
+	.section	.debug_info
+	.uleb128	279	; ref to abbrev 279
+	.section	.debug_abbrev
+	.uleb128	279
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname279:
+	.string		"SERNUM7"
+	.section	.debug_info
+	.long		.Lname279
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #280: variable SERNUM8
+	.section	.debug_info
+	.uleb128	280	; ref to abbrev 280
+	.section	.debug_abbrev
+	.uleb128	280
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname280:
+	.string		"SERNUM8"
+	.section	.debug_info
+	.long		.Lname280
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #281: variable SERNUM9
+	.section	.debug_info
+	.uleb128	281	; ref to abbrev 281
+	.section	.debug_abbrev
+	.uleb128	281
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname281:
+	.string		"SERNUM9"
+	.section	.debug_info
+	.long		.Lname281
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x19
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #282: variable SERNUM10
+	.section	.debug_info
+	.uleb128	282	; ref to abbrev 282
+	.section	.debug_abbrev
+	.uleb128	282
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname282:
+	.string		"SERNUM10"
+	.section	.debug_info
+	.long		.Lname282
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x1A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #283: variable SERNUM11
+	.section	.debug_info
+	.uleb128	283	; ref to abbrev 283
+	.section	.debug_abbrev
+	.uleb128	283
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname283:
+	.string		"SERNUM11"
+	.section	.debug_info
+	.long		.Lname283
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x1B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #284: variable SERNUM12
+	.section	.debug_info
+	.uleb128	284	; ref to abbrev 284
+	.section	.debug_abbrev
+	.uleb128	284
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname284:
+	.string		"SERNUM12"
+	.section	.debug_info
+	.long		.Lname284
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x1C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #285: variable SERNUM13
+	.section	.debug_info
+	.uleb128	285	; ref to abbrev 285
+	.section	.debug_abbrev
+	.uleb128	285
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname285:
+	.string		"SERNUM13"
+	.section	.debug_info
+	.long		.Lname285
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x1D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #286: variable SERNUM14
+	.section	.debug_info
+	.uleb128	286	; ref to abbrev 286
+	.section	.debug_abbrev
+	.uleb128	286
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname286:
+	.string		"SERNUM14"
+	.section	.debug_info
+	.long		.Lname286
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x1E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #287: variable SERNUM15
+	.section	.debug_info
+	.uleb128	287	; ref to abbrev 287
+	.section	.debug_abbrev
+	.uleb128	287
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname287:
+	.string		"SERNUM15"
+	.section	.debug_info
+	.long		.Lname287
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x1F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #288: variable CTRLA
+	.section	.debug_info
+	.uleb128	288	; ref to abbrev 288
+	.section	.debug_abbrev
+	.uleb128	288
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname288:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname288
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0050 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #289: variable CTRLA
+	.section	.debug_info
+	.uleb128	289	; ref to abbrev 289
+	.section	.debug_abbrev
+	.uleb128	289
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname289:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname289
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #290: variable CTRLB
+	.section	.debug_info
+	.uleb128	290	; ref to abbrev 290
+	.section	.debug_abbrev
+	.uleb128	290
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname290:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname290
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #291: variable INTCTRL
+	.section	.debug_info
+	.uleb128	291	; ref to abbrev 291
+	.section	.debug_abbrev
+	.uleb128	291
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname291:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname291
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #292: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	292	; ref to abbrev 292
+	.section	.debug_abbrev
+	.uleb128	292
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname292:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname292
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #293: variable DATA
+	.section	.debug_info
+	.uleb128	293	; ref to abbrev 293
+	.section	.debug_abbrev
+	.uleb128	293
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname293:
+	.string		"DATA"
+	.section	.debug_info
+	.long		.Lname293
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #294: variable REVID
+	.section	.debug_info
+	.uleb128	294	; ref to abbrev 294
+	.section	.debug_abbrev
+	.uleb128	294
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname294:
+	.string		"REVID"
+	.section	.debug_info
+	.long		.Lname294
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0F00 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #295: variable OCDMCTRL
+	.section	.debug_info
+	.uleb128	295	; ref to abbrev 295
+	.section	.debug_abbrev
+	.uleb128	295
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname295:
+	.string		"OCDMCTRL"
+	.section	.debug_info
+	.long		.Lname295
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0F00 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #296: variable OCDMSTATUS
+	.section	.debug_info
+	.uleb128	296	; ref to abbrev 296
+	.section	.debug_abbrev
+	.uleb128	296
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname296:
+	.string		"OCDMSTATUS"
+	.section	.debug_info
+	.long		.Lname296
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0F00 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #297: variable CTRLA
+	.section	.debug_info
+	.uleb128	297	; ref to abbrev 297
+	.section	.debug_abbrev
+	.uleb128	297
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname297:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname297
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #298: variable CTRLB
+	.section	.debug_info
+	.uleb128	298	; ref to abbrev 298
+	.section	.debug_abbrev
+	.uleb128	298
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname298:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname298
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #299: variable CTRLC
+	.section	.debug_info
+	.uleb128	299	; ref to abbrev 299
+	.section	.debug_abbrev
+	.uleb128	299
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname299:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname299
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #300: variable CTRLD
+	.section	.debug_info
+	.uleb128	300	; ref to abbrev 300
+	.section	.debug_abbrev
+	.uleb128	300
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname300:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname300
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #301: variable CTRLECLR
+	.section	.debug_info
+	.uleb128	301	; ref to abbrev 301
+	.section	.debug_abbrev
+	.uleb128	301
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname301:
+	.string		"CTRLECLR"
+	.section	.debug_info
+	.long		.Lname301
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #302: variable CTRLESET
+	.section	.debug_info
+	.uleb128	302	; ref to abbrev 302
+	.section	.debug_abbrev
+	.uleb128	302
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname302:
+	.string		"CTRLESET"
+	.section	.debug_info
+	.long		.Lname302
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #303: variable CTRLFCLR
+	.section	.debug_info
+	.uleb128	303	; ref to abbrev 303
+	.section	.debug_abbrev
+	.uleb128	303
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname303:
+	.string		"CTRLFCLR"
+	.section	.debug_info
+	.long		.Lname303
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #304: variable CTRLFSET
+	.section	.debug_info
+	.uleb128	304	; ref to abbrev 304
+	.section	.debug_abbrev
+	.uleb128	304
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname304:
+	.string		"CTRLFSET"
+	.section	.debug_info
+	.long		.Lname304
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #305: variable EVCTRL
+	.section	.debug_info
+	.uleb128	305	; ref to abbrev 305
+	.section	.debug_abbrev
+	.uleb128	305
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname305:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname305
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #306: variable INTCTRL
+	.section	.debug_info
+	.uleb128	306	; ref to abbrev 306
+	.section	.debug_abbrev
+	.uleb128	306
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname306:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname306
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #307: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	307	; ref to abbrev 307
+	.section	.debug_abbrev
+	.uleb128	307
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname307:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname307
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #308: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	308	; ref to abbrev 308
+	.section	.debug_abbrev
+	.uleb128	308
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname308:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname308
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #309: variable TEMP
+	.section	.debug_info
+	.uleb128	309	; ref to abbrev 309
+	.section	.debug_abbrev
+	.uleb128	309
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname309:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname309
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #310: variable CNT
+	.section	.debug_info
+	.uleb128	310	; ref to abbrev 310
+	.section	.debug_abbrev
+	.uleb128	310
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname310:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname310
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #311: variable PER
+	.section	.debug_info
+	.uleb128	311	; ref to abbrev 311
+	.section	.debug_abbrev
+	.uleb128	311
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname311:
+	.string		"PER"
+	.section	.debug_info
+	.long		.Lname311
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x26
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #312: variable CMP0
+	.section	.debug_info
+	.uleb128	312	; ref to abbrev 312
+	.section	.debug_abbrev
+	.uleb128	312
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname312:
+	.string		"CMP0"
+	.section	.debug_info
+	.long		.Lname312
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x28
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #313: variable CMP1
+	.section	.debug_info
+	.uleb128	313	; ref to abbrev 313
+	.section	.debug_abbrev
+	.uleb128	313
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname313:
+	.string		"CMP1"
+	.section	.debug_info
+	.long		.Lname313
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #314: variable CMP2
+	.section	.debug_info
+	.uleb128	314	; ref to abbrev 314
+	.section	.debug_abbrev
+	.uleb128	314
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname314:
+	.string		"CMP2"
+	.section	.debug_info
+	.long		.Lname314
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #315: variable PERBUF
+	.section	.debug_info
+	.uleb128	315	; ref to abbrev 315
+	.section	.debug_abbrev
+	.uleb128	315
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname315:
+	.string		"PERBUF"
+	.section	.debug_info
+	.long		.Lname315
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x36
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #316: variable CMP0BUF
+	.section	.debug_info
+	.uleb128	316	; ref to abbrev 316
+	.section	.debug_abbrev
+	.uleb128	316
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname316:
+	.string		"CMP0BUF"
+	.section	.debug_info
+	.long		.Lname316
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x38
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #317: variable CMP1BUF
+	.section	.debug_info
+	.uleb128	317	; ref to abbrev 317
+	.section	.debug_abbrev
+	.uleb128	317
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname317:
+	.string		"CMP1BUF"
+	.section	.debug_info
+	.long		.Lname317
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x3A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #318: variable CMP2BUF
+	.section	.debug_info
+	.uleb128	318	; ref to abbrev 318
+	.section	.debug_abbrev
+	.uleb128	318
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname318:
+	.string		"CMP2BUF"
+	.section	.debug_info
+	.long		.Lname318
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x3C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #319: variable CTRLA
+	.section	.debug_info
+	.uleb128	319	; ref to abbrev 319
+	.section	.debug_abbrev
+	.uleb128	319
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname319:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname319
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #320: variable CTRLB
+	.section	.debug_info
+	.uleb128	320	; ref to abbrev 320
+	.section	.debug_abbrev
+	.uleb128	320
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname320:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname320
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #321: variable CTRLC
+	.section	.debug_info
+	.uleb128	321	; ref to abbrev 321
+	.section	.debug_abbrev
+	.uleb128	321
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname321:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname321
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #322: variable CTRLD
+	.section	.debug_info
+	.uleb128	322	; ref to abbrev 322
+	.section	.debug_abbrev
+	.uleb128	322
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname322:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname322
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #323: variable CTRLECLR
+	.section	.debug_info
+	.uleb128	323	; ref to abbrev 323
+	.section	.debug_abbrev
+	.uleb128	323
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname323:
+	.string		"CTRLECLR"
+	.section	.debug_info
+	.long		.Lname323
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #324: variable CTRLESET
+	.section	.debug_info
+	.uleb128	324	; ref to abbrev 324
+	.section	.debug_abbrev
+	.uleb128	324
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname324:
+	.string		"CTRLESET"
+	.section	.debug_info
+	.long		.Lname324
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #325: variable INTCTRL
+	.section	.debug_info
+	.uleb128	325	; ref to abbrev 325
+	.section	.debug_abbrev
+	.uleb128	325
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname325:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname325
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #326: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	326	; ref to abbrev 326
+	.section	.debug_abbrev
+	.uleb128	326
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname326:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname326
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #327: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	327	; ref to abbrev 327
+	.section	.debug_abbrev
+	.uleb128	327
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname327:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname327
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #328: variable LCNT
+	.section	.debug_info
+	.uleb128	328	; ref to abbrev 328
+	.section	.debug_abbrev
+	.uleb128	328
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname328:
+	.string		"LCNT"
+	.section	.debug_info
+	.long		.Lname328
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #329: variable HCNT
+	.section	.debug_info
+	.uleb128	329	; ref to abbrev 329
+	.section	.debug_abbrev
+	.uleb128	329
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname329:
+	.string		"HCNT"
+	.section	.debug_info
+	.long		.Lname329
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x21
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #330: variable LPER
+	.section	.debug_info
+	.uleb128	330	; ref to abbrev 330
+	.section	.debug_abbrev
+	.uleb128	330
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname330:
+	.string		"LPER"
+	.section	.debug_info
+	.long		.Lname330
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x26
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #331: variable HPER
+	.section	.debug_info
+	.uleb128	331	; ref to abbrev 331
+	.section	.debug_abbrev
+	.uleb128	331
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname331:
+	.string		"HPER"
+	.section	.debug_info
+	.long		.Lname331
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x27
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #332: variable LCMP0
+	.section	.debug_info
+	.uleb128	332	; ref to abbrev 332
+	.section	.debug_abbrev
+	.uleb128	332
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname332:
+	.string		"LCMP0"
+	.section	.debug_info
+	.long		.Lname332
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x28
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #333: variable HCMP0
+	.section	.debug_info
+	.uleb128	333	; ref to abbrev 333
+	.section	.debug_abbrev
+	.uleb128	333
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname333:
+	.string		"HCMP0"
+	.section	.debug_info
+	.long		.Lname333
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x29
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #334: variable LCMP1
+	.section	.debug_info
+	.uleb128	334	; ref to abbrev 334
+	.section	.debug_abbrev
+	.uleb128	334
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname334:
+	.string		"LCMP1"
+	.section	.debug_info
+	.long		.Lname334
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #335: variable HCMP1
+	.section	.debug_info
+	.uleb128	335	; ref to abbrev 335
+	.section	.debug_abbrev
+	.uleb128	335
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname335:
+	.string		"HCMP1"
+	.section	.debug_info
+	.long		.Lname335
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #336: variable LCMP2
+	.section	.debug_info
+	.uleb128	336	; ref to abbrev 336
+	.section	.debug_abbrev
+	.uleb128	336
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname336:
+	.string		"LCMP2"
+	.section	.debug_info
+	.long		.Lname336
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #337: variable HCMP2
+	.section	.debug_info
+	.uleb128	337	; ref to abbrev 337
+	.section	.debug_abbrev
+	.uleb128	337
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname337:
+	.string		"HCMP2"
+	.section	.debug_info
+	.long		.Lname337
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #338: variable CTRLA
+	.section	.debug_info
+	.uleb128	338	; ref to abbrev 338
+	.section	.debug_abbrev
+	.uleb128	338
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname338:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname338
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #339: variable CTRLB
+	.section	.debug_info
+	.uleb128	339	; ref to abbrev 339
+	.section	.debug_abbrev
+	.uleb128	339
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname339:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname339
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #340: variable EVCTRL
+	.section	.debug_info
+	.uleb128	340	; ref to abbrev 340
+	.section	.debug_abbrev
+	.uleb128	340
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname340:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname340
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #341: variable INTCTRL
+	.section	.debug_info
+	.uleb128	341	; ref to abbrev 341
+	.section	.debug_abbrev
+	.uleb128	341
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname341:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname341
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #342: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	342	; ref to abbrev 342
+	.section	.debug_abbrev
+	.uleb128	342
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname342:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname342
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #343: variable STATUS
+	.section	.debug_info
+	.uleb128	343	; ref to abbrev 343
+	.section	.debug_abbrev
+	.uleb128	343
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname343:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname343
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #344: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	344	; ref to abbrev 344
+	.section	.debug_abbrev
+	.uleb128	344
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname344:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname344
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #345: variable TEMP
+	.section	.debug_info
+	.uleb128	345	; ref to abbrev 345
+	.section	.debug_abbrev
+	.uleb128	345
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname345:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname345
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #346: variable CNT
+	.section	.debug_info
+	.uleb128	346	; ref to abbrev 346
+	.section	.debug_abbrev
+	.uleb128	346
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname346:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname346
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #347: variable CCMP
+	.section	.debug_info
+	.uleb128	347	; ref to abbrev 347
+	.section	.debug_abbrev
+	.uleb128	347
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname347:
+	.string		"CCMP"
+	.section	.debug_info
+	.long		.Lname347
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #348: variable CTRLA
+	.section	.debug_info
+	.uleb128	348	; ref to abbrev 348
+	.section	.debug_abbrev
+	.uleb128	348
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname348:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname348
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #349: variable CTRLB
+	.section	.debug_info
+	.uleb128	349	; ref to abbrev 349
+	.section	.debug_abbrev
+	.uleb128	349
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname349:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname349
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #350: variable EVCTRL
+	.section	.debug_info
+	.uleb128	350	; ref to abbrev 350
+	.section	.debug_abbrev
+	.uleb128	350
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname350:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname350
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #351: variable INTCTRL
+	.section	.debug_info
+	.uleb128	351	; ref to abbrev 351
+	.section	.debug_abbrev
+	.uleb128	351
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname351:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname351
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #352: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	352	; ref to abbrev 352
+	.section	.debug_abbrev
+	.uleb128	352
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname352:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname352
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #353: variable STATUS
+	.section	.debug_info
+	.uleb128	353	; ref to abbrev 353
+	.section	.debug_abbrev
+	.uleb128	353
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname353:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname353
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #354: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	354	; ref to abbrev 354
+	.section	.debug_abbrev
+	.uleb128	354
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname354:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname354
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #355: variable TEMP
+	.section	.debug_info
+	.uleb128	355	; ref to abbrev 355
+	.section	.debug_abbrev
+	.uleb128	355
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname355:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname355
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #356: variable CNT
+	.section	.debug_info
+	.uleb128	356	; ref to abbrev 356
+	.section	.debug_abbrev
+	.uleb128	356
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname356:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname356
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #357: variable CCMP
+	.section	.debug_info
+	.uleb128	357	; ref to abbrev 357
+	.section	.debug_abbrev
+	.uleb128	357
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname357:
+	.string		"CCMP"
+	.section	.debug_info
+	.long		.Lname357
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #358: variable CTRLA
+	.section	.debug_info
+	.uleb128	358	; ref to abbrev 358
+	.section	.debug_abbrev
+	.uleb128	358
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname358:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname358
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #359: variable CTRLB
+	.section	.debug_info
+	.uleb128	359	; ref to abbrev 359
+	.section	.debug_abbrev
+	.uleb128	359
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname359:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname359
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #360: variable EVCTRL
+	.section	.debug_info
+	.uleb128	360	; ref to abbrev 360
+	.section	.debug_abbrev
+	.uleb128	360
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname360:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname360
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #361: variable INTCTRL
+	.section	.debug_info
+	.uleb128	361	; ref to abbrev 361
+	.section	.debug_abbrev
+	.uleb128	361
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname361:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname361
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #362: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	362	; ref to abbrev 362
+	.section	.debug_abbrev
+	.uleb128	362
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname362:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname362
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #363: variable STATUS
+	.section	.debug_info
+	.uleb128	363	; ref to abbrev 363
+	.section	.debug_abbrev
+	.uleb128	363
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname363:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname363
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #364: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	364	; ref to abbrev 364
+	.section	.debug_abbrev
+	.uleb128	364
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname364:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname364
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #365: variable TEMP
+	.section	.debug_info
+	.uleb128	365	; ref to abbrev 365
+	.section	.debug_abbrev
+	.uleb128	365
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname365:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname365
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #366: variable CNT
+	.section	.debug_info
+	.uleb128	366	; ref to abbrev 366
+	.section	.debug_abbrev
+	.uleb128	366
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname366:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname366
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #367: variable CCMP
+	.section	.debug_info
+	.uleb128	367	; ref to abbrev 367
+	.section	.debug_abbrev
+	.uleb128	367
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname367:
+	.string		"CCMP"
+	.section	.debug_info
+	.long		.Lname367
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #368: variable CTRLA
+	.section	.debug_info
+	.uleb128	368	; ref to abbrev 368
+	.section	.debug_abbrev
+	.uleb128	368
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname368:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname368
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #369: variable DUALCTRL
+	.section	.debug_info
+	.uleb128	369	; ref to abbrev 369
+	.section	.debug_abbrev
+	.uleb128	369
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname369:
+	.string		"DUALCTRL"
+	.section	.debug_info
+	.long		.Lname369
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #370: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	370	; ref to abbrev 370
+	.section	.debug_abbrev
+	.uleb128	370
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname370:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname370
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #371: variable MCTRLA
+	.section	.debug_info
+	.uleb128	371	; ref to abbrev 371
+	.section	.debug_abbrev
+	.uleb128	371
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname371:
+	.string		"MCTRLA"
+	.section	.debug_info
+	.long		.Lname371
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #372: variable MCTRLB
+	.section	.debug_info
+	.uleb128	372	; ref to abbrev 372
+	.section	.debug_abbrev
+	.uleb128	372
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname372:
+	.string		"MCTRLB"
+	.section	.debug_info
+	.long		.Lname372
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #373: variable MSTATUS
+	.section	.debug_info
+	.uleb128	373	; ref to abbrev 373
+	.section	.debug_abbrev
+	.uleb128	373
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname373:
+	.string		"MSTATUS"
+	.section	.debug_info
+	.long		.Lname373
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #374: variable MBAUD
+	.section	.debug_info
+	.uleb128	374	; ref to abbrev 374
+	.section	.debug_abbrev
+	.uleb128	374
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname374:
+	.string		"MBAUD"
+	.section	.debug_info
+	.long		.Lname374
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #375: variable MADDR
+	.section	.debug_info
+	.uleb128	375	; ref to abbrev 375
+	.section	.debug_abbrev
+	.uleb128	375
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname375:
+	.string		"MADDR"
+	.section	.debug_info
+	.long		.Lname375
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #376: variable MDATA
+	.section	.debug_info
+	.uleb128	376	; ref to abbrev 376
+	.section	.debug_abbrev
+	.uleb128	376
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname376:
+	.string		"MDATA"
+	.section	.debug_info
+	.long		.Lname376
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #377: variable SCTRLA
+	.section	.debug_info
+	.uleb128	377	; ref to abbrev 377
+	.section	.debug_abbrev
+	.uleb128	377
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname377:
+	.string		"SCTRLA"
+	.section	.debug_info
+	.long		.Lname377
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #378: variable SCTRLB
+	.section	.debug_info
+	.uleb128	378	; ref to abbrev 378
+	.section	.debug_abbrev
+	.uleb128	378
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname378:
+	.string		"SCTRLB"
+	.section	.debug_info
+	.long		.Lname378
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #379: variable SSTATUS
+	.section	.debug_info
+	.uleb128	379	; ref to abbrev 379
+	.section	.debug_abbrev
+	.uleb128	379
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname379:
+	.string		"SSTATUS"
+	.section	.debug_info
+	.long		.Lname379
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #380: variable SADDR
+	.section	.debug_info
+	.uleb128	380	; ref to abbrev 380
+	.section	.debug_abbrev
+	.uleb128	380
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname380:
+	.string		"SADDR"
+	.section	.debug_info
+	.long		.Lname380
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #381: variable SDATA
+	.section	.debug_info
+	.uleb128	381	; ref to abbrev 381
+	.section	.debug_abbrev
+	.uleb128	381
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname381:
+	.string		"SDATA"
+	.section	.debug_info
+	.long		.Lname381
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xD
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #382: variable SADDRMASK
+	.section	.debug_info
+	.uleb128	382	; ref to abbrev 382
+	.section	.debug_abbrev
+	.uleb128	382
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname382:
+	.string		"SADDRMASK"
+	.section	.debug_info
+	.long		.Lname382
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xE
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #383: variable RXDATAL
+	.section	.debug_info
+	.uleb128	383	; ref to abbrev 383
+	.section	.debug_abbrev
+	.uleb128	383
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname383:
+	.string		"RXDATAL"
+	.section	.debug_info
+	.long		.Lname383
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #384: variable RXDATAH
+	.section	.debug_info
+	.uleb128	384	; ref to abbrev 384
+	.section	.debug_abbrev
+	.uleb128	384
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname384:
+	.string		"RXDATAH"
+	.section	.debug_info
+	.long		.Lname384
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #385: variable TXDATAL
+	.section	.debug_info
+	.uleb128	385	; ref to abbrev 385
+	.section	.debug_abbrev
+	.uleb128	385
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname385:
+	.string		"TXDATAL"
+	.section	.debug_info
+	.long		.Lname385
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #386: variable TXDATAH
+	.section	.debug_info
+	.uleb128	386	; ref to abbrev 386
+	.section	.debug_abbrev
+	.uleb128	386
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname386:
+	.string		"TXDATAH"
+	.section	.debug_info
+	.long		.Lname386
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #387: variable STATUS
+	.section	.debug_info
+	.uleb128	387	; ref to abbrev 387
+	.section	.debug_abbrev
+	.uleb128	387
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname387:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname387
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #388: variable CTRLA
+	.section	.debug_info
+	.uleb128	388	; ref to abbrev 388
+	.section	.debug_abbrev
+	.uleb128	388
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname388:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname388
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #389: variable CTRLB
+	.section	.debug_info
+	.uleb128	389	; ref to abbrev 389
+	.section	.debug_abbrev
+	.uleb128	389
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname389:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname389
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #390: variable CTRLC
+	.section	.debug_info
+	.uleb128	390	; ref to abbrev 390
+	.section	.debug_abbrev
+	.uleb128	390
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname390:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname390
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #391: variable BAUD
+	.section	.debug_info
+	.uleb128	391	; ref to abbrev 391
+	.section	.debug_abbrev
+	.uleb128	391
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname391:
+	.string		"BAUD"
+	.section	.debug_info
+	.long		.Lname391
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #392: variable CTRLD
+	.section	.debug_info
+	.uleb128	392	; ref to abbrev 392
+	.section	.debug_abbrev
+	.uleb128	392
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname392:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname392
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #393: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	393	; ref to abbrev 393
+	.section	.debug_abbrev
+	.uleb128	393
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname393:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname393
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #394: variable EVCTRL
+	.section	.debug_info
+	.uleb128	394	; ref to abbrev 394
+	.section	.debug_abbrev
+	.uleb128	394
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname394:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname394
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #395: variable TXPLCTRL
+	.section	.debug_info
+	.uleb128	395	; ref to abbrev 395
+	.section	.debug_abbrev
+	.uleb128	395
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname395:
+	.string		"TXPLCTRL"
+	.section	.debug_info
+	.long		.Lname395
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xD
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #396: variable RXPLCTRL
+	.section	.debug_info
+	.uleb128	396	; ref to abbrev 396
+	.section	.debug_abbrev
+	.uleb128	396
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname396:
+	.string		"RXPLCTRL"
+	.section	.debug_info
+	.long		.Lname396
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xE
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #397: variable RXDATAL
+	.section	.debug_info
+	.uleb128	397	; ref to abbrev 397
+	.section	.debug_abbrev
+	.uleb128	397
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname397:
+	.string		"RXDATAL"
+	.section	.debug_info
+	.long		.Lname397
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #398: variable RXDATAH
+	.section	.debug_info
+	.uleb128	398	; ref to abbrev 398
+	.section	.debug_abbrev
+	.uleb128	398
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname398:
+	.string		"RXDATAH"
+	.section	.debug_info
+	.long		.Lname398
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #399: variable TXDATAL
+	.section	.debug_info
+	.uleb128	399	; ref to abbrev 399
+	.section	.debug_abbrev
+	.uleb128	399
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname399:
+	.string		"TXDATAL"
+	.section	.debug_info
+	.long		.Lname399
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #400: variable TXDATAH
+	.section	.debug_info
+	.uleb128	400	; ref to abbrev 400
+	.section	.debug_abbrev
+	.uleb128	400
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname400:
+	.string		"TXDATAH"
+	.section	.debug_info
+	.long		.Lname400
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #401: variable STATUS
+	.section	.debug_info
+	.uleb128	401	; ref to abbrev 401
+	.section	.debug_abbrev
+	.uleb128	401
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname401:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname401
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #402: variable CTRLA
+	.section	.debug_info
+	.uleb128	402	; ref to abbrev 402
+	.section	.debug_abbrev
+	.uleb128	402
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname402:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname402
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #403: variable CTRLB
+	.section	.debug_info
+	.uleb128	403	; ref to abbrev 403
+	.section	.debug_abbrev
+	.uleb128	403
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname403:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname403
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #404: variable CTRLC
+	.section	.debug_info
+	.uleb128	404	; ref to abbrev 404
+	.section	.debug_abbrev
+	.uleb128	404
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname404:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname404
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #405: variable BAUD
+	.section	.debug_info
+	.uleb128	405	; ref to abbrev 405
+	.section	.debug_abbrev
+	.uleb128	405
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname405:
+	.string		"BAUD"
+	.section	.debug_info
+	.long		.Lname405
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #406: variable CTRLD
+	.section	.debug_info
+	.uleb128	406	; ref to abbrev 406
+	.section	.debug_abbrev
+	.uleb128	406
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname406:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname406
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #407: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	407	; ref to abbrev 407
+	.section	.debug_abbrev
+	.uleb128	407
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname407:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname407
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #408: variable EVCTRL
+	.section	.debug_info
+	.uleb128	408	; ref to abbrev 408
+	.section	.debug_abbrev
+	.uleb128	408
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname408:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname408
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #409: variable TXPLCTRL
+	.section	.debug_info
+	.uleb128	409	; ref to abbrev 409
+	.section	.debug_abbrev
+	.uleb128	409
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname409:
+	.string		"TXPLCTRL"
+	.section	.debug_info
+	.long		.Lname409
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0xD
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #410: variable RXPLCTRL
+	.section	.debug_info
+	.uleb128	410	; ref to abbrev 410
+	.section	.debug_abbrev
+	.uleb128	410
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname410:
+	.string		"RXPLCTRL"
+	.section	.debug_info
+	.long		.Lname410
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0xE
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #411: variable RXDATAL
+	.section	.debug_info
+	.uleb128	411	; ref to abbrev 411
+	.section	.debug_abbrev
+	.uleb128	411
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname411:
+	.string		"RXDATAL"
+	.section	.debug_info
+	.long		.Lname411
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #412: variable RXDATAH
+	.section	.debug_info
+	.uleb128	412	; ref to abbrev 412
+	.section	.debug_abbrev
+	.uleb128	412
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname412:
+	.string		"RXDATAH"
+	.section	.debug_info
+	.long		.Lname412
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #413: variable TXDATAL
+	.section	.debug_info
+	.uleb128	413	; ref to abbrev 413
+	.section	.debug_abbrev
+	.uleb128	413
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname413:
+	.string		"TXDATAL"
+	.section	.debug_info
+	.long		.Lname413
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #414: variable TXDATAH
+	.section	.debug_info
+	.uleb128	414	; ref to abbrev 414
+	.section	.debug_abbrev
+	.uleb128	414
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname414:
+	.string		"TXDATAH"
+	.section	.debug_info
+	.long		.Lname414
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #415: variable STATUS
+	.section	.debug_info
+	.uleb128	415	; ref to abbrev 415
+	.section	.debug_abbrev
+	.uleb128	415
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname415:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname415
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #416: variable CTRLA
+	.section	.debug_info
+	.uleb128	416	; ref to abbrev 416
+	.section	.debug_abbrev
+	.uleb128	416
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname416:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname416
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #417: variable CTRLB
+	.section	.debug_info
+	.uleb128	417	; ref to abbrev 417
+	.section	.debug_abbrev
+	.uleb128	417
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname417:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname417
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #418: variable CTRLC
+	.section	.debug_info
+	.uleb128	418	; ref to abbrev 418
+	.section	.debug_abbrev
+	.uleb128	418
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname418:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname418
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #419: variable BAUD
+	.section	.debug_info
+	.uleb128	419	; ref to abbrev 419
+	.section	.debug_abbrev
+	.uleb128	419
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname419:
+	.string		"BAUD"
+	.section	.debug_info
+	.long		.Lname419
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #420: variable CTRLD
+	.section	.debug_info
+	.uleb128	420	; ref to abbrev 420
+	.section	.debug_abbrev
+	.uleb128	420
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname420:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname420
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #421: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	421	; ref to abbrev 421
+	.section	.debug_abbrev
+	.uleb128	421
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname421:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname421
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #422: variable EVCTRL
+	.section	.debug_info
+	.uleb128	422	; ref to abbrev 422
+	.section	.debug_abbrev
+	.uleb128	422
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname422:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname422
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #423: variable TXPLCTRL
+	.section	.debug_info
+	.uleb128	423	; ref to abbrev 423
+	.section	.debug_abbrev
+	.uleb128	423
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname423:
+	.string		"TXPLCTRL"
+	.section	.debug_info
+	.long		.Lname423
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0xD
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #424: variable RXPLCTRL
+	.section	.debug_info
+	.uleb128	424	; ref to abbrev 424
+	.section	.debug_abbrev
+	.uleb128	424
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname424:
+	.string		"RXPLCTRL"
+	.section	.debug_info
+	.long		.Lname424
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0xE
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #425: variable USERROW0
+	.section	.debug_info
+	.uleb128	425	; ref to abbrev 425
+	.section	.debug_abbrev
+	.uleb128	425
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname425:
+	.string		"USERROW0"
+	.section	.debug_info
+	.long		.Lname425
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #426: variable USERROW1
+	.section	.debug_info
+	.uleb128	426	; ref to abbrev 426
+	.section	.debug_abbrev
+	.uleb128	426
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname426:
+	.string		"USERROW1"
+	.section	.debug_info
+	.long		.Lname426
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #427: variable USERROW2
+	.section	.debug_info
+	.uleb128	427	; ref to abbrev 427
+	.section	.debug_abbrev
+	.uleb128	427
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname427:
+	.string		"USERROW2"
+	.section	.debug_info
+	.long		.Lname427
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #428: variable USERROW3
+	.section	.debug_info
+	.uleb128	428	; ref to abbrev 428
+	.section	.debug_abbrev
+	.uleb128	428
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname428:
+	.string		"USERROW3"
+	.section	.debug_info
+	.long		.Lname428
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #429: variable USERROW4
+	.section	.debug_info
+	.uleb128	429	; ref to abbrev 429
+	.section	.debug_abbrev
+	.uleb128	429
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname429:
+	.string		"USERROW4"
+	.section	.debug_info
+	.long		.Lname429
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #430: variable USERROW5
+	.section	.debug_info
+	.uleb128	430	; ref to abbrev 430
+	.section	.debug_abbrev
+	.uleb128	430
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname430:
+	.string		"USERROW5"
+	.section	.debug_info
+	.long		.Lname430
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #431: variable USERROW6
+	.section	.debug_info
+	.uleb128	431	; ref to abbrev 431
+	.section	.debug_abbrev
+	.uleb128	431
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname431:
+	.string		"USERROW6"
+	.section	.debug_info
+	.long		.Lname431
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #432: variable USERROW7
+	.section	.debug_info
+	.uleb128	432	; ref to abbrev 432
+	.section	.debug_abbrev
+	.uleb128	432
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname432:
+	.string		"USERROW7"
+	.section	.debug_info
+	.long		.Lname432
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #433: variable USERROW8
+	.section	.debug_info
+	.uleb128	433	; ref to abbrev 433
+	.section	.debug_abbrev
+	.uleb128	433
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname433:
+	.string		"USERROW8"
+	.section	.debug_info
+	.long		.Lname433
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #434: variable USERROW9
+	.section	.debug_info
+	.uleb128	434	; ref to abbrev 434
+	.section	.debug_abbrev
+	.uleb128	434
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname434:
+	.string		"USERROW9"
+	.section	.debug_info
+	.long		.Lname434
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #435: variable USERROW10
+	.section	.debug_info
+	.uleb128	435	; ref to abbrev 435
+	.section	.debug_abbrev
+	.uleb128	435
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname435:
+	.string		"USERROW10"
+	.section	.debug_info
+	.long		.Lname435
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #436: variable USERROW11
+	.section	.debug_info
+	.uleb128	436	; ref to abbrev 436
+	.section	.debug_abbrev
+	.uleb128	436
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname436:
+	.string		"USERROW11"
+	.section	.debug_info
+	.long		.Lname436
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #437: variable USERROW12
+	.section	.debug_info
+	.uleb128	437	; ref to abbrev 437
+	.section	.debug_abbrev
+	.uleb128	437
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname437:
+	.string		"USERROW12"
+	.section	.debug_info
+	.long		.Lname437
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #438: variable USERROW13
+	.section	.debug_info
+	.uleb128	438	; ref to abbrev 438
+	.section	.debug_abbrev
+	.uleb128	438
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname438:
+	.string		"USERROW13"
+	.section	.debug_info
+	.long		.Lname438
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #439: variable USERROW14
+	.section	.debug_info
+	.uleb128	439	; ref to abbrev 439
+	.section	.debug_abbrev
+	.uleb128	439
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname439:
+	.string		"USERROW14"
+	.section	.debug_info
+	.long		.Lname439
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #440: variable USERROW15
+	.section	.debug_info
+	.uleb128	440	; ref to abbrev 440
+	.section	.debug_abbrev
+	.uleb128	440
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname440:
+	.string		"USERROW15"
+	.section	.debug_info
+	.long		.Lname440
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x0F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #441: variable USERROW16
+	.section	.debug_info
+	.uleb128	441	; ref to abbrev 441
+	.section	.debug_abbrev
+	.uleb128	441
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname441:
+	.string		"USERROW16"
+	.section	.debug_info
+	.long		.Lname441
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #442: variable USERROW17
+	.section	.debug_info
+	.uleb128	442	; ref to abbrev 442
+	.section	.debug_abbrev
+	.uleb128	442
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname442:
+	.string		"USERROW17"
+	.section	.debug_info
+	.long		.Lname442
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #443: variable USERROW18
+	.section	.debug_info
+	.uleb128	443	; ref to abbrev 443
+	.section	.debug_abbrev
+	.uleb128	443
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname443:
+	.string		"USERROW18"
+	.section	.debug_info
+	.long		.Lname443
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #444: variable USERROW19
+	.section	.debug_info
+	.uleb128	444	; ref to abbrev 444
+	.section	.debug_abbrev
+	.uleb128	444
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname444:
+	.string		"USERROW19"
+	.section	.debug_info
+	.long		.Lname444
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #445: variable USERROW20
+	.section	.debug_info
+	.uleb128	445	; ref to abbrev 445
+	.section	.debug_abbrev
+	.uleb128	445
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname445:
+	.string		"USERROW20"
+	.section	.debug_info
+	.long		.Lname445
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #446: variable USERROW21
+	.section	.debug_info
+	.uleb128	446	; ref to abbrev 446
+	.section	.debug_abbrev
+	.uleb128	446
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname446:
+	.string		"USERROW21"
+	.section	.debug_info
+	.long		.Lname446
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #447: variable USERROW22
+	.section	.debug_info
+	.uleb128	447	; ref to abbrev 447
+	.section	.debug_abbrev
+	.uleb128	447
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname447:
+	.string		"USERROW22"
+	.section	.debug_info
+	.long		.Lname447
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #448: variable USERROW23
+	.section	.debug_info
+	.uleb128	448	; ref to abbrev 448
+	.section	.debug_abbrev
+	.uleb128	448
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname448:
+	.string		"USERROW23"
+	.section	.debug_info
+	.long		.Lname448
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #449: variable USERROW24
+	.section	.debug_info
+	.uleb128	449	; ref to abbrev 449
+	.section	.debug_abbrev
+	.uleb128	449
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname449:
+	.string		"USERROW24"
+	.section	.debug_info
+	.long		.Lname449
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #450: variable USERROW25
+	.section	.debug_info
+	.uleb128	450	; ref to abbrev 450
+	.section	.debug_abbrev
+	.uleb128	450
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname450:
+	.string		"USERROW25"
+	.section	.debug_info
+	.long		.Lname450
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x19
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #451: variable USERROW26
+	.section	.debug_info
+	.uleb128	451	; ref to abbrev 451
+	.section	.debug_abbrev
+	.uleb128	451
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname451:
+	.string		"USERROW26"
+	.section	.debug_info
+	.long		.Lname451
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #452: variable USERROW27
+	.section	.debug_info
+	.uleb128	452	; ref to abbrev 452
+	.section	.debug_abbrev
+	.uleb128	452
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname452:
+	.string		"USERROW27"
+	.section	.debug_info
+	.long		.Lname452
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #453: variable USERROW28
+	.section	.debug_info
+	.uleb128	453	; ref to abbrev 453
+	.section	.debug_abbrev
+	.uleb128	453
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname453:
+	.string		"USERROW28"
+	.section	.debug_info
+	.long		.Lname453
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #454: variable USERROW29
+	.section	.debug_info
+	.uleb128	454	; ref to abbrev 454
+	.section	.debug_abbrev
+	.uleb128	454
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname454:
+	.string		"USERROW29"
+	.section	.debug_info
+	.long		.Lname454
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #455: variable USERROW30
+	.section	.debug_info
+	.uleb128	455	; ref to abbrev 455
+	.section	.debug_abbrev
+	.uleb128	455
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname455:
+	.string		"USERROW30"
+	.section	.debug_info
+	.long		.Lname455
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #456: variable USERROW31
+	.section	.debug_info
+	.uleb128	456	; ref to abbrev 456
+	.section	.debug_abbrev
+	.uleb128	456
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname456:
+	.string		"USERROW31"
+	.section	.debug_info
+	.long		.Lname456
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #457: variable USERROW32
+	.section	.debug_info
+	.uleb128	457	; ref to abbrev 457
+	.section	.debug_abbrev
+	.uleb128	457
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname457:
+	.string		"USERROW32"
+	.section	.debug_info
+	.long		.Lname457
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #458: variable USERROW33
+	.section	.debug_info
+	.uleb128	458	; ref to abbrev 458
+	.section	.debug_abbrev
+	.uleb128	458
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname458:
+	.string		"USERROW33"
+	.section	.debug_info
+	.long		.Lname458
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x21
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #459: variable USERROW34
+	.section	.debug_info
+	.uleb128	459	; ref to abbrev 459
+	.section	.debug_abbrev
+	.uleb128	459
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname459:
+	.string		"USERROW34"
+	.section	.debug_info
+	.long		.Lname459
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x22
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #460: variable USERROW35
+	.section	.debug_info
+	.uleb128	460	; ref to abbrev 460
+	.section	.debug_abbrev
+	.uleb128	460
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname460:
+	.string		"USERROW35"
+	.section	.debug_info
+	.long		.Lname460
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x23
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #461: variable USERROW36
+	.section	.debug_info
+	.uleb128	461	; ref to abbrev 461
+	.section	.debug_abbrev
+	.uleb128	461
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname461:
+	.string		"USERROW36"
+	.section	.debug_info
+	.long		.Lname461
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x24
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #462: variable USERROW37
+	.section	.debug_info
+	.uleb128	462	; ref to abbrev 462
+	.section	.debug_abbrev
+	.uleb128	462
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname462:
+	.string		"USERROW37"
+	.section	.debug_info
+	.long		.Lname462
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x25
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #463: variable USERROW38
+	.section	.debug_info
+	.uleb128	463	; ref to abbrev 463
+	.section	.debug_abbrev
+	.uleb128	463
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname463:
+	.string		"USERROW38"
+	.section	.debug_info
+	.long		.Lname463
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x26
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #464: variable USERROW39
+	.section	.debug_info
+	.uleb128	464	; ref to abbrev 464
+	.section	.debug_abbrev
+	.uleb128	464
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname464:
+	.string		"USERROW39"
+	.section	.debug_info
+	.long		.Lname464
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x27
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #465: variable USERROW40
+	.section	.debug_info
+	.uleb128	465	; ref to abbrev 465
+	.section	.debug_abbrev
+	.uleb128	465
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname465:
+	.string		"USERROW40"
+	.section	.debug_info
+	.long		.Lname465
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x28
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #466: variable USERROW41
+	.section	.debug_info
+	.uleb128	466	; ref to abbrev 466
+	.section	.debug_abbrev
+	.uleb128	466
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname466:
+	.string		"USERROW41"
+	.section	.debug_info
+	.long		.Lname466
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x29
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #467: variable USERROW42
+	.section	.debug_info
+	.uleb128	467	; ref to abbrev 467
+	.section	.debug_abbrev
+	.uleb128	467
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname467:
+	.string		"USERROW42"
+	.section	.debug_info
+	.long		.Lname467
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x2A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #468: variable USERROW43
+	.section	.debug_info
+	.uleb128	468	; ref to abbrev 468
+	.section	.debug_abbrev
+	.uleb128	468
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname468:
+	.string		"USERROW43"
+	.section	.debug_info
+	.long		.Lname468
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x2B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #469: variable USERROW44
+	.section	.debug_info
+	.uleb128	469	; ref to abbrev 469
+	.section	.debug_abbrev
+	.uleb128	469
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname469:
+	.string		"USERROW44"
+	.section	.debug_info
+	.long		.Lname469
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x2C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #470: variable USERROW45
+	.section	.debug_info
+	.uleb128	470	; ref to abbrev 470
+	.section	.debug_abbrev
+	.uleb128	470
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname470:
+	.string		"USERROW45"
+	.section	.debug_info
+	.long		.Lname470
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x2D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #471: variable USERROW46
+	.section	.debug_info
+	.uleb128	471	; ref to abbrev 471
+	.section	.debug_abbrev
+	.uleb128	471
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname471:
+	.string		"USERROW46"
+	.section	.debug_info
+	.long		.Lname471
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x2E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #472: variable USERROW47
+	.section	.debug_info
+	.uleb128	472	; ref to abbrev 472
+	.section	.debug_abbrev
+	.uleb128	472
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname472:
+	.string		"USERROW47"
+	.section	.debug_info
+	.long		.Lname472
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x2F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #473: variable USERROW48
+	.section	.debug_info
+	.uleb128	473	; ref to abbrev 473
+	.section	.debug_abbrev
+	.uleb128	473
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname473:
+	.string		"USERROW48"
+	.section	.debug_info
+	.long		.Lname473
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x30
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #474: variable USERROW49
+	.section	.debug_info
+	.uleb128	474	; ref to abbrev 474
+	.section	.debug_abbrev
+	.uleb128	474
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname474:
+	.string		"USERROW49"
+	.section	.debug_info
+	.long		.Lname474
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x31
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #475: variable USERROW50
+	.section	.debug_info
+	.uleb128	475	; ref to abbrev 475
+	.section	.debug_abbrev
+	.uleb128	475
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname475:
+	.string		"USERROW50"
+	.section	.debug_info
+	.long		.Lname475
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x32
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #476: variable USERROW51
+	.section	.debug_info
+	.uleb128	476	; ref to abbrev 476
+	.section	.debug_abbrev
+	.uleb128	476
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname476:
+	.string		"USERROW51"
+	.section	.debug_info
+	.long		.Lname476
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x33
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #477: variable USERROW52
+	.section	.debug_info
+	.uleb128	477	; ref to abbrev 477
+	.section	.debug_abbrev
+	.uleb128	477
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname477:
+	.string		"USERROW52"
+	.section	.debug_info
+	.long		.Lname477
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x34
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #478: variable USERROW53
+	.section	.debug_info
+	.uleb128	478	; ref to abbrev 478
+	.section	.debug_abbrev
+	.uleb128	478
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname478:
+	.string		"USERROW53"
+	.section	.debug_info
+	.long		.Lname478
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x35
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #479: variable USERROW54
+	.section	.debug_info
+	.uleb128	479	; ref to abbrev 479
+	.section	.debug_abbrev
+	.uleb128	479
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname479:
+	.string		"USERROW54"
+	.section	.debug_info
+	.long		.Lname479
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x36
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #480: variable USERROW55
+	.section	.debug_info
+	.uleb128	480	; ref to abbrev 480
+	.section	.debug_abbrev
+	.uleb128	480
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname480:
+	.string		"USERROW55"
+	.section	.debug_info
+	.long		.Lname480
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x37
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #481: variable USERROW56
+	.section	.debug_info
+	.uleb128	481	; ref to abbrev 481
+	.section	.debug_abbrev
+	.uleb128	481
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname481:
+	.string		"USERROW56"
+	.section	.debug_info
+	.long		.Lname481
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x38
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #482: variable USERROW57
+	.section	.debug_info
+	.uleb128	482	; ref to abbrev 482
+	.section	.debug_abbrev
+	.uleb128	482
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname482:
+	.string		"USERROW57"
+	.section	.debug_info
+	.long		.Lname482
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x39
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #483: variable USERROW58
+	.section	.debug_info
+	.uleb128	483	; ref to abbrev 483
+	.section	.debug_abbrev
+	.uleb128	483
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname483:
+	.string		"USERROW58"
+	.section	.debug_info
+	.long		.Lname483
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x3A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #484: variable USERROW59
+	.section	.debug_info
+	.uleb128	484	; ref to abbrev 484
+	.section	.debug_abbrev
+	.uleb128	484
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname484:
+	.string		"USERROW59"
+	.section	.debug_info
+	.long		.Lname484
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x3B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #485: variable USERROW60
+	.section	.debug_info
+	.uleb128	485	; ref to abbrev 485
+	.section	.debug_abbrev
+	.uleb128	485
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname485:
+	.string		"USERROW60"
+	.section	.debug_info
+	.long		.Lname485
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x3C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #486: variable USERROW61
+	.section	.debug_info
+	.uleb128	486	; ref to abbrev 486
+	.section	.debug_abbrev
+	.uleb128	486
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname486:
+	.string		"USERROW61"
+	.section	.debug_info
+	.long		.Lname486
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x3D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #487: variable USERROW62
+	.section	.debug_info
+	.uleb128	487	; ref to abbrev 487
+	.section	.debug_abbrev
+	.uleb128	487
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname487:
+	.string		"USERROW62"
+	.section	.debug_info
+	.long		.Lname487
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x3E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #488: variable USERROW63
+	.section	.debug_info
+	.uleb128	488	; ref to abbrev 488
+	.section	.debug_abbrev
+	.uleb128	488
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname488:
+	.string		"USERROW63"
+	.section	.debug_info
+	.long		.Lname488
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x3F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #489: variable DIR
+	.section	.debug_info
+	.uleb128	489	; ref to abbrev 489
+	.section	.debug_abbrev
+	.uleb128	489
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname489:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname489
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0000 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #490: variable OUT
+	.section	.debug_info
+	.uleb128	490	; ref to abbrev 490
+	.section	.debug_abbrev
+	.uleb128	490
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname490:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname490
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0000 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #491: variable IN
+	.section	.debug_info
+	.uleb128	491	; ref to abbrev 491
+	.section	.debug_abbrev
+	.uleb128	491
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname491:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname491
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0000 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #492: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	492	; ref to abbrev 492
+	.section	.debug_abbrev
+	.uleb128	492
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname492:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname492
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0000 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #493: variable DIR
+	.section	.debug_info
+	.uleb128	493	; ref to abbrev 493
+	.section	.debug_abbrev
+	.uleb128	493
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname493:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname493
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0008 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #494: variable OUT
+	.section	.debug_info
+	.uleb128	494	; ref to abbrev 494
+	.section	.debug_abbrev
+	.uleb128	494
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname494:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname494
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0008 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #495: variable IN
+	.section	.debug_info
+	.uleb128	495	; ref to abbrev 495
+	.section	.debug_abbrev
+	.uleb128	495
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname495:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname495
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0008 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #496: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	496	; ref to abbrev 496
+	.section	.debug_abbrev
+	.uleb128	496
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname496:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname496
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0008 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #497: variable DIR
+	.section	.debug_info
+	.uleb128	497	; ref to abbrev 497
+	.section	.debug_abbrev
+	.uleb128	497
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname497:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname497
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x000C + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #498: variable OUT
+	.section	.debug_info
+	.uleb128	498	; ref to abbrev 498
+	.section	.debug_abbrev
+	.uleb128	498
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname498:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname498
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x000C + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #499: variable IN
+	.section	.debug_info
+	.uleb128	499	; ref to abbrev 499
+	.section	.debug_abbrev
+	.uleb128	499
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname499:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname499
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x000C + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #500: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	500	; ref to abbrev 500
+	.section	.debug_abbrev
+	.uleb128	500
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname500:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname500
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x000C + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #501: variable DIR
+	.section	.debug_info
+	.uleb128	501	; ref to abbrev 501
+	.section	.debug_abbrev
+	.uleb128	501
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname501:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname501
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0014 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #502: variable OUT
+	.section	.debug_info
+	.uleb128	502	; ref to abbrev 502
+	.section	.debug_abbrev
+	.uleb128	502
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname502:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname502
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0014 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #503: variable IN
+	.section	.debug_info
+	.uleb128	503	; ref to abbrev 503
+	.section	.debug_abbrev
+	.uleb128	503
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname503:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname503
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0014 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #504: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	504	; ref to abbrev 504
+	.section	.debug_abbrev
+	.uleb128	504
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname504:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname504
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0014 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #505: variable DAC0REF
+	.section	.debug_info
+	.uleb128	505	; ref to abbrev 505
+	.section	.debug_abbrev
+	.uleb128	505
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname505:
+	.string		"DAC0REF"
+	.section	.debug_info
+	.long		.Lname505
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00B0 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #506: variable ACREF
+	.section	.debug_info
+	.uleb128	506	; ref to abbrev 506
+	.section	.debug_abbrev
+	.uleb128	506
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname506:
+	.string		"ACREF"
+	.section	.debug_info
+	.long		.Lname506
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00B0 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #507: variable CTRLA
+	.section	.debug_info
+	.uleb128	507	; ref to abbrev 507
+	.section	.debug_abbrev
+	.uleb128	507
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname507:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname507
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0100 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #508: variable STATUS
+	.section	.debug_info
+	.uleb128	508	; ref to abbrev 508
+	.section	.debug_abbrev
+	.uleb128	508
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname508:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname508
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0100 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+	;; trailer
+	.section	.debug_abbrev
+	.uleb128	0
+
+	.section	.debug_info
+	.uleb128	0
+.Leinfo:

--- a/crt1/iosym/avr32ea32.S
+++ b/crt1/iosym/avr32ea32.S
@@ -1,0 +1,26945 @@
+/* This file is part of avr-libc.
+
+   Automatically created by devtools/ioreg.pl
+   DO NOT EDIT!
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in
+     the documentation and/or other materials provided with the
+     distribution.
+
+   * Neither the name of the copyright holders nor the names of
+     contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE. */
+
+/* $Id$ */
+
+#include <avr/version.h>
+
+#define DW_TAG_array_type               0x01
+#define DW_TAG_compile_unit             0x11
+#define DW_TAG_typedef                  0x16
+#define DW_TAG_subrange_type            0x21
+#define DW_TAG_base_type                0x24
+#define DW_TAG_variable                 0x34
+
+#define DW_FORM_addr                    0x01
+#define DW_FORM_block1                  0x0a
+#define DW_FORM_block2                  0x03
+#define DW_FORM_block4                  0x04
+#define DW_FORM_data1                   0x0b
+#define DW_FORM_data2                   0x05
+#define DW_FORM_data4                   0x06
+#define DW_FORM_data8                   0x07
+#define DW_FORM_string                  0x08
+#define DW_FORM_flag                    0x0c
+#define DW_FORM_strp                    0x0e
+#define DW_FORM_ref1                    0x11
+#define DW_FORM_ref2                    0x12
+#define DW_FORM_ref4                    0x13
+#define DW_FORM_ref8                    0x14
+
+#define DW_AT_location                  0x02
+#define DW_AT_name                      0x03
+#define DW_AT_byte_size                 0x0b
+#define DW_AT_stmt_list                 0x10
+#define DW_AT_language                  0x13
+#define DW_AT_producer                  0x25
+#define DW_AT_upper_bound               0x2f
+#define DW_AT_decl_file                 0x3a
+#define DW_AT_decl_line                 0x3b
+#define DW_AT_encoding                  0x3e
+#define DW_AT_external                  0x3f
+#define DW_AT_type                      0x49
+
+#define DW_LANG_C89                     0x0001
+
+#define DW_CHILDREN_no                  0x00
+#define DW_CHILDREN_yes                 0x01
+
+#define DW_ATE_unsigned                 0x7
+#define DW_ATE_unsigned_char            0x8
+
+#define DW_OP_addr                      0x03
+.eject
+	.section	.debug_abbrev, "", @progbits
+.Ldebug_abbrev0:
+	.section	.debug_info, "", @progbits
+	.section	.debug_line, "", @progbits
+.Ldebug_line0:
+	.section	.debug_str, "", @progbits
+
+	.section	.debug_info, "", @progbits
+	;; compilation unit header
+.Lssinfo:
+	.long	.Leinfo - .Lsinfo
+.Lsinfo:
+	.word	2		; DWARF-2
+	.long	.Ldebug_abbrev0
+	.byte	4		; sizeof(address)
+
+
+	;; DIE #1: compilation unit
+	.section	.debug_info
+	.uleb128	1	; ref to abbrev 1
+	.section	.debug_abbrev
+	.uleb128	1
+	.uleb128	DW_TAG_compile_unit
+	.byte		DW_CHILDREN_yes
+
+	.uleb128	DW_AT_producer
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lproducer:
+	.ascii		"avr-libc "
+	.asciz		__AVR_LIBC_VERSION_STRING__
+	.section	.debug_info
+	.long		.Lproducer
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_stmt_list
+	.uleb128	DW_FORM_data4
+	.section	.debug_info
+	.long		.Ldebug_line0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+	;; DIE #2: base type uint8_t
+	.section	.debug_info
+.Luint8_t:
+	.uleb128	2	; ref to abbrev 2
+	.section	.debug_abbrev
+	.uleb128	2
+	.uleb128	DW_TAG_base_type
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Luint8_t_name:
+	.string		"uint8_t"
+	.section	.debug_info
+	.long		.Luint8_t_name
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_byte_size
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_encoding
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		DW_ATE_unsigned_char
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+	;; DIE #3: base type uint16_t
+	.section	.debug_info
+.Luint16_t:
+	.uleb128	3	; ref to abbrev 3
+	.section	.debug_abbrev
+	.uleb128	3
+	.uleb128	DW_TAG_base_type
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Luint16_t_name:
+	.string		"uint16_t"
+	.section	.debug_info
+	.long		.Luint16_t_name
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_byte_size
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		2
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_encoding
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		DW_ATE_unsigned
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #4: variable CTRLA
+	.section	.debug_info
+	.uleb128	4	; ref to abbrev 4
+	.section	.debug_abbrev
+	.uleb128	4
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname4:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname4
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #5: variable CTRLB
+	.section	.debug_info
+	.uleb128	5	; ref to abbrev 5
+	.section	.debug_abbrev
+	.uleb128	5
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname5:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname5
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #6: variable MUXCTRL
+	.section	.debug_info
+	.uleb128	6	; ref to abbrev 6
+	.section	.debug_abbrev
+	.uleb128	6
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname6:
+	.string		"MUXCTRL"
+	.section	.debug_info
+	.long		.Lname6
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #7: variable DACREF
+	.section	.debug_info
+	.uleb128	7	; ref to abbrev 7
+	.section	.debug_abbrev
+	.uleb128	7
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname7:
+	.string		"DACREF"
+	.section	.debug_info
+	.long		.Lname7
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #8: variable INTCTRL
+	.section	.debug_info
+	.uleb128	8	; ref to abbrev 8
+	.section	.debug_abbrev
+	.uleb128	8
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname8:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname8
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #9: variable STATUS
+	.section	.debug_info
+	.uleb128	9	; ref to abbrev 9
+	.section	.debug_abbrev
+	.uleb128	9
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname9:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname9
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #10: variable CTRLA
+	.section	.debug_info
+	.uleb128	10	; ref to abbrev 10
+	.section	.debug_abbrev
+	.uleb128	10
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname10:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname10
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #11: variable CTRLB
+	.section	.debug_info
+	.uleb128	11	; ref to abbrev 11
+	.section	.debug_abbrev
+	.uleb128	11
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname11:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname11
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #12: variable MUXCTRL
+	.section	.debug_info
+	.uleb128	12	; ref to abbrev 12
+	.section	.debug_abbrev
+	.uleb128	12
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname12:
+	.string		"MUXCTRL"
+	.section	.debug_info
+	.long		.Lname12
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #13: variable DACREF
+	.section	.debug_info
+	.uleb128	13	; ref to abbrev 13
+	.section	.debug_abbrev
+	.uleb128	13
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname13:
+	.string		"DACREF"
+	.section	.debug_info
+	.long		.Lname13
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #14: variable INTCTRL
+	.section	.debug_info
+	.uleb128	14	; ref to abbrev 14
+	.section	.debug_abbrev
+	.uleb128	14
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname14:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname14
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #15: variable STATUS
+	.section	.debug_info
+	.uleb128	15	; ref to abbrev 15
+	.section	.debug_abbrev
+	.uleb128	15
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname15:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname15
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #16: variable CTRLA
+	.section	.debug_info
+	.uleb128	16	; ref to abbrev 16
+	.section	.debug_abbrev
+	.uleb128	16
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname16:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname16
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #17: variable CTRLB
+	.section	.debug_info
+	.uleb128	17	; ref to abbrev 17
+	.section	.debug_abbrev
+	.uleb128	17
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname17:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname17
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #18: variable CTRLC
+	.section	.debug_info
+	.uleb128	18	; ref to abbrev 18
+	.section	.debug_abbrev
+	.uleb128	18
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname18:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname18
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #19: variable CTRLD
+	.section	.debug_info
+	.uleb128	19	; ref to abbrev 19
+	.section	.debug_abbrev
+	.uleb128	19
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname19:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname19
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #20: variable INTCTRL
+	.section	.debug_info
+	.uleb128	20	; ref to abbrev 20
+	.section	.debug_abbrev
+	.uleb128	20
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname20:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname20
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #21: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	21	; ref to abbrev 21
+	.section	.debug_abbrev
+	.uleb128	21
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname21:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname21
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #22: variable STATUS
+	.section	.debug_info
+	.uleb128	22	; ref to abbrev 22
+	.section	.debug_abbrev
+	.uleb128	22
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname22:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname22
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #23: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	23	; ref to abbrev 23
+	.section	.debug_abbrev
+	.uleb128	23
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname23:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname23
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #24: variable CTRLE
+	.section	.debug_info
+	.uleb128	24	; ref to abbrev 24
+	.section	.debug_abbrev
+	.uleb128	24
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname24:
+	.string		"CTRLE"
+	.section	.debug_info
+	.long		.Lname24
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #25: variable CTRLF
+	.section	.debug_info
+	.uleb128	25	; ref to abbrev 25
+	.section	.debug_abbrev
+	.uleb128	25
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname25:
+	.string		"CTRLF"
+	.section	.debug_info
+	.long		.Lname25
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #26: variable COMMAND
+	.section	.debug_info
+	.uleb128	26	; ref to abbrev 26
+	.section	.debug_abbrev
+	.uleb128	26
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname26:
+	.string		"COMMAND"
+	.section	.debug_info
+	.long		.Lname26
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #27: variable PGACTRL
+	.section	.debug_info
+	.uleb128	27	; ref to abbrev 27
+	.section	.debug_abbrev
+	.uleb128	27
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname27:
+	.string		"PGACTRL"
+	.section	.debug_info
+	.long		.Lname27
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #28: variable MUXPOS
+	.section	.debug_info
+	.uleb128	28	; ref to abbrev 28
+	.section	.debug_abbrev
+	.uleb128	28
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname28:
+	.string		"MUXPOS"
+	.section	.debug_info
+	.long		.Lname28
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #29: variable MUXNEG
+	.section	.debug_info
+	.uleb128	29	; ref to abbrev 29
+	.section	.debug_abbrev
+	.uleb128	29
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname29:
+	.string		"MUXNEG"
+	.section	.debug_info
+	.long		.Lname29
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #30: base type uint32_t
+	.section	.debug_info
+.Luint32_t:
+	.uleb128	30	; ref to abbrev 30
+	.section	.debug_abbrev
+	.uleb128	30
+	.uleb128	DW_TAG_base_type
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Luint32_t_name:
+	.string		"uint32_t"
+	.section	.debug_info
+	.long		.Luint32_t_name
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_byte_size
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		4
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_encoding
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		DW_ATE_unsigned
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #31: variable RESULT
+	.section	.debug_info
+	.uleb128	31	; ref to abbrev 31
+	.section	.debug_abbrev
+	.uleb128	31
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname31:
+	.string		"RESULT"
+	.section	.debug_info
+	.long		.Lname31
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint32_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #32: variable SAMPLE
+	.section	.debug_info
+	.uleb128	32	; ref to abbrev 32
+	.section	.debug_abbrev
+	.uleb128	32
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname32:
+	.string		"SAMPLE"
+	.section	.debug_info
+	.long		.Lname32
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #33: variable TEMP0
+	.section	.debug_info
+	.uleb128	33	; ref to abbrev 33
+	.section	.debug_abbrev
+	.uleb128	33
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname33:
+	.string		"TEMP0"
+	.section	.debug_info
+	.long		.Lname33
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #34: variable TEMP1
+	.section	.debug_info
+	.uleb128	34	; ref to abbrev 34
+	.section	.debug_abbrev
+	.uleb128	34
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname34:
+	.string		"TEMP1"
+	.section	.debug_info
+	.long		.Lname34
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x19
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #35: variable TEMP2
+	.section	.debug_info
+	.uleb128	35	; ref to abbrev 35
+	.section	.debug_abbrev
+	.uleb128	35
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname35:
+	.string		"TEMP2"
+	.section	.debug_info
+	.long		.Lname35
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x1A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #36: variable WINLT
+	.section	.debug_info
+	.uleb128	36	; ref to abbrev 36
+	.section	.debug_abbrev
+	.uleb128	36
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname36:
+	.string		"WINLT"
+	.section	.debug_info
+	.long		.Lname36
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x1C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #37: variable WINHT
+	.section	.debug_info
+	.uleb128	37	; ref to abbrev 37
+	.section	.debug_abbrev
+	.uleb128	37
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname37:
+	.string		"WINHT"
+	.section	.debug_info
+	.long		.Lname37
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x1E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #38: variable CTRLA
+	.section	.debug_info
+	.uleb128	38	; ref to abbrev 38
+	.section	.debug_abbrev
+	.uleb128	38
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname38:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname38
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #39: variable CTRLB
+	.section	.debug_info
+	.uleb128	39	; ref to abbrev 39
+	.section	.debug_abbrev
+	.uleb128	39
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname39:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname39
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #40: variable VLMCTRLA
+	.section	.debug_info
+	.uleb128	40	; ref to abbrev 40
+	.section	.debug_abbrev
+	.uleb128	40
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname40:
+	.string		"VLMCTRLA"
+	.section	.debug_info
+	.long		.Lname40
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #41: variable INTCTRL
+	.section	.debug_info
+	.uleb128	41	; ref to abbrev 41
+	.section	.debug_abbrev
+	.uleb128	41
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname41:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname41
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #42: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	42	; ref to abbrev 42
+	.section	.debug_abbrev
+	.uleb128	42
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname42:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname42
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #43: variable STATUS
+	.section	.debug_info
+	.uleb128	43	; ref to abbrev 43
+	.section	.debug_abbrev
+	.uleb128	43
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname43:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname43
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #44: variable CTRLA
+	.section	.debug_info
+	.uleb128	44	; ref to abbrev 44
+	.section	.debug_abbrev
+	.uleb128	44
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname44:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname44
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #45: variable SEQCTRL0
+	.section	.debug_info
+	.uleb128	45	; ref to abbrev 45
+	.section	.debug_abbrev
+	.uleb128	45
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname45:
+	.string		"SEQCTRL0"
+	.section	.debug_info
+	.long		.Lname45
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #46: variable SEQCTRL1
+	.section	.debug_info
+	.uleb128	46	; ref to abbrev 46
+	.section	.debug_abbrev
+	.uleb128	46
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname46:
+	.string		"SEQCTRL1"
+	.section	.debug_info
+	.long		.Lname46
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #47: variable INTCTRL0
+	.section	.debug_info
+	.uleb128	47	; ref to abbrev 47
+	.section	.debug_abbrev
+	.uleb128	47
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname47:
+	.string		"INTCTRL0"
+	.section	.debug_info
+	.long		.Lname47
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #48: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	48	; ref to abbrev 48
+	.section	.debug_abbrev
+	.uleb128	48
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname48:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname48
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #49: variable LUT0CTRLA
+	.section	.debug_info
+	.uleb128	49	; ref to abbrev 49
+	.section	.debug_abbrev
+	.uleb128	49
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname49:
+	.string		"LUT0CTRLA"
+	.section	.debug_info
+	.long		.Lname49
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #50: variable LUT0CTRLB
+	.section	.debug_info
+	.uleb128	50	; ref to abbrev 50
+	.section	.debug_abbrev
+	.uleb128	50
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname50:
+	.string		"LUT0CTRLB"
+	.section	.debug_info
+	.long		.Lname50
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #51: variable LUT0CTRLC
+	.section	.debug_info
+	.uleb128	51	; ref to abbrev 51
+	.section	.debug_abbrev
+	.uleb128	51
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname51:
+	.string		"LUT0CTRLC"
+	.section	.debug_info
+	.long		.Lname51
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #52: variable TRUTH0
+	.section	.debug_info
+	.uleb128	52	; ref to abbrev 52
+	.section	.debug_abbrev
+	.uleb128	52
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname52:
+	.string		"TRUTH0"
+	.section	.debug_info
+	.long		.Lname52
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #53: variable LUT1CTRLA
+	.section	.debug_info
+	.uleb128	53	; ref to abbrev 53
+	.section	.debug_abbrev
+	.uleb128	53
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname53:
+	.string		"LUT1CTRLA"
+	.section	.debug_info
+	.long		.Lname53
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #54: variable LUT1CTRLB
+	.section	.debug_info
+	.uleb128	54	; ref to abbrev 54
+	.section	.debug_abbrev
+	.uleb128	54
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname54:
+	.string		"LUT1CTRLB"
+	.section	.debug_info
+	.long		.Lname54
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #55: variable LUT1CTRLC
+	.section	.debug_info
+	.uleb128	55	; ref to abbrev 55
+	.section	.debug_abbrev
+	.uleb128	55
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname55:
+	.string		"LUT1CTRLC"
+	.section	.debug_info
+	.long		.Lname55
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #56: variable TRUTH1
+	.section	.debug_info
+	.uleb128	56	; ref to abbrev 56
+	.section	.debug_abbrev
+	.uleb128	56
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname56:
+	.string		"TRUTH1"
+	.section	.debug_info
+	.long		.Lname56
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #57: variable LUT2CTRLA
+	.section	.debug_info
+	.uleb128	57	; ref to abbrev 57
+	.section	.debug_abbrev
+	.uleb128	57
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname57:
+	.string		"LUT2CTRLA"
+	.section	.debug_info
+	.long		.Lname57
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #58: variable LUT2CTRLB
+	.section	.debug_info
+	.uleb128	58	; ref to abbrev 58
+	.section	.debug_abbrev
+	.uleb128	58
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname58:
+	.string		"LUT2CTRLB"
+	.section	.debug_info
+	.long		.Lname58
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #59: variable LUT2CTRLC
+	.section	.debug_info
+	.uleb128	59	; ref to abbrev 59
+	.section	.debug_abbrev
+	.uleb128	59
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname59:
+	.string		"LUT2CTRLC"
+	.section	.debug_info
+	.long		.Lname59
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #60: variable TRUTH2
+	.section	.debug_info
+	.uleb128	60	; ref to abbrev 60
+	.section	.debug_abbrev
+	.uleb128	60
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname60:
+	.string		"TRUTH2"
+	.section	.debug_info
+	.long		.Lname60
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #61: variable LUT3CTRLA
+	.section	.debug_info
+	.uleb128	61	; ref to abbrev 61
+	.section	.debug_abbrev
+	.uleb128	61
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname61:
+	.string		"LUT3CTRLA"
+	.section	.debug_info
+	.long		.Lname61
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #62: variable LUT3CTRLB
+	.section	.debug_info
+	.uleb128	62	; ref to abbrev 62
+	.section	.debug_abbrev
+	.uleb128	62
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname62:
+	.string		"LUT3CTRLB"
+	.section	.debug_info
+	.long		.Lname62
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #63: variable LUT3CTRLC
+	.section	.debug_info
+	.uleb128	63	; ref to abbrev 63
+	.section	.debug_abbrev
+	.uleb128	63
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname63:
+	.string		"LUT3CTRLC"
+	.section	.debug_info
+	.long		.Lname63
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #64: variable TRUTH3
+	.section	.debug_info
+	.uleb128	64	; ref to abbrev 64
+	.section	.debug_abbrev
+	.uleb128	64
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname64:
+	.string		"TRUTH3"
+	.section	.debug_info
+	.long		.Lname64
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #65: variable MCLKCTRLA
+	.section	.debug_info
+	.uleb128	65	; ref to abbrev 65
+	.section	.debug_abbrev
+	.uleb128	65
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname65:
+	.string		"MCLKCTRLA"
+	.section	.debug_info
+	.long		.Lname65
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #66: variable MCLKCTRLB
+	.section	.debug_info
+	.uleb128	66	; ref to abbrev 66
+	.section	.debug_abbrev
+	.uleb128	66
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname66:
+	.string		"MCLKCTRLB"
+	.section	.debug_info
+	.long		.Lname66
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #67: variable MCLKCTRLC
+	.section	.debug_info
+	.uleb128	67	; ref to abbrev 67
+	.section	.debug_abbrev
+	.uleb128	67
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname67:
+	.string		"MCLKCTRLC"
+	.section	.debug_info
+	.long		.Lname67
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #68: variable MCLKINTCTRL
+	.section	.debug_info
+	.uleb128	68	; ref to abbrev 68
+	.section	.debug_abbrev
+	.uleb128	68
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname68:
+	.string		"MCLKINTCTRL"
+	.section	.debug_info
+	.long		.Lname68
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #69: variable MCLKINTFLAGS
+	.section	.debug_info
+	.uleb128	69	; ref to abbrev 69
+	.section	.debug_abbrev
+	.uleb128	69
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname69:
+	.string		"MCLKINTFLAGS"
+	.section	.debug_info
+	.long		.Lname69
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #70: variable MCLKSTATUS
+	.section	.debug_info
+	.uleb128	70	; ref to abbrev 70
+	.section	.debug_abbrev
+	.uleb128	70
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname70:
+	.string		"MCLKSTATUS"
+	.section	.debug_info
+	.long		.Lname70
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #71: variable MCLKTIMEBASE
+	.section	.debug_info
+	.uleb128	71	; ref to abbrev 71
+	.section	.debug_abbrev
+	.uleb128	71
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname71:
+	.string		"MCLKTIMEBASE"
+	.section	.debug_info
+	.long		.Lname71
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #72: variable OSCHFCTRLA
+	.section	.debug_info
+	.uleb128	72	; ref to abbrev 72
+	.section	.debug_abbrev
+	.uleb128	72
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname72:
+	.string		"OSCHFCTRLA"
+	.section	.debug_info
+	.long		.Lname72
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #73: variable OSCHFTUNE
+	.section	.debug_info
+	.uleb128	73	; ref to abbrev 73
+	.section	.debug_abbrev
+	.uleb128	73
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname73:
+	.string		"OSCHFTUNE"
+	.section	.debug_info
+	.long		.Lname73
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #74: variable OSC32KCTRLA
+	.section	.debug_info
+	.uleb128	74	; ref to abbrev 74
+	.section	.debug_abbrev
+	.uleb128	74
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname74:
+	.string		"OSC32KCTRLA"
+	.section	.debug_info
+	.long		.Lname74
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #75: variable XOSC32KCTRLA
+	.section	.debug_info
+	.uleb128	75	; ref to abbrev 75
+	.section	.debug_abbrev
+	.uleb128	75
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname75:
+	.string		"XOSC32KCTRLA"
+	.section	.debug_info
+	.long		.Lname75
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x1C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #76: variable XOSCHFCTRLA
+	.section	.debug_info
+	.uleb128	76	; ref to abbrev 76
+	.section	.debug_abbrev
+	.uleb128	76
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname76:
+	.string		"XOSCHFCTRLA"
+	.section	.debug_info
+	.long		.Lname76
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #77: variable CCP
+	.section	.debug_info
+	.uleb128	77	; ref to abbrev 77
+	.section	.debug_abbrev
+	.uleb128	77
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname77:
+	.string		"CCP"
+	.section	.debug_info
+	.long		.Lname77
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0030 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #78: variable SP
+	.section	.debug_info
+	.uleb128	78	; ref to abbrev 78
+	.section	.debug_abbrev
+	.uleb128	78
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname78:
+	.string		"SP"
+	.section	.debug_info
+	.long		.Lname78
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0030 + 0xD
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #79: variable SREG
+	.section	.debug_info
+	.uleb128	79	; ref to abbrev 79
+	.section	.debug_abbrev
+	.uleb128	79
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname79:
+	.string		"SREG"
+	.section	.debug_info
+	.long		.Lname79
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0030 + 0xF
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #80: variable CTRLA
+	.section	.debug_info
+	.uleb128	80	; ref to abbrev 80
+	.section	.debug_abbrev
+	.uleb128	80
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname80:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname80
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0110 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #81: variable STATUS
+	.section	.debug_info
+	.uleb128	81	; ref to abbrev 81
+	.section	.debug_abbrev
+	.uleb128	81
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname81:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname81
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0110 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #82: variable LVL0PRI
+	.section	.debug_info
+	.uleb128	82	; ref to abbrev 82
+	.section	.debug_abbrev
+	.uleb128	82
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname82:
+	.string		"LVL0PRI"
+	.section	.debug_info
+	.long		.Lname82
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0110 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #83: variable LVL1VEC
+	.section	.debug_info
+	.uleb128	83	; ref to abbrev 83
+	.section	.debug_abbrev
+	.uleb128	83
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname83:
+	.string		"LVL1VEC"
+	.section	.debug_info
+	.long		.Lname83
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0110 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #84: variable CTRLA
+	.section	.debug_info
+	.uleb128	84	; ref to abbrev 84
+	.section	.debug_abbrev
+	.uleb128	84
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname84:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname84
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0120 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #85: variable CTRLB
+	.section	.debug_info
+	.uleb128	85	; ref to abbrev 85
+	.section	.debug_abbrev
+	.uleb128	85
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname85:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname85
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0120 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #86: variable STATUS
+	.section	.debug_info
+	.uleb128	86	; ref to abbrev 86
+	.section	.debug_abbrev
+	.uleb128	86
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname86:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname86
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0120 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #87: variable CTRLA
+	.section	.debug_info
+	.uleb128	87	; ref to abbrev 87
+	.section	.debug_abbrev
+	.uleb128	87
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname87:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname87
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x06A0 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #88: variable DATA
+	.section	.debug_info
+	.uleb128	88	; ref to abbrev 88
+	.section	.debug_abbrev
+	.uleb128	88
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname88:
+	.string		"DATA"
+	.section	.debug_info
+	.long		.Lname88
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x06A0 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #89: variable SWEVENTA
+	.section	.debug_info
+	.uleb128	89	; ref to abbrev 89
+	.section	.debug_abbrev
+	.uleb128	89
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname89:
+	.string		"SWEVENTA"
+	.section	.debug_info
+	.long		.Lname89
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #90: variable CHANNEL0
+	.section	.debug_info
+	.uleb128	90	; ref to abbrev 90
+	.section	.debug_abbrev
+	.uleb128	90
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname90:
+	.string		"CHANNEL0"
+	.section	.debug_info
+	.long		.Lname90
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #91: variable CHANNEL1
+	.section	.debug_info
+	.uleb128	91	; ref to abbrev 91
+	.section	.debug_abbrev
+	.uleb128	91
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname91:
+	.string		"CHANNEL1"
+	.section	.debug_info
+	.long		.Lname91
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #92: variable CHANNEL2
+	.section	.debug_info
+	.uleb128	92	; ref to abbrev 92
+	.section	.debug_abbrev
+	.uleb128	92
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname92:
+	.string		"CHANNEL2"
+	.section	.debug_info
+	.long		.Lname92
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #93: variable CHANNEL3
+	.section	.debug_info
+	.uleb128	93	; ref to abbrev 93
+	.section	.debug_abbrev
+	.uleb128	93
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname93:
+	.string		"CHANNEL3"
+	.section	.debug_info
+	.long		.Lname93
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #94: variable CHANNEL4
+	.section	.debug_info
+	.uleb128	94	; ref to abbrev 94
+	.section	.debug_abbrev
+	.uleb128	94
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname94:
+	.string		"CHANNEL4"
+	.section	.debug_info
+	.long		.Lname94
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #95: variable CHANNEL5
+	.section	.debug_info
+	.uleb128	95	; ref to abbrev 95
+	.section	.debug_abbrev
+	.uleb128	95
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname95:
+	.string		"CHANNEL5"
+	.section	.debug_info
+	.long		.Lname95
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #96: variable USERCCLLUT0A
+	.section	.debug_info
+	.uleb128	96	; ref to abbrev 96
+	.section	.debug_abbrev
+	.uleb128	96
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname96:
+	.string		"USERCCLLUT0A"
+	.section	.debug_info
+	.long		.Lname96
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #97: variable USERCCLLUT0B
+	.section	.debug_info
+	.uleb128	97	; ref to abbrev 97
+	.section	.debug_abbrev
+	.uleb128	97
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname97:
+	.string		"USERCCLLUT0B"
+	.section	.debug_info
+	.long		.Lname97
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x21
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #98: variable USERCCLLUT1A
+	.section	.debug_info
+	.uleb128	98	; ref to abbrev 98
+	.section	.debug_abbrev
+	.uleb128	98
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname98:
+	.string		"USERCCLLUT1A"
+	.section	.debug_info
+	.long		.Lname98
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x22
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #99: variable USERCCLLUT1B
+	.section	.debug_info
+	.uleb128	99	; ref to abbrev 99
+	.section	.debug_abbrev
+	.uleb128	99
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname99:
+	.string		"USERCCLLUT1B"
+	.section	.debug_info
+	.long		.Lname99
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x23
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #100: variable USERCCLLUT2A
+	.section	.debug_info
+	.uleb128	100	; ref to abbrev 100
+	.section	.debug_abbrev
+	.uleb128	100
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname100:
+	.string		"USERCCLLUT2A"
+	.section	.debug_info
+	.long		.Lname100
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x24
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #101: variable USERCCLLUT2B
+	.section	.debug_info
+	.uleb128	101	; ref to abbrev 101
+	.section	.debug_abbrev
+	.uleb128	101
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname101:
+	.string		"USERCCLLUT2B"
+	.section	.debug_info
+	.long		.Lname101
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x25
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #102: variable USERCCLLUT3A
+	.section	.debug_info
+	.uleb128	102	; ref to abbrev 102
+	.section	.debug_abbrev
+	.uleb128	102
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname102:
+	.string		"USERCCLLUT3A"
+	.section	.debug_info
+	.long		.Lname102
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x26
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #103: variable USERCCLLUT3B
+	.section	.debug_info
+	.uleb128	103	; ref to abbrev 103
+	.section	.debug_abbrev
+	.uleb128	103
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname103:
+	.string		"USERCCLLUT3B"
+	.section	.debug_info
+	.long		.Lname103
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x27
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #104: variable USERADC0START
+	.section	.debug_info
+	.uleb128	104	; ref to abbrev 104
+	.section	.debug_abbrev
+	.uleb128	104
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname104:
+	.string		"USERADC0START"
+	.section	.debug_info
+	.long		.Lname104
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x28
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #105: variable USEREVSYSEVOUTA
+	.section	.debug_info
+	.uleb128	105	; ref to abbrev 105
+	.section	.debug_abbrev
+	.uleb128	105
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname105:
+	.string		"USEREVSYSEVOUTA"
+	.section	.debug_info
+	.long		.Lname105
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x29
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #106: variable USEREVSYSEVOUTC
+	.section	.debug_info
+	.uleb128	106	; ref to abbrev 106
+	.section	.debug_abbrev
+	.uleb128	106
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname106:
+	.string		"USEREVSYSEVOUTC"
+	.section	.debug_info
+	.long		.Lname106
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #107: variable USEREVSYSEVOUTD
+	.section	.debug_info
+	.uleb128	107	; ref to abbrev 107
+	.section	.debug_abbrev
+	.uleb128	107
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname107:
+	.string		"USEREVSYSEVOUTD"
+	.section	.debug_info
+	.long		.Lname107
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #108: variable USEREVSYSEVOUTF
+	.section	.debug_info
+	.uleb128	108	; ref to abbrev 108
+	.section	.debug_abbrev
+	.uleb128	108
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname108:
+	.string		"USEREVSYSEVOUTF"
+	.section	.debug_info
+	.long		.Lname108
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #109: variable USERUSART0IRDA
+	.section	.debug_info
+	.uleb128	109	; ref to abbrev 109
+	.section	.debug_abbrev
+	.uleb128	109
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname109:
+	.string		"USERUSART0IRDA"
+	.section	.debug_info
+	.long		.Lname109
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #110: variable USERUSART1IRDA
+	.section	.debug_info
+	.uleb128	110	; ref to abbrev 110
+	.section	.debug_abbrev
+	.uleb128	110
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname110:
+	.string		"USERUSART1IRDA"
+	.section	.debug_info
+	.long		.Lname110
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x30
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #111: variable USERUSART2IRDA
+	.section	.debug_info
+	.uleb128	111	; ref to abbrev 111
+	.section	.debug_abbrev
+	.uleb128	111
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname111:
+	.string		"USERUSART2IRDA"
+	.section	.debug_info
+	.long		.Lname111
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x31
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #112: variable USERTCA0CNTA
+	.section	.debug_info
+	.uleb128	112	; ref to abbrev 112
+	.section	.debug_abbrev
+	.uleb128	112
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname112:
+	.string		"USERTCA0CNTA"
+	.section	.debug_info
+	.long		.Lname112
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x32
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #113: variable USERTCA0CNTB
+	.section	.debug_info
+	.uleb128	113	; ref to abbrev 113
+	.section	.debug_abbrev
+	.uleb128	113
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname113:
+	.string		"USERTCA0CNTB"
+	.section	.debug_info
+	.long		.Lname113
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x33
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #114: variable USERTCA1CNTA
+	.section	.debug_info
+	.uleb128	114	; ref to abbrev 114
+	.section	.debug_abbrev
+	.uleb128	114
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname114:
+	.string		"USERTCA1CNTA"
+	.section	.debug_info
+	.long		.Lname114
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x34
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #115: variable USERTCA1CNTB
+	.section	.debug_info
+	.uleb128	115	; ref to abbrev 115
+	.section	.debug_abbrev
+	.uleb128	115
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname115:
+	.string		"USERTCA1CNTB"
+	.section	.debug_info
+	.long		.Lname115
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x35
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #116: variable USERTCB0CAPT
+	.section	.debug_info
+	.uleb128	116	; ref to abbrev 116
+	.section	.debug_abbrev
+	.uleb128	116
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname116:
+	.string		"USERTCB0CAPT"
+	.section	.debug_info
+	.long		.Lname116
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x36
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #117: variable USERTCB0COUNT
+	.section	.debug_info
+	.uleb128	117	; ref to abbrev 117
+	.section	.debug_abbrev
+	.uleb128	117
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname117:
+	.string		"USERTCB0COUNT"
+	.section	.debug_info
+	.long		.Lname117
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x37
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #118: variable USERTCB1CAPT
+	.section	.debug_info
+	.uleb128	118	; ref to abbrev 118
+	.section	.debug_abbrev
+	.uleb128	118
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname118:
+	.string		"USERTCB1CAPT"
+	.section	.debug_info
+	.long		.Lname118
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x38
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #119: variable USERTCB1COUNT
+	.section	.debug_info
+	.uleb128	119	; ref to abbrev 119
+	.section	.debug_abbrev
+	.uleb128	119
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname119:
+	.string		"USERTCB1COUNT"
+	.section	.debug_info
+	.long		.Lname119
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x39
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #120: variable USERTCB2CAPT
+	.section	.debug_info
+	.uleb128	120	; ref to abbrev 120
+	.section	.debug_abbrev
+	.uleb128	120
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname120:
+	.string		"USERTCB2CAPT"
+	.section	.debug_info
+	.long		.Lname120
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x3A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #121: variable USERTCB2COUNT
+	.section	.debug_info
+	.uleb128	121	; ref to abbrev 121
+	.section	.debug_abbrev
+	.uleb128	121
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname121:
+	.string		"USERTCB2COUNT"
+	.section	.debug_info
+	.long		.Lname121
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x3B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #122: variable USERTCB3CAPT
+	.section	.debug_info
+	.uleb128	122	; ref to abbrev 122
+	.section	.debug_abbrev
+	.uleb128	122
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname122:
+	.string		"USERTCB3CAPT"
+	.section	.debug_info
+	.long		.Lname122
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x3C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #123: variable USERTCB3COUNT
+	.section	.debug_info
+	.uleb128	123	; ref to abbrev 123
+	.section	.debug_abbrev
+	.uleb128	123
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname123:
+	.string		"USERTCB3COUNT"
+	.section	.debug_info
+	.long		.Lname123
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x3D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #124: variable WDTCFG
+	.section	.debug_info
+	.uleb128	124	; ref to abbrev 124
+	.section	.debug_abbrev
+	.uleb128	124
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname124:
+	.string		"WDTCFG"
+	.section	.debug_info
+	.long		.Lname124
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #125: variable BODCFG
+	.section	.debug_info
+	.uleb128	125	; ref to abbrev 125
+	.section	.debug_abbrev
+	.uleb128	125
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname125:
+	.string		"BODCFG"
+	.section	.debug_info
+	.long		.Lname125
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #126: variable OSCCFG
+	.section	.debug_info
+	.uleb128	126	; ref to abbrev 126
+	.section	.debug_abbrev
+	.uleb128	126
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname126:
+	.string		"OSCCFG"
+	.section	.debug_info
+	.long		.Lname126
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #127: variable SYSCFG0
+	.section	.debug_info
+	.uleb128	127	; ref to abbrev 127
+	.section	.debug_abbrev
+	.uleb128	127
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname127:
+	.string		"SYSCFG0"
+	.section	.debug_info
+	.long		.Lname127
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #128: variable SYSCFG1
+	.section	.debug_info
+	.uleb128	128	; ref to abbrev 128
+	.section	.debug_abbrev
+	.uleb128	128
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname128:
+	.string		"SYSCFG1"
+	.section	.debug_info
+	.long		.Lname128
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #129: variable CODESIZE
+	.section	.debug_info
+	.uleb128	129	; ref to abbrev 129
+	.section	.debug_abbrev
+	.uleb128	129
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname129:
+	.string		"CODESIZE"
+	.section	.debug_info
+	.long		.Lname129
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #130: variable BOOTSIZE
+	.section	.debug_info
+	.uleb128	130	; ref to abbrev 130
+	.section	.debug_abbrev
+	.uleb128	130
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname130:
+	.string		"BOOTSIZE"
+	.section	.debug_info
+	.long		.Lname130
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #131: variable GPR0
+	.section	.debug_info
+	.uleb128	131	; ref to abbrev 131
+	.section	.debug_abbrev
+	.uleb128	131
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname131:
+	.string		"GPR0"
+	.section	.debug_info
+	.long		.Lname131
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x001C + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #132: variable GPR1
+	.section	.debug_info
+	.uleb128	132	; ref to abbrev 132
+	.section	.debug_abbrev
+	.uleb128	132
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname132:
+	.string		"GPR1"
+	.section	.debug_info
+	.long		.Lname132
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x001C + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #133: variable GPR2
+	.section	.debug_info
+	.uleb128	133	; ref to abbrev 133
+	.section	.debug_abbrev
+	.uleb128	133
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname133:
+	.string		"GPR2"
+	.section	.debug_info
+	.long		.Lname133
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x001C + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #134: variable GPR3
+	.section	.debug_info
+	.uleb128	134	; ref to abbrev 134
+	.section	.debug_abbrev
+	.uleb128	134
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname134:
+	.string		"GPR3"
+	.section	.debug_info
+	.long		.Lname134
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x001C + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #135: variable KEY
+	.section	.debug_info
+	.uleb128	135	; ref to abbrev 135
+	.section	.debug_abbrev
+	.uleb128	135
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname135:
+	.string		"KEY"
+	.section	.debug_info
+	.long		.Lname135
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint32_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1040 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #136: variable CTRLA
+	.section	.debug_info
+	.uleb128	136	; ref to abbrev 136
+	.section	.debug_abbrev
+	.uleb128	136
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname136:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname136
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #137: variable CTRLB
+	.section	.debug_info
+	.uleb128	137	; ref to abbrev 137
+	.section	.debug_abbrev
+	.uleb128	137
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname137:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname137
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #138: variable INTCTRL
+	.section	.debug_info
+	.uleb128	138	; ref to abbrev 138
+	.section	.debug_abbrev
+	.uleb128	138
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname138:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname138
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #139: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	139	; ref to abbrev 139
+	.section	.debug_abbrev
+	.uleb128	139
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname139:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname139
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #140: variable STATUS
+	.section	.debug_info
+	.uleb128	140	; ref to abbrev 140
+	.section	.debug_abbrev
+	.uleb128	140
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname140:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname140
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #141: variable DATA
+	.section	.debug_info
+	.uleb128	141	; ref to abbrev 141
+	.section	.debug_abbrev
+	.uleb128	141
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname141:
+	.string		"DATA"
+	.section	.debug_info
+	.long		.Lname141
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #142: variable ADDR
+	.section	.debug_info
+	.uleb128	142	; ref to abbrev 142
+	.section	.debug_abbrev
+	.uleb128	142
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname142:
+	.string		"ADDR"
+	.section	.debug_info
+	.long		.Lname142
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint32_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #143: variable DIR
+	.section	.debug_info
+	.uleb128	143	; ref to abbrev 143
+	.section	.debug_abbrev
+	.uleb128	143
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname143:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname143
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #144: variable DIRSET
+	.section	.debug_info
+	.uleb128	144	; ref to abbrev 144
+	.section	.debug_abbrev
+	.uleb128	144
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname144:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname144
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #145: variable DIRCLR
+	.section	.debug_info
+	.uleb128	145	; ref to abbrev 145
+	.section	.debug_abbrev
+	.uleb128	145
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname145:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname145
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #146: variable DIRTGL
+	.section	.debug_info
+	.uleb128	146	; ref to abbrev 146
+	.section	.debug_abbrev
+	.uleb128	146
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname146:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname146
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #147: variable OUT
+	.section	.debug_info
+	.uleb128	147	; ref to abbrev 147
+	.section	.debug_abbrev
+	.uleb128	147
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname147:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname147
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #148: variable OUTSET
+	.section	.debug_info
+	.uleb128	148	; ref to abbrev 148
+	.section	.debug_abbrev
+	.uleb128	148
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname148:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname148
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #149: variable OUTCLR
+	.section	.debug_info
+	.uleb128	149	; ref to abbrev 149
+	.section	.debug_abbrev
+	.uleb128	149
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname149:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname149
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #150: variable OUTTGL
+	.section	.debug_info
+	.uleb128	150	; ref to abbrev 150
+	.section	.debug_abbrev
+	.uleb128	150
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname150:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname150
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #151: variable IN
+	.section	.debug_info
+	.uleb128	151	; ref to abbrev 151
+	.section	.debug_abbrev
+	.uleb128	151
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname151:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname151
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #152: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	152	; ref to abbrev 152
+	.section	.debug_abbrev
+	.uleb128	152
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname152:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname152
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #153: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	153	; ref to abbrev 153
+	.section	.debug_abbrev
+	.uleb128	153
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname153:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname153
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #154: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	154	; ref to abbrev 154
+	.section	.debug_abbrev
+	.uleb128	154
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname154:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname154
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #155: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	155	; ref to abbrev 155
+	.section	.debug_abbrev
+	.uleb128	155
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname155:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname155
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #156: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	156	; ref to abbrev 156
+	.section	.debug_abbrev
+	.uleb128	156
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname156:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname156
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #157: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	157	; ref to abbrev 157
+	.section	.debug_abbrev
+	.uleb128	157
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname157:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname157
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #158: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	158	; ref to abbrev 158
+	.section	.debug_abbrev
+	.uleb128	158
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname158:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname158
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #159: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	159	; ref to abbrev 159
+	.section	.debug_abbrev
+	.uleb128	159
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname159:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname159
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #160: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	160	; ref to abbrev 160
+	.section	.debug_abbrev
+	.uleb128	160
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname160:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname160
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #161: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	161	; ref to abbrev 161
+	.section	.debug_abbrev
+	.uleb128	161
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname161:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname161
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #162: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	162	; ref to abbrev 162
+	.section	.debug_abbrev
+	.uleb128	162
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname162:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname162
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #163: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	163	; ref to abbrev 163
+	.section	.debug_abbrev
+	.uleb128	163
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname163:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname163
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #164: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	164	; ref to abbrev 164
+	.section	.debug_abbrev
+	.uleb128	164
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname164:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname164
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #165: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	165	; ref to abbrev 165
+	.section	.debug_abbrev
+	.uleb128	165
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname165:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname165
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #166: variable EVGENCTRL
+	.section	.debug_info
+	.uleb128	166	; ref to abbrev 166
+	.section	.debug_abbrev
+	.uleb128	166
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname166:
+	.string		"EVGENCTRL"
+	.section	.debug_info
+	.long		.Lname166
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #167: variable DIR
+	.section	.debug_info
+	.uleb128	167	; ref to abbrev 167
+	.section	.debug_abbrev
+	.uleb128	167
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname167:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname167
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #168: variable DIRSET
+	.section	.debug_info
+	.uleb128	168	; ref to abbrev 168
+	.section	.debug_abbrev
+	.uleb128	168
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname168:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname168
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #169: variable DIRCLR
+	.section	.debug_info
+	.uleb128	169	; ref to abbrev 169
+	.section	.debug_abbrev
+	.uleb128	169
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname169:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname169
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #170: variable DIRTGL
+	.section	.debug_info
+	.uleb128	170	; ref to abbrev 170
+	.section	.debug_abbrev
+	.uleb128	170
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname170:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname170
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #171: variable OUT
+	.section	.debug_info
+	.uleb128	171	; ref to abbrev 171
+	.section	.debug_abbrev
+	.uleb128	171
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname171:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname171
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #172: variable OUTSET
+	.section	.debug_info
+	.uleb128	172	; ref to abbrev 172
+	.section	.debug_abbrev
+	.uleb128	172
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname172:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname172
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #173: variable OUTCLR
+	.section	.debug_info
+	.uleb128	173	; ref to abbrev 173
+	.section	.debug_abbrev
+	.uleb128	173
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname173:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname173
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #174: variable OUTTGL
+	.section	.debug_info
+	.uleb128	174	; ref to abbrev 174
+	.section	.debug_abbrev
+	.uleb128	174
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname174:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname174
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #175: variable IN
+	.section	.debug_info
+	.uleb128	175	; ref to abbrev 175
+	.section	.debug_abbrev
+	.uleb128	175
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname175:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname175
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #176: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	176	; ref to abbrev 176
+	.section	.debug_abbrev
+	.uleb128	176
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname176:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname176
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #177: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	177	; ref to abbrev 177
+	.section	.debug_abbrev
+	.uleb128	177
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname177:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname177
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #178: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	178	; ref to abbrev 178
+	.section	.debug_abbrev
+	.uleb128	178
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname178:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname178
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #179: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	179	; ref to abbrev 179
+	.section	.debug_abbrev
+	.uleb128	179
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname179:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname179
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #180: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	180	; ref to abbrev 180
+	.section	.debug_abbrev
+	.uleb128	180
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname180:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname180
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #181: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	181	; ref to abbrev 181
+	.section	.debug_abbrev
+	.uleb128	181
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname181:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname181
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #182: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	182	; ref to abbrev 182
+	.section	.debug_abbrev
+	.uleb128	182
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname182:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname182
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #183: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	183	; ref to abbrev 183
+	.section	.debug_abbrev
+	.uleb128	183
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname183:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname183
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #184: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	184	; ref to abbrev 184
+	.section	.debug_abbrev
+	.uleb128	184
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname184:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname184
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #185: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	185	; ref to abbrev 185
+	.section	.debug_abbrev
+	.uleb128	185
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname185:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname185
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #186: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	186	; ref to abbrev 186
+	.section	.debug_abbrev
+	.uleb128	186
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname186:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname186
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #187: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	187	; ref to abbrev 187
+	.section	.debug_abbrev
+	.uleb128	187
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname187:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname187
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #188: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	188	; ref to abbrev 188
+	.section	.debug_abbrev
+	.uleb128	188
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname188:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname188
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #189: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	189	; ref to abbrev 189
+	.section	.debug_abbrev
+	.uleb128	189
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname189:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname189
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #190: variable EVGENCTRL
+	.section	.debug_info
+	.uleb128	190	; ref to abbrev 190
+	.section	.debug_abbrev
+	.uleb128	190
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname190:
+	.string		"EVGENCTRL"
+	.section	.debug_info
+	.long		.Lname190
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #191: variable DIR
+	.section	.debug_info
+	.uleb128	191	; ref to abbrev 191
+	.section	.debug_abbrev
+	.uleb128	191
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname191:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname191
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #192: variable DIRSET
+	.section	.debug_info
+	.uleb128	192	; ref to abbrev 192
+	.section	.debug_abbrev
+	.uleb128	192
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname192:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname192
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #193: variable DIRCLR
+	.section	.debug_info
+	.uleb128	193	; ref to abbrev 193
+	.section	.debug_abbrev
+	.uleb128	193
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname193:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname193
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #194: variable DIRTGL
+	.section	.debug_info
+	.uleb128	194	; ref to abbrev 194
+	.section	.debug_abbrev
+	.uleb128	194
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname194:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname194
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #195: variable OUT
+	.section	.debug_info
+	.uleb128	195	; ref to abbrev 195
+	.section	.debug_abbrev
+	.uleb128	195
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname195:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname195
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #196: variable OUTSET
+	.section	.debug_info
+	.uleb128	196	; ref to abbrev 196
+	.section	.debug_abbrev
+	.uleb128	196
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname196:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname196
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #197: variable OUTCLR
+	.section	.debug_info
+	.uleb128	197	; ref to abbrev 197
+	.section	.debug_abbrev
+	.uleb128	197
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname197:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname197
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #198: variable OUTTGL
+	.section	.debug_info
+	.uleb128	198	; ref to abbrev 198
+	.section	.debug_abbrev
+	.uleb128	198
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname198:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname198
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #199: variable IN
+	.section	.debug_info
+	.uleb128	199	; ref to abbrev 199
+	.section	.debug_abbrev
+	.uleb128	199
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname199:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname199
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #200: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	200	; ref to abbrev 200
+	.section	.debug_abbrev
+	.uleb128	200
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname200:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname200
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #201: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	201	; ref to abbrev 201
+	.section	.debug_abbrev
+	.uleb128	201
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname201:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname201
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #202: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	202	; ref to abbrev 202
+	.section	.debug_abbrev
+	.uleb128	202
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname202:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname202
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #203: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	203	; ref to abbrev 203
+	.section	.debug_abbrev
+	.uleb128	203
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname203:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname203
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #204: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	204	; ref to abbrev 204
+	.section	.debug_abbrev
+	.uleb128	204
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname204:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname204
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #205: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	205	; ref to abbrev 205
+	.section	.debug_abbrev
+	.uleb128	205
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname205:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname205
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #206: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	206	; ref to abbrev 206
+	.section	.debug_abbrev
+	.uleb128	206
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname206:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname206
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #207: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	207	; ref to abbrev 207
+	.section	.debug_abbrev
+	.uleb128	207
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname207:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname207
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #208: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	208	; ref to abbrev 208
+	.section	.debug_abbrev
+	.uleb128	208
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname208:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname208
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #209: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	209	; ref to abbrev 209
+	.section	.debug_abbrev
+	.uleb128	209
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname209:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname209
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #210: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	210	; ref to abbrev 210
+	.section	.debug_abbrev
+	.uleb128	210
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname210:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname210
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #211: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	211	; ref to abbrev 211
+	.section	.debug_abbrev
+	.uleb128	211
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname211:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname211
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #212: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	212	; ref to abbrev 212
+	.section	.debug_abbrev
+	.uleb128	212
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname212:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname212
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #213: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	213	; ref to abbrev 213
+	.section	.debug_abbrev
+	.uleb128	213
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname213:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname213
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #214: variable EVGENCTRL
+	.section	.debug_info
+	.uleb128	214	; ref to abbrev 214
+	.section	.debug_abbrev
+	.uleb128	214
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname214:
+	.string		"EVGENCTRL"
+	.section	.debug_info
+	.long		.Lname214
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #215: variable DIR
+	.section	.debug_info
+	.uleb128	215	; ref to abbrev 215
+	.section	.debug_abbrev
+	.uleb128	215
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname215:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname215
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #216: variable DIRSET
+	.section	.debug_info
+	.uleb128	216	; ref to abbrev 216
+	.section	.debug_abbrev
+	.uleb128	216
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname216:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname216
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #217: variable DIRCLR
+	.section	.debug_info
+	.uleb128	217	; ref to abbrev 217
+	.section	.debug_abbrev
+	.uleb128	217
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname217:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname217
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #218: variable DIRTGL
+	.section	.debug_info
+	.uleb128	218	; ref to abbrev 218
+	.section	.debug_abbrev
+	.uleb128	218
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname218:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname218
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #219: variable OUT
+	.section	.debug_info
+	.uleb128	219	; ref to abbrev 219
+	.section	.debug_abbrev
+	.uleb128	219
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname219:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname219
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #220: variable OUTSET
+	.section	.debug_info
+	.uleb128	220	; ref to abbrev 220
+	.section	.debug_abbrev
+	.uleb128	220
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname220:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname220
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #221: variable OUTCLR
+	.section	.debug_info
+	.uleb128	221	; ref to abbrev 221
+	.section	.debug_abbrev
+	.uleb128	221
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname221:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname221
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #222: variable OUTTGL
+	.section	.debug_info
+	.uleb128	222	; ref to abbrev 222
+	.section	.debug_abbrev
+	.uleb128	222
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname222:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname222
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #223: variable IN
+	.section	.debug_info
+	.uleb128	223	; ref to abbrev 223
+	.section	.debug_abbrev
+	.uleb128	223
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname223:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname223
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #224: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	224	; ref to abbrev 224
+	.section	.debug_abbrev
+	.uleb128	224
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname224:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname224
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #225: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	225	; ref to abbrev 225
+	.section	.debug_abbrev
+	.uleb128	225
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname225:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname225
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #226: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	226	; ref to abbrev 226
+	.section	.debug_abbrev
+	.uleb128	226
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname226:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname226
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #227: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	227	; ref to abbrev 227
+	.section	.debug_abbrev
+	.uleb128	227
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname227:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname227
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #228: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	228	; ref to abbrev 228
+	.section	.debug_abbrev
+	.uleb128	228
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname228:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname228
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #229: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	229	; ref to abbrev 229
+	.section	.debug_abbrev
+	.uleb128	229
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname229:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname229
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #230: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	230	; ref to abbrev 230
+	.section	.debug_abbrev
+	.uleb128	230
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname230:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname230
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #231: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	231	; ref to abbrev 231
+	.section	.debug_abbrev
+	.uleb128	231
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname231:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname231
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #232: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	232	; ref to abbrev 232
+	.section	.debug_abbrev
+	.uleb128	232
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname232:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname232
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #233: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	233	; ref to abbrev 233
+	.section	.debug_abbrev
+	.uleb128	233
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname233:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname233
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #234: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	234	; ref to abbrev 234
+	.section	.debug_abbrev
+	.uleb128	234
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname234:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname234
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #235: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	235	; ref to abbrev 235
+	.section	.debug_abbrev
+	.uleb128	235
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname235:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname235
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #236: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	236	; ref to abbrev 236
+	.section	.debug_abbrev
+	.uleb128	236
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname236:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname236
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #237: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	237	; ref to abbrev 237
+	.section	.debug_abbrev
+	.uleb128	237
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname237:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname237
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #238: variable EVGENCTRL
+	.section	.debug_info
+	.uleb128	238	; ref to abbrev 238
+	.section	.debug_abbrev
+	.uleb128	238
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname238:
+	.string		"EVGENCTRL"
+	.section	.debug_info
+	.long		.Lname238
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #239: variable EVSYSROUTEA
+	.section	.debug_info
+	.uleb128	239	; ref to abbrev 239
+	.section	.debug_abbrev
+	.uleb128	239
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname239:
+	.string		"EVSYSROUTEA"
+	.section	.debug_info
+	.long		.Lname239
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #240: variable CCLROUTEA
+	.section	.debug_info
+	.uleb128	240	; ref to abbrev 240
+	.section	.debug_abbrev
+	.uleb128	240
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname240:
+	.string		"CCLROUTEA"
+	.section	.debug_info
+	.long		.Lname240
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #241: variable USARTROUTEA
+	.section	.debug_info
+	.uleb128	241	; ref to abbrev 241
+	.section	.debug_abbrev
+	.uleb128	241
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname241:
+	.string		"USARTROUTEA"
+	.section	.debug_info
+	.long		.Lname241
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #242: variable USARTROUTEB
+	.section	.debug_info
+	.uleb128	242	; ref to abbrev 242
+	.section	.debug_abbrev
+	.uleb128	242
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname242:
+	.string		"USARTROUTEB"
+	.section	.debug_info
+	.long		.Lname242
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #243: variable SPIROUTEA
+	.section	.debug_info
+	.uleb128	243	; ref to abbrev 243
+	.section	.debug_abbrev
+	.uleb128	243
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname243:
+	.string		"SPIROUTEA"
+	.section	.debug_info
+	.long		.Lname243
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #244: variable TWIROUTEA
+	.section	.debug_info
+	.uleb128	244	; ref to abbrev 244
+	.section	.debug_abbrev
+	.uleb128	244
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname244:
+	.string		"TWIROUTEA"
+	.section	.debug_info
+	.long		.Lname244
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #245: variable TCAROUTEA
+	.section	.debug_info
+	.uleb128	245	; ref to abbrev 245
+	.section	.debug_abbrev
+	.uleb128	245
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname245:
+	.string		"TCAROUTEA"
+	.section	.debug_info
+	.long		.Lname245
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #246: variable TCBROUTEA
+	.section	.debug_info
+	.uleb128	246	; ref to abbrev 246
+	.section	.debug_abbrev
+	.uleb128	246
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname246:
+	.string		"TCBROUTEA"
+	.section	.debug_info
+	.long		.Lname246
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #247: variable ACROUTEA
+	.section	.debug_info
+	.uleb128	247	; ref to abbrev 247
+	.section	.debug_abbrev
+	.uleb128	247
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname247:
+	.string		"ACROUTEA"
+	.section	.debug_info
+	.long		.Lname247
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #248: variable RSTFR
+	.section	.debug_info
+	.uleb128	248	; ref to abbrev 248
+	.section	.debug_abbrev
+	.uleb128	248
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname248:
+	.string		"RSTFR"
+	.section	.debug_info
+	.long		.Lname248
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0040 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #249: variable SWRR
+	.section	.debug_info
+	.uleb128	249	; ref to abbrev 249
+	.section	.debug_abbrev
+	.uleb128	249
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname249:
+	.string		"SWRR"
+	.section	.debug_info
+	.long		.Lname249
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0040 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #250: variable CTRLA
+	.section	.debug_info
+	.uleb128	250	; ref to abbrev 250
+	.section	.debug_abbrev
+	.uleb128	250
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname250:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname250
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #251: variable STATUS
+	.section	.debug_info
+	.uleb128	251	; ref to abbrev 251
+	.section	.debug_abbrev
+	.uleb128	251
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname251:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname251
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #252: variable INTCTRL
+	.section	.debug_info
+	.uleb128	252	; ref to abbrev 252
+	.section	.debug_abbrev
+	.uleb128	252
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname252:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname252
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #253: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	253	; ref to abbrev 253
+	.section	.debug_abbrev
+	.uleb128	253
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname253:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname253
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #254: variable TEMP
+	.section	.debug_info
+	.uleb128	254	; ref to abbrev 254
+	.section	.debug_abbrev
+	.uleb128	254
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname254:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname254
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #255: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	255	; ref to abbrev 255
+	.section	.debug_abbrev
+	.uleb128	255
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname255:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname255
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #256: variable CALIB
+	.section	.debug_info
+	.uleb128	256	; ref to abbrev 256
+	.section	.debug_abbrev
+	.uleb128	256
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname256:
+	.string		"CALIB"
+	.section	.debug_info
+	.long		.Lname256
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #257: variable CLKSEL
+	.section	.debug_info
+	.uleb128	257	; ref to abbrev 257
+	.section	.debug_abbrev
+	.uleb128	257
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname257:
+	.string		"CLKSEL"
+	.section	.debug_info
+	.long		.Lname257
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #258: variable CNT
+	.section	.debug_info
+	.uleb128	258	; ref to abbrev 258
+	.section	.debug_abbrev
+	.uleb128	258
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname258:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname258
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #259: variable PER
+	.section	.debug_info
+	.uleb128	259	; ref to abbrev 259
+	.section	.debug_abbrev
+	.uleb128	259
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname259:
+	.string		"PER"
+	.section	.debug_info
+	.long		.Lname259
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #260: variable CMP
+	.section	.debug_info
+	.uleb128	260	; ref to abbrev 260
+	.section	.debug_abbrev
+	.uleb128	260
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname260:
+	.string		"CMP"
+	.section	.debug_info
+	.long		.Lname260
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #261: variable PITCTRLA
+	.section	.debug_info
+	.uleb128	261	; ref to abbrev 261
+	.section	.debug_abbrev
+	.uleb128	261
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname261:
+	.string		"PITCTRLA"
+	.section	.debug_info
+	.long		.Lname261
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #262: variable PITSTATUS
+	.section	.debug_info
+	.uleb128	262	; ref to abbrev 262
+	.section	.debug_abbrev
+	.uleb128	262
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname262:
+	.string		"PITSTATUS"
+	.section	.debug_info
+	.long		.Lname262
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #263: variable PITINTCTRL
+	.section	.debug_info
+	.uleb128	263	; ref to abbrev 263
+	.section	.debug_abbrev
+	.uleb128	263
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname263:
+	.string		"PITINTCTRL"
+	.section	.debug_info
+	.long		.Lname263
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #264: variable PITINTFLAGS
+	.section	.debug_info
+	.uleb128	264	; ref to abbrev 264
+	.section	.debug_abbrev
+	.uleb128	264
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname264:
+	.string		"PITINTFLAGS"
+	.section	.debug_info
+	.long		.Lname264
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #265: variable PITDBGCTRL
+	.section	.debug_info
+	.uleb128	265	; ref to abbrev 265
+	.section	.debug_abbrev
+	.uleb128	265
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname265:
+	.string		"PITDBGCTRL"
+	.section	.debug_info
+	.long		.Lname265
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #266: variable PITEVGENCTRLA
+	.section	.debug_info
+	.uleb128	266	; ref to abbrev 266
+	.section	.debug_abbrev
+	.uleb128	266
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname266:
+	.string		"PITEVGENCTRLA"
+	.section	.debug_info
+	.long		.Lname266
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #267: variable DEVICEID0
+	.section	.debug_info
+	.uleb128	267	; ref to abbrev 267
+	.section	.debug_abbrev
+	.uleb128	267
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname267:
+	.string		"DEVICEID0"
+	.section	.debug_info
+	.long		.Lname267
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #268: variable DEVICEID1
+	.section	.debug_info
+	.uleb128	268	; ref to abbrev 268
+	.section	.debug_abbrev
+	.uleb128	268
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname268:
+	.string		"DEVICEID1"
+	.section	.debug_info
+	.long		.Lname268
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #269: variable DEVICEID2
+	.section	.debug_info
+	.uleb128	269	; ref to abbrev 269
+	.section	.debug_abbrev
+	.uleb128	269
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname269:
+	.string		"DEVICEID2"
+	.section	.debug_info
+	.long		.Lname269
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #270: variable TEMPSENSE0
+	.section	.debug_info
+	.uleb128	270	; ref to abbrev 270
+	.section	.debug_abbrev
+	.uleb128	270
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname270:
+	.string		"TEMPSENSE0"
+	.section	.debug_info
+	.long		.Lname270
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #271: variable TEMPSENSE1
+	.section	.debug_info
+	.uleb128	271	; ref to abbrev 271
+	.section	.debug_abbrev
+	.uleb128	271
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname271:
+	.string		"TEMPSENSE1"
+	.section	.debug_info
+	.long		.Lname271
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #272: variable SERNUM0
+	.section	.debug_info
+	.uleb128	272	; ref to abbrev 272
+	.section	.debug_abbrev
+	.uleb128	272
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname272:
+	.string		"SERNUM0"
+	.section	.debug_info
+	.long		.Lname272
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #273: variable SERNUM1
+	.section	.debug_info
+	.uleb128	273	; ref to abbrev 273
+	.section	.debug_abbrev
+	.uleb128	273
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname273:
+	.string		"SERNUM1"
+	.section	.debug_info
+	.long		.Lname273
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #274: variable SERNUM2
+	.section	.debug_info
+	.uleb128	274	; ref to abbrev 274
+	.section	.debug_abbrev
+	.uleb128	274
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname274:
+	.string		"SERNUM2"
+	.section	.debug_info
+	.long		.Lname274
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #275: variable SERNUM3
+	.section	.debug_info
+	.uleb128	275	; ref to abbrev 275
+	.section	.debug_abbrev
+	.uleb128	275
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname275:
+	.string		"SERNUM3"
+	.section	.debug_info
+	.long		.Lname275
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #276: variable SERNUM4
+	.section	.debug_info
+	.uleb128	276	; ref to abbrev 276
+	.section	.debug_abbrev
+	.uleb128	276
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname276:
+	.string		"SERNUM4"
+	.section	.debug_info
+	.long		.Lname276
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #277: variable SERNUM5
+	.section	.debug_info
+	.uleb128	277	; ref to abbrev 277
+	.section	.debug_abbrev
+	.uleb128	277
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname277:
+	.string		"SERNUM5"
+	.section	.debug_info
+	.long		.Lname277
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #278: variable SERNUM6
+	.section	.debug_info
+	.uleb128	278	; ref to abbrev 278
+	.section	.debug_abbrev
+	.uleb128	278
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname278:
+	.string		"SERNUM6"
+	.section	.debug_info
+	.long		.Lname278
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #279: variable SERNUM7
+	.section	.debug_info
+	.uleb128	279	; ref to abbrev 279
+	.section	.debug_abbrev
+	.uleb128	279
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname279:
+	.string		"SERNUM7"
+	.section	.debug_info
+	.long		.Lname279
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #280: variable SERNUM8
+	.section	.debug_info
+	.uleb128	280	; ref to abbrev 280
+	.section	.debug_abbrev
+	.uleb128	280
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname280:
+	.string		"SERNUM8"
+	.section	.debug_info
+	.long		.Lname280
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #281: variable SERNUM9
+	.section	.debug_info
+	.uleb128	281	; ref to abbrev 281
+	.section	.debug_abbrev
+	.uleb128	281
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname281:
+	.string		"SERNUM9"
+	.section	.debug_info
+	.long		.Lname281
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x19
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #282: variable SERNUM10
+	.section	.debug_info
+	.uleb128	282	; ref to abbrev 282
+	.section	.debug_abbrev
+	.uleb128	282
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname282:
+	.string		"SERNUM10"
+	.section	.debug_info
+	.long		.Lname282
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x1A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #283: variable SERNUM11
+	.section	.debug_info
+	.uleb128	283	; ref to abbrev 283
+	.section	.debug_abbrev
+	.uleb128	283
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname283:
+	.string		"SERNUM11"
+	.section	.debug_info
+	.long		.Lname283
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x1B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #284: variable SERNUM12
+	.section	.debug_info
+	.uleb128	284	; ref to abbrev 284
+	.section	.debug_abbrev
+	.uleb128	284
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname284:
+	.string		"SERNUM12"
+	.section	.debug_info
+	.long		.Lname284
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x1C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #285: variable SERNUM13
+	.section	.debug_info
+	.uleb128	285	; ref to abbrev 285
+	.section	.debug_abbrev
+	.uleb128	285
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname285:
+	.string		"SERNUM13"
+	.section	.debug_info
+	.long		.Lname285
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x1D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #286: variable SERNUM14
+	.section	.debug_info
+	.uleb128	286	; ref to abbrev 286
+	.section	.debug_abbrev
+	.uleb128	286
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname286:
+	.string		"SERNUM14"
+	.section	.debug_info
+	.long		.Lname286
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x1E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #287: variable SERNUM15
+	.section	.debug_info
+	.uleb128	287	; ref to abbrev 287
+	.section	.debug_abbrev
+	.uleb128	287
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname287:
+	.string		"SERNUM15"
+	.section	.debug_info
+	.long		.Lname287
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x1F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #288: variable CTRLA
+	.section	.debug_info
+	.uleb128	288	; ref to abbrev 288
+	.section	.debug_abbrev
+	.uleb128	288
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname288:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname288
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0050 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #289: variable CTRLA
+	.section	.debug_info
+	.uleb128	289	; ref to abbrev 289
+	.section	.debug_abbrev
+	.uleb128	289
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname289:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname289
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #290: variable CTRLB
+	.section	.debug_info
+	.uleb128	290	; ref to abbrev 290
+	.section	.debug_abbrev
+	.uleb128	290
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname290:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname290
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #291: variable INTCTRL
+	.section	.debug_info
+	.uleb128	291	; ref to abbrev 291
+	.section	.debug_abbrev
+	.uleb128	291
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname291:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname291
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #292: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	292	; ref to abbrev 292
+	.section	.debug_abbrev
+	.uleb128	292
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname292:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname292
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #293: variable DATA
+	.section	.debug_info
+	.uleb128	293	; ref to abbrev 293
+	.section	.debug_abbrev
+	.uleb128	293
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname293:
+	.string		"DATA"
+	.section	.debug_info
+	.long		.Lname293
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #294: variable REVID
+	.section	.debug_info
+	.uleb128	294	; ref to abbrev 294
+	.section	.debug_abbrev
+	.uleb128	294
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname294:
+	.string		"REVID"
+	.section	.debug_info
+	.long		.Lname294
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0F00 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #295: variable OCDMCTRL
+	.section	.debug_info
+	.uleb128	295	; ref to abbrev 295
+	.section	.debug_abbrev
+	.uleb128	295
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname295:
+	.string		"OCDMCTRL"
+	.section	.debug_info
+	.long		.Lname295
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0F00 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #296: variable OCDMSTATUS
+	.section	.debug_info
+	.uleb128	296	; ref to abbrev 296
+	.section	.debug_abbrev
+	.uleb128	296
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname296:
+	.string		"OCDMSTATUS"
+	.section	.debug_info
+	.long		.Lname296
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0F00 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #297: variable CTRLA
+	.section	.debug_info
+	.uleb128	297	; ref to abbrev 297
+	.section	.debug_abbrev
+	.uleb128	297
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname297:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname297
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #298: variable CTRLB
+	.section	.debug_info
+	.uleb128	298	; ref to abbrev 298
+	.section	.debug_abbrev
+	.uleb128	298
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname298:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname298
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #299: variable CTRLC
+	.section	.debug_info
+	.uleb128	299	; ref to abbrev 299
+	.section	.debug_abbrev
+	.uleb128	299
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname299:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname299
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #300: variable CTRLD
+	.section	.debug_info
+	.uleb128	300	; ref to abbrev 300
+	.section	.debug_abbrev
+	.uleb128	300
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname300:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname300
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #301: variable CTRLECLR
+	.section	.debug_info
+	.uleb128	301	; ref to abbrev 301
+	.section	.debug_abbrev
+	.uleb128	301
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname301:
+	.string		"CTRLECLR"
+	.section	.debug_info
+	.long		.Lname301
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #302: variable CTRLESET
+	.section	.debug_info
+	.uleb128	302	; ref to abbrev 302
+	.section	.debug_abbrev
+	.uleb128	302
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname302:
+	.string		"CTRLESET"
+	.section	.debug_info
+	.long		.Lname302
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #303: variable CTRLFCLR
+	.section	.debug_info
+	.uleb128	303	; ref to abbrev 303
+	.section	.debug_abbrev
+	.uleb128	303
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname303:
+	.string		"CTRLFCLR"
+	.section	.debug_info
+	.long		.Lname303
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #304: variable CTRLFSET
+	.section	.debug_info
+	.uleb128	304	; ref to abbrev 304
+	.section	.debug_abbrev
+	.uleb128	304
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname304:
+	.string		"CTRLFSET"
+	.section	.debug_info
+	.long		.Lname304
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #305: variable EVCTRL
+	.section	.debug_info
+	.uleb128	305	; ref to abbrev 305
+	.section	.debug_abbrev
+	.uleb128	305
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname305:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname305
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #306: variable INTCTRL
+	.section	.debug_info
+	.uleb128	306	; ref to abbrev 306
+	.section	.debug_abbrev
+	.uleb128	306
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname306:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname306
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #307: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	307	; ref to abbrev 307
+	.section	.debug_abbrev
+	.uleb128	307
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname307:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname307
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #308: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	308	; ref to abbrev 308
+	.section	.debug_abbrev
+	.uleb128	308
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname308:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname308
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #309: variable TEMP
+	.section	.debug_info
+	.uleb128	309	; ref to abbrev 309
+	.section	.debug_abbrev
+	.uleb128	309
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname309:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname309
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #310: variable CNT
+	.section	.debug_info
+	.uleb128	310	; ref to abbrev 310
+	.section	.debug_abbrev
+	.uleb128	310
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname310:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname310
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #311: variable PER
+	.section	.debug_info
+	.uleb128	311	; ref to abbrev 311
+	.section	.debug_abbrev
+	.uleb128	311
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname311:
+	.string		"PER"
+	.section	.debug_info
+	.long		.Lname311
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x26
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #312: variable CMP0
+	.section	.debug_info
+	.uleb128	312	; ref to abbrev 312
+	.section	.debug_abbrev
+	.uleb128	312
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname312:
+	.string		"CMP0"
+	.section	.debug_info
+	.long		.Lname312
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x28
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #313: variable CMP1
+	.section	.debug_info
+	.uleb128	313	; ref to abbrev 313
+	.section	.debug_abbrev
+	.uleb128	313
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname313:
+	.string		"CMP1"
+	.section	.debug_info
+	.long		.Lname313
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #314: variable CMP2
+	.section	.debug_info
+	.uleb128	314	; ref to abbrev 314
+	.section	.debug_abbrev
+	.uleb128	314
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname314:
+	.string		"CMP2"
+	.section	.debug_info
+	.long		.Lname314
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #315: variable PERBUF
+	.section	.debug_info
+	.uleb128	315	; ref to abbrev 315
+	.section	.debug_abbrev
+	.uleb128	315
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname315:
+	.string		"PERBUF"
+	.section	.debug_info
+	.long		.Lname315
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x36
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #316: variable CMP0BUF
+	.section	.debug_info
+	.uleb128	316	; ref to abbrev 316
+	.section	.debug_abbrev
+	.uleb128	316
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname316:
+	.string		"CMP0BUF"
+	.section	.debug_info
+	.long		.Lname316
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x38
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #317: variable CMP1BUF
+	.section	.debug_info
+	.uleb128	317	; ref to abbrev 317
+	.section	.debug_abbrev
+	.uleb128	317
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname317:
+	.string		"CMP1BUF"
+	.section	.debug_info
+	.long		.Lname317
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x3A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #318: variable CMP2BUF
+	.section	.debug_info
+	.uleb128	318	; ref to abbrev 318
+	.section	.debug_abbrev
+	.uleb128	318
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname318:
+	.string		"CMP2BUF"
+	.section	.debug_info
+	.long		.Lname318
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x3C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #319: variable CTRLA
+	.section	.debug_info
+	.uleb128	319	; ref to abbrev 319
+	.section	.debug_abbrev
+	.uleb128	319
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname319:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname319
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #320: variable CTRLB
+	.section	.debug_info
+	.uleb128	320	; ref to abbrev 320
+	.section	.debug_abbrev
+	.uleb128	320
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname320:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname320
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #321: variable CTRLC
+	.section	.debug_info
+	.uleb128	321	; ref to abbrev 321
+	.section	.debug_abbrev
+	.uleb128	321
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname321:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname321
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #322: variable CTRLD
+	.section	.debug_info
+	.uleb128	322	; ref to abbrev 322
+	.section	.debug_abbrev
+	.uleb128	322
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname322:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname322
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #323: variable CTRLECLR
+	.section	.debug_info
+	.uleb128	323	; ref to abbrev 323
+	.section	.debug_abbrev
+	.uleb128	323
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname323:
+	.string		"CTRLECLR"
+	.section	.debug_info
+	.long		.Lname323
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #324: variable CTRLESET
+	.section	.debug_info
+	.uleb128	324	; ref to abbrev 324
+	.section	.debug_abbrev
+	.uleb128	324
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname324:
+	.string		"CTRLESET"
+	.section	.debug_info
+	.long		.Lname324
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #325: variable INTCTRL
+	.section	.debug_info
+	.uleb128	325	; ref to abbrev 325
+	.section	.debug_abbrev
+	.uleb128	325
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname325:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname325
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #326: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	326	; ref to abbrev 326
+	.section	.debug_abbrev
+	.uleb128	326
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname326:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname326
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #327: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	327	; ref to abbrev 327
+	.section	.debug_abbrev
+	.uleb128	327
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname327:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname327
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #328: variable LCNT
+	.section	.debug_info
+	.uleb128	328	; ref to abbrev 328
+	.section	.debug_abbrev
+	.uleb128	328
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname328:
+	.string		"LCNT"
+	.section	.debug_info
+	.long		.Lname328
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #329: variable HCNT
+	.section	.debug_info
+	.uleb128	329	; ref to abbrev 329
+	.section	.debug_abbrev
+	.uleb128	329
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname329:
+	.string		"HCNT"
+	.section	.debug_info
+	.long		.Lname329
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x21
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #330: variable LPER
+	.section	.debug_info
+	.uleb128	330	; ref to abbrev 330
+	.section	.debug_abbrev
+	.uleb128	330
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname330:
+	.string		"LPER"
+	.section	.debug_info
+	.long		.Lname330
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x26
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #331: variable HPER
+	.section	.debug_info
+	.uleb128	331	; ref to abbrev 331
+	.section	.debug_abbrev
+	.uleb128	331
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname331:
+	.string		"HPER"
+	.section	.debug_info
+	.long		.Lname331
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x27
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #332: variable LCMP0
+	.section	.debug_info
+	.uleb128	332	; ref to abbrev 332
+	.section	.debug_abbrev
+	.uleb128	332
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname332:
+	.string		"LCMP0"
+	.section	.debug_info
+	.long		.Lname332
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x28
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #333: variable HCMP0
+	.section	.debug_info
+	.uleb128	333	; ref to abbrev 333
+	.section	.debug_abbrev
+	.uleb128	333
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname333:
+	.string		"HCMP0"
+	.section	.debug_info
+	.long		.Lname333
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x29
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #334: variable LCMP1
+	.section	.debug_info
+	.uleb128	334	; ref to abbrev 334
+	.section	.debug_abbrev
+	.uleb128	334
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname334:
+	.string		"LCMP1"
+	.section	.debug_info
+	.long		.Lname334
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #335: variable HCMP1
+	.section	.debug_info
+	.uleb128	335	; ref to abbrev 335
+	.section	.debug_abbrev
+	.uleb128	335
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname335:
+	.string		"HCMP1"
+	.section	.debug_info
+	.long		.Lname335
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #336: variable LCMP2
+	.section	.debug_info
+	.uleb128	336	; ref to abbrev 336
+	.section	.debug_abbrev
+	.uleb128	336
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname336:
+	.string		"LCMP2"
+	.section	.debug_info
+	.long		.Lname336
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #337: variable HCMP2
+	.section	.debug_info
+	.uleb128	337	; ref to abbrev 337
+	.section	.debug_abbrev
+	.uleb128	337
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname337:
+	.string		"HCMP2"
+	.section	.debug_info
+	.long		.Lname337
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #338: variable CTRLA
+	.section	.debug_info
+	.uleb128	338	; ref to abbrev 338
+	.section	.debug_abbrev
+	.uleb128	338
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname338:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname338
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #339: variable CTRLB
+	.section	.debug_info
+	.uleb128	339	; ref to abbrev 339
+	.section	.debug_abbrev
+	.uleb128	339
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname339:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname339
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #340: variable EVCTRL
+	.section	.debug_info
+	.uleb128	340	; ref to abbrev 340
+	.section	.debug_abbrev
+	.uleb128	340
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname340:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname340
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #341: variable INTCTRL
+	.section	.debug_info
+	.uleb128	341	; ref to abbrev 341
+	.section	.debug_abbrev
+	.uleb128	341
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname341:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname341
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #342: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	342	; ref to abbrev 342
+	.section	.debug_abbrev
+	.uleb128	342
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname342:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname342
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #343: variable STATUS
+	.section	.debug_info
+	.uleb128	343	; ref to abbrev 343
+	.section	.debug_abbrev
+	.uleb128	343
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname343:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname343
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #344: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	344	; ref to abbrev 344
+	.section	.debug_abbrev
+	.uleb128	344
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname344:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname344
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #345: variable TEMP
+	.section	.debug_info
+	.uleb128	345	; ref to abbrev 345
+	.section	.debug_abbrev
+	.uleb128	345
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname345:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname345
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #346: variable CNT
+	.section	.debug_info
+	.uleb128	346	; ref to abbrev 346
+	.section	.debug_abbrev
+	.uleb128	346
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname346:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname346
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #347: variable CCMP
+	.section	.debug_info
+	.uleb128	347	; ref to abbrev 347
+	.section	.debug_abbrev
+	.uleb128	347
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname347:
+	.string		"CCMP"
+	.section	.debug_info
+	.long		.Lname347
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #348: variable CTRLA
+	.section	.debug_info
+	.uleb128	348	; ref to abbrev 348
+	.section	.debug_abbrev
+	.uleb128	348
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname348:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname348
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #349: variable CTRLB
+	.section	.debug_info
+	.uleb128	349	; ref to abbrev 349
+	.section	.debug_abbrev
+	.uleb128	349
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname349:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname349
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #350: variable EVCTRL
+	.section	.debug_info
+	.uleb128	350	; ref to abbrev 350
+	.section	.debug_abbrev
+	.uleb128	350
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname350:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname350
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #351: variable INTCTRL
+	.section	.debug_info
+	.uleb128	351	; ref to abbrev 351
+	.section	.debug_abbrev
+	.uleb128	351
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname351:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname351
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #352: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	352	; ref to abbrev 352
+	.section	.debug_abbrev
+	.uleb128	352
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname352:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname352
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #353: variable STATUS
+	.section	.debug_info
+	.uleb128	353	; ref to abbrev 353
+	.section	.debug_abbrev
+	.uleb128	353
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname353:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname353
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #354: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	354	; ref to abbrev 354
+	.section	.debug_abbrev
+	.uleb128	354
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname354:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname354
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #355: variable TEMP
+	.section	.debug_info
+	.uleb128	355	; ref to abbrev 355
+	.section	.debug_abbrev
+	.uleb128	355
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname355:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname355
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #356: variable CNT
+	.section	.debug_info
+	.uleb128	356	; ref to abbrev 356
+	.section	.debug_abbrev
+	.uleb128	356
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname356:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname356
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #357: variable CCMP
+	.section	.debug_info
+	.uleb128	357	; ref to abbrev 357
+	.section	.debug_abbrev
+	.uleb128	357
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname357:
+	.string		"CCMP"
+	.section	.debug_info
+	.long		.Lname357
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #358: variable CTRLA
+	.section	.debug_info
+	.uleb128	358	; ref to abbrev 358
+	.section	.debug_abbrev
+	.uleb128	358
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname358:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname358
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #359: variable CTRLB
+	.section	.debug_info
+	.uleb128	359	; ref to abbrev 359
+	.section	.debug_abbrev
+	.uleb128	359
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname359:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname359
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #360: variable EVCTRL
+	.section	.debug_info
+	.uleb128	360	; ref to abbrev 360
+	.section	.debug_abbrev
+	.uleb128	360
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname360:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname360
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #361: variable INTCTRL
+	.section	.debug_info
+	.uleb128	361	; ref to abbrev 361
+	.section	.debug_abbrev
+	.uleb128	361
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname361:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname361
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #362: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	362	; ref to abbrev 362
+	.section	.debug_abbrev
+	.uleb128	362
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname362:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname362
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #363: variable STATUS
+	.section	.debug_info
+	.uleb128	363	; ref to abbrev 363
+	.section	.debug_abbrev
+	.uleb128	363
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname363:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname363
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #364: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	364	; ref to abbrev 364
+	.section	.debug_abbrev
+	.uleb128	364
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname364:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname364
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #365: variable TEMP
+	.section	.debug_info
+	.uleb128	365	; ref to abbrev 365
+	.section	.debug_abbrev
+	.uleb128	365
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname365:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname365
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #366: variable CNT
+	.section	.debug_info
+	.uleb128	366	; ref to abbrev 366
+	.section	.debug_abbrev
+	.uleb128	366
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname366:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname366
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #367: variable CCMP
+	.section	.debug_info
+	.uleb128	367	; ref to abbrev 367
+	.section	.debug_abbrev
+	.uleb128	367
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname367:
+	.string		"CCMP"
+	.section	.debug_info
+	.long		.Lname367
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #368: variable CTRLA
+	.section	.debug_info
+	.uleb128	368	; ref to abbrev 368
+	.section	.debug_abbrev
+	.uleb128	368
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname368:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname368
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #369: variable DUALCTRL
+	.section	.debug_info
+	.uleb128	369	; ref to abbrev 369
+	.section	.debug_abbrev
+	.uleb128	369
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname369:
+	.string		"DUALCTRL"
+	.section	.debug_info
+	.long		.Lname369
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #370: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	370	; ref to abbrev 370
+	.section	.debug_abbrev
+	.uleb128	370
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname370:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname370
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #371: variable MCTRLA
+	.section	.debug_info
+	.uleb128	371	; ref to abbrev 371
+	.section	.debug_abbrev
+	.uleb128	371
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname371:
+	.string		"MCTRLA"
+	.section	.debug_info
+	.long		.Lname371
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #372: variable MCTRLB
+	.section	.debug_info
+	.uleb128	372	; ref to abbrev 372
+	.section	.debug_abbrev
+	.uleb128	372
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname372:
+	.string		"MCTRLB"
+	.section	.debug_info
+	.long		.Lname372
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #373: variable MSTATUS
+	.section	.debug_info
+	.uleb128	373	; ref to abbrev 373
+	.section	.debug_abbrev
+	.uleb128	373
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname373:
+	.string		"MSTATUS"
+	.section	.debug_info
+	.long		.Lname373
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #374: variable MBAUD
+	.section	.debug_info
+	.uleb128	374	; ref to abbrev 374
+	.section	.debug_abbrev
+	.uleb128	374
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname374:
+	.string		"MBAUD"
+	.section	.debug_info
+	.long		.Lname374
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #375: variable MADDR
+	.section	.debug_info
+	.uleb128	375	; ref to abbrev 375
+	.section	.debug_abbrev
+	.uleb128	375
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname375:
+	.string		"MADDR"
+	.section	.debug_info
+	.long		.Lname375
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #376: variable MDATA
+	.section	.debug_info
+	.uleb128	376	; ref to abbrev 376
+	.section	.debug_abbrev
+	.uleb128	376
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname376:
+	.string		"MDATA"
+	.section	.debug_info
+	.long		.Lname376
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #377: variable SCTRLA
+	.section	.debug_info
+	.uleb128	377	; ref to abbrev 377
+	.section	.debug_abbrev
+	.uleb128	377
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname377:
+	.string		"SCTRLA"
+	.section	.debug_info
+	.long		.Lname377
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #378: variable SCTRLB
+	.section	.debug_info
+	.uleb128	378	; ref to abbrev 378
+	.section	.debug_abbrev
+	.uleb128	378
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname378:
+	.string		"SCTRLB"
+	.section	.debug_info
+	.long		.Lname378
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #379: variable SSTATUS
+	.section	.debug_info
+	.uleb128	379	; ref to abbrev 379
+	.section	.debug_abbrev
+	.uleb128	379
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname379:
+	.string		"SSTATUS"
+	.section	.debug_info
+	.long		.Lname379
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #380: variable SADDR
+	.section	.debug_info
+	.uleb128	380	; ref to abbrev 380
+	.section	.debug_abbrev
+	.uleb128	380
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname380:
+	.string		"SADDR"
+	.section	.debug_info
+	.long		.Lname380
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #381: variable SDATA
+	.section	.debug_info
+	.uleb128	381	; ref to abbrev 381
+	.section	.debug_abbrev
+	.uleb128	381
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname381:
+	.string		"SDATA"
+	.section	.debug_info
+	.long		.Lname381
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xD
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #382: variable SADDRMASK
+	.section	.debug_info
+	.uleb128	382	; ref to abbrev 382
+	.section	.debug_abbrev
+	.uleb128	382
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname382:
+	.string		"SADDRMASK"
+	.section	.debug_info
+	.long		.Lname382
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xE
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #383: variable RXDATAL
+	.section	.debug_info
+	.uleb128	383	; ref to abbrev 383
+	.section	.debug_abbrev
+	.uleb128	383
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname383:
+	.string		"RXDATAL"
+	.section	.debug_info
+	.long		.Lname383
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #384: variable RXDATAH
+	.section	.debug_info
+	.uleb128	384	; ref to abbrev 384
+	.section	.debug_abbrev
+	.uleb128	384
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname384:
+	.string		"RXDATAH"
+	.section	.debug_info
+	.long		.Lname384
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #385: variable TXDATAL
+	.section	.debug_info
+	.uleb128	385	; ref to abbrev 385
+	.section	.debug_abbrev
+	.uleb128	385
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname385:
+	.string		"TXDATAL"
+	.section	.debug_info
+	.long		.Lname385
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #386: variable TXDATAH
+	.section	.debug_info
+	.uleb128	386	; ref to abbrev 386
+	.section	.debug_abbrev
+	.uleb128	386
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname386:
+	.string		"TXDATAH"
+	.section	.debug_info
+	.long		.Lname386
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #387: variable STATUS
+	.section	.debug_info
+	.uleb128	387	; ref to abbrev 387
+	.section	.debug_abbrev
+	.uleb128	387
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname387:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname387
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #388: variable CTRLA
+	.section	.debug_info
+	.uleb128	388	; ref to abbrev 388
+	.section	.debug_abbrev
+	.uleb128	388
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname388:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname388
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #389: variable CTRLB
+	.section	.debug_info
+	.uleb128	389	; ref to abbrev 389
+	.section	.debug_abbrev
+	.uleb128	389
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname389:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname389
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #390: variable CTRLC
+	.section	.debug_info
+	.uleb128	390	; ref to abbrev 390
+	.section	.debug_abbrev
+	.uleb128	390
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname390:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname390
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #391: variable BAUD
+	.section	.debug_info
+	.uleb128	391	; ref to abbrev 391
+	.section	.debug_abbrev
+	.uleb128	391
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname391:
+	.string		"BAUD"
+	.section	.debug_info
+	.long		.Lname391
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #392: variable CTRLD
+	.section	.debug_info
+	.uleb128	392	; ref to abbrev 392
+	.section	.debug_abbrev
+	.uleb128	392
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname392:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname392
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #393: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	393	; ref to abbrev 393
+	.section	.debug_abbrev
+	.uleb128	393
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname393:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname393
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #394: variable EVCTRL
+	.section	.debug_info
+	.uleb128	394	; ref to abbrev 394
+	.section	.debug_abbrev
+	.uleb128	394
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname394:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname394
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #395: variable TXPLCTRL
+	.section	.debug_info
+	.uleb128	395	; ref to abbrev 395
+	.section	.debug_abbrev
+	.uleb128	395
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname395:
+	.string		"TXPLCTRL"
+	.section	.debug_info
+	.long		.Lname395
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xD
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #396: variable RXPLCTRL
+	.section	.debug_info
+	.uleb128	396	; ref to abbrev 396
+	.section	.debug_abbrev
+	.uleb128	396
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname396:
+	.string		"RXPLCTRL"
+	.section	.debug_info
+	.long		.Lname396
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xE
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #397: variable RXDATAL
+	.section	.debug_info
+	.uleb128	397	; ref to abbrev 397
+	.section	.debug_abbrev
+	.uleb128	397
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname397:
+	.string		"RXDATAL"
+	.section	.debug_info
+	.long		.Lname397
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #398: variable RXDATAH
+	.section	.debug_info
+	.uleb128	398	; ref to abbrev 398
+	.section	.debug_abbrev
+	.uleb128	398
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname398:
+	.string		"RXDATAH"
+	.section	.debug_info
+	.long		.Lname398
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #399: variable TXDATAL
+	.section	.debug_info
+	.uleb128	399	; ref to abbrev 399
+	.section	.debug_abbrev
+	.uleb128	399
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname399:
+	.string		"TXDATAL"
+	.section	.debug_info
+	.long		.Lname399
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #400: variable TXDATAH
+	.section	.debug_info
+	.uleb128	400	; ref to abbrev 400
+	.section	.debug_abbrev
+	.uleb128	400
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname400:
+	.string		"TXDATAH"
+	.section	.debug_info
+	.long		.Lname400
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #401: variable STATUS
+	.section	.debug_info
+	.uleb128	401	; ref to abbrev 401
+	.section	.debug_abbrev
+	.uleb128	401
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname401:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname401
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #402: variable CTRLA
+	.section	.debug_info
+	.uleb128	402	; ref to abbrev 402
+	.section	.debug_abbrev
+	.uleb128	402
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname402:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname402
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #403: variable CTRLB
+	.section	.debug_info
+	.uleb128	403	; ref to abbrev 403
+	.section	.debug_abbrev
+	.uleb128	403
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname403:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname403
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #404: variable CTRLC
+	.section	.debug_info
+	.uleb128	404	; ref to abbrev 404
+	.section	.debug_abbrev
+	.uleb128	404
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname404:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname404
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #405: variable BAUD
+	.section	.debug_info
+	.uleb128	405	; ref to abbrev 405
+	.section	.debug_abbrev
+	.uleb128	405
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname405:
+	.string		"BAUD"
+	.section	.debug_info
+	.long		.Lname405
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #406: variable CTRLD
+	.section	.debug_info
+	.uleb128	406	; ref to abbrev 406
+	.section	.debug_abbrev
+	.uleb128	406
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname406:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname406
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #407: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	407	; ref to abbrev 407
+	.section	.debug_abbrev
+	.uleb128	407
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname407:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname407
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #408: variable EVCTRL
+	.section	.debug_info
+	.uleb128	408	; ref to abbrev 408
+	.section	.debug_abbrev
+	.uleb128	408
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname408:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname408
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #409: variable TXPLCTRL
+	.section	.debug_info
+	.uleb128	409	; ref to abbrev 409
+	.section	.debug_abbrev
+	.uleb128	409
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname409:
+	.string		"TXPLCTRL"
+	.section	.debug_info
+	.long		.Lname409
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0xD
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #410: variable RXPLCTRL
+	.section	.debug_info
+	.uleb128	410	; ref to abbrev 410
+	.section	.debug_abbrev
+	.uleb128	410
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname410:
+	.string		"RXPLCTRL"
+	.section	.debug_info
+	.long		.Lname410
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0xE
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #411: variable RXDATAL
+	.section	.debug_info
+	.uleb128	411	; ref to abbrev 411
+	.section	.debug_abbrev
+	.uleb128	411
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname411:
+	.string		"RXDATAL"
+	.section	.debug_info
+	.long		.Lname411
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #412: variable RXDATAH
+	.section	.debug_info
+	.uleb128	412	; ref to abbrev 412
+	.section	.debug_abbrev
+	.uleb128	412
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname412:
+	.string		"RXDATAH"
+	.section	.debug_info
+	.long		.Lname412
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #413: variable TXDATAL
+	.section	.debug_info
+	.uleb128	413	; ref to abbrev 413
+	.section	.debug_abbrev
+	.uleb128	413
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname413:
+	.string		"TXDATAL"
+	.section	.debug_info
+	.long		.Lname413
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #414: variable TXDATAH
+	.section	.debug_info
+	.uleb128	414	; ref to abbrev 414
+	.section	.debug_abbrev
+	.uleb128	414
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname414:
+	.string		"TXDATAH"
+	.section	.debug_info
+	.long		.Lname414
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #415: variable STATUS
+	.section	.debug_info
+	.uleb128	415	; ref to abbrev 415
+	.section	.debug_abbrev
+	.uleb128	415
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname415:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname415
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #416: variable CTRLA
+	.section	.debug_info
+	.uleb128	416	; ref to abbrev 416
+	.section	.debug_abbrev
+	.uleb128	416
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname416:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname416
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #417: variable CTRLB
+	.section	.debug_info
+	.uleb128	417	; ref to abbrev 417
+	.section	.debug_abbrev
+	.uleb128	417
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname417:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname417
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #418: variable CTRLC
+	.section	.debug_info
+	.uleb128	418	; ref to abbrev 418
+	.section	.debug_abbrev
+	.uleb128	418
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname418:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname418
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #419: variable BAUD
+	.section	.debug_info
+	.uleb128	419	; ref to abbrev 419
+	.section	.debug_abbrev
+	.uleb128	419
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname419:
+	.string		"BAUD"
+	.section	.debug_info
+	.long		.Lname419
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #420: variable CTRLD
+	.section	.debug_info
+	.uleb128	420	; ref to abbrev 420
+	.section	.debug_abbrev
+	.uleb128	420
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname420:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname420
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #421: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	421	; ref to abbrev 421
+	.section	.debug_abbrev
+	.uleb128	421
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname421:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname421
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #422: variable EVCTRL
+	.section	.debug_info
+	.uleb128	422	; ref to abbrev 422
+	.section	.debug_abbrev
+	.uleb128	422
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname422:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname422
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #423: variable TXPLCTRL
+	.section	.debug_info
+	.uleb128	423	; ref to abbrev 423
+	.section	.debug_abbrev
+	.uleb128	423
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname423:
+	.string		"TXPLCTRL"
+	.section	.debug_info
+	.long		.Lname423
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0xD
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #424: variable RXPLCTRL
+	.section	.debug_info
+	.uleb128	424	; ref to abbrev 424
+	.section	.debug_abbrev
+	.uleb128	424
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname424:
+	.string		"RXPLCTRL"
+	.section	.debug_info
+	.long		.Lname424
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0xE
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #425: variable USERROW0
+	.section	.debug_info
+	.uleb128	425	; ref to abbrev 425
+	.section	.debug_abbrev
+	.uleb128	425
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname425:
+	.string		"USERROW0"
+	.section	.debug_info
+	.long		.Lname425
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #426: variable USERROW1
+	.section	.debug_info
+	.uleb128	426	; ref to abbrev 426
+	.section	.debug_abbrev
+	.uleb128	426
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname426:
+	.string		"USERROW1"
+	.section	.debug_info
+	.long		.Lname426
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #427: variable USERROW2
+	.section	.debug_info
+	.uleb128	427	; ref to abbrev 427
+	.section	.debug_abbrev
+	.uleb128	427
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname427:
+	.string		"USERROW2"
+	.section	.debug_info
+	.long		.Lname427
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #428: variable USERROW3
+	.section	.debug_info
+	.uleb128	428	; ref to abbrev 428
+	.section	.debug_abbrev
+	.uleb128	428
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname428:
+	.string		"USERROW3"
+	.section	.debug_info
+	.long		.Lname428
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #429: variable USERROW4
+	.section	.debug_info
+	.uleb128	429	; ref to abbrev 429
+	.section	.debug_abbrev
+	.uleb128	429
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname429:
+	.string		"USERROW4"
+	.section	.debug_info
+	.long		.Lname429
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #430: variable USERROW5
+	.section	.debug_info
+	.uleb128	430	; ref to abbrev 430
+	.section	.debug_abbrev
+	.uleb128	430
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname430:
+	.string		"USERROW5"
+	.section	.debug_info
+	.long		.Lname430
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #431: variable USERROW6
+	.section	.debug_info
+	.uleb128	431	; ref to abbrev 431
+	.section	.debug_abbrev
+	.uleb128	431
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname431:
+	.string		"USERROW6"
+	.section	.debug_info
+	.long		.Lname431
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #432: variable USERROW7
+	.section	.debug_info
+	.uleb128	432	; ref to abbrev 432
+	.section	.debug_abbrev
+	.uleb128	432
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname432:
+	.string		"USERROW7"
+	.section	.debug_info
+	.long		.Lname432
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #433: variable USERROW8
+	.section	.debug_info
+	.uleb128	433	; ref to abbrev 433
+	.section	.debug_abbrev
+	.uleb128	433
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname433:
+	.string		"USERROW8"
+	.section	.debug_info
+	.long		.Lname433
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #434: variable USERROW9
+	.section	.debug_info
+	.uleb128	434	; ref to abbrev 434
+	.section	.debug_abbrev
+	.uleb128	434
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname434:
+	.string		"USERROW9"
+	.section	.debug_info
+	.long		.Lname434
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #435: variable USERROW10
+	.section	.debug_info
+	.uleb128	435	; ref to abbrev 435
+	.section	.debug_abbrev
+	.uleb128	435
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname435:
+	.string		"USERROW10"
+	.section	.debug_info
+	.long		.Lname435
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #436: variable USERROW11
+	.section	.debug_info
+	.uleb128	436	; ref to abbrev 436
+	.section	.debug_abbrev
+	.uleb128	436
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname436:
+	.string		"USERROW11"
+	.section	.debug_info
+	.long		.Lname436
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #437: variable USERROW12
+	.section	.debug_info
+	.uleb128	437	; ref to abbrev 437
+	.section	.debug_abbrev
+	.uleb128	437
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname437:
+	.string		"USERROW12"
+	.section	.debug_info
+	.long		.Lname437
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #438: variable USERROW13
+	.section	.debug_info
+	.uleb128	438	; ref to abbrev 438
+	.section	.debug_abbrev
+	.uleb128	438
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname438:
+	.string		"USERROW13"
+	.section	.debug_info
+	.long		.Lname438
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #439: variable USERROW14
+	.section	.debug_info
+	.uleb128	439	; ref to abbrev 439
+	.section	.debug_abbrev
+	.uleb128	439
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname439:
+	.string		"USERROW14"
+	.section	.debug_info
+	.long		.Lname439
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #440: variable USERROW15
+	.section	.debug_info
+	.uleb128	440	; ref to abbrev 440
+	.section	.debug_abbrev
+	.uleb128	440
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname440:
+	.string		"USERROW15"
+	.section	.debug_info
+	.long		.Lname440
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x0F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #441: variable USERROW16
+	.section	.debug_info
+	.uleb128	441	; ref to abbrev 441
+	.section	.debug_abbrev
+	.uleb128	441
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname441:
+	.string		"USERROW16"
+	.section	.debug_info
+	.long		.Lname441
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #442: variable USERROW17
+	.section	.debug_info
+	.uleb128	442	; ref to abbrev 442
+	.section	.debug_abbrev
+	.uleb128	442
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname442:
+	.string		"USERROW17"
+	.section	.debug_info
+	.long		.Lname442
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #443: variable USERROW18
+	.section	.debug_info
+	.uleb128	443	; ref to abbrev 443
+	.section	.debug_abbrev
+	.uleb128	443
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname443:
+	.string		"USERROW18"
+	.section	.debug_info
+	.long		.Lname443
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #444: variable USERROW19
+	.section	.debug_info
+	.uleb128	444	; ref to abbrev 444
+	.section	.debug_abbrev
+	.uleb128	444
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname444:
+	.string		"USERROW19"
+	.section	.debug_info
+	.long		.Lname444
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #445: variable USERROW20
+	.section	.debug_info
+	.uleb128	445	; ref to abbrev 445
+	.section	.debug_abbrev
+	.uleb128	445
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname445:
+	.string		"USERROW20"
+	.section	.debug_info
+	.long		.Lname445
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #446: variable USERROW21
+	.section	.debug_info
+	.uleb128	446	; ref to abbrev 446
+	.section	.debug_abbrev
+	.uleb128	446
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname446:
+	.string		"USERROW21"
+	.section	.debug_info
+	.long		.Lname446
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #447: variable USERROW22
+	.section	.debug_info
+	.uleb128	447	; ref to abbrev 447
+	.section	.debug_abbrev
+	.uleb128	447
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname447:
+	.string		"USERROW22"
+	.section	.debug_info
+	.long		.Lname447
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #448: variable USERROW23
+	.section	.debug_info
+	.uleb128	448	; ref to abbrev 448
+	.section	.debug_abbrev
+	.uleb128	448
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname448:
+	.string		"USERROW23"
+	.section	.debug_info
+	.long		.Lname448
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #449: variable USERROW24
+	.section	.debug_info
+	.uleb128	449	; ref to abbrev 449
+	.section	.debug_abbrev
+	.uleb128	449
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname449:
+	.string		"USERROW24"
+	.section	.debug_info
+	.long		.Lname449
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #450: variable USERROW25
+	.section	.debug_info
+	.uleb128	450	; ref to abbrev 450
+	.section	.debug_abbrev
+	.uleb128	450
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname450:
+	.string		"USERROW25"
+	.section	.debug_info
+	.long		.Lname450
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x19
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #451: variable USERROW26
+	.section	.debug_info
+	.uleb128	451	; ref to abbrev 451
+	.section	.debug_abbrev
+	.uleb128	451
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname451:
+	.string		"USERROW26"
+	.section	.debug_info
+	.long		.Lname451
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #452: variable USERROW27
+	.section	.debug_info
+	.uleb128	452	; ref to abbrev 452
+	.section	.debug_abbrev
+	.uleb128	452
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname452:
+	.string		"USERROW27"
+	.section	.debug_info
+	.long		.Lname452
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #453: variable USERROW28
+	.section	.debug_info
+	.uleb128	453	; ref to abbrev 453
+	.section	.debug_abbrev
+	.uleb128	453
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname453:
+	.string		"USERROW28"
+	.section	.debug_info
+	.long		.Lname453
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #454: variable USERROW29
+	.section	.debug_info
+	.uleb128	454	; ref to abbrev 454
+	.section	.debug_abbrev
+	.uleb128	454
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname454:
+	.string		"USERROW29"
+	.section	.debug_info
+	.long		.Lname454
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #455: variable USERROW30
+	.section	.debug_info
+	.uleb128	455	; ref to abbrev 455
+	.section	.debug_abbrev
+	.uleb128	455
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname455:
+	.string		"USERROW30"
+	.section	.debug_info
+	.long		.Lname455
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #456: variable USERROW31
+	.section	.debug_info
+	.uleb128	456	; ref to abbrev 456
+	.section	.debug_abbrev
+	.uleb128	456
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname456:
+	.string		"USERROW31"
+	.section	.debug_info
+	.long		.Lname456
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #457: variable USERROW32
+	.section	.debug_info
+	.uleb128	457	; ref to abbrev 457
+	.section	.debug_abbrev
+	.uleb128	457
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname457:
+	.string		"USERROW32"
+	.section	.debug_info
+	.long		.Lname457
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #458: variable USERROW33
+	.section	.debug_info
+	.uleb128	458	; ref to abbrev 458
+	.section	.debug_abbrev
+	.uleb128	458
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname458:
+	.string		"USERROW33"
+	.section	.debug_info
+	.long		.Lname458
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x21
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #459: variable USERROW34
+	.section	.debug_info
+	.uleb128	459	; ref to abbrev 459
+	.section	.debug_abbrev
+	.uleb128	459
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname459:
+	.string		"USERROW34"
+	.section	.debug_info
+	.long		.Lname459
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x22
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #460: variable USERROW35
+	.section	.debug_info
+	.uleb128	460	; ref to abbrev 460
+	.section	.debug_abbrev
+	.uleb128	460
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname460:
+	.string		"USERROW35"
+	.section	.debug_info
+	.long		.Lname460
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x23
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #461: variable USERROW36
+	.section	.debug_info
+	.uleb128	461	; ref to abbrev 461
+	.section	.debug_abbrev
+	.uleb128	461
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname461:
+	.string		"USERROW36"
+	.section	.debug_info
+	.long		.Lname461
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x24
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #462: variable USERROW37
+	.section	.debug_info
+	.uleb128	462	; ref to abbrev 462
+	.section	.debug_abbrev
+	.uleb128	462
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname462:
+	.string		"USERROW37"
+	.section	.debug_info
+	.long		.Lname462
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x25
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #463: variable USERROW38
+	.section	.debug_info
+	.uleb128	463	; ref to abbrev 463
+	.section	.debug_abbrev
+	.uleb128	463
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname463:
+	.string		"USERROW38"
+	.section	.debug_info
+	.long		.Lname463
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x26
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #464: variable USERROW39
+	.section	.debug_info
+	.uleb128	464	; ref to abbrev 464
+	.section	.debug_abbrev
+	.uleb128	464
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname464:
+	.string		"USERROW39"
+	.section	.debug_info
+	.long		.Lname464
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x27
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #465: variable USERROW40
+	.section	.debug_info
+	.uleb128	465	; ref to abbrev 465
+	.section	.debug_abbrev
+	.uleb128	465
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname465:
+	.string		"USERROW40"
+	.section	.debug_info
+	.long		.Lname465
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x28
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #466: variable USERROW41
+	.section	.debug_info
+	.uleb128	466	; ref to abbrev 466
+	.section	.debug_abbrev
+	.uleb128	466
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname466:
+	.string		"USERROW41"
+	.section	.debug_info
+	.long		.Lname466
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x29
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #467: variable USERROW42
+	.section	.debug_info
+	.uleb128	467	; ref to abbrev 467
+	.section	.debug_abbrev
+	.uleb128	467
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname467:
+	.string		"USERROW42"
+	.section	.debug_info
+	.long		.Lname467
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x2A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #468: variable USERROW43
+	.section	.debug_info
+	.uleb128	468	; ref to abbrev 468
+	.section	.debug_abbrev
+	.uleb128	468
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname468:
+	.string		"USERROW43"
+	.section	.debug_info
+	.long		.Lname468
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x2B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #469: variable USERROW44
+	.section	.debug_info
+	.uleb128	469	; ref to abbrev 469
+	.section	.debug_abbrev
+	.uleb128	469
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname469:
+	.string		"USERROW44"
+	.section	.debug_info
+	.long		.Lname469
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x2C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #470: variable USERROW45
+	.section	.debug_info
+	.uleb128	470	; ref to abbrev 470
+	.section	.debug_abbrev
+	.uleb128	470
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname470:
+	.string		"USERROW45"
+	.section	.debug_info
+	.long		.Lname470
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x2D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #471: variable USERROW46
+	.section	.debug_info
+	.uleb128	471	; ref to abbrev 471
+	.section	.debug_abbrev
+	.uleb128	471
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname471:
+	.string		"USERROW46"
+	.section	.debug_info
+	.long		.Lname471
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x2E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #472: variable USERROW47
+	.section	.debug_info
+	.uleb128	472	; ref to abbrev 472
+	.section	.debug_abbrev
+	.uleb128	472
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname472:
+	.string		"USERROW47"
+	.section	.debug_info
+	.long		.Lname472
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x2F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #473: variable USERROW48
+	.section	.debug_info
+	.uleb128	473	; ref to abbrev 473
+	.section	.debug_abbrev
+	.uleb128	473
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname473:
+	.string		"USERROW48"
+	.section	.debug_info
+	.long		.Lname473
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x30
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #474: variable USERROW49
+	.section	.debug_info
+	.uleb128	474	; ref to abbrev 474
+	.section	.debug_abbrev
+	.uleb128	474
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname474:
+	.string		"USERROW49"
+	.section	.debug_info
+	.long		.Lname474
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x31
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #475: variable USERROW50
+	.section	.debug_info
+	.uleb128	475	; ref to abbrev 475
+	.section	.debug_abbrev
+	.uleb128	475
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname475:
+	.string		"USERROW50"
+	.section	.debug_info
+	.long		.Lname475
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x32
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #476: variable USERROW51
+	.section	.debug_info
+	.uleb128	476	; ref to abbrev 476
+	.section	.debug_abbrev
+	.uleb128	476
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname476:
+	.string		"USERROW51"
+	.section	.debug_info
+	.long		.Lname476
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x33
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #477: variable USERROW52
+	.section	.debug_info
+	.uleb128	477	; ref to abbrev 477
+	.section	.debug_abbrev
+	.uleb128	477
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname477:
+	.string		"USERROW52"
+	.section	.debug_info
+	.long		.Lname477
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x34
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #478: variable USERROW53
+	.section	.debug_info
+	.uleb128	478	; ref to abbrev 478
+	.section	.debug_abbrev
+	.uleb128	478
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname478:
+	.string		"USERROW53"
+	.section	.debug_info
+	.long		.Lname478
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x35
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #479: variable USERROW54
+	.section	.debug_info
+	.uleb128	479	; ref to abbrev 479
+	.section	.debug_abbrev
+	.uleb128	479
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname479:
+	.string		"USERROW54"
+	.section	.debug_info
+	.long		.Lname479
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x36
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #480: variable USERROW55
+	.section	.debug_info
+	.uleb128	480	; ref to abbrev 480
+	.section	.debug_abbrev
+	.uleb128	480
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname480:
+	.string		"USERROW55"
+	.section	.debug_info
+	.long		.Lname480
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x37
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #481: variable USERROW56
+	.section	.debug_info
+	.uleb128	481	; ref to abbrev 481
+	.section	.debug_abbrev
+	.uleb128	481
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname481:
+	.string		"USERROW56"
+	.section	.debug_info
+	.long		.Lname481
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x38
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #482: variable USERROW57
+	.section	.debug_info
+	.uleb128	482	; ref to abbrev 482
+	.section	.debug_abbrev
+	.uleb128	482
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname482:
+	.string		"USERROW57"
+	.section	.debug_info
+	.long		.Lname482
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x39
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #483: variable USERROW58
+	.section	.debug_info
+	.uleb128	483	; ref to abbrev 483
+	.section	.debug_abbrev
+	.uleb128	483
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname483:
+	.string		"USERROW58"
+	.section	.debug_info
+	.long		.Lname483
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x3A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #484: variable USERROW59
+	.section	.debug_info
+	.uleb128	484	; ref to abbrev 484
+	.section	.debug_abbrev
+	.uleb128	484
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname484:
+	.string		"USERROW59"
+	.section	.debug_info
+	.long		.Lname484
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x3B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #485: variable USERROW60
+	.section	.debug_info
+	.uleb128	485	; ref to abbrev 485
+	.section	.debug_abbrev
+	.uleb128	485
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname485:
+	.string		"USERROW60"
+	.section	.debug_info
+	.long		.Lname485
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x3C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #486: variable USERROW61
+	.section	.debug_info
+	.uleb128	486	; ref to abbrev 486
+	.section	.debug_abbrev
+	.uleb128	486
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname486:
+	.string		"USERROW61"
+	.section	.debug_info
+	.long		.Lname486
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x3D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #487: variable USERROW62
+	.section	.debug_info
+	.uleb128	487	; ref to abbrev 487
+	.section	.debug_abbrev
+	.uleb128	487
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname487:
+	.string		"USERROW62"
+	.section	.debug_info
+	.long		.Lname487
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x3E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #488: variable USERROW63
+	.section	.debug_info
+	.uleb128	488	; ref to abbrev 488
+	.section	.debug_abbrev
+	.uleb128	488
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname488:
+	.string		"USERROW63"
+	.section	.debug_info
+	.long		.Lname488
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x3F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #489: variable DIR
+	.section	.debug_info
+	.uleb128	489	; ref to abbrev 489
+	.section	.debug_abbrev
+	.uleb128	489
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname489:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname489
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0000 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #490: variable OUT
+	.section	.debug_info
+	.uleb128	490	; ref to abbrev 490
+	.section	.debug_abbrev
+	.uleb128	490
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname490:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname490
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0000 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #491: variable IN
+	.section	.debug_info
+	.uleb128	491	; ref to abbrev 491
+	.section	.debug_abbrev
+	.uleb128	491
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname491:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname491
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0000 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #492: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	492	; ref to abbrev 492
+	.section	.debug_abbrev
+	.uleb128	492
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname492:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname492
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0000 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #493: variable DIR
+	.section	.debug_info
+	.uleb128	493	; ref to abbrev 493
+	.section	.debug_abbrev
+	.uleb128	493
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname493:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname493
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0008 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #494: variable OUT
+	.section	.debug_info
+	.uleb128	494	; ref to abbrev 494
+	.section	.debug_abbrev
+	.uleb128	494
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname494:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname494
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0008 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #495: variable IN
+	.section	.debug_info
+	.uleb128	495	; ref to abbrev 495
+	.section	.debug_abbrev
+	.uleb128	495
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname495:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname495
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0008 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #496: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	496	; ref to abbrev 496
+	.section	.debug_abbrev
+	.uleb128	496
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname496:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname496
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0008 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #497: variable DIR
+	.section	.debug_info
+	.uleb128	497	; ref to abbrev 497
+	.section	.debug_abbrev
+	.uleb128	497
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname497:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname497
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x000C + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #498: variable OUT
+	.section	.debug_info
+	.uleb128	498	; ref to abbrev 498
+	.section	.debug_abbrev
+	.uleb128	498
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname498:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname498
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x000C + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #499: variable IN
+	.section	.debug_info
+	.uleb128	499	; ref to abbrev 499
+	.section	.debug_abbrev
+	.uleb128	499
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname499:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname499
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x000C + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #500: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	500	; ref to abbrev 500
+	.section	.debug_abbrev
+	.uleb128	500
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname500:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname500
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x000C + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #501: variable DIR
+	.section	.debug_info
+	.uleb128	501	; ref to abbrev 501
+	.section	.debug_abbrev
+	.uleb128	501
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname501:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname501
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0014 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #502: variable OUT
+	.section	.debug_info
+	.uleb128	502	; ref to abbrev 502
+	.section	.debug_abbrev
+	.uleb128	502
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname502:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname502
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0014 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #503: variable IN
+	.section	.debug_info
+	.uleb128	503	; ref to abbrev 503
+	.section	.debug_abbrev
+	.uleb128	503
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname503:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname503
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0014 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #504: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	504	; ref to abbrev 504
+	.section	.debug_abbrev
+	.uleb128	504
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname504:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname504
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0014 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #505: variable DAC0REF
+	.section	.debug_info
+	.uleb128	505	; ref to abbrev 505
+	.section	.debug_abbrev
+	.uleb128	505
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname505:
+	.string		"DAC0REF"
+	.section	.debug_info
+	.long		.Lname505
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00B0 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #506: variable ACREF
+	.section	.debug_info
+	.uleb128	506	; ref to abbrev 506
+	.section	.debug_abbrev
+	.uleb128	506
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname506:
+	.string		"ACREF"
+	.section	.debug_info
+	.long		.Lname506
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00B0 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #507: variable CTRLA
+	.section	.debug_info
+	.uleb128	507	; ref to abbrev 507
+	.section	.debug_abbrev
+	.uleb128	507
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname507:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname507
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0100 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #508: variable STATUS
+	.section	.debug_info
+	.uleb128	508	; ref to abbrev 508
+	.section	.debug_abbrev
+	.uleb128	508
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname508:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname508
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0100 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+	;; trailer
+	.section	.debug_abbrev
+	.uleb128	0
+
+	.section	.debug_info
+	.uleb128	0
+.Leinfo:

--- a/crt1/iosym/avr32ea48.S
+++ b/crt1/iosym/avr32ea48.S
@@ -1,0 +1,32722 @@
+/* This file is part of avr-libc.
+
+   Automatically created by devtools/ioreg.pl
+   DO NOT EDIT!
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in
+     the documentation and/or other materials provided with the
+     distribution.
+
+   * Neither the name of the copyright holders nor the names of
+     contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE. */
+
+/* $Id$ */
+
+#include <avr/version.h>
+
+#define DW_TAG_array_type               0x01
+#define DW_TAG_compile_unit             0x11
+#define DW_TAG_typedef                  0x16
+#define DW_TAG_subrange_type            0x21
+#define DW_TAG_base_type                0x24
+#define DW_TAG_variable                 0x34
+
+#define DW_FORM_addr                    0x01
+#define DW_FORM_block1                  0x0a
+#define DW_FORM_block2                  0x03
+#define DW_FORM_block4                  0x04
+#define DW_FORM_data1                   0x0b
+#define DW_FORM_data2                   0x05
+#define DW_FORM_data4                   0x06
+#define DW_FORM_data8                   0x07
+#define DW_FORM_string                  0x08
+#define DW_FORM_flag                    0x0c
+#define DW_FORM_strp                    0x0e
+#define DW_FORM_ref1                    0x11
+#define DW_FORM_ref2                    0x12
+#define DW_FORM_ref4                    0x13
+#define DW_FORM_ref8                    0x14
+
+#define DW_AT_location                  0x02
+#define DW_AT_name                      0x03
+#define DW_AT_byte_size                 0x0b
+#define DW_AT_stmt_list                 0x10
+#define DW_AT_language                  0x13
+#define DW_AT_producer                  0x25
+#define DW_AT_upper_bound               0x2f
+#define DW_AT_decl_file                 0x3a
+#define DW_AT_decl_line                 0x3b
+#define DW_AT_encoding                  0x3e
+#define DW_AT_external                  0x3f
+#define DW_AT_type                      0x49
+
+#define DW_LANG_C89                     0x0001
+
+#define DW_CHILDREN_no                  0x00
+#define DW_CHILDREN_yes                 0x01
+
+#define DW_ATE_unsigned                 0x7
+#define DW_ATE_unsigned_char            0x8
+
+#define DW_OP_addr                      0x03
+.eject
+	.section	.debug_abbrev, "", @progbits
+.Ldebug_abbrev0:
+	.section	.debug_info, "", @progbits
+	.section	.debug_line, "", @progbits
+.Ldebug_line0:
+	.section	.debug_str, "", @progbits
+
+	.section	.debug_info, "", @progbits
+	;; compilation unit header
+.Lssinfo:
+	.long	.Leinfo - .Lsinfo
+.Lsinfo:
+	.word	2		; DWARF-2
+	.long	.Ldebug_abbrev0
+	.byte	4		; sizeof(address)
+
+
+	;; DIE #1: compilation unit
+	.section	.debug_info
+	.uleb128	1	; ref to abbrev 1
+	.section	.debug_abbrev
+	.uleb128	1
+	.uleb128	DW_TAG_compile_unit
+	.byte		DW_CHILDREN_yes
+
+	.uleb128	DW_AT_producer
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lproducer:
+	.ascii		"avr-libc "
+	.asciz		__AVR_LIBC_VERSION_STRING__
+	.section	.debug_info
+	.long		.Lproducer
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_stmt_list
+	.uleb128	DW_FORM_data4
+	.section	.debug_info
+	.long		.Ldebug_line0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+	;; DIE #2: base type uint8_t
+	.section	.debug_info
+.Luint8_t:
+	.uleb128	2	; ref to abbrev 2
+	.section	.debug_abbrev
+	.uleb128	2
+	.uleb128	DW_TAG_base_type
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Luint8_t_name:
+	.string		"uint8_t"
+	.section	.debug_info
+	.long		.Luint8_t_name
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_byte_size
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_encoding
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		DW_ATE_unsigned_char
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+	;; DIE #3: base type uint16_t
+	.section	.debug_info
+.Luint16_t:
+	.uleb128	3	; ref to abbrev 3
+	.section	.debug_abbrev
+	.uleb128	3
+	.uleb128	DW_TAG_base_type
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Luint16_t_name:
+	.string		"uint16_t"
+	.section	.debug_info
+	.long		.Luint16_t_name
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_byte_size
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		2
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_encoding
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		DW_ATE_unsigned
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #4: variable CTRLA
+	.section	.debug_info
+	.uleb128	4	; ref to abbrev 4
+	.section	.debug_abbrev
+	.uleb128	4
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname4:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname4
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #5: variable CTRLB
+	.section	.debug_info
+	.uleb128	5	; ref to abbrev 5
+	.section	.debug_abbrev
+	.uleb128	5
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname5:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname5
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #6: variable MUXCTRL
+	.section	.debug_info
+	.uleb128	6	; ref to abbrev 6
+	.section	.debug_abbrev
+	.uleb128	6
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname6:
+	.string		"MUXCTRL"
+	.section	.debug_info
+	.long		.Lname6
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #7: variable DACREF
+	.section	.debug_info
+	.uleb128	7	; ref to abbrev 7
+	.section	.debug_abbrev
+	.uleb128	7
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname7:
+	.string		"DACREF"
+	.section	.debug_info
+	.long		.Lname7
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #8: variable INTCTRL
+	.section	.debug_info
+	.uleb128	8	; ref to abbrev 8
+	.section	.debug_abbrev
+	.uleb128	8
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname8:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname8
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #9: variable STATUS
+	.section	.debug_info
+	.uleb128	9	; ref to abbrev 9
+	.section	.debug_abbrev
+	.uleb128	9
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname9:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname9
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #10: variable CTRLA
+	.section	.debug_info
+	.uleb128	10	; ref to abbrev 10
+	.section	.debug_abbrev
+	.uleb128	10
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname10:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname10
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #11: variable CTRLB
+	.section	.debug_info
+	.uleb128	11	; ref to abbrev 11
+	.section	.debug_abbrev
+	.uleb128	11
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname11:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname11
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #12: variable MUXCTRL
+	.section	.debug_info
+	.uleb128	12	; ref to abbrev 12
+	.section	.debug_abbrev
+	.uleb128	12
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname12:
+	.string		"MUXCTRL"
+	.section	.debug_info
+	.long		.Lname12
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #13: variable DACREF
+	.section	.debug_info
+	.uleb128	13	; ref to abbrev 13
+	.section	.debug_abbrev
+	.uleb128	13
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname13:
+	.string		"DACREF"
+	.section	.debug_info
+	.long		.Lname13
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #14: variable INTCTRL
+	.section	.debug_info
+	.uleb128	14	; ref to abbrev 14
+	.section	.debug_abbrev
+	.uleb128	14
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname14:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname14
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #15: variable STATUS
+	.section	.debug_info
+	.uleb128	15	; ref to abbrev 15
+	.section	.debug_abbrev
+	.uleb128	15
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname15:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname15
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #16: variable CTRLA
+	.section	.debug_info
+	.uleb128	16	; ref to abbrev 16
+	.section	.debug_abbrev
+	.uleb128	16
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname16:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname16
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #17: variable CTRLB
+	.section	.debug_info
+	.uleb128	17	; ref to abbrev 17
+	.section	.debug_abbrev
+	.uleb128	17
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname17:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname17
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #18: variable CTRLC
+	.section	.debug_info
+	.uleb128	18	; ref to abbrev 18
+	.section	.debug_abbrev
+	.uleb128	18
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname18:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname18
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #19: variable CTRLD
+	.section	.debug_info
+	.uleb128	19	; ref to abbrev 19
+	.section	.debug_abbrev
+	.uleb128	19
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname19:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname19
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #20: variable INTCTRL
+	.section	.debug_info
+	.uleb128	20	; ref to abbrev 20
+	.section	.debug_abbrev
+	.uleb128	20
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname20:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname20
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #21: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	21	; ref to abbrev 21
+	.section	.debug_abbrev
+	.uleb128	21
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname21:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname21
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #22: variable STATUS
+	.section	.debug_info
+	.uleb128	22	; ref to abbrev 22
+	.section	.debug_abbrev
+	.uleb128	22
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname22:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname22
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #23: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	23	; ref to abbrev 23
+	.section	.debug_abbrev
+	.uleb128	23
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname23:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname23
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #24: variable CTRLE
+	.section	.debug_info
+	.uleb128	24	; ref to abbrev 24
+	.section	.debug_abbrev
+	.uleb128	24
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname24:
+	.string		"CTRLE"
+	.section	.debug_info
+	.long		.Lname24
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #25: variable CTRLF
+	.section	.debug_info
+	.uleb128	25	; ref to abbrev 25
+	.section	.debug_abbrev
+	.uleb128	25
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname25:
+	.string		"CTRLF"
+	.section	.debug_info
+	.long		.Lname25
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #26: variable COMMAND
+	.section	.debug_info
+	.uleb128	26	; ref to abbrev 26
+	.section	.debug_abbrev
+	.uleb128	26
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname26:
+	.string		"COMMAND"
+	.section	.debug_info
+	.long		.Lname26
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #27: variable PGACTRL
+	.section	.debug_info
+	.uleb128	27	; ref to abbrev 27
+	.section	.debug_abbrev
+	.uleb128	27
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname27:
+	.string		"PGACTRL"
+	.section	.debug_info
+	.long		.Lname27
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #28: variable MUXPOS
+	.section	.debug_info
+	.uleb128	28	; ref to abbrev 28
+	.section	.debug_abbrev
+	.uleb128	28
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname28:
+	.string		"MUXPOS"
+	.section	.debug_info
+	.long		.Lname28
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #29: variable MUXNEG
+	.section	.debug_info
+	.uleb128	29	; ref to abbrev 29
+	.section	.debug_abbrev
+	.uleb128	29
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname29:
+	.string		"MUXNEG"
+	.section	.debug_info
+	.long		.Lname29
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #30: base type uint32_t
+	.section	.debug_info
+.Luint32_t:
+	.uleb128	30	; ref to abbrev 30
+	.section	.debug_abbrev
+	.uleb128	30
+	.uleb128	DW_TAG_base_type
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Luint32_t_name:
+	.string		"uint32_t"
+	.section	.debug_info
+	.long		.Luint32_t_name
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_byte_size
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		4
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_encoding
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		DW_ATE_unsigned
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #31: variable RESULT
+	.section	.debug_info
+	.uleb128	31	; ref to abbrev 31
+	.section	.debug_abbrev
+	.uleb128	31
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname31:
+	.string		"RESULT"
+	.section	.debug_info
+	.long		.Lname31
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint32_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #32: variable SAMPLE
+	.section	.debug_info
+	.uleb128	32	; ref to abbrev 32
+	.section	.debug_abbrev
+	.uleb128	32
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname32:
+	.string		"SAMPLE"
+	.section	.debug_info
+	.long		.Lname32
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #33: variable TEMP0
+	.section	.debug_info
+	.uleb128	33	; ref to abbrev 33
+	.section	.debug_abbrev
+	.uleb128	33
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname33:
+	.string		"TEMP0"
+	.section	.debug_info
+	.long		.Lname33
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #34: variable TEMP1
+	.section	.debug_info
+	.uleb128	34	; ref to abbrev 34
+	.section	.debug_abbrev
+	.uleb128	34
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname34:
+	.string		"TEMP1"
+	.section	.debug_info
+	.long		.Lname34
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x19
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #35: variable TEMP2
+	.section	.debug_info
+	.uleb128	35	; ref to abbrev 35
+	.section	.debug_abbrev
+	.uleb128	35
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname35:
+	.string		"TEMP2"
+	.section	.debug_info
+	.long		.Lname35
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x1A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #36: variable WINLT
+	.section	.debug_info
+	.uleb128	36	; ref to abbrev 36
+	.section	.debug_abbrev
+	.uleb128	36
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname36:
+	.string		"WINLT"
+	.section	.debug_info
+	.long		.Lname36
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x1C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #37: variable WINHT
+	.section	.debug_info
+	.uleb128	37	; ref to abbrev 37
+	.section	.debug_abbrev
+	.uleb128	37
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname37:
+	.string		"WINHT"
+	.section	.debug_info
+	.long		.Lname37
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x1E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #38: variable CTRLA
+	.section	.debug_info
+	.uleb128	38	; ref to abbrev 38
+	.section	.debug_abbrev
+	.uleb128	38
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname38:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname38
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #39: variable CTRLB
+	.section	.debug_info
+	.uleb128	39	; ref to abbrev 39
+	.section	.debug_abbrev
+	.uleb128	39
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname39:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname39
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #40: variable VLMCTRLA
+	.section	.debug_info
+	.uleb128	40	; ref to abbrev 40
+	.section	.debug_abbrev
+	.uleb128	40
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname40:
+	.string		"VLMCTRLA"
+	.section	.debug_info
+	.long		.Lname40
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #41: variable INTCTRL
+	.section	.debug_info
+	.uleb128	41	; ref to abbrev 41
+	.section	.debug_abbrev
+	.uleb128	41
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname41:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname41
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #42: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	42	; ref to abbrev 42
+	.section	.debug_abbrev
+	.uleb128	42
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname42:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname42
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #43: variable STATUS
+	.section	.debug_info
+	.uleb128	43	; ref to abbrev 43
+	.section	.debug_abbrev
+	.uleb128	43
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname43:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname43
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #44: variable CTRLA
+	.section	.debug_info
+	.uleb128	44	; ref to abbrev 44
+	.section	.debug_abbrev
+	.uleb128	44
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname44:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname44
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #45: variable SEQCTRL0
+	.section	.debug_info
+	.uleb128	45	; ref to abbrev 45
+	.section	.debug_abbrev
+	.uleb128	45
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname45:
+	.string		"SEQCTRL0"
+	.section	.debug_info
+	.long		.Lname45
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #46: variable SEQCTRL1
+	.section	.debug_info
+	.uleb128	46	; ref to abbrev 46
+	.section	.debug_abbrev
+	.uleb128	46
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname46:
+	.string		"SEQCTRL1"
+	.section	.debug_info
+	.long		.Lname46
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #47: variable INTCTRL0
+	.section	.debug_info
+	.uleb128	47	; ref to abbrev 47
+	.section	.debug_abbrev
+	.uleb128	47
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname47:
+	.string		"INTCTRL0"
+	.section	.debug_info
+	.long		.Lname47
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #48: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	48	; ref to abbrev 48
+	.section	.debug_abbrev
+	.uleb128	48
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname48:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname48
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #49: variable LUT0CTRLA
+	.section	.debug_info
+	.uleb128	49	; ref to abbrev 49
+	.section	.debug_abbrev
+	.uleb128	49
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname49:
+	.string		"LUT0CTRLA"
+	.section	.debug_info
+	.long		.Lname49
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #50: variable LUT0CTRLB
+	.section	.debug_info
+	.uleb128	50	; ref to abbrev 50
+	.section	.debug_abbrev
+	.uleb128	50
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname50:
+	.string		"LUT0CTRLB"
+	.section	.debug_info
+	.long		.Lname50
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #51: variable LUT0CTRLC
+	.section	.debug_info
+	.uleb128	51	; ref to abbrev 51
+	.section	.debug_abbrev
+	.uleb128	51
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname51:
+	.string		"LUT0CTRLC"
+	.section	.debug_info
+	.long		.Lname51
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #52: variable TRUTH0
+	.section	.debug_info
+	.uleb128	52	; ref to abbrev 52
+	.section	.debug_abbrev
+	.uleb128	52
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname52:
+	.string		"TRUTH0"
+	.section	.debug_info
+	.long		.Lname52
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #53: variable LUT1CTRLA
+	.section	.debug_info
+	.uleb128	53	; ref to abbrev 53
+	.section	.debug_abbrev
+	.uleb128	53
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname53:
+	.string		"LUT1CTRLA"
+	.section	.debug_info
+	.long		.Lname53
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #54: variable LUT1CTRLB
+	.section	.debug_info
+	.uleb128	54	; ref to abbrev 54
+	.section	.debug_abbrev
+	.uleb128	54
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname54:
+	.string		"LUT1CTRLB"
+	.section	.debug_info
+	.long		.Lname54
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #55: variable LUT1CTRLC
+	.section	.debug_info
+	.uleb128	55	; ref to abbrev 55
+	.section	.debug_abbrev
+	.uleb128	55
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname55:
+	.string		"LUT1CTRLC"
+	.section	.debug_info
+	.long		.Lname55
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #56: variable TRUTH1
+	.section	.debug_info
+	.uleb128	56	; ref to abbrev 56
+	.section	.debug_abbrev
+	.uleb128	56
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname56:
+	.string		"TRUTH1"
+	.section	.debug_info
+	.long		.Lname56
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #57: variable LUT2CTRLA
+	.section	.debug_info
+	.uleb128	57	; ref to abbrev 57
+	.section	.debug_abbrev
+	.uleb128	57
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname57:
+	.string		"LUT2CTRLA"
+	.section	.debug_info
+	.long		.Lname57
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #58: variable LUT2CTRLB
+	.section	.debug_info
+	.uleb128	58	; ref to abbrev 58
+	.section	.debug_abbrev
+	.uleb128	58
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname58:
+	.string		"LUT2CTRLB"
+	.section	.debug_info
+	.long		.Lname58
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #59: variable LUT2CTRLC
+	.section	.debug_info
+	.uleb128	59	; ref to abbrev 59
+	.section	.debug_abbrev
+	.uleb128	59
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname59:
+	.string		"LUT2CTRLC"
+	.section	.debug_info
+	.long		.Lname59
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #60: variable TRUTH2
+	.section	.debug_info
+	.uleb128	60	; ref to abbrev 60
+	.section	.debug_abbrev
+	.uleb128	60
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname60:
+	.string		"TRUTH2"
+	.section	.debug_info
+	.long		.Lname60
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #61: variable LUT3CTRLA
+	.section	.debug_info
+	.uleb128	61	; ref to abbrev 61
+	.section	.debug_abbrev
+	.uleb128	61
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname61:
+	.string		"LUT3CTRLA"
+	.section	.debug_info
+	.long		.Lname61
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #62: variable LUT3CTRLB
+	.section	.debug_info
+	.uleb128	62	; ref to abbrev 62
+	.section	.debug_abbrev
+	.uleb128	62
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname62:
+	.string		"LUT3CTRLB"
+	.section	.debug_info
+	.long		.Lname62
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #63: variable LUT3CTRLC
+	.section	.debug_info
+	.uleb128	63	; ref to abbrev 63
+	.section	.debug_abbrev
+	.uleb128	63
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname63:
+	.string		"LUT3CTRLC"
+	.section	.debug_info
+	.long		.Lname63
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #64: variable TRUTH3
+	.section	.debug_info
+	.uleb128	64	; ref to abbrev 64
+	.section	.debug_abbrev
+	.uleb128	64
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname64:
+	.string		"TRUTH3"
+	.section	.debug_info
+	.long		.Lname64
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #65: variable MCLKCTRLA
+	.section	.debug_info
+	.uleb128	65	; ref to abbrev 65
+	.section	.debug_abbrev
+	.uleb128	65
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname65:
+	.string		"MCLKCTRLA"
+	.section	.debug_info
+	.long		.Lname65
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #66: variable MCLKCTRLB
+	.section	.debug_info
+	.uleb128	66	; ref to abbrev 66
+	.section	.debug_abbrev
+	.uleb128	66
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname66:
+	.string		"MCLKCTRLB"
+	.section	.debug_info
+	.long		.Lname66
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #67: variable MCLKCTRLC
+	.section	.debug_info
+	.uleb128	67	; ref to abbrev 67
+	.section	.debug_abbrev
+	.uleb128	67
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname67:
+	.string		"MCLKCTRLC"
+	.section	.debug_info
+	.long		.Lname67
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #68: variable MCLKINTCTRL
+	.section	.debug_info
+	.uleb128	68	; ref to abbrev 68
+	.section	.debug_abbrev
+	.uleb128	68
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname68:
+	.string		"MCLKINTCTRL"
+	.section	.debug_info
+	.long		.Lname68
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #69: variable MCLKINTFLAGS
+	.section	.debug_info
+	.uleb128	69	; ref to abbrev 69
+	.section	.debug_abbrev
+	.uleb128	69
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname69:
+	.string		"MCLKINTFLAGS"
+	.section	.debug_info
+	.long		.Lname69
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #70: variable MCLKSTATUS
+	.section	.debug_info
+	.uleb128	70	; ref to abbrev 70
+	.section	.debug_abbrev
+	.uleb128	70
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname70:
+	.string		"MCLKSTATUS"
+	.section	.debug_info
+	.long		.Lname70
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #71: variable MCLKTIMEBASE
+	.section	.debug_info
+	.uleb128	71	; ref to abbrev 71
+	.section	.debug_abbrev
+	.uleb128	71
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname71:
+	.string		"MCLKTIMEBASE"
+	.section	.debug_info
+	.long		.Lname71
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #72: variable OSCHFCTRLA
+	.section	.debug_info
+	.uleb128	72	; ref to abbrev 72
+	.section	.debug_abbrev
+	.uleb128	72
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname72:
+	.string		"OSCHFCTRLA"
+	.section	.debug_info
+	.long		.Lname72
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #73: variable OSCHFTUNE
+	.section	.debug_info
+	.uleb128	73	; ref to abbrev 73
+	.section	.debug_abbrev
+	.uleb128	73
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname73:
+	.string		"OSCHFTUNE"
+	.section	.debug_info
+	.long		.Lname73
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #74: variable OSC32KCTRLA
+	.section	.debug_info
+	.uleb128	74	; ref to abbrev 74
+	.section	.debug_abbrev
+	.uleb128	74
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname74:
+	.string		"OSC32KCTRLA"
+	.section	.debug_info
+	.long		.Lname74
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #75: variable XOSC32KCTRLA
+	.section	.debug_info
+	.uleb128	75	; ref to abbrev 75
+	.section	.debug_abbrev
+	.uleb128	75
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname75:
+	.string		"XOSC32KCTRLA"
+	.section	.debug_info
+	.long		.Lname75
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x1C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #76: variable XOSCHFCTRLA
+	.section	.debug_info
+	.uleb128	76	; ref to abbrev 76
+	.section	.debug_abbrev
+	.uleb128	76
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname76:
+	.string		"XOSCHFCTRLA"
+	.section	.debug_info
+	.long		.Lname76
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #77: variable CCP
+	.section	.debug_info
+	.uleb128	77	; ref to abbrev 77
+	.section	.debug_abbrev
+	.uleb128	77
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname77:
+	.string		"CCP"
+	.section	.debug_info
+	.long		.Lname77
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0030 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #78: variable SP
+	.section	.debug_info
+	.uleb128	78	; ref to abbrev 78
+	.section	.debug_abbrev
+	.uleb128	78
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname78:
+	.string		"SP"
+	.section	.debug_info
+	.long		.Lname78
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0030 + 0xD
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #79: variable SREG
+	.section	.debug_info
+	.uleb128	79	; ref to abbrev 79
+	.section	.debug_abbrev
+	.uleb128	79
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname79:
+	.string		"SREG"
+	.section	.debug_info
+	.long		.Lname79
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0030 + 0xF
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #80: variable CTRLA
+	.section	.debug_info
+	.uleb128	80	; ref to abbrev 80
+	.section	.debug_abbrev
+	.uleb128	80
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname80:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname80
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0110 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #81: variable STATUS
+	.section	.debug_info
+	.uleb128	81	; ref to abbrev 81
+	.section	.debug_abbrev
+	.uleb128	81
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname81:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname81
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0110 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #82: variable LVL0PRI
+	.section	.debug_info
+	.uleb128	82	; ref to abbrev 82
+	.section	.debug_abbrev
+	.uleb128	82
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname82:
+	.string		"LVL0PRI"
+	.section	.debug_info
+	.long		.Lname82
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0110 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #83: variable LVL1VEC
+	.section	.debug_info
+	.uleb128	83	; ref to abbrev 83
+	.section	.debug_abbrev
+	.uleb128	83
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname83:
+	.string		"LVL1VEC"
+	.section	.debug_info
+	.long		.Lname83
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0110 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #84: variable CTRLA
+	.section	.debug_info
+	.uleb128	84	; ref to abbrev 84
+	.section	.debug_abbrev
+	.uleb128	84
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname84:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname84
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0120 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #85: variable CTRLB
+	.section	.debug_info
+	.uleb128	85	; ref to abbrev 85
+	.section	.debug_abbrev
+	.uleb128	85
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname85:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname85
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0120 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #86: variable STATUS
+	.section	.debug_info
+	.uleb128	86	; ref to abbrev 86
+	.section	.debug_abbrev
+	.uleb128	86
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname86:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname86
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0120 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #87: variable CTRLA
+	.section	.debug_info
+	.uleb128	87	; ref to abbrev 87
+	.section	.debug_abbrev
+	.uleb128	87
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname87:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname87
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x06A0 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #88: variable DATA
+	.section	.debug_info
+	.uleb128	88	; ref to abbrev 88
+	.section	.debug_abbrev
+	.uleb128	88
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname88:
+	.string		"DATA"
+	.section	.debug_info
+	.long		.Lname88
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x06A0 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #89: variable SWEVENTA
+	.section	.debug_info
+	.uleb128	89	; ref to abbrev 89
+	.section	.debug_abbrev
+	.uleb128	89
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname89:
+	.string		"SWEVENTA"
+	.section	.debug_info
+	.long		.Lname89
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #90: variable CHANNEL0
+	.section	.debug_info
+	.uleb128	90	; ref to abbrev 90
+	.section	.debug_abbrev
+	.uleb128	90
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname90:
+	.string		"CHANNEL0"
+	.section	.debug_info
+	.long		.Lname90
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #91: variable CHANNEL1
+	.section	.debug_info
+	.uleb128	91	; ref to abbrev 91
+	.section	.debug_abbrev
+	.uleb128	91
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname91:
+	.string		"CHANNEL1"
+	.section	.debug_info
+	.long		.Lname91
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #92: variable CHANNEL2
+	.section	.debug_info
+	.uleb128	92	; ref to abbrev 92
+	.section	.debug_abbrev
+	.uleb128	92
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname92:
+	.string		"CHANNEL2"
+	.section	.debug_info
+	.long		.Lname92
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #93: variable CHANNEL3
+	.section	.debug_info
+	.uleb128	93	; ref to abbrev 93
+	.section	.debug_abbrev
+	.uleb128	93
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname93:
+	.string		"CHANNEL3"
+	.section	.debug_info
+	.long		.Lname93
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #94: variable CHANNEL4
+	.section	.debug_info
+	.uleb128	94	; ref to abbrev 94
+	.section	.debug_abbrev
+	.uleb128	94
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname94:
+	.string		"CHANNEL4"
+	.section	.debug_info
+	.long		.Lname94
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #95: variable CHANNEL5
+	.section	.debug_info
+	.uleb128	95	; ref to abbrev 95
+	.section	.debug_abbrev
+	.uleb128	95
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname95:
+	.string		"CHANNEL5"
+	.section	.debug_info
+	.long		.Lname95
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #96: variable USERCCLLUT0A
+	.section	.debug_info
+	.uleb128	96	; ref to abbrev 96
+	.section	.debug_abbrev
+	.uleb128	96
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname96:
+	.string		"USERCCLLUT0A"
+	.section	.debug_info
+	.long		.Lname96
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #97: variable USERCCLLUT0B
+	.section	.debug_info
+	.uleb128	97	; ref to abbrev 97
+	.section	.debug_abbrev
+	.uleb128	97
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname97:
+	.string		"USERCCLLUT0B"
+	.section	.debug_info
+	.long		.Lname97
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x21
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #98: variable USERCCLLUT1A
+	.section	.debug_info
+	.uleb128	98	; ref to abbrev 98
+	.section	.debug_abbrev
+	.uleb128	98
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname98:
+	.string		"USERCCLLUT1A"
+	.section	.debug_info
+	.long		.Lname98
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x22
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #99: variable USERCCLLUT1B
+	.section	.debug_info
+	.uleb128	99	; ref to abbrev 99
+	.section	.debug_abbrev
+	.uleb128	99
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname99:
+	.string		"USERCCLLUT1B"
+	.section	.debug_info
+	.long		.Lname99
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x23
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #100: variable USERCCLLUT2A
+	.section	.debug_info
+	.uleb128	100	; ref to abbrev 100
+	.section	.debug_abbrev
+	.uleb128	100
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname100:
+	.string		"USERCCLLUT2A"
+	.section	.debug_info
+	.long		.Lname100
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x24
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #101: variable USERCCLLUT2B
+	.section	.debug_info
+	.uleb128	101	; ref to abbrev 101
+	.section	.debug_abbrev
+	.uleb128	101
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname101:
+	.string		"USERCCLLUT2B"
+	.section	.debug_info
+	.long		.Lname101
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x25
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #102: variable USERCCLLUT3A
+	.section	.debug_info
+	.uleb128	102	; ref to abbrev 102
+	.section	.debug_abbrev
+	.uleb128	102
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname102:
+	.string		"USERCCLLUT3A"
+	.section	.debug_info
+	.long		.Lname102
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x26
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #103: variable USERCCLLUT3B
+	.section	.debug_info
+	.uleb128	103	; ref to abbrev 103
+	.section	.debug_abbrev
+	.uleb128	103
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname103:
+	.string		"USERCCLLUT3B"
+	.section	.debug_info
+	.long		.Lname103
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x27
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #104: variable USERADC0START
+	.section	.debug_info
+	.uleb128	104	; ref to abbrev 104
+	.section	.debug_abbrev
+	.uleb128	104
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname104:
+	.string		"USERADC0START"
+	.section	.debug_info
+	.long		.Lname104
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x28
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #105: variable USEREVSYSEVOUTA
+	.section	.debug_info
+	.uleb128	105	; ref to abbrev 105
+	.section	.debug_abbrev
+	.uleb128	105
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname105:
+	.string		"USEREVSYSEVOUTA"
+	.section	.debug_info
+	.long		.Lname105
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x29
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #106: variable USEREVSYSEVOUTB
+	.section	.debug_info
+	.uleb128	106	; ref to abbrev 106
+	.section	.debug_abbrev
+	.uleb128	106
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname106:
+	.string		"USEREVSYSEVOUTB"
+	.section	.debug_info
+	.long		.Lname106
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #107: variable USEREVSYSEVOUTC
+	.section	.debug_info
+	.uleb128	107	; ref to abbrev 107
+	.section	.debug_abbrev
+	.uleb128	107
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname107:
+	.string		"USEREVSYSEVOUTC"
+	.section	.debug_info
+	.long		.Lname107
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #108: variable USEREVSYSEVOUTD
+	.section	.debug_info
+	.uleb128	108	; ref to abbrev 108
+	.section	.debug_abbrev
+	.uleb128	108
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname108:
+	.string		"USEREVSYSEVOUTD"
+	.section	.debug_info
+	.long		.Lname108
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #109: variable USEREVSYSEVOUTE
+	.section	.debug_info
+	.uleb128	109	; ref to abbrev 109
+	.section	.debug_abbrev
+	.uleb128	109
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname109:
+	.string		"USEREVSYSEVOUTE"
+	.section	.debug_info
+	.long		.Lname109
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #110: variable USEREVSYSEVOUTF
+	.section	.debug_info
+	.uleb128	110	; ref to abbrev 110
+	.section	.debug_abbrev
+	.uleb128	110
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname110:
+	.string		"USEREVSYSEVOUTF"
+	.section	.debug_info
+	.long		.Lname110
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #111: variable USERUSART0IRDA
+	.section	.debug_info
+	.uleb128	111	; ref to abbrev 111
+	.section	.debug_abbrev
+	.uleb128	111
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname111:
+	.string		"USERUSART0IRDA"
+	.section	.debug_info
+	.long		.Lname111
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #112: variable USERUSART1IRDA
+	.section	.debug_info
+	.uleb128	112	; ref to abbrev 112
+	.section	.debug_abbrev
+	.uleb128	112
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname112:
+	.string		"USERUSART1IRDA"
+	.section	.debug_info
+	.long		.Lname112
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x30
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #113: variable USERUSART2IRDA
+	.section	.debug_info
+	.uleb128	113	; ref to abbrev 113
+	.section	.debug_abbrev
+	.uleb128	113
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname113:
+	.string		"USERUSART2IRDA"
+	.section	.debug_info
+	.long		.Lname113
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x31
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #114: variable USERTCA0CNTA
+	.section	.debug_info
+	.uleb128	114	; ref to abbrev 114
+	.section	.debug_abbrev
+	.uleb128	114
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname114:
+	.string		"USERTCA0CNTA"
+	.section	.debug_info
+	.long		.Lname114
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x32
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #115: variable USERTCA0CNTB
+	.section	.debug_info
+	.uleb128	115	; ref to abbrev 115
+	.section	.debug_abbrev
+	.uleb128	115
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname115:
+	.string		"USERTCA0CNTB"
+	.section	.debug_info
+	.long		.Lname115
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x33
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #116: variable USERTCA1CNTA
+	.section	.debug_info
+	.uleb128	116	; ref to abbrev 116
+	.section	.debug_abbrev
+	.uleb128	116
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname116:
+	.string		"USERTCA1CNTA"
+	.section	.debug_info
+	.long		.Lname116
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x34
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #117: variable USERTCA1CNTB
+	.section	.debug_info
+	.uleb128	117	; ref to abbrev 117
+	.section	.debug_abbrev
+	.uleb128	117
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname117:
+	.string		"USERTCA1CNTB"
+	.section	.debug_info
+	.long		.Lname117
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x35
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #118: variable USERTCB0CAPT
+	.section	.debug_info
+	.uleb128	118	; ref to abbrev 118
+	.section	.debug_abbrev
+	.uleb128	118
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname118:
+	.string		"USERTCB0CAPT"
+	.section	.debug_info
+	.long		.Lname118
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x36
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #119: variable USERTCB0COUNT
+	.section	.debug_info
+	.uleb128	119	; ref to abbrev 119
+	.section	.debug_abbrev
+	.uleb128	119
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname119:
+	.string		"USERTCB0COUNT"
+	.section	.debug_info
+	.long		.Lname119
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x37
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #120: variable USERTCB1CAPT
+	.section	.debug_info
+	.uleb128	120	; ref to abbrev 120
+	.section	.debug_abbrev
+	.uleb128	120
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname120:
+	.string		"USERTCB1CAPT"
+	.section	.debug_info
+	.long		.Lname120
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x38
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #121: variable USERTCB1COUNT
+	.section	.debug_info
+	.uleb128	121	; ref to abbrev 121
+	.section	.debug_abbrev
+	.uleb128	121
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname121:
+	.string		"USERTCB1COUNT"
+	.section	.debug_info
+	.long		.Lname121
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x39
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #122: variable USERTCB2CAPT
+	.section	.debug_info
+	.uleb128	122	; ref to abbrev 122
+	.section	.debug_abbrev
+	.uleb128	122
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname122:
+	.string		"USERTCB2CAPT"
+	.section	.debug_info
+	.long		.Lname122
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x3A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #123: variable USERTCB2COUNT
+	.section	.debug_info
+	.uleb128	123	; ref to abbrev 123
+	.section	.debug_abbrev
+	.uleb128	123
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname123:
+	.string		"USERTCB2COUNT"
+	.section	.debug_info
+	.long		.Lname123
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x3B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #124: variable USERTCB3CAPT
+	.section	.debug_info
+	.uleb128	124	; ref to abbrev 124
+	.section	.debug_abbrev
+	.uleb128	124
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname124:
+	.string		"USERTCB3CAPT"
+	.section	.debug_info
+	.long		.Lname124
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x3C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #125: variable USERTCB3COUNT
+	.section	.debug_info
+	.uleb128	125	; ref to abbrev 125
+	.section	.debug_abbrev
+	.uleb128	125
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname125:
+	.string		"USERTCB3COUNT"
+	.section	.debug_info
+	.long		.Lname125
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x3D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #126: variable WDTCFG
+	.section	.debug_info
+	.uleb128	126	; ref to abbrev 126
+	.section	.debug_abbrev
+	.uleb128	126
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname126:
+	.string		"WDTCFG"
+	.section	.debug_info
+	.long		.Lname126
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #127: variable BODCFG
+	.section	.debug_info
+	.uleb128	127	; ref to abbrev 127
+	.section	.debug_abbrev
+	.uleb128	127
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname127:
+	.string		"BODCFG"
+	.section	.debug_info
+	.long		.Lname127
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #128: variable OSCCFG
+	.section	.debug_info
+	.uleb128	128	; ref to abbrev 128
+	.section	.debug_abbrev
+	.uleb128	128
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname128:
+	.string		"OSCCFG"
+	.section	.debug_info
+	.long		.Lname128
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #129: variable SYSCFG0
+	.section	.debug_info
+	.uleb128	129	; ref to abbrev 129
+	.section	.debug_abbrev
+	.uleb128	129
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname129:
+	.string		"SYSCFG0"
+	.section	.debug_info
+	.long		.Lname129
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #130: variable SYSCFG1
+	.section	.debug_info
+	.uleb128	130	; ref to abbrev 130
+	.section	.debug_abbrev
+	.uleb128	130
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname130:
+	.string		"SYSCFG1"
+	.section	.debug_info
+	.long		.Lname130
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #131: variable CODESIZE
+	.section	.debug_info
+	.uleb128	131	; ref to abbrev 131
+	.section	.debug_abbrev
+	.uleb128	131
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname131:
+	.string		"CODESIZE"
+	.section	.debug_info
+	.long		.Lname131
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #132: variable BOOTSIZE
+	.section	.debug_info
+	.uleb128	132	; ref to abbrev 132
+	.section	.debug_abbrev
+	.uleb128	132
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname132:
+	.string		"BOOTSIZE"
+	.section	.debug_info
+	.long		.Lname132
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #133: variable GPR0
+	.section	.debug_info
+	.uleb128	133	; ref to abbrev 133
+	.section	.debug_abbrev
+	.uleb128	133
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname133:
+	.string		"GPR0"
+	.section	.debug_info
+	.long		.Lname133
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x001C + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #134: variable GPR1
+	.section	.debug_info
+	.uleb128	134	; ref to abbrev 134
+	.section	.debug_abbrev
+	.uleb128	134
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname134:
+	.string		"GPR1"
+	.section	.debug_info
+	.long		.Lname134
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x001C + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #135: variable GPR2
+	.section	.debug_info
+	.uleb128	135	; ref to abbrev 135
+	.section	.debug_abbrev
+	.uleb128	135
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname135:
+	.string		"GPR2"
+	.section	.debug_info
+	.long		.Lname135
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x001C + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #136: variable GPR3
+	.section	.debug_info
+	.uleb128	136	; ref to abbrev 136
+	.section	.debug_abbrev
+	.uleb128	136
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname136:
+	.string		"GPR3"
+	.section	.debug_info
+	.long		.Lname136
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x001C + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #137: variable KEY
+	.section	.debug_info
+	.uleb128	137	; ref to abbrev 137
+	.section	.debug_abbrev
+	.uleb128	137
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname137:
+	.string		"KEY"
+	.section	.debug_info
+	.long		.Lname137
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint32_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1040 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #138: variable CTRLA
+	.section	.debug_info
+	.uleb128	138	; ref to abbrev 138
+	.section	.debug_abbrev
+	.uleb128	138
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname138:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname138
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #139: variable CTRLB
+	.section	.debug_info
+	.uleb128	139	; ref to abbrev 139
+	.section	.debug_abbrev
+	.uleb128	139
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname139:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname139
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #140: variable INTCTRL
+	.section	.debug_info
+	.uleb128	140	; ref to abbrev 140
+	.section	.debug_abbrev
+	.uleb128	140
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname140:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname140
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #141: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	141	; ref to abbrev 141
+	.section	.debug_abbrev
+	.uleb128	141
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname141:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname141
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #142: variable STATUS
+	.section	.debug_info
+	.uleb128	142	; ref to abbrev 142
+	.section	.debug_abbrev
+	.uleb128	142
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname142:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname142
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #143: variable DATA
+	.section	.debug_info
+	.uleb128	143	; ref to abbrev 143
+	.section	.debug_abbrev
+	.uleb128	143
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname143:
+	.string		"DATA"
+	.section	.debug_info
+	.long		.Lname143
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #144: variable ADDR
+	.section	.debug_info
+	.uleb128	144	; ref to abbrev 144
+	.section	.debug_abbrev
+	.uleb128	144
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname144:
+	.string		"ADDR"
+	.section	.debug_info
+	.long		.Lname144
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint32_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #145: variable DIR
+	.section	.debug_info
+	.uleb128	145	; ref to abbrev 145
+	.section	.debug_abbrev
+	.uleb128	145
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname145:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname145
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #146: variable DIRSET
+	.section	.debug_info
+	.uleb128	146	; ref to abbrev 146
+	.section	.debug_abbrev
+	.uleb128	146
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname146:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname146
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #147: variable DIRCLR
+	.section	.debug_info
+	.uleb128	147	; ref to abbrev 147
+	.section	.debug_abbrev
+	.uleb128	147
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname147:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname147
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #148: variable DIRTGL
+	.section	.debug_info
+	.uleb128	148	; ref to abbrev 148
+	.section	.debug_abbrev
+	.uleb128	148
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname148:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname148
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #149: variable OUT
+	.section	.debug_info
+	.uleb128	149	; ref to abbrev 149
+	.section	.debug_abbrev
+	.uleb128	149
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname149:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname149
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #150: variable OUTSET
+	.section	.debug_info
+	.uleb128	150	; ref to abbrev 150
+	.section	.debug_abbrev
+	.uleb128	150
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname150:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname150
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #151: variable OUTCLR
+	.section	.debug_info
+	.uleb128	151	; ref to abbrev 151
+	.section	.debug_abbrev
+	.uleb128	151
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname151:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname151
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #152: variable OUTTGL
+	.section	.debug_info
+	.uleb128	152	; ref to abbrev 152
+	.section	.debug_abbrev
+	.uleb128	152
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname152:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname152
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #153: variable IN
+	.section	.debug_info
+	.uleb128	153	; ref to abbrev 153
+	.section	.debug_abbrev
+	.uleb128	153
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname153:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname153
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #154: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	154	; ref to abbrev 154
+	.section	.debug_abbrev
+	.uleb128	154
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname154:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname154
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #155: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	155	; ref to abbrev 155
+	.section	.debug_abbrev
+	.uleb128	155
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname155:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname155
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #156: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	156	; ref to abbrev 156
+	.section	.debug_abbrev
+	.uleb128	156
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname156:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname156
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #157: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	157	; ref to abbrev 157
+	.section	.debug_abbrev
+	.uleb128	157
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname157:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname157
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #158: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	158	; ref to abbrev 158
+	.section	.debug_abbrev
+	.uleb128	158
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname158:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname158
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #159: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	159	; ref to abbrev 159
+	.section	.debug_abbrev
+	.uleb128	159
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname159:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname159
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #160: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	160	; ref to abbrev 160
+	.section	.debug_abbrev
+	.uleb128	160
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname160:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname160
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #161: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	161	; ref to abbrev 161
+	.section	.debug_abbrev
+	.uleb128	161
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname161:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname161
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #162: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	162	; ref to abbrev 162
+	.section	.debug_abbrev
+	.uleb128	162
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname162:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname162
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #163: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	163	; ref to abbrev 163
+	.section	.debug_abbrev
+	.uleb128	163
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname163:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname163
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #164: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	164	; ref to abbrev 164
+	.section	.debug_abbrev
+	.uleb128	164
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname164:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname164
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #165: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	165	; ref to abbrev 165
+	.section	.debug_abbrev
+	.uleb128	165
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname165:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname165
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #166: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	166	; ref to abbrev 166
+	.section	.debug_abbrev
+	.uleb128	166
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname166:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname166
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #167: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	167	; ref to abbrev 167
+	.section	.debug_abbrev
+	.uleb128	167
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname167:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname167
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #168: variable EVGENCTRL
+	.section	.debug_info
+	.uleb128	168	; ref to abbrev 168
+	.section	.debug_abbrev
+	.uleb128	168
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname168:
+	.string		"EVGENCTRL"
+	.section	.debug_info
+	.long		.Lname168
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #169: variable DIR
+	.section	.debug_info
+	.uleb128	169	; ref to abbrev 169
+	.section	.debug_abbrev
+	.uleb128	169
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname169:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname169
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #170: variable DIRSET
+	.section	.debug_info
+	.uleb128	170	; ref to abbrev 170
+	.section	.debug_abbrev
+	.uleb128	170
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname170:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname170
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #171: variable DIRCLR
+	.section	.debug_info
+	.uleb128	171	; ref to abbrev 171
+	.section	.debug_abbrev
+	.uleb128	171
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname171:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname171
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #172: variable DIRTGL
+	.section	.debug_info
+	.uleb128	172	; ref to abbrev 172
+	.section	.debug_abbrev
+	.uleb128	172
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname172:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname172
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #173: variable OUT
+	.section	.debug_info
+	.uleb128	173	; ref to abbrev 173
+	.section	.debug_abbrev
+	.uleb128	173
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname173:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname173
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #174: variable OUTSET
+	.section	.debug_info
+	.uleb128	174	; ref to abbrev 174
+	.section	.debug_abbrev
+	.uleb128	174
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname174:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname174
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #175: variable OUTCLR
+	.section	.debug_info
+	.uleb128	175	; ref to abbrev 175
+	.section	.debug_abbrev
+	.uleb128	175
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname175:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname175
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #176: variable OUTTGL
+	.section	.debug_info
+	.uleb128	176	; ref to abbrev 176
+	.section	.debug_abbrev
+	.uleb128	176
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname176:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname176
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #177: variable IN
+	.section	.debug_info
+	.uleb128	177	; ref to abbrev 177
+	.section	.debug_abbrev
+	.uleb128	177
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname177:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname177
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #178: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	178	; ref to abbrev 178
+	.section	.debug_abbrev
+	.uleb128	178
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname178:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname178
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #179: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	179	; ref to abbrev 179
+	.section	.debug_abbrev
+	.uleb128	179
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname179:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname179
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #180: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	180	; ref to abbrev 180
+	.section	.debug_abbrev
+	.uleb128	180
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname180:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname180
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #181: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	181	; ref to abbrev 181
+	.section	.debug_abbrev
+	.uleb128	181
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname181:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname181
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #182: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	182	; ref to abbrev 182
+	.section	.debug_abbrev
+	.uleb128	182
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname182:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname182
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #183: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	183	; ref to abbrev 183
+	.section	.debug_abbrev
+	.uleb128	183
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname183:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname183
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #184: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	184	; ref to abbrev 184
+	.section	.debug_abbrev
+	.uleb128	184
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname184:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname184
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #185: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	185	; ref to abbrev 185
+	.section	.debug_abbrev
+	.uleb128	185
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname185:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname185
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #186: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	186	; ref to abbrev 186
+	.section	.debug_abbrev
+	.uleb128	186
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname186:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname186
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #187: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	187	; ref to abbrev 187
+	.section	.debug_abbrev
+	.uleb128	187
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname187:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname187
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #188: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	188	; ref to abbrev 188
+	.section	.debug_abbrev
+	.uleb128	188
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname188:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname188
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #189: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	189	; ref to abbrev 189
+	.section	.debug_abbrev
+	.uleb128	189
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname189:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname189
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #190: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	190	; ref to abbrev 190
+	.section	.debug_abbrev
+	.uleb128	190
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname190:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname190
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #191: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	191	; ref to abbrev 191
+	.section	.debug_abbrev
+	.uleb128	191
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname191:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname191
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #192: variable EVGENCTRL
+	.section	.debug_info
+	.uleb128	192	; ref to abbrev 192
+	.section	.debug_abbrev
+	.uleb128	192
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname192:
+	.string		"EVGENCTRL"
+	.section	.debug_info
+	.long		.Lname192
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #193: variable DIR
+	.section	.debug_info
+	.uleb128	193	; ref to abbrev 193
+	.section	.debug_abbrev
+	.uleb128	193
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname193:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname193
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #194: variable DIRSET
+	.section	.debug_info
+	.uleb128	194	; ref to abbrev 194
+	.section	.debug_abbrev
+	.uleb128	194
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname194:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname194
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #195: variable DIRCLR
+	.section	.debug_info
+	.uleb128	195	; ref to abbrev 195
+	.section	.debug_abbrev
+	.uleb128	195
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname195:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname195
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #196: variable DIRTGL
+	.section	.debug_info
+	.uleb128	196	; ref to abbrev 196
+	.section	.debug_abbrev
+	.uleb128	196
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname196:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname196
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #197: variable OUT
+	.section	.debug_info
+	.uleb128	197	; ref to abbrev 197
+	.section	.debug_abbrev
+	.uleb128	197
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname197:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname197
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #198: variable OUTSET
+	.section	.debug_info
+	.uleb128	198	; ref to abbrev 198
+	.section	.debug_abbrev
+	.uleb128	198
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname198:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname198
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #199: variable OUTCLR
+	.section	.debug_info
+	.uleb128	199	; ref to abbrev 199
+	.section	.debug_abbrev
+	.uleb128	199
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname199:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname199
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #200: variable OUTTGL
+	.section	.debug_info
+	.uleb128	200	; ref to abbrev 200
+	.section	.debug_abbrev
+	.uleb128	200
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname200:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname200
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #201: variable IN
+	.section	.debug_info
+	.uleb128	201	; ref to abbrev 201
+	.section	.debug_abbrev
+	.uleb128	201
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname201:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname201
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #202: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	202	; ref to abbrev 202
+	.section	.debug_abbrev
+	.uleb128	202
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname202:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname202
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #203: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	203	; ref to abbrev 203
+	.section	.debug_abbrev
+	.uleb128	203
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname203:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname203
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #204: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	204	; ref to abbrev 204
+	.section	.debug_abbrev
+	.uleb128	204
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname204:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname204
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #205: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	205	; ref to abbrev 205
+	.section	.debug_abbrev
+	.uleb128	205
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname205:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname205
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #206: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	206	; ref to abbrev 206
+	.section	.debug_abbrev
+	.uleb128	206
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname206:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname206
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #207: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	207	; ref to abbrev 207
+	.section	.debug_abbrev
+	.uleb128	207
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname207:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname207
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #208: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	208	; ref to abbrev 208
+	.section	.debug_abbrev
+	.uleb128	208
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname208:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname208
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #209: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	209	; ref to abbrev 209
+	.section	.debug_abbrev
+	.uleb128	209
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname209:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname209
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #210: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	210	; ref to abbrev 210
+	.section	.debug_abbrev
+	.uleb128	210
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname210:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname210
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #211: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	211	; ref to abbrev 211
+	.section	.debug_abbrev
+	.uleb128	211
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname211:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname211
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #212: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	212	; ref to abbrev 212
+	.section	.debug_abbrev
+	.uleb128	212
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname212:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname212
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #213: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	213	; ref to abbrev 213
+	.section	.debug_abbrev
+	.uleb128	213
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname213:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname213
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #214: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	214	; ref to abbrev 214
+	.section	.debug_abbrev
+	.uleb128	214
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname214:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname214
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #215: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	215	; ref to abbrev 215
+	.section	.debug_abbrev
+	.uleb128	215
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname215:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname215
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #216: variable EVGENCTRL
+	.section	.debug_info
+	.uleb128	216	; ref to abbrev 216
+	.section	.debug_abbrev
+	.uleb128	216
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname216:
+	.string		"EVGENCTRL"
+	.section	.debug_info
+	.long		.Lname216
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #217: variable DIR
+	.section	.debug_info
+	.uleb128	217	; ref to abbrev 217
+	.section	.debug_abbrev
+	.uleb128	217
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname217:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname217
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #218: variable DIRSET
+	.section	.debug_info
+	.uleb128	218	; ref to abbrev 218
+	.section	.debug_abbrev
+	.uleb128	218
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname218:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname218
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #219: variable DIRCLR
+	.section	.debug_info
+	.uleb128	219	; ref to abbrev 219
+	.section	.debug_abbrev
+	.uleb128	219
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname219:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname219
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #220: variable DIRTGL
+	.section	.debug_info
+	.uleb128	220	; ref to abbrev 220
+	.section	.debug_abbrev
+	.uleb128	220
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname220:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname220
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #221: variable OUT
+	.section	.debug_info
+	.uleb128	221	; ref to abbrev 221
+	.section	.debug_abbrev
+	.uleb128	221
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname221:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname221
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #222: variable OUTSET
+	.section	.debug_info
+	.uleb128	222	; ref to abbrev 222
+	.section	.debug_abbrev
+	.uleb128	222
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname222:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname222
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #223: variable OUTCLR
+	.section	.debug_info
+	.uleb128	223	; ref to abbrev 223
+	.section	.debug_abbrev
+	.uleb128	223
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname223:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname223
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #224: variable OUTTGL
+	.section	.debug_info
+	.uleb128	224	; ref to abbrev 224
+	.section	.debug_abbrev
+	.uleb128	224
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname224:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname224
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #225: variable IN
+	.section	.debug_info
+	.uleb128	225	; ref to abbrev 225
+	.section	.debug_abbrev
+	.uleb128	225
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname225:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname225
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #226: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	226	; ref to abbrev 226
+	.section	.debug_abbrev
+	.uleb128	226
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname226:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname226
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #227: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	227	; ref to abbrev 227
+	.section	.debug_abbrev
+	.uleb128	227
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname227:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname227
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #228: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	228	; ref to abbrev 228
+	.section	.debug_abbrev
+	.uleb128	228
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname228:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname228
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #229: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	229	; ref to abbrev 229
+	.section	.debug_abbrev
+	.uleb128	229
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname229:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname229
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #230: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	230	; ref to abbrev 230
+	.section	.debug_abbrev
+	.uleb128	230
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname230:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname230
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #231: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	231	; ref to abbrev 231
+	.section	.debug_abbrev
+	.uleb128	231
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname231:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname231
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #232: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	232	; ref to abbrev 232
+	.section	.debug_abbrev
+	.uleb128	232
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname232:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname232
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #233: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	233	; ref to abbrev 233
+	.section	.debug_abbrev
+	.uleb128	233
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname233:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname233
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #234: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	234	; ref to abbrev 234
+	.section	.debug_abbrev
+	.uleb128	234
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname234:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname234
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #235: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	235	; ref to abbrev 235
+	.section	.debug_abbrev
+	.uleb128	235
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname235:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname235
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #236: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	236	; ref to abbrev 236
+	.section	.debug_abbrev
+	.uleb128	236
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname236:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname236
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #237: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	237	; ref to abbrev 237
+	.section	.debug_abbrev
+	.uleb128	237
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname237:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname237
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #238: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	238	; ref to abbrev 238
+	.section	.debug_abbrev
+	.uleb128	238
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname238:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname238
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #239: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	239	; ref to abbrev 239
+	.section	.debug_abbrev
+	.uleb128	239
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname239:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname239
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #240: variable EVGENCTRL
+	.section	.debug_info
+	.uleb128	240	; ref to abbrev 240
+	.section	.debug_abbrev
+	.uleb128	240
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname240:
+	.string		"EVGENCTRL"
+	.section	.debug_info
+	.long		.Lname240
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #241: variable DIR
+	.section	.debug_info
+	.uleb128	241	; ref to abbrev 241
+	.section	.debug_abbrev
+	.uleb128	241
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname241:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname241
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #242: variable DIRSET
+	.section	.debug_info
+	.uleb128	242	; ref to abbrev 242
+	.section	.debug_abbrev
+	.uleb128	242
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname242:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname242
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #243: variable DIRCLR
+	.section	.debug_info
+	.uleb128	243	; ref to abbrev 243
+	.section	.debug_abbrev
+	.uleb128	243
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname243:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname243
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #244: variable DIRTGL
+	.section	.debug_info
+	.uleb128	244	; ref to abbrev 244
+	.section	.debug_abbrev
+	.uleb128	244
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname244:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname244
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #245: variable OUT
+	.section	.debug_info
+	.uleb128	245	; ref to abbrev 245
+	.section	.debug_abbrev
+	.uleb128	245
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname245:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname245
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #246: variable OUTSET
+	.section	.debug_info
+	.uleb128	246	; ref to abbrev 246
+	.section	.debug_abbrev
+	.uleb128	246
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname246:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname246
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #247: variable OUTCLR
+	.section	.debug_info
+	.uleb128	247	; ref to abbrev 247
+	.section	.debug_abbrev
+	.uleb128	247
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname247:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname247
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #248: variable OUTTGL
+	.section	.debug_info
+	.uleb128	248	; ref to abbrev 248
+	.section	.debug_abbrev
+	.uleb128	248
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname248:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname248
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #249: variable IN
+	.section	.debug_info
+	.uleb128	249	; ref to abbrev 249
+	.section	.debug_abbrev
+	.uleb128	249
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname249:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname249
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #250: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	250	; ref to abbrev 250
+	.section	.debug_abbrev
+	.uleb128	250
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname250:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname250
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #251: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	251	; ref to abbrev 251
+	.section	.debug_abbrev
+	.uleb128	251
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname251:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname251
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #252: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	252	; ref to abbrev 252
+	.section	.debug_abbrev
+	.uleb128	252
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname252:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname252
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #253: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	253	; ref to abbrev 253
+	.section	.debug_abbrev
+	.uleb128	253
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname253:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname253
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #254: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	254	; ref to abbrev 254
+	.section	.debug_abbrev
+	.uleb128	254
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname254:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname254
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #255: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	255	; ref to abbrev 255
+	.section	.debug_abbrev
+	.uleb128	255
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname255:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname255
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #256: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	256	; ref to abbrev 256
+	.section	.debug_abbrev
+	.uleb128	256
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname256:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname256
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #257: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	257	; ref to abbrev 257
+	.section	.debug_abbrev
+	.uleb128	257
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname257:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname257
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #258: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	258	; ref to abbrev 258
+	.section	.debug_abbrev
+	.uleb128	258
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname258:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname258
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #259: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	259	; ref to abbrev 259
+	.section	.debug_abbrev
+	.uleb128	259
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname259:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname259
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #260: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	260	; ref to abbrev 260
+	.section	.debug_abbrev
+	.uleb128	260
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname260:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname260
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #261: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	261	; ref to abbrev 261
+	.section	.debug_abbrev
+	.uleb128	261
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname261:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname261
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #262: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	262	; ref to abbrev 262
+	.section	.debug_abbrev
+	.uleb128	262
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname262:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname262
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #263: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	263	; ref to abbrev 263
+	.section	.debug_abbrev
+	.uleb128	263
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname263:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname263
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #264: variable EVGENCTRL
+	.section	.debug_info
+	.uleb128	264	; ref to abbrev 264
+	.section	.debug_abbrev
+	.uleb128	264
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname264:
+	.string		"EVGENCTRL"
+	.section	.debug_info
+	.long		.Lname264
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #265: variable DIR
+	.section	.debug_info
+	.uleb128	265	; ref to abbrev 265
+	.section	.debug_abbrev
+	.uleb128	265
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname265:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname265
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #266: variable DIRSET
+	.section	.debug_info
+	.uleb128	266	; ref to abbrev 266
+	.section	.debug_abbrev
+	.uleb128	266
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname266:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname266
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #267: variable DIRCLR
+	.section	.debug_info
+	.uleb128	267	; ref to abbrev 267
+	.section	.debug_abbrev
+	.uleb128	267
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname267:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname267
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #268: variable DIRTGL
+	.section	.debug_info
+	.uleb128	268	; ref to abbrev 268
+	.section	.debug_abbrev
+	.uleb128	268
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname268:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname268
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #269: variable OUT
+	.section	.debug_info
+	.uleb128	269	; ref to abbrev 269
+	.section	.debug_abbrev
+	.uleb128	269
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname269:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname269
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #270: variable OUTSET
+	.section	.debug_info
+	.uleb128	270	; ref to abbrev 270
+	.section	.debug_abbrev
+	.uleb128	270
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname270:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname270
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #271: variable OUTCLR
+	.section	.debug_info
+	.uleb128	271	; ref to abbrev 271
+	.section	.debug_abbrev
+	.uleb128	271
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname271:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname271
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #272: variable OUTTGL
+	.section	.debug_info
+	.uleb128	272	; ref to abbrev 272
+	.section	.debug_abbrev
+	.uleb128	272
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname272:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname272
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #273: variable IN
+	.section	.debug_info
+	.uleb128	273	; ref to abbrev 273
+	.section	.debug_abbrev
+	.uleb128	273
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname273:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname273
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #274: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	274	; ref to abbrev 274
+	.section	.debug_abbrev
+	.uleb128	274
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname274:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname274
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #275: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	275	; ref to abbrev 275
+	.section	.debug_abbrev
+	.uleb128	275
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname275:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname275
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #276: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	276	; ref to abbrev 276
+	.section	.debug_abbrev
+	.uleb128	276
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname276:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname276
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #277: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	277	; ref to abbrev 277
+	.section	.debug_abbrev
+	.uleb128	277
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname277:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname277
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #278: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	278	; ref to abbrev 278
+	.section	.debug_abbrev
+	.uleb128	278
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname278:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname278
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #279: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	279	; ref to abbrev 279
+	.section	.debug_abbrev
+	.uleb128	279
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname279:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname279
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #280: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	280	; ref to abbrev 280
+	.section	.debug_abbrev
+	.uleb128	280
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname280:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname280
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #281: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	281	; ref to abbrev 281
+	.section	.debug_abbrev
+	.uleb128	281
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname281:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname281
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #282: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	282	; ref to abbrev 282
+	.section	.debug_abbrev
+	.uleb128	282
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname282:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname282
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #283: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	283	; ref to abbrev 283
+	.section	.debug_abbrev
+	.uleb128	283
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname283:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname283
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #284: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	284	; ref to abbrev 284
+	.section	.debug_abbrev
+	.uleb128	284
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname284:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname284
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #285: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	285	; ref to abbrev 285
+	.section	.debug_abbrev
+	.uleb128	285
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname285:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname285
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #286: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	286	; ref to abbrev 286
+	.section	.debug_abbrev
+	.uleb128	286
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname286:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname286
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #287: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	287	; ref to abbrev 287
+	.section	.debug_abbrev
+	.uleb128	287
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname287:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname287
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #288: variable EVGENCTRL
+	.section	.debug_info
+	.uleb128	288	; ref to abbrev 288
+	.section	.debug_abbrev
+	.uleb128	288
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname288:
+	.string		"EVGENCTRL"
+	.section	.debug_info
+	.long		.Lname288
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #289: variable EVSYSROUTEA
+	.section	.debug_info
+	.uleb128	289	; ref to abbrev 289
+	.section	.debug_abbrev
+	.uleb128	289
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname289:
+	.string		"EVSYSROUTEA"
+	.section	.debug_info
+	.long		.Lname289
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #290: variable CCLROUTEA
+	.section	.debug_info
+	.uleb128	290	; ref to abbrev 290
+	.section	.debug_abbrev
+	.uleb128	290
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname290:
+	.string		"CCLROUTEA"
+	.section	.debug_info
+	.long		.Lname290
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #291: variable USARTROUTEA
+	.section	.debug_info
+	.uleb128	291	; ref to abbrev 291
+	.section	.debug_abbrev
+	.uleb128	291
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname291:
+	.string		"USARTROUTEA"
+	.section	.debug_info
+	.long		.Lname291
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #292: variable USARTROUTEB
+	.section	.debug_info
+	.uleb128	292	; ref to abbrev 292
+	.section	.debug_abbrev
+	.uleb128	292
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname292:
+	.string		"USARTROUTEB"
+	.section	.debug_info
+	.long		.Lname292
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #293: variable SPIROUTEA
+	.section	.debug_info
+	.uleb128	293	; ref to abbrev 293
+	.section	.debug_abbrev
+	.uleb128	293
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname293:
+	.string		"SPIROUTEA"
+	.section	.debug_info
+	.long		.Lname293
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #294: variable TWIROUTEA
+	.section	.debug_info
+	.uleb128	294	; ref to abbrev 294
+	.section	.debug_abbrev
+	.uleb128	294
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname294:
+	.string		"TWIROUTEA"
+	.section	.debug_info
+	.long		.Lname294
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #295: variable TCAROUTEA
+	.section	.debug_info
+	.uleb128	295	; ref to abbrev 295
+	.section	.debug_abbrev
+	.uleb128	295
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname295:
+	.string		"TCAROUTEA"
+	.section	.debug_info
+	.long		.Lname295
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #296: variable TCBROUTEA
+	.section	.debug_info
+	.uleb128	296	; ref to abbrev 296
+	.section	.debug_abbrev
+	.uleb128	296
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname296:
+	.string		"TCBROUTEA"
+	.section	.debug_info
+	.long		.Lname296
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #297: variable ACROUTEA
+	.section	.debug_info
+	.uleb128	297	; ref to abbrev 297
+	.section	.debug_abbrev
+	.uleb128	297
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname297:
+	.string		"ACROUTEA"
+	.section	.debug_info
+	.long		.Lname297
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #298: variable RSTFR
+	.section	.debug_info
+	.uleb128	298	; ref to abbrev 298
+	.section	.debug_abbrev
+	.uleb128	298
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname298:
+	.string		"RSTFR"
+	.section	.debug_info
+	.long		.Lname298
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0040 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #299: variable SWRR
+	.section	.debug_info
+	.uleb128	299	; ref to abbrev 299
+	.section	.debug_abbrev
+	.uleb128	299
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname299:
+	.string		"SWRR"
+	.section	.debug_info
+	.long		.Lname299
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0040 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #300: variable CTRLA
+	.section	.debug_info
+	.uleb128	300	; ref to abbrev 300
+	.section	.debug_abbrev
+	.uleb128	300
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname300:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname300
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #301: variable STATUS
+	.section	.debug_info
+	.uleb128	301	; ref to abbrev 301
+	.section	.debug_abbrev
+	.uleb128	301
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname301:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname301
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #302: variable INTCTRL
+	.section	.debug_info
+	.uleb128	302	; ref to abbrev 302
+	.section	.debug_abbrev
+	.uleb128	302
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname302:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname302
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #303: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	303	; ref to abbrev 303
+	.section	.debug_abbrev
+	.uleb128	303
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname303:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname303
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #304: variable TEMP
+	.section	.debug_info
+	.uleb128	304	; ref to abbrev 304
+	.section	.debug_abbrev
+	.uleb128	304
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname304:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname304
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #305: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	305	; ref to abbrev 305
+	.section	.debug_abbrev
+	.uleb128	305
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname305:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname305
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #306: variable CALIB
+	.section	.debug_info
+	.uleb128	306	; ref to abbrev 306
+	.section	.debug_abbrev
+	.uleb128	306
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname306:
+	.string		"CALIB"
+	.section	.debug_info
+	.long		.Lname306
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #307: variable CLKSEL
+	.section	.debug_info
+	.uleb128	307	; ref to abbrev 307
+	.section	.debug_abbrev
+	.uleb128	307
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname307:
+	.string		"CLKSEL"
+	.section	.debug_info
+	.long		.Lname307
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #308: variable CNT
+	.section	.debug_info
+	.uleb128	308	; ref to abbrev 308
+	.section	.debug_abbrev
+	.uleb128	308
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname308:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname308
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #309: variable PER
+	.section	.debug_info
+	.uleb128	309	; ref to abbrev 309
+	.section	.debug_abbrev
+	.uleb128	309
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname309:
+	.string		"PER"
+	.section	.debug_info
+	.long		.Lname309
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #310: variable CMP
+	.section	.debug_info
+	.uleb128	310	; ref to abbrev 310
+	.section	.debug_abbrev
+	.uleb128	310
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname310:
+	.string		"CMP"
+	.section	.debug_info
+	.long		.Lname310
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #311: variable PITCTRLA
+	.section	.debug_info
+	.uleb128	311	; ref to abbrev 311
+	.section	.debug_abbrev
+	.uleb128	311
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname311:
+	.string		"PITCTRLA"
+	.section	.debug_info
+	.long		.Lname311
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #312: variable PITSTATUS
+	.section	.debug_info
+	.uleb128	312	; ref to abbrev 312
+	.section	.debug_abbrev
+	.uleb128	312
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname312:
+	.string		"PITSTATUS"
+	.section	.debug_info
+	.long		.Lname312
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #313: variable PITINTCTRL
+	.section	.debug_info
+	.uleb128	313	; ref to abbrev 313
+	.section	.debug_abbrev
+	.uleb128	313
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname313:
+	.string		"PITINTCTRL"
+	.section	.debug_info
+	.long		.Lname313
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #314: variable PITINTFLAGS
+	.section	.debug_info
+	.uleb128	314	; ref to abbrev 314
+	.section	.debug_abbrev
+	.uleb128	314
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname314:
+	.string		"PITINTFLAGS"
+	.section	.debug_info
+	.long		.Lname314
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #315: variable PITDBGCTRL
+	.section	.debug_info
+	.uleb128	315	; ref to abbrev 315
+	.section	.debug_abbrev
+	.uleb128	315
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname315:
+	.string		"PITDBGCTRL"
+	.section	.debug_info
+	.long		.Lname315
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #316: variable PITEVGENCTRLA
+	.section	.debug_info
+	.uleb128	316	; ref to abbrev 316
+	.section	.debug_abbrev
+	.uleb128	316
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname316:
+	.string		"PITEVGENCTRLA"
+	.section	.debug_info
+	.long		.Lname316
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #317: variable DEVICEID0
+	.section	.debug_info
+	.uleb128	317	; ref to abbrev 317
+	.section	.debug_abbrev
+	.uleb128	317
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname317:
+	.string		"DEVICEID0"
+	.section	.debug_info
+	.long		.Lname317
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #318: variable DEVICEID1
+	.section	.debug_info
+	.uleb128	318	; ref to abbrev 318
+	.section	.debug_abbrev
+	.uleb128	318
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname318:
+	.string		"DEVICEID1"
+	.section	.debug_info
+	.long		.Lname318
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #319: variable DEVICEID2
+	.section	.debug_info
+	.uleb128	319	; ref to abbrev 319
+	.section	.debug_abbrev
+	.uleb128	319
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname319:
+	.string		"DEVICEID2"
+	.section	.debug_info
+	.long		.Lname319
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #320: variable TEMPSENSE0
+	.section	.debug_info
+	.uleb128	320	; ref to abbrev 320
+	.section	.debug_abbrev
+	.uleb128	320
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname320:
+	.string		"TEMPSENSE0"
+	.section	.debug_info
+	.long		.Lname320
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #321: variable TEMPSENSE1
+	.section	.debug_info
+	.uleb128	321	; ref to abbrev 321
+	.section	.debug_abbrev
+	.uleb128	321
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname321:
+	.string		"TEMPSENSE1"
+	.section	.debug_info
+	.long		.Lname321
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #322: variable SERNUM0
+	.section	.debug_info
+	.uleb128	322	; ref to abbrev 322
+	.section	.debug_abbrev
+	.uleb128	322
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname322:
+	.string		"SERNUM0"
+	.section	.debug_info
+	.long		.Lname322
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #323: variable SERNUM1
+	.section	.debug_info
+	.uleb128	323	; ref to abbrev 323
+	.section	.debug_abbrev
+	.uleb128	323
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname323:
+	.string		"SERNUM1"
+	.section	.debug_info
+	.long		.Lname323
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #324: variable SERNUM2
+	.section	.debug_info
+	.uleb128	324	; ref to abbrev 324
+	.section	.debug_abbrev
+	.uleb128	324
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname324:
+	.string		"SERNUM2"
+	.section	.debug_info
+	.long		.Lname324
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #325: variable SERNUM3
+	.section	.debug_info
+	.uleb128	325	; ref to abbrev 325
+	.section	.debug_abbrev
+	.uleb128	325
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname325:
+	.string		"SERNUM3"
+	.section	.debug_info
+	.long		.Lname325
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #326: variable SERNUM4
+	.section	.debug_info
+	.uleb128	326	; ref to abbrev 326
+	.section	.debug_abbrev
+	.uleb128	326
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname326:
+	.string		"SERNUM4"
+	.section	.debug_info
+	.long		.Lname326
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #327: variable SERNUM5
+	.section	.debug_info
+	.uleb128	327	; ref to abbrev 327
+	.section	.debug_abbrev
+	.uleb128	327
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname327:
+	.string		"SERNUM5"
+	.section	.debug_info
+	.long		.Lname327
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #328: variable SERNUM6
+	.section	.debug_info
+	.uleb128	328	; ref to abbrev 328
+	.section	.debug_abbrev
+	.uleb128	328
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname328:
+	.string		"SERNUM6"
+	.section	.debug_info
+	.long		.Lname328
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #329: variable SERNUM7
+	.section	.debug_info
+	.uleb128	329	; ref to abbrev 329
+	.section	.debug_abbrev
+	.uleb128	329
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname329:
+	.string		"SERNUM7"
+	.section	.debug_info
+	.long		.Lname329
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #330: variable SERNUM8
+	.section	.debug_info
+	.uleb128	330	; ref to abbrev 330
+	.section	.debug_abbrev
+	.uleb128	330
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname330:
+	.string		"SERNUM8"
+	.section	.debug_info
+	.long		.Lname330
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #331: variable SERNUM9
+	.section	.debug_info
+	.uleb128	331	; ref to abbrev 331
+	.section	.debug_abbrev
+	.uleb128	331
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname331:
+	.string		"SERNUM9"
+	.section	.debug_info
+	.long		.Lname331
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x19
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #332: variable SERNUM10
+	.section	.debug_info
+	.uleb128	332	; ref to abbrev 332
+	.section	.debug_abbrev
+	.uleb128	332
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname332:
+	.string		"SERNUM10"
+	.section	.debug_info
+	.long		.Lname332
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x1A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #333: variable SERNUM11
+	.section	.debug_info
+	.uleb128	333	; ref to abbrev 333
+	.section	.debug_abbrev
+	.uleb128	333
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname333:
+	.string		"SERNUM11"
+	.section	.debug_info
+	.long		.Lname333
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x1B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #334: variable SERNUM12
+	.section	.debug_info
+	.uleb128	334	; ref to abbrev 334
+	.section	.debug_abbrev
+	.uleb128	334
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname334:
+	.string		"SERNUM12"
+	.section	.debug_info
+	.long		.Lname334
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x1C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #335: variable SERNUM13
+	.section	.debug_info
+	.uleb128	335	; ref to abbrev 335
+	.section	.debug_abbrev
+	.uleb128	335
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname335:
+	.string		"SERNUM13"
+	.section	.debug_info
+	.long		.Lname335
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x1D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #336: variable SERNUM14
+	.section	.debug_info
+	.uleb128	336	; ref to abbrev 336
+	.section	.debug_abbrev
+	.uleb128	336
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname336:
+	.string		"SERNUM14"
+	.section	.debug_info
+	.long		.Lname336
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x1E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #337: variable SERNUM15
+	.section	.debug_info
+	.uleb128	337	; ref to abbrev 337
+	.section	.debug_abbrev
+	.uleb128	337
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname337:
+	.string		"SERNUM15"
+	.section	.debug_info
+	.long		.Lname337
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x1F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #338: variable CTRLA
+	.section	.debug_info
+	.uleb128	338	; ref to abbrev 338
+	.section	.debug_abbrev
+	.uleb128	338
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname338:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname338
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0050 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #339: variable CTRLA
+	.section	.debug_info
+	.uleb128	339	; ref to abbrev 339
+	.section	.debug_abbrev
+	.uleb128	339
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname339:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname339
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #340: variable CTRLB
+	.section	.debug_info
+	.uleb128	340	; ref to abbrev 340
+	.section	.debug_abbrev
+	.uleb128	340
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname340:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname340
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #341: variable INTCTRL
+	.section	.debug_info
+	.uleb128	341	; ref to abbrev 341
+	.section	.debug_abbrev
+	.uleb128	341
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname341:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname341
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #342: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	342	; ref to abbrev 342
+	.section	.debug_abbrev
+	.uleb128	342
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname342:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname342
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #343: variable DATA
+	.section	.debug_info
+	.uleb128	343	; ref to abbrev 343
+	.section	.debug_abbrev
+	.uleb128	343
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname343:
+	.string		"DATA"
+	.section	.debug_info
+	.long		.Lname343
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #344: variable REVID
+	.section	.debug_info
+	.uleb128	344	; ref to abbrev 344
+	.section	.debug_abbrev
+	.uleb128	344
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname344:
+	.string		"REVID"
+	.section	.debug_info
+	.long		.Lname344
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0F00 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #345: variable OCDMCTRL
+	.section	.debug_info
+	.uleb128	345	; ref to abbrev 345
+	.section	.debug_abbrev
+	.uleb128	345
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname345:
+	.string		"OCDMCTRL"
+	.section	.debug_info
+	.long		.Lname345
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0F00 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #346: variable OCDMSTATUS
+	.section	.debug_info
+	.uleb128	346	; ref to abbrev 346
+	.section	.debug_abbrev
+	.uleb128	346
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname346:
+	.string		"OCDMSTATUS"
+	.section	.debug_info
+	.long		.Lname346
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0F00 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #347: variable CTRLA
+	.section	.debug_info
+	.uleb128	347	; ref to abbrev 347
+	.section	.debug_abbrev
+	.uleb128	347
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname347:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname347
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #348: variable CTRLB
+	.section	.debug_info
+	.uleb128	348	; ref to abbrev 348
+	.section	.debug_abbrev
+	.uleb128	348
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname348:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname348
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #349: variable CTRLC
+	.section	.debug_info
+	.uleb128	349	; ref to abbrev 349
+	.section	.debug_abbrev
+	.uleb128	349
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname349:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname349
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #350: variable CTRLD
+	.section	.debug_info
+	.uleb128	350	; ref to abbrev 350
+	.section	.debug_abbrev
+	.uleb128	350
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname350:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname350
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #351: variable CTRLECLR
+	.section	.debug_info
+	.uleb128	351	; ref to abbrev 351
+	.section	.debug_abbrev
+	.uleb128	351
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname351:
+	.string		"CTRLECLR"
+	.section	.debug_info
+	.long		.Lname351
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #352: variable CTRLESET
+	.section	.debug_info
+	.uleb128	352	; ref to abbrev 352
+	.section	.debug_abbrev
+	.uleb128	352
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname352:
+	.string		"CTRLESET"
+	.section	.debug_info
+	.long		.Lname352
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #353: variable CTRLFCLR
+	.section	.debug_info
+	.uleb128	353	; ref to abbrev 353
+	.section	.debug_abbrev
+	.uleb128	353
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname353:
+	.string		"CTRLFCLR"
+	.section	.debug_info
+	.long		.Lname353
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #354: variable CTRLFSET
+	.section	.debug_info
+	.uleb128	354	; ref to abbrev 354
+	.section	.debug_abbrev
+	.uleb128	354
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname354:
+	.string		"CTRLFSET"
+	.section	.debug_info
+	.long		.Lname354
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #355: variable EVCTRL
+	.section	.debug_info
+	.uleb128	355	; ref to abbrev 355
+	.section	.debug_abbrev
+	.uleb128	355
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname355:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname355
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #356: variable INTCTRL
+	.section	.debug_info
+	.uleb128	356	; ref to abbrev 356
+	.section	.debug_abbrev
+	.uleb128	356
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname356:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname356
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #357: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	357	; ref to abbrev 357
+	.section	.debug_abbrev
+	.uleb128	357
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname357:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname357
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #358: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	358	; ref to abbrev 358
+	.section	.debug_abbrev
+	.uleb128	358
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname358:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname358
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #359: variable TEMP
+	.section	.debug_info
+	.uleb128	359	; ref to abbrev 359
+	.section	.debug_abbrev
+	.uleb128	359
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname359:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname359
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #360: variable CNT
+	.section	.debug_info
+	.uleb128	360	; ref to abbrev 360
+	.section	.debug_abbrev
+	.uleb128	360
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname360:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname360
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #361: variable PER
+	.section	.debug_info
+	.uleb128	361	; ref to abbrev 361
+	.section	.debug_abbrev
+	.uleb128	361
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname361:
+	.string		"PER"
+	.section	.debug_info
+	.long		.Lname361
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x26
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #362: variable CMP0
+	.section	.debug_info
+	.uleb128	362	; ref to abbrev 362
+	.section	.debug_abbrev
+	.uleb128	362
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname362:
+	.string		"CMP0"
+	.section	.debug_info
+	.long		.Lname362
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x28
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #363: variable CMP1
+	.section	.debug_info
+	.uleb128	363	; ref to abbrev 363
+	.section	.debug_abbrev
+	.uleb128	363
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname363:
+	.string		"CMP1"
+	.section	.debug_info
+	.long		.Lname363
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #364: variable CMP2
+	.section	.debug_info
+	.uleb128	364	; ref to abbrev 364
+	.section	.debug_abbrev
+	.uleb128	364
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname364:
+	.string		"CMP2"
+	.section	.debug_info
+	.long		.Lname364
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #365: variable PERBUF
+	.section	.debug_info
+	.uleb128	365	; ref to abbrev 365
+	.section	.debug_abbrev
+	.uleb128	365
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname365:
+	.string		"PERBUF"
+	.section	.debug_info
+	.long		.Lname365
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x36
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #366: variable CMP0BUF
+	.section	.debug_info
+	.uleb128	366	; ref to abbrev 366
+	.section	.debug_abbrev
+	.uleb128	366
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname366:
+	.string		"CMP0BUF"
+	.section	.debug_info
+	.long		.Lname366
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x38
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #367: variable CMP1BUF
+	.section	.debug_info
+	.uleb128	367	; ref to abbrev 367
+	.section	.debug_abbrev
+	.uleb128	367
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname367:
+	.string		"CMP1BUF"
+	.section	.debug_info
+	.long		.Lname367
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x3A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #368: variable CMP2BUF
+	.section	.debug_info
+	.uleb128	368	; ref to abbrev 368
+	.section	.debug_abbrev
+	.uleb128	368
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname368:
+	.string		"CMP2BUF"
+	.section	.debug_info
+	.long		.Lname368
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x3C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #369: variable CTRLA
+	.section	.debug_info
+	.uleb128	369	; ref to abbrev 369
+	.section	.debug_abbrev
+	.uleb128	369
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname369:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname369
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #370: variable CTRLB
+	.section	.debug_info
+	.uleb128	370	; ref to abbrev 370
+	.section	.debug_abbrev
+	.uleb128	370
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname370:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname370
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #371: variable CTRLC
+	.section	.debug_info
+	.uleb128	371	; ref to abbrev 371
+	.section	.debug_abbrev
+	.uleb128	371
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname371:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname371
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #372: variable CTRLD
+	.section	.debug_info
+	.uleb128	372	; ref to abbrev 372
+	.section	.debug_abbrev
+	.uleb128	372
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname372:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname372
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #373: variable CTRLECLR
+	.section	.debug_info
+	.uleb128	373	; ref to abbrev 373
+	.section	.debug_abbrev
+	.uleb128	373
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname373:
+	.string		"CTRLECLR"
+	.section	.debug_info
+	.long		.Lname373
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #374: variable CTRLESET
+	.section	.debug_info
+	.uleb128	374	; ref to abbrev 374
+	.section	.debug_abbrev
+	.uleb128	374
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname374:
+	.string		"CTRLESET"
+	.section	.debug_info
+	.long		.Lname374
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #375: variable INTCTRL
+	.section	.debug_info
+	.uleb128	375	; ref to abbrev 375
+	.section	.debug_abbrev
+	.uleb128	375
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname375:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname375
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #376: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	376	; ref to abbrev 376
+	.section	.debug_abbrev
+	.uleb128	376
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname376:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname376
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #377: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	377	; ref to abbrev 377
+	.section	.debug_abbrev
+	.uleb128	377
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname377:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname377
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #378: variable LCNT
+	.section	.debug_info
+	.uleb128	378	; ref to abbrev 378
+	.section	.debug_abbrev
+	.uleb128	378
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname378:
+	.string		"LCNT"
+	.section	.debug_info
+	.long		.Lname378
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #379: variable HCNT
+	.section	.debug_info
+	.uleb128	379	; ref to abbrev 379
+	.section	.debug_abbrev
+	.uleb128	379
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname379:
+	.string		"HCNT"
+	.section	.debug_info
+	.long		.Lname379
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x21
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #380: variable LPER
+	.section	.debug_info
+	.uleb128	380	; ref to abbrev 380
+	.section	.debug_abbrev
+	.uleb128	380
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname380:
+	.string		"LPER"
+	.section	.debug_info
+	.long		.Lname380
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x26
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #381: variable HPER
+	.section	.debug_info
+	.uleb128	381	; ref to abbrev 381
+	.section	.debug_abbrev
+	.uleb128	381
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname381:
+	.string		"HPER"
+	.section	.debug_info
+	.long		.Lname381
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x27
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #382: variable LCMP0
+	.section	.debug_info
+	.uleb128	382	; ref to abbrev 382
+	.section	.debug_abbrev
+	.uleb128	382
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname382:
+	.string		"LCMP0"
+	.section	.debug_info
+	.long		.Lname382
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x28
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #383: variable HCMP0
+	.section	.debug_info
+	.uleb128	383	; ref to abbrev 383
+	.section	.debug_abbrev
+	.uleb128	383
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname383:
+	.string		"HCMP0"
+	.section	.debug_info
+	.long		.Lname383
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x29
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #384: variable LCMP1
+	.section	.debug_info
+	.uleb128	384	; ref to abbrev 384
+	.section	.debug_abbrev
+	.uleb128	384
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname384:
+	.string		"LCMP1"
+	.section	.debug_info
+	.long		.Lname384
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #385: variable HCMP1
+	.section	.debug_info
+	.uleb128	385	; ref to abbrev 385
+	.section	.debug_abbrev
+	.uleb128	385
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname385:
+	.string		"HCMP1"
+	.section	.debug_info
+	.long		.Lname385
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #386: variable LCMP2
+	.section	.debug_info
+	.uleb128	386	; ref to abbrev 386
+	.section	.debug_abbrev
+	.uleb128	386
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname386:
+	.string		"LCMP2"
+	.section	.debug_info
+	.long		.Lname386
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #387: variable HCMP2
+	.section	.debug_info
+	.uleb128	387	; ref to abbrev 387
+	.section	.debug_abbrev
+	.uleb128	387
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname387:
+	.string		"HCMP2"
+	.section	.debug_info
+	.long		.Lname387
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #388: variable CTRLA
+	.section	.debug_info
+	.uleb128	388	; ref to abbrev 388
+	.section	.debug_abbrev
+	.uleb128	388
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname388:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname388
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #389: variable CTRLB
+	.section	.debug_info
+	.uleb128	389	; ref to abbrev 389
+	.section	.debug_abbrev
+	.uleb128	389
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname389:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname389
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #390: variable CTRLC
+	.section	.debug_info
+	.uleb128	390	; ref to abbrev 390
+	.section	.debug_abbrev
+	.uleb128	390
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname390:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname390
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #391: variable CTRLD
+	.section	.debug_info
+	.uleb128	391	; ref to abbrev 391
+	.section	.debug_abbrev
+	.uleb128	391
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname391:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname391
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #392: variable CTRLECLR
+	.section	.debug_info
+	.uleb128	392	; ref to abbrev 392
+	.section	.debug_abbrev
+	.uleb128	392
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname392:
+	.string		"CTRLECLR"
+	.section	.debug_info
+	.long		.Lname392
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #393: variable CTRLESET
+	.section	.debug_info
+	.uleb128	393	; ref to abbrev 393
+	.section	.debug_abbrev
+	.uleb128	393
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname393:
+	.string		"CTRLESET"
+	.section	.debug_info
+	.long		.Lname393
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #394: variable CTRLFCLR
+	.section	.debug_info
+	.uleb128	394	; ref to abbrev 394
+	.section	.debug_abbrev
+	.uleb128	394
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname394:
+	.string		"CTRLFCLR"
+	.section	.debug_info
+	.long		.Lname394
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #395: variable CTRLFSET
+	.section	.debug_info
+	.uleb128	395	; ref to abbrev 395
+	.section	.debug_abbrev
+	.uleb128	395
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname395:
+	.string		"CTRLFSET"
+	.section	.debug_info
+	.long		.Lname395
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #396: variable EVCTRL
+	.section	.debug_info
+	.uleb128	396	; ref to abbrev 396
+	.section	.debug_abbrev
+	.uleb128	396
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname396:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname396
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #397: variable INTCTRL
+	.section	.debug_info
+	.uleb128	397	; ref to abbrev 397
+	.section	.debug_abbrev
+	.uleb128	397
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname397:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname397
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #398: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	398	; ref to abbrev 398
+	.section	.debug_abbrev
+	.uleb128	398
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname398:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname398
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #399: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	399	; ref to abbrev 399
+	.section	.debug_abbrev
+	.uleb128	399
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname399:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname399
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #400: variable TEMP
+	.section	.debug_info
+	.uleb128	400	; ref to abbrev 400
+	.section	.debug_abbrev
+	.uleb128	400
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname400:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname400
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x0F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #401: variable CNT
+	.section	.debug_info
+	.uleb128	401	; ref to abbrev 401
+	.section	.debug_abbrev
+	.uleb128	401
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname401:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname401
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #402: variable PER
+	.section	.debug_info
+	.uleb128	402	; ref to abbrev 402
+	.section	.debug_abbrev
+	.uleb128	402
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname402:
+	.string		"PER"
+	.section	.debug_info
+	.long		.Lname402
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x26
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #403: variable CMP0
+	.section	.debug_info
+	.uleb128	403	; ref to abbrev 403
+	.section	.debug_abbrev
+	.uleb128	403
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname403:
+	.string		"CMP0"
+	.section	.debug_info
+	.long		.Lname403
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x28
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #404: variable CMP1
+	.section	.debug_info
+	.uleb128	404	; ref to abbrev 404
+	.section	.debug_abbrev
+	.uleb128	404
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname404:
+	.string		"CMP1"
+	.section	.debug_info
+	.long		.Lname404
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x2A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #405: variable CMP2
+	.section	.debug_info
+	.uleb128	405	; ref to abbrev 405
+	.section	.debug_abbrev
+	.uleb128	405
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname405:
+	.string		"CMP2"
+	.section	.debug_info
+	.long		.Lname405
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x2C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #406: variable PERBUF
+	.section	.debug_info
+	.uleb128	406	; ref to abbrev 406
+	.section	.debug_abbrev
+	.uleb128	406
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname406:
+	.string		"PERBUF"
+	.section	.debug_info
+	.long		.Lname406
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x36
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #407: variable CMP0BUF
+	.section	.debug_info
+	.uleb128	407	; ref to abbrev 407
+	.section	.debug_abbrev
+	.uleb128	407
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname407:
+	.string		"CMP0BUF"
+	.section	.debug_info
+	.long		.Lname407
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x38
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #408: variable CMP1BUF
+	.section	.debug_info
+	.uleb128	408	; ref to abbrev 408
+	.section	.debug_abbrev
+	.uleb128	408
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname408:
+	.string		"CMP1BUF"
+	.section	.debug_info
+	.long		.Lname408
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x3A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #409: variable CMP2BUF
+	.section	.debug_info
+	.uleb128	409	; ref to abbrev 409
+	.section	.debug_abbrev
+	.uleb128	409
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname409:
+	.string		"CMP2BUF"
+	.section	.debug_info
+	.long		.Lname409
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x3C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #410: variable CTRLA
+	.section	.debug_info
+	.uleb128	410	; ref to abbrev 410
+	.section	.debug_abbrev
+	.uleb128	410
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname410:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname410
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #411: variable CTRLB
+	.section	.debug_info
+	.uleb128	411	; ref to abbrev 411
+	.section	.debug_abbrev
+	.uleb128	411
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname411:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname411
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #412: variable CTRLC
+	.section	.debug_info
+	.uleb128	412	; ref to abbrev 412
+	.section	.debug_abbrev
+	.uleb128	412
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname412:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname412
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #413: variable CTRLD
+	.section	.debug_info
+	.uleb128	413	; ref to abbrev 413
+	.section	.debug_abbrev
+	.uleb128	413
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname413:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname413
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #414: variable CTRLECLR
+	.section	.debug_info
+	.uleb128	414	; ref to abbrev 414
+	.section	.debug_abbrev
+	.uleb128	414
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname414:
+	.string		"CTRLECLR"
+	.section	.debug_info
+	.long		.Lname414
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #415: variable CTRLESET
+	.section	.debug_info
+	.uleb128	415	; ref to abbrev 415
+	.section	.debug_abbrev
+	.uleb128	415
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname415:
+	.string		"CTRLESET"
+	.section	.debug_info
+	.long		.Lname415
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #416: variable INTCTRL
+	.section	.debug_info
+	.uleb128	416	; ref to abbrev 416
+	.section	.debug_abbrev
+	.uleb128	416
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname416:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname416
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #417: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	417	; ref to abbrev 417
+	.section	.debug_abbrev
+	.uleb128	417
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname417:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname417
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #418: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	418	; ref to abbrev 418
+	.section	.debug_abbrev
+	.uleb128	418
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname418:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname418
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #419: variable LCNT
+	.section	.debug_info
+	.uleb128	419	; ref to abbrev 419
+	.section	.debug_abbrev
+	.uleb128	419
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname419:
+	.string		"LCNT"
+	.section	.debug_info
+	.long		.Lname419
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #420: variable HCNT
+	.section	.debug_info
+	.uleb128	420	; ref to abbrev 420
+	.section	.debug_abbrev
+	.uleb128	420
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname420:
+	.string		"HCNT"
+	.section	.debug_info
+	.long		.Lname420
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x21
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #421: variable LPER
+	.section	.debug_info
+	.uleb128	421	; ref to abbrev 421
+	.section	.debug_abbrev
+	.uleb128	421
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname421:
+	.string		"LPER"
+	.section	.debug_info
+	.long		.Lname421
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x26
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #422: variable HPER
+	.section	.debug_info
+	.uleb128	422	; ref to abbrev 422
+	.section	.debug_abbrev
+	.uleb128	422
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname422:
+	.string		"HPER"
+	.section	.debug_info
+	.long		.Lname422
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x27
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #423: variable LCMP0
+	.section	.debug_info
+	.uleb128	423	; ref to abbrev 423
+	.section	.debug_abbrev
+	.uleb128	423
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname423:
+	.string		"LCMP0"
+	.section	.debug_info
+	.long		.Lname423
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x28
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #424: variable HCMP0
+	.section	.debug_info
+	.uleb128	424	; ref to abbrev 424
+	.section	.debug_abbrev
+	.uleb128	424
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname424:
+	.string		"HCMP0"
+	.section	.debug_info
+	.long		.Lname424
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x29
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #425: variable LCMP1
+	.section	.debug_info
+	.uleb128	425	; ref to abbrev 425
+	.section	.debug_abbrev
+	.uleb128	425
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname425:
+	.string		"LCMP1"
+	.section	.debug_info
+	.long		.Lname425
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x2A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #426: variable HCMP1
+	.section	.debug_info
+	.uleb128	426	; ref to abbrev 426
+	.section	.debug_abbrev
+	.uleb128	426
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname426:
+	.string		"HCMP1"
+	.section	.debug_info
+	.long		.Lname426
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x2B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #427: variable LCMP2
+	.section	.debug_info
+	.uleb128	427	; ref to abbrev 427
+	.section	.debug_abbrev
+	.uleb128	427
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname427:
+	.string		"LCMP2"
+	.section	.debug_info
+	.long		.Lname427
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x2C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #428: variable HCMP2
+	.section	.debug_info
+	.uleb128	428	; ref to abbrev 428
+	.section	.debug_abbrev
+	.uleb128	428
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname428:
+	.string		"HCMP2"
+	.section	.debug_info
+	.long		.Lname428
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x2D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #429: variable CTRLA
+	.section	.debug_info
+	.uleb128	429	; ref to abbrev 429
+	.section	.debug_abbrev
+	.uleb128	429
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname429:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname429
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #430: variable CTRLB
+	.section	.debug_info
+	.uleb128	430	; ref to abbrev 430
+	.section	.debug_abbrev
+	.uleb128	430
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname430:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname430
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #431: variable EVCTRL
+	.section	.debug_info
+	.uleb128	431	; ref to abbrev 431
+	.section	.debug_abbrev
+	.uleb128	431
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname431:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname431
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #432: variable INTCTRL
+	.section	.debug_info
+	.uleb128	432	; ref to abbrev 432
+	.section	.debug_abbrev
+	.uleb128	432
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname432:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname432
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #433: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	433	; ref to abbrev 433
+	.section	.debug_abbrev
+	.uleb128	433
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname433:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname433
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #434: variable STATUS
+	.section	.debug_info
+	.uleb128	434	; ref to abbrev 434
+	.section	.debug_abbrev
+	.uleb128	434
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname434:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname434
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #435: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	435	; ref to abbrev 435
+	.section	.debug_abbrev
+	.uleb128	435
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname435:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname435
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #436: variable TEMP
+	.section	.debug_info
+	.uleb128	436	; ref to abbrev 436
+	.section	.debug_abbrev
+	.uleb128	436
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname436:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname436
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #437: variable CNT
+	.section	.debug_info
+	.uleb128	437	; ref to abbrev 437
+	.section	.debug_abbrev
+	.uleb128	437
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname437:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname437
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #438: variable CCMP
+	.section	.debug_info
+	.uleb128	438	; ref to abbrev 438
+	.section	.debug_abbrev
+	.uleb128	438
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname438:
+	.string		"CCMP"
+	.section	.debug_info
+	.long		.Lname438
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #439: variable CTRLA
+	.section	.debug_info
+	.uleb128	439	; ref to abbrev 439
+	.section	.debug_abbrev
+	.uleb128	439
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname439:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname439
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #440: variable CTRLB
+	.section	.debug_info
+	.uleb128	440	; ref to abbrev 440
+	.section	.debug_abbrev
+	.uleb128	440
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname440:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname440
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #441: variable EVCTRL
+	.section	.debug_info
+	.uleb128	441	; ref to abbrev 441
+	.section	.debug_abbrev
+	.uleb128	441
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname441:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname441
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #442: variable INTCTRL
+	.section	.debug_info
+	.uleb128	442	; ref to abbrev 442
+	.section	.debug_abbrev
+	.uleb128	442
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname442:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname442
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #443: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	443	; ref to abbrev 443
+	.section	.debug_abbrev
+	.uleb128	443
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname443:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname443
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #444: variable STATUS
+	.section	.debug_info
+	.uleb128	444	; ref to abbrev 444
+	.section	.debug_abbrev
+	.uleb128	444
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname444:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname444
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #445: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	445	; ref to abbrev 445
+	.section	.debug_abbrev
+	.uleb128	445
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname445:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname445
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #446: variable TEMP
+	.section	.debug_info
+	.uleb128	446	; ref to abbrev 446
+	.section	.debug_abbrev
+	.uleb128	446
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname446:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname446
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #447: variable CNT
+	.section	.debug_info
+	.uleb128	447	; ref to abbrev 447
+	.section	.debug_abbrev
+	.uleb128	447
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname447:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname447
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #448: variable CCMP
+	.section	.debug_info
+	.uleb128	448	; ref to abbrev 448
+	.section	.debug_abbrev
+	.uleb128	448
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname448:
+	.string		"CCMP"
+	.section	.debug_info
+	.long		.Lname448
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #449: variable CTRLA
+	.section	.debug_info
+	.uleb128	449	; ref to abbrev 449
+	.section	.debug_abbrev
+	.uleb128	449
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname449:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname449
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #450: variable CTRLB
+	.section	.debug_info
+	.uleb128	450	; ref to abbrev 450
+	.section	.debug_abbrev
+	.uleb128	450
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname450:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname450
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #451: variable EVCTRL
+	.section	.debug_info
+	.uleb128	451	; ref to abbrev 451
+	.section	.debug_abbrev
+	.uleb128	451
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname451:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname451
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #452: variable INTCTRL
+	.section	.debug_info
+	.uleb128	452	; ref to abbrev 452
+	.section	.debug_abbrev
+	.uleb128	452
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname452:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname452
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #453: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	453	; ref to abbrev 453
+	.section	.debug_abbrev
+	.uleb128	453
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname453:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname453
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #454: variable STATUS
+	.section	.debug_info
+	.uleb128	454	; ref to abbrev 454
+	.section	.debug_abbrev
+	.uleb128	454
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname454:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname454
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #455: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	455	; ref to abbrev 455
+	.section	.debug_abbrev
+	.uleb128	455
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname455:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname455
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #456: variable TEMP
+	.section	.debug_info
+	.uleb128	456	; ref to abbrev 456
+	.section	.debug_abbrev
+	.uleb128	456
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname456:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname456
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #457: variable CNT
+	.section	.debug_info
+	.uleb128	457	; ref to abbrev 457
+	.section	.debug_abbrev
+	.uleb128	457
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname457:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname457
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #458: variable CCMP
+	.section	.debug_info
+	.uleb128	458	; ref to abbrev 458
+	.section	.debug_abbrev
+	.uleb128	458
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname458:
+	.string		"CCMP"
+	.section	.debug_info
+	.long		.Lname458
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #459: variable CTRLA
+	.section	.debug_info
+	.uleb128	459	; ref to abbrev 459
+	.section	.debug_abbrev
+	.uleb128	459
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname459:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname459
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B30 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #460: variable CTRLB
+	.section	.debug_info
+	.uleb128	460	; ref to abbrev 460
+	.section	.debug_abbrev
+	.uleb128	460
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname460:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname460
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B30 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #461: variable EVCTRL
+	.section	.debug_info
+	.uleb128	461	; ref to abbrev 461
+	.section	.debug_abbrev
+	.uleb128	461
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname461:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname461
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B30 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #462: variable INTCTRL
+	.section	.debug_info
+	.uleb128	462	; ref to abbrev 462
+	.section	.debug_abbrev
+	.uleb128	462
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname462:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname462
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B30 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #463: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	463	; ref to abbrev 463
+	.section	.debug_abbrev
+	.uleb128	463
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname463:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname463
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B30 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #464: variable STATUS
+	.section	.debug_info
+	.uleb128	464	; ref to abbrev 464
+	.section	.debug_abbrev
+	.uleb128	464
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname464:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname464
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B30 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #465: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	465	; ref to abbrev 465
+	.section	.debug_abbrev
+	.uleb128	465
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname465:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname465
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B30 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #466: variable TEMP
+	.section	.debug_info
+	.uleb128	466	; ref to abbrev 466
+	.section	.debug_abbrev
+	.uleb128	466
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname466:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname466
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B30 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #467: variable CNT
+	.section	.debug_info
+	.uleb128	467	; ref to abbrev 467
+	.section	.debug_abbrev
+	.uleb128	467
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname467:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname467
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B30 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #468: variable CCMP
+	.section	.debug_info
+	.uleb128	468	; ref to abbrev 468
+	.section	.debug_abbrev
+	.uleb128	468
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname468:
+	.string		"CCMP"
+	.section	.debug_info
+	.long		.Lname468
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B30 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #469: variable CTRLA
+	.section	.debug_info
+	.uleb128	469	; ref to abbrev 469
+	.section	.debug_abbrev
+	.uleb128	469
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname469:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname469
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #470: variable DUALCTRL
+	.section	.debug_info
+	.uleb128	470	; ref to abbrev 470
+	.section	.debug_abbrev
+	.uleb128	470
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname470:
+	.string		"DUALCTRL"
+	.section	.debug_info
+	.long		.Lname470
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #471: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	471	; ref to abbrev 471
+	.section	.debug_abbrev
+	.uleb128	471
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname471:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname471
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #472: variable MCTRLA
+	.section	.debug_info
+	.uleb128	472	; ref to abbrev 472
+	.section	.debug_abbrev
+	.uleb128	472
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname472:
+	.string		"MCTRLA"
+	.section	.debug_info
+	.long		.Lname472
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #473: variable MCTRLB
+	.section	.debug_info
+	.uleb128	473	; ref to abbrev 473
+	.section	.debug_abbrev
+	.uleb128	473
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname473:
+	.string		"MCTRLB"
+	.section	.debug_info
+	.long		.Lname473
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #474: variable MSTATUS
+	.section	.debug_info
+	.uleb128	474	; ref to abbrev 474
+	.section	.debug_abbrev
+	.uleb128	474
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname474:
+	.string		"MSTATUS"
+	.section	.debug_info
+	.long		.Lname474
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #475: variable MBAUD
+	.section	.debug_info
+	.uleb128	475	; ref to abbrev 475
+	.section	.debug_abbrev
+	.uleb128	475
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname475:
+	.string		"MBAUD"
+	.section	.debug_info
+	.long		.Lname475
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #476: variable MADDR
+	.section	.debug_info
+	.uleb128	476	; ref to abbrev 476
+	.section	.debug_abbrev
+	.uleb128	476
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname476:
+	.string		"MADDR"
+	.section	.debug_info
+	.long		.Lname476
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #477: variable MDATA
+	.section	.debug_info
+	.uleb128	477	; ref to abbrev 477
+	.section	.debug_abbrev
+	.uleb128	477
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname477:
+	.string		"MDATA"
+	.section	.debug_info
+	.long		.Lname477
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #478: variable SCTRLA
+	.section	.debug_info
+	.uleb128	478	; ref to abbrev 478
+	.section	.debug_abbrev
+	.uleb128	478
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname478:
+	.string		"SCTRLA"
+	.section	.debug_info
+	.long		.Lname478
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #479: variable SCTRLB
+	.section	.debug_info
+	.uleb128	479	; ref to abbrev 479
+	.section	.debug_abbrev
+	.uleb128	479
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname479:
+	.string		"SCTRLB"
+	.section	.debug_info
+	.long		.Lname479
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #480: variable SSTATUS
+	.section	.debug_info
+	.uleb128	480	; ref to abbrev 480
+	.section	.debug_abbrev
+	.uleb128	480
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname480:
+	.string		"SSTATUS"
+	.section	.debug_info
+	.long		.Lname480
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #481: variable SADDR
+	.section	.debug_info
+	.uleb128	481	; ref to abbrev 481
+	.section	.debug_abbrev
+	.uleb128	481
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname481:
+	.string		"SADDR"
+	.section	.debug_info
+	.long		.Lname481
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #482: variable SDATA
+	.section	.debug_info
+	.uleb128	482	; ref to abbrev 482
+	.section	.debug_abbrev
+	.uleb128	482
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname482:
+	.string		"SDATA"
+	.section	.debug_info
+	.long		.Lname482
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xD
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #483: variable SADDRMASK
+	.section	.debug_info
+	.uleb128	483	; ref to abbrev 483
+	.section	.debug_abbrev
+	.uleb128	483
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname483:
+	.string		"SADDRMASK"
+	.section	.debug_info
+	.long		.Lname483
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xE
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #484: variable RXDATAL
+	.section	.debug_info
+	.uleb128	484	; ref to abbrev 484
+	.section	.debug_abbrev
+	.uleb128	484
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname484:
+	.string		"RXDATAL"
+	.section	.debug_info
+	.long		.Lname484
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #485: variable RXDATAH
+	.section	.debug_info
+	.uleb128	485	; ref to abbrev 485
+	.section	.debug_abbrev
+	.uleb128	485
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname485:
+	.string		"RXDATAH"
+	.section	.debug_info
+	.long		.Lname485
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #486: variable TXDATAL
+	.section	.debug_info
+	.uleb128	486	; ref to abbrev 486
+	.section	.debug_abbrev
+	.uleb128	486
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname486:
+	.string		"TXDATAL"
+	.section	.debug_info
+	.long		.Lname486
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #487: variable TXDATAH
+	.section	.debug_info
+	.uleb128	487	; ref to abbrev 487
+	.section	.debug_abbrev
+	.uleb128	487
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname487:
+	.string		"TXDATAH"
+	.section	.debug_info
+	.long		.Lname487
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #488: variable STATUS
+	.section	.debug_info
+	.uleb128	488	; ref to abbrev 488
+	.section	.debug_abbrev
+	.uleb128	488
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname488:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname488
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #489: variable CTRLA
+	.section	.debug_info
+	.uleb128	489	; ref to abbrev 489
+	.section	.debug_abbrev
+	.uleb128	489
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname489:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname489
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #490: variable CTRLB
+	.section	.debug_info
+	.uleb128	490	; ref to abbrev 490
+	.section	.debug_abbrev
+	.uleb128	490
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname490:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname490
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #491: variable CTRLC
+	.section	.debug_info
+	.uleb128	491	; ref to abbrev 491
+	.section	.debug_abbrev
+	.uleb128	491
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname491:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname491
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #492: variable BAUD
+	.section	.debug_info
+	.uleb128	492	; ref to abbrev 492
+	.section	.debug_abbrev
+	.uleb128	492
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname492:
+	.string		"BAUD"
+	.section	.debug_info
+	.long		.Lname492
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #493: variable CTRLD
+	.section	.debug_info
+	.uleb128	493	; ref to abbrev 493
+	.section	.debug_abbrev
+	.uleb128	493
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname493:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname493
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #494: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	494	; ref to abbrev 494
+	.section	.debug_abbrev
+	.uleb128	494
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname494:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname494
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #495: variable EVCTRL
+	.section	.debug_info
+	.uleb128	495	; ref to abbrev 495
+	.section	.debug_abbrev
+	.uleb128	495
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname495:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname495
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #496: variable TXPLCTRL
+	.section	.debug_info
+	.uleb128	496	; ref to abbrev 496
+	.section	.debug_abbrev
+	.uleb128	496
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname496:
+	.string		"TXPLCTRL"
+	.section	.debug_info
+	.long		.Lname496
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xD
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #497: variable RXPLCTRL
+	.section	.debug_info
+	.uleb128	497	; ref to abbrev 497
+	.section	.debug_abbrev
+	.uleb128	497
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname497:
+	.string		"RXPLCTRL"
+	.section	.debug_info
+	.long		.Lname497
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xE
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #498: variable RXDATAL
+	.section	.debug_info
+	.uleb128	498	; ref to abbrev 498
+	.section	.debug_abbrev
+	.uleb128	498
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname498:
+	.string		"RXDATAL"
+	.section	.debug_info
+	.long		.Lname498
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #499: variable RXDATAH
+	.section	.debug_info
+	.uleb128	499	; ref to abbrev 499
+	.section	.debug_abbrev
+	.uleb128	499
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname499:
+	.string		"RXDATAH"
+	.section	.debug_info
+	.long		.Lname499
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #500: variable TXDATAL
+	.section	.debug_info
+	.uleb128	500	; ref to abbrev 500
+	.section	.debug_abbrev
+	.uleb128	500
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname500:
+	.string		"TXDATAL"
+	.section	.debug_info
+	.long		.Lname500
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #501: variable TXDATAH
+	.section	.debug_info
+	.uleb128	501	; ref to abbrev 501
+	.section	.debug_abbrev
+	.uleb128	501
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname501:
+	.string		"TXDATAH"
+	.section	.debug_info
+	.long		.Lname501
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #502: variable STATUS
+	.section	.debug_info
+	.uleb128	502	; ref to abbrev 502
+	.section	.debug_abbrev
+	.uleb128	502
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname502:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname502
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #503: variable CTRLA
+	.section	.debug_info
+	.uleb128	503	; ref to abbrev 503
+	.section	.debug_abbrev
+	.uleb128	503
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname503:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname503
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #504: variable CTRLB
+	.section	.debug_info
+	.uleb128	504	; ref to abbrev 504
+	.section	.debug_abbrev
+	.uleb128	504
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname504:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname504
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #505: variable CTRLC
+	.section	.debug_info
+	.uleb128	505	; ref to abbrev 505
+	.section	.debug_abbrev
+	.uleb128	505
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname505:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname505
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #506: variable BAUD
+	.section	.debug_info
+	.uleb128	506	; ref to abbrev 506
+	.section	.debug_abbrev
+	.uleb128	506
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname506:
+	.string		"BAUD"
+	.section	.debug_info
+	.long		.Lname506
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #507: variable CTRLD
+	.section	.debug_info
+	.uleb128	507	; ref to abbrev 507
+	.section	.debug_abbrev
+	.uleb128	507
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname507:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname507
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #508: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	508	; ref to abbrev 508
+	.section	.debug_abbrev
+	.uleb128	508
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname508:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname508
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #509: variable EVCTRL
+	.section	.debug_info
+	.uleb128	509	; ref to abbrev 509
+	.section	.debug_abbrev
+	.uleb128	509
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname509:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname509
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #510: variable TXPLCTRL
+	.section	.debug_info
+	.uleb128	510	; ref to abbrev 510
+	.section	.debug_abbrev
+	.uleb128	510
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname510:
+	.string		"TXPLCTRL"
+	.section	.debug_info
+	.long		.Lname510
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0xD
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #511: variable RXPLCTRL
+	.section	.debug_info
+	.uleb128	511	; ref to abbrev 511
+	.section	.debug_abbrev
+	.uleb128	511
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname511:
+	.string		"RXPLCTRL"
+	.section	.debug_info
+	.long		.Lname511
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0xE
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #512: variable RXDATAL
+	.section	.debug_info
+	.uleb128	512	; ref to abbrev 512
+	.section	.debug_abbrev
+	.uleb128	512
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname512:
+	.string		"RXDATAL"
+	.section	.debug_info
+	.long		.Lname512
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #513: variable RXDATAH
+	.section	.debug_info
+	.uleb128	513	; ref to abbrev 513
+	.section	.debug_abbrev
+	.uleb128	513
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname513:
+	.string		"RXDATAH"
+	.section	.debug_info
+	.long		.Lname513
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #514: variable TXDATAL
+	.section	.debug_info
+	.uleb128	514	; ref to abbrev 514
+	.section	.debug_abbrev
+	.uleb128	514
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname514:
+	.string		"TXDATAL"
+	.section	.debug_info
+	.long		.Lname514
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #515: variable TXDATAH
+	.section	.debug_info
+	.uleb128	515	; ref to abbrev 515
+	.section	.debug_abbrev
+	.uleb128	515
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname515:
+	.string		"TXDATAH"
+	.section	.debug_info
+	.long		.Lname515
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #516: variable STATUS
+	.section	.debug_info
+	.uleb128	516	; ref to abbrev 516
+	.section	.debug_abbrev
+	.uleb128	516
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname516:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname516
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #517: variable CTRLA
+	.section	.debug_info
+	.uleb128	517	; ref to abbrev 517
+	.section	.debug_abbrev
+	.uleb128	517
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname517:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname517
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #518: variable CTRLB
+	.section	.debug_info
+	.uleb128	518	; ref to abbrev 518
+	.section	.debug_abbrev
+	.uleb128	518
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname518:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname518
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #519: variable CTRLC
+	.section	.debug_info
+	.uleb128	519	; ref to abbrev 519
+	.section	.debug_abbrev
+	.uleb128	519
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname519:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname519
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #520: variable BAUD
+	.section	.debug_info
+	.uleb128	520	; ref to abbrev 520
+	.section	.debug_abbrev
+	.uleb128	520
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname520:
+	.string		"BAUD"
+	.section	.debug_info
+	.long		.Lname520
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #521: variable CTRLD
+	.section	.debug_info
+	.uleb128	521	; ref to abbrev 521
+	.section	.debug_abbrev
+	.uleb128	521
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname521:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname521
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #522: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	522	; ref to abbrev 522
+	.section	.debug_abbrev
+	.uleb128	522
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname522:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname522
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #523: variable EVCTRL
+	.section	.debug_info
+	.uleb128	523	; ref to abbrev 523
+	.section	.debug_abbrev
+	.uleb128	523
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname523:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname523
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #524: variable TXPLCTRL
+	.section	.debug_info
+	.uleb128	524	; ref to abbrev 524
+	.section	.debug_abbrev
+	.uleb128	524
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname524:
+	.string		"TXPLCTRL"
+	.section	.debug_info
+	.long		.Lname524
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0xD
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #525: variable RXPLCTRL
+	.section	.debug_info
+	.uleb128	525	; ref to abbrev 525
+	.section	.debug_abbrev
+	.uleb128	525
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname525:
+	.string		"RXPLCTRL"
+	.section	.debug_info
+	.long		.Lname525
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0xE
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #526: variable USERROW0
+	.section	.debug_info
+	.uleb128	526	; ref to abbrev 526
+	.section	.debug_abbrev
+	.uleb128	526
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname526:
+	.string		"USERROW0"
+	.section	.debug_info
+	.long		.Lname526
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #527: variable USERROW1
+	.section	.debug_info
+	.uleb128	527	; ref to abbrev 527
+	.section	.debug_abbrev
+	.uleb128	527
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname527:
+	.string		"USERROW1"
+	.section	.debug_info
+	.long		.Lname527
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #528: variable USERROW2
+	.section	.debug_info
+	.uleb128	528	; ref to abbrev 528
+	.section	.debug_abbrev
+	.uleb128	528
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname528:
+	.string		"USERROW2"
+	.section	.debug_info
+	.long		.Lname528
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #529: variable USERROW3
+	.section	.debug_info
+	.uleb128	529	; ref to abbrev 529
+	.section	.debug_abbrev
+	.uleb128	529
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname529:
+	.string		"USERROW3"
+	.section	.debug_info
+	.long		.Lname529
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #530: variable USERROW4
+	.section	.debug_info
+	.uleb128	530	; ref to abbrev 530
+	.section	.debug_abbrev
+	.uleb128	530
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname530:
+	.string		"USERROW4"
+	.section	.debug_info
+	.long		.Lname530
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #531: variable USERROW5
+	.section	.debug_info
+	.uleb128	531	; ref to abbrev 531
+	.section	.debug_abbrev
+	.uleb128	531
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname531:
+	.string		"USERROW5"
+	.section	.debug_info
+	.long		.Lname531
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #532: variable USERROW6
+	.section	.debug_info
+	.uleb128	532	; ref to abbrev 532
+	.section	.debug_abbrev
+	.uleb128	532
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname532:
+	.string		"USERROW6"
+	.section	.debug_info
+	.long		.Lname532
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #533: variable USERROW7
+	.section	.debug_info
+	.uleb128	533	; ref to abbrev 533
+	.section	.debug_abbrev
+	.uleb128	533
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname533:
+	.string		"USERROW7"
+	.section	.debug_info
+	.long		.Lname533
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #534: variable USERROW8
+	.section	.debug_info
+	.uleb128	534	; ref to abbrev 534
+	.section	.debug_abbrev
+	.uleb128	534
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname534:
+	.string		"USERROW8"
+	.section	.debug_info
+	.long		.Lname534
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #535: variable USERROW9
+	.section	.debug_info
+	.uleb128	535	; ref to abbrev 535
+	.section	.debug_abbrev
+	.uleb128	535
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname535:
+	.string		"USERROW9"
+	.section	.debug_info
+	.long		.Lname535
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #536: variable USERROW10
+	.section	.debug_info
+	.uleb128	536	; ref to abbrev 536
+	.section	.debug_abbrev
+	.uleb128	536
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname536:
+	.string		"USERROW10"
+	.section	.debug_info
+	.long		.Lname536
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #537: variable USERROW11
+	.section	.debug_info
+	.uleb128	537	; ref to abbrev 537
+	.section	.debug_abbrev
+	.uleb128	537
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname537:
+	.string		"USERROW11"
+	.section	.debug_info
+	.long		.Lname537
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #538: variable USERROW12
+	.section	.debug_info
+	.uleb128	538	; ref to abbrev 538
+	.section	.debug_abbrev
+	.uleb128	538
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname538:
+	.string		"USERROW12"
+	.section	.debug_info
+	.long		.Lname538
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #539: variable USERROW13
+	.section	.debug_info
+	.uleb128	539	; ref to abbrev 539
+	.section	.debug_abbrev
+	.uleb128	539
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname539:
+	.string		"USERROW13"
+	.section	.debug_info
+	.long		.Lname539
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #540: variable USERROW14
+	.section	.debug_info
+	.uleb128	540	; ref to abbrev 540
+	.section	.debug_abbrev
+	.uleb128	540
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname540:
+	.string		"USERROW14"
+	.section	.debug_info
+	.long		.Lname540
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #541: variable USERROW15
+	.section	.debug_info
+	.uleb128	541	; ref to abbrev 541
+	.section	.debug_abbrev
+	.uleb128	541
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname541:
+	.string		"USERROW15"
+	.section	.debug_info
+	.long		.Lname541
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x0F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #542: variable USERROW16
+	.section	.debug_info
+	.uleb128	542	; ref to abbrev 542
+	.section	.debug_abbrev
+	.uleb128	542
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname542:
+	.string		"USERROW16"
+	.section	.debug_info
+	.long		.Lname542
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #543: variable USERROW17
+	.section	.debug_info
+	.uleb128	543	; ref to abbrev 543
+	.section	.debug_abbrev
+	.uleb128	543
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname543:
+	.string		"USERROW17"
+	.section	.debug_info
+	.long		.Lname543
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #544: variable USERROW18
+	.section	.debug_info
+	.uleb128	544	; ref to abbrev 544
+	.section	.debug_abbrev
+	.uleb128	544
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname544:
+	.string		"USERROW18"
+	.section	.debug_info
+	.long		.Lname544
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #545: variable USERROW19
+	.section	.debug_info
+	.uleb128	545	; ref to abbrev 545
+	.section	.debug_abbrev
+	.uleb128	545
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname545:
+	.string		"USERROW19"
+	.section	.debug_info
+	.long		.Lname545
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #546: variable USERROW20
+	.section	.debug_info
+	.uleb128	546	; ref to abbrev 546
+	.section	.debug_abbrev
+	.uleb128	546
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname546:
+	.string		"USERROW20"
+	.section	.debug_info
+	.long		.Lname546
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #547: variable USERROW21
+	.section	.debug_info
+	.uleb128	547	; ref to abbrev 547
+	.section	.debug_abbrev
+	.uleb128	547
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname547:
+	.string		"USERROW21"
+	.section	.debug_info
+	.long		.Lname547
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #548: variable USERROW22
+	.section	.debug_info
+	.uleb128	548	; ref to abbrev 548
+	.section	.debug_abbrev
+	.uleb128	548
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname548:
+	.string		"USERROW22"
+	.section	.debug_info
+	.long		.Lname548
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #549: variable USERROW23
+	.section	.debug_info
+	.uleb128	549	; ref to abbrev 549
+	.section	.debug_abbrev
+	.uleb128	549
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname549:
+	.string		"USERROW23"
+	.section	.debug_info
+	.long		.Lname549
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #550: variable USERROW24
+	.section	.debug_info
+	.uleb128	550	; ref to abbrev 550
+	.section	.debug_abbrev
+	.uleb128	550
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname550:
+	.string		"USERROW24"
+	.section	.debug_info
+	.long		.Lname550
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #551: variable USERROW25
+	.section	.debug_info
+	.uleb128	551	; ref to abbrev 551
+	.section	.debug_abbrev
+	.uleb128	551
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname551:
+	.string		"USERROW25"
+	.section	.debug_info
+	.long		.Lname551
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x19
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #552: variable USERROW26
+	.section	.debug_info
+	.uleb128	552	; ref to abbrev 552
+	.section	.debug_abbrev
+	.uleb128	552
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname552:
+	.string		"USERROW26"
+	.section	.debug_info
+	.long		.Lname552
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #553: variable USERROW27
+	.section	.debug_info
+	.uleb128	553	; ref to abbrev 553
+	.section	.debug_abbrev
+	.uleb128	553
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname553:
+	.string		"USERROW27"
+	.section	.debug_info
+	.long		.Lname553
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #554: variable USERROW28
+	.section	.debug_info
+	.uleb128	554	; ref to abbrev 554
+	.section	.debug_abbrev
+	.uleb128	554
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname554:
+	.string		"USERROW28"
+	.section	.debug_info
+	.long		.Lname554
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #555: variable USERROW29
+	.section	.debug_info
+	.uleb128	555	; ref to abbrev 555
+	.section	.debug_abbrev
+	.uleb128	555
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname555:
+	.string		"USERROW29"
+	.section	.debug_info
+	.long		.Lname555
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #556: variable USERROW30
+	.section	.debug_info
+	.uleb128	556	; ref to abbrev 556
+	.section	.debug_abbrev
+	.uleb128	556
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname556:
+	.string		"USERROW30"
+	.section	.debug_info
+	.long		.Lname556
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #557: variable USERROW31
+	.section	.debug_info
+	.uleb128	557	; ref to abbrev 557
+	.section	.debug_abbrev
+	.uleb128	557
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname557:
+	.string		"USERROW31"
+	.section	.debug_info
+	.long		.Lname557
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #558: variable USERROW32
+	.section	.debug_info
+	.uleb128	558	; ref to abbrev 558
+	.section	.debug_abbrev
+	.uleb128	558
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname558:
+	.string		"USERROW32"
+	.section	.debug_info
+	.long		.Lname558
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #559: variable USERROW33
+	.section	.debug_info
+	.uleb128	559	; ref to abbrev 559
+	.section	.debug_abbrev
+	.uleb128	559
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname559:
+	.string		"USERROW33"
+	.section	.debug_info
+	.long		.Lname559
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x21
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #560: variable USERROW34
+	.section	.debug_info
+	.uleb128	560	; ref to abbrev 560
+	.section	.debug_abbrev
+	.uleb128	560
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname560:
+	.string		"USERROW34"
+	.section	.debug_info
+	.long		.Lname560
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x22
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #561: variable USERROW35
+	.section	.debug_info
+	.uleb128	561	; ref to abbrev 561
+	.section	.debug_abbrev
+	.uleb128	561
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname561:
+	.string		"USERROW35"
+	.section	.debug_info
+	.long		.Lname561
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x23
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #562: variable USERROW36
+	.section	.debug_info
+	.uleb128	562	; ref to abbrev 562
+	.section	.debug_abbrev
+	.uleb128	562
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname562:
+	.string		"USERROW36"
+	.section	.debug_info
+	.long		.Lname562
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x24
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #563: variable USERROW37
+	.section	.debug_info
+	.uleb128	563	; ref to abbrev 563
+	.section	.debug_abbrev
+	.uleb128	563
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname563:
+	.string		"USERROW37"
+	.section	.debug_info
+	.long		.Lname563
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x25
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #564: variable USERROW38
+	.section	.debug_info
+	.uleb128	564	; ref to abbrev 564
+	.section	.debug_abbrev
+	.uleb128	564
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname564:
+	.string		"USERROW38"
+	.section	.debug_info
+	.long		.Lname564
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x26
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #565: variable USERROW39
+	.section	.debug_info
+	.uleb128	565	; ref to abbrev 565
+	.section	.debug_abbrev
+	.uleb128	565
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname565:
+	.string		"USERROW39"
+	.section	.debug_info
+	.long		.Lname565
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x27
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #566: variable USERROW40
+	.section	.debug_info
+	.uleb128	566	; ref to abbrev 566
+	.section	.debug_abbrev
+	.uleb128	566
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname566:
+	.string		"USERROW40"
+	.section	.debug_info
+	.long		.Lname566
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x28
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #567: variable USERROW41
+	.section	.debug_info
+	.uleb128	567	; ref to abbrev 567
+	.section	.debug_abbrev
+	.uleb128	567
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname567:
+	.string		"USERROW41"
+	.section	.debug_info
+	.long		.Lname567
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x29
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #568: variable USERROW42
+	.section	.debug_info
+	.uleb128	568	; ref to abbrev 568
+	.section	.debug_abbrev
+	.uleb128	568
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname568:
+	.string		"USERROW42"
+	.section	.debug_info
+	.long		.Lname568
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x2A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #569: variable USERROW43
+	.section	.debug_info
+	.uleb128	569	; ref to abbrev 569
+	.section	.debug_abbrev
+	.uleb128	569
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname569:
+	.string		"USERROW43"
+	.section	.debug_info
+	.long		.Lname569
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x2B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #570: variable USERROW44
+	.section	.debug_info
+	.uleb128	570	; ref to abbrev 570
+	.section	.debug_abbrev
+	.uleb128	570
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname570:
+	.string		"USERROW44"
+	.section	.debug_info
+	.long		.Lname570
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x2C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #571: variable USERROW45
+	.section	.debug_info
+	.uleb128	571	; ref to abbrev 571
+	.section	.debug_abbrev
+	.uleb128	571
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname571:
+	.string		"USERROW45"
+	.section	.debug_info
+	.long		.Lname571
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x2D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #572: variable USERROW46
+	.section	.debug_info
+	.uleb128	572	; ref to abbrev 572
+	.section	.debug_abbrev
+	.uleb128	572
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname572:
+	.string		"USERROW46"
+	.section	.debug_info
+	.long		.Lname572
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x2E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #573: variable USERROW47
+	.section	.debug_info
+	.uleb128	573	; ref to abbrev 573
+	.section	.debug_abbrev
+	.uleb128	573
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname573:
+	.string		"USERROW47"
+	.section	.debug_info
+	.long		.Lname573
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x2F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #574: variable USERROW48
+	.section	.debug_info
+	.uleb128	574	; ref to abbrev 574
+	.section	.debug_abbrev
+	.uleb128	574
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname574:
+	.string		"USERROW48"
+	.section	.debug_info
+	.long		.Lname574
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x30
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #575: variable USERROW49
+	.section	.debug_info
+	.uleb128	575	; ref to abbrev 575
+	.section	.debug_abbrev
+	.uleb128	575
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname575:
+	.string		"USERROW49"
+	.section	.debug_info
+	.long		.Lname575
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x31
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #576: variable USERROW50
+	.section	.debug_info
+	.uleb128	576	; ref to abbrev 576
+	.section	.debug_abbrev
+	.uleb128	576
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname576:
+	.string		"USERROW50"
+	.section	.debug_info
+	.long		.Lname576
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x32
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #577: variable USERROW51
+	.section	.debug_info
+	.uleb128	577	; ref to abbrev 577
+	.section	.debug_abbrev
+	.uleb128	577
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname577:
+	.string		"USERROW51"
+	.section	.debug_info
+	.long		.Lname577
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x33
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #578: variable USERROW52
+	.section	.debug_info
+	.uleb128	578	; ref to abbrev 578
+	.section	.debug_abbrev
+	.uleb128	578
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname578:
+	.string		"USERROW52"
+	.section	.debug_info
+	.long		.Lname578
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x34
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #579: variable USERROW53
+	.section	.debug_info
+	.uleb128	579	; ref to abbrev 579
+	.section	.debug_abbrev
+	.uleb128	579
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname579:
+	.string		"USERROW53"
+	.section	.debug_info
+	.long		.Lname579
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x35
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #580: variable USERROW54
+	.section	.debug_info
+	.uleb128	580	; ref to abbrev 580
+	.section	.debug_abbrev
+	.uleb128	580
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname580:
+	.string		"USERROW54"
+	.section	.debug_info
+	.long		.Lname580
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x36
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #581: variable USERROW55
+	.section	.debug_info
+	.uleb128	581	; ref to abbrev 581
+	.section	.debug_abbrev
+	.uleb128	581
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname581:
+	.string		"USERROW55"
+	.section	.debug_info
+	.long		.Lname581
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x37
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #582: variable USERROW56
+	.section	.debug_info
+	.uleb128	582	; ref to abbrev 582
+	.section	.debug_abbrev
+	.uleb128	582
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname582:
+	.string		"USERROW56"
+	.section	.debug_info
+	.long		.Lname582
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x38
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #583: variable USERROW57
+	.section	.debug_info
+	.uleb128	583	; ref to abbrev 583
+	.section	.debug_abbrev
+	.uleb128	583
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname583:
+	.string		"USERROW57"
+	.section	.debug_info
+	.long		.Lname583
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x39
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #584: variable USERROW58
+	.section	.debug_info
+	.uleb128	584	; ref to abbrev 584
+	.section	.debug_abbrev
+	.uleb128	584
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname584:
+	.string		"USERROW58"
+	.section	.debug_info
+	.long		.Lname584
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x3A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #585: variable USERROW59
+	.section	.debug_info
+	.uleb128	585	; ref to abbrev 585
+	.section	.debug_abbrev
+	.uleb128	585
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname585:
+	.string		"USERROW59"
+	.section	.debug_info
+	.long		.Lname585
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x3B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #586: variable USERROW60
+	.section	.debug_info
+	.uleb128	586	; ref to abbrev 586
+	.section	.debug_abbrev
+	.uleb128	586
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname586:
+	.string		"USERROW60"
+	.section	.debug_info
+	.long		.Lname586
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x3C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #587: variable USERROW61
+	.section	.debug_info
+	.uleb128	587	; ref to abbrev 587
+	.section	.debug_abbrev
+	.uleb128	587
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname587:
+	.string		"USERROW61"
+	.section	.debug_info
+	.long		.Lname587
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x3D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #588: variable USERROW62
+	.section	.debug_info
+	.uleb128	588	; ref to abbrev 588
+	.section	.debug_abbrev
+	.uleb128	588
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname588:
+	.string		"USERROW62"
+	.section	.debug_info
+	.long		.Lname588
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x3E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #589: variable USERROW63
+	.section	.debug_info
+	.uleb128	589	; ref to abbrev 589
+	.section	.debug_abbrev
+	.uleb128	589
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname589:
+	.string		"USERROW63"
+	.section	.debug_info
+	.long		.Lname589
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x3F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #590: variable DIR
+	.section	.debug_info
+	.uleb128	590	; ref to abbrev 590
+	.section	.debug_abbrev
+	.uleb128	590
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname590:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname590
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0000 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #591: variable OUT
+	.section	.debug_info
+	.uleb128	591	; ref to abbrev 591
+	.section	.debug_abbrev
+	.uleb128	591
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname591:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname591
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0000 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #592: variable IN
+	.section	.debug_info
+	.uleb128	592	; ref to abbrev 592
+	.section	.debug_abbrev
+	.uleb128	592
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname592:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname592
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0000 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #593: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	593	; ref to abbrev 593
+	.section	.debug_abbrev
+	.uleb128	593
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname593:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname593
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0000 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #594: variable DIR
+	.section	.debug_info
+	.uleb128	594	; ref to abbrev 594
+	.section	.debug_abbrev
+	.uleb128	594
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname594:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname594
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0004 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #595: variable OUT
+	.section	.debug_info
+	.uleb128	595	; ref to abbrev 595
+	.section	.debug_abbrev
+	.uleb128	595
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname595:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname595
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0004 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #596: variable IN
+	.section	.debug_info
+	.uleb128	596	; ref to abbrev 596
+	.section	.debug_abbrev
+	.uleb128	596
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname596:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname596
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0004 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #597: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	597	; ref to abbrev 597
+	.section	.debug_abbrev
+	.uleb128	597
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname597:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname597
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0004 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #598: variable DIR
+	.section	.debug_info
+	.uleb128	598	; ref to abbrev 598
+	.section	.debug_abbrev
+	.uleb128	598
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname598:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname598
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0008 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #599: variable OUT
+	.section	.debug_info
+	.uleb128	599	; ref to abbrev 599
+	.section	.debug_abbrev
+	.uleb128	599
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname599:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname599
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0008 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #600: variable IN
+	.section	.debug_info
+	.uleb128	600	; ref to abbrev 600
+	.section	.debug_abbrev
+	.uleb128	600
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname600:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname600
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0008 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #601: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	601	; ref to abbrev 601
+	.section	.debug_abbrev
+	.uleb128	601
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname601:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname601
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0008 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #602: variable DIR
+	.section	.debug_info
+	.uleb128	602	; ref to abbrev 602
+	.section	.debug_abbrev
+	.uleb128	602
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname602:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname602
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x000C + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #603: variable OUT
+	.section	.debug_info
+	.uleb128	603	; ref to abbrev 603
+	.section	.debug_abbrev
+	.uleb128	603
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname603:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname603
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x000C + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #604: variable IN
+	.section	.debug_info
+	.uleb128	604	; ref to abbrev 604
+	.section	.debug_abbrev
+	.uleb128	604
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname604:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname604
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x000C + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #605: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	605	; ref to abbrev 605
+	.section	.debug_abbrev
+	.uleb128	605
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname605:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname605
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x000C + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #606: variable DIR
+	.section	.debug_info
+	.uleb128	606	; ref to abbrev 606
+	.section	.debug_abbrev
+	.uleb128	606
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname606:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname606
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0010 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #607: variable OUT
+	.section	.debug_info
+	.uleb128	607	; ref to abbrev 607
+	.section	.debug_abbrev
+	.uleb128	607
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname607:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname607
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0010 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #608: variable IN
+	.section	.debug_info
+	.uleb128	608	; ref to abbrev 608
+	.section	.debug_abbrev
+	.uleb128	608
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname608:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname608
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0010 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #609: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	609	; ref to abbrev 609
+	.section	.debug_abbrev
+	.uleb128	609
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname609:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname609
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0010 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #610: variable DIR
+	.section	.debug_info
+	.uleb128	610	; ref to abbrev 610
+	.section	.debug_abbrev
+	.uleb128	610
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname610:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname610
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0014 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #611: variable OUT
+	.section	.debug_info
+	.uleb128	611	; ref to abbrev 611
+	.section	.debug_abbrev
+	.uleb128	611
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname611:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname611
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0014 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #612: variable IN
+	.section	.debug_info
+	.uleb128	612	; ref to abbrev 612
+	.section	.debug_abbrev
+	.uleb128	612
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname612:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname612
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0014 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #613: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	613	; ref to abbrev 613
+	.section	.debug_abbrev
+	.uleb128	613
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname613:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname613
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0014 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #614: variable DAC0REF
+	.section	.debug_info
+	.uleb128	614	; ref to abbrev 614
+	.section	.debug_abbrev
+	.uleb128	614
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname614:
+	.string		"DAC0REF"
+	.section	.debug_info
+	.long		.Lname614
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00B0 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #615: variable ACREF
+	.section	.debug_info
+	.uleb128	615	; ref to abbrev 615
+	.section	.debug_abbrev
+	.uleb128	615
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname615:
+	.string		"ACREF"
+	.section	.debug_info
+	.long		.Lname615
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00B0 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #616: variable CTRLA
+	.section	.debug_info
+	.uleb128	616	; ref to abbrev 616
+	.section	.debug_abbrev
+	.uleb128	616
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname616:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname616
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0100 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #617: variable STATUS
+	.section	.debug_info
+	.uleb128	617	; ref to abbrev 617
+	.section	.debug_abbrev
+	.uleb128	617
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname617:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname617
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0100 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+	;; trailer
+	.section	.debug_abbrev
+	.uleb128	0
+
+	.section	.debug_info
+	.uleb128	0
+.Leinfo:

--- a/crt1/iosym/avr64ea28.S
+++ b/crt1/iosym/avr64ea28.S
@@ -1,0 +1,26945 @@
+/* This file is part of avr-libc.
+
+   Automatically created by devtools/ioreg.pl
+   DO NOT EDIT!
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in
+     the documentation and/or other materials provided with the
+     distribution.
+
+   * Neither the name of the copyright holders nor the names of
+     contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE. */
+
+/* $Id$ */
+
+#include <avr/version.h>
+
+#define DW_TAG_array_type               0x01
+#define DW_TAG_compile_unit             0x11
+#define DW_TAG_typedef                  0x16
+#define DW_TAG_subrange_type            0x21
+#define DW_TAG_base_type                0x24
+#define DW_TAG_variable                 0x34
+
+#define DW_FORM_addr                    0x01
+#define DW_FORM_block1                  0x0a
+#define DW_FORM_block2                  0x03
+#define DW_FORM_block4                  0x04
+#define DW_FORM_data1                   0x0b
+#define DW_FORM_data2                   0x05
+#define DW_FORM_data4                   0x06
+#define DW_FORM_data8                   0x07
+#define DW_FORM_string                  0x08
+#define DW_FORM_flag                    0x0c
+#define DW_FORM_strp                    0x0e
+#define DW_FORM_ref1                    0x11
+#define DW_FORM_ref2                    0x12
+#define DW_FORM_ref4                    0x13
+#define DW_FORM_ref8                    0x14
+
+#define DW_AT_location                  0x02
+#define DW_AT_name                      0x03
+#define DW_AT_byte_size                 0x0b
+#define DW_AT_stmt_list                 0x10
+#define DW_AT_language                  0x13
+#define DW_AT_producer                  0x25
+#define DW_AT_upper_bound               0x2f
+#define DW_AT_decl_file                 0x3a
+#define DW_AT_decl_line                 0x3b
+#define DW_AT_encoding                  0x3e
+#define DW_AT_external                  0x3f
+#define DW_AT_type                      0x49
+
+#define DW_LANG_C89                     0x0001
+
+#define DW_CHILDREN_no                  0x00
+#define DW_CHILDREN_yes                 0x01
+
+#define DW_ATE_unsigned                 0x7
+#define DW_ATE_unsigned_char            0x8
+
+#define DW_OP_addr                      0x03
+.eject
+	.section	.debug_abbrev, "", @progbits
+.Ldebug_abbrev0:
+	.section	.debug_info, "", @progbits
+	.section	.debug_line, "", @progbits
+.Ldebug_line0:
+	.section	.debug_str, "", @progbits
+
+	.section	.debug_info, "", @progbits
+	;; compilation unit header
+.Lssinfo:
+	.long	.Leinfo - .Lsinfo
+.Lsinfo:
+	.word	2		; DWARF-2
+	.long	.Ldebug_abbrev0
+	.byte	4		; sizeof(address)
+
+
+	;; DIE #1: compilation unit
+	.section	.debug_info
+	.uleb128	1	; ref to abbrev 1
+	.section	.debug_abbrev
+	.uleb128	1
+	.uleb128	DW_TAG_compile_unit
+	.byte		DW_CHILDREN_yes
+
+	.uleb128	DW_AT_producer
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lproducer:
+	.ascii		"avr-libc "
+	.asciz		__AVR_LIBC_VERSION_STRING__
+	.section	.debug_info
+	.long		.Lproducer
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_stmt_list
+	.uleb128	DW_FORM_data4
+	.section	.debug_info
+	.long		.Ldebug_line0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+	;; DIE #2: base type uint8_t
+	.section	.debug_info
+.Luint8_t:
+	.uleb128	2	; ref to abbrev 2
+	.section	.debug_abbrev
+	.uleb128	2
+	.uleb128	DW_TAG_base_type
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Luint8_t_name:
+	.string		"uint8_t"
+	.section	.debug_info
+	.long		.Luint8_t_name
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_byte_size
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_encoding
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		DW_ATE_unsigned_char
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+	;; DIE #3: base type uint16_t
+	.section	.debug_info
+.Luint16_t:
+	.uleb128	3	; ref to abbrev 3
+	.section	.debug_abbrev
+	.uleb128	3
+	.uleb128	DW_TAG_base_type
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Luint16_t_name:
+	.string		"uint16_t"
+	.section	.debug_info
+	.long		.Luint16_t_name
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_byte_size
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		2
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_encoding
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		DW_ATE_unsigned
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #4: variable CTRLA
+	.section	.debug_info
+	.uleb128	4	; ref to abbrev 4
+	.section	.debug_abbrev
+	.uleb128	4
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname4:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname4
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #5: variable CTRLB
+	.section	.debug_info
+	.uleb128	5	; ref to abbrev 5
+	.section	.debug_abbrev
+	.uleb128	5
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname5:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname5
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #6: variable MUXCTRL
+	.section	.debug_info
+	.uleb128	6	; ref to abbrev 6
+	.section	.debug_abbrev
+	.uleb128	6
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname6:
+	.string		"MUXCTRL"
+	.section	.debug_info
+	.long		.Lname6
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #7: variable DACREF
+	.section	.debug_info
+	.uleb128	7	; ref to abbrev 7
+	.section	.debug_abbrev
+	.uleb128	7
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname7:
+	.string		"DACREF"
+	.section	.debug_info
+	.long		.Lname7
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #8: variable INTCTRL
+	.section	.debug_info
+	.uleb128	8	; ref to abbrev 8
+	.section	.debug_abbrev
+	.uleb128	8
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname8:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname8
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #9: variable STATUS
+	.section	.debug_info
+	.uleb128	9	; ref to abbrev 9
+	.section	.debug_abbrev
+	.uleb128	9
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname9:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname9
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #10: variable CTRLA
+	.section	.debug_info
+	.uleb128	10	; ref to abbrev 10
+	.section	.debug_abbrev
+	.uleb128	10
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname10:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname10
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #11: variable CTRLB
+	.section	.debug_info
+	.uleb128	11	; ref to abbrev 11
+	.section	.debug_abbrev
+	.uleb128	11
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname11:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname11
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #12: variable MUXCTRL
+	.section	.debug_info
+	.uleb128	12	; ref to abbrev 12
+	.section	.debug_abbrev
+	.uleb128	12
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname12:
+	.string		"MUXCTRL"
+	.section	.debug_info
+	.long		.Lname12
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #13: variable DACREF
+	.section	.debug_info
+	.uleb128	13	; ref to abbrev 13
+	.section	.debug_abbrev
+	.uleb128	13
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname13:
+	.string		"DACREF"
+	.section	.debug_info
+	.long		.Lname13
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #14: variable INTCTRL
+	.section	.debug_info
+	.uleb128	14	; ref to abbrev 14
+	.section	.debug_abbrev
+	.uleb128	14
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname14:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname14
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #15: variable STATUS
+	.section	.debug_info
+	.uleb128	15	; ref to abbrev 15
+	.section	.debug_abbrev
+	.uleb128	15
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname15:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname15
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #16: variable CTRLA
+	.section	.debug_info
+	.uleb128	16	; ref to abbrev 16
+	.section	.debug_abbrev
+	.uleb128	16
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname16:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname16
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #17: variable CTRLB
+	.section	.debug_info
+	.uleb128	17	; ref to abbrev 17
+	.section	.debug_abbrev
+	.uleb128	17
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname17:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname17
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #18: variable CTRLC
+	.section	.debug_info
+	.uleb128	18	; ref to abbrev 18
+	.section	.debug_abbrev
+	.uleb128	18
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname18:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname18
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #19: variable CTRLD
+	.section	.debug_info
+	.uleb128	19	; ref to abbrev 19
+	.section	.debug_abbrev
+	.uleb128	19
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname19:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname19
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #20: variable INTCTRL
+	.section	.debug_info
+	.uleb128	20	; ref to abbrev 20
+	.section	.debug_abbrev
+	.uleb128	20
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname20:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname20
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #21: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	21	; ref to abbrev 21
+	.section	.debug_abbrev
+	.uleb128	21
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname21:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname21
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #22: variable STATUS
+	.section	.debug_info
+	.uleb128	22	; ref to abbrev 22
+	.section	.debug_abbrev
+	.uleb128	22
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname22:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname22
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #23: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	23	; ref to abbrev 23
+	.section	.debug_abbrev
+	.uleb128	23
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname23:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname23
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #24: variable CTRLE
+	.section	.debug_info
+	.uleb128	24	; ref to abbrev 24
+	.section	.debug_abbrev
+	.uleb128	24
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname24:
+	.string		"CTRLE"
+	.section	.debug_info
+	.long		.Lname24
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #25: variable CTRLF
+	.section	.debug_info
+	.uleb128	25	; ref to abbrev 25
+	.section	.debug_abbrev
+	.uleb128	25
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname25:
+	.string		"CTRLF"
+	.section	.debug_info
+	.long		.Lname25
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #26: variable COMMAND
+	.section	.debug_info
+	.uleb128	26	; ref to abbrev 26
+	.section	.debug_abbrev
+	.uleb128	26
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname26:
+	.string		"COMMAND"
+	.section	.debug_info
+	.long		.Lname26
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #27: variable PGACTRL
+	.section	.debug_info
+	.uleb128	27	; ref to abbrev 27
+	.section	.debug_abbrev
+	.uleb128	27
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname27:
+	.string		"PGACTRL"
+	.section	.debug_info
+	.long		.Lname27
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #28: variable MUXPOS
+	.section	.debug_info
+	.uleb128	28	; ref to abbrev 28
+	.section	.debug_abbrev
+	.uleb128	28
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname28:
+	.string		"MUXPOS"
+	.section	.debug_info
+	.long		.Lname28
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #29: variable MUXNEG
+	.section	.debug_info
+	.uleb128	29	; ref to abbrev 29
+	.section	.debug_abbrev
+	.uleb128	29
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname29:
+	.string		"MUXNEG"
+	.section	.debug_info
+	.long		.Lname29
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #30: base type uint32_t
+	.section	.debug_info
+.Luint32_t:
+	.uleb128	30	; ref to abbrev 30
+	.section	.debug_abbrev
+	.uleb128	30
+	.uleb128	DW_TAG_base_type
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Luint32_t_name:
+	.string		"uint32_t"
+	.section	.debug_info
+	.long		.Luint32_t_name
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_byte_size
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		4
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_encoding
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		DW_ATE_unsigned
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #31: variable RESULT
+	.section	.debug_info
+	.uleb128	31	; ref to abbrev 31
+	.section	.debug_abbrev
+	.uleb128	31
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname31:
+	.string		"RESULT"
+	.section	.debug_info
+	.long		.Lname31
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint32_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #32: variable SAMPLE
+	.section	.debug_info
+	.uleb128	32	; ref to abbrev 32
+	.section	.debug_abbrev
+	.uleb128	32
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname32:
+	.string		"SAMPLE"
+	.section	.debug_info
+	.long		.Lname32
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #33: variable TEMP0
+	.section	.debug_info
+	.uleb128	33	; ref to abbrev 33
+	.section	.debug_abbrev
+	.uleb128	33
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname33:
+	.string		"TEMP0"
+	.section	.debug_info
+	.long		.Lname33
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #34: variable TEMP1
+	.section	.debug_info
+	.uleb128	34	; ref to abbrev 34
+	.section	.debug_abbrev
+	.uleb128	34
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname34:
+	.string		"TEMP1"
+	.section	.debug_info
+	.long		.Lname34
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x19
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #35: variable TEMP2
+	.section	.debug_info
+	.uleb128	35	; ref to abbrev 35
+	.section	.debug_abbrev
+	.uleb128	35
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname35:
+	.string		"TEMP2"
+	.section	.debug_info
+	.long		.Lname35
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x1A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #36: variable WINLT
+	.section	.debug_info
+	.uleb128	36	; ref to abbrev 36
+	.section	.debug_abbrev
+	.uleb128	36
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname36:
+	.string		"WINLT"
+	.section	.debug_info
+	.long		.Lname36
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x1C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #37: variable WINHT
+	.section	.debug_info
+	.uleb128	37	; ref to abbrev 37
+	.section	.debug_abbrev
+	.uleb128	37
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname37:
+	.string		"WINHT"
+	.section	.debug_info
+	.long		.Lname37
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x1E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #38: variable CTRLA
+	.section	.debug_info
+	.uleb128	38	; ref to abbrev 38
+	.section	.debug_abbrev
+	.uleb128	38
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname38:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname38
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #39: variable CTRLB
+	.section	.debug_info
+	.uleb128	39	; ref to abbrev 39
+	.section	.debug_abbrev
+	.uleb128	39
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname39:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname39
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #40: variable VLMCTRLA
+	.section	.debug_info
+	.uleb128	40	; ref to abbrev 40
+	.section	.debug_abbrev
+	.uleb128	40
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname40:
+	.string		"VLMCTRLA"
+	.section	.debug_info
+	.long		.Lname40
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #41: variable INTCTRL
+	.section	.debug_info
+	.uleb128	41	; ref to abbrev 41
+	.section	.debug_abbrev
+	.uleb128	41
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname41:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname41
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #42: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	42	; ref to abbrev 42
+	.section	.debug_abbrev
+	.uleb128	42
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname42:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname42
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #43: variable STATUS
+	.section	.debug_info
+	.uleb128	43	; ref to abbrev 43
+	.section	.debug_abbrev
+	.uleb128	43
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname43:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname43
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #44: variable CTRLA
+	.section	.debug_info
+	.uleb128	44	; ref to abbrev 44
+	.section	.debug_abbrev
+	.uleb128	44
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname44:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname44
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #45: variable SEQCTRL0
+	.section	.debug_info
+	.uleb128	45	; ref to abbrev 45
+	.section	.debug_abbrev
+	.uleb128	45
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname45:
+	.string		"SEQCTRL0"
+	.section	.debug_info
+	.long		.Lname45
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #46: variable SEQCTRL1
+	.section	.debug_info
+	.uleb128	46	; ref to abbrev 46
+	.section	.debug_abbrev
+	.uleb128	46
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname46:
+	.string		"SEQCTRL1"
+	.section	.debug_info
+	.long		.Lname46
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #47: variable INTCTRL0
+	.section	.debug_info
+	.uleb128	47	; ref to abbrev 47
+	.section	.debug_abbrev
+	.uleb128	47
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname47:
+	.string		"INTCTRL0"
+	.section	.debug_info
+	.long		.Lname47
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #48: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	48	; ref to abbrev 48
+	.section	.debug_abbrev
+	.uleb128	48
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname48:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname48
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #49: variable LUT0CTRLA
+	.section	.debug_info
+	.uleb128	49	; ref to abbrev 49
+	.section	.debug_abbrev
+	.uleb128	49
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname49:
+	.string		"LUT0CTRLA"
+	.section	.debug_info
+	.long		.Lname49
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #50: variable LUT0CTRLB
+	.section	.debug_info
+	.uleb128	50	; ref to abbrev 50
+	.section	.debug_abbrev
+	.uleb128	50
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname50:
+	.string		"LUT0CTRLB"
+	.section	.debug_info
+	.long		.Lname50
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #51: variable LUT0CTRLC
+	.section	.debug_info
+	.uleb128	51	; ref to abbrev 51
+	.section	.debug_abbrev
+	.uleb128	51
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname51:
+	.string		"LUT0CTRLC"
+	.section	.debug_info
+	.long		.Lname51
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #52: variable TRUTH0
+	.section	.debug_info
+	.uleb128	52	; ref to abbrev 52
+	.section	.debug_abbrev
+	.uleb128	52
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname52:
+	.string		"TRUTH0"
+	.section	.debug_info
+	.long		.Lname52
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #53: variable LUT1CTRLA
+	.section	.debug_info
+	.uleb128	53	; ref to abbrev 53
+	.section	.debug_abbrev
+	.uleb128	53
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname53:
+	.string		"LUT1CTRLA"
+	.section	.debug_info
+	.long		.Lname53
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #54: variable LUT1CTRLB
+	.section	.debug_info
+	.uleb128	54	; ref to abbrev 54
+	.section	.debug_abbrev
+	.uleb128	54
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname54:
+	.string		"LUT1CTRLB"
+	.section	.debug_info
+	.long		.Lname54
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #55: variable LUT1CTRLC
+	.section	.debug_info
+	.uleb128	55	; ref to abbrev 55
+	.section	.debug_abbrev
+	.uleb128	55
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname55:
+	.string		"LUT1CTRLC"
+	.section	.debug_info
+	.long		.Lname55
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #56: variable TRUTH1
+	.section	.debug_info
+	.uleb128	56	; ref to abbrev 56
+	.section	.debug_abbrev
+	.uleb128	56
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname56:
+	.string		"TRUTH1"
+	.section	.debug_info
+	.long		.Lname56
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #57: variable LUT2CTRLA
+	.section	.debug_info
+	.uleb128	57	; ref to abbrev 57
+	.section	.debug_abbrev
+	.uleb128	57
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname57:
+	.string		"LUT2CTRLA"
+	.section	.debug_info
+	.long		.Lname57
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #58: variable LUT2CTRLB
+	.section	.debug_info
+	.uleb128	58	; ref to abbrev 58
+	.section	.debug_abbrev
+	.uleb128	58
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname58:
+	.string		"LUT2CTRLB"
+	.section	.debug_info
+	.long		.Lname58
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #59: variable LUT2CTRLC
+	.section	.debug_info
+	.uleb128	59	; ref to abbrev 59
+	.section	.debug_abbrev
+	.uleb128	59
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname59:
+	.string		"LUT2CTRLC"
+	.section	.debug_info
+	.long		.Lname59
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #60: variable TRUTH2
+	.section	.debug_info
+	.uleb128	60	; ref to abbrev 60
+	.section	.debug_abbrev
+	.uleb128	60
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname60:
+	.string		"TRUTH2"
+	.section	.debug_info
+	.long		.Lname60
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #61: variable LUT3CTRLA
+	.section	.debug_info
+	.uleb128	61	; ref to abbrev 61
+	.section	.debug_abbrev
+	.uleb128	61
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname61:
+	.string		"LUT3CTRLA"
+	.section	.debug_info
+	.long		.Lname61
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #62: variable LUT3CTRLB
+	.section	.debug_info
+	.uleb128	62	; ref to abbrev 62
+	.section	.debug_abbrev
+	.uleb128	62
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname62:
+	.string		"LUT3CTRLB"
+	.section	.debug_info
+	.long		.Lname62
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #63: variable LUT3CTRLC
+	.section	.debug_info
+	.uleb128	63	; ref to abbrev 63
+	.section	.debug_abbrev
+	.uleb128	63
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname63:
+	.string		"LUT3CTRLC"
+	.section	.debug_info
+	.long		.Lname63
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #64: variable TRUTH3
+	.section	.debug_info
+	.uleb128	64	; ref to abbrev 64
+	.section	.debug_abbrev
+	.uleb128	64
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname64:
+	.string		"TRUTH3"
+	.section	.debug_info
+	.long		.Lname64
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #65: variable MCLKCTRLA
+	.section	.debug_info
+	.uleb128	65	; ref to abbrev 65
+	.section	.debug_abbrev
+	.uleb128	65
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname65:
+	.string		"MCLKCTRLA"
+	.section	.debug_info
+	.long		.Lname65
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #66: variable MCLKCTRLB
+	.section	.debug_info
+	.uleb128	66	; ref to abbrev 66
+	.section	.debug_abbrev
+	.uleb128	66
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname66:
+	.string		"MCLKCTRLB"
+	.section	.debug_info
+	.long		.Lname66
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #67: variable MCLKCTRLC
+	.section	.debug_info
+	.uleb128	67	; ref to abbrev 67
+	.section	.debug_abbrev
+	.uleb128	67
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname67:
+	.string		"MCLKCTRLC"
+	.section	.debug_info
+	.long		.Lname67
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #68: variable MCLKINTCTRL
+	.section	.debug_info
+	.uleb128	68	; ref to abbrev 68
+	.section	.debug_abbrev
+	.uleb128	68
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname68:
+	.string		"MCLKINTCTRL"
+	.section	.debug_info
+	.long		.Lname68
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #69: variable MCLKINTFLAGS
+	.section	.debug_info
+	.uleb128	69	; ref to abbrev 69
+	.section	.debug_abbrev
+	.uleb128	69
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname69:
+	.string		"MCLKINTFLAGS"
+	.section	.debug_info
+	.long		.Lname69
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #70: variable MCLKSTATUS
+	.section	.debug_info
+	.uleb128	70	; ref to abbrev 70
+	.section	.debug_abbrev
+	.uleb128	70
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname70:
+	.string		"MCLKSTATUS"
+	.section	.debug_info
+	.long		.Lname70
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #71: variable MCLKTIMEBASE
+	.section	.debug_info
+	.uleb128	71	; ref to abbrev 71
+	.section	.debug_abbrev
+	.uleb128	71
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname71:
+	.string		"MCLKTIMEBASE"
+	.section	.debug_info
+	.long		.Lname71
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #72: variable OSCHFCTRLA
+	.section	.debug_info
+	.uleb128	72	; ref to abbrev 72
+	.section	.debug_abbrev
+	.uleb128	72
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname72:
+	.string		"OSCHFCTRLA"
+	.section	.debug_info
+	.long		.Lname72
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #73: variable OSCHFTUNE
+	.section	.debug_info
+	.uleb128	73	; ref to abbrev 73
+	.section	.debug_abbrev
+	.uleb128	73
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname73:
+	.string		"OSCHFTUNE"
+	.section	.debug_info
+	.long		.Lname73
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #74: variable OSC32KCTRLA
+	.section	.debug_info
+	.uleb128	74	; ref to abbrev 74
+	.section	.debug_abbrev
+	.uleb128	74
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname74:
+	.string		"OSC32KCTRLA"
+	.section	.debug_info
+	.long		.Lname74
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #75: variable XOSC32KCTRLA
+	.section	.debug_info
+	.uleb128	75	; ref to abbrev 75
+	.section	.debug_abbrev
+	.uleb128	75
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname75:
+	.string		"XOSC32KCTRLA"
+	.section	.debug_info
+	.long		.Lname75
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x1C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #76: variable XOSCHFCTRLA
+	.section	.debug_info
+	.uleb128	76	; ref to abbrev 76
+	.section	.debug_abbrev
+	.uleb128	76
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname76:
+	.string		"XOSCHFCTRLA"
+	.section	.debug_info
+	.long		.Lname76
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #77: variable CCP
+	.section	.debug_info
+	.uleb128	77	; ref to abbrev 77
+	.section	.debug_abbrev
+	.uleb128	77
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname77:
+	.string		"CCP"
+	.section	.debug_info
+	.long		.Lname77
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0030 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #78: variable SP
+	.section	.debug_info
+	.uleb128	78	; ref to abbrev 78
+	.section	.debug_abbrev
+	.uleb128	78
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname78:
+	.string		"SP"
+	.section	.debug_info
+	.long		.Lname78
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0030 + 0xD
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #79: variable SREG
+	.section	.debug_info
+	.uleb128	79	; ref to abbrev 79
+	.section	.debug_abbrev
+	.uleb128	79
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname79:
+	.string		"SREG"
+	.section	.debug_info
+	.long		.Lname79
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0030 + 0xF
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #80: variable CTRLA
+	.section	.debug_info
+	.uleb128	80	; ref to abbrev 80
+	.section	.debug_abbrev
+	.uleb128	80
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname80:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname80
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0110 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #81: variable STATUS
+	.section	.debug_info
+	.uleb128	81	; ref to abbrev 81
+	.section	.debug_abbrev
+	.uleb128	81
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname81:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname81
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0110 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #82: variable LVL0PRI
+	.section	.debug_info
+	.uleb128	82	; ref to abbrev 82
+	.section	.debug_abbrev
+	.uleb128	82
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname82:
+	.string		"LVL0PRI"
+	.section	.debug_info
+	.long		.Lname82
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0110 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #83: variable LVL1VEC
+	.section	.debug_info
+	.uleb128	83	; ref to abbrev 83
+	.section	.debug_abbrev
+	.uleb128	83
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname83:
+	.string		"LVL1VEC"
+	.section	.debug_info
+	.long		.Lname83
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0110 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #84: variable CTRLA
+	.section	.debug_info
+	.uleb128	84	; ref to abbrev 84
+	.section	.debug_abbrev
+	.uleb128	84
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname84:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname84
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0120 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #85: variable CTRLB
+	.section	.debug_info
+	.uleb128	85	; ref to abbrev 85
+	.section	.debug_abbrev
+	.uleb128	85
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname85:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname85
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0120 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #86: variable STATUS
+	.section	.debug_info
+	.uleb128	86	; ref to abbrev 86
+	.section	.debug_abbrev
+	.uleb128	86
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname86:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname86
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0120 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #87: variable CTRLA
+	.section	.debug_info
+	.uleb128	87	; ref to abbrev 87
+	.section	.debug_abbrev
+	.uleb128	87
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname87:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname87
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x06A0 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #88: variable DATA
+	.section	.debug_info
+	.uleb128	88	; ref to abbrev 88
+	.section	.debug_abbrev
+	.uleb128	88
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname88:
+	.string		"DATA"
+	.section	.debug_info
+	.long		.Lname88
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x06A0 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #89: variable SWEVENTA
+	.section	.debug_info
+	.uleb128	89	; ref to abbrev 89
+	.section	.debug_abbrev
+	.uleb128	89
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname89:
+	.string		"SWEVENTA"
+	.section	.debug_info
+	.long		.Lname89
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #90: variable CHANNEL0
+	.section	.debug_info
+	.uleb128	90	; ref to abbrev 90
+	.section	.debug_abbrev
+	.uleb128	90
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname90:
+	.string		"CHANNEL0"
+	.section	.debug_info
+	.long		.Lname90
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #91: variable CHANNEL1
+	.section	.debug_info
+	.uleb128	91	; ref to abbrev 91
+	.section	.debug_abbrev
+	.uleb128	91
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname91:
+	.string		"CHANNEL1"
+	.section	.debug_info
+	.long		.Lname91
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #92: variable CHANNEL2
+	.section	.debug_info
+	.uleb128	92	; ref to abbrev 92
+	.section	.debug_abbrev
+	.uleb128	92
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname92:
+	.string		"CHANNEL2"
+	.section	.debug_info
+	.long		.Lname92
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #93: variable CHANNEL3
+	.section	.debug_info
+	.uleb128	93	; ref to abbrev 93
+	.section	.debug_abbrev
+	.uleb128	93
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname93:
+	.string		"CHANNEL3"
+	.section	.debug_info
+	.long		.Lname93
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #94: variable CHANNEL4
+	.section	.debug_info
+	.uleb128	94	; ref to abbrev 94
+	.section	.debug_abbrev
+	.uleb128	94
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname94:
+	.string		"CHANNEL4"
+	.section	.debug_info
+	.long		.Lname94
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #95: variable CHANNEL5
+	.section	.debug_info
+	.uleb128	95	; ref to abbrev 95
+	.section	.debug_abbrev
+	.uleb128	95
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname95:
+	.string		"CHANNEL5"
+	.section	.debug_info
+	.long		.Lname95
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #96: variable USERCCLLUT0A
+	.section	.debug_info
+	.uleb128	96	; ref to abbrev 96
+	.section	.debug_abbrev
+	.uleb128	96
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname96:
+	.string		"USERCCLLUT0A"
+	.section	.debug_info
+	.long		.Lname96
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #97: variable USERCCLLUT0B
+	.section	.debug_info
+	.uleb128	97	; ref to abbrev 97
+	.section	.debug_abbrev
+	.uleb128	97
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname97:
+	.string		"USERCCLLUT0B"
+	.section	.debug_info
+	.long		.Lname97
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x21
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #98: variable USERCCLLUT1A
+	.section	.debug_info
+	.uleb128	98	; ref to abbrev 98
+	.section	.debug_abbrev
+	.uleb128	98
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname98:
+	.string		"USERCCLLUT1A"
+	.section	.debug_info
+	.long		.Lname98
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x22
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #99: variable USERCCLLUT1B
+	.section	.debug_info
+	.uleb128	99	; ref to abbrev 99
+	.section	.debug_abbrev
+	.uleb128	99
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname99:
+	.string		"USERCCLLUT1B"
+	.section	.debug_info
+	.long		.Lname99
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x23
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #100: variable USERCCLLUT2A
+	.section	.debug_info
+	.uleb128	100	; ref to abbrev 100
+	.section	.debug_abbrev
+	.uleb128	100
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname100:
+	.string		"USERCCLLUT2A"
+	.section	.debug_info
+	.long		.Lname100
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x24
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #101: variable USERCCLLUT2B
+	.section	.debug_info
+	.uleb128	101	; ref to abbrev 101
+	.section	.debug_abbrev
+	.uleb128	101
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname101:
+	.string		"USERCCLLUT2B"
+	.section	.debug_info
+	.long		.Lname101
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x25
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #102: variable USERCCLLUT3A
+	.section	.debug_info
+	.uleb128	102	; ref to abbrev 102
+	.section	.debug_abbrev
+	.uleb128	102
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname102:
+	.string		"USERCCLLUT3A"
+	.section	.debug_info
+	.long		.Lname102
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x26
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #103: variable USERCCLLUT3B
+	.section	.debug_info
+	.uleb128	103	; ref to abbrev 103
+	.section	.debug_abbrev
+	.uleb128	103
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname103:
+	.string		"USERCCLLUT3B"
+	.section	.debug_info
+	.long		.Lname103
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x27
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #104: variable USERADC0START
+	.section	.debug_info
+	.uleb128	104	; ref to abbrev 104
+	.section	.debug_abbrev
+	.uleb128	104
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname104:
+	.string		"USERADC0START"
+	.section	.debug_info
+	.long		.Lname104
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x28
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #105: variable USEREVSYSEVOUTA
+	.section	.debug_info
+	.uleb128	105	; ref to abbrev 105
+	.section	.debug_abbrev
+	.uleb128	105
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname105:
+	.string		"USEREVSYSEVOUTA"
+	.section	.debug_info
+	.long		.Lname105
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x29
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #106: variable USEREVSYSEVOUTC
+	.section	.debug_info
+	.uleb128	106	; ref to abbrev 106
+	.section	.debug_abbrev
+	.uleb128	106
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname106:
+	.string		"USEREVSYSEVOUTC"
+	.section	.debug_info
+	.long		.Lname106
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #107: variable USEREVSYSEVOUTD
+	.section	.debug_info
+	.uleb128	107	; ref to abbrev 107
+	.section	.debug_abbrev
+	.uleb128	107
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname107:
+	.string		"USEREVSYSEVOUTD"
+	.section	.debug_info
+	.long		.Lname107
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #108: variable USEREVSYSEVOUTF
+	.section	.debug_info
+	.uleb128	108	; ref to abbrev 108
+	.section	.debug_abbrev
+	.uleb128	108
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname108:
+	.string		"USEREVSYSEVOUTF"
+	.section	.debug_info
+	.long		.Lname108
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #109: variable USERUSART0IRDA
+	.section	.debug_info
+	.uleb128	109	; ref to abbrev 109
+	.section	.debug_abbrev
+	.uleb128	109
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname109:
+	.string		"USERUSART0IRDA"
+	.section	.debug_info
+	.long		.Lname109
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #110: variable USERUSART1IRDA
+	.section	.debug_info
+	.uleb128	110	; ref to abbrev 110
+	.section	.debug_abbrev
+	.uleb128	110
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname110:
+	.string		"USERUSART1IRDA"
+	.section	.debug_info
+	.long		.Lname110
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x30
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #111: variable USERUSART2IRDA
+	.section	.debug_info
+	.uleb128	111	; ref to abbrev 111
+	.section	.debug_abbrev
+	.uleb128	111
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname111:
+	.string		"USERUSART2IRDA"
+	.section	.debug_info
+	.long		.Lname111
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x31
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #112: variable USERTCA0CNTA
+	.section	.debug_info
+	.uleb128	112	; ref to abbrev 112
+	.section	.debug_abbrev
+	.uleb128	112
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname112:
+	.string		"USERTCA0CNTA"
+	.section	.debug_info
+	.long		.Lname112
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x32
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #113: variable USERTCA0CNTB
+	.section	.debug_info
+	.uleb128	113	; ref to abbrev 113
+	.section	.debug_abbrev
+	.uleb128	113
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname113:
+	.string		"USERTCA0CNTB"
+	.section	.debug_info
+	.long		.Lname113
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x33
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #114: variable USERTCA1CNTA
+	.section	.debug_info
+	.uleb128	114	; ref to abbrev 114
+	.section	.debug_abbrev
+	.uleb128	114
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname114:
+	.string		"USERTCA1CNTA"
+	.section	.debug_info
+	.long		.Lname114
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x34
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #115: variable USERTCA1CNTB
+	.section	.debug_info
+	.uleb128	115	; ref to abbrev 115
+	.section	.debug_abbrev
+	.uleb128	115
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname115:
+	.string		"USERTCA1CNTB"
+	.section	.debug_info
+	.long		.Lname115
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x35
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #116: variable USERTCB0CAPT
+	.section	.debug_info
+	.uleb128	116	; ref to abbrev 116
+	.section	.debug_abbrev
+	.uleb128	116
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname116:
+	.string		"USERTCB0CAPT"
+	.section	.debug_info
+	.long		.Lname116
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x36
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #117: variable USERTCB0COUNT
+	.section	.debug_info
+	.uleb128	117	; ref to abbrev 117
+	.section	.debug_abbrev
+	.uleb128	117
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname117:
+	.string		"USERTCB0COUNT"
+	.section	.debug_info
+	.long		.Lname117
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x37
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #118: variable USERTCB1CAPT
+	.section	.debug_info
+	.uleb128	118	; ref to abbrev 118
+	.section	.debug_abbrev
+	.uleb128	118
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname118:
+	.string		"USERTCB1CAPT"
+	.section	.debug_info
+	.long		.Lname118
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x38
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #119: variable USERTCB1COUNT
+	.section	.debug_info
+	.uleb128	119	; ref to abbrev 119
+	.section	.debug_abbrev
+	.uleb128	119
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname119:
+	.string		"USERTCB1COUNT"
+	.section	.debug_info
+	.long		.Lname119
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x39
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #120: variable USERTCB2CAPT
+	.section	.debug_info
+	.uleb128	120	; ref to abbrev 120
+	.section	.debug_abbrev
+	.uleb128	120
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname120:
+	.string		"USERTCB2CAPT"
+	.section	.debug_info
+	.long		.Lname120
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x3A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #121: variable USERTCB2COUNT
+	.section	.debug_info
+	.uleb128	121	; ref to abbrev 121
+	.section	.debug_abbrev
+	.uleb128	121
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname121:
+	.string		"USERTCB2COUNT"
+	.section	.debug_info
+	.long		.Lname121
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x3B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #122: variable USERTCB3CAPT
+	.section	.debug_info
+	.uleb128	122	; ref to abbrev 122
+	.section	.debug_abbrev
+	.uleb128	122
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname122:
+	.string		"USERTCB3CAPT"
+	.section	.debug_info
+	.long		.Lname122
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x3C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #123: variable USERTCB3COUNT
+	.section	.debug_info
+	.uleb128	123	; ref to abbrev 123
+	.section	.debug_abbrev
+	.uleb128	123
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname123:
+	.string		"USERTCB3COUNT"
+	.section	.debug_info
+	.long		.Lname123
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x3D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #124: variable WDTCFG
+	.section	.debug_info
+	.uleb128	124	; ref to abbrev 124
+	.section	.debug_abbrev
+	.uleb128	124
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname124:
+	.string		"WDTCFG"
+	.section	.debug_info
+	.long		.Lname124
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #125: variable BODCFG
+	.section	.debug_info
+	.uleb128	125	; ref to abbrev 125
+	.section	.debug_abbrev
+	.uleb128	125
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname125:
+	.string		"BODCFG"
+	.section	.debug_info
+	.long		.Lname125
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #126: variable OSCCFG
+	.section	.debug_info
+	.uleb128	126	; ref to abbrev 126
+	.section	.debug_abbrev
+	.uleb128	126
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname126:
+	.string		"OSCCFG"
+	.section	.debug_info
+	.long		.Lname126
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #127: variable SYSCFG0
+	.section	.debug_info
+	.uleb128	127	; ref to abbrev 127
+	.section	.debug_abbrev
+	.uleb128	127
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname127:
+	.string		"SYSCFG0"
+	.section	.debug_info
+	.long		.Lname127
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #128: variable SYSCFG1
+	.section	.debug_info
+	.uleb128	128	; ref to abbrev 128
+	.section	.debug_abbrev
+	.uleb128	128
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname128:
+	.string		"SYSCFG1"
+	.section	.debug_info
+	.long		.Lname128
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #129: variable CODESIZE
+	.section	.debug_info
+	.uleb128	129	; ref to abbrev 129
+	.section	.debug_abbrev
+	.uleb128	129
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname129:
+	.string		"CODESIZE"
+	.section	.debug_info
+	.long		.Lname129
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #130: variable BOOTSIZE
+	.section	.debug_info
+	.uleb128	130	; ref to abbrev 130
+	.section	.debug_abbrev
+	.uleb128	130
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname130:
+	.string		"BOOTSIZE"
+	.section	.debug_info
+	.long		.Lname130
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #131: variable GPR0
+	.section	.debug_info
+	.uleb128	131	; ref to abbrev 131
+	.section	.debug_abbrev
+	.uleb128	131
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname131:
+	.string		"GPR0"
+	.section	.debug_info
+	.long		.Lname131
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x001C + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #132: variable GPR1
+	.section	.debug_info
+	.uleb128	132	; ref to abbrev 132
+	.section	.debug_abbrev
+	.uleb128	132
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname132:
+	.string		"GPR1"
+	.section	.debug_info
+	.long		.Lname132
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x001C + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #133: variable GPR2
+	.section	.debug_info
+	.uleb128	133	; ref to abbrev 133
+	.section	.debug_abbrev
+	.uleb128	133
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname133:
+	.string		"GPR2"
+	.section	.debug_info
+	.long		.Lname133
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x001C + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #134: variable GPR3
+	.section	.debug_info
+	.uleb128	134	; ref to abbrev 134
+	.section	.debug_abbrev
+	.uleb128	134
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname134:
+	.string		"GPR3"
+	.section	.debug_info
+	.long		.Lname134
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x001C + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #135: variable KEY
+	.section	.debug_info
+	.uleb128	135	; ref to abbrev 135
+	.section	.debug_abbrev
+	.uleb128	135
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname135:
+	.string		"KEY"
+	.section	.debug_info
+	.long		.Lname135
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint32_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1040 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #136: variable CTRLA
+	.section	.debug_info
+	.uleb128	136	; ref to abbrev 136
+	.section	.debug_abbrev
+	.uleb128	136
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname136:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname136
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #137: variable CTRLB
+	.section	.debug_info
+	.uleb128	137	; ref to abbrev 137
+	.section	.debug_abbrev
+	.uleb128	137
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname137:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname137
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #138: variable INTCTRL
+	.section	.debug_info
+	.uleb128	138	; ref to abbrev 138
+	.section	.debug_abbrev
+	.uleb128	138
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname138:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname138
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #139: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	139	; ref to abbrev 139
+	.section	.debug_abbrev
+	.uleb128	139
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname139:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname139
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #140: variable STATUS
+	.section	.debug_info
+	.uleb128	140	; ref to abbrev 140
+	.section	.debug_abbrev
+	.uleb128	140
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname140:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname140
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #141: variable DATA
+	.section	.debug_info
+	.uleb128	141	; ref to abbrev 141
+	.section	.debug_abbrev
+	.uleb128	141
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname141:
+	.string		"DATA"
+	.section	.debug_info
+	.long		.Lname141
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #142: variable ADDR
+	.section	.debug_info
+	.uleb128	142	; ref to abbrev 142
+	.section	.debug_abbrev
+	.uleb128	142
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname142:
+	.string		"ADDR"
+	.section	.debug_info
+	.long		.Lname142
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint32_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #143: variable DIR
+	.section	.debug_info
+	.uleb128	143	; ref to abbrev 143
+	.section	.debug_abbrev
+	.uleb128	143
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname143:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname143
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #144: variable DIRSET
+	.section	.debug_info
+	.uleb128	144	; ref to abbrev 144
+	.section	.debug_abbrev
+	.uleb128	144
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname144:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname144
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #145: variable DIRCLR
+	.section	.debug_info
+	.uleb128	145	; ref to abbrev 145
+	.section	.debug_abbrev
+	.uleb128	145
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname145:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname145
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #146: variable DIRTGL
+	.section	.debug_info
+	.uleb128	146	; ref to abbrev 146
+	.section	.debug_abbrev
+	.uleb128	146
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname146:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname146
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #147: variable OUT
+	.section	.debug_info
+	.uleb128	147	; ref to abbrev 147
+	.section	.debug_abbrev
+	.uleb128	147
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname147:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname147
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #148: variable OUTSET
+	.section	.debug_info
+	.uleb128	148	; ref to abbrev 148
+	.section	.debug_abbrev
+	.uleb128	148
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname148:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname148
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #149: variable OUTCLR
+	.section	.debug_info
+	.uleb128	149	; ref to abbrev 149
+	.section	.debug_abbrev
+	.uleb128	149
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname149:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname149
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #150: variable OUTTGL
+	.section	.debug_info
+	.uleb128	150	; ref to abbrev 150
+	.section	.debug_abbrev
+	.uleb128	150
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname150:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname150
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #151: variable IN
+	.section	.debug_info
+	.uleb128	151	; ref to abbrev 151
+	.section	.debug_abbrev
+	.uleb128	151
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname151:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname151
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #152: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	152	; ref to abbrev 152
+	.section	.debug_abbrev
+	.uleb128	152
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname152:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname152
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #153: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	153	; ref to abbrev 153
+	.section	.debug_abbrev
+	.uleb128	153
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname153:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname153
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #154: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	154	; ref to abbrev 154
+	.section	.debug_abbrev
+	.uleb128	154
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname154:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname154
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #155: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	155	; ref to abbrev 155
+	.section	.debug_abbrev
+	.uleb128	155
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname155:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname155
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #156: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	156	; ref to abbrev 156
+	.section	.debug_abbrev
+	.uleb128	156
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname156:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname156
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #157: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	157	; ref to abbrev 157
+	.section	.debug_abbrev
+	.uleb128	157
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname157:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname157
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #158: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	158	; ref to abbrev 158
+	.section	.debug_abbrev
+	.uleb128	158
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname158:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname158
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #159: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	159	; ref to abbrev 159
+	.section	.debug_abbrev
+	.uleb128	159
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname159:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname159
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #160: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	160	; ref to abbrev 160
+	.section	.debug_abbrev
+	.uleb128	160
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname160:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname160
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #161: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	161	; ref to abbrev 161
+	.section	.debug_abbrev
+	.uleb128	161
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname161:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname161
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #162: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	162	; ref to abbrev 162
+	.section	.debug_abbrev
+	.uleb128	162
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname162:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname162
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #163: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	163	; ref to abbrev 163
+	.section	.debug_abbrev
+	.uleb128	163
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname163:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname163
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #164: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	164	; ref to abbrev 164
+	.section	.debug_abbrev
+	.uleb128	164
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname164:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname164
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #165: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	165	; ref to abbrev 165
+	.section	.debug_abbrev
+	.uleb128	165
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname165:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname165
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #166: variable EVGENCTRL
+	.section	.debug_info
+	.uleb128	166	; ref to abbrev 166
+	.section	.debug_abbrev
+	.uleb128	166
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname166:
+	.string		"EVGENCTRL"
+	.section	.debug_info
+	.long		.Lname166
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #167: variable DIR
+	.section	.debug_info
+	.uleb128	167	; ref to abbrev 167
+	.section	.debug_abbrev
+	.uleb128	167
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname167:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname167
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #168: variable DIRSET
+	.section	.debug_info
+	.uleb128	168	; ref to abbrev 168
+	.section	.debug_abbrev
+	.uleb128	168
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname168:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname168
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #169: variable DIRCLR
+	.section	.debug_info
+	.uleb128	169	; ref to abbrev 169
+	.section	.debug_abbrev
+	.uleb128	169
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname169:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname169
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #170: variable DIRTGL
+	.section	.debug_info
+	.uleb128	170	; ref to abbrev 170
+	.section	.debug_abbrev
+	.uleb128	170
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname170:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname170
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #171: variable OUT
+	.section	.debug_info
+	.uleb128	171	; ref to abbrev 171
+	.section	.debug_abbrev
+	.uleb128	171
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname171:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname171
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #172: variable OUTSET
+	.section	.debug_info
+	.uleb128	172	; ref to abbrev 172
+	.section	.debug_abbrev
+	.uleb128	172
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname172:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname172
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #173: variable OUTCLR
+	.section	.debug_info
+	.uleb128	173	; ref to abbrev 173
+	.section	.debug_abbrev
+	.uleb128	173
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname173:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname173
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #174: variable OUTTGL
+	.section	.debug_info
+	.uleb128	174	; ref to abbrev 174
+	.section	.debug_abbrev
+	.uleb128	174
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname174:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname174
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #175: variable IN
+	.section	.debug_info
+	.uleb128	175	; ref to abbrev 175
+	.section	.debug_abbrev
+	.uleb128	175
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname175:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname175
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #176: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	176	; ref to abbrev 176
+	.section	.debug_abbrev
+	.uleb128	176
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname176:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname176
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #177: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	177	; ref to abbrev 177
+	.section	.debug_abbrev
+	.uleb128	177
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname177:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname177
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #178: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	178	; ref to abbrev 178
+	.section	.debug_abbrev
+	.uleb128	178
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname178:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname178
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #179: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	179	; ref to abbrev 179
+	.section	.debug_abbrev
+	.uleb128	179
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname179:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname179
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #180: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	180	; ref to abbrev 180
+	.section	.debug_abbrev
+	.uleb128	180
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname180:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname180
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #181: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	181	; ref to abbrev 181
+	.section	.debug_abbrev
+	.uleb128	181
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname181:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname181
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #182: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	182	; ref to abbrev 182
+	.section	.debug_abbrev
+	.uleb128	182
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname182:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname182
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #183: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	183	; ref to abbrev 183
+	.section	.debug_abbrev
+	.uleb128	183
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname183:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname183
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #184: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	184	; ref to abbrev 184
+	.section	.debug_abbrev
+	.uleb128	184
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname184:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname184
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #185: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	185	; ref to abbrev 185
+	.section	.debug_abbrev
+	.uleb128	185
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname185:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname185
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #186: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	186	; ref to abbrev 186
+	.section	.debug_abbrev
+	.uleb128	186
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname186:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname186
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #187: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	187	; ref to abbrev 187
+	.section	.debug_abbrev
+	.uleb128	187
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname187:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname187
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #188: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	188	; ref to abbrev 188
+	.section	.debug_abbrev
+	.uleb128	188
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname188:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname188
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #189: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	189	; ref to abbrev 189
+	.section	.debug_abbrev
+	.uleb128	189
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname189:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname189
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #190: variable EVGENCTRL
+	.section	.debug_info
+	.uleb128	190	; ref to abbrev 190
+	.section	.debug_abbrev
+	.uleb128	190
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname190:
+	.string		"EVGENCTRL"
+	.section	.debug_info
+	.long		.Lname190
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #191: variable DIR
+	.section	.debug_info
+	.uleb128	191	; ref to abbrev 191
+	.section	.debug_abbrev
+	.uleb128	191
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname191:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname191
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #192: variable DIRSET
+	.section	.debug_info
+	.uleb128	192	; ref to abbrev 192
+	.section	.debug_abbrev
+	.uleb128	192
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname192:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname192
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #193: variable DIRCLR
+	.section	.debug_info
+	.uleb128	193	; ref to abbrev 193
+	.section	.debug_abbrev
+	.uleb128	193
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname193:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname193
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #194: variable DIRTGL
+	.section	.debug_info
+	.uleb128	194	; ref to abbrev 194
+	.section	.debug_abbrev
+	.uleb128	194
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname194:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname194
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #195: variable OUT
+	.section	.debug_info
+	.uleb128	195	; ref to abbrev 195
+	.section	.debug_abbrev
+	.uleb128	195
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname195:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname195
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #196: variable OUTSET
+	.section	.debug_info
+	.uleb128	196	; ref to abbrev 196
+	.section	.debug_abbrev
+	.uleb128	196
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname196:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname196
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #197: variable OUTCLR
+	.section	.debug_info
+	.uleb128	197	; ref to abbrev 197
+	.section	.debug_abbrev
+	.uleb128	197
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname197:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname197
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #198: variable OUTTGL
+	.section	.debug_info
+	.uleb128	198	; ref to abbrev 198
+	.section	.debug_abbrev
+	.uleb128	198
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname198:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname198
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #199: variable IN
+	.section	.debug_info
+	.uleb128	199	; ref to abbrev 199
+	.section	.debug_abbrev
+	.uleb128	199
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname199:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname199
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #200: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	200	; ref to abbrev 200
+	.section	.debug_abbrev
+	.uleb128	200
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname200:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname200
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #201: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	201	; ref to abbrev 201
+	.section	.debug_abbrev
+	.uleb128	201
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname201:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname201
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #202: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	202	; ref to abbrev 202
+	.section	.debug_abbrev
+	.uleb128	202
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname202:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname202
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #203: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	203	; ref to abbrev 203
+	.section	.debug_abbrev
+	.uleb128	203
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname203:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname203
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #204: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	204	; ref to abbrev 204
+	.section	.debug_abbrev
+	.uleb128	204
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname204:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname204
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #205: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	205	; ref to abbrev 205
+	.section	.debug_abbrev
+	.uleb128	205
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname205:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname205
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #206: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	206	; ref to abbrev 206
+	.section	.debug_abbrev
+	.uleb128	206
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname206:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname206
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #207: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	207	; ref to abbrev 207
+	.section	.debug_abbrev
+	.uleb128	207
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname207:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname207
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #208: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	208	; ref to abbrev 208
+	.section	.debug_abbrev
+	.uleb128	208
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname208:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname208
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #209: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	209	; ref to abbrev 209
+	.section	.debug_abbrev
+	.uleb128	209
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname209:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname209
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #210: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	210	; ref to abbrev 210
+	.section	.debug_abbrev
+	.uleb128	210
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname210:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname210
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #211: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	211	; ref to abbrev 211
+	.section	.debug_abbrev
+	.uleb128	211
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname211:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname211
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #212: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	212	; ref to abbrev 212
+	.section	.debug_abbrev
+	.uleb128	212
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname212:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname212
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #213: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	213	; ref to abbrev 213
+	.section	.debug_abbrev
+	.uleb128	213
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname213:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname213
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #214: variable EVGENCTRL
+	.section	.debug_info
+	.uleb128	214	; ref to abbrev 214
+	.section	.debug_abbrev
+	.uleb128	214
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname214:
+	.string		"EVGENCTRL"
+	.section	.debug_info
+	.long		.Lname214
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #215: variable DIR
+	.section	.debug_info
+	.uleb128	215	; ref to abbrev 215
+	.section	.debug_abbrev
+	.uleb128	215
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname215:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname215
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #216: variable DIRSET
+	.section	.debug_info
+	.uleb128	216	; ref to abbrev 216
+	.section	.debug_abbrev
+	.uleb128	216
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname216:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname216
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #217: variable DIRCLR
+	.section	.debug_info
+	.uleb128	217	; ref to abbrev 217
+	.section	.debug_abbrev
+	.uleb128	217
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname217:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname217
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #218: variable DIRTGL
+	.section	.debug_info
+	.uleb128	218	; ref to abbrev 218
+	.section	.debug_abbrev
+	.uleb128	218
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname218:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname218
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #219: variable OUT
+	.section	.debug_info
+	.uleb128	219	; ref to abbrev 219
+	.section	.debug_abbrev
+	.uleb128	219
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname219:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname219
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #220: variable OUTSET
+	.section	.debug_info
+	.uleb128	220	; ref to abbrev 220
+	.section	.debug_abbrev
+	.uleb128	220
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname220:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname220
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #221: variable OUTCLR
+	.section	.debug_info
+	.uleb128	221	; ref to abbrev 221
+	.section	.debug_abbrev
+	.uleb128	221
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname221:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname221
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #222: variable OUTTGL
+	.section	.debug_info
+	.uleb128	222	; ref to abbrev 222
+	.section	.debug_abbrev
+	.uleb128	222
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname222:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname222
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #223: variable IN
+	.section	.debug_info
+	.uleb128	223	; ref to abbrev 223
+	.section	.debug_abbrev
+	.uleb128	223
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname223:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname223
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #224: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	224	; ref to abbrev 224
+	.section	.debug_abbrev
+	.uleb128	224
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname224:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname224
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #225: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	225	; ref to abbrev 225
+	.section	.debug_abbrev
+	.uleb128	225
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname225:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname225
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #226: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	226	; ref to abbrev 226
+	.section	.debug_abbrev
+	.uleb128	226
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname226:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname226
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #227: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	227	; ref to abbrev 227
+	.section	.debug_abbrev
+	.uleb128	227
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname227:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname227
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #228: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	228	; ref to abbrev 228
+	.section	.debug_abbrev
+	.uleb128	228
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname228:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname228
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #229: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	229	; ref to abbrev 229
+	.section	.debug_abbrev
+	.uleb128	229
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname229:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname229
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #230: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	230	; ref to abbrev 230
+	.section	.debug_abbrev
+	.uleb128	230
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname230:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname230
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #231: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	231	; ref to abbrev 231
+	.section	.debug_abbrev
+	.uleb128	231
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname231:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname231
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #232: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	232	; ref to abbrev 232
+	.section	.debug_abbrev
+	.uleb128	232
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname232:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname232
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #233: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	233	; ref to abbrev 233
+	.section	.debug_abbrev
+	.uleb128	233
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname233:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname233
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #234: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	234	; ref to abbrev 234
+	.section	.debug_abbrev
+	.uleb128	234
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname234:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname234
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #235: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	235	; ref to abbrev 235
+	.section	.debug_abbrev
+	.uleb128	235
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname235:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname235
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #236: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	236	; ref to abbrev 236
+	.section	.debug_abbrev
+	.uleb128	236
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname236:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname236
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #237: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	237	; ref to abbrev 237
+	.section	.debug_abbrev
+	.uleb128	237
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname237:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname237
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #238: variable EVGENCTRL
+	.section	.debug_info
+	.uleb128	238	; ref to abbrev 238
+	.section	.debug_abbrev
+	.uleb128	238
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname238:
+	.string		"EVGENCTRL"
+	.section	.debug_info
+	.long		.Lname238
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #239: variable EVSYSROUTEA
+	.section	.debug_info
+	.uleb128	239	; ref to abbrev 239
+	.section	.debug_abbrev
+	.uleb128	239
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname239:
+	.string		"EVSYSROUTEA"
+	.section	.debug_info
+	.long		.Lname239
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #240: variable CCLROUTEA
+	.section	.debug_info
+	.uleb128	240	; ref to abbrev 240
+	.section	.debug_abbrev
+	.uleb128	240
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname240:
+	.string		"CCLROUTEA"
+	.section	.debug_info
+	.long		.Lname240
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #241: variable USARTROUTEA
+	.section	.debug_info
+	.uleb128	241	; ref to abbrev 241
+	.section	.debug_abbrev
+	.uleb128	241
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname241:
+	.string		"USARTROUTEA"
+	.section	.debug_info
+	.long		.Lname241
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #242: variable USARTROUTEB
+	.section	.debug_info
+	.uleb128	242	; ref to abbrev 242
+	.section	.debug_abbrev
+	.uleb128	242
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname242:
+	.string		"USARTROUTEB"
+	.section	.debug_info
+	.long		.Lname242
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #243: variable SPIROUTEA
+	.section	.debug_info
+	.uleb128	243	; ref to abbrev 243
+	.section	.debug_abbrev
+	.uleb128	243
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname243:
+	.string		"SPIROUTEA"
+	.section	.debug_info
+	.long		.Lname243
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #244: variable TWIROUTEA
+	.section	.debug_info
+	.uleb128	244	; ref to abbrev 244
+	.section	.debug_abbrev
+	.uleb128	244
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname244:
+	.string		"TWIROUTEA"
+	.section	.debug_info
+	.long		.Lname244
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #245: variable TCAROUTEA
+	.section	.debug_info
+	.uleb128	245	; ref to abbrev 245
+	.section	.debug_abbrev
+	.uleb128	245
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname245:
+	.string		"TCAROUTEA"
+	.section	.debug_info
+	.long		.Lname245
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #246: variable TCBROUTEA
+	.section	.debug_info
+	.uleb128	246	; ref to abbrev 246
+	.section	.debug_abbrev
+	.uleb128	246
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname246:
+	.string		"TCBROUTEA"
+	.section	.debug_info
+	.long		.Lname246
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #247: variable ACROUTEA
+	.section	.debug_info
+	.uleb128	247	; ref to abbrev 247
+	.section	.debug_abbrev
+	.uleb128	247
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname247:
+	.string		"ACROUTEA"
+	.section	.debug_info
+	.long		.Lname247
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #248: variable RSTFR
+	.section	.debug_info
+	.uleb128	248	; ref to abbrev 248
+	.section	.debug_abbrev
+	.uleb128	248
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname248:
+	.string		"RSTFR"
+	.section	.debug_info
+	.long		.Lname248
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0040 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #249: variable SWRR
+	.section	.debug_info
+	.uleb128	249	; ref to abbrev 249
+	.section	.debug_abbrev
+	.uleb128	249
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname249:
+	.string		"SWRR"
+	.section	.debug_info
+	.long		.Lname249
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0040 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #250: variable CTRLA
+	.section	.debug_info
+	.uleb128	250	; ref to abbrev 250
+	.section	.debug_abbrev
+	.uleb128	250
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname250:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname250
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #251: variable STATUS
+	.section	.debug_info
+	.uleb128	251	; ref to abbrev 251
+	.section	.debug_abbrev
+	.uleb128	251
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname251:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname251
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #252: variable INTCTRL
+	.section	.debug_info
+	.uleb128	252	; ref to abbrev 252
+	.section	.debug_abbrev
+	.uleb128	252
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname252:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname252
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #253: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	253	; ref to abbrev 253
+	.section	.debug_abbrev
+	.uleb128	253
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname253:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname253
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #254: variable TEMP
+	.section	.debug_info
+	.uleb128	254	; ref to abbrev 254
+	.section	.debug_abbrev
+	.uleb128	254
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname254:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname254
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #255: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	255	; ref to abbrev 255
+	.section	.debug_abbrev
+	.uleb128	255
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname255:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname255
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #256: variable CALIB
+	.section	.debug_info
+	.uleb128	256	; ref to abbrev 256
+	.section	.debug_abbrev
+	.uleb128	256
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname256:
+	.string		"CALIB"
+	.section	.debug_info
+	.long		.Lname256
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #257: variable CLKSEL
+	.section	.debug_info
+	.uleb128	257	; ref to abbrev 257
+	.section	.debug_abbrev
+	.uleb128	257
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname257:
+	.string		"CLKSEL"
+	.section	.debug_info
+	.long		.Lname257
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #258: variable CNT
+	.section	.debug_info
+	.uleb128	258	; ref to abbrev 258
+	.section	.debug_abbrev
+	.uleb128	258
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname258:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname258
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #259: variable PER
+	.section	.debug_info
+	.uleb128	259	; ref to abbrev 259
+	.section	.debug_abbrev
+	.uleb128	259
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname259:
+	.string		"PER"
+	.section	.debug_info
+	.long		.Lname259
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #260: variable CMP
+	.section	.debug_info
+	.uleb128	260	; ref to abbrev 260
+	.section	.debug_abbrev
+	.uleb128	260
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname260:
+	.string		"CMP"
+	.section	.debug_info
+	.long		.Lname260
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #261: variable PITCTRLA
+	.section	.debug_info
+	.uleb128	261	; ref to abbrev 261
+	.section	.debug_abbrev
+	.uleb128	261
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname261:
+	.string		"PITCTRLA"
+	.section	.debug_info
+	.long		.Lname261
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #262: variable PITSTATUS
+	.section	.debug_info
+	.uleb128	262	; ref to abbrev 262
+	.section	.debug_abbrev
+	.uleb128	262
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname262:
+	.string		"PITSTATUS"
+	.section	.debug_info
+	.long		.Lname262
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #263: variable PITINTCTRL
+	.section	.debug_info
+	.uleb128	263	; ref to abbrev 263
+	.section	.debug_abbrev
+	.uleb128	263
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname263:
+	.string		"PITINTCTRL"
+	.section	.debug_info
+	.long		.Lname263
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #264: variable PITINTFLAGS
+	.section	.debug_info
+	.uleb128	264	; ref to abbrev 264
+	.section	.debug_abbrev
+	.uleb128	264
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname264:
+	.string		"PITINTFLAGS"
+	.section	.debug_info
+	.long		.Lname264
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #265: variable PITDBGCTRL
+	.section	.debug_info
+	.uleb128	265	; ref to abbrev 265
+	.section	.debug_abbrev
+	.uleb128	265
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname265:
+	.string		"PITDBGCTRL"
+	.section	.debug_info
+	.long		.Lname265
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #266: variable PITEVGENCTRLA
+	.section	.debug_info
+	.uleb128	266	; ref to abbrev 266
+	.section	.debug_abbrev
+	.uleb128	266
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname266:
+	.string		"PITEVGENCTRLA"
+	.section	.debug_info
+	.long		.Lname266
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #267: variable DEVICEID0
+	.section	.debug_info
+	.uleb128	267	; ref to abbrev 267
+	.section	.debug_abbrev
+	.uleb128	267
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname267:
+	.string		"DEVICEID0"
+	.section	.debug_info
+	.long		.Lname267
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #268: variable DEVICEID1
+	.section	.debug_info
+	.uleb128	268	; ref to abbrev 268
+	.section	.debug_abbrev
+	.uleb128	268
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname268:
+	.string		"DEVICEID1"
+	.section	.debug_info
+	.long		.Lname268
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #269: variable DEVICEID2
+	.section	.debug_info
+	.uleb128	269	; ref to abbrev 269
+	.section	.debug_abbrev
+	.uleb128	269
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname269:
+	.string		"DEVICEID2"
+	.section	.debug_info
+	.long		.Lname269
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #270: variable TEMPSENSE0
+	.section	.debug_info
+	.uleb128	270	; ref to abbrev 270
+	.section	.debug_abbrev
+	.uleb128	270
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname270:
+	.string		"TEMPSENSE0"
+	.section	.debug_info
+	.long		.Lname270
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #271: variable TEMPSENSE1
+	.section	.debug_info
+	.uleb128	271	; ref to abbrev 271
+	.section	.debug_abbrev
+	.uleb128	271
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname271:
+	.string		"TEMPSENSE1"
+	.section	.debug_info
+	.long		.Lname271
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #272: variable SERNUM0
+	.section	.debug_info
+	.uleb128	272	; ref to abbrev 272
+	.section	.debug_abbrev
+	.uleb128	272
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname272:
+	.string		"SERNUM0"
+	.section	.debug_info
+	.long		.Lname272
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #273: variable SERNUM1
+	.section	.debug_info
+	.uleb128	273	; ref to abbrev 273
+	.section	.debug_abbrev
+	.uleb128	273
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname273:
+	.string		"SERNUM1"
+	.section	.debug_info
+	.long		.Lname273
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #274: variable SERNUM2
+	.section	.debug_info
+	.uleb128	274	; ref to abbrev 274
+	.section	.debug_abbrev
+	.uleb128	274
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname274:
+	.string		"SERNUM2"
+	.section	.debug_info
+	.long		.Lname274
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #275: variable SERNUM3
+	.section	.debug_info
+	.uleb128	275	; ref to abbrev 275
+	.section	.debug_abbrev
+	.uleb128	275
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname275:
+	.string		"SERNUM3"
+	.section	.debug_info
+	.long		.Lname275
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #276: variable SERNUM4
+	.section	.debug_info
+	.uleb128	276	; ref to abbrev 276
+	.section	.debug_abbrev
+	.uleb128	276
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname276:
+	.string		"SERNUM4"
+	.section	.debug_info
+	.long		.Lname276
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #277: variable SERNUM5
+	.section	.debug_info
+	.uleb128	277	; ref to abbrev 277
+	.section	.debug_abbrev
+	.uleb128	277
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname277:
+	.string		"SERNUM5"
+	.section	.debug_info
+	.long		.Lname277
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #278: variable SERNUM6
+	.section	.debug_info
+	.uleb128	278	; ref to abbrev 278
+	.section	.debug_abbrev
+	.uleb128	278
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname278:
+	.string		"SERNUM6"
+	.section	.debug_info
+	.long		.Lname278
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #279: variable SERNUM7
+	.section	.debug_info
+	.uleb128	279	; ref to abbrev 279
+	.section	.debug_abbrev
+	.uleb128	279
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname279:
+	.string		"SERNUM7"
+	.section	.debug_info
+	.long		.Lname279
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #280: variable SERNUM8
+	.section	.debug_info
+	.uleb128	280	; ref to abbrev 280
+	.section	.debug_abbrev
+	.uleb128	280
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname280:
+	.string		"SERNUM8"
+	.section	.debug_info
+	.long		.Lname280
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #281: variable SERNUM9
+	.section	.debug_info
+	.uleb128	281	; ref to abbrev 281
+	.section	.debug_abbrev
+	.uleb128	281
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname281:
+	.string		"SERNUM9"
+	.section	.debug_info
+	.long		.Lname281
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x19
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #282: variable SERNUM10
+	.section	.debug_info
+	.uleb128	282	; ref to abbrev 282
+	.section	.debug_abbrev
+	.uleb128	282
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname282:
+	.string		"SERNUM10"
+	.section	.debug_info
+	.long		.Lname282
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x1A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #283: variable SERNUM11
+	.section	.debug_info
+	.uleb128	283	; ref to abbrev 283
+	.section	.debug_abbrev
+	.uleb128	283
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname283:
+	.string		"SERNUM11"
+	.section	.debug_info
+	.long		.Lname283
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x1B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #284: variable SERNUM12
+	.section	.debug_info
+	.uleb128	284	; ref to abbrev 284
+	.section	.debug_abbrev
+	.uleb128	284
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname284:
+	.string		"SERNUM12"
+	.section	.debug_info
+	.long		.Lname284
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x1C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #285: variable SERNUM13
+	.section	.debug_info
+	.uleb128	285	; ref to abbrev 285
+	.section	.debug_abbrev
+	.uleb128	285
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname285:
+	.string		"SERNUM13"
+	.section	.debug_info
+	.long		.Lname285
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x1D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #286: variable SERNUM14
+	.section	.debug_info
+	.uleb128	286	; ref to abbrev 286
+	.section	.debug_abbrev
+	.uleb128	286
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname286:
+	.string		"SERNUM14"
+	.section	.debug_info
+	.long		.Lname286
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x1E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #287: variable SERNUM15
+	.section	.debug_info
+	.uleb128	287	; ref to abbrev 287
+	.section	.debug_abbrev
+	.uleb128	287
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname287:
+	.string		"SERNUM15"
+	.section	.debug_info
+	.long		.Lname287
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x1F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #288: variable CTRLA
+	.section	.debug_info
+	.uleb128	288	; ref to abbrev 288
+	.section	.debug_abbrev
+	.uleb128	288
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname288:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname288
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0050 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #289: variable CTRLA
+	.section	.debug_info
+	.uleb128	289	; ref to abbrev 289
+	.section	.debug_abbrev
+	.uleb128	289
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname289:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname289
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #290: variable CTRLB
+	.section	.debug_info
+	.uleb128	290	; ref to abbrev 290
+	.section	.debug_abbrev
+	.uleb128	290
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname290:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname290
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #291: variable INTCTRL
+	.section	.debug_info
+	.uleb128	291	; ref to abbrev 291
+	.section	.debug_abbrev
+	.uleb128	291
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname291:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname291
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #292: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	292	; ref to abbrev 292
+	.section	.debug_abbrev
+	.uleb128	292
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname292:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname292
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #293: variable DATA
+	.section	.debug_info
+	.uleb128	293	; ref to abbrev 293
+	.section	.debug_abbrev
+	.uleb128	293
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname293:
+	.string		"DATA"
+	.section	.debug_info
+	.long		.Lname293
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #294: variable REVID
+	.section	.debug_info
+	.uleb128	294	; ref to abbrev 294
+	.section	.debug_abbrev
+	.uleb128	294
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname294:
+	.string		"REVID"
+	.section	.debug_info
+	.long		.Lname294
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0F00 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #295: variable OCDMCTRL
+	.section	.debug_info
+	.uleb128	295	; ref to abbrev 295
+	.section	.debug_abbrev
+	.uleb128	295
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname295:
+	.string		"OCDMCTRL"
+	.section	.debug_info
+	.long		.Lname295
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0F00 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #296: variable OCDMSTATUS
+	.section	.debug_info
+	.uleb128	296	; ref to abbrev 296
+	.section	.debug_abbrev
+	.uleb128	296
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname296:
+	.string		"OCDMSTATUS"
+	.section	.debug_info
+	.long		.Lname296
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0F00 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #297: variable CTRLA
+	.section	.debug_info
+	.uleb128	297	; ref to abbrev 297
+	.section	.debug_abbrev
+	.uleb128	297
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname297:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname297
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #298: variable CTRLB
+	.section	.debug_info
+	.uleb128	298	; ref to abbrev 298
+	.section	.debug_abbrev
+	.uleb128	298
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname298:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname298
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #299: variable CTRLC
+	.section	.debug_info
+	.uleb128	299	; ref to abbrev 299
+	.section	.debug_abbrev
+	.uleb128	299
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname299:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname299
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #300: variable CTRLD
+	.section	.debug_info
+	.uleb128	300	; ref to abbrev 300
+	.section	.debug_abbrev
+	.uleb128	300
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname300:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname300
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #301: variable CTRLECLR
+	.section	.debug_info
+	.uleb128	301	; ref to abbrev 301
+	.section	.debug_abbrev
+	.uleb128	301
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname301:
+	.string		"CTRLECLR"
+	.section	.debug_info
+	.long		.Lname301
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #302: variable CTRLESET
+	.section	.debug_info
+	.uleb128	302	; ref to abbrev 302
+	.section	.debug_abbrev
+	.uleb128	302
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname302:
+	.string		"CTRLESET"
+	.section	.debug_info
+	.long		.Lname302
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #303: variable CTRLFCLR
+	.section	.debug_info
+	.uleb128	303	; ref to abbrev 303
+	.section	.debug_abbrev
+	.uleb128	303
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname303:
+	.string		"CTRLFCLR"
+	.section	.debug_info
+	.long		.Lname303
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #304: variable CTRLFSET
+	.section	.debug_info
+	.uleb128	304	; ref to abbrev 304
+	.section	.debug_abbrev
+	.uleb128	304
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname304:
+	.string		"CTRLFSET"
+	.section	.debug_info
+	.long		.Lname304
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #305: variable EVCTRL
+	.section	.debug_info
+	.uleb128	305	; ref to abbrev 305
+	.section	.debug_abbrev
+	.uleb128	305
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname305:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname305
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #306: variable INTCTRL
+	.section	.debug_info
+	.uleb128	306	; ref to abbrev 306
+	.section	.debug_abbrev
+	.uleb128	306
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname306:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname306
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #307: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	307	; ref to abbrev 307
+	.section	.debug_abbrev
+	.uleb128	307
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname307:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname307
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #308: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	308	; ref to abbrev 308
+	.section	.debug_abbrev
+	.uleb128	308
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname308:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname308
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #309: variable TEMP
+	.section	.debug_info
+	.uleb128	309	; ref to abbrev 309
+	.section	.debug_abbrev
+	.uleb128	309
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname309:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname309
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #310: variable CNT
+	.section	.debug_info
+	.uleb128	310	; ref to abbrev 310
+	.section	.debug_abbrev
+	.uleb128	310
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname310:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname310
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #311: variable PER
+	.section	.debug_info
+	.uleb128	311	; ref to abbrev 311
+	.section	.debug_abbrev
+	.uleb128	311
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname311:
+	.string		"PER"
+	.section	.debug_info
+	.long		.Lname311
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x26
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #312: variable CMP0
+	.section	.debug_info
+	.uleb128	312	; ref to abbrev 312
+	.section	.debug_abbrev
+	.uleb128	312
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname312:
+	.string		"CMP0"
+	.section	.debug_info
+	.long		.Lname312
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x28
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #313: variable CMP1
+	.section	.debug_info
+	.uleb128	313	; ref to abbrev 313
+	.section	.debug_abbrev
+	.uleb128	313
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname313:
+	.string		"CMP1"
+	.section	.debug_info
+	.long		.Lname313
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #314: variable CMP2
+	.section	.debug_info
+	.uleb128	314	; ref to abbrev 314
+	.section	.debug_abbrev
+	.uleb128	314
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname314:
+	.string		"CMP2"
+	.section	.debug_info
+	.long		.Lname314
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #315: variable PERBUF
+	.section	.debug_info
+	.uleb128	315	; ref to abbrev 315
+	.section	.debug_abbrev
+	.uleb128	315
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname315:
+	.string		"PERBUF"
+	.section	.debug_info
+	.long		.Lname315
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x36
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #316: variable CMP0BUF
+	.section	.debug_info
+	.uleb128	316	; ref to abbrev 316
+	.section	.debug_abbrev
+	.uleb128	316
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname316:
+	.string		"CMP0BUF"
+	.section	.debug_info
+	.long		.Lname316
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x38
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #317: variable CMP1BUF
+	.section	.debug_info
+	.uleb128	317	; ref to abbrev 317
+	.section	.debug_abbrev
+	.uleb128	317
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname317:
+	.string		"CMP1BUF"
+	.section	.debug_info
+	.long		.Lname317
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x3A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #318: variable CMP2BUF
+	.section	.debug_info
+	.uleb128	318	; ref to abbrev 318
+	.section	.debug_abbrev
+	.uleb128	318
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname318:
+	.string		"CMP2BUF"
+	.section	.debug_info
+	.long		.Lname318
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x3C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #319: variable CTRLA
+	.section	.debug_info
+	.uleb128	319	; ref to abbrev 319
+	.section	.debug_abbrev
+	.uleb128	319
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname319:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname319
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #320: variable CTRLB
+	.section	.debug_info
+	.uleb128	320	; ref to abbrev 320
+	.section	.debug_abbrev
+	.uleb128	320
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname320:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname320
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #321: variable CTRLC
+	.section	.debug_info
+	.uleb128	321	; ref to abbrev 321
+	.section	.debug_abbrev
+	.uleb128	321
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname321:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname321
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #322: variable CTRLD
+	.section	.debug_info
+	.uleb128	322	; ref to abbrev 322
+	.section	.debug_abbrev
+	.uleb128	322
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname322:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname322
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #323: variable CTRLECLR
+	.section	.debug_info
+	.uleb128	323	; ref to abbrev 323
+	.section	.debug_abbrev
+	.uleb128	323
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname323:
+	.string		"CTRLECLR"
+	.section	.debug_info
+	.long		.Lname323
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #324: variable CTRLESET
+	.section	.debug_info
+	.uleb128	324	; ref to abbrev 324
+	.section	.debug_abbrev
+	.uleb128	324
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname324:
+	.string		"CTRLESET"
+	.section	.debug_info
+	.long		.Lname324
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #325: variable INTCTRL
+	.section	.debug_info
+	.uleb128	325	; ref to abbrev 325
+	.section	.debug_abbrev
+	.uleb128	325
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname325:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname325
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #326: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	326	; ref to abbrev 326
+	.section	.debug_abbrev
+	.uleb128	326
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname326:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname326
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #327: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	327	; ref to abbrev 327
+	.section	.debug_abbrev
+	.uleb128	327
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname327:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname327
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #328: variable LCNT
+	.section	.debug_info
+	.uleb128	328	; ref to abbrev 328
+	.section	.debug_abbrev
+	.uleb128	328
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname328:
+	.string		"LCNT"
+	.section	.debug_info
+	.long		.Lname328
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #329: variable HCNT
+	.section	.debug_info
+	.uleb128	329	; ref to abbrev 329
+	.section	.debug_abbrev
+	.uleb128	329
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname329:
+	.string		"HCNT"
+	.section	.debug_info
+	.long		.Lname329
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x21
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #330: variable LPER
+	.section	.debug_info
+	.uleb128	330	; ref to abbrev 330
+	.section	.debug_abbrev
+	.uleb128	330
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname330:
+	.string		"LPER"
+	.section	.debug_info
+	.long		.Lname330
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x26
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #331: variable HPER
+	.section	.debug_info
+	.uleb128	331	; ref to abbrev 331
+	.section	.debug_abbrev
+	.uleb128	331
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname331:
+	.string		"HPER"
+	.section	.debug_info
+	.long		.Lname331
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x27
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #332: variable LCMP0
+	.section	.debug_info
+	.uleb128	332	; ref to abbrev 332
+	.section	.debug_abbrev
+	.uleb128	332
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname332:
+	.string		"LCMP0"
+	.section	.debug_info
+	.long		.Lname332
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x28
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #333: variable HCMP0
+	.section	.debug_info
+	.uleb128	333	; ref to abbrev 333
+	.section	.debug_abbrev
+	.uleb128	333
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname333:
+	.string		"HCMP0"
+	.section	.debug_info
+	.long		.Lname333
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x29
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #334: variable LCMP1
+	.section	.debug_info
+	.uleb128	334	; ref to abbrev 334
+	.section	.debug_abbrev
+	.uleb128	334
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname334:
+	.string		"LCMP1"
+	.section	.debug_info
+	.long		.Lname334
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #335: variable HCMP1
+	.section	.debug_info
+	.uleb128	335	; ref to abbrev 335
+	.section	.debug_abbrev
+	.uleb128	335
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname335:
+	.string		"HCMP1"
+	.section	.debug_info
+	.long		.Lname335
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #336: variable LCMP2
+	.section	.debug_info
+	.uleb128	336	; ref to abbrev 336
+	.section	.debug_abbrev
+	.uleb128	336
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname336:
+	.string		"LCMP2"
+	.section	.debug_info
+	.long		.Lname336
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #337: variable HCMP2
+	.section	.debug_info
+	.uleb128	337	; ref to abbrev 337
+	.section	.debug_abbrev
+	.uleb128	337
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname337:
+	.string		"HCMP2"
+	.section	.debug_info
+	.long		.Lname337
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #338: variable CTRLA
+	.section	.debug_info
+	.uleb128	338	; ref to abbrev 338
+	.section	.debug_abbrev
+	.uleb128	338
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname338:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname338
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #339: variable CTRLB
+	.section	.debug_info
+	.uleb128	339	; ref to abbrev 339
+	.section	.debug_abbrev
+	.uleb128	339
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname339:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname339
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #340: variable EVCTRL
+	.section	.debug_info
+	.uleb128	340	; ref to abbrev 340
+	.section	.debug_abbrev
+	.uleb128	340
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname340:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname340
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #341: variable INTCTRL
+	.section	.debug_info
+	.uleb128	341	; ref to abbrev 341
+	.section	.debug_abbrev
+	.uleb128	341
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname341:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname341
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #342: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	342	; ref to abbrev 342
+	.section	.debug_abbrev
+	.uleb128	342
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname342:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname342
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #343: variable STATUS
+	.section	.debug_info
+	.uleb128	343	; ref to abbrev 343
+	.section	.debug_abbrev
+	.uleb128	343
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname343:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname343
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #344: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	344	; ref to abbrev 344
+	.section	.debug_abbrev
+	.uleb128	344
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname344:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname344
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #345: variable TEMP
+	.section	.debug_info
+	.uleb128	345	; ref to abbrev 345
+	.section	.debug_abbrev
+	.uleb128	345
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname345:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname345
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #346: variable CNT
+	.section	.debug_info
+	.uleb128	346	; ref to abbrev 346
+	.section	.debug_abbrev
+	.uleb128	346
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname346:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname346
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #347: variable CCMP
+	.section	.debug_info
+	.uleb128	347	; ref to abbrev 347
+	.section	.debug_abbrev
+	.uleb128	347
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname347:
+	.string		"CCMP"
+	.section	.debug_info
+	.long		.Lname347
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #348: variable CTRLA
+	.section	.debug_info
+	.uleb128	348	; ref to abbrev 348
+	.section	.debug_abbrev
+	.uleb128	348
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname348:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname348
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #349: variable CTRLB
+	.section	.debug_info
+	.uleb128	349	; ref to abbrev 349
+	.section	.debug_abbrev
+	.uleb128	349
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname349:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname349
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #350: variable EVCTRL
+	.section	.debug_info
+	.uleb128	350	; ref to abbrev 350
+	.section	.debug_abbrev
+	.uleb128	350
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname350:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname350
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #351: variable INTCTRL
+	.section	.debug_info
+	.uleb128	351	; ref to abbrev 351
+	.section	.debug_abbrev
+	.uleb128	351
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname351:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname351
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #352: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	352	; ref to abbrev 352
+	.section	.debug_abbrev
+	.uleb128	352
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname352:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname352
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #353: variable STATUS
+	.section	.debug_info
+	.uleb128	353	; ref to abbrev 353
+	.section	.debug_abbrev
+	.uleb128	353
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname353:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname353
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #354: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	354	; ref to abbrev 354
+	.section	.debug_abbrev
+	.uleb128	354
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname354:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname354
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #355: variable TEMP
+	.section	.debug_info
+	.uleb128	355	; ref to abbrev 355
+	.section	.debug_abbrev
+	.uleb128	355
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname355:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname355
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #356: variable CNT
+	.section	.debug_info
+	.uleb128	356	; ref to abbrev 356
+	.section	.debug_abbrev
+	.uleb128	356
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname356:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname356
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #357: variable CCMP
+	.section	.debug_info
+	.uleb128	357	; ref to abbrev 357
+	.section	.debug_abbrev
+	.uleb128	357
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname357:
+	.string		"CCMP"
+	.section	.debug_info
+	.long		.Lname357
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #358: variable CTRLA
+	.section	.debug_info
+	.uleb128	358	; ref to abbrev 358
+	.section	.debug_abbrev
+	.uleb128	358
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname358:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname358
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #359: variable CTRLB
+	.section	.debug_info
+	.uleb128	359	; ref to abbrev 359
+	.section	.debug_abbrev
+	.uleb128	359
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname359:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname359
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #360: variable EVCTRL
+	.section	.debug_info
+	.uleb128	360	; ref to abbrev 360
+	.section	.debug_abbrev
+	.uleb128	360
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname360:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname360
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #361: variable INTCTRL
+	.section	.debug_info
+	.uleb128	361	; ref to abbrev 361
+	.section	.debug_abbrev
+	.uleb128	361
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname361:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname361
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #362: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	362	; ref to abbrev 362
+	.section	.debug_abbrev
+	.uleb128	362
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname362:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname362
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #363: variable STATUS
+	.section	.debug_info
+	.uleb128	363	; ref to abbrev 363
+	.section	.debug_abbrev
+	.uleb128	363
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname363:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname363
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #364: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	364	; ref to abbrev 364
+	.section	.debug_abbrev
+	.uleb128	364
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname364:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname364
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #365: variable TEMP
+	.section	.debug_info
+	.uleb128	365	; ref to abbrev 365
+	.section	.debug_abbrev
+	.uleb128	365
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname365:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname365
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #366: variable CNT
+	.section	.debug_info
+	.uleb128	366	; ref to abbrev 366
+	.section	.debug_abbrev
+	.uleb128	366
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname366:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname366
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #367: variable CCMP
+	.section	.debug_info
+	.uleb128	367	; ref to abbrev 367
+	.section	.debug_abbrev
+	.uleb128	367
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname367:
+	.string		"CCMP"
+	.section	.debug_info
+	.long		.Lname367
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #368: variable CTRLA
+	.section	.debug_info
+	.uleb128	368	; ref to abbrev 368
+	.section	.debug_abbrev
+	.uleb128	368
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname368:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname368
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #369: variable DUALCTRL
+	.section	.debug_info
+	.uleb128	369	; ref to abbrev 369
+	.section	.debug_abbrev
+	.uleb128	369
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname369:
+	.string		"DUALCTRL"
+	.section	.debug_info
+	.long		.Lname369
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #370: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	370	; ref to abbrev 370
+	.section	.debug_abbrev
+	.uleb128	370
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname370:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname370
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #371: variable MCTRLA
+	.section	.debug_info
+	.uleb128	371	; ref to abbrev 371
+	.section	.debug_abbrev
+	.uleb128	371
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname371:
+	.string		"MCTRLA"
+	.section	.debug_info
+	.long		.Lname371
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #372: variable MCTRLB
+	.section	.debug_info
+	.uleb128	372	; ref to abbrev 372
+	.section	.debug_abbrev
+	.uleb128	372
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname372:
+	.string		"MCTRLB"
+	.section	.debug_info
+	.long		.Lname372
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #373: variable MSTATUS
+	.section	.debug_info
+	.uleb128	373	; ref to abbrev 373
+	.section	.debug_abbrev
+	.uleb128	373
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname373:
+	.string		"MSTATUS"
+	.section	.debug_info
+	.long		.Lname373
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #374: variable MBAUD
+	.section	.debug_info
+	.uleb128	374	; ref to abbrev 374
+	.section	.debug_abbrev
+	.uleb128	374
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname374:
+	.string		"MBAUD"
+	.section	.debug_info
+	.long		.Lname374
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #375: variable MADDR
+	.section	.debug_info
+	.uleb128	375	; ref to abbrev 375
+	.section	.debug_abbrev
+	.uleb128	375
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname375:
+	.string		"MADDR"
+	.section	.debug_info
+	.long		.Lname375
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #376: variable MDATA
+	.section	.debug_info
+	.uleb128	376	; ref to abbrev 376
+	.section	.debug_abbrev
+	.uleb128	376
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname376:
+	.string		"MDATA"
+	.section	.debug_info
+	.long		.Lname376
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #377: variable SCTRLA
+	.section	.debug_info
+	.uleb128	377	; ref to abbrev 377
+	.section	.debug_abbrev
+	.uleb128	377
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname377:
+	.string		"SCTRLA"
+	.section	.debug_info
+	.long		.Lname377
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #378: variable SCTRLB
+	.section	.debug_info
+	.uleb128	378	; ref to abbrev 378
+	.section	.debug_abbrev
+	.uleb128	378
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname378:
+	.string		"SCTRLB"
+	.section	.debug_info
+	.long		.Lname378
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #379: variable SSTATUS
+	.section	.debug_info
+	.uleb128	379	; ref to abbrev 379
+	.section	.debug_abbrev
+	.uleb128	379
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname379:
+	.string		"SSTATUS"
+	.section	.debug_info
+	.long		.Lname379
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #380: variable SADDR
+	.section	.debug_info
+	.uleb128	380	; ref to abbrev 380
+	.section	.debug_abbrev
+	.uleb128	380
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname380:
+	.string		"SADDR"
+	.section	.debug_info
+	.long		.Lname380
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #381: variable SDATA
+	.section	.debug_info
+	.uleb128	381	; ref to abbrev 381
+	.section	.debug_abbrev
+	.uleb128	381
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname381:
+	.string		"SDATA"
+	.section	.debug_info
+	.long		.Lname381
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xD
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #382: variable SADDRMASK
+	.section	.debug_info
+	.uleb128	382	; ref to abbrev 382
+	.section	.debug_abbrev
+	.uleb128	382
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname382:
+	.string		"SADDRMASK"
+	.section	.debug_info
+	.long		.Lname382
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xE
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #383: variable RXDATAL
+	.section	.debug_info
+	.uleb128	383	; ref to abbrev 383
+	.section	.debug_abbrev
+	.uleb128	383
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname383:
+	.string		"RXDATAL"
+	.section	.debug_info
+	.long		.Lname383
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #384: variable RXDATAH
+	.section	.debug_info
+	.uleb128	384	; ref to abbrev 384
+	.section	.debug_abbrev
+	.uleb128	384
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname384:
+	.string		"RXDATAH"
+	.section	.debug_info
+	.long		.Lname384
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #385: variable TXDATAL
+	.section	.debug_info
+	.uleb128	385	; ref to abbrev 385
+	.section	.debug_abbrev
+	.uleb128	385
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname385:
+	.string		"TXDATAL"
+	.section	.debug_info
+	.long		.Lname385
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #386: variable TXDATAH
+	.section	.debug_info
+	.uleb128	386	; ref to abbrev 386
+	.section	.debug_abbrev
+	.uleb128	386
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname386:
+	.string		"TXDATAH"
+	.section	.debug_info
+	.long		.Lname386
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #387: variable STATUS
+	.section	.debug_info
+	.uleb128	387	; ref to abbrev 387
+	.section	.debug_abbrev
+	.uleb128	387
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname387:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname387
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #388: variable CTRLA
+	.section	.debug_info
+	.uleb128	388	; ref to abbrev 388
+	.section	.debug_abbrev
+	.uleb128	388
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname388:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname388
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #389: variable CTRLB
+	.section	.debug_info
+	.uleb128	389	; ref to abbrev 389
+	.section	.debug_abbrev
+	.uleb128	389
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname389:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname389
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #390: variable CTRLC
+	.section	.debug_info
+	.uleb128	390	; ref to abbrev 390
+	.section	.debug_abbrev
+	.uleb128	390
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname390:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname390
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #391: variable BAUD
+	.section	.debug_info
+	.uleb128	391	; ref to abbrev 391
+	.section	.debug_abbrev
+	.uleb128	391
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname391:
+	.string		"BAUD"
+	.section	.debug_info
+	.long		.Lname391
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #392: variable CTRLD
+	.section	.debug_info
+	.uleb128	392	; ref to abbrev 392
+	.section	.debug_abbrev
+	.uleb128	392
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname392:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname392
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #393: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	393	; ref to abbrev 393
+	.section	.debug_abbrev
+	.uleb128	393
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname393:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname393
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #394: variable EVCTRL
+	.section	.debug_info
+	.uleb128	394	; ref to abbrev 394
+	.section	.debug_abbrev
+	.uleb128	394
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname394:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname394
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #395: variable TXPLCTRL
+	.section	.debug_info
+	.uleb128	395	; ref to abbrev 395
+	.section	.debug_abbrev
+	.uleb128	395
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname395:
+	.string		"TXPLCTRL"
+	.section	.debug_info
+	.long		.Lname395
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xD
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #396: variable RXPLCTRL
+	.section	.debug_info
+	.uleb128	396	; ref to abbrev 396
+	.section	.debug_abbrev
+	.uleb128	396
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname396:
+	.string		"RXPLCTRL"
+	.section	.debug_info
+	.long		.Lname396
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xE
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #397: variable RXDATAL
+	.section	.debug_info
+	.uleb128	397	; ref to abbrev 397
+	.section	.debug_abbrev
+	.uleb128	397
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname397:
+	.string		"RXDATAL"
+	.section	.debug_info
+	.long		.Lname397
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #398: variable RXDATAH
+	.section	.debug_info
+	.uleb128	398	; ref to abbrev 398
+	.section	.debug_abbrev
+	.uleb128	398
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname398:
+	.string		"RXDATAH"
+	.section	.debug_info
+	.long		.Lname398
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #399: variable TXDATAL
+	.section	.debug_info
+	.uleb128	399	; ref to abbrev 399
+	.section	.debug_abbrev
+	.uleb128	399
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname399:
+	.string		"TXDATAL"
+	.section	.debug_info
+	.long		.Lname399
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #400: variable TXDATAH
+	.section	.debug_info
+	.uleb128	400	; ref to abbrev 400
+	.section	.debug_abbrev
+	.uleb128	400
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname400:
+	.string		"TXDATAH"
+	.section	.debug_info
+	.long		.Lname400
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #401: variable STATUS
+	.section	.debug_info
+	.uleb128	401	; ref to abbrev 401
+	.section	.debug_abbrev
+	.uleb128	401
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname401:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname401
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #402: variable CTRLA
+	.section	.debug_info
+	.uleb128	402	; ref to abbrev 402
+	.section	.debug_abbrev
+	.uleb128	402
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname402:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname402
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #403: variable CTRLB
+	.section	.debug_info
+	.uleb128	403	; ref to abbrev 403
+	.section	.debug_abbrev
+	.uleb128	403
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname403:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname403
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #404: variable CTRLC
+	.section	.debug_info
+	.uleb128	404	; ref to abbrev 404
+	.section	.debug_abbrev
+	.uleb128	404
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname404:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname404
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #405: variable BAUD
+	.section	.debug_info
+	.uleb128	405	; ref to abbrev 405
+	.section	.debug_abbrev
+	.uleb128	405
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname405:
+	.string		"BAUD"
+	.section	.debug_info
+	.long		.Lname405
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #406: variable CTRLD
+	.section	.debug_info
+	.uleb128	406	; ref to abbrev 406
+	.section	.debug_abbrev
+	.uleb128	406
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname406:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname406
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #407: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	407	; ref to abbrev 407
+	.section	.debug_abbrev
+	.uleb128	407
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname407:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname407
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #408: variable EVCTRL
+	.section	.debug_info
+	.uleb128	408	; ref to abbrev 408
+	.section	.debug_abbrev
+	.uleb128	408
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname408:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname408
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #409: variable TXPLCTRL
+	.section	.debug_info
+	.uleb128	409	; ref to abbrev 409
+	.section	.debug_abbrev
+	.uleb128	409
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname409:
+	.string		"TXPLCTRL"
+	.section	.debug_info
+	.long		.Lname409
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0xD
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #410: variable RXPLCTRL
+	.section	.debug_info
+	.uleb128	410	; ref to abbrev 410
+	.section	.debug_abbrev
+	.uleb128	410
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname410:
+	.string		"RXPLCTRL"
+	.section	.debug_info
+	.long		.Lname410
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0xE
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #411: variable RXDATAL
+	.section	.debug_info
+	.uleb128	411	; ref to abbrev 411
+	.section	.debug_abbrev
+	.uleb128	411
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname411:
+	.string		"RXDATAL"
+	.section	.debug_info
+	.long		.Lname411
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #412: variable RXDATAH
+	.section	.debug_info
+	.uleb128	412	; ref to abbrev 412
+	.section	.debug_abbrev
+	.uleb128	412
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname412:
+	.string		"RXDATAH"
+	.section	.debug_info
+	.long		.Lname412
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #413: variable TXDATAL
+	.section	.debug_info
+	.uleb128	413	; ref to abbrev 413
+	.section	.debug_abbrev
+	.uleb128	413
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname413:
+	.string		"TXDATAL"
+	.section	.debug_info
+	.long		.Lname413
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #414: variable TXDATAH
+	.section	.debug_info
+	.uleb128	414	; ref to abbrev 414
+	.section	.debug_abbrev
+	.uleb128	414
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname414:
+	.string		"TXDATAH"
+	.section	.debug_info
+	.long		.Lname414
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #415: variable STATUS
+	.section	.debug_info
+	.uleb128	415	; ref to abbrev 415
+	.section	.debug_abbrev
+	.uleb128	415
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname415:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname415
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #416: variable CTRLA
+	.section	.debug_info
+	.uleb128	416	; ref to abbrev 416
+	.section	.debug_abbrev
+	.uleb128	416
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname416:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname416
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #417: variable CTRLB
+	.section	.debug_info
+	.uleb128	417	; ref to abbrev 417
+	.section	.debug_abbrev
+	.uleb128	417
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname417:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname417
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #418: variable CTRLC
+	.section	.debug_info
+	.uleb128	418	; ref to abbrev 418
+	.section	.debug_abbrev
+	.uleb128	418
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname418:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname418
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #419: variable BAUD
+	.section	.debug_info
+	.uleb128	419	; ref to abbrev 419
+	.section	.debug_abbrev
+	.uleb128	419
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname419:
+	.string		"BAUD"
+	.section	.debug_info
+	.long		.Lname419
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #420: variable CTRLD
+	.section	.debug_info
+	.uleb128	420	; ref to abbrev 420
+	.section	.debug_abbrev
+	.uleb128	420
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname420:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname420
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #421: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	421	; ref to abbrev 421
+	.section	.debug_abbrev
+	.uleb128	421
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname421:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname421
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #422: variable EVCTRL
+	.section	.debug_info
+	.uleb128	422	; ref to abbrev 422
+	.section	.debug_abbrev
+	.uleb128	422
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname422:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname422
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #423: variable TXPLCTRL
+	.section	.debug_info
+	.uleb128	423	; ref to abbrev 423
+	.section	.debug_abbrev
+	.uleb128	423
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname423:
+	.string		"TXPLCTRL"
+	.section	.debug_info
+	.long		.Lname423
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0xD
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #424: variable RXPLCTRL
+	.section	.debug_info
+	.uleb128	424	; ref to abbrev 424
+	.section	.debug_abbrev
+	.uleb128	424
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname424:
+	.string		"RXPLCTRL"
+	.section	.debug_info
+	.long		.Lname424
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0xE
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #425: variable USERROW0
+	.section	.debug_info
+	.uleb128	425	; ref to abbrev 425
+	.section	.debug_abbrev
+	.uleb128	425
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname425:
+	.string		"USERROW0"
+	.section	.debug_info
+	.long		.Lname425
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #426: variable USERROW1
+	.section	.debug_info
+	.uleb128	426	; ref to abbrev 426
+	.section	.debug_abbrev
+	.uleb128	426
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname426:
+	.string		"USERROW1"
+	.section	.debug_info
+	.long		.Lname426
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #427: variable USERROW2
+	.section	.debug_info
+	.uleb128	427	; ref to abbrev 427
+	.section	.debug_abbrev
+	.uleb128	427
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname427:
+	.string		"USERROW2"
+	.section	.debug_info
+	.long		.Lname427
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #428: variable USERROW3
+	.section	.debug_info
+	.uleb128	428	; ref to abbrev 428
+	.section	.debug_abbrev
+	.uleb128	428
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname428:
+	.string		"USERROW3"
+	.section	.debug_info
+	.long		.Lname428
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #429: variable USERROW4
+	.section	.debug_info
+	.uleb128	429	; ref to abbrev 429
+	.section	.debug_abbrev
+	.uleb128	429
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname429:
+	.string		"USERROW4"
+	.section	.debug_info
+	.long		.Lname429
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #430: variable USERROW5
+	.section	.debug_info
+	.uleb128	430	; ref to abbrev 430
+	.section	.debug_abbrev
+	.uleb128	430
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname430:
+	.string		"USERROW5"
+	.section	.debug_info
+	.long		.Lname430
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #431: variable USERROW6
+	.section	.debug_info
+	.uleb128	431	; ref to abbrev 431
+	.section	.debug_abbrev
+	.uleb128	431
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname431:
+	.string		"USERROW6"
+	.section	.debug_info
+	.long		.Lname431
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #432: variable USERROW7
+	.section	.debug_info
+	.uleb128	432	; ref to abbrev 432
+	.section	.debug_abbrev
+	.uleb128	432
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname432:
+	.string		"USERROW7"
+	.section	.debug_info
+	.long		.Lname432
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #433: variable USERROW8
+	.section	.debug_info
+	.uleb128	433	; ref to abbrev 433
+	.section	.debug_abbrev
+	.uleb128	433
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname433:
+	.string		"USERROW8"
+	.section	.debug_info
+	.long		.Lname433
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #434: variable USERROW9
+	.section	.debug_info
+	.uleb128	434	; ref to abbrev 434
+	.section	.debug_abbrev
+	.uleb128	434
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname434:
+	.string		"USERROW9"
+	.section	.debug_info
+	.long		.Lname434
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #435: variable USERROW10
+	.section	.debug_info
+	.uleb128	435	; ref to abbrev 435
+	.section	.debug_abbrev
+	.uleb128	435
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname435:
+	.string		"USERROW10"
+	.section	.debug_info
+	.long		.Lname435
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #436: variable USERROW11
+	.section	.debug_info
+	.uleb128	436	; ref to abbrev 436
+	.section	.debug_abbrev
+	.uleb128	436
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname436:
+	.string		"USERROW11"
+	.section	.debug_info
+	.long		.Lname436
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #437: variable USERROW12
+	.section	.debug_info
+	.uleb128	437	; ref to abbrev 437
+	.section	.debug_abbrev
+	.uleb128	437
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname437:
+	.string		"USERROW12"
+	.section	.debug_info
+	.long		.Lname437
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #438: variable USERROW13
+	.section	.debug_info
+	.uleb128	438	; ref to abbrev 438
+	.section	.debug_abbrev
+	.uleb128	438
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname438:
+	.string		"USERROW13"
+	.section	.debug_info
+	.long		.Lname438
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #439: variable USERROW14
+	.section	.debug_info
+	.uleb128	439	; ref to abbrev 439
+	.section	.debug_abbrev
+	.uleb128	439
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname439:
+	.string		"USERROW14"
+	.section	.debug_info
+	.long		.Lname439
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #440: variable USERROW15
+	.section	.debug_info
+	.uleb128	440	; ref to abbrev 440
+	.section	.debug_abbrev
+	.uleb128	440
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname440:
+	.string		"USERROW15"
+	.section	.debug_info
+	.long		.Lname440
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x0F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #441: variable USERROW16
+	.section	.debug_info
+	.uleb128	441	; ref to abbrev 441
+	.section	.debug_abbrev
+	.uleb128	441
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname441:
+	.string		"USERROW16"
+	.section	.debug_info
+	.long		.Lname441
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #442: variable USERROW17
+	.section	.debug_info
+	.uleb128	442	; ref to abbrev 442
+	.section	.debug_abbrev
+	.uleb128	442
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname442:
+	.string		"USERROW17"
+	.section	.debug_info
+	.long		.Lname442
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #443: variable USERROW18
+	.section	.debug_info
+	.uleb128	443	; ref to abbrev 443
+	.section	.debug_abbrev
+	.uleb128	443
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname443:
+	.string		"USERROW18"
+	.section	.debug_info
+	.long		.Lname443
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #444: variable USERROW19
+	.section	.debug_info
+	.uleb128	444	; ref to abbrev 444
+	.section	.debug_abbrev
+	.uleb128	444
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname444:
+	.string		"USERROW19"
+	.section	.debug_info
+	.long		.Lname444
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #445: variable USERROW20
+	.section	.debug_info
+	.uleb128	445	; ref to abbrev 445
+	.section	.debug_abbrev
+	.uleb128	445
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname445:
+	.string		"USERROW20"
+	.section	.debug_info
+	.long		.Lname445
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #446: variable USERROW21
+	.section	.debug_info
+	.uleb128	446	; ref to abbrev 446
+	.section	.debug_abbrev
+	.uleb128	446
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname446:
+	.string		"USERROW21"
+	.section	.debug_info
+	.long		.Lname446
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #447: variable USERROW22
+	.section	.debug_info
+	.uleb128	447	; ref to abbrev 447
+	.section	.debug_abbrev
+	.uleb128	447
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname447:
+	.string		"USERROW22"
+	.section	.debug_info
+	.long		.Lname447
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #448: variable USERROW23
+	.section	.debug_info
+	.uleb128	448	; ref to abbrev 448
+	.section	.debug_abbrev
+	.uleb128	448
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname448:
+	.string		"USERROW23"
+	.section	.debug_info
+	.long		.Lname448
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #449: variable USERROW24
+	.section	.debug_info
+	.uleb128	449	; ref to abbrev 449
+	.section	.debug_abbrev
+	.uleb128	449
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname449:
+	.string		"USERROW24"
+	.section	.debug_info
+	.long		.Lname449
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #450: variable USERROW25
+	.section	.debug_info
+	.uleb128	450	; ref to abbrev 450
+	.section	.debug_abbrev
+	.uleb128	450
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname450:
+	.string		"USERROW25"
+	.section	.debug_info
+	.long		.Lname450
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x19
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #451: variable USERROW26
+	.section	.debug_info
+	.uleb128	451	; ref to abbrev 451
+	.section	.debug_abbrev
+	.uleb128	451
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname451:
+	.string		"USERROW26"
+	.section	.debug_info
+	.long		.Lname451
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #452: variable USERROW27
+	.section	.debug_info
+	.uleb128	452	; ref to abbrev 452
+	.section	.debug_abbrev
+	.uleb128	452
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname452:
+	.string		"USERROW27"
+	.section	.debug_info
+	.long		.Lname452
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #453: variable USERROW28
+	.section	.debug_info
+	.uleb128	453	; ref to abbrev 453
+	.section	.debug_abbrev
+	.uleb128	453
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname453:
+	.string		"USERROW28"
+	.section	.debug_info
+	.long		.Lname453
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #454: variable USERROW29
+	.section	.debug_info
+	.uleb128	454	; ref to abbrev 454
+	.section	.debug_abbrev
+	.uleb128	454
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname454:
+	.string		"USERROW29"
+	.section	.debug_info
+	.long		.Lname454
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #455: variable USERROW30
+	.section	.debug_info
+	.uleb128	455	; ref to abbrev 455
+	.section	.debug_abbrev
+	.uleb128	455
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname455:
+	.string		"USERROW30"
+	.section	.debug_info
+	.long		.Lname455
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #456: variable USERROW31
+	.section	.debug_info
+	.uleb128	456	; ref to abbrev 456
+	.section	.debug_abbrev
+	.uleb128	456
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname456:
+	.string		"USERROW31"
+	.section	.debug_info
+	.long		.Lname456
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #457: variable USERROW32
+	.section	.debug_info
+	.uleb128	457	; ref to abbrev 457
+	.section	.debug_abbrev
+	.uleb128	457
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname457:
+	.string		"USERROW32"
+	.section	.debug_info
+	.long		.Lname457
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #458: variable USERROW33
+	.section	.debug_info
+	.uleb128	458	; ref to abbrev 458
+	.section	.debug_abbrev
+	.uleb128	458
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname458:
+	.string		"USERROW33"
+	.section	.debug_info
+	.long		.Lname458
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x21
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #459: variable USERROW34
+	.section	.debug_info
+	.uleb128	459	; ref to abbrev 459
+	.section	.debug_abbrev
+	.uleb128	459
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname459:
+	.string		"USERROW34"
+	.section	.debug_info
+	.long		.Lname459
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x22
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #460: variable USERROW35
+	.section	.debug_info
+	.uleb128	460	; ref to abbrev 460
+	.section	.debug_abbrev
+	.uleb128	460
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname460:
+	.string		"USERROW35"
+	.section	.debug_info
+	.long		.Lname460
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x23
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #461: variable USERROW36
+	.section	.debug_info
+	.uleb128	461	; ref to abbrev 461
+	.section	.debug_abbrev
+	.uleb128	461
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname461:
+	.string		"USERROW36"
+	.section	.debug_info
+	.long		.Lname461
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x24
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #462: variable USERROW37
+	.section	.debug_info
+	.uleb128	462	; ref to abbrev 462
+	.section	.debug_abbrev
+	.uleb128	462
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname462:
+	.string		"USERROW37"
+	.section	.debug_info
+	.long		.Lname462
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x25
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #463: variable USERROW38
+	.section	.debug_info
+	.uleb128	463	; ref to abbrev 463
+	.section	.debug_abbrev
+	.uleb128	463
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname463:
+	.string		"USERROW38"
+	.section	.debug_info
+	.long		.Lname463
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x26
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #464: variable USERROW39
+	.section	.debug_info
+	.uleb128	464	; ref to abbrev 464
+	.section	.debug_abbrev
+	.uleb128	464
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname464:
+	.string		"USERROW39"
+	.section	.debug_info
+	.long		.Lname464
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x27
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #465: variable USERROW40
+	.section	.debug_info
+	.uleb128	465	; ref to abbrev 465
+	.section	.debug_abbrev
+	.uleb128	465
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname465:
+	.string		"USERROW40"
+	.section	.debug_info
+	.long		.Lname465
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x28
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #466: variable USERROW41
+	.section	.debug_info
+	.uleb128	466	; ref to abbrev 466
+	.section	.debug_abbrev
+	.uleb128	466
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname466:
+	.string		"USERROW41"
+	.section	.debug_info
+	.long		.Lname466
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x29
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #467: variable USERROW42
+	.section	.debug_info
+	.uleb128	467	; ref to abbrev 467
+	.section	.debug_abbrev
+	.uleb128	467
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname467:
+	.string		"USERROW42"
+	.section	.debug_info
+	.long		.Lname467
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x2A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #468: variable USERROW43
+	.section	.debug_info
+	.uleb128	468	; ref to abbrev 468
+	.section	.debug_abbrev
+	.uleb128	468
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname468:
+	.string		"USERROW43"
+	.section	.debug_info
+	.long		.Lname468
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x2B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #469: variable USERROW44
+	.section	.debug_info
+	.uleb128	469	; ref to abbrev 469
+	.section	.debug_abbrev
+	.uleb128	469
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname469:
+	.string		"USERROW44"
+	.section	.debug_info
+	.long		.Lname469
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x2C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #470: variable USERROW45
+	.section	.debug_info
+	.uleb128	470	; ref to abbrev 470
+	.section	.debug_abbrev
+	.uleb128	470
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname470:
+	.string		"USERROW45"
+	.section	.debug_info
+	.long		.Lname470
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x2D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #471: variable USERROW46
+	.section	.debug_info
+	.uleb128	471	; ref to abbrev 471
+	.section	.debug_abbrev
+	.uleb128	471
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname471:
+	.string		"USERROW46"
+	.section	.debug_info
+	.long		.Lname471
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x2E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #472: variable USERROW47
+	.section	.debug_info
+	.uleb128	472	; ref to abbrev 472
+	.section	.debug_abbrev
+	.uleb128	472
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname472:
+	.string		"USERROW47"
+	.section	.debug_info
+	.long		.Lname472
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x2F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #473: variable USERROW48
+	.section	.debug_info
+	.uleb128	473	; ref to abbrev 473
+	.section	.debug_abbrev
+	.uleb128	473
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname473:
+	.string		"USERROW48"
+	.section	.debug_info
+	.long		.Lname473
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x30
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #474: variable USERROW49
+	.section	.debug_info
+	.uleb128	474	; ref to abbrev 474
+	.section	.debug_abbrev
+	.uleb128	474
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname474:
+	.string		"USERROW49"
+	.section	.debug_info
+	.long		.Lname474
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x31
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #475: variable USERROW50
+	.section	.debug_info
+	.uleb128	475	; ref to abbrev 475
+	.section	.debug_abbrev
+	.uleb128	475
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname475:
+	.string		"USERROW50"
+	.section	.debug_info
+	.long		.Lname475
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x32
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #476: variable USERROW51
+	.section	.debug_info
+	.uleb128	476	; ref to abbrev 476
+	.section	.debug_abbrev
+	.uleb128	476
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname476:
+	.string		"USERROW51"
+	.section	.debug_info
+	.long		.Lname476
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x33
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #477: variable USERROW52
+	.section	.debug_info
+	.uleb128	477	; ref to abbrev 477
+	.section	.debug_abbrev
+	.uleb128	477
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname477:
+	.string		"USERROW52"
+	.section	.debug_info
+	.long		.Lname477
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x34
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #478: variable USERROW53
+	.section	.debug_info
+	.uleb128	478	; ref to abbrev 478
+	.section	.debug_abbrev
+	.uleb128	478
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname478:
+	.string		"USERROW53"
+	.section	.debug_info
+	.long		.Lname478
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x35
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #479: variable USERROW54
+	.section	.debug_info
+	.uleb128	479	; ref to abbrev 479
+	.section	.debug_abbrev
+	.uleb128	479
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname479:
+	.string		"USERROW54"
+	.section	.debug_info
+	.long		.Lname479
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x36
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #480: variable USERROW55
+	.section	.debug_info
+	.uleb128	480	; ref to abbrev 480
+	.section	.debug_abbrev
+	.uleb128	480
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname480:
+	.string		"USERROW55"
+	.section	.debug_info
+	.long		.Lname480
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x37
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #481: variable USERROW56
+	.section	.debug_info
+	.uleb128	481	; ref to abbrev 481
+	.section	.debug_abbrev
+	.uleb128	481
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname481:
+	.string		"USERROW56"
+	.section	.debug_info
+	.long		.Lname481
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x38
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #482: variable USERROW57
+	.section	.debug_info
+	.uleb128	482	; ref to abbrev 482
+	.section	.debug_abbrev
+	.uleb128	482
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname482:
+	.string		"USERROW57"
+	.section	.debug_info
+	.long		.Lname482
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x39
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #483: variable USERROW58
+	.section	.debug_info
+	.uleb128	483	; ref to abbrev 483
+	.section	.debug_abbrev
+	.uleb128	483
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname483:
+	.string		"USERROW58"
+	.section	.debug_info
+	.long		.Lname483
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x3A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #484: variable USERROW59
+	.section	.debug_info
+	.uleb128	484	; ref to abbrev 484
+	.section	.debug_abbrev
+	.uleb128	484
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname484:
+	.string		"USERROW59"
+	.section	.debug_info
+	.long		.Lname484
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x3B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #485: variable USERROW60
+	.section	.debug_info
+	.uleb128	485	; ref to abbrev 485
+	.section	.debug_abbrev
+	.uleb128	485
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname485:
+	.string		"USERROW60"
+	.section	.debug_info
+	.long		.Lname485
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x3C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #486: variable USERROW61
+	.section	.debug_info
+	.uleb128	486	; ref to abbrev 486
+	.section	.debug_abbrev
+	.uleb128	486
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname486:
+	.string		"USERROW61"
+	.section	.debug_info
+	.long		.Lname486
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x3D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #487: variable USERROW62
+	.section	.debug_info
+	.uleb128	487	; ref to abbrev 487
+	.section	.debug_abbrev
+	.uleb128	487
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname487:
+	.string		"USERROW62"
+	.section	.debug_info
+	.long		.Lname487
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x3E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #488: variable USERROW63
+	.section	.debug_info
+	.uleb128	488	; ref to abbrev 488
+	.section	.debug_abbrev
+	.uleb128	488
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname488:
+	.string		"USERROW63"
+	.section	.debug_info
+	.long		.Lname488
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x3F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #489: variable DIR
+	.section	.debug_info
+	.uleb128	489	; ref to abbrev 489
+	.section	.debug_abbrev
+	.uleb128	489
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname489:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname489
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0000 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #490: variable OUT
+	.section	.debug_info
+	.uleb128	490	; ref to abbrev 490
+	.section	.debug_abbrev
+	.uleb128	490
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname490:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname490
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0000 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #491: variable IN
+	.section	.debug_info
+	.uleb128	491	; ref to abbrev 491
+	.section	.debug_abbrev
+	.uleb128	491
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname491:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname491
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0000 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #492: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	492	; ref to abbrev 492
+	.section	.debug_abbrev
+	.uleb128	492
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname492:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname492
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0000 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #493: variable DIR
+	.section	.debug_info
+	.uleb128	493	; ref to abbrev 493
+	.section	.debug_abbrev
+	.uleb128	493
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname493:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname493
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0008 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #494: variable OUT
+	.section	.debug_info
+	.uleb128	494	; ref to abbrev 494
+	.section	.debug_abbrev
+	.uleb128	494
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname494:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname494
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0008 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #495: variable IN
+	.section	.debug_info
+	.uleb128	495	; ref to abbrev 495
+	.section	.debug_abbrev
+	.uleb128	495
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname495:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname495
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0008 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #496: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	496	; ref to abbrev 496
+	.section	.debug_abbrev
+	.uleb128	496
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname496:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname496
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0008 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #497: variable DIR
+	.section	.debug_info
+	.uleb128	497	; ref to abbrev 497
+	.section	.debug_abbrev
+	.uleb128	497
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname497:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname497
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x000C + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #498: variable OUT
+	.section	.debug_info
+	.uleb128	498	; ref to abbrev 498
+	.section	.debug_abbrev
+	.uleb128	498
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname498:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname498
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x000C + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #499: variable IN
+	.section	.debug_info
+	.uleb128	499	; ref to abbrev 499
+	.section	.debug_abbrev
+	.uleb128	499
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname499:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname499
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x000C + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #500: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	500	; ref to abbrev 500
+	.section	.debug_abbrev
+	.uleb128	500
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname500:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname500
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x000C + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #501: variable DIR
+	.section	.debug_info
+	.uleb128	501	; ref to abbrev 501
+	.section	.debug_abbrev
+	.uleb128	501
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname501:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname501
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0014 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #502: variable OUT
+	.section	.debug_info
+	.uleb128	502	; ref to abbrev 502
+	.section	.debug_abbrev
+	.uleb128	502
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname502:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname502
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0014 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #503: variable IN
+	.section	.debug_info
+	.uleb128	503	; ref to abbrev 503
+	.section	.debug_abbrev
+	.uleb128	503
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname503:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname503
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0014 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #504: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	504	; ref to abbrev 504
+	.section	.debug_abbrev
+	.uleb128	504
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname504:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname504
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0014 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #505: variable DAC0REF
+	.section	.debug_info
+	.uleb128	505	; ref to abbrev 505
+	.section	.debug_abbrev
+	.uleb128	505
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname505:
+	.string		"DAC0REF"
+	.section	.debug_info
+	.long		.Lname505
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00B0 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #506: variable ACREF
+	.section	.debug_info
+	.uleb128	506	; ref to abbrev 506
+	.section	.debug_abbrev
+	.uleb128	506
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname506:
+	.string		"ACREF"
+	.section	.debug_info
+	.long		.Lname506
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00B0 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #507: variable CTRLA
+	.section	.debug_info
+	.uleb128	507	; ref to abbrev 507
+	.section	.debug_abbrev
+	.uleb128	507
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname507:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname507
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0100 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #508: variable STATUS
+	.section	.debug_info
+	.uleb128	508	; ref to abbrev 508
+	.section	.debug_abbrev
+	.uleb128	508
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname508:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname508
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0100 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+	;; trailer
+	.section	.debug_abbrev
+	.uleb128	0
+
+	.section	.debug_info
+	.uleb128	0
+.Leinfo:

--- a/crt1/iosym/avr64ea32.S
+++ b/crt1/iosym/avr64ea32.S
@@ -1,0 +1,26945 @@
+/* This file is part of avr-libc.
+
+   Automatically created by devtools/ioreg.pl
+   DO NOT EDIT!
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in
+     the documentation and/or other materials provided with the
+     distribution.
+
+   * Neither the name of the copyright holders nor the names of
+     contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE. */
+
+/* $Id$ */
+
+#include <avr/version.h>
+
+#define DW_TAG_array_type               0x01
+#define DW_TAG_compile_unit             0x11
+#define DW_TAG_typedef                  0x16
+#define DW_TAG_subrange_type            0x21
+#define DW_TAG_base_type                0x24
+#define DW_TAG_variable                 0x34
+
+#define DW_FORM_addr                    0x01
+#define DW_FORM_block1                  0x0a
+#define DW_FORM_block2                  0x03
+#define DW_FORM_block4                  0x04
+#define DW_FORM_data1                   0x0b
+#define DW_FORM_data2                   0x05
+#define DW_FORM_data4                   0x06
+#define DW_FORM_data8                   0x07
+#define DW_FORM_string                  0x08
+#define DW_FORM_flag                    0x0c
+#define DW_FORM_strp                    0x0e
+#define DW_FORM_ref1                    0x11
+#define DW_FORM_ref2                    0x12
+#define DW_FORM_ref4                    0x13
+#define DW_FORM_ref8                    0x14
+
+#define DW_AT_location                  0x02
+#define DW_AT_name                      0x03
+#define DW_AT_byte_size                 0x0b
+#define DW_AT_stmt_list                 0x10
+#define DW_AT_language                  0x13
+#define DW_AT_producer                  0x25
+#define DW_AT_upper_bound               0x2f
+#define DW_AT_decl_file                 0x3a
+#define DW_AT_decl_line                 0x3b
+#define DW_AT_encoding                  0x3e
+#define DW_AT_external                  0x3f
+#define DW_AT_type                      0x49
+
+#define DW_LANG_C89                     0x0001
+
+#define DW_CHILDREN_no                  0x00
+#define DW_CHILDREN_yes                 0x01
+
+#define DW_ATE_unsigned                 0x7
+#define DW_ATE_unsigned_char            0x8
+
+#define DW_OP_addr                      0x03
+.eject
+	.section	.debug_abbrev, "", @progbits
+.Ldebug_abbrev0:
+	.section	.debug_info, "", @progbits
+	.section	.debug_line, "", @progbits
+.Ldebug_line0:
+	.section	.debug_str, "", @progbits
+
+	.section	.debug_info, "", @progbits
+	;; compilation unit header
+.Lssinfo:
+	.long	.Leinfo - .Lsinfo
+.Lsinfo:
+	.word	2		; DWARF-2
+	.long	.Ldebug_abbrev0
+	.byte	4		; sizeof(address)
+
+
+	;; DIE #1: compilation unit
+	.section	.debug_info
+	.uleb128	1	; ref to abbrev 1
+	.section	.debug_abbrev
+	.uleb128	1
+	.uleb128	DW_TAG_compile_unit
+	.byte		DW_CHILDREN_yes
+
+	.uleb128	DW_AT_producer
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lproducer:
+	.ascii		"avr-libc "
+	.asciz		__AVR_LIBC_VERSION_STRING__
+	.section	.debug_info
+	.long		.Lproducer
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_stmt_list
+	.uleb128	DW_FORM_data4
+	.section	.debug_info
+	.long		.Ldebug_line0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+	;; DIE #2: base type uint8_t
+	.section	.debug_info
+.Luint8_t:
+	.uleb128	2	; ref to abbrev 2
+	.section	.debug_abbrev
+	.uleb128	2
+	.uleb128	DW_TAG_base_type
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Luint8_t_name:
+	.string		"uint8_t"
+	.section	.debug_info
+	.long		.Luint8_t_name
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_byte_size
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_encoding
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		DW_ATE_unsigned_char
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+	;; DIE #3: base type uint16_t
+	.section	.debug_info
+.Luint16_t:
+	.uleb128	3	; ref to abbrev 3
+	.section	.debug_abbrev
+	.uleb128	3
+	.uleb128	DW_TAG_base_type
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Luint16_t_name:
+	.string		"uint16_t"
+	.section	.debug_info
+	.long		.Luint16_t_name
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_byte_size
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		2
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_encoding
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		DW_ATE_unsigned
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #4: variable CTRLA
+	.section	.debug_info
+	.uleb128	4	; ref to abbrev 4
+	.section	.debug_abbrev
+	.uleb128	4
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname4:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname4
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #5: variable CTRLB
+	.section	.debug_info
+	.uleb128	5	; ref to abbrev 5
+	.section	.debug_abbrev
+	.uleb128	5
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname5:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname5
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #6: variable MUXCTRL
+	.section	.debug_info
+	.uleb128	6	; ref to abbrev 6
+	.section	.debug_abbrev
+	.uleb128	6
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname6:
+	.string		"MUXCTRL"
+	.section	.debug_info
+	.long		.Lname6
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #7: variable DACREF
+	.section	.debug_info
+	.uleb128	7	; ref to abbrev 7
+	.section	.debug_abbrev
+	.uleb128	7
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname7:
+	.string		"DACREF"
+	.section	.debug_info
+	.long		.Lname7
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #8: variable INTCTRL
+	.section	.debug_info
+	.uleb128	8	; ref to abbrev 8
+	.section	.debug_abbrev
+	.uleb128	8
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname8:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname8
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #9: variable STATUS
+	.section	.debug_info
+	.uleb128	9	; ref to abbrev 9
+	.section	.debug_abbrev
+	.uleb128	9
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname9:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname9
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #10: variable CTRLA
+	.section	.debug_info
+	.uleb128	10	; ref to abbrev 10
+	.section	.debug_abbrev
+	.uleb128	10
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname10:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname10
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #11: variable CTRLB
+	.section	.debug_info
+	.uleb128	11	; ref to abbrev 11
+	.section	.debug_abbrev
+	.uleb128	11
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname11:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname11
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #12: variable MUXCTRL
+	.section	.debug_info
+	.uleb128	12	; ref to abbrev 12
+	.section	.debug_abbrev
+	.uleb128	12
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname12:
+	.string		"MUXCTRL"
+	.section	.debug_info
+	.long		.Lname12
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #13: variable DACREF
+	.section	.debug_info
+	.uleb128	13	; ref to abbrev 13
+	.section	.debug_abbrev
+	.uleb128	13
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname13:
+	.string		"DACREF"
+	.section	.debug_info
+	.long		.Lname13
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #14: variable INTCTRL
+	.section	.debug_info
+	.uleb128	14	; ref to abbrev 14
+	.section	.debug_abbrev
+	.uleb128	14
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname14:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname14
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #15: variable STATUS
+	.section	.debug_info
+	.uleb128	15	; ref to abbrev 15
+	.section	.debug_abbrev
+	.uleb128	15
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname15:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname15
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #16: variable CTRLA
+	.section	.debug_info
+	.uleb128	16	; ref to abbrev 16
+	.section	.debug_abbrev
+	.uleb128	16
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname16:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname16
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #17: variable CTRLB
+	.section	.debug_info
+	.uleb128	17	; ref to abbrev 17
+	.section	.debug_abbrev
+	.uleb128	17
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname17:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname17
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #18: variable CTRLC
+	.section	.debug_info
+	.uleb128	18	; ref to abbrev 18
+	.section	.debug_abbrev
+	.uleb128	18
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname18:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname18
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #19: variable CTRLD
+	.section	.debug_info
+	.uleb128	19	; ref to abbrev 19
+	.section	.debug_abbrev
+	.uleb128	19
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname19:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname19
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #20: variable INTCTRL
+	.section	.debug_info
+	.uleb128	20	; ref to abbrev 20
+	.section	.debug_abbrev
+	.uleb128	20
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname20:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname20
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #21: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	21	; ref to abbrev 21
+	.section	.debug_abbrev
+	.uleb128	21
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname21:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname21
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #22: variable STATUS
+	.section	.debug_info
+	.uleb128	22	; ref to abbrev 22
+	.section	.debug_abbrev
+	.uleb128	22
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname22:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname22
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #23: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	23	; ref to abbrev 23
+	.section	.debug_abbrev
+	.uleb128	23
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname23:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname23
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #24: variable CTRLE
+	.section	.debug_info
+	.uleb128	24	; ref to abbrev 24
+	.section	.debug_abbrev
+	.uleb128	24
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname24:
+	.string		"CTRLE"
+	.section	.debug_info
+	.long		.Lname24
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #25: variable CTRLF
+	.section	.debug_info
+	.uleb128	25	; ref to abbrev 25
+	.section	.debug_abbrev
+	.uleb128	25
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname25:
+	.string		"CTRLF"
+	.section	.debug_info
+	.long		.Lname25
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #26: variable COMMAND
+	.section	.debug_info
+	.uleb128	26	; ref to abbrev 26
+	.section	.debug_abbrev
+	.uleb128	26
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname26:
+	.string		"COMMAND"
+	.section	.debug_info
+	.long		.Lname26
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #27: variable PGACTRL
+	.section	.debug_info
+	.uleb128	27	; ref to abbrev 27
+	.section	.debug_abbrev
+	.uleb128	27
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname27:
+	.string		"PGACTRL"
+	.section	.debug_info
+	.long		.Lname27
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #28: variable MUXPOS
+	.section	.debug_info
+	.uleb128	28	; ref to abbrev 28
+	.section	.debug_abbrev
+	.uleb128	28
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname28:
+	.string		"MUXPOS"
+	.section	.debug_info
+	.long		.Lname28
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #29: variable MUXNEG
+	.section	.debug_info
+	.uleb128	29	; ref to abbrev 29
+	.section	.debug_abbrev
+	.uleb128	29
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname29:
+	.string		"MUXNEG"
+	.section	.debug_info
+	.long		.Lname29
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #30: base type uint32_t
+	.section	.debug_info
+.Luint32_t:
+	.uleb128	30	; ref to abbrev 30
+	.section	.debug_abbrev
+	.uleb128	30
+	.uleb128	DW_TAG_base_type
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Luint32_t_name:
+	.string		"uint32_t"
+	.section	.debug_info
+	.long		.Luint32_t_name
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_byte_size
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		4
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_encoding
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		DW_ATE_unsigned
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #31: variable RESULT
+	.section	.debug_info
+	.uleb128	31	; ref to abbrev 31
+	.section	.debug_abbrev
+	.uleb128	31
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname31:
+	.string		"RESULT"
+	.section	.debug_info
+	.long		.Lname31
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint32_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #32: variable SAMPLE
+	.section	.debug_info
+	.uleb128	32	; ref to abbrev 32
+	.section	.debug_abbrev
+	.uleb128	32
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname32:
+	.string		"SAMPLE"
+	.section	.debug_info
+	.long		.Lname32
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #33: variable TEMP0
+	.section	.debug_info
+	.uleb128	33	; ref to abbrev 33
+	.section	.debug_abbrev
+	.uleb128	33
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname33:
+	.string		"TEMP0"
+	.section	.debug_info
+	.long		.Lname33
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #34: variable TEMP1
+	.section	.debug_info
+	.uleb128	34	; ref to abbrev 34
+	.section	.debug_abbrev
+	.uleb128	34
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname34:
+	.string		"TEMP1"
+	.section	.debug_info
+	.long		.Lname34
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x19
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #35: variable TEMP2
+	.section	.debug_info
+	.uleb128	35	; ref to abbrev 35
+	.section	.debug_abbrev
+	.uleb128	35
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname35:
+	.string		"TEMP2"
+	.section	.debug_info
+	.long		.Lname35
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x1A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #36: variable WINLT
+	.section	.debug_info
+	.uleb128	36	; ref to abbrev 36
+	.section	.debug_abbrev
+	.uleb128	36
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname36:
+	.string		"WINLT"
+	.section	.debug_info
+	.long		.Lname36
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x1C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #37: variable WINHT
+	.section	.debug_info
+	.uleb128	37	; ref to abbrev 37
+	.section	.debug_abbrev
+	.uleb128	37
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname37:
+	.string		"WINHT"
+	.section	.debug_info
+	.long		.Lname37
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x1E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #38: variable CTRLA
+	.section	.debug_info
+	.uleb128	38	; ref to abbrev 38
+	.section	.debug_abbrev
+	.uleb128	38
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname38:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname38
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #39: variable CTRLB
+	.section	.debug_info
+	.uleb128	39	; ref to abbrev 39
+	.section	.debug_abbrev
+	.uleb128	39
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname39:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname39
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #40: variable VLMCTRLA
+	.section	.debug_info
+	.uleb128	40	; ref to abbrev 40
+	.section	.debug_abbrev
+	.uleb128	40
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname40:
+	.string		"VLMCTRLA"
+	.section	.debug_info
+	.long		.Lname40
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #41: variable INTCTRL
+	.section	.debug_info
+	.uleb128	41	; ref to abbrev 41
+	.section	.debug_abbrev
+	.uleb128	41
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname41:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname41
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #42: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	42	; ref to abbrev 42
+	.section	.debug_abbrev
+	.uleb128	42
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname42:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname42
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #43: variable STATUS
+	.section	.debug_info
+	.uleb128	43	; ref to abbrev 43
+	.section	.debug_abbrev
+	.uleb128	43
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname43:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname43
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #44: variable CTRLA
+	.section	.debug_info
+	.uleb128	44	; ref to abbrev 44
+	.section	.debug_abbrev
+	.uleb128	44
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname44:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname44
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #45: variable SEQCTRL0
+	.section	.debug_info
+	.uleb128	45	; ref to abbrev 45
+	.section	.debug_abbrev
+	.uleb128	45
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname45:
+	.string		"SEQCTRL0"
+	.section	.debug_info
+	.long		.Lname45
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #46: variable SEQCTRL1
+	.section	.debug_info
+	.uleb128	46	; ref to abbrev 46
+	.section	.debug_abbrev
+	.uleb128	46
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname46:
+	.string		"SEQCTRL1"
+	.section	.debug_info
+	.long		.Lname46
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #47: variable INTCTRL0
+	.section	.debug_info
+	.uleb128	47	; ref to abbrev 47
+	.section	.debug_abbrev
+	.uleb128	47
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname47:
+	.string		"INTCTRL0"
+	.section	.debug_info
+	.long		.Lname47
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #48: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	48	; ref to abbrev 48
+	.section	.debug_abbrev
+	.uleb128	48
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname48:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname48
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #49: variable LUT0CTRLA
+	.section	.debug_info
+	.uleb128	49	; ref to abbrev 49
+	.section	.debug_abbrev
+	.uleb128	49
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname49:
+	.string		"LUT0CTRLA"
+	.section	.debug_info
+	.long		.Lname49
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #50: variable LUT0CTRLB
+	.section	.debug_info
+	.uleb128	50	; ref to abbrev 50
+	.section	.debug_abbrev
+	.uleb128	50
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname50:
+	.string		"LUT0CTRLB"
+	.section	.debug_info
+	.long		.Lname50
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #51: variable LUT0CTRLC
+	.section	.debug_info
+	.uleb128	51	; ref to abbrev 51
+	.section	.debug_abbrev
+	.uleb128	51
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname51:
+	.string		"LUT0CTRLC"
+	.section	.debug_info
+	.long		.Lname51
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #52: variable TRUTH0
+	.section	.debug_info
+	.uleb128	52	; ref to abbrev 52
+	.section	.debug_abbrev
+	.uleb128	52
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname52:
+	.string		"TRUTH0"
+	.section	.debug_info
+	.long		.Lname52
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #53: variable LUT1CTRLA
+	.section	.debug_info
+	.uleb128	53	; ref to abbrev 53
+	.section	.debug_abbrev
+	.uleb128	53
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname53:
+	.string		"LUT1CTRLA"
+	.section	.debug_info
+	.long		.Lname53
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #54: variable LUT1CTRLB
+	.section	.debug_info
+	.uleb128	54	; ref to abbrev 54
+	.section	.debug_abbrev
+	.uleb128	54
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname54:
+	.string		"LUT1CTRLB"
+	.section	.debug_info
+	.long		.Lname54
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #55: variable LUT1CTRLC
+	.section	.debug_info
+	.uleb128	55	; ref to abbrev 55
+	.section	.debug_abbrev
+	.uleb128	55
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname55:
+	.string		"LUT1CTRLC"
+	.section	.debug_info
+	.long		.Lname55
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #56: variable TRUTH1
+	.section	.debug_info
+	.uleb128	56	; ref to abbrev 56
+	.section	.debug_abbrev
+	.uleb128	56
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname56:
+	.string		"TRUTH1"
+	.section	.debug_info
+	.long		.Lname56
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #57: variable LUT2CTRLA
+	.section	.debug_info
+	.uleb128	57	; ref to abbrev 57
+	.section	.debug_abbrev
+	.uleb128	57
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname57:
+	.string		"LUT2CTRLA"
+	.section	.debug_info
+	.long		.Lname57
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #58: variable LUT2CTRLB
+	.section	.debug_info
+	.uleb128	58	; ref to abbrev 58
+	.section	.debug_abbrev
+	.uleb128	58
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname58:
+	.string		"LUT2CTRLB"
+	.section	.debug_info
+	.long		.Lname58
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #59: variable LUT2CTRLC
+	.section	.debug_info
+	.uleb128	59	; ref to abbrev 59
+	.section	.debug_abbrev
+	.uleb128	59
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname59:
+	.string		"LUT2CTRLC"
+	.section	.debug_info
+	.long		.Lname59
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #60: variable TRUTH2
+	.section	.debug_info
+	.uleb128	60	; ref to abbrev 60
+	.section	.debug_abbrev
+	.uleb128	60
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname60:
+	.string		"TRUTH2"
+	.section	.debug_info
+	.long		.Lname60
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #61: variable LUT3CTRLA
+	.section	.debug_info
+	.uleb128	61	; ref to abbrev 61
+	.section	.debug_abbrev
+	.uleb128	61
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname61:
+	.string		"LUT3CTRLA"
+	.section	.debug_info
+	.long		.Lname61
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #62: variable LUT3CTRLB
+	.section	.debug_info
+	.uleb128	62	; ref to abbrev 62
+	.section	.debug_abbrev
+	.uleb128	62
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname62:
+	.string		"LUT3CTRLB"
+	.section	.debug_info
+	.long		.Lname62
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #63: variable LUT3CTRLC
+	.section	.debug_info
+	.uleb128	63	; ref to abbrev 63
+	.section	.debug_abbrev
+	.uleb128	63
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname63:
+	.string		"LUT3CTRLC"
+	.section	.debug_info
+	.long		.Lname63
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #64: variable TRUTH3
+	.section	.debug_info
+	.uleb128	64	; ref to abbrev 64
+	.section	.debug_abbrev
+	.uleb128	64
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname64:
+	.string		"TRUTH3"
+	.section	.debug_info
+	.long		.Lname64
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #65: variable MCLKCTRLA
+	.section	.debug_info
+	.uleb128	65	; ref to abbrev 65
+	.section	.debug_abbrev
+	.uleb128	65
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname65:
+	.string		"MCLKCTRLA"
+	.section	.debug_info
+	.long		.Lname65
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #66: variable MCLKCTRLB
+	.section	.debug_info
+	.uleb128	66	; ref to abbrev 66
+	.section	.debug_abbrev
+	.uleb128	66
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname66:
+	.string		"MCLKCTRLB"
+	.section	.debug_info
+	.long		.Lname66
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #67: variable MCLKCTRLC
+	.section	.debug_info
+	.uleb128	67	; ref to abbrev 67
+	.section	.debug_abbrev
+	.uleb128	67
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname67:
+	.string		"MCLKCTRLC"
+	.section	.debug_info
+	.long		.Lname67
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #68: variable MCLKINTCTRL
+	.section	.debug_info
+	.uleb128	68	; ref to abbrev 68
+	.section	.debug_abbrev
+	.uleb128	68
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname68:
+	.string		"MCLKINTCTRL"
+	.section	.debug_info
+	.long		.Lname68
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #69: variable MCLKINTFLAGS
+	.section	.debug_info
+	.uleb128	69	; ref to abbrev 69
+	.section	.debug_abbrev
+	.uleb128	69
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname69:
+	.string		"MCLKINTFLAGS"
+	.section	.debug_info
+	.long		.Lname69
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #70: variable MCLKSTATUS
+	.section	.debug_info
+	.uleb128	70	; ref to abbrev 70
+	.section	.debug_abbrev
+	.uleb128	70
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname70:
+	.string		"MCLKSTATUS"
+	.section	.debug_info
+	.long		.Lname70
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #71: variable MCLKTIMEBASE
+	.section	.debug_info
+	.uleb128	71	; ref to abbrev 71
+	.section	.debug_abbrev
+	.uleb128	71
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname71:
+	.string		"MCLKTIMEBASE"
+	.section	.debug_info
+	.long		.Lname71
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #72: variable OSCHFCTRLA
+	.section	.debug_info
+	.uleb128	72	; ref to abbrev 72
+	.section	.debug_abbrev
+	.uleb128	72
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname72:
+	.string		"OSCHFCTRLA"
+	.section	.debug_info
+	.long		.Lname72
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #73: variable OSCHFTUNE
+	.section	.debug_info
+	.uleb128	73	; ref to abbrev 73
+	.section	.debug_abbrev
+	.uleb128	73
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname73:
+	.string		"OSCHFTUNE"
+	.section	.debug_info
+	.long		.Lname73
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #74: variable OSC32KCTRLA
+	.section	.debug_info
+	.uleb128	74	; ref to abbrev 74
+	.section	.debug_abbrev
+	.uleb128	74
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname74:
+	.string		"OSC32KCTRLA"
+	.section	.debug_info
+	.long		.Lname74
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #75: variable XOSC32KCTRLA
+	.section	.debug_info
+	.uleb128	75	; ref to abbrev 75
+	.section	.debug_abbrev
+	.uleb128	75
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname75:
+	.string		"XOSC32KCTRLA"
+	.section	.debug_info
+	.long		.Lname75
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x1C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #76: variable XOSCHFCTRLA
+	.section	.debug_info
+	.uleb128	76	; ref to abbrev 76
+	.section	.debug_abbrev
+	.uleb128	76
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname76:
+	.string		"XOSCHFCTRLA"
+	.section	.debug_info
+	.long		.Lname76
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #77: variable CCP
+	.section	.debug_info
+	.uleb128	77	; ref to abbrev 77
+	.section	.debug_abbrev
+	.uleb128	77
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname77:
+	.string		"CCP"
+	.section	.debug_info
+	.long		.Lname77
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0030 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #78: variable SP
+	.section	.debug_info
+	.uleb128	78	; ref to abbrev 78
+	.section	.debug_abbrev
+	.uleb128	78
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname78:
+	.string		"SP"
+	.section	.debug_info
+	.long		.Lname78
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0030 + 0xD
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #79: variable SREG
+	.section	.debug_info
+	.uleb128	79	; ref to abbrev 79
+	.section	.debug_abbrev
+	.uleb128	79
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname79:
+	.string		"SREG"
+	.section	.debug_info
+	.long		.Lname79
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0030 + 0xF
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #80: variable CTRLA
+	.section	.debug_info
+	.uleb128	80	; ref to abbrev 80
+	.section	.debug_abbrev
+	.uleb128	80
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname80:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname80
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0110 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #81: variable STATUS
+	.section	.debug_info
+	.uleb128	81	; ref to abbrev 81
+	.section	.debug_abbrev
+	.uleb128	81
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname81:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname81
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0110 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #82: variable LVL0PRI
+	.section	.debug_info
+	.uleb128	82	; ref to abbrev 82
+	.section	.debug_abbrev
+	.uleb128	82
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname82:
+	.string		"LVL0PRI"
+	.section	.debug_info
+	.long		.Lname82
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0110 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #83: variable LVL1VEC
+	.section	.debug_info
+	.uleb128	83	; ref to abbrev 83
+	.section	.debug_abbrev
+	.uleb128	83
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname83:
+	.string		"LVL1VEC"
+	.section	.debug_info
+	.long		.Lname83
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0110 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #84: variable CTRLA
+	.section	.debug_info
+	.uleb128	84	; ref to abbrev 84
+	.section	.debug_abbrev
+	.uleb128	84
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname84:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname84
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0120 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #85: variable CTRLB
+	.section	.debug_info
+	.uleb128	85	; ref to abbrev 85
+	.section	.debug_abbrev
+	.uleb128	85
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname85:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname85
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0120 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #86: variable STATUS
+	.section	.debug_info
+	.uleb128	86	; ref to abbrev 86
+	.section	.debug_abbrev
+	.uleb128	86
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname86:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname86
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0120 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #87: variable CTRLA
+	.section	.debug_info
+	.uleb128	87	; ref to abbrev 87
+	.section	.debug_abbrev
+	.uleb128	87
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname87:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname87
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x06A0 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #88: variable DATA
+	.section	.debug_info
+	.uleb128	88	; ref to abbrev 88
+	.section	.debug_abbrev
+	.uleb128	88
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname88:
+	.string		"DATA"
+	.section	.debug_info
+	.long		.Lname88
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x06A0 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #89: variable SWEVENTA
+	.section	.debug_info
+	.uleb128	89	; ref to abbrev 89
+	.section	.debug_abbrev
+	.uleb128	89
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname89:
+	.string		"SWEVENTA"
+	.section	.debug_info
+	.long		.Lname89
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #90: variable CHANNEL0
+	.section	.debug_info
+	.uleb128	90	; ref to abbrev 90
+	.section	.debug_abbrev
+	.uleb128	90
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname90:
+	.string		"CHANNEL0"
+	.section	.debug_info
+	.long		.Lname90
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #91: variable CHANNEL1
+	.section	.debug_info
+	.uleb128	91	; ref to abbrev 91
+	.section	.debug_abbrev
+	.uleb128	91
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname91:
+	.string		"CHANNEL1"
+	.section	.debug_info
+	.long		.Lname91
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #92: variable CHANNEL2
+	.section	.debug_info
+	.uleb128	92	; ref to abbrev 92
+	.section	.debug_abbrev
+	.uleb128	92
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname92:
+	.string		"CHANNEL2"
+	.section	.debug_info
+	.long		.Lname92
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #93: variable CHANNEL3
+	.section	.debug_info
+	.uleb128	93	; ref to abbrev 93
+	.section	.debug_abbrev
+	.uleb128	93
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname93:
+	.string		"CHANNEL3"
+	.section	.debug_info
+	.long		.Lname93
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #94: variable CHANNEL4
+	.section	.debug_info
+	.uleb128	94	; ref to abbrev 94
+	.section	.debug_abbrev
+	.uleb128	94
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname94:
+	.string		"CHANNEL4"
+	.section	.debug_info
+	.long		.Lname94
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #95: variable CHANNEL5
+	.section	.debug_info
+	.uleb128	95	; ref to abbrev 95
+	.section	.debug_abbrev
+	.uleb128	95
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname95:
+	.string		"CHANNEL5"
+	.section	.debug_info
+	.long		.Lname95
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #96: variable USERCCLLUT0A
+	.section	.debug_info
+	.uleb128	96	; ref to abbrev 96
+	.section	.debug_abbrev
+	.uleb128	96
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname96:
+	.string		"USERCCLLUT0A"
+	.section	.debug_info
+	.long		.Lname96
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #97: variable USERCCLLUT0B
+	.section	.debug_info
+	.uleb128	97	; ref to abbrev 97
+	.section	.debug_abbrev
+	.uleb128	97
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname97:
+	.string		"USERCCLLUT0B"
+	.section	.debug_info
+	.long		.Lname97
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x21
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #98: variable USERCCLLUT1A
+	.section	.debug_info
+	.uleb128	98	; ref to abbrev 98
+	.section	.debug_abbrev
+	.uleb128	98
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname98:
+	.string		"USERCCLLUT1A"
+	.section	.debug_info
+	.long		.Lname98
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x22
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #99: variable USERCCLLUT1B
+	.section	.debug_info
+	.uleb128	99	; ref to abbrev 99
+	.section	.debug_abbrev
+	.uleb128	99
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname99:
+	.string		"USERCCLLUT1B"
+	.section	.debug_info
+	.long		.Lname99
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x23
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #100: variable USERCCLLUT2A
+	.section	.debug_info
+	.uleb128	100	; ref to abbrev 100
+	.section	.debug_abbrev
+	.uleb128	100
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname100:
+	.string		"USERCCLLUT2A"
+	.section	.debug_info
+	.long		.Lname100
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x24
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #101: variable USERCCLLUT2B
+	.section	.debug_info
+	.uleb128	101	; ref to abbrev 101
+	.section	.debug_abbrev
+	.uleb128	101
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname101:
+	.string		"USERCCLLUT2B"
+	.section	.debug_info
+	.long		.Lname101
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x25
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #102: variable USERCCLLUT3A
+	.section	.debug_info
+	.uleb128	102	; ref to abbrev 102
+	.section	.debug_abbrev
+	.uleb128	102
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname102:
+	.string		"USERCCLLUT3A"
+	.section	.debug_info
+	.long		.Lname102
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x26
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #103: variable USERCCLLUT3B
+	.section	.debug_info
+	.uleb128	103	; ref to abbrev 103
+	.section	.debug_abbrev
+	.uleb128	103
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname103:
+	.string		"USERCCLLUT3B"
+	.section	.debug_info
+	.long		.Lname103
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x27
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #104: variable USERADC0START
+	.section	.debug_info
+	.uleb128	104	; ref to abbrev 104
+	.section	.debug_abbrev
+	.uleb128	104
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname104:
+	.string		"USERADC0START"
+	.section	.debug_info
+	.long		.Lname104
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x28
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #105: variable USEREVSYSEVOUTA
+	.section	.debug_info
+	.uleb128	105	; ref to abbrev 105
+	.section	.debug_abbrev
+	.uleb128	105
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname105:
+	.string		"USEREVSYSEVOUTA"
+	.section	.debug_info
+	.long		.Lname105
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x29
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #106: variable USEREVSYSEVOUTC
+	.section	.debug_info
+	.uleb128	106	; ref to abbrev 106
+	.section	.debug_abbrev
+	.uleb128	106
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname106:
+	.string		"USEREVSYSEVOUTC"
+	.section	.debug_info
+	.long		.Lname106
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #107: variable USEREVSYSEVOUTD
+	.section	.debug_info
+	.uleb128	107	; ref to abbrev 107
+	.section	.debug_abbrev
+	.uleb128	107
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname107:
+	.string		"USEREVSYSEVOUTD"
+	.section	.debug_info
+	.long		.Lname107
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #108: variable USEREVSYSEVOUTF
+	.section	.debug_info
+	.uleb128	108	; ref to abbrev 108
+	.section	.debug_abbrev
+	.uleb128	108
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname108:
+	.string		"USEREVSYSEVOUTF"
+	.section	.debug_info
+	.long		.Lname108
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #109: variable USERUSART0IRDA
+	.section	.debug_info
+	.uleb128	109	; ref to abbrev 109
+	.section	.debug_abbrev
+	.uleb128	109
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname109:
+	.string		"USERUSART0IRDA"
+	.section	.debug_info
+	.long		.Lname109
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #110: variable USERUSART1IRDA
+	.section	.debug_info
+	.uleb128	110	; ref to abbrev 110
+	.section	.debug_abbrev
+	.uleb128	110
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname110:
+	.string		"USERUSART1IRDA"
+	.section	.debug_info
+	.long		.Lname110
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x30
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #111: variable USERUSART2IRDA
+	.section	.debug_info
+	.uleb128	111	; ref to abbrev 111
+	.section	.debug_abbrev
+	.uleb128	111
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname111:
+	.string		"USERUSART2IRDA"
+	.section	.debug_info
+	.long		.Lname111
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x31
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #112: variable USERTCA0CNTA
+	.section	.debug_info
+	.uleb128	112	; ref to abbrev 112
+	.section	.debug_abbrev
+	.uleb128	112
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname112:
+	.string		"USERTCA0CNTA"
+	.section	.debug_info
+	.long		.Lname112
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x32
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #113: variable USERTCA0CNTB
+	.section	.debug_info
+	.uleb128	113	; ref to abbrev 113
+	.section	.debug_abbrev
+	.uleb128	113
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname113:
+	.string		"USERTCA0CNTB"
+	.section	.debug_info
+	.long		.Lname113
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x33
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #114: variable USERTCA1CNTA
+	.section	.debug_info
+	.uleb128	114	; ref to abbrev 114
+	.section	.debug_abbrev
+	.uleb128	114
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname114:
+	.string		"USERTCA1CNTA"
+	.section	.debug_info
+	.long		.Lname114
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x34
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #115: variable USERTCA1CNTB
+	.section	.debug_info
+	.uleb128	115	; ref to abbrev 115
+	.section	.debug_abbrev
+	.uleb128	115
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname115:
+	.string		"USERTCA1CNTB"
+	.section	.debug_info
+	.long		.Lname115
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x35
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #116: variable USERTCB0CAPT
+	.section	.debug_info
+	.uleb128	116	; ref to abbrev 116
+	.section	.debug_abbrev
+	.uleb128	116
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname116:
+	.string		"USERTCB0CAPT"
+	.section	.debug_info
+	.long		.Lname116
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x36
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #117: variable USERTCB0COUNT
+	.section	.debug_info
+	.uleb128	117	; ref to abbrev 117
+	.section	.debug_abbrev
+	.uleb128	117
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname117:
+	.string		"USERTCB0COUNT"
+	.section	.debug_info
+	.long		.Lname117
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x37
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #118: variable USERTCB1CAPT
+	.section	.debug_info
+	.uleb128	118	; ref to abbrev 118
+	.section	.debug_abbrev
+	.uleb128	118
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname118:
+	.string		"USERTCB1CAPT"
+	.section	.debug_info
+	.long		.Lname118
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x38
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #119: variable USERTCB1COUNT
+	.section	.debug_info
+	.uleb128	119	; ref to abbrev 119
+	.section	.debug_abbrev
+	.uleb128	119
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname119:
+	.string		"USERTCB1COUNT"
+	.section	.debug_info
+	.long		.Lname119
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x39
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #120: variable USERTCB2CAPT
+	.section	.debug_info
+	.uleb128	120	; ref to abbrev 120
+	.section	.debug_abbrev
+	.uleb128	120
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname120:
+	.string		"USERTCB2CAPT"
+	.section	.debug_info
+	.long		.Lname120
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x3A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #121: variable USERTCB2COUNT
+	.section	.debug_info
+	.uleb128	121	; ref to abbrev 121
+	.section	.debug_abbrev
+	.uleb128	121
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname121:
+	.string		"USERTCB2COUNT"
+	.section	.debug_info
+	.long		.Lname121
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x3B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #122: variable USERTCB3CAPT
+	.section	.debug_info
+	.uleb128	122	; ref to abbrev 122
+	.section	.debug_abbrev
+	.uleb128	122
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname122:
+	.string		"USERTCB3CAPT"
+	.section	.debug_info
+	.long		.Lname122
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x3C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #123: variable USERTCB3COUNT
+	.section	.debug_info
+	.uleb128	123	; ref to abbrev 123
+	.section	.debug_abbrev
+	.uleb128	123
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname123:
+	.string		"USERTCB3COUNT"
+	.section	.debug_info
+	.long		.Lname123
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x3D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #124: variable WDTCFG
+	.section	.debug_info
+	.uleb128	124	; ref to abbrev 124
+	.section	.debug_abbrev
+	.uleb128	124
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname124:
+	.string		"WDTCFG"
+	.section	.debug_info
+	.long		.Lname124
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #125: variable BODCFG
+	.section	.debug_info
+	.uleb128	125	; ref to abbrev 125
+	.section	.debug_abbrev
+	.uleb128	125
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname125:
+	.string		"BODCFG"
+	.section	.debug_info
+	.long		.Lname125
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #126: variable OSCCFG
+	.section	.debug_info
+	.uleb128	126	; ref to abbrev 126
+	.section	.debug_abbrev
+	.uleb128	126
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname126:
+	.string		"OSCCFG"
+	.section	.debug_info
+	.long		.Lname126
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #127: variable SYSCFG0
+	.section	.debug_info
+	.uleb128	127	; ref to abbrev 127
+	.section	.debug_abbrev
+	.uleb128	127
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname127:
+	.string		"SYSCFG0"
+	.section	.debug_info
+	.long		.Lname127
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #128: variable SYSCFG1
+	.section	.debug_info
+	.uleb128	128	; ref to abbrev 128
+	.section	.debug_abbrev
+	.uleb128	128
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname128:
+	.string		"SYSCFG1"
+	.section	.debug_info
+	.long		.Lname128
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #129: variable CODESIZE
+	.section	.debug_info
+	.uleb128	129	; ref to abbrev 129
+	.section	.debug_abbrev
+	.uleb128	129
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname129:
+	.string		"CODESIZE"
+	.section	.debug_info
+	.long		.Lname129
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #130: variable BOOTSIZE
+	.section	.debug_info
+	.uleb128	130	; ref to abbrev 130
+	.section	.debug_abbrev
+	.uleb128	130
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname130:
+	.string		"BOOTSIZE"
+	.section	.debug_info
+	.long		.Lname130
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #131: variable GPR0
+	.section	.debug_info
+	.uleb128	131	; ref to abbrev 131
+	.section	.debug_abbrev
+	.uleb128	131
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname131:
+	.string		"GPR0"
+	.section	.debug_info
+	.long		.Lname131
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x001C + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #132: variable GPR1
+	.section	.debug_info
+	.uleb128	132	; ref to abbrev 132
+	.section	.debug_abbrev
+	.uleb128	132
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname132:
+	.string		"GPR1"
+	.section	.debug_info
+	.long		.Lname132
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x001C + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #133: variable GPR2
+	.section	.debug_info
+	.uleb128	133	; ref to abbrev 133
+	.section	.debug_abbrev
+	.uleb128	133
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname133:
+	.string		"GPR2"
+	.section	.debug_info
+	.long		.Lname133
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x001C + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #134: variable GPR3
+	.section	.debug_info
+	.uleb128	134	; ref to abbrev 134
+	.section	.debug_abbrev
+	.uleb128	134
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname134:
+	.string		"GPR3"
+	.section	.debug_info
+	.long		.Lname134
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x001C + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #135: variable KEY
+	.section	.debug_info
+	.uleb128	135	; ref to abbrev 135
+	.section	.debug_abbrev
+	.uleb128	135
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname135:
+	.string		"KEY"
+	.section	.debug_info
+	.long		.Lname135
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint32_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1040 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #136: variable CTRLA
+	.section	.debug_info
+	.uleb128	136	; ref to abbrev 136
+	.section	.debug_abbrev
+	.uleb128	136
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname136:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname136
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #137: variable CTRLB
+	.section	.debug_info
+	.uleb128	137	; ref to abbrev 137
+	.section	.debug_abbrev
+	.uleb128	137
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname137:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname137
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #138: variable INTCTRL
+	.section	.debug_info
+	.uleb128	138	; ref to abbrev 138
+	.section	.debug_abbrev
+	.uleb128	138
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname138:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname138
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #139: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	139	; ref to abbrev 139
+	.section	.debug_abbrev
+	.uleb128	139
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname139:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname139
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #140: variable STATUS
+	.section	.debug_info
+	.uleb128	140	; ref to abbrev 140
+	.section	.debug_abbrev
+	.uleb128	140
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname140:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname140
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #141: variable DATA
+	.section	.debug_info
+	.uleb128	141	; ref to abbrev 141
+	.section	.debug_abbrev
+	.uleb128	141
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname141:
+	.string		"DATA"
+	.section	.debug_info
+	.long		.Lname141
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #142: variable ADDR
+	.section	.debug_info
+	.uleb128	142	; ref to abbrev 142
+	.section	.debug_abbrev
+	.uleb128	142
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname142:
+	.string		"ADDR"
+	.section	.debug_info
+	.long		.Lname142
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint32_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #143: variable DIR
+	.section	.debug_info
+	.uleb128	143	; ref to abbrev 143
+	.section	.debug_abbrev
+	.uleb128	143
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname143:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname143
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #144: variable DIRSET
+	.section	.debug_info
+	.uleb128	144	; ref to abbrev 144
+	.section	.debug_abbrev
+	.uleb128	144
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname144:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname144
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #145: variable DIRCLR
+	.section	.debug_info
+	.uleb128	145	; ref to abbrev 145
+	.section	.debug_abbrev
+	.uleb128	145
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname145:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname145
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #146: variable DIRTGL
+	.section	.debug_info
+	.uleb128	146	; ref to abbrev 146
+	.section	.debug_abbrev
+	.uleb128	146
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname146:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname146
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #147: variable OUT
+	.section	.debug_info
+	.uleb128	147	; ref to abbrev 147
+	.section	.debug_abbrev
+	.uleb128	147
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname147:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname147
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #148: variable OUTSET
+	.section	.debug_info
+	.uleb128	148	; ref to abbrev 148
+	.section	.debug_abbrev
+	.uleb128	148
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname148:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname148
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #149: variable OUTCLR
+	.section	.debug_info
+	.uleb128	149	; ref to abbrev 149
+	.section	.debug_abbrev
+	.uleb128	149
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname149:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname149
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #150: variable OUTTGL
+	.section	.debug_info
+	.uleb128	150	; ref to abbrev 150
+	.section	.debug_abbrev
+	.uleb128	150
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname150:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname150
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #151: variable IN
+	.section	.debug_info
+	.uleb128	151	; ref to abbrev 151
+	.section	.debug_abbrev
+	.uleb128	151
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname151:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname151
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #152: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	152	; ref to abbrev 152
+	.section	.debug_abbrev
+	.uleb128	152
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname152:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname152
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #153: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	153	; ref to abbrev 153
+	.section	.debug_abbrev
+	.uleb128	153
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname153:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname153
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #154: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	154	; ref to abbrev 154
+	.section	.debug_abbrev
+	.uleb128	154
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname154:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname154
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #155: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	155	; ref to abbrev 155
+	.section	.debug_abbrev
+	.uleb128	155
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname155:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname155
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #156: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	156	; ref to abbrev 156
+	.section	.debug_abbrev
+	.uleb128	156
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname156:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname156
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #157: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	157	; ref to abbrev 157
+	.section	.debug_abbrev
+	.uleb128	157
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname157:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname157
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #158: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	158	; ref to abbrev 158
+	.section	.debug_abbrev
+	.uleb128	158
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname158:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname158
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #159: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	159	; ref to abbrev 159
+	.section	.debug_abbrev
+	.uleb128	159
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname159:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname159
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #160: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	160	; ref to abbrev 160
+	.section	.debug_abbrev
+	.uleb128	160
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname160:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname160
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #161: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	161	; ref to abbrev 161
+	.section	.debug_abbrev
+	.uleb128	161
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname161:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname161
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #162: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	162	; ref to abbrev 162
+	.section	.debug_abbrev
+	.uleb128	162
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname162:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname162
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #163: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	163	; ref to abbrev 163
+	.section	.debug_abbrev
+	.uleb128	163
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname163:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname163
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #164: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	164	; ref to abbrev 164
+	.section	.debug_abbrev
+	.uleb128	164
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname164:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname164
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #165: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	165	; ref to abbrev 165
+	.section	.debug_abbrev
+	.uleb128	165
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname165:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname165
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #166: variable EVGENCTRL
+	.section	.debug_info
+	.uleb128	166	; ref to abbrev 166
+	.section	.debug_abbrev
+	.uleb128	166
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname166:
+	.string		"EVGENCTRL"
+	.section	.debug_info
+	.long		.Lname166
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #167: variable DIR
+	.section	.debug_info
+	.uleb128	167	; ref to abbrev 167
+	.section	.debug_abbrev
+	.uleb128	167
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname167:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname167
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #168: variable DIRSET
+	.section	.debug_info
+	.uleb128	168	; ref to abbrev 168
+	.section	.debug_abbrev
+	.uleb128	168
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname168:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname168
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #169: variable DIRCLR
+	.section	.debug_info
+	.uleb128	169	; ref to abbrev 169
+	.section	.debug_abbrev
+	.uleb128	169
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname169:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname169
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #170: variable DIRTGL
+	.section	.debug_info
+	.uleb128	170	; ref to abbrev 170
+	.section	.debug_abbrev
+	.uleb128	170
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname170:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname170
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #171: variable OUT
+	.section	.debug_info
+	.uleb128	171	; ref to abbrev 171
+	.section	.debug_abbrev
+	.uleb128	171
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname171:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname171
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #172: variable OUTSET
+	.section	.debug_info
+	.uleb128	172	; ref to abbrev 172
+	.section	.debug_abbrev
+	.uleb128	172
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname172:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname172
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #173: variable OUTCLR
+	.section	.debug_info
+	.uleb128	173	; ref to abbrev 173
+	.section	.debug_abbrev
+	.uleb128	173
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname173:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname173
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #174: variable OUTTGL
+	.section	.debug_info
+	.uleb128	174	; ref to abbrev 174
+	.section	.debug_abbrev
+	.uleb128	174
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname174:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname174
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #175: variable IN
+	.section	.debug_info
+	.uleb128	175	; ref to abbrev 175
+	.section	.debug_abbrev
+	.uleb128	175
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname175:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname175
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #176: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	176	; ref to abbrev 176
+	.section	.debug_abbrev
+	.uleb128	176
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname176:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname176
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #177: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	177	; ref to abbrev 177
+	.section	.debug_abbrev
+	.uleb128	177
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname177:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname177
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #178: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	178	; ref to abbrev 178
+	.section	.debug_abbrev
+	.uleb128	178
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname178:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname178
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #179: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	179	; ref to abbrev 179
+	.section	.debug_abbrev
+	.uleb128	179
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname179:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname179
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #180: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	180	; ref to abbrev 180
+	.section	.debug_abbrev
+	.uleb128	180
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname180:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname180
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #181: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	181	; ref to abbrev 181
+	.section	.debug_abbrev
+	.uleb128	181
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname181:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname181
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #182: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	182	; ref to abbrev 182
+	.section	.debug_abbrev
+	.uleb128	182
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname182:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname182
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #183: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	183	; ref to abbrev 183
+	.section	.debug_abbrev
+	.uleb128	183
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname183:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname183
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #184: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	184	; ref to abbrev 184
+	.section	.debug_abbrev
+	.uleb128	184
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname184:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname184
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #185: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	185	; ref to abbrev 185
+	.section	.debug_abbrev
+	.uleb128	185
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname185:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname185
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #186: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	186	; ref to abbrev 186
+	.section	.debug_abbrev
+	.uleb128	186
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname186:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname186
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #187: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	187	; ref to abbrev 187
+	.section	.debug_abbrev
+	.uleb128	187
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname187:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname187
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #188: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	188	; ref to abbrev 188
+	.section	.debug_abbrev
+	.uleb128	188
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname188:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname188
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #189: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	189	; ref to abbrev 189
+	.section	.debug_abbrev
+	.uleb128	189
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname189:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname189
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #190: variable EVGENCTRL
+	.section	.debug_info
+	.uleb128	190	; ref to abbrev 190
+	.section	.debug_abbrev
+	.uleb128	190
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname190:
+	.string		"EVGENCTRL"
+	.section	.debug_info
+	.long		.Lname190
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #191: variable DIR
+	.section	.debug_info
+	.uleb128	191	; ref to abbrev 191
+	.section	.debug_abbrev
+	.uleb128	191
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname191:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname191
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #192: variable DIRSET
+	.section	.debug_info
+	.uleb128	192	; ref to abbrev 192
+	.section	.debug_abbrev
+	.uleb128	192
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname192:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname192
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #193: variable DIRCLR
+	.section	.debug_info
+	.uleb128	193	; ref to abbrev 193
+	.section	.debug_abbrev
+	.uleb128	193
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname193:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname193
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #194: variable DIRTGL
+	.section	.debug_info
+	.uleb128	194	; ref to abbrev 194
+	.section	.debug_abbrev
+	.uleb128	194
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname194:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname194
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #195: variable OUT
+	.section	.debug_info
+	.uleb128	195	; ref to abbrev 195
+	.section	.debug_abbrev
+	.uleb128	195
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname195:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname195
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #196: variable OUTSET
+	.section	.debug_info
+	.uleb128	196	; ref to abbrev 196
+	.section	.debug_abbrev
+	.uleb128	196
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname196:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname196
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #197: variable OUTCLR
+	.section	.debug_info
+	.uleb128	197	; ref to abbrev 197
+	.section	.debug_abbrev
+	.uleb128	197
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname197:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname197
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #198: variable OUTTGL
+	.section	.debug_info
+	.uleb128	198	; ref to abbrev 198
+	.section	.debug_abbrev
+	.uleb128	198
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname198:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname198
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #199: variable IN
+	.section	.debug_info
+	.uleb128	199	; ref to abbrev 199
+	.section	.debug_abbrev
+	.uleb128	199
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname199:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname199
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #200: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	200	; ref to abbrev 200
+	.section	.debug_abbrev
+	.uleb128	200
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname200:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname200
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #201: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	201	; ref to abbrev 201
+	.section	.debug_abbrev
+	.uleb128	201
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname201:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname201
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #202: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	202	; ref to abbrev 202
+	.section	.debug_abbrev
+	.uleb128	202
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname202:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname202
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #203: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	203	; ref to abbrev 203
+	.section	.debug_abbrev
+	.uleb128	203
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname203:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname203
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #204: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	204	; ref to abbrev 204
+	.section	.debug_abbrev
+	.uleb128	204
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname204:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname204
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #205: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	205	; ref to abbrev 205
+	.section	.debug_abbrev
+	.uleb128	205
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname205:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname205
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #206: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	206	; ref to abbrev 206
+	.section	.debug_abbrev
+	.uleb128	206
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname206:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname206
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #207: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	207	; ref to abbrev 207
+	.section	.debug_abbrev
+	.uleb128	207
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname207:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname207
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #208: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	208	; ref to abbrev 208
+	.section	.debug_abbrev
+	.uleb128	208
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname208:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname208
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #209: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	209	; ref to abbrev 209
+	.section	.debug_abbrev
+	.uleb128	209
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname209:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname209
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #210: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	210	; ref to abbrev 210
+	.section	.debug_abbrev
+	.uleb128	210
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname210:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname210
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #211: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	211	; ref to abbrev 211
+	.section	.debug_abbrev
+	.uleb128	211
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname211:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname211
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #212: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	212	; ref to abbrev 212
+	.section	.debug_abbrev
+	.uleb128	212
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname212:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname212
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #213: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	213	; ref to abbrev 213
+	.section	.debug_abbrev
+	.uleb128	213
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname213:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname213
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #214: variable EVGENCTRL
+	.section	.debug_info
+	.uleb128	214	; ref to abbrev 214
+	.section	.debug_abbrev
+	.uleb128	214
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname214:
+	.string		"EVGENCTRL"
+	.section	.debug_info
+	.long		.Lname214
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #215: variable DIR
+	.section	.debug_info
+	.uleb128	215	; ref to abbrev 215
+	.section	.debug_abbrev
+	.uleb128	215
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname215:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname215
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #216: variable DIRSET
+	.section	.debug_info
+	.uleb128	216	; ref to abbrev 216
+	.section	.debug_abbrev
+	.uleb128	216
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname216:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname216
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #217: variable DIRCLR
+	.section	.debug_info
+	.uleb128	217	; ref to abbrev 217
+	.section	.debug_abbrev
+	.uleb128	217
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname217:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname217
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #218: variable DIRTGL
+	.section	.debug_info
+	.uleb128	218	; ref to abbrev 218
+	.section	.debug_abbrev
+	.uleb128	218
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname218:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname218
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #219: variable OUT
+	.section	.debug_info
+	.uleb128	219	; ref to abbrev 219
+	.section	.debug_abbrev
+	.uleb128	219
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname219:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname219
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #220: variable OUTSET
+	.section	.debug_info
+	.uleb128	220	; ref to abbrev 220
+	.section	.debug_abbrev
+	.uleb128	220
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname220:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname220
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #221: variable OUTCLR
+	.section	.debug_info
+	.uleb128	221	; ref to abbrev 221
+	.section	.debug_abbrev
+	.uleb128	221
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname221:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname221
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #222: variable OUTTGL
+	.section	.debug_info
+	.uleb128	222	; ref to abbrev 222
+	.section	.debug_abbrev
+	.uleb128	222
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname222:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname222
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #223: variable IN
+	.section	.debug_info
+	.uleb128	223	; ref to abbrev 223
+	.section	.debug_abbrev
+	.uleb128	223
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname223:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname223
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #224: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	224	; ref to abbrev 224
+	.section	.debug_abbrev
+	.uleb128	224
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname224:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname224
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #225: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	225	; ref to abbrev 225
+	.section	.debug_abbrev
+	.uleb128	225
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname225:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname225
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #226: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	226	; ref to abbrev 226
+	.section	.debug_abbrev
+	.uleb128	226
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname226:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname226
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #227: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	227	; ref to abbrev 227
+	.section	.debug_abbrev
+	.uleb128	227
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname227:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname227
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #228: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	228	; ref to abbrev 228
+	.section	.debug_abbrev
+	.uleb128	228
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname228:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname228
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #229: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	229	; ref to abbrev 229
+	.section	.debug_abbrev
+	.uleb128	229
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname229:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname229
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #230: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	230	; ref to abbrev 230
+	.section	.debug_abbrev
+	.uleb128	230
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname230:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname230
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #231: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	231	; ref to abbrev 231
+	.section	.debug_abbrev
+	.uleb128	231
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname231:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname231
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #232: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	232	; ref to abbrev 232
+	.section	.debug_abbrev
+	.uleb128	232
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname232:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname232
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #233: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	233	; ref to abbrev 233
+	.section	.debug_abbrev
+	.uleb128	233
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname233:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname233
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #234: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	234	; ref to abbrev 234
+	.section	.debug_abbrev
+	.uleb128	234
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname234:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname234
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #235: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	235	; ref to abbrev 235
+	.section	.debug_abbrev
+	.uleb128	235
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname235:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname235
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #236: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	236	; ref to abbrev 236
+	.section	.debug_abbrev
+	.uleb128	236
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname236:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname236
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #237: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	237	; ref to abbrev 237
+	.section	.debug_abbrev
+	.uleb128	237
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname237:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname237
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #238: variable EVGENCTRL
+	.section	.debug_info
+	.uleb128	238	; ref to abbrev 238
+	.section	.debug_abbrev
+	.uleb128	238
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname238:
+	.string		"EVGENCTRL"
+	.section	.debug_info
+	.long		.Lname238
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #239: variable EVSYSROUTEA
+	.section	.debug_info
+	.uleb128	239	; ref to abbrev 239
+	.section	.debug_abbrev
+	.uleb128	239
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname239:
+	.string		"EVSYSROUTEA"
+	.section	.debug_info
+	.long		.Lname239
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #240: variable CCLROUTEA
+	.section	.debug_info
+	.uleb128	240	; ref to abbrev 240
+	.section	.debug_abbrev
+	.uleb128	240
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname240:
+	.string		"CCLROUTEA"
+	.section	.debug_info
+	.long		.Lname240
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #241: variable USARTROUTEA
+	.section	.debug_info
+	.uleb128	241	; ref to abbrev 241
+	.section	.debug_abbrev
+	.uleb128	241
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname241:
+	.string		"USARTROUTEA"
+	.section	.debug_info
+	.long		.Lname241
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #242: variable USARTROUTEB
+	.section	.debug_info
+	.uleb128	242	; ref to abbrev 242
+	.section	.debug_abbrev
+	.uleb128	242
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname242:
+	.string		"USARTROUTEB"
+	.section	.debug_info
+	.long		.Lname242
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #243: variable SPIROUTEA
+	.section	.debug_info
+	.uleb128	243	; ref to abbrev 243
+	.section	.debug_abbrev
+	.uleb128	243
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname243:
+	.string		"SPIROUTEA"
+	.section	.debug_info
+	.long		.Lname243
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #244: variable TWIROUTEA
+	.section	.debug_info
+	.uleb128	244	; ref to abbrev 244
+	.section	.debug_abbrev
+	.uleb128	244
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname244:
+	.string		"TWIROUTEA"
+	.section	.debug_info
+	.long		.Lname244
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #245: variable TCAROUTEA
+	.section	.debug_info
+	.uleb128	245	; ref to abbrev 245
+	.section	.debug_abbrev
+	.uleb128	245
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname245:
+	.string		"TCAROUTEA"
+	.section	.debug_info
+	.long		.Lname245
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #246: variable TCBROUTEA
+	.section	.debug_info
+	.uleb128	246	; ref to abbrev 246
+	.section	.debug_abbrev
+	.uleb128	246
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname246:
+	.string		"TCBROUTEA"
+	.section	.debug_info
+	.long		.Lname246
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #247: variable ACROUTEA
+	.section	.debug_info
+	.uleb128	247	; ref to abbrev 247
+	.section	.debug_abbrev
+	.uleb128	247
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname247:
+	.string		"ACROUTEA"
+	.section	.debug_info
+	.long		.Lname247
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #248: variable RSTFR
+	.section	.debug_info
+	.uleb128	248	; ref to abbrev 248
+	.section	.debug_abbrev
+	.uleb128	248
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname248:
+	.string		"RSTFR"
+	.section	.debug_info
+	.long		.Lname248
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0040 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #249: variable SWRR
+	.section	.debug_info
+	.uleb128	249	; ref to abbrev 249
+	.section	.debug_abbrev
+	.uleb128	249
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname249:
+	.string		"SWRR"
+	.section	.debug_info
+	.long		.Lname249
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0040 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #250: variable CTRLA
+	.section	.debug_info
+	.uleb128	250	; ref to abbrev 250
+	.section	.debug_abbrev
+	.uleb128	250
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname250:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname250
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #251: variable STATUS
+	.section	.debug_info
+	.uleb128	251	; ref to abbrev 251
+	.section	.debug_abbrev
+	.uleb128	251
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname251:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname251
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #252: variable INTCTRL
+	.section	.debug_info
+	.uleb128	252	; ref to abbrev 252
+	.section	.debug_abbrev
+	.uleb128	252
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname252:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname252
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #253: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	253	; ref to abbrev 253
+	.section	.debug_abbrev
+	.uleb128	253
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname253:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname253
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #254: variable TEMP
+	.section	.debug_info
+	.uleb128	254	; ref to abbrev 254
+	.section	.debug_abbrev
+	.uleb128	254
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname254:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname254
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #255: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	255	; ref to abbrev 255
+	.section	.debug_abbrev
+	.uleb128	255
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname255:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname255
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #256: variable CALIB
+	.section	.debug_info
+	.uleb128	256	; ref to abbrev 256
+	.section	.debug_abbrev
+	.uleb128	256
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname256:
+	.string		"CALIB"
+	.section	.debug_info
+	.long		.Lname256
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #257: variable CLKSEL
+	.section	.debug_info
+	.uleb128	257	; ref to abbrev 257
+	.section	.debug_abbrev
+	.uleb128	257
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname257:
+	.string		"CLKSEL"
+	.section	.debug_info
+	.long		.Lname257
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #258: variable CNT
+	.section	.debug_info
+	.uleb128	258	; ref to abbrev 258
+	.section	.debug_abbrev
+	.uleb128	258
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname258:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname258
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #259: variable PER
+	.section	.debug_info
+	.uleb128	259	; ref to abbrev 259
+	.section	.debug_abbrev
+	.uleb128	259
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname259:
+	.string		"PER"
+	.section	.debug_info
+	.long		.Lname259
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #260: variable CMP
+	.section	.debug_info
+	.uleb128	260	; ref to abbrev 260
+	.section	.debug_abbrev
+	.uleb128	260
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname260:
+	.string		"CMP"
+	.section	.debug_info
+	.long		.Lname260
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #261: variable PITCTRLA
+	.section	.debug_info
+	.uleb128	261	; ref to abbrev 261
+	.section	.debug_abbrev
+	.uleb128	261
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname261:
+	.string		"PITCTRLA"
+	.section	.debug_info
+	.long		.Lname261
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #262: variable PITSTATUS
+	.section	.debug_info
+	.uleb128	262	; ref to abbrev 262
+	.section	.debug_abbrev
+	.uleb128	262
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname262:
+	.string		"PITSTATUS"
+	.section	.debug_info
+	.long		.Lname262
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #263: variable PITINTCTRL
+	.section	.debug_info
+	.uleb128	263	; ref to abbrev 263
+	.section	.debug_abbrev
+	.uleb128	263
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname263:
+	.string		"PITINTCTRL"
+	.section	.debug_info
+	.long		.Lname263
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #264: variable PITINTFLAGS
+	.section	.debug_info
+	.uleb128	264	; ref to abbrev 264
+	.section	.debug_abbrev
+	.uleb128	264
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname264:
+	.string		"PITINTFLAGS"
+	.section	.debug_info
+	.long		.Lname264
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #265: variable PITDBGCTRL
+	.section	.debug_info
+	.uleb128	265	; ref to abbrev 265
+	.section	.debug_abbrev
+	.uleb128	265
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname265:
+	.string		"PITDBGCTRL"
+	.section	.debug_info
+	.long		.Lname265
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #266: variable PITEVGENCTRLA
+	.section	.debug_info
+	.uleb128	266	; ref to abbrev 266
+	.section	.debug_abbrev
+	.uleb128	266
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname266:
+	.string		"PITEVGENCTRLA"
+	.section	.debug_info
+	.long		.Lname266
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #267: variable DEVICEID0
+	.section	.debug_info
+	.uleb128	267	; ref to abbrev 267
+	.section	.debug_abbrev
+	.uleb128	267
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname267:
+	.string		"DEVICEID0"
+	.section	.debug_info
+	.long		.Lname267
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #268: variable DEVICEID1
+	.section	.debug_info
+	.uleb128	268	; ref to abbrev 268
+	.section	.debug_abbrev
+	.uleb128	268
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname268:
+	.string		"DEVICEID1"
+	.section	.debug_info
+	.long		.Lname268
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #269: variable DEVICEID2
+	.section	.debug_info
+	.uleb128	269	; ref to abbrev 269
+	.section	.debug_abbrev
+	.uleb128	269
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname269:
+	.string		"DEVICEID2"
+	.section	.debug_info
+	.long		.Lname269
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #270: variable TEMPSENSE0
+	.section	.debug_info
+	.uleb128	270	; ref to abbrev 270
+	.section	.debug_abbrev
+	.uleb128	270
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname270:
+	.string		"TEMPSENSE0"
+	.section	.debug_info
+	.long		.Lname270
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #271: variable TEMPSENSE1
+	.section	.debug_info
+	.uleb128	271	; ref to abbrev 271
+	.section	.debug_abbrev
+	.uleb128	271
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname271:
+	.string		"TEMPSENSE1"
+	.section	.debug_info
+	.long		.Lname271
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #272: variable SERNUM0
+	.section	.debug_info
+	.uleb128	272	; ref to abbrev 272
+	.section	.debug_abbrev
+	.uleb128	272
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname272:
+	.string		"SERNUM0"
+	.section	.debug_info
+	.long		.Lname272
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #273: variable SERNUM1
+	.section	.debug_info
+	.uleb128	273	; ref to abbrev 273
+	.section	.debug_abbrev
+	.uleb128	273
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname273:
+	.string		"SERNUM1"
+	.section	.debug_info
+	.long		.Lname273
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #274: variable SERNUM2
+	.section	.debug_info
+	.uleb128	274	; ref to abbrev 274
+	.section	.debug_abbrev
+	.uleb128	274
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname274:
+	.string		"SERNUM2"
+	.section	.debug_info
+	.long		.Lname274
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #275: variable SERNUM3
+	.section	.debug_info
+	.uleb128	275	; ref to abbrev 275
+	.section	.debug_abbrev
+	.uleb128	275
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname275:
+	.string		"SERNUM3"
+	.section	.debug_info
+	.long		.Lname275
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #276: variable SERNUM4
+	.section	.debug_info
+	.uleb128	276	; ref to abbrev 276
+	.section	.debug_abbrev
+	.uleb128	276
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname276:
+	.string		"SERNUM4"
+	.section	.debug_info
+	.long		.Lname276
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #277: variable SERNUM5
+	.section	.debug_info
+	.uleb128	277	; ref to abbrev 277
+	.section	.debug_abbrev
+	.uleb128	277
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname277:
+	.string		"SERNUM5"
+	.section	.debug_info
+	.long		.Lname277
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #278: variable SERNUM6
+	.section	.debug_info
+	.uleb128	278	; ref to abbrev 278
+	.section	.debug_abbrev
+	.uleb128	278
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname278:
+	.string		"SERNUM6"
+	.section	.debug_info
+	.long		.Lname278
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #279: variable SERNUM7
+	.section	.debug_info
+	.uleb128	279	; ref to abbrev 279
+	.section	.debug_abbrev
+	.uleb128	279
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname279:
+	.string		"SERNUM7"
+	.section	.debug_info
+	.long		.Lname279
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #280: variable SERNUM8
+	.section	.debug_info
+	.uleb128	280	; ref to abbrev 280
+	.section	.debug_abbrev
+	.uleb128	280
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname280:
+	.string		"SERNUM8"
+	.section	.debug_info
+	.long		.Lname280
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #281: variable SERNUM9
+	.section	.debug_info
+	.uleb128	281	; ref to abbrev 281
+	.section	.debug_abbrev
+	.uleb128	281
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname281:
+	.string		"SERNUM9"
+	.section	.debug_info
+	.long		.Lname281
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x19
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #282: variable SERNUM10
+	.section	.debug_info
+	.uleb128	282	; ref to abbrev 282
+	.section	.debug_abbrev
+	.uleb128	282
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname282:
+	.string		"SERNUM10"
+	.section	.debug_info
+	.long		.Lname282
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x1A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #283: variable SERNUM11
+	.section	.debug_info
+	.uleb128	283	; ref to abbrev 283
+	.section	.debug_abbrev
+	.uleb128	283
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname283:
+	.string		"SERNUM11"
+	.section	.debug_info
+	.long		.Lname283
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x1B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #284: variable SERNUM12
+	.section	.debug_info
+	.uleb128	284	; ref to abbrev 284
+	.section	.debug_abbrev
+	.uleb128	284
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname284:
+	.string		"SERNUM12"
+	.section	.debug_info
+	.long		.Lname284
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x1C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #285: variable SERNUM13
+	.section	.debug_info
+	.uleb128	285	; ref to abbrev 285
+	.section	.debug_abbrev
+	.uleb128	285
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname285:
+	.string		"SERNUM13"
+	.section	.debug_info
+	.long		.Lname285
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x1D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #286: variable SERNUM14
+	.section	.debug_info
+	.uleb128	286	; ref to abbrev 286
+	.section	.debug_abbrev
+	.uleb128	286
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname286:
+	.string		"SERNUM14"
+	.section	.debug_info
+	.long		.Lname286
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x1E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #287: variable SERNUM15
+	.section	.debug_info
+	.uleb128	287	; ref to abbrev 287
+	.section	.debug_abbrev
+	.uleb128	287
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname287:
+	.string		"SERNUM15"
+	.section	.debug_info
+	.long		.Lname287
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x1F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #288: variable CTRLA
+	.section	.debug_info
+	.uleb128	288	; ref to abbrev 288
+	.section	.debug_abbrev
+	.uleb128	288
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname288:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname288
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0050 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #289: variable CTRLA
+	.section	.debug_info
+	.uleb128	289	; ref to abbrev 289
+	.section	.debug_abbrev
+	.uleb128	289
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname289:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname289
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #290: variable CTRLB
+	.section	.debug_info
+	.uleb128	290	; ref to abbrev 290
+	.section	.debug_abbrev
+	.uleb128	290
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname290:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname290
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #291: variable INTCTRL
+	.section	.debug_info
+	.uleb128	291	; ref to abbrev 291
+	.section	.debug_abbrev
+	.uleb128	291
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname291:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname291
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #292: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	292	; ref to abbrev 292
+	.section	.debug_abbrev
+	.uleb128	292
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname292:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname292
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #293: variable DATA
+	.section	.debug_info
+	.uleb128	293	; ref to abbrev 293
+	.section	.debug_abbrev
+	.uleb128	293
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname293:
+	.string		"DATA"
+	.section	.debug_info
+	.long		.Lname293
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #294: variable REVID
+	.section	.debug_info
+	.uleb128	294	; ref to abbrev 294
+	.section	.debug_abbrev
+	.uleb128	294
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname294:
+	.string		"REVID"
+	.section	.debug_info
+	.long		.Lname294
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0F00 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #295: variable OCDMCTRL
+	.section	.debug_info
+	.uleb128	295	; ref to abbrev 295
+	.section	.debug_abbrev
+	.uleb128	295
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname295:
+	.string		"OCDMCTRL"
+	.section	.debug_info
+	.long		.Lname295
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0F00 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #296: variable OCDMSTATUS
+	.section	.debug_info
+	.uleb128	296	; ref to abbrev 296
+	.section	.debug_abbrev
+	.uleb128	296
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname296:
+	.string		"OCDMSTATUS"
+	.section	.debug_info
+	.long		.Lname296
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0F00 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #297: variable CTRLA
+	.section	.debug_info
+	.uleb128	297	; ref to abbrev 297
+	.section	.debug_abbrev
+	.uleb128	297
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname297:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname297
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #298: variable CTRLB
+	.section	.debug_info
+	.uleb128	298	; ref to abbrev 298
+	.section	.debug_abbrev
+	.uleb128	298
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname298:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname298
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #299: variable CTRLC
+	.section	.debug_info
+	.uleb128	299	; ref to abbrev 299
+	.section	.debug_abbrev
+	.uleb128	299
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname299:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname299
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #300: variable CTRLD
+	.section	.debug_info
+	.uleb128	300	; ref to abbrev 300
+	.section	.debug_abbrev
+	.uleb128	300
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname300:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname300
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #301: variable CTRLECLR
+	.section	.debug_info
+	.uleb128	301	; ref to abbrev 301
+	.section	.debug_abbrev
+	.uleb128	301
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname301:
+	.string		"CTRLECLR"
+	.section	.debug_info
+	.long		.Lname301
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #302: variable CTRLESET
+	.section	.debug_info
+	.uleb128	302	; ref to abbrev 302
+	.section	.debug_abbrev
+	.uleb128	302
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname302:
+	.string		"CTRLESET"
+	.section	.debug_info
+	.long		.Lname302
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #303: variable CTRLFCLR
+	.section	.debug_info
+	.uleb128	303	; ref to abbrev 303
+	.section	.debug_abbrev
+	.uleb128	303
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname303:
+	.string		"CTRLFCLR"
+	.section	.debug_info
+	.long		.Lname303
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #304: variable CTRLFSET
+	.section	.debug_info
+	.uleb128	304	; ref to abbrev 304
+	.section	.debug_abbrev
+	.uleb128	304
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname304:
+	.string		"CTRLFSET"
+	.section	.debug_info
+	.long		.Lname304
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #305: variable EVCTRL
+	.section	.debug_info
+	.uleb128	305	; ref to abbrev 305
+	.section	.debug_abbrev
+	.uleb128	305
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname305:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname305
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #306: variable INTCTRL
+	.section	.debug_info
+	.uleb128	306	; ref to abbrev 306
+	.section	.debug_abbrev
+	.uleb128	306
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname306:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname306
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #307: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	307	; ref to abbrev 307
+	.section	.debug_abbrev
+	.uleb128	307
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname307:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname307
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #308: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	308	; ref to abbrev 308
+	.section	.debug_abbrev
+	.uleb128	308
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname308:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname308
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #309: variable TEMP
+	.section	.debug_info
+	.uleb128	309	; ref to abbrev 309
+	.section	.debug_abbrev
+	.uleb128	309
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname309:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname309
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #310: variable CNT
+	.section	.debug_info
+	.uleb128	310	; ref to abbrev 310
+	.section	.debug_abbrev
+	.uleb128	310
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname310:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname310
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #311: variable PER
+	.section	.debug_info
+	.uleb128	311	; ref to abbrev 311
+	.section	.debug_abbrev
+	.uleb128	311
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname311:
+	.string		"PER"
+	.section	.debug_info
+	.long		.Lname311
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x26
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #312: variable CMP0
+	.section	.debug_info
+	.uleb128	312	; ref to abbrev 312
+	.section	.debug_abbrev
+	.uleb128	312
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname312:
+	.string		"CMP0"
+	.section	.debug_info
+	.long		.Lname312
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x28
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #313: variable CMP1
+	.section	.debug_info
+	.uleb128	313	; ref to abbrev 313
+	.section	.debug_abbrev
+	.uleb128	313
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname313:
+	.string		"CMP1"
+	.section	.debug_info
+	.long		.Lname313
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #314: variable CMP2
+	.section	.debug_info
+	.uleb128	314	; ref to abbrev 314
+	.section	.debug_abbrev
+	.uleb128	314
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname314:
+	.string		"CMP2"
+	.section	.debug_info
+	.long		.Lname314
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #315: variable PERBUF
+	.section	.debug_info
+	.uleb128	315	; ref to abbrev 315
+	.section	.debug_abbrev
+	.uleb128	315
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname315:
+	.string		"PERBUF"
+	.section	.debug_info
+	.long		.Lname315
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x36
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #316: variable CMP0BUF
+	.section	.debug_info
+	.uleb128	316	; ref to abbrev 316
+	.section	.debug_abbrev
+	.uleb128	316
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname316:
+	.string		"CMP0BUF"
+	.section	.debug_info
+	.long		.Lname316
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x38
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #317: variable CMP1BUF
+	.section	.debug_info
+	.uleb128	317	; ref to abbrev 317
+	.section	.debug_abbrev
+	.uleb128	317
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname317:
+	.string		"CMP1BUF"
+	.section	.debug_info
+	.long		.Lname317
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x3A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #318: variable CMP2BUF
+	.section	.debug_info
+	.uleb128	318	; ref to abbrev 318
+	.section	.debug_abbrev
+	.uleb128	318
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname318:
+	.string		"CMP2BUF"
+	.section	.debug_info
+	.long		.Lname318
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x3C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #319: variable CTRLA
+	.section	.debug_info
+	.uleb128	319	; ref to abbrev 319
+	.section	.debug_abbrev
+	.uleb128	319
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname319:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname319
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #320: variable CTRLB
+	.section	.debug_info
+	.uleb128	320	; ref to abbrev 320
+	.section	.debug_abbrev
+	.uleb128	320
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname320:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname320
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #321: variable CTRLC
+	.section	.debug_info
+	.uleb128	321	; ref to abbrev 321
+	.section	.debug_abbrev
+	.uleb128	321
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname321:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname321
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #322: variable CTRLD
+	.section	.debug_info
+	.uleb128	322	; ref to abbrev 322
+	.section	.debug_abbrev
+	.uleb128	322
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname322:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname322
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #323: variable CTRLECLR
+	.section	.debug_info
+	.uleb128	323	; ref to abbrev 323
+	.section	.debug_abbrev
+	.uleb128	323
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname323:
+	.string		"CTRLECLR"
+	.section	.debug_info
+	.long		.Lname323
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #324: variable CTRLESET
+	.section	.debug_info
+	.uleb128	324	; ref to abbrev 324
+	.section	.debug_abbrev
+	.uleb128	324
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname324:
+	.string		"CTRLESET"
+	.section	.debug_info
+	.long		.Lname324
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #325: variable INTCTRL
+	.section	.debug_info
+	.uleb128	325	; ref to abbrev 325
+	.section	.debug_abbrev
+	.uleb128	325
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname325:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname325
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #326: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	326	; ref to abbrev 326
+	.section	.debug_abbrev
+	.uleb128	326
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname326:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname326
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #327: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	327	; ref to abbrev 327
+	.section	.debug_abbrev
+	.uleb128	327
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname327:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname327
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #328: variable LCNT
+	.section	.debug_info
+	.uleb128	328	; ref to abbrev 328
+	.section	.debug_abbrev
+	.uleb128	328
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname328:
+	.string		"LCNT"
+	.section	.debug_info
+	.long		.Lname328
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #329: variable HCNT
+	.section	.debug_info
+	.uleb128	329	; ref to abbrev 329
+	.section	.debug_abbrev
+	.uleb128	329
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname329:
+	.string		"HCNT"
+	.section	.debug_info
+	.long		.Lname329
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x21
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #330: variable LPER
+	.section	.debug_info
+	.uleb128	330	; ref to abbrev 330
+	.section	.debug_abbrev
+	.uleb128	330
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname330:
+	.string		"LPER"
+	.section	.debug_info
+	.long		.Lname330
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x26
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #331: variable HPER
+	.section	.debug_info
+	.uleb128	331	; ref to abbrev 331
+	.section	.debug_abbrev
+	.uleb128	331
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname331:
+	.string		"HPER"
+	.section	.debug_info
+	.long		.Lname331
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x27
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #332: variable LCMP0
+	.section	.debug_info
+	.uleb128	332	; ref to abbrev 332
+	.section	.debug_abbrev
+	.uleb128	332
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname332:
+	.string		"LCMP0"
+	.section	.debug_info
+	.long		.Lname332
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x28
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #333: variable HCMP0
+	.section	.debug_info
+	.uleb128	333	; ref to abbrev 333
+	.section	.debug_abbrev
+	.uleb128	333
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname333:
+	.string		"HCMP0"
+	.section	.debug_info
+	.long		.Lname333
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x29
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #334: variable LCMP1
+	.section	.debug_info
+	.uleb128	334	; ref to abbrev 334
+	.section	.debug_abbrev
+	.uleb128	334
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname334:
+	.string		"LCMP1"
+	.section	.debug_info
+	.long		.Lname334
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #335: variable HCMP1
+	.section	.debug_info
+	.uleb128	335	; ref to abbrev 335
+	.section	.debug_abbrev
+	.uleb128	335
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname335:
+	.string		"HCMP1"
+	.section	.debug_info
+	.long		.Lname335
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #336: variable LCMP2
+	.section	.debug_info
+	.uleb128	336	; ref to abbrev 336
+	.section	.debug_abbrev
+	.uleb128	336
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname336:
+	.string		"LCMP2"
+	.section	.debug_info
+	.long		.Lname336
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #337: variable HCMP2
+	.section	.debug_info
+	.uleb128	337	; ref to abbrev 337
+	.section	.debug_abbrev
+	.uleb128	337
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname337:
+	.string		"HCMP2"
+	.section	.debug_info
+	.long		.Lname337
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #338: variable CTRLA
+	.section	.debug_info
+	.uleb128	338	; ref to abbrev 338
+	.section	.debug_abbrev
+	.uleb128	338
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname338:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname338
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #339: variable CTRLB
+	.section	.debug_info
+	.uleb128	339	; ref to abbrev 339
+	.section	.debug_abbrev
+	.uleb128	339
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname339:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname339
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #340: variable EVCTRL
+	.section	.debug_info
+	.uleb128	340	; ref to abbrev 340
+	.section	.debug_abbrev
+	.uleb128	340
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname340:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname340
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #341: variable INTCTRL
+	.section	.debug_info
+	.uleb128	341	; ref to abbrev 341
+	.section	.debug_abbrev
+	.uleb128	341
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname341:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname341
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #342: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	342	; ref to abbrev 342
+	.section	.debug_abbrev
+	.uleb128	342
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname342:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname342
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #343: variable STATUS
+	.section	.debug_info
+	.uleb128	343	; ref to abbrev 343
+	.section	.debug_abbrev
+	.uleb128	343
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname343:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname343
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #344: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	344	; ref to abbrev 344
+	.section	.debug_abbrev
+	.uleb128	344
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname344:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname344
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #345: variable TEMP
+	.section	.debug_info
+	.uleb128	345	; ref to abbrev 345
+	.section	.debug_abbrev
+	.uleb128	345
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname345:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname345
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #346: variable CNT
+	.section	.debug_info
+	.uleb128	346	; ref to abbrev 346
+	.section	.debug_abbrev
+	.uleb128	346
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname346:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname346
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #347: variable CCMP
+	.section	.debug_info
+	.uleb128	347	; ref to abbrev 347
+	.section	.debug_abbrev
+	.uleb128	347
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname347:
+	.string		"CCMP"
+	.section	.debug_info
+	.long		.Lname347
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #348: variable CTRLA
+	.section	.debug_info
+	.uleb128	348	; ref to abbrev 348
+	.section	.debug_abbrev
+	.uleb128	348
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname348:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname348
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #349: variable CTRLB
+	.section	.debug_info
+	.uleb128	349	; ref to abbrev 349
+	.section	.debug_abbrev
+	.uleb128	349
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname349:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname349
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #350: variable EVCTRL
+	.section	.debug_info
+	.uleb128	350	; ref to abbrev 350
+	.section	.debug_abbrev
+	.uleb128	350
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname350:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname350
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #351: variable INTCTRL
+	.section	.debug_info
+	.uleb128	351	; ref to abbrev 351
+	.section	.debug_abbrev
+	.uleb128	351
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname351:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname351
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #352: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	352	; ref to abbrev 352
+	.section	.debug_abbrev
+	.uleb128	352
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname352:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname352
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #353: variable STATUS
+	.section	.debug_info
+	.uleb128	353	; ref to abbrev 353
+	.section	.debug_abbrev
+	.uleb128	353
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname353:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname353
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #354: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	354	; ref to abbrev 354
+	.section	.debug_abbrev
+	.uleb128	354
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname354:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname354
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #355: variable TEMP
+	.section	.debug_info
+	.uleb128	355	; ref to abbrev 355
+	.section	.debug_abbrev
+	.uleb128	355
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname355:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname355
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #356: variable CNT
+	.section	.debug_info
+	.uleb128	356	; ref to abbrev 356
+	.section	.debug_abbrev
+	.uleb128	356
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname356:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname356
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #357: variable CCMP
+	.section	.debug_info
+	.uleb128	357	; ref to abbrev 357
+	.section	.debug_abbrev
+	.uleb128	357
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname357:
+	.string		"CCMP"
+	.section	.debug_info
+	.long		.Lname357
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #358: variable CTRLA
+	.section	.debug_info
+	.uleb128	358	; ref to abbrev 358
+	.section	.debug_abbrev
+	.uleb128	358
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname358:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname358
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #359: variable CTRLB
+	.section	.debug_info
+	.uleb128	359	; ref to abbrev 359
+	.section	.debug_abbrev
+	.uleb128	359
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname359:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname359
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #360: variable EVCTRL
+	.section	.debug_info
+	.uleb128	360	; ref to abbrev 360
+	.section	.debug_abbrev
+	.uleb128	360
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname360:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname360
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #361: variable INTCTRL
+	.section	.debug_info
+	.uleb128	361	; ref to abbrev 361
+	.section	.debug_abbrev
+	.uleb128	361
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname361:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname361
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #362: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	362	; ref to abbrev 362
+	.section	.debug_abbrev
+	.uleb128	362
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname362:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname362
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #363: variable STATUS
+	.section	.debug_info
+	.uleb128	363	; ref to abbrev 363
+	.section	.debug_abbrev
+	.uleb128	363
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname363:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname363
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #364: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	364	; ref to abbrev 364
+	.section	.debug_abbrev
+	.uleb128	364
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname364:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname364
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #365: variable TEMP
+	.section	.debug_info
+	.uleb128	365	; ref to abbrev 365
+	.section	.debug_abbrev
+	.uleb128	365
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname365:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname365
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #366: variable CNT
+	.section	.debug_info
+	.uleb128	366	; ref to abbrev 366
+	.section	.debug_abbrev
+	.uleb128	366
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname366:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname366
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #367: variable CCMP
+	.section	.debug_info
+	.uleb128	367	; ref to abbrev 367
+	.section	.debug_abbrev
+	.uleb128	367
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname367:
+	.string		"CCMP"
+	.section	.debug_info
+	.long		.Lname367
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #368: variable CTRLA
+	.section	.debug_info
+	.uleb128	368	; ref to abbrev 368
+	.section	.debug_abbrev
+	.uleb128	368
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname368:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname368
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #369: variable DUALCTRL
+	.section	.debug_info
+	.uleb128	369	; ref to abbrev 369
+	.section	.debug_abbrev
+	.uleb128	369
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname369:
+	.string		"DUALCTRL"
+	.section	.debug_info
+	.long		.Lname369
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #370: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	370	; ref to abbrev 370
+	.section	.debug_abbrev
+	.uleb128	370
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname370:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname370
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #371: variable MCTRLA
+	.section	.debug_info
+	.uleb128	371	; ref to abbrev 371
+	.section	.debug_abbrev
+	.uleb128	371
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname371:
+	.string		"MCTRLA"
+	.section	.debug_info
+	.long		.Lname371
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #372: variable MCTRLB
+	.section	.debug_info
+	.uleb128	372	; ref to abbrev 372
+	.section	.debug_abbrev
+	.uleb128	372
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname372:
+	.string		"MCTRLB"
+	.section	.debug_info
+	.long		.Lname372
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #373: variable MSTATUS
+	.section	.debug_info
+	.uleb128	373	; ref to abbrev 373
+	.section	.debug_abbrev
+	.uleb128	373
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname373:
+	.string		"MSTATUS"
+	.section	.debug_info
+	.long		.Lname373
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #374: variable MBAUD
+	.section	.debug_info
+	.uleb128	374	; ref to abbrev 374
+	.section	.debug_abbrev
+	.uleb128	374
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname374:
+	.string		"MBAUD"
+	.section	.debug_info
+	.long		.Lname374
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #375: variable MADDR
+	.section	.debug_info
+	.uleb128	375	; ref to abbrev 375
+	.section	.debug_abbrev
+	.uleb128	375
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname375:
+	.string		"MADDR"
+	.section	.debug_info
+	.long		.Lname375
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #376: variable MDATA
+	.section	.debug_info
+	.uleb128	376	; ref to abbrev 376
+	.section	.debug_abbrev
+	.uleb128	376
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname376:
+	.string		"MDATA"
+	.section	.debug_info
+	.long		.Lname376
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #377: variable SCTRLA
+	.section	.debug_info
+	.uleb128	377	; ref to abbrev 377
+	.section	.debug_abbrev
+	.uleb128	377
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname377:
+	.string		"SCTRLA"
+	.section	.debug_info
+	.long		.Lname377
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #378: variable SCTRLB
+	.section	.debug_info
+	.uleb128	378	; ref to abbrev 378
+	.section	.debug_abbrev
+	.uleb128	378
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname378:
+	.string		"SCTRLB"
+	.section	.debug_info
+	.long		.Lname378
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #379: variable SSTATUS
+	.section	.debug_info
+	.uleb128	379	; ref to abbrev 379
+	.section	.debug_abbrev
+	.uleb128	379
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname379:
+	.string		"SSTATUS"
+	.section	.debug_info
+	.long		.Lname379
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #380: variable SADDR
+	.section	.debug_info
+	.uleb128	380	; ref to abbrev 380
+	.section	.debug_abbrev
+	.uleb128	380
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname380:
+	.string		"SADDR"
+	.section	.debug_info
+	.long		.Lname380
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #381: variable SDATA
+	.section	.debug_info
+	.uleb128	381	; ref to abbrev 381
+	.section	.debug_abbrev
+	.uleb128	381
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname381:
+	.string		"SDATA"
+	.section	.debug_info
+	.long		.Lname381
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xD
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #382: variable SADDRMASK
+	.section	.debug_info
+	.uleb128	382	; ref to abbrev 382
+	.section	.debug_abbrev
+	.uleb128	382
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname382:
+	.string		"SADDRMASK"
+	.section	.debug_info
+	.long		.Lname382
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xE
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #383: variable RXDATAL
+	.section	.debug_info
+	.uleb128	383	; ref to abbrev 383
+	.section	.debug_abbrev
+	.uleb128	383
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname383:
+	.string		"RXDATAL"
+	.section	.debug_info
+	.long		.Lname383
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #384: variable RXDATAH
+	.section	.debug_info
+	.uleb128	384	; ref to abbrev 384
+	.section	.debug_abbrev
+	.uleb128	384
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname384:
+	.string		"RXDATAH"
+	.section	.debug_info
+	.long		.Lname384
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #385: variable TXDATAL
+	.section	.debug_info
+	.uleb128	385	; ref to abbrev 385
+	.section	.debug_abbrev
+	.uleb128	385
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname385:
+	.string		"TXDATAL"
+	.section	.debug_info
+	.long		.Lname385
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #386: variable TXDATAH
+	.section	.debug_info
+	.uleb128	386	; ref to abbrev 386
+	.section	.debug_abbrev
+	.uleb128	386
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname386:
+	.string		"TXDATAH"
+	.section	.debug_info
+	.long		.Lname386
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #387: variable STATUS
+	.section	.debug_info
+	.uleb128	387	; ref to abbrev 387
+	.section	.debug_abbrev
+	.uleb128	387
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname387:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname387
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #388: variable CTRLA
+	.section	.debug_info
+	.uleb128	388	; ref to abbrev 388
+	.section	.debug_abbrev
+	.uleb128	388
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname388:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname388
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #389: variable CTRLB
+	.section	.debug_info
+	.uleb128	389	; ref to abbrev 389
+	.section	.debug_abbrev
+	.uleb128	389
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname389:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname389
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #390: variable CTRLC
+	.section	.debug_info
+	.uleb128	390	; ref to abbrev 390
+	.section	.debug_abbrev
+	.uleb128	390
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname390:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname390
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #391: variable BAUD
+	.section	.debug_info
+	.uleb128	391	; ref to abbrev 391
+	.section	.debug_abbrev
+	.uleb128	391
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname391:
+	.string		"BAUD"
+	.section	.debug_info
+	.long		.Lname391
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #392: variable CTRLD
+	.section	.debug_info
+	.uleb128	392	; ref to abbrev 392
+	.section	.debug_abbrev
+	.uleb128	392
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname392:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname392
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #393: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	393	; ref to abbrev 393
+	.section	.debug_abbrev
+	.uleb128	393
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname393:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname393
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #394: variable EVCTRL
+	.section	.debug_info
+	.uleb128	394	; ref to abbrev 394
+	.section	.debug_abbrev
+	.uleb128	394
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname394:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname394
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #395: variable TXPLCTRL
+	.section	.debug_info
+	.uleb128	395	; ref to abbrev 395
+	.section	.debug_abbrev
+	.uleb128	395
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname395:
+	.string		"TXPLCTRL"
+	.section	.debug_info
+	.long		.Lname395
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xD
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #396: variable RXPLCTRL
+	.section	.debug_info
+	.uleb128	396	; ref to abbrev 396
+	.section	.debug_abbrev
+	.uleb128	396
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname396:
+	.string		"RXPLCTRL"
+	.section	.debug_info
+	.long		.Lname396
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xE
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #397: variable RXDATAL
+	.section	.debug_info
+	.uleb128	397	; ref to abbrev 397
+	.section	.debug_abbrev
+	.uleb128	397
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname397:
+	.string		"RXDATAL"
+	.section	.debug_info
+	.long		.Lname397
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #398: variable RXDATAH
+	.section	.debug_info
+	.uleb128	398	; ref to abbrev 398
+	.section	.debug_abbrev
+	.uleb128	398
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname398:
+	.string		"RXDATAH"
+	.section	.debug_info
+	.long		.Lname398
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #399: variable TXDATAL
+	.section	.debug_info
+	.uleb128	399	; ref to abbrev 399
+	.section	.debug_abbrev
+	.uleb128	399
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname399:
+	.string		"TXDATAL"
+	.section	.debug_info
+	.long		.Lname399
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #400: variable TXDATAH
+	.section	.debug_info
+	.uleb128	400	; ref to abbrev 400
+	.section	.debug_abbrev
+	.uleb128	400
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname400:
+	.string		"TXDATAH"
+	.section	.debug_info
+	.long		.Lname400
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #401: variable STATUS
+	.section	.debug_info
+	.uleb128	401	; ref to abbrev 401
+	.section	.debug_abbrev
+	.uleb128	401
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname401:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname401
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #402: variable CTRLA
+	.section	.debug_info
+	.uleb128	402	; ref to abbrev 402
+	.section	.debug_abbrev
+	.uleb128	402
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname402:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname402
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #403: variable CTRLB
+	.section	.debug_info
+	.uleb128	403	; ref to abbrev 403
+	.section	.debug_abbrev
+	.uleb128	403
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname403:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname403
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #404: variable CTRLC
+	.section	.debug_info
+	.uleb128	404	; ref to abbrev 404
+	.section	.debug_abbrev
+	.uleb128	404
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname404:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname404
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #405: variable BAUD
+	.section	.debug_info
+	.uleb128	405	; ref to abbrev 405
+	.section	.debug_abbrev
+	.uleb128	405
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname405:
+	.string		"BAUD"
+	.section	.debug_info
+	.long		.Lname405
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #406: variable CTRLD
+	.section	.debug_info
+	.uleb128	406	; ref to abbrev 406
+	.section	.debug_abbrev
+	.uleb128	406
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname406:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname406
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #407: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	407	; ref to abbrev 407
+	.section	.debug_abbrev
+	.uleb128	407
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname407:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname407
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #408: variable EVCTRL
+	.section	.debug_info
+	.uleb128	408	; ref to abbrev 408
+	.section	.debug_abbrev
+	.uleb128	408
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname408:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname408
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #409: variable TXPLCTRL
+	.section	.debug_info
+	.uleb128	409	; ref to abbrev 409
+	.section	.debug_abbrev
+	.uleb128	409
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname409:
+	.string		"TXPLCTRL"
+	.section	.debug_info
+	.long		.Lname409
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0xD
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #410: variable RXPLCTRL
+	.section	.debug_info
+	.uleb128	410	; ref to abbrev 410
+	.section	.debug_abbrev
+	.uleb128	410
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname410:
+	.string		"RXPLCTRL"
+	.section	.debug_info
+	.long		.Lname410
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0xE
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #411: variable RXDATAL
+	.section	.debug_info
+	.uleb128	411	; ref to abbrev 411
+	.section	.debug_abbrev
+	.uleb128	411
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname411:
+	.string		"RXDATAL"
+	.section	.debug_info
+	.long		.Lname411
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #412: variable RXDATAH
+	.section	.debug_info
+	.uleb128	412	; ref to abbrev 412
+	.section	.debug_abbrev
+	.uleb128	412
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname412:
+	.string		"RXDATAH"
+	.section	.debug_info
+	.long		.Lname412
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #413: variable TXDATAL
+	.section	.debug_info
+	.uleb128	413	; ref to abbrev 413
+	.section	.debug_abbrev
+	.uleb128	413
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname413:
+	.string		"TXDATAL"
+	.section	.debug_info
+	.long		.Lname413
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #414: variable TXDATAH
+	.section	.debug_info
+	.uleb128	414	; ref to abbrev 414
+	.section	.debug_abbrev
+	.uleb128	414
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname414:
+	.string		"TXDATAH"
+	.section	.debug_info
+	.long		.Lname414
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #415: variable STATUS
+	.section	.debug_info
+	.uleb128	415	; ref to abbrev 415
+	.section	.debug_abbrev
+	.uleb128	415
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname415:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname415
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #416: variable CTRLA
+	.section	.debug_info
+	.uleb128	416	; ref to abbrev 416
+	.section	.debug_abbrev
+	.uleb128	416
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname416:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname416
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #417: variable CTRLB
+	.section	.debug_info
+	.uleb128	417	; ref to abbrev 417
+	.section	.debug_abbrev
+	.uleb128	417
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname417:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname417
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #418: variable CTRLC
+	.section	.debug_info
+	.uleb128	418	; ref to abbrev 418
+	.section	.debug_abbrev
+	.uleb128	418
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname418:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname418
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #419: variable BAUD
+	.section	.debug_info
+	.uleb128	419	; ref to abbrev 419
+	.section	.debug_abbrev
+	.uleb128	419
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname419:
+	.string		"BAUD"
+	.section	.debug_info
+	.long		.Lname419
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #420: variable CTRLD
+	.section	.debug_info
+	.uleb128	420	; ref to abbrev 420
+	.section	.debug_abbrev
+	.uleb128	420
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname420:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname420
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #421: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	421	; ref to abbrev 421
+	.section	.debug_abbrev
+	.uleb128	421
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname421:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname421
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #422: variable EVCTRL
+	.section	.debug_info
+	.uleb128	422	; ref to abbrev 422
+	.section	.debug_abbrev
+	.uleb128	422
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname422:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname422
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #423: variable TXPLCTRL
+	.section	.debug_info
+	.uleb128	423	; ref to abbrev 423
+	.section	.debug_abbrev
+	.uleb128	423
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname423:
+	.string		"TXPLCTRL"
+	.section	.debug_info
+	.long		.Lname423
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0xD
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #424: variable RXPLCTRL
+	.section	.debug_info
+	.uleb128	424	; ref to abbrev 424
+	.section	.debug_abbrev
+	.uleb128	424
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname424:
+	.string		"RXPLCTRL"
+	.section	.debug_info
+	.long		.Lname424
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0xE
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #425: variable USERROW0
+	.section	.debug_info
+	.uleb128	425	; ref to abbrev 425
+	.section	.debug_abbrev
+	.uleb128	425
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname425:
+	.string		"USERROW0"
+	.section	.debug_info
+	.long		.Lname425
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #426: variable USERROW1
+	.section	.debug_info
+	.uleb128	426	; ref to abbrev 426
+	.section	.debug_abbrev
+	.uleb128	426
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname426:
+	.string		"USERROW1"
+	.section	.debug_info
+	.long		.Lname426
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #427: variable USERROW2
+	.section	.debug_info
+	.uleb128	427	; ref to abbrev 427
+	.section	.debug_abbrev
+	.uleb128	427
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname427:
+	.string		"USERROW2"
+	.section	.debug_info
+	.long		.Lname427
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #428: variable USERROW3
+	.section	.debug_info
+	.uleb128	428	; ref to abbrev 428
+	.section	.debug_abbrev
+	.uleb128	428
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname428:
+	.string		"USERROW3"
+	.section	.debug_info
+	.long		.Lname428
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #429: variable USERROW4
+	.section	.debug_info
+	.uleb128	429	; ref to abbrev 429
+	.section	.debug_abbrev
+	.uleb128	429
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname429:
+	.string		"USERROW4"
+	.section	.debug_info
+	.long		.Lname429
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #430: variable USERROW5
+	.section	.debug_info
+	.uleb128	430	; ref to abbrev 430
+	.section	.debug_abbrev
+	.uleb128	430
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname430:
+	.string		"USERROW5"
+	.section	.debug_info
+	.long		.Lname430
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #431: variable USERROW6
+	.section	.debug_info
+	.uleb128	431	; ref to abbrev 431
+	.section	.debug_abbrev
+	.uleb128	431
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname431:
+	.string		"USERROW6"
+	.section	.debug_info
+	.long		.Lname431
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #432: variable USERROW7
+	.section	.debug_info
+	.uleb128	432	; ref to abbrev 432
+	.section	.debug_abbrev
+	.uleb128	432
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname432:
+	.string		"USERROW7"
+	.section	.debug_info
+	.long		.Lname432
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #433: variable USERROW8
+	.section	.debug_info
+	.uleb128	433	; ref to abbrev 433
+	.section	.debug_abbrev
+	.uleb128	433
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname433:
+	.string		"USERROW8"
+	.section	.debug_info
+	.long		.Lname433
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #434: variable USERROW9
+	.section	.debug_info
+	.uleb128	434	; ref to abbrev 434
+	.section	.debug_abbrev
+	.uleb128	434
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname434:
+	.string		"USERROW9"
+	.section	.debug_info
+	.long		.Lname434
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #435: variable USERROW10
+	.section	.debug_info
+	.uleb128	435	; ref to abbrev 435
+	.section	.debug_abbrev
+	.uleb128	435
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname435:
+	.string		"USERROW10"
+	.section	.debug_info
+	.long		.Lname435
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #436: variable USERROW11
+	.section	.debug_info
+	.uleb128	436	; ref to abbrev 436
+	.section	.debug_abbrev
+	.uleb128	436
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname436:
+	.string		"USERROW11"
+	.section	.debug_info
+	.long		.Lname436
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #437: variable USERROW12
+	.section	.debug_info
+	.uleb128	437	; ref to abbrev 437
+	.section	.debug_abbrev
+	.uleb128	437
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname437:
+	.string		"USERROW12"
+	.section	.debug_info
+	.long		.Lname437
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #438: variable USERROW13
+	.section	.debug_info
+	.uleb128	438	; ref to abbrev 438
+	.section	.debug_abbrev
+	.uleb128	438
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname438:
+	.string		"USERROW13"
+	.section	.debug_info
+	.long		.Lname438
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #439: variable USERROW14
+	.section	.debug_info
+	.uleb128	439	; ref to abbrev 439
+	.section	.debug_abbrev
+	.uleb128	439
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname439:
+	.string		"USERROW14"
+	.section	.debug_info
+	.long		.Lname439
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #440: variable USERROW15
+	.section	.debug_info
+	.uleb128	440	; ref to abbrev 440
+	.section	.debug_abbrev
+	.uleb128	440
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname440:
+	.string		"USERROW15"
+	.section	.debug_info
+	.long		.Lname440
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x0F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #441: variable USERROW16
+	.section	.debug_info
+	.uleb128	441	; ref to abbrev 441
+	.section	.debug_abbrev
+	.uleb128	441
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname441:
+	.string		"USERROW16"
+	.section	.debug_info
+	.long		.Lname441
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #442: variable USERROW17
+	.section	.debug_info
+	.uleb128	442	; ref to abbrev 442
+	.section	.debug_abbrev
+	.uleb128	442
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname442:
+	.string		"USERROW17"
+	.section	.debug_info
+	.long		.Lname442
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #443: variable USERROW18
+	.section	.debug_info
+	.uleb128	443	; ref to abbrev 443
+	.section	.debug_abbrev
+	.uleb128	443
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname443:
+	.string		"USERROW18"
+	.section	.debug_info
+	.long		.Lname443
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #444: variable USERROW19
+	.section	.debug_info
+	.uleb128	444	; ref to abbrev 444
+	.section	.debug_abbrev
+	.uleb128	444
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname444:
+	.string		"USERROW19"
+	.section	.debug_info
+	.long		.Lname444
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #445: variable USERROW20
+	.section	.debug_info
+	.uleb128	445	; ref to abbrev 445
+	.section	.debug_abbrev
+	.uleb128	445
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname445:
+	.string		"USERROW20"
+	.section	.debug_info
+	.long		.Lname445
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #446: variable USERROW21
+	.section	.debug_info
+	.uleb128	446	; ref to abbrev 446
+	.section	.debug_abbrev
+	.uleb128	446
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname446:
+	.string		"USERROW21"
+	.section	.debug_info
+	.long		.Lname446
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #447: variable USERROW22
+	.section	.debug_info
+	.uleb128	447	; ref to abbrev 447
+	.section	.debug_abbrev
+	.uleb128	447
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname447:
+	.string		"USERROW22"
+	.section	.debug_info
+	.long		.Lname447
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #448: variable USERROW23
+	.section	.debug_info
+	.uleb128	448	; ref to abbrev 448
+	.section	.debug_abbrev
+	.uleb128	448
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname448:
+	.string		"USERROW23"
+	.section	.debug_info
+	.long		.Lname448
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #449: variable USERROW24
+	.section	.debug_info
+	.uleb128	449	; ref to abbrev 449
+	.section	.debug_abbrev
+	.uleb128	449
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname449:
+	.string		"USERROW24"
+	.section	.debug_info
+	.long		.Lname449
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #450: variable USERROW25
+	.section	.debug_info
+	.uleb128	450	; ref to abbrev 450
+	.section	.debug_abbrev
+	.uleb128	450
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname450:
+	.string		"USERROW25"
+	.section	.debug_info
+	.long		.Lname450
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x19
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #451: variable USERROW26
+	.section	.debug_info
+	.uleb128	451	; ref to abbrev 451
+	.section	.debug_abbrev
+	.uleb128	451
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname451:
+	.string		"USERROW26"
+	.section	.debug_info
+	.long		.Lname451
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #452: variable USERROW27
+	.section	.debug_info
+	.uleb128	452	; ref to abbrev 452
+	.section	.debug_abbrev
+	.uleb128	452
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname452:
+	.string		"USERROW27"
+	.section	.debug_info
+	.long		.Lname452
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #453: variable USERROW28
+	.section	.debug_info
+	.uleb128	453	; ref to abbrev 453
+	.section	.debug_abbrev
+	.uleb128	453
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname453:
+	.string		"USERROW28"
+	.section	.debug_info
+	.long		.Lname453
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #454: variable USERROW29
+	.section	.debug_info
+	.uleb128	454	; ref to abbrev 454
+	.section	.debug_abbrev
+	.uleb128	454
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname454:
+	.string		"USERROW29"
+	.section	.debug_info
+	.long		.Lname454
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #455: variable USERROW30
+	.section	.debug_info
+	.uleb128	455	; ref to abbrev 455
+	.section	.debug_abbrev
+	.uleb128	455
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname455:
+	.string		"USERROW30"
+	.section	.debug_info
+	.long		.Lname455
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #456: variable USERROW31
+	.section	.debug_info
+	.uleb128	456	; ref to abbrev 456
+	.section	.debug_abbrev
+	.uleb128	456
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname456:
+	.string		"USERROW31"
+	.section	.debug_info
+	.long		.Lname456
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #457: variable USERROW32
+	.section	.debug_info
+	.uleb128	457	; ref to abbrev 457
+	.section	.debug_abbrev
+	.uleb128	457
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname457:
+	.string		"USERROW32"
+	.section	.debug_info
+	.long		.Lname457
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #458: variable USERROW33
+	.section	.debug_info
+	.uleb128	458	; ref to abbrev 458
+	.section	.debug_abbrev
+	.uleb128	458
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname458:
+	.string		"USERROW33"
+	.section	.debug_info
+	.long		.Lname458
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x21
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #459: variable USERROW34
+	.section	.debug_info
+	.uleb128	459	; ref to abbrev 459
+	.section	.debug_abbrev
+	.uleb128	459
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname459:
+	.string		"USERROW34"
+	.section	.debug_info
+	.long		.Lname459
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x22
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #460: variable USERROW35
+	.section	.debug_info
+	.uleb128	460	; ref to abbrev 460
+	.section	.debug_abbrev
+	.uleb128	460
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname460:
+	.string		"USERROW35"
+	.section	.debug_info
+	.long		.Lname460
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x23
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #461: variable USERROW36
+	.section	.debug_info
+	.uleb128	461	; ref to abbrev 461
+	.section	.debug_abbrev
+	.uleb128	461
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname461:
+	.string		"USERROW36"
+	.section	.debug_info
+	.long		.Lname461
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x24
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #462: variable USERROW37
+	.section	.debug_info
+	.uleb128	462	; ref to abbrev 462
+	.section	.debug_abbrev
+	.uleb128	462
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname462:
+	.string		"USERROW37"
+	.section	.debug_info
+	.long		.Lname462
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x25
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #463: variable USERROW38
+	.section	.debug_info
+	.uleb128	463	; ref to abbrev 463
+	.section	.debug_abbrev
+	.uleb128	463
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname463:
+	.string		"USERROW38"
+	.section	.debug_info
+	.long		.Lname463
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x26
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #464: variable USERROW39
+	.section	.debug_info
+	.uleb128	464	; ref to abbrev 464
+	.section	.debug_abbrev
+	.uleb128	464
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname464:
+	.string		"USERROW39"
+	.section	.debug_info
+	.long		.Lname464
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x27
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #465: variable USERROW40
+	.section	.debug_info
+	.uleb128	465	; ref to abbrev 465
+	.section	.debug_abbrev
+	.uleb128	465
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname465:
+	.string		"USERROW40"
+	.section	.debug_info
+	.long		.Lname465
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x28
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #466: variable USERROW41
+	.section	.debug_info
+	.uleb128	466	; ref to abbrev 466
+	.section	.debug_abbrev
+	.uleb128	466
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname466:
+	.string		"USERROW41"
+	.section	.debug_info
+	.long		.Lname466
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x29
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #467: variable USERROW42
+	.section	.debug_info
+	.uleb128	467	; ref to abbrev 467
+	.section	.debug_abbrev
+	.uleb128	467
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname467:
+	.string		"USERROW42"
+	.section	.debug_info
+	.long		.Lname467
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x2A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #468: variable USERROW43
+	.section	.debug_info
+	.uleb128	468	; ref to abbrev 468
+	.section	.debug_abbrev
+	.uleb128	468
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname468:
+	.string		"USERROW43"
+	.section	.debug_info
+	.long		.Lname468
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x2B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #469: variable USERROW44
+	.section	.debug_info
+	.uleb128	469	; ref to abbrev 469
+	.section	.debug_abbrev
+	.uleb128	469
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname469:
+	.string		"USERROW44"
+	.section	.debug_info
+	.long		.Lname469
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x2C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #470: variable USERROW45
+	.section	.debug_info
+	.uleb128	470	; ref to abbrev 470
+	.section	.debug_abbrev
+	.uleb128	470
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname470:
+	.string		"USERROW45"
+	.section	.debug_info
+	.long		.Lname470
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x2D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #471: variable USERROW46
+	.section	.debug_info
+	.uleb128	471	; ref to abbrev 471
+	.section	.debug_abbrev
+	.uleb128	471
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname471:
+	.string		"USERROW46"
+	.section	.debug_info
+	.long		.Lname471
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x2E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #472: variable USERROW47
+	.section	.debug_info
+	.uleb128	472	; ref to abbrev 472
+	.section	.debug_abbrev
+	.uleb128	472
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname472:
+	.string		"USERROW47"
+	.section	.debug_info
+	.long		.Lname472
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x2F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #473: variable USERROW48
+	.section	.debug_info
+	.uleb128	473	; ref to abbrev 473
+	.section	.debug_abbrev
+	.uleb128	473
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname473:
+	.string		"USERROW48"
+	.section	.debug_info
+	.long		.Lname473
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x30
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #474: variable USERROW49
+	.section	.debug_info
+	.uleb128	474	; ref to abbrev 474
+	.section	.debug_abbrev
+	.uleb128	474
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname474:
+	.string		"USERROW49"
+	.section	.debug_info
+	.long		.Lname474
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x31
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #475: variable USERROW50
+	.section	.debug_info
+	.uleb128	475	; ref to abbrev 475
+	.section	.debug_abbrev
+	.uleb128	475
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname475:
+	.string		"USERROW50"
+	.section	.debug_info
+	.long		.Lname475
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x32
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #476: variable USERROW51
+	.section	.debug_info
+	.uleb128	476	; ref to abbrev 476
+	.section	.debug_abbrev
+	.uleb128	476
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname476:
+	.string		"USERROW51"
+	.section	.debug_info
+	.long		.Lname476
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x33
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #477: variable USERROW52
+	.section	.debug_info
+	.uleb128	477	; ref to abbrev 477
+	.section	.debug_abbrev
+	.uleb128	477
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname477:
+	.string		"USERROW52"
+	.section	.debug_info
+	.long		.Lname477
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x34
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #478: variable USERROW53
+	.section	.debug_info
+	.uleb128	478	; ref to abbrev 478
+	.section	.debug_abbrev
+	.uleb128	478
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname478:
+	.string		"USERROW53"
+	.section	.debug_info
+	.long		.Lname478
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x35
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #479: variable USERROW54
+	.section	.debug_info
+	.uleb128	479	; ref to abbrev 479
+	.section	.debug_abbrev
+	.uleb128	479
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname479:
+	.string		"USERROW54"
+	.section	.debug_info
+	.long		.Lname479
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x36
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #480: variable USERROW55
+	.section	.debug_info
+	.uleb128	480	; ref to abbrev 480
+	.section	.debug_abbrev
+	.uleb128	480
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname480:
+	.string		"USERROW55"
+	.section	.debug_info
+	.long		.Lname480
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x37
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #481: variable USERROW56
+	.section	.debug_info
+	.uleb128	481	; ref to abbrev 481
+	.section	.debug_abbrev
+	.uleb128	481
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname481:
+	.string		"USERROW56"
+	.section	.debug_info
+	.long		.Lname481
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x38
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #482: variable USERROW57
+	.section	.debug_info
+	.uleb128	482	; ref to abbrev 482
+	.section	.debug_abbrev
+	.uleb128	482
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname482:
+	.string		"USERROW57"
+	.section	.debug_info
+	.long		.Lname482
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x39
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #483: variable USERROW58
+	.section	.debug_info
+	.uleb128	483	; ref to abbrev 483
+	.section	.debug_abbrev
+	.uleb128	483
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname483:
+	.string		"USERROW58"
+	.section	.debug_info
+	.long		.Lname483
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x3A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #484: variable USERROW59
+	.section	.debug_info
+	.uleb128	484	; ref to abbrev 484
+	.section	.debug_abbrev
+	.uleb128	484
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname484:
+	.string		"USERROW59"
+	.section	.debug_info
+	.long		.Lname484
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x3B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #485: variable USERROW60
+	.section	.debug_info
+	.uleb128	485	; ref to abbrev 485
+	.section	.debug_abbrev
+	.uleb128	485
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname485:
+	.string		"USERROW60"
+	.section	.debug_info
+	.long		.Lname485
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x3C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #486: variable USERROW61
+	.section	.debug_info
+	.uleb128	486	; ref to abbrev 486
+	.section	.debug_abbrev
+	.uleb128	486
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname486:
+	.string		"USERROW61"
+	.section	.debug_info
+	.long		.Lname486
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x3D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #487: variable USERROW62
+	.section	.debug_info
+	.uleb128	487	; ref to abbrev 487
+	.section	.debug_abbrev
+	.uleb128	487
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname487:
+	.string		"USERROW62"
+	.section	.debug_info
+	.long		.Lname487
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x3E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #488: variable USERROW63
+	.section	.debug_info
+	.uleb128	488	; ref to abbrev 488
+	.section	.debug_abbrev
+	.uleb128	488
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname488:
+	.string		"USERROW63"
+	.section	.debug_info
+	.long		.Lname488
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x3F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #489: variable DIR
+	.section	.debug_info
+	.uleb128	489	; ref to abbrev 489
+	.section	.debug_abbrev
+	.uleb128	489
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname489:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname489
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0000 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #490: variable OUT
+	.section	.debug_info
+	.uleb128	490	; ref to abbrev 490
+	.section	.debug_abbrev
+	.uleb128	490
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname490:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname490
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0000 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #491: variable IN
+	.section	.debug_info
+	.uleb128	491	; ref to abbrev 491
+	.section	.debug_abbrev
+	.uleb128	491
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname491:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname491
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0000 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #492: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	492	; ref to abbrev 492
+	.section	.debug_abbrev
+	.uleb128	492
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname492:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname492
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0000 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #493: variable DIR
+	.section	.debug_info
+	.uleb128	493	; ref to abbrev 493
+	.section	.debug_abbrev
+	.uleb128	493
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname493:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname493
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0008 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #494: variable OUT
+	.section	.debug_info
+	.uleb128	494	; ref to abbrev 494
+	.section	.debug_abbrev
+	.uleb128	494
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname494:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname494
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0008 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #495: variable IN
+	.section	.debug_info
+	.uleb128	495	; ref to abbrev 495
+	.section	.debug_abbrev
+	.uleb128	495
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname495:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname495
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0008 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #496: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	496	; ref to abbrev 496
+	.section	.debug_abbrev
+	.uleb128	496
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname496:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname496
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0008 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #497: variable DIR
+	.section	.debug_info
+	.uleb128	497	; ref to abbrev 497
+	.section	.debug_abbrev
+	.uleb128	497
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname497:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname497
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x000C + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #498: variable OUT
+	.section	.debug_info
+	.uleb128	498	; ref to abbrev 498
+	.section	.debug_abbrev
+	.uleb128	498
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname498:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname498
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x000C + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #499: variable IN
+	.section	.debug_info
+	.uleb128	499	; ref to abbrev 499
+	.section	.debug_abbrev
+	.uleb128	499
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname499:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname499
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x000C + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #500: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	500	; ref to abbrev 500
+	.section	.debug_abbrev
+	.uleb128	500
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname500:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname500
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x000C + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #501: variable DIR
+	.section	.debug_info
+	.uleb128	501	; ref to abbrev 501
+	.section	.debug_abbrev
+	.uleb128	501
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname501:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname501
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0014 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #502: variable OUT
+	.section	.debug_info
+	.uleb128	502	; ref to abbrev 502
+	.section	.debug_abbrev
+	.uleb128	502
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname502:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname502
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0014 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #503: variable IN
+	.section	.debug_info
+	.uleb128	503	; ref to abbrev 503
+	.section	.debug_abbrev
+	.uleb128	503
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname503:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname503
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0014 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #504: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	504	; ref to abbrev 504
+	.section	.debug_abbrev
+	.uleb128	504
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname504:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname504
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0014 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #505: variable DAC0REF
+	.section	.debug_info
+	.uleb128	505	; ref to abbrev 505
+	.section	.debug_abbrev
+	.uleb128	505
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname505:
+	.string		"DAC0REF"
+	.section	.debug_info
+	.long		.Lname505
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00B0 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #506: variable ACREF
+	.section	.debug_info
+	.uleb128	506	; ref to abbrev 506
+	.section	.debug_abbrev
+	.uleb128	506
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname506:
+	.string		"ACREF"
+	.section	.debug_info
+	.long		.Lname506
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00B0 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #507: variable CTRLA
+	.section	.debug_info
+	.uleb128	507	; ref to abbrev 507
+	.section	.debug_abbrev
+	.uleb128	507
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname507:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname507
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0100 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #508: variable STATUS
+	.section	.debug_info
+	.uleb128	508	; ref to abbrev 508
+	.section	.debug_abbrev
+	.uleb128	508
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname508:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname508
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0100 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+	;; trailer
+	.section	.debug_abbrev
+	.uleb128	0
+
+	.section	.debug_info
+	.uleb128	0
+.Leinfo:

--- a/crt1/iosym/avr64ea48.S
+++ b/crt1/iosym/avr64ea48.S
@@ -1,0 +1,32722 @@
+/* This file is part of avr-libc.
+
+   Automatically created by devtools/ioreg.pl
+   DO NOT EDIT!
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in
+     the documentation and/or other materials provided with the
+     distribution.
+
+   * Neither the name of the copyright holders nor the names of
+     contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE. */
+
+/* $Id$ */
+
+#include <avr/version.h>
+
+#define DW_TAG_array_type               0x01
+#define DW_TAG_compile_unit             0x11
+#define DW_TAG_typedef                  0x16
+#define DW_TAG_subrange_type            0x21
+#define DW_TAG_base_type                0x24
+#define DW_TAG_variable                 0x34
+
+#define DW_FORM_addr                    0x01
+#define DW_FORM_block1                  0x0a
+#define DW_FORM_block2                  0x03
+#define DW_FORM_block4                  0x04
+#define DW_FORM_data1                   0x0b
+#define DW_FORM_data2                   0x05
+#define DW_FORM_data4                   0x06
+#define DW_FORM_data8                   0x07
+#define DW_FORM_string                  0x08
+#define DW_FORM_flag                    0x0c
+#define DW_FORM_strp                    0x0e
+#define DW_FORM_ref1                    0x11
+#define DW_FORM_ref2                    0x12
+#define DW_FORM_ref4                    0x13
+#define DW_FORM_ref8                    0x14
+
+#define DW_AT_location                  0x02
+#define DW_AT_name                      0x03
+#define DW_AT_byte_size                 0x0b
+#define DW_AT_stmt_list                 0x10
+#define DW_AT_language                  0x13
+#define DW_AT_producer                  0x25
+#define DW_AT_upper_bound               0x2f
+#define DW_AT_decl_file                 0x3a
+#define DW_AT_decl_line                 0x3b
+#define DW_AT_encoding                  0x3e
+#define DW_AT_external                  0x3f
+#define DW_AT_type                      0x49
+
+#define DW_LANG_C89                     0x0001
+
+#define DW_CHILDREN_no                  0x00
+#define DW_CHILDREN_yes                 0x01
+
+#define DW_ATE_unsigned                 0x7
+#define DW_ATE_unsigned_char            0x8
+
+#define DW_OP_addr                      0x03
+.eject
+	.section	.debug_abbrev, "", @progbits
+.Ldebug_abbrev0:
+	.section	.debug_info, "", @progbits
+	.section	.debug_line, "", @progbits
+.Ldebug_line0:
+	.section	.debug_str, "", @progbits
+
+	.section	.debug_info, "", @progbits
+	;; compilation unit header
+.Lssinfo:
+	.long	.Leinfo - .Lsinfo
+.Lsinfo:
+	.word	2		; DWARF-2
+	.long	.Ldebug_abbrev0
+	.byte	4		; sizeof(address)
+
+
+	;; DIE #1: compilation unit
+	.section	.debug_info
+	.uleb128	1	; ref to abbrev 1
+	.section	.debug_abbrev
+	.uleb128	1
+	.uleb128	DW_TAG_compile_unit
+	.byte		DW_CHILDREN_yes
+
+	.uleb128	DW_AT_producer
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lproducer:
+	.ascii		"avr-libc "
+	.asciz		__AVR_LIBC_VERSION_STRING__
+	.section	.debug_info
+	.long		.Lproducer
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_stmt_list
+	.uleb128	DW_FORM_data4
+	.section	.debug_info
+	.long		.Ldebug_line0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+	;; DIE #2: base type uint8_t
+	.section	.debug_info
+.Luint8_t:
+	.uleb128	2	; ref to abbrev 2
+	.section	.debug_abbrev
+	.uleb128	2
+	.uleb128	DW_TAG_base_type
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Luint8_t_name:
+	.string		"uint8_t"
+	.section	.debug_info
+	.long		.Luint8_t_name
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_byte_size
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_encoding
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		DW_ATE_unsigned_char
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+	;; DIE #3: base type uint16_t
+	.section	.debug_info
+.Luint16_t:
+	.uleb128	3	; ref to abbrev 3
+	.section	.debug_abbrev
+	.uleb128	3
+	.uleb128	DW_TAG_base_type
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Luint16_t_name:
+	.string		"uint16_t"
+	.section	.debug_info
+	.long		.Luint16_t_name
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_byte_size
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		2
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_encoding
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		DW_ATE_unsigned
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #4: variable CTRLA
+	.section	.debug_info
+	.uleb128	4	; ref to abbrev 4
+	.section	.debug_abbrev
+	.uleb128	4
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname4:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname4
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #5: variable CTRLB
+	.section	.debug_info
+	.uleb128	5	; ref to abbrev 5
+	.section	.debug_abbrev
+	.uleb128	5
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname5:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname5
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #6: variable MUXCTRL
+	.section	.debug_info
+	.uleb128	6	; ref to abbrev 6
+	.section	.debug_abbrev
+	.uleb128	6
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname6:
+	.string		"MUXCTRL"
+	.section	.debug_info
+	.long		.Lname6
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #7: variable DACREF
+	.section	.debug_info
+	.uleb128	7	; ref to abbrev 7
+	.section	.debug_abbrev
+	.uleb128	7
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname7:
+	.string		"DACREF"
+	.section	.debug_info
+	.long		.Lname7
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #8: variable INTCTRL
+	.section	.debug_info
+	.uleb128	8	; ref to abbrev 8
+	.section	.debug_abbrev
+	.uleb128	8
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname8:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname8
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #9: variable STATUS
+	.section	.debug_info
+	.uleb128	9	; ref to abbrev 9
+	.section	.debug_abbrev
+	.uleb128	9
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname9:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname9
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0680 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #10: variable CTRLA
+	.section	.debug_info
+	.uleb128	10	; ref to abbrev 10
+	.section	.debug_abbrev
+	.uleb128	10
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname10:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname10
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #11: variable CTRLB
+	.section	.debug_info
+	.uleb128	11	; ref to abbrev 11
+	.section	.debug_abbrev
+	.uleb128	11
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname11:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname11
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #12: variable MUXCTRL
+	.section	.debug_info
+	.uleb128	12	; ref to abbrev 12
+	.section	.debug_abbrev
+	.uleb128	12
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname12:
+	.string		"MUXCTRL"
+	.section	.debug_info
+	.long		.Lname12
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #13: variable DACREF
+	.section	.debug_info
+	.uleb128	13	; ref to abbrev 13
+	.section	.debug_abbrev
+	.uleb128	13
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname13:
+	.string		"DACREF"
+	.section	.debug_info
+	.long		.Lname13
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #14: variable INTCTRL
+	.section	.debug_info
+	.uleb128	14	; ref to abbrev 14
+	.section	.debug_abbrev
+	.uleb128	14
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname14:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname14
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #15: variable STATUS
+	.section	.debug_info
+	.uleb128	15	; ref to abbrev 15
+	.section	.debug_abbrev
+	.uleb128	15
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname15:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname15
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0688 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #16: variable CTRLA
+	.section	.debug_info
+	.uleb128	16	; ref to abbrev 16
+	.section	.debug_abbrev
+	.uleb128	16
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname16:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname16
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #17: variable CTRLB
+	.section	.debug_info
+	.uleb128	17	; ref to abbrev 17
+	.section	.debug_abbrev
+	.uleb128	17
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname17:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname17
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #18: variable CTRLC
+	.section	.debug_info
+	.uleb128	18	; ref to abbrev 18
+	.section	.debug_abbrev
+	.uleb128	18
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname18:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname18
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #19: variable CTRLD
+	.section	.debug_info
+	.uleb128	19	; ref to abbrev 19
+	.section	.debug_abbrev
+	.uleb128	19
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname19:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname19
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #20: variable INTCTRL
+	.section	.debug_info
+	.uleb128	20	; ref to abbrev 20
+	.section	.debug_abbrev
+	.uleb128	20
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname20:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname20
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #21: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	21	; ref to abbrev 21
+	.section	.debug_abbrev
+	.uleb128	21
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname21:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname21
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #22: variable STATUS
+	.section	.debug_info
+	.uleb128	22	; ref to abbrev 22
+	.section	.debug_abbrev
+	.uleb128	22
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname22:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname22
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #23: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	23	; ref to abbrev 23
+	.section	.debug_abbrev
+	.uleb128	23
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname23:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname23
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #24: variable CTRLE
+	.section	.debug_info
+	.uleb128	24	; ref to abbrev 24
+	.section	.debug_abbrev
+	.uleb128	24
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname24:
+	.string		"CTRLE"
+	.section	.debug_info
+	.long		.Lname24
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #25: variable CTRLF
+	.section	.debug_info
+	.uleb128	25	; ref to abbrev 25
+	.section	.debug_abbrev
+	.uleb128	25
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname25:
+	.string		"CTRLF"
+	.section	.debug_info
+	.long		.Lname25
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #26: variable COMMAND
+	.section	.debug_info
+	.uleb128	26	; ref to abbrev 26
+	.section	.debug_abbrev
+	.uleb128	26
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname26:
+	.string		"COMMAND"
+	.section	.debug_info
+	.long		.Lname26
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #27: variable PGACTRL
+	.section	.debug_info
+	.uleb128	27	; ref to abbrev 27
+	.section	.debug_abbrev
+	.uleb128	27
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname27:
+	.string		"PGACTRL"
+	.section	.debug_info
+	.long		.Lname27
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #28: variable MUXPOS
+	.section	.debug_info
+	.uleb128	28	; ref to abbrev 28
+	.section	.debug_abbrev
+	.uleb128	28
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname28:
+	.string		"MUXPOS"
+	.section	.debug_info
+	.long		.Lname28
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #29: variable MUXNEG
+	.section	.debug_info
+	.uleb128	29	; ref to abbrev 29
+	.section	.debug_abbrev
+	.uleb128	29
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname29:
+	.string		"MUXNEG"
+	.section	.debug_info
+	.long		.Lname29
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #30: base type uint32_t
+	.section	.debug_info
+.Luint32_t:
+	.uleb128	30	; ref to abbrev 30
+	.section	.debug_abbrev
+	.uleb128	30
+	.uleb128	DW_TAG_base_type
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Luint32_t_name:
+	.string		"uint32_t"
+	.section	.debug_info
+	.long		.Luint32_t_name
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_byte_size
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		4
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_encoding
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		DW_ATE_unsigned
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #31: variable RESULT
+	.section	.debug_info
+	.uleb128	31	; ref to abbrev 31
+	.section	.debug_abbrev
+	.uleb128	31
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname31:
+	.string		"RESULT"
+	.section	.debug_info
+	.long		.Lname31
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint32_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #32: variable SAMPLE
+	.section	.debug_info
+	.uleb128	32	; ref to abbrev 32
+	.section	.debug_abbrev
+	.uleb128	32
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname32:
+	.string		"SAMPLE"
+	.section	.debug_info
+	.long		.Lname32
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #33: variable TEMP0
+	.section	.debug_info
+	.uleb128	33	; ref to abbrev 33
+	.section	.debug_abbrev
+	.uleb128	33
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname33:
+	.string		"TEMP0"
+	.section	.debug_info
+	.long		.Lname33
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #34: variable TEMP1
+	.section	.debug_info
+	.uleb128	34	; ref to abbrev 34
+	.section	.debug_abbrev
+	.uleb128	34
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname34:
+	.string		"TEMP1"
+	.section	.debug_info
+	.long		.Lname34
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x19
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #35: variable TEMP2
+	.section	.debug_info
+	.uleb128	35	; ref to abbrev 35
+	.section	.debug_abbrev
+	.uleb128	35
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname35:
+	.string		"TEMP2"
+	.section	.debug_info
+	.long		.Lname35
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x1A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #36: variable WINLT
+	.section	.debug_info
+	.uleb128	36	; ref to abbrev 36
+	.section	.debug_abbrev
+	.uleb128	36
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname36:
+	.string		"WINLT"
+	.section	.debug_info
+	.long		.Lname36
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x1C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #37: variable WINHT
+	.section	.debug_info
+	.uleb128	37	; ref to abbrev 37
+	.section	.debug_abbrev
+	.uleb128	37
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname37:
+	.string		"WINHT"
+	.section	.debug_info
+	.long		.Lname37
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0600 + 0x1E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #38: variable CTRLA
+	.section	.debug_info
+	.uleb128	38	; ref to abbrev 38
+	.section	.debug_abbrev
+	.uleb128	38
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname38:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname38
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #39: variable CTRLB
+	.section	.debug_info
+	.uleb128	39	; ref to abbrev 39
+	.section	.debug_abbrev
+	.uleb128	39
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname39:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname39
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #40: variable VLMCTRLA
+	.section	.debug_info
+	.uleb128	40	; ref to abbrev 40
+	.section	.debug_abbrev
+	.uleb128	40
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname40:
+	.string		"VLMCTRLA"
+	.section	.debug_info
+	.long		.Lname40
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #41: variable INTCTRL
+	.section	.debug_info
+	.uleb128	41	; ref to abbrev 41
+	.section	.debug_abbrev
+	.uleb128	41
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname41:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname41
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #42: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	42	; ref to abbrev 42
+	.section	.debug_abbrev
+	.uleb128	42
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname42:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname42
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #43: variable STATUS
+	.section	.debug_info
+	.uleb128	43	; ref to abbrev 43
+	.section	.debug_abbrev
+	.uleb128	43
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname43:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname43
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00A0 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #44: variable CTRLA
+	.section	.debug_info
+	.uleb128	44	; ref to abbrev 44
+	.section	.debug_abbrev
+	.uleb128	44
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname44:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname44
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #45: variable SEQCTRL0
+	.section	.debug_info
+	.uleb128	45	; ref to abbrev 45
+	.section	.debug_abbrev
+	.uleb128	45
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname45:
+	.string		"SEQCTRL0"
+	.section	.debug_info
+	.long		.Lname45
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #46: variable SEQCTRL1
+	.section	.debug_info
+	.uleb128	46	; ref to abbrev 46
+	.section	.debug_abbrev
+	.uleb128	46
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname46:
+	.string		"SEQCTRL1"
+	.section	.debug_info
+	.long		.Lname46
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #47: variable INTCTRL0
+	.section	.debug_info
+	.uleb128	47	; ref to abbrev 47
+	.section	.debug_abbrev
+	.uleb128	47
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname47:
+	.string		"INTCTRL0"
+	.section	.debug_info
+	.long		.Lname47
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #48: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	48	; ref to abbrev 48
+	.section	.debug_abbrev
+	.uleb128	48
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname48:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname48
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #49: variable LUT0CTRLA
+	.section	.debug_info
+	.uleb128	49	; ref to abbrev 49
+	.section	.debug_abbrev
+	.uleb128	49
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname49:
+	.string		"LUT0CTRLA"
+	.section	.debug_info
+	.long		.Lname49
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #50: variable LUT0CTRLB
+	.section	.debug_info
+	.uleb128	50	; ref to abbrev 50
+	.section	.debug_abbrev
+	.uleb128	50
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname50:
+	.string		"LUT0CTRLB"
+	.section	.debug_info
+	.long		.Lname50
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #51: variable LUT0CTRLC
+	.section	.debug_info
+	.uleb128	51	; ref to abbrev 51
+	.section	.debug_abbrev
+	.uleb128	51
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname51:
+	.string		"LUT0CTRLC"
+	.section	.debug_info
+	.long		.Lname51
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #52: variable TRUTH0
+	.section	.debug_info
+	.uleb128	52	; ref to abbrev 52
+	.section	.debug_abbrev
+	.uleb128	52
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname52:
+	.string		"TRUTH0"
+	.section	.debug_info
+	.long		.Lname52
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #53: variable LUT1CTRLA
+	.section	.debug_info
+	.uleb128	53	; ref to abbrev 53
+	.section	.debug_abbrev
+	.uleb128	53
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname53:
+	.string		"LUT1CTRLA"
+	.section	.debug_info
+	.long		.Lname53
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #54: variable LUT1CTRLB
+	.section	.debug_info
+	.uleb128	54	; ref to abbrev 54
+	.section	.debug_abbrev
+	.uleb128	54
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname54:
+	.string		"LUT1CTRLB"
+	.section	.debug_info
+	.long		.Lname54
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #55: variable LUT1CTRLC
+	.section	.debug_info
+	.uleb128	55	; ref to abbrev 55
+	.section	.debug_abbrev
+	.uleb128	55
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname55:
+	.string		"LUT1CTRLC"
+	.section	.debug_info
+	.long		.Lname55
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #56: variable TRUTH1
+	.section	.debug_info
+	.uleb128	56	; ref to abbrev 56
+	.section	.debug_abbrev
+	.uleb128	56
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname56:
+	.string		"TRUTH1"
+	.section	.debug_info
+	.long		.Lname56
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x0F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #57: variable LUT2CTRLA
+	.section	.debug_info
+	.uleb128	57	; ref to abbrev 57
+	.section	.debug_abbrev
+	.uleb128	57
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname57:
+	.string		"LUT2CTRLA"
+	.section	.debug_info
+	.long		.Lname57
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #58: variable LUT2CTRLB
+	.section	.debug_info
+	.uleb128	58	; ref to abbrev 58
+	.section	.debug_abbrev
+	.uleb128	58
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname58:
+	.string		"LUT2CTRLB"
+	.section	.debug_info
+	.long		.Lname58
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #59: variable LUT2CTRLC
+	.section	.debug_info
+	.uleb128	59	; ref to abbrev 59
+	.section	.debug_abbrev
+	.uleb128	59
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname59:
+	.string		"LUT2CTRLC"
+	.section	.debug_info
+	.long		.Lname59
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #60: variable TRUTH2
+	.section	.debug_info
+	.uleb128	60	; ref to abbrev 60
+	.section	.debug_abbrev
+	.uleb128	60
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname60:
+	.string		"TRUTH2"
+	.section	.debug_info
+	.long		.Lname60
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #61: variable LUT3CTRLA
+	.section	.debug_info
+	.uleb128	61	; ref to abbrev 61
+	.section	.debug_abbrev
+	.uleb128	61
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname61:
+	.string		"LUT3CTRLA"
+	.section	.debug_info
+	.long		.Lname61
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #62: variable LUT3CTRLB
+	.section	.debug_info
+	.uleb128	62	; ref to abbrev 62
+	.section	.debug_abbrev
+	.uleb128	62
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname62:
+	.string		"LUT3CTRLB"
+	.section	.debug_info
+	.long		.Lname62
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #63: variable LUT3CTRLC
+	.section	.debug_info
+	.uleb128	63	; ref to abbrev 63
+	.section	.debug_abbrev
+	.uleb128	63
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname63:
+	.string		"LUT3CTRLC"
+	.section	.debug_info
+	.long		.Lname63
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #64: variable TRUTH3
+	.section	.debug_info
+	.uleb128	64	; ref to abbrev 64
+	.section	.debug_abbrev
+	.uleb128	64
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname64:
+	.string		"TRUTH3"
+	.section	.debug_info
+	.long		.Lname64
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x01C0 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #65: variable MCLKCTRLA
+	.section	.debug_info
+	.uleb128	65	; ref to abbrev 65
+	.section	.debug_abbrev
+	.uleb128	65
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname65:
+	.string		"MCLKCTRLA"
+	.section	.debug_info
+	.long		.Lname65
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #66: variable MCLKCTRLB
+	.section	.debug_info
+	.uleb128	66	; ref to abbrev 66
+	.section	.debug_abbrev
+	.uleb128	66
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname66:
+	.string		"MCLKCTRLB"
+	.section	.debug_info
+	.long		.Lname66
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #67: variable MCLKCTRLC
+	.section	.debug_info
+	.uleb128	67	; ref to abbrev 67
+	.section	.debug_abbrev
+	.uleb128	67
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname67:
+	.string		"MCLKCTRLC"
+	.section	.debug_info
+	.long		.Lname67
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #68: variable MCLKINTCTRL
+	.section	.debug_info
+	.uleb128	68	; ref to abbrev 68
+	.section	.debug_abbrev
+	.uleb128	68
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname68:
+	.string		"MCLKINTCTRL"
+	.section	.debug_info
+	.long		.Lname68
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #69: variable MCLKINTFLAGS
+	.section	.debug_info
+	.uleb128	69	; ref to abbrev 69
+	.section	.debug_abbrev
+	.uleb128	69
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname69:
+	.string		"MCLKINTFLAGS"
+	.section	.debug_info
+	.long		.Lname69
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #70: variable MCLKSTATUS
+	.section	.debug_info
+	.uleb128	70	; ref to abbrev 70
+	.section	.debug_abbrev
+	.uleb128	70
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname70:
+	.string		"MCLKSTATUS"
+	.section	.debug_info
+	.long		.Lname70
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #71: variable MCLKTIMEBASE
+	.section	.debug_info
+	.uleb128	71	; ref to abbrev 71
+	.section	.debug_abbrev
+	.uleb128	71
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname71:
+	.string		"MCLKTIMEBASE"
+	.section	.debug_info
+	.long		.Lname71
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #72: variable OSCHFCTRLA
+	.section	.debug_info
+	.uleb128	72	; ref to abbrev 72
+	.section	.debug_abbrev
+	.uleb128	72
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname72:
+	.string		"OSCHFCTRLA"
+	.section	.debug_info
+	.long		.Lname72
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #73: variable OSCHFTUNE
+	.section	.debug_info
+	.uleb128	73	; ref to abbrev 73
+	.section	.debug_abbrev
+	.uleb128	73
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname73:
+	.string		"OSCHFTUNE"
+	.section	.debug_info
+	.long		.Lname73
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #74: variable OSC32KCTRLA
+	.section	.debug_info
+	.uleb128	74	; ref to abbrev 74
+	.section	.debug_abbrev
+	.uleb128	74
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname74:
+	.string		"OSC32KCTRLA"
+	.section	.debug_info
+	.long		.Lname74
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #75: variable XOSC32KCTRLA
+	.section	.debug_info
+	.uleb128	75	; ref to abbrev 75
+	.section	.debug_abbrev
+	.uleb128	75
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname75:
+	.string		"XOSC32KCTRLA"
+	.section	.debug_info
+	.long		.Lname75
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x1C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #76: variable XOSCHFCTRLA
+	.section	.debug_info
+	.uleb128	76	; ref to abbrev 76
+	.section	.debug_abbrev
+	.uleb128	76
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname76:
+	.string		"XOSCHFCTRLA"
+	.section	.debug_info
+	.long		.Lname76
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0060 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #77: variable CCP
+	.section	.debug_info
+	.uleb128	77	; ref to abbrev 77
+	.section	.debug_abbrev
+	.uleb128	77
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname77:
+	.string		"CCP"
+	.section	.debug_info
+	.long		.Lname77
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0030 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #78: variable SP
+	.section	.debug_info
+	.uleb128	78	; ref to abbrev 78
+	.section	.debug_abbrev
+	.uleb128	78
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname78:
+	.string		"SP"
+	.section	.debug_info
+	.long		.Lname78
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0030 + 0xD
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #79: variable SREG
+	.section	.debug_info
+	.uleb128	79	; ref to abbrev 79
+	.section	.debug_abbrev
+	.uleb128	79
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname79:
+	.string		"SREG"
+	.section	.debug_info
+	.long		.Lname79
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0030 + 0xF
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #80: variable CTRLA
+	.section	.debug_info
+	.uleb128	80	; ref to abbrev 80
+	.section	.debug_abbrev
+	.uleb128	80
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname80:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname80
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0110 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #81: variable STATUS
+	.section	.debug_info
+	.uleb128	81	; ref to abbrev 81
+	.section	.debug_abbrev
+	.uleb128	81
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname81:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname81
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0110 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #82: variable LVL0PRI
+	.section	.debug_info
+	.uleb128	82	; ref to abbrev 82
+	.section	.debug_abbrev
+	.uleb128	82
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname82:
+	.string		"LVL0PRI"
+	.section	.debug_info
+	.long		.Lname82
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0110 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #83: variable LVL1VEC
+	.section	.debug_info
+	.uleb128	83	; ref to abbrev 83
+	.section	.debug_abbrev
+	.uleb128	83
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname83:
+	.string		"LVL1VEC"
+	.section	.debug_info
+	.long		.Lname83
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0110 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #84: variable CTRLA
+	.section	.debug_info
+	.uleb128	84	; ref to abbrev 84
+	.section	.debug_abbrev
+	.uleb128	84
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname84:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname84
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0120 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #85: variable CTRLB
+	.section	.debug_info
+	.uleb128	85	; ref to abbrev 85
+	.section	.debug_abbrev
+	.uleb128	85
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname85:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname85
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0120 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #86: variable STATUS
+	.section	.debug_info
+	.uleb128	86	; ref to abbrev 86
+	.section	.debug_abbrev
+	.uleb128	86
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname86:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname86
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0120 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #87: variable CTRLA
+	.section	.debug_info
+	.uleb128	87	; ref to abbrev 87
+	.section	.debug_abbrev
+	.uleb128	87
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname87:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname87
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x06A0 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #88: variable DATA
+	.section	.debug_info
+	.uleb128	88	; ref to abbrev 88
+	.section	.debug_abbrev
+	.uleb128	88
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname88:
+	.string		"DATA"
+	.section	.debug_info
+	.long		.Lname88
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x06A0 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #89: variable SWEVENTA
+	.section	.debug_info
+	.uleb128	89	; ref to abbrev 89
+	.section	.debug_abbrev
+	.uleb128	89
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname89:
+	.string		"SWEVENTA"
+	.section	.debug_info
+	.long		.Lname89
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #90: variable CHANNEL0
+	.section	.debug_info
+	.uleb128	90	; ref to abbrev 90
+	.section	.debug_abbrev
+	.uleb128	90
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname90:
+	.string		"CHANNEL0"
+	.section	.debug_info
+	.long		.Lname90
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #91: variable CHANNEL1
+	.section	.debug_info
+	.uleb128	91	; ref to abbrev 91
+	.section	.debug_abbrev
+	.uleb128	91
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname91:
+	.string		"CHANNEL1"
+	.section	.debug_info
+	.long		.Lname91
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #92: variable CHANNEL2
+	.section	.debug_info
+	.uleb128	92	; ref to abbrev 92
+	.section	.debug_abbrev
+	.uleb128	92
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname92:
+	.string		"CHANNEL2"
+	.section	.debug_info
+	.long		.Lname92
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #93: variable CHANNEL3
+	.section	.debug_info
+	.uleb128	93	; ref to abbrev 93
+	.section	.debug_abbrev
+	.uleb128	93
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname93:
+	.string		"CHANNEL3"
+	.section	.debug_info
+	.long		.Lname93
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #94: variable CHANNEL4
+	.section	.debug_info
+	.uleb128	94	; ref to abbrev 94
+	.section	.debug_abbrev
+	.uleb128	94
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname94:
+	.string		"CHANNEL4"
+	.section	.debug_info
+	.long		.Lname94
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #95: variable CHANNEL5
+	.section	.debug_info
+	.uleb128	95	; ref to abbrev 95
+	.section	.debug_abbrev
+	.uleb128	95
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname95:
+	.string		"CHANNEL5"
+	.section	.debug_info
+	.long		.Lname95
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #96: variable USERCCLLUT0A
+	.section	.debug_info
+	.uleb128	96	; ref to abbrev 96
+	.section	.debug_abbrev
+	.uleb128	96
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname96:
+	.string		"USERCCLLUT0A"
+	.section	.debug_info
+	.long		.Lname96
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #97: variable USERCCLLUT0B
+	.section	.debug_info
+	.uleb128	97	; ref to abbrev 97
+	.section	.debug_abbrev
+	.uleb128	97
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname97:
+	.string		"USERCCLLUT0B"
+	.section	.debug_info
+	.long		.Lname97
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x21
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #98: variable USERCCLLUT1A
+	.section	.debug_info
+	.uleb128	98	; ref to abbrev 98
+	.section	.debug_abbrev
+	.uleb128	98
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname98:
+	.string		"USERCCLLUT1A"
+	.section	.debug_info
+	.long		.Lname98
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x22
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #99: variable USERCCLLUT1B
+	.section	.debug_info
+	.uleb128	99	; ref to abbrev 99
+	.section	.debug_abbrev
+	.uleb128	99
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname99:
+	.string		"USERCCLLUT1B"
+	.section	.debug_info
+	.long		.Lname99
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x23
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #100: variable USERCCLLUT2A
+	.section	.debug_info
+	.uleb128	100	; ref to abbrev 100
+	.section	.debug_abbrev
+	.uleb128	100
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname100:
+	.string		"USERCCLLUT2A"
+	.section	.debug_info
+	.long		.Lname100
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x24
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #101: variable USERCCLLUT2B
+	.section	.debug_info
+	.uleb128	101	; ref to abbrev 101
+	.section	.debug_abbrev
+	.uleb128	101
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname101:
+	.string		"USERCCLLUT2B"
+	.section	.debug_info
+	.long		.Lname101
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x25
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #102: variable USERCCLLUT3A
+	.section	.debug_info
+	.uleb128	102	; ref to abbrev 102
+	.section	.debug_abbrev
+	.uleb128	102
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname102:
+	.string		"USERCCLLUT3A"
+	.section	.debug_info
+	.long		.Lname102
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x26
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #103: variable USERCCLLUT3B
+	.section	.debug_info
+	.uleb128	103	; ref to abbrev 103
+	.section	.debug_abbrev
+	.uleb128	103
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname103:
+	.string		"USERCCLLUT3B"
+	.section	.debug_info
+	.long		.Lname103
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x27
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #104: variable USERADC0START
+	.section	.debug_info
+	.uleb128	104	; ref to abbrev 104
+	.section	.debug_abbrev
+	.uleb128	104
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname104:
+	.string		"USERADC0START"
+	.section	.debug_info
+	.long		.Lname104
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x28
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #105: variable USEREVSYSEVOUTA
+	.section	.debug_info
+	.uleb128	105	; ref to abbrev 105
+	.section	.debug_abbrev
+	.uleb128	105
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname105:
+	.string		"USEREVSYSEVOUTA"
+	.section	.debug_info
+	.long		.Lname105
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x29
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #106: variable USEREVSYSEVOUTB
+	.section	.debug_info
+	.uleb128	106	; ref to abbrev 106
+	.section	.debug_abbrev
+	.uleb128	106
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname106:
+	.string		"USEREVSYSEVOUTB"
+	.section	.debug_info
+	.long		.Lname106
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #107: variable USEREVSYSEVOUTC
+	.section	.debug_info
+	.uleb128	107	; ref to abbrev 107
+	.section	.debug_abbrev
+	.uleb128	107
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname107:
+	.string		"USEREVSYSEVOUTC"
+	.section	.debug_info
+	.long		.Lname107
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #108: variable USEREVSYSEVOUTD
+	.section	.debug_info
+	.uleb128	108	; ref to abbrev 108
+	.section	.debug_abbrev
+	.uleb128	108
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname108:
+	.string		"USEREVSYSEVOUTD"
+	.section	.debug_info
+	.long		.Lname108
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #109: variable USEREVSYSEVOUTE
+	.section	.debug_info
+	.uleb128	109	; ref to abbrev 109
+	.section	.debug_abbrev
+	.uleb128	109
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname109:
+	.string		"USEREVSYSEVOUTE"
+	.section	.debug_info
+	.long		.Lname109
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #110: variable USEREVSYSEVOUTF
+	.section	.debug_info
+	.uleb128	110	; ref to abbrev 110
+	.section	.debug_abbrev
+	.uleb128	110
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname110:
+	.string		"USEREVSYSEVOUTF"
+	.section	.debug_info
+	.long		.Lname110
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #111: variable USERUSART0IRDA
+	.section	.debug_info
+	.uleb128	111	; ref to abbrev 111
+	.section	.debug_abbrev
+	.uleb128	111
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname111:
+	.string		"USERUSART0IRDA"
+	.section	.debug_info
+	.long		.Lname111
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x2F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #112: variable USERUSART1IRDA
+	.section	.debug_info
+	.uleb128	112	; ref to abbrev 112
+	.section	.debug_abbrev
+	.uleb128	112
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname112:
+	.string		"USERUSART1IRDA"
+	.section	.debug_info
+	.long		.Lname112
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x30
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #113: variable USERUSART2IRDA
+	.section	.debug_info
+	.uleb128	113	; ref to abbrev 113
+	.section	.debug_abbrev
+	.uleb128	113
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname113:
+	.string		"USERUSART2IRDA"
+	.section	.debug_info
+	.long		.Lname113
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x31
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #114: variable USERTCA0CNTA
+	.section	.debug_info
+	.uleb128	114	; ref to abbrev 114
+	.section	.debug_abbrev
+	.uleb128	114
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname114:
+	.string		"USERTCA0CNTA"
+	.section	.debug_info
+	.long		.Lname114
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x32
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #115: variable USERTCA0CNTB
+	.section	.debug_info
+	.uleb128	115	; ref to abbrev 115
+	.section	.debug_abbrev
+	.uleb128	115
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname115:
+	.string		"USERTCA0CNTB"
+	.section	.debug_info
+	.long		.Lname115
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x33
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #116: variable USERTCA1CNTA
+	.section	.debug_info
+	.uleb128	116	; ref to abbrev 116
+	.section	.debug_abbrev
+	.uleb128	116
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname116:
+	.string		"USERTCA1CNTA"
+	.section	.debug_info
+	.long		.Lname116
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x34
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #117: variable USERTCA1CNTB
+	.section	.debug_info
+	.uleb128	117	; ref to abbrev 117
+	.section	.debug_abbrev
+	.uleb128	117
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname117:
+	.string		"USERTCA1CNTB"
+	.section	.debug_info
+	.long		.Lname117
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x35
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #118: variable USERTCB0CAPT
+	.section	.debug_info
+	.uleb128	118	; ref to abbrev 118
+	.section	.debug_abbrev
+	.uleb128	118
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname118:
+	.string		"USERTCB0CAPT"
+	.section	.debug_info
+	.long		.Lname118
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x36
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #119: variable USERTCB0COUNT
+	.section	.debug_info
+	.uleb128	119	; ref to abbrev 119
+	.section	.debug_abbrev
+	.uleb128	119
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname119:
+	.string		"USERTCB0COUNT"
+	.section	.debug_info
+	.long		.Lname119
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x37
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #120: variable USERTCB1CAPT
+	.section	.debug_info
+	.uleb128	120	; ref to abbrev 120
+	.section	.debug_abbrev
+	.uleb128	120
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname120:
+	.string		"USERTCB1CAPT"
+	.section	.debug_info
+	.long		.Lname120
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x38
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #121: variable USERTCB1COUNT
+	.section	.debug_info
+	.uleb128	121	; ref to abbrev 121
+	.section	.debug_abbrev
+	.uleb128	121
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname121:
+	.string		"USERTCB1COUNT"
+	.section	.debug_info
+	.long		.Lname121
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x39
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #122: variable USERTCB2CAPT
+	.section	.debug_info
+	.uleb128	122	; ref to abbrev 122
+	.section	.debug_abbrev
+	.uleb128	122
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname122:
+	.string		"USERTCB2CAPT"
+	.section	.debug_info
+	.long		.Lname122
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x3A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #123: variable USERTCB2COUNT
+	.section	.debug_info
+	.uleb128	123	; ref to abbrev 123
+	.section	.debug_abbrev
+	.uleb128	123
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname123:
+	.string		"USERTCB2COUNT"
+	.section	.debug_info
+	.long		.Lname123
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x3B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #124: variable USERTCB3CAPT
+	.section	.debug_info
+	.uleb128	124	; ref to abbrev 124
+	.section	.debug_abbrev
+	.uleb128	124
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname124:
+	.string		"USERTCB3CAPT"
+	.section	.debug_info
+	.long		.Lname124
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x3C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #125: variable USERTCB3COUNT
+	.section	.debug_info
+	.uleb128	125	; ref to abbrev 125
+	.section	.debug_abbrev
+	.uleb128	125
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname125:
+	.string		"USERTCB3COUNT"
+	.section	.debug_info
+	.long		.Lname125
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0200 + 0x3D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #126: variable WDTCFG
+	.section	.debug_info
+	.uleb128	126	; ref to abbrev 126
+	.section	.debug_abbrev
+	.uleb128	126
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname126:
+	.string		"WDTCFG"
+	.section	.debug_info
+	.long		.Lname126
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #127: variable BODCFG
+	.section	.debug_info
+	.uleb128	127	; ref to abbrev 127
+	.section	.debug_abbrev
+	.uleb128	127
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname127:
+	.string		"BODCFG"
+	.section	.debug_info
+	.long		.Lname127
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #128: variable OSCCFG
+	.section	.debug_info
+	.uleb128	128	; ref to abbrev 128
+	.section	.debug_abbrev
+	.uleb128	128
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname128:
+	.string		"OSCCFG"
+	.section	.debug_info
+	.long		.Lname128
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #129: variable SYSCFG0
+	.section	.debug_info
+	.uleb128	129	; ref to abbrev 129
+	.section	.debug_abbrev
+	.uleb128	129
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname129:
+	.string		"SYSCFG0"
+	.section	.debug_info
+	.long		.Lname129
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #130: variable SYSCFG1
+	.section	.debug_info
+	.uleb128	130	; ref to abbrev 130
+	.section	.debug_abbrev
+	.uleb128	130
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname130:
+	.string		"SYSCFG1"
+	.section	.debug_info
+	.long		.Lname130
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #131: variable CODESIZE
+	.section	.debug_info
+	.uleb128	131	; ref to abbrev 131
+	.section	.debug_abbrev
+	.uleb128	131
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname131:
+	.string		"CODESIZE"
+	.section	.debug_info
+	.long		.Lname131
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #132: variable BOOTSIZE
+	.section	.debug_info
+	.uleb128	132	; ref to abbrev 132
+	.section	.debug_abbrev
+	.uleb128	132
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname132:
+	.string		"BOOTSIZE"
+	.section	.debug_info
+	.long		.Lname132
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1050 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #133: variable GPR0
+	.section	.debug_info
+	.uleb128	133	; ref to abbrev 133
+	.section	.debug_abbrev
+	.uleb128	133
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname133:
+	.string		"GPR0"
+	.section	.debug_info
+	.long		.Lname133
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x001C + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #134: variable GPR1
+	.section	.debug_info
+	.uleb128	134	; ref to abbrev 134
+	.section	.debug_abbrev
+	.uleb128	134
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname134:
+	.string		"GPR1"
+	.section	.debug_info
+	.long		.Lname134
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x001C + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #135: variable GPR2
+	.section	.debug_info
+	.uleb128	135	; ref to abbrev 135
+	.section	.debug_abbrev
+	.uleb128	135
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname135:
+	.string		"GPR2"
+	.section	.debug_info
+	.long		.Lname135
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x001C + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #136: variable GPR3
+	.section	.debug_info
+	.uleb128	136	; ref to abbrev 136
+	.section	.debug_abbrev
+	.uleb128	136
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname136:
+	.string		"GPR3"
+	.section	.debug_info
+	.long		.Lname136
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x001C + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #137: variable KEY
+	.section	.debug_info
+	.uleb128	137	; ref to abbrev 137
+	.section	.debug_abbrev
+	.uleb128	137
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname137:
+	.string		"KEY"
+	.section	.debug_info
+	.long		.Lname137
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint32_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1040 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #138: variable CTRLA
+	.section	.debug_info
+	.uleb128	138	; ref to abbrev 138
+	.section	.debug_abbrev
+	.uleb128	138
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname138:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname138
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #139: variable CTRLB
+	.section	.debug_info
+	.uleb128	139	; ref to abbrev 139
+	.section	.debug_abbrev
+	.uleb128	139
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname139:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname139
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #140: variable INTCTRL
+	.section	.debug_info
+	.uleb128	140	; ref to abbrev 140
+	.section	.debug_abbrev
+	.uleb128	140
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname140:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname140
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #141: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	141	; ref to abbrev 141
+	.section	.debug_abbrev
+	.uleb128	141
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname141:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname141
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #142: variable STATUS
+	.section	.debug_info
+	.uleb128	142	; ref to abbrev 142
+	.section	.debug_abbrev
+	.uleb128	142
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname142:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname142
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #143: variable DATA
+	.section	.debug_info
+	.uleb128	143	; ref to abbrev 143
+	.section	.debug_abbrev
+	.uleb128	143
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname143:
+	.string		"DATA"
+	.section	.debug_info
+	.long		.Lname143
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #144: variable ADDR
+	.section	.debug_info
+	.uleb128	144	; ref to abbrev 144
+	.section	.debug_abbrev
+	.uleb128	144
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname144:
+	.string		"ADDR"
+	.section	.debug_info
+	.long		.Lname144
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint32_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1000 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #145: variable DIR
+	.section	.debug_info
+	.uleb128	145	; ref to abbrev 145
+	.section	.debug_abbrev
+	.uleb128	145
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname145:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname145
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #146: variable DIRSET
+	.section	.debug_info
+	.uleb128	146	; ref to abbrev 146
+	.section	.debug_abbrev
+	.uleb128	146
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname146:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname146
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #147: variable DIRCLR
+	.section	.debug_info
+	.uleb128	147	; ref to abbrev 147
+	.section	.debug_abbrev
+	.uleb128	147
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname147:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname147
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #148: variable DIRTGL
+	.section	.debug_info
+	.uleb128	148	; ref to abbrev 148
+	.section	.debug_abbrev
+	.uleb128	148
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname148:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname148
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #149: variable OUT
+	.section	.debug_info
+	.uleb128	149	; ref to abbrev 149
+	.section	.debug_abbrev
+	.uleb128	149
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname149:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname149
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #150: variable OUTSET
+	.section	.debug_info
+	.uleb128	150	; ref to abbrev 150
+	.section	.debug_abbrev
+	.uleb128	150
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname150:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname150
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #151: variable OUTCLR
+	.section	.debug_info
+	.uleb128	151	; ref to abbrev 151
+	.section	.debug_abbrev
+	.uleb128	151
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname151:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname151
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #152: variable OUTTGL
+	.section	.debug_info
+	.uleb128	152	; ref to abbrev 152
+	.section	.debug_abbrev
+	.uleb128	152
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname152:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname152
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #153: variable IN
+	.section	.debug_info
+	.uleb128	153	; ref to abbrev 153
+	.section	.debug_abbrev
+	.uleb128	153
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname153:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname153
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #154: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	154	; ref to abbrev 154
+	.section	.debug_abbrev
+	.uleb128	154
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname154:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname154
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #155: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	155	; ref to abbrev 155
+	.section	.debug_abbrev
+	.uleb128	155
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname155:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname155
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #156: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	156	; ref to abbrev 156
+	.section	.debug_abbrev
+	.uleb128	156
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname156:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname156
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #157: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	157	; ref to abbrev 157
+	.section	.debug_abbrev
+	.uleb128	157
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname157:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname157
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #158: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	158	; ref to abbrev 158
+	.section	.debug_abbrev
+	.uleb128	158
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname158:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname158
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #159: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	159	; ref to abbrev 159
+	.section	.debug_abbrev
+	.uleb128	159
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname159:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname159
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #160: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	160	; ref to abbrev 160
+	.section	.debug_abbrev
+	.uleb128	160
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname160:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname160
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #161: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	161	; ref to abbrev 161
+	.section	.debug_abbrev
+	.uleb128	161
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname161:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname161
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #162: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	162	; ref to abbrev 162
+	.section	.debug_abbrev
+	.uleb128	162
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname162:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname162
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #163: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	163	; ref to abbrev 163
+	.section	.debug_abbrev
+	.uleb128	163
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname163:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname163
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #164: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	164	; ref to abbrev 164
+	.section	.debug_abbrev
+	.uleb128	164
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname164:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname164
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #165: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	165	; ref to abbrev 165
+	.section	.debug_abbrev
+	.uleb128	165
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname165:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname165
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #166: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	166	; ref to abbrev 166
+	.section	.debug_abbrev
+	.uleb128	166
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname166:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname166
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #167: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	167	; ref to abbrev 167
+	.section	.debug_abbrev
+	.uleb128	167
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname167:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname167
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #168: variable EVGENCTRL
+	.section	.debug_info
+	.uleb128	168	; ref to abbrev 168
+	.section	.debug_abbrev
+	.uleb128	168
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname168:
+	.string		"EVGENCTRL"
+	.section	.debug_info
+	.long		.Lname168
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0400 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #169: variable DIR
+	.section	.debug_info
+	.uleb128	169	; ref to abbrev 169
+	.section	.debug_abbrev
+	.uleb128	169
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname169:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname169
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #170: variable DIRSET
+	.section	.debug_info
+	.uleb128	170	; ref to abbrev 170
+	.section	.debug_abbrev
+	.uleb128	170
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname170:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname170
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #171: variable DIRCLR
+	.section	.debug_info
+	.uleb128	171	; ref to abbrev 171
+	.section	.debug_abbrev
+	.uleb128	171
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname171:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname171
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #172: variable DIRTGL
+	.section	.debug_info
+	.uleb128	172	; ref to abbrev 172
+	.section	.debug_abbrev
+	.uleb128	172
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname172:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname172
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #173: variable OUT
+	.section	.debug_info
+	.uleb128	173	; ref to abbrev 173
+	.section	.debug_abbrev
+	.uleb128	173
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname173:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname173
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #174: variable OUTSET
+	.section	.debug_info
+	.uleb128	174	; ref to abbrev 174
+	.section	.debug_abbrev
+	.uleb128	174
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname174:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname174
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #175: variable OUTCLR
+	.section	.debug_info
+	.uleb128	175	; ref to abbrev 175
+	.section	.debug_abbrev
+	.uleb128	175
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname175:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname175
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #176: variable OUTTGL
+	.section	.debug_info
+	.uleb128	176	; ref to abbrev 176
+	.section	.debug_abbrev
+	.uleb128	176
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname176:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname176
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #177: variable IN
+	.section	.debug_info
+	.uleb128	177	; ref to abbrev 177
+	.section	.debug_abbrev
+	.uleb128	177
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname177:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname177
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #178: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	178	; ref to abbrev 178
+	.section	.debug_abbrev
+	.uleb128	178
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname178:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname178
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #179: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	179	; ref to abbrev 179
+	.section	.debug_abbrev
+	.uleb128	179
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname179:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname179
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #180: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	180	; ref to abbrev 180
+	.section	.debug_abbrev
+	.uleb128	180
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname180:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname180
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #181: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	181	; ref to abbrev 181
+	.section	.debug_abbrev
+	.uleb128	181
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname181:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname181
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #182: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	182	; ref to abbrev 182
+	.section	.debug_abbrev
+	.uleb128	182
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname182:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname182
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #183: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	183	; ref to abbrev 183
+	.section	.debug_abbrev
+	.uleb128	183
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname183:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname183
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #184: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	184	; ref to abbrev 184
+	.section	.debug_abbrev
+	.uleb128	184
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname184:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname184
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #185: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	185	; ref to abbrev 185
+	.section	.debug_abbrev
+	.uleb128	185
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname185:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname185
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #186: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	186	; ref to abbrev 186
+	.section	.debug_abbrev
+	.uleb128	186
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname186:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname186
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #187: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	187	; ref to abbrev 187
+	.section	.debug_abbrev
+	.uleb128	187
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname187:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname187
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #188: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	188	; ref to abbrev 188
+	.section	.debug_abbrev
+	.uleb128	188
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname188:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname188
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #189: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	189	; ref to abbrev 189
+	.section	.debug_abbrev
+	.uleb128	189
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname189:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname189
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #190: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	190	; ref to abbrev 190
+	.section	.debug_abbrev
+	.uleb128	190
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname190:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname190
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #191: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	191	; ref to abbrev 191
+	.section	.debug_abbrev
+	.uleb128	191
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname191:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname191
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #192: variable EVGENCTRL
+	.section	.debug_info
+	.uleb128	192	; ref to abbrev 192
+	.section	.debug_abbrev
+	.uleb128	192
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname192:
+	.string		"EVGENCTRL"
+	.section	.debug_info
+	.long		.Lname192
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0420 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #193: variable DIR
+	.section	.debug_info
+	.uleb128	193	; ref to abbrev 193
+	.section	.debug_abbrev
+	.uleb128	193
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname193:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname193
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #194: variable DIRSET
+	.section	.debug_info
+	.uleb128	194	; ref to abbrev 194
+	.section	.debug_abbrev
+	.uleb128	194
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname194:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname194
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #195: variable DIRCLR
+	.section	.debug_info
+	.uleb128	195	; ref to abbrev 195
+	.section	.debug_abbrev
+	.uleb128	195
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname195:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname195
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #196: variable DIRTGL
+	.section	.debug_info
+	.uleb128	196	; ref to abbrev 196
+	.section	.debug_abbrev
+	.uleb128	196
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname196:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname196
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #197: variable OUT
+	.section	.debug_info
+	.uleb128	197	; ref to abbrev 197
+	.section	.debug_abbrev
+	.uleb128	197
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname197:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname197
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #198: variable OUTSET
+	.section	.debug_info
+	.uleb128	198	; ref to abbrev 198
+	.section	.debug_abbrev
+	.uleb128	198
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname198:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname198
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #199: variable OUTCLR
+	.section	.debug_info
+	.uleb128	199	; ref to abbrev 199
+	.section	.debug_abbrev
+	.uleb128	199
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname199:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname199
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #200: variable OUTTGL
+	.section	.debug_info
+	.uleb128	200	; ref to abbrev 200
+	.section	.debug_abbrev
+	.uleb128	200
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname200:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname200
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #201: variable IN
+	.section	.debug_info
+	.uleb128	201	; ref to abbrev 201
+	.section	.debug_abbrev
+	.uleb128	201
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname201:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname201
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #202: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	202	; ref to abbrev 202
+	.section	.debug_abbrev
+	.uleb128	202
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname202:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname202
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #203: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	203	; ref to abbrev 203
+	.section	.debug_abbrev
+	.uleb128	203
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname203:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname203
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #204: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	204	; ref to abbrev 204
+	.section	.debug_abbrev
+	.uleb128	204
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname204:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname204
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #205: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	205	; ref to abbrev 205
+	.section	.debug_abbrev
+	.uleb128	205
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname205:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname205
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #206: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	206	; ref to abbrev 206
+	.section	.debug_abbrev
+	.uleb128	206
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname206:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname206
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #207: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	207	; ref to abbrev 207
+	.section	.debug_abbrev
+	.uleb128	207
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname207:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname207
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #208: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	208	; ref to abbrev 208
+	.section	.debug_abbrev
+	.uleb128	208
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname208:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname208
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #209: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	209	; ref to abbrev 209
+	.section	.debug_abbrev
+	.uleb128	209
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname209:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname209
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #210: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	210	; ref to abbrev 210
+	.section	.debug_abbrev
+	.uleb128	210
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname210:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname210
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #211: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	211	; ref to abbrev 211
+	.section	.debug_abbrev
+	.uleb128	211
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname211:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname211
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #212: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	212	; ref to abbrev 212
+	.section	.debug_abbrev
+	.uleb128	212
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname212:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname212
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #213: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	213	; ref to abbrev 213
+	.section	.debug_abbrev
+	.uleb128	213
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname213:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname213
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #214: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	214	; ref to abbrev 214
+	.section	.debug_abbrev
+	.uleb128	214
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname214:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname214
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #215: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	215	; ref to abbrev 215
+	.section	.debug_abbrev
+	.uleb128	215
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname215:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname215
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #216: variable EVGENCTRL
+	.section	.debug_info
+	.uleb128	216	; ref to abbrev 216
+	.section	.debug_abbrev
+	.uleb128	216
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname216:
+	.string		"EVGENCTRL"
+	.section	.debug_info
+	.long		.Lname216
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0440 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #217: variable DIR
+	.section	.debug_info
+	.uleb128	217	; ref to abbrev 217
+	.section	.debug_abbrev
+	.uleb128	217
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname217:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname217
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #218: variable DIRSET
+	.section	.debug_info
+	.uleb128	218	; ref to abbrev 218
+	.section	.debug_abbrev
+	.uleb128	218
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname218:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname218
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #219: variable DIRCLR
+	.section	.debug_info
+	.uleb128	219	; ref to abbrev 219
+	.section	.debug_abbrev
+	.uleb128	219
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname219:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname219
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #220: variable DIRTGL
+	.section	.debug_info
+	.uleb128	220	; ref to abbrev 220
+	.section	.debug_abbrev
+	.uleb128	220
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname220:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname220
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #221: variable OUT
+	.section	.debug_info
+	.uleb128	221	; ref to abbrev 221
+	.section	.debug_abbrev
+	.uleb128	221
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname221:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname221
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #222: variable OUTSET
+	.section	.debug_info
+	.uleb128	222	; ref to abbrev 222
+	.section	.debug_abbrev
+	.uleb128	222
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname222:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname222
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #223: variable OUTCLR
+	.section	.debug_info
+	.uleb128	223	; ref to abbrev 223
+	.section	.debug_abbrev
+	.uleb128	223
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname223:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname223
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #224: variable OUTTGL
+	.section	.debug_info
+	.uleb128	224	; ref to abbrev 224
+	.section	.debug_abbrev
+	.uleb128	224
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname224:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname224
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #225: variable IN
+	.section	.debug_info
+	.uleb128	225	; ref to abbrev 225
+	.section	.debug_abbrev
+	.uleb128	225
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname225:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname225
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #226: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	226	; ref to abbrev 226
+	.section	.debug_abbrev
+	.uleb128	226
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname226:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname226
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #227: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	227	; ref to abbrev 227
+	.section	.debug_abbrev
+	.uleb128	227
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname227:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname227
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #228: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	228	; ref to abbrev 228
+	.section	.debug_abbrev
+	.uleb128	228
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname228:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname228
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #229: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	229	; ref to abbrev 229
+	.section	.debug_abbrev
+	.uleb128	229
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname229:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname229
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #230: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	230	; ref to abbrev 230
+	.section	.debug_abbrev
+	.uleb128	230
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname230:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname230
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #231: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	231	; ref to abbrev 231
+	.section	.debug_abbrev
+	.uleb128	231
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname231:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname231
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #232: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	232	; ref to abbrev 232
+	.section	.debug_abbrev
+	.uleb128	232
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname232:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname232
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #233: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	233	; ref to abbrev 233
+	.section	.debug_abbrev
+	.uleb128	233
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname233:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname233
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #234: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	234	; ref to abbrev 234
+	.section	.debug_abbrev
+	.uleb128	234
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname234:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname234
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #235: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	235	; ref to abbrev 235
+	.section	.debug_abbrev
+	.uleb128	235
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname235:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname235
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #236: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	236	; ref to abbrev 236
+	.section	.debug_abbrev
+	.uleb128	236
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname236:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname236
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #237: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	237	; ref to abbrev 237
+	.section	.debug_abbrev
+	.uleb128	237
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname237:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname237
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #238: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	238	; ref to abbrev 238
+	.section	.debug_abbrev
+	.uleb128	238
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname238:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname238
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #239: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	239	; ref to abbrev 239
+	.section	.debug_abbrev
+	.uleb128	239
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname239:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname239
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #240: variable EVGENCTRL
+	.section	.debug_info
+	.uleb128	240	; ref to abbrev 240
+	.section	.debug_abbrev
+	.uleb128	240
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname240:
+	.string		"EVGENCTRL"
+	.section	.debug_info
+	.long		.Lname240
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0460 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #241: variable DIR
+	.section	.debug_info
+	.uleb128	241	; ref to abbrev 241
+	.section	.debug_abbrev
+	.uleb128	241
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname241:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname241
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #242: variable DIRSET
+	.section	.debug_info
+	.uleb128	242	; ref to abbrev 242
+	.section	.debug_abbrev
+	.uleb128	242
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname242:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname242
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #243: variable DIRCLR
+	.section	.debug_info
+	.uleb128	243	; ref to abbrev 243
+	.section	.debug_abbrev
+	.uleb128	243
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname243:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname243
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #244: variable DIRTGL
+	.section	.debug_info
+	.uleb128	244	; ref to abbrev 244
+	.section	.debug_abbrev
+	.uleb128	244
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname244:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname244
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #245: variable OUT
+	.section	.debug_info
+	.uleb128	245	; ref to abbrev 245
+	.section	.debug_abbrev
+	.uleb128	245
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname245:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname245
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #246: variable OUTSET
+	.section	.debug_info
+	.uleb128	246	; ref to abbrev 246
+	.section	.debug_abbrev
+	.uleb128	246
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname246:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname246
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #247: variable OUTCLR
+	.section	.debug_info
+	.uleb128	247	; ref to abbrev 247
+	.section	.debug_abbrev
+	.uleb128	247
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname247:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname247
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #248: variable OUTTGL
+	.section	.debug_info
+	.uleb128	248	; ref to abbrev 248
+	.section	.debug_abbrev
+	.uleb128	248
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname248:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname248
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #249: variable IN
+	.section	.debug_info
+	.uleb128	249	; ref to abbrev 249
+	.section	.debug_abbrev
+	.uleb128	249
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname249:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname249
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #250: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	250	; ref to abbrev 250
+	.section	.debug_abbrev
+	.uleb128	250
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname250:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname250
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #251: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	251	; ref to abbrev 251
+	.section	.debug_abbrev
+	.uleb128	251
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname251:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname251
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #252: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	252	; ref to abbrev 252
+	.section	.debug_abbrev
+	.uleb128	252
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname252:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname252
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #253: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	253	; ref to abbrev 253
+	.section	.debug_abbrev
+	.uleb128	253
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname253:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname253
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #254: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	254	; ref to abbrev 254
+	.section	.debug_abbrev
+	.uleb128	254
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname254:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname254
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #255: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	255	; ref to abbrev 255
+	.section	.debug_abbrev
+	.uleb128	255
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname255:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname255
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #256: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	256	; ref to abbrev 256
+	.section	.debug_abbrev
+	.uleb128	256
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname256:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname256
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #257: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	257	; ref to abbrev 257
+	.section	.debug_abbrev
+	.uleb128	257
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname257:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname257
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #258: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	258	; ref to abbrev 258
+	.section	.debug_abbrev
+	.uleb128	258
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname258:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname258
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #259: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	259	; ref to abbrev 259
+	.section	.debug_abbrev
+	.uleb128	259
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname259:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname259
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #260: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	260	; ref to abbrev 260
+	.section	.debug_abbrev
+	.uleb128	260
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname260:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname260
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #261: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	261	; ref to abbrev 261
+	.section	.debug_abbrev
+	.uleb128	261
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname261:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname261
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #262: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	262	; ref to abbrev 262
+	.section	.debug_abbrev
+	.uleb128	262
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname262:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname262
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #263: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	263	; ref to abbrev 263
+	.section	.debug_abbrev
+	.uleb128	263
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname263:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname263
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #264: variable EVGENCTRL
+	.section	.debug_info
+	.uleb128	264	; ref to abbrev 264
+	.section	.debug_abbrev
+	.uleb128	264
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname264:
+	.string		"EVGENCTRL"
+	.section	.debug_info
+	.long		.Lname264
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0480 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #265: variable DIR
+	.section	.debug_info
+	.uleb128	265	; ref to abbrev 265
+	.section	.debug_abbrev
+	.uleb128	265
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname265:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname265
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #266: variable DIRSET
+	.section	.debug_info
+	.uleb128	266	; ref to abbrev 266
+	.section	.debug_abbrev
+	.uleb128	266
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname266:
+	.string		"DIRSET"
+	.section	.debug_info
+	.long		.Lname266
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #267: variable DIRCLR
+	.section	.debug_info
+	.uleb128	267	; ref to abbrev 267
+	.section	.debug_abbrev
+	.uleb128	267
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname267:
+	.string		"DIRCLR"
+	.section	.debug_info
+	.long		.Lname267
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #268: variable DIRTGL
+	.section	.debug_info
+	.uleb128	268	; ref to abbrev 268
+	.section	.debug_abbrev
+	.uleb128	268
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname268:
+	.string		"DIRTGL"
+	.section	.debug_info
+	.long		.Lname268
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #269: variable OUT
+	.section	.debug_info
+	.uleb128	269	; ref to abbrev 269
+	.section	.debug_abbrev
+	.uleb128	269
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname269:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname269
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #270: variable OUTSET
+	.section	.debug_info
+	.uleb128	270	; ref to abbrev 270
+	.section	.debug_abbrev
+	.uleb128	270
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname270:
+	.string		"OUTSET"
+	.section	.debug_info
+	.long		.Lname270
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #271: variable OUTCLR
+	.section	.debug_info
+	.uleb128	271	; ref to abbrev 271
+	.section	.debug_abbrev
+	.uleb128	271
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname271:
+	.string		"OUTCLR"
+	.section	.debug_info
+	.long		.Lname271
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #272: variable OUTTGL
+	.section	.debug_info
+	.uleb128	272	; ref to abbrev 272
+	.section	.debug_abbrev
+	.uleb128	272
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname272:
+	.string		"OUTTGL"
+	.section	.debug_info
+	.long		.Lname272
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #273: variable IN
+	.section	.debug_info
+	.uleb128	273	; ref to abbrev 273
+	.section	.debug_abbrev
+	.uleb128	273
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname273:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname273
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #274: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	274	; ref to abbrev 274
+	.section	.debug_abbrev
+	.uleb128	274
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname274:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname274
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #275: variable PORTCTRL
+	.section	.debug_info
+	.uleb128	275	; ref to abbrev 275
+	.section	.debug_abbrev
+	.uleb128	275
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname275:
+	.string		"PORTCTRL"
+	.section	.debug_info
+	.long		.Lname275
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #276: variable PINCONFIG
+	.section	.debug_info
+	.uleb128	276	; ref to abbrev 276
+	.section	.debug_abbrev
+	.uleb128	276
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname276:
+	.string		"PINCONFIG"
+	.section	.debug_info
+	.long		.Lname276
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #277: variable PINCTRLUPD
+	.section	.debug_info
+	.uleb128	277	; ref to abbrev 277
+	.section	.debug_abbrev
+	.uleb128	277
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname277:
+	.string		"PINCTRLUPD"
+	.section	.debug_info
+	.long		.Lname277
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #278: variable PINCTRLSET
+	.section	.debug_info
+	.uleb128	278	; ref to abbrev 278
+	.section	.debug_abbrev
+	.uleb128	278
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname278:
+	.string		"PINCTRLSET"
+	.section	.debug_info
+	.long		.Lname278
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #279: variable PINCTRLCLR
+	.section	.debug_info
+	.uleb128	279	; ref to abbrev 279
+	.section	.debug_abbrev
+	.uleb128	279
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname279:
+	.string		"PINCTRLCLR"
+	.section	.debug_info
+	.long		.Lname279
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #280: variable PIN0CTRL
+	.section	.debug_info
+	.uleb128	280	; ref to abbrev 280
+	.section	.debug_abbrev
+	.uleb128	280
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname280:
+	.string		"PIN0CTRL"
+	.section	.debug_info
+	.long		.Lname280
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #281: variable PIN1CTRL
+	.section	.debug_info
+	.uleb128	281	; ref to abbrev 281
+	.section	.debug_abbrev
+	.uleb128	281
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname281:
+	.string		"PIN1CTRL"
+	.section	.debug_info
+	.long		.Lname281
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #282: variable PIN2CTRL
+	.section	.debug_info
+	.uleb128	282	; ref to abbrev 282
+	.section	.debug_abbrev
+	.uleb128	282
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname282:
+	.string		"PIN2CTRL"
+	.section	.debug_info
+	.long		.Lname282
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #283: variable PIN3CTRL
+	.section	.debug_info
+	.uleb128	283	; ref to abbrev 283
+	.section	.debug_abbrev
+	.uleb128	283
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname283:
+	.string		"PIN3CTRL"
+	.section	.debug_info
+	.long		.Lname283
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #284: variable PIN4CTRL
+	.section	.debug_info
+	.uleb128	284	; ref to abbrev 284
+	.section	.debug_abbrev
+	.uleb128	284
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname284:
+	.string		"PIN4CTRL"
+	.section	.debug_info
+	.long		.Lname284
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #285: variable PIN5CTRL
+	.section	.debug_info
+	.uleb128	285	; ref to abbrev 285
+	.section	.debug_abbrev
+	.uleb128	285
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname285:
+	.string		"PIN5CTRL"
+	.section	.debug_info
+	.long		.Lname285
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #286: variable PIN6CTRL
+	.section	.debug_info
+	.uleb128	286	; ref to abbrev 286
+	.section	.debug_abbrev
+	.uleb128	286
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname286:
+	.string		"PIN6CTRL"
+	.section	.debug_info
+	.long		.Lname286
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #287: variable PIN7CTRL
+	.section	.debug_info
+	.uleb128	287	; ref to abbrev 287
+	.section	.debug_abbrev
+	.uleb128	287
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname287:
+	.string		"PIN7CTRL"
+	.section	.debug_info
+	.long		.Lname287
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #288: variable EVGENCTRL
+	.section	.debug_info
+	.uleb128	288	; ref to abbrev 288
+	.section	.debug_abbrev
+	.uleb128	288
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname288:
+	.string		"EVGENCTRL"
+	.section	.debug_info
+	.long		.Lname288
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x04A0 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #289: variable EVSYSROUTEA
+	.section	.debug_info
+	.uleb128	289	; ref to abbrev 289
+	.section	.debug_abbrev
+	.uleb128	289
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname289:
+	.string		"EVSYSROUTEA"
+	.section	.debug_info
+	.long		.Lname289
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #290: variable CCLROUTEA
+	.section	.debug_info
+	.uleb128	290	; ref to abbrev 290
+	.section	.debug_abbrev
+	.uleb128	290
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname290:
+	.string		"CCLROUTEA"
+	.section	.debug_info
+	.long		.Lname290
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #291: variable USARTROUTEA
+	.section	.debug_info
+	.uleb128	291	; ref to abbrev 291
+	.section	.debug_abbrev
+	.uleb128	291
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname291:
+	.string		"USARTROUTEA"
+	.section	.debug_info
+	.long		.Lname291
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #292: variable USARTROUTEB
+	.section	.debug_info
+	.uleb128	292	; ref to abbrev 292
+	.section	.debug_abbrev
+	.uleb128	292
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname292:
+	.string		"USARTROUTEB"
+	.section	.debug_info
+	.long		.Lname292
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #293: variable SPIROUTEA
+	.section	.debug_info
+	.uleb128	293	; ref to abbrev 293
+	.section	.debug_abbrev
+	.uleb128	293
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname293:
+	.string		"SPIROUTEA"
+	.section	.debug_info
+	.long		.Lname293
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #294: variable TWIROUTEA
+	.section	.debug_info
+	.uleb128	294	; ref to abbrev 294
+	.section	.debug_abbrev
+	.uleb128	294
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname294:
+	.string		"TWIROUTEA"
+	.section	.debug_info
+	.long		.Lname294
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #295: variable TCAROUTEA
+	.section	.debug_info
+	.uleb128	295	; ref to abbrev 295
+	.section	.debug_abbrev
+	.uleb128	295
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname295:
+	.string		"TCAROUTEA"
+	.section	.debug_info
+	.long		.Lname295
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #296: variable TCBROUTEA
+	.section	.debug_info
+	.uleb128	296	; ref to abbrev 296
+	.section	.debug_abbrev
+	.uleb128	296
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname296:
+	.string		"TCBROUTEA"
+	.section	.debug_info
+	.long		.Lname296
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #297: variable ACROUTEA
+	.section	.debug_info
+	.uleb128	297	; ref to abbrev 297
+	.section	.debug_abbrev
+	.uleb128	297
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname297:
+	.string		"ACROUTEA"
+	.section	.debug_info
+	.long		.Lname297
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x05E0 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #298: variable RSTFR
+	.section	.debug_info
+	.uleb128	298	; ref to abbrev 298
+	.section	.debug_abbrev
+	.uleb128	298
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname298:
+	.string		"RSTFR"
+	.section	.debug_info
+	.long		.Lname298
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0040 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #299: variable SWRR
+	.section	.debug_info
+	.uleb128	299	; ref to abbrev 299
+	.section	.debug_abbrev
+	.uleb128	299
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname299:
+	.string		"SWRR"
+	.section	.debug_info
+	.long		.Lname299
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0040 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #300: variable CTRLA
+	.section	.debug_info
+	.uleb128	300	; ref to abbrev 300
+	.section	.debug_abbrev
+	.uleb128	300
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname300:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname300
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #301: variable STATUS
+	.section	.debug_info
+	.uleb128	301	; ref to abbrev 301
+	.section	.debug_abbrev
+	.uleb128	301
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname301:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname301
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #302: variable INTCTRL
+	.section	.debug_info
+	.uleb128	302	; ref to abbrev 302
+	.section	.debug_abbrev
+	.uleb128	302
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname302:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname302
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #303: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	303	; ref to abbrev 303
+	.section	.debug_abbrev
+	.uleb128	303
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname303:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname303
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #304: variable TEMP
+	.section	.debug_info
+	.uleb128	304	; ref to abbrev 304
+	.section	.debug_abbrev
+	.uleb128	304
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname304:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname304
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #305: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	305	; ref to abbrev 305
+	.section	.debug_abbrev
+	.uleb128	305
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname305:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname305
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #306: variable CALIB
+	.section	.debug_info
+	.uleb128	306	; ref to abbrev 306
+	.section	.debug_abbrev
+	.uleb128	306
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname306:
+	.string		"CALIB"
+	.section	.debug_info
+	.long		.Lname306
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #307: variable CLKSEL
+	.section	.debug_info
+	.uleb128	307	; ref to abbrev 307
+	.section	.debug_abbrev
+	.uleb128	307
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname307:
+	.string		"CLKSEL"
+	.section	.debug_info
+	.long		.Lname307
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #308: variable CNT
+	.section	.debug_info
+	.uleb128	308	; ref to abbrev 308
+	.section	.debug_abbrev
+	.uleb128	308
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname308:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname308
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #309: variable PER
+	.section	.debug_info
+	.uleb128	309	; ref to abbrev 309
+	.section	.debug_abbrev
+	.uleb128	309
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname309:
+	.string		"PER"
+	.section	.debug_info
+	.long		.Lname309
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #310: variable CMP
+	.section	.debug_info
+	.uleb128	310	; ref to abbrev 310
+	.section	.debug_abbrev
+	.uleb128	310
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname310:
+	.string		"CMP"
+	.section	.debug_info
+	.long		.Lname310
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #311: variable PITCTRLA
+	.section	.debug_info
+	.uleb128	311	; ref to abbrev 311
+	.section	.debug_abbrev
+	.uleb128	311
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname311:
+	.string		"PITCTRLA"
+	.section	.debug_info
+	.long		.Lname311
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #312: variable PITSTATUS
+	.section	.debug_info
+	.uleb128	312	; ref to abbrev 312
+	.section	.debug_abbrev
+	.uleb128	312
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname312:
+	.string		"PITSTATUS"
+	.section	.debug_info
+	.long		.Lname312
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #313: variable PITINTCTRL
+	.section	.debug_info
+	.uleb128	313	; ref to abbrev 313
+	.section	.debug_abbrev
+	.uleb128	313
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname313:
+	.string		"PITINTCTRL"
+	.section	.debug_info
+	.long		.Lname313
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #314: variable PITINTFLAGS
+	.section	.debug_info
+	.uleb128	314	; ref to abbrev 314
+	.section	.debug_abbrev
+	.uleb128	314
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname314:
+	.string		"PITINTFLAGS"
+	.section	.debug_info
+	.long		.Lname314
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #315: variable PITDBGCTRL
+	.section	.debug_info
+	.uleb128	315	; ref to abbrev 315
+	.section	.debug_abbrev
+	.uleb128	315
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname315:
+	.string		"PITDBGCTRL"
+	.section	.debug_info
+	.long		.Lname315
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #316: variable PITEVGENCTRLA
+	.section	.debug_info
+	.uleb128	316	; ref to abbrev 316
+	.section	.debug_abbrev
+	.uleb128	316
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname316:
+	.string		"PITEVGENCTRLA"
+	.section	.debug_info
+	.long		.Lname316
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0140 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #317: variable DEVICEID0
+	.section	.debug_info
+	.uleb128	317	; ref to abbrev 317
+	.section	.debug_abbrev
+	.uleb128	317
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname317:
+	.string		"DEVICEID0"
+	.section	.debug_info
+	.long		.Lname317
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #318: variable DEVICEID1
+	.section	.debug_info
+	.uleb128	318	; ref to abbrev 318
+	.section	.debug_abbrev
+	.uleb128	318
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname318:
+	.string		"DEVICEID1"
+	.section	.debug_info
+	.long		.Lname318
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #319: variable DEVICEID2
+	.section	.debug_info
+	.uleb128	319	; ref to abbrev 319
+	.section	.debug_abbrev
+	.uleb128	319
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname319:
+	.string		"DEVICEID2"
+	.section	.debug_info
+	.long		.Lname319
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #320: variable TEMPSENSE0
+	.section	.debug_info
+	.uleb128	320	; ref to abbrev 320
+	.section	.debug_abbrev
+	.uleb128	320
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname320:
+	.string		"TEMPSENSE0"
+	.section	.debug_info
+	.long		.Lname320
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #321: variable TEMPSENSE1
+	.section	.debug_info
+	.uleb128	321	; ref to abbrev 321
+	.section	.debug_abbrev
+	.uleb128	321
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname321:
+	.string		"TEMPSENSE1"
+	.section	.debug_info
+	.long		.Lname321
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #322: variable SERNUM0
+	.section	.debug_info
+	.uleb128	322	; ref to abbrev 322
+	.section	.debug_abbrev
+	.uleb128	322
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname322:
+	.string		"SERNUM0"
+	.section	.debug_info
+	.long		.Lname322
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #323: variable SERNUM1
+	.section	.debug_info
+	.uleb128	323	; ref to abbrev 323
+	.section	.debug_abbrev
+	.uleb128	323
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname323:
+	.string		"SERNUM1"
+	.section	.debug_info
+	.long		.Lname323
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #324: variable SERNUM2
+	.section	.debug_info
+	.uleb128	324	; ref to abbrev 324
+	.section	.debug_abbrev
+	.uleb128	324
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname324:
+	.string		"SERNUM2"
+	.section	.debug_info
+	.long		.Lname324
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #325: variable SERNUM3
+	.section	.debug_info
+	.uleb128	325	; ref to abbrev 325
+	.section	.debug_abbrev
+	.uleb128	325
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname325:
+	.string		"SERNUM3"
+	.section	.debug_info
+	.long		.Lname325
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #326: variable SERNUM4
+	.section	.debug_info
+	.uleb128	326	; ref to abbrev 326
+	.section	.debug_abbrev
+	.uleb128	326
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname326:
+	.string		"SERNUM4"
+	.section	.debug_info
+	.long		.Lname326
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #327: variable SERNUM5
+	.section	.debug_info
+	.uleb128	327	; ref to abbrev 327
+	.section	.debug_abbrev
+	.uleb128	327
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname327:
+	.string		"SERNUM5"
+	.section	.debug_info
+	.long		.Lname327
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #328: variable SERNUM6
+	.section	.debug_info
+	.uleb128	328	; ref to abbrev 328
+	.section	.debug_abbrev
+	.uleb128	328
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname328:
+	.string		"SERNUM6"
+	.section	.debug_info
+	.long		.Lname328
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #329: variable SERNUM7
+	.section	.debug_info
+	.uleb128	329	; ref to abbrev 329
+	.section	.debug_abbrev
+	.uleb128	329
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname329:
+	.string		"SERNUM7"
+	.section	.debug_info
+	.long		.Lname329
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #330: variable SERNUM8
+	.section	.debug_info
+	.uleb128	330	; ref to abbrev 330
+	.section	.debug_abbrev
+	.uleb128	330
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname330:
+	.string		"SERNUM8"
+	.section	.debug_info
+	.long		.Lname330
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #331: variable SERNUM9
+	.section	.debug_info
+	.uleb128	331	; ref to abbrev 331
+	.section	.debug_abbrev
+	.uleb128	331
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname331:
+	.string		"SERNUM9"
+	.section	.debug_info
+	.long		.Lname331
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x19
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #332: variable SERNUM10
+	.section	.debug_info
+	.uleb128	332	; ref to abbrev 332
+	.section	.debug_abbrev
+	.uleb128	332
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname332:
+	.string		"SERNUM10"
+	.section	.debug_info
+	.long		.Lname332
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x1A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #333: variable SERNUM11
+	.section	.debug_info
+	.uleb128	333	; ref to abbrev 333
+	.section	.debug_abbrev
+	.uleb128	333
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname333:
+	.string		"SERNUM11"
+	.section	.debug_info
+	.long		.Lname333
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x1B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #334: variable SERNUM12
+	.section	.debug_info
+	.uleb128	334	; ref to abbrev 334
+	.section	.debug_abbrev
+	.uleb128	334
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname334:
+	.string		"SERNUM12"
+	.section	.debug_info
+	.long		.Lname334
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x1C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #335: variable SERNUM13
+	.section	.debug_info
+	.uleb128	335	; ref to abbrev 335
+	.section	.debug_abbrev
+	.uleb128	335
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname335:
+	.string		"SERNUM13"
+	.section	.debug_info
+	.long		.Lname335
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x1D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #336: variable SERNUM14
+	.section	.debug_info
+	.uleb128	336	; ref to abbrev 336
+	.section	.debug_abbrev
+	.uleb128	336
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname336:
+	.string		"SERNUM14"
+	.section	.debug_info
+	.long		.Lname336
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x1E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #337: variable SERNUM15
+	.section	.debug_info
+	.uleb128	337	; ref to abbrev 337
+	.section	.debug_abbrev
+	.uleb128	337
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname337:
+	.string		"SERNUM15"
+	.section	.debug_info
+	.long		.Lname337
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1100 + 0x1F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #338: variable CTRLA
+	.section	.debug_info
+	.uleb128	338	; ref to abbrev 338
+	.section	.debug_abbrev
+	.uleb128	338
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname338:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname338
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0050 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #339: variable CTRLA
+	.section	.debug_info
+	.uleb128	339	; ref to abbrev 339
+	.section	.debug_abbrev
+	.uleb128	339
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname339:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname339
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #340: variable CTRLB
+	.section	.debug_info
+	.uleb128	340	; ref to abbrev 340
+	.section	.debug_abbrev
+	.uleb128	340
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname340:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname340
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #341: variable INTCTRL
+	.section	.debug_info
+	.uleb128	341	; ref to abbrev 341
+	.section	.debug_abbrev
+	.uleb128	341
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname341:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname341
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #342: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	342	; ref to abbrev 342
+	.section	.debug_abbrev
+	.uleb128	342
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname342:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname342
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #343: variable DATA
+	.section	.debug_info
+	.uleb128	343	; ref to abbrev 343
+	.section	.debug_abbrev
+	.uleb128	343
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname343:
+	.string		"DATA"
+	.section	.debug_info
+	.long		.Lname343
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0940 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #344: variable REVID
+	.section	.debug_info
+	.uleb128	344	; ref to abbrev 344
+	.section	.debug_abbrev
+	.uleb128	344
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname344:
+	.string		"REVID"
+	.section	.debug_info
+	.long		.Lname344
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0F00 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #345: variable OCDMCTRL
+	.section	.debug_info
+	.uleb128	345	; ref to abbrev 345
+	.section	.debug_abbrev
+	.uleb128	345
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname345:
+	.string		"OCDMCTRL"
+	.section	.debug_info
+	.long		.Lname345
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0F00 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #346: variable OCDMSTATUS
+	.section	.debug_info
+	.uleb128	346	; ref to abbrev 346
+	.section	.debug_abbrev
+	.uleb128	346
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname346:
+	.string		"OCDMSTATUS"
+	.section	.debug_info
+	.long		.Lname346
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0F00 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #347: variable CTRLA
+	.section	.debug_info
+	.uleb128	347	; ref to abbrev 347
+	.section	.debug_abbrev
+	.uleb128	347
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname347:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname347
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #348: variable CTRLB
+	.section	.debug_info
+	.uleb128	348	; ref to abbrev 348
+	.section	.debug_abbrev
+	.uleb128	348
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname348:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname348
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #349: variable CTRLC
+	.section	.debug_info
+	.uleb128	349	; ref to abbrev 349
+	.section	.debug_abbrev
+	.uleb128	349
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname349:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname349
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #350: variable CTRLD
+	.section	.debug_info
+	.uleb128	350	; ref to abbrev 350
+	.section	.debug_abbrev
+	.uleb128	350
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname350:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname350
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #351: variable CTRLECLR
+	.section	.debug_info
+	.uleb128	351	; ref to abbrev 351
+	.section	.debug_abbrev
+	.uleb128	351
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname351:
+	.string		"CTRLECLR"
+	.section	.debug_info
+	.long		.Lname351
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #352: variable CTRLESET
+	.section	.debug_info
+	.uleb128	352	; ref to abbrev 352
+	.section	.debug_abbrev
+	.uleb128	352
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname352:
+	.string		"CTRLESET"
+	.section	.debug_info
+	.long		.Lname352
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #353: variable CTRLFCLR
+	.section	.debug_info
+	.uleb128	353	; ref to abbrev 353
+	.section	.debug_abbrev
+	.uleb128	353
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname353:
+	.string		"CTRLFCLR"
+	.section	.debug_info
+	.long		.Lname353
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #354: variable CTRLFSET
+	.section	.debug_info
+	.uleb128	354	; ref to abbrev 354
+	.section	.debug_abbrev
+	.uleb128	354
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname354:
+	.string		"CTRLFSET"
+	.section	.debug_info
+	.long		.Lname354
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #355: variable EVCTRL
+	.section	.debug_info
+	.uleb128	355	; ref to abbrev 355
+	.section	.debug_abbrev
+	.uleb128	355
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname355:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname355
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #356: variable INTCTRL
+	.section	.debug_info
+	.uleb128	356	; ref to abbrev 356
+	.section	.debug_abbrev
+	.uleb128	356
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname356:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname356
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #357: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	357	; ref to abbrev 357
+	.section	.debug_abbrev
+	.uleb128	357
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname357:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname357
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #358: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	358	; ref to abbrev 358
+	.section	.debug_abbrev
+	.uleb128	358
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname358:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname358
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #359: variable TEMP
+	.section	.debug_info
+	.uleb128	359	; ref to abbrev 359
+	.section	.debug_abbrev
+	.uleb128	359
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname359:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname359
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #360: variable CNT
+	.section	.debug_info
+	.uleb128	360	; ref to abbrev 360
+	.section	.debug_abbrev
+	.uleb128	360
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname360:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname360
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #361: variable PER
+	.section	.debug_info
+	.uleb128	361	; ref to abbrev 361
+	.section	.debug_abbrev
+	.uleb128	361
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname361:
+	.string		"PER"
+	.section	.debug_info
+	.long		.Lname361
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x26
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #362: variable CMP0
+	.section	.debug_info
+	.uleb128	362	; ref to abbrev 362
+	.section	.debug_abbrev
+	.uleb128	362
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname362:
+	.string		"CMP0"
+	.section	.debug_info
+	.long		.Lname362
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x28
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #363: variable CMP1
+	.section	.debug_info
+	.uleb128	363	; ref to abbrev 363
+	.section	.debug_abbrev
+	.uleb128	363
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname363:
+	.string		"CMP1"
+	.section	.debug_info
+	.long		.Lname363
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #364: variable CMP2
+	.section	.debug_info
+	.uleb128	364	; ref to abbrev 364
+	.section	.debug_abbrev
+	.uleb128	364
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname364:
+	.string		"CMP2"
+	.section	.debug_info
+	.long		.Lname364
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #365: variable PERBUF
+	.section	.debug_info
+	.uleb128	365	; ref to abbrev 365
+	.section	.debug_abbrev
+	.uleb128	365
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname365:
+	.string		"PERBUF"
+	.section	.debug_info
+	.long		.Lname365
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x36
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #366: variable CMP0BUF
+	.section	.debug_info
+	.uleb128	366	; ref to abbrev 366
+	.section	.debug_abbrev
+	.uleb128	366
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname366:
+	.string		"CMP0BUF"
+	.section	.debug_info
+	.long		.Lname366
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x38
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #367: variable CMP1BUF
+	.section	.debug_info
+	.uleb128	367	; ref to abbrev 367
+	.section	.debug_abbrev
+	.uleb128	367
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname367:
+	.string		"CMP1BUF"
+	.section	.debug_info
+	.long		.Lname367
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x3A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #368: variable CMP2BUF
+	.section	.debug_info
+	.uleb128	368	; ref to abbrev 368
+	.section	.debug_abbrev
+	.uleb128	368
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname368:
+	.string		"CMP2BUF"
+	.section	.debug_info
+	.long		.Lname368
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x3C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #369: variable CTRLA
+	.section	.debug_info
+	.uleb128	369	; ref to abbrev 369
+	.section	.debug_abbrev
+	.uleb128	369
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname369:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname369
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #370: variable CTRLB
+	.section	.debug_info
+	.uleb128	370	; ref to abbrev 370
+	.section	.debug_abbrev
+	.uleb128	370
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname370:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname370
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #371: variable CTRLC
+	.section	.debug_info
+	.uleb128	371	; ref to abbrev 371
+	.section	.debug_abbrev
+	.uleb128	371
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname371:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname371
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #372: variable CTRLD
+	.section	.debug_info
+	.uleb128	372	; ref to abbrev 372
+	.section	.debug_abbrev
+	.uleb128	372
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname372:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname372
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #373: variable CTRLECLR
+	.section	.debug_info
+	.uleb128	373	; ref to abbrev 373
+	.section	.debug_abbrev
+	.uleb128	373
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname373:
+	.string		"CTRLECLR"
+	.section	.debug_info
+	.long		.Lname373
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #374: variable CTRLESET
+	.section	.debug_info
+	.uleb128	374	; ref to abbrev 374
+	.section	.debug_abbrev
+	.uleb128	374
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname374:
+	.string		"CTRLESET"
+	.section	.debug_info
+	.long		.Lname374
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #375: variable INTCTRL
+	.section	.debug_info
+	.uleb128	375	; ref to abbrev 375
+	.section	.debug_abbrev
+	.uleb128	375
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname375:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname375
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #376: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	376	; ref to abbrev 376
+	.section	.debug_abbrev
+	.uleb128	376
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname376:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname376
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #377: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	377	; ref to abbrev 377
+	.section	.debug_abbrev
+	.uleb128	377
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname377:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname377
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #378: variable LCNT
+	.section	.debug_info
+	.uleb128	378	; ref to abbrev 378
+	.section	.debug_abbrev
+	.uleb128	378
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname378:
+	.string		"LCNT"
+	.section	.debug_info
+	.long		.Lname378
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #379: variable HCNT
+	.section	.debug_info
+	.uleb128	379	; ref to abbrev 379
+	.section	.debug_abbrev
+	.uleb128	379
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname379:
+	.string		"HCNT"
+	.section	.debug_info
+	.long		.Lname379
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x21
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #380: variable LPER
+	.section	.debug_info
+	.uleb128	380	; ref to abbrev 380
+	.section	.debug_abbrev
+	.uleb128	380
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname380:
+	.string		"LPER"
+	.section	.debug_info
+	.long		.Lname380
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x26
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #381: variable HPER
+	.section	.debug_info
+	.uleb128	381	; ref to abbrev 381
+	.section	.debug_abbrev
+	.uleb128	381
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname381:
+	.string		"HPER"
+	.section	.debug_info
+	.long		.Lname381
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x27
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #382: variable LCMP0
+	.section	.debug_info
+	.uleb128	382	; ref to abbrev 382
+	.section	.debug_abbrev
+	.uleb128	382
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname382:
+	.string		"LCMP0"
+	.section	.debug_info
+	.long		.Lname382
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x28
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #383: variable HCMP0
+	.section	.debug_info
+	.uleb128	383	; ref to abbrev 383
+	.section	.debug_abbrev
+	.uleb128	383
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname383:
+	.string		"HCMP0"
+	.section	.debug_info
+	.long		.Lname383
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x29
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #384: variable LCMP1
+	.section	.debug_info
+	.uleb128	384	; ref to abbrev 384
+	.section	.debug_abbrev
+	.uleb128	384
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname384:
+	.string		"LCMP1"
+	.section	.debug_info
+	.long		.Lname384
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #385: variable HCMP1
+	.section	.debug_info
+	.uleb128	385	; ref to abbrev 385
+	.section	.debug_abbrev
+	.uleb128	385
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname385:
+	.string		"HCMP1"
+	.section	.debug_info
+	.long		.Lname385
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #386: variable LCMP2
+	.section	.debug_info
+	.uleb128	386	; ref to abbrev 386
+	.section	.debug_abbrev
+	.uleb128	386
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname386:
+	.string		"LCMP2"
+	.section	.debug_info
+	.long		.Lname386
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #387: variable HCMP2
+	.section	.debug_info
+	.uleb128	387	; ref to abbrev 387
+	.section	.debug_abbrev
+	.uleb128	387
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname387:
+	.string		"HCMP2"
+	.section	.debug_info
+	.long		.Lname387
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A00 + 0x2D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #388: variable CTRLA
+	.section	.debug_info
+	.uleb128	388	; ref to abbrev 388
+	.section	.debug_abbrev
+	.uleb128	388
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname388:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname388
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #389: variable CTRLB
+	.section	.debug_info
+	.uleb128	389	; ref to abbrev 389
+	.section	.debug_abbrev
+	.uleb128	389
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname389:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname389
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #390: variable CTRLC
+	.section	.debug_info
+	.uleb128	390	; ref to abbrev 390
+	.section	.debug_abbrev
+	.uleb128	390
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname390:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname390
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #391: variable CTRLD
+	.section	.debug_info
+	.uleb128	391	; ref to abbrev 391
+	.section	.debug_abbrev
+	.uleb128	391
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname391:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname391
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #392: variable CTRLECLR
+	.section	.debug_info
+	.uleb128	392	; ref to abbrev 392
+	.section	.debug_abbrev
+	.uleb128	392
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname392:
+	.string		"CTRLECLR"
+	.section	.debug_info
+	.long		.Lname392
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #393: variable CTRLESET
+	.section	.debug_info
+	.uleb128	393	; ref to abbrev 393
+	.section	.debug_abbrev
+	.uleb128	393
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname393:
+	.string		"CTRLESET"
+	.section	.debug_info
+	.long		.Lname393
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #394: variable CTRLFCLR
+	.section	.debug_info
+	.uleb128	394	; ref to abbrev 394
+	.section	.debug_abbrev
+	.uleb128	394
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname394:
+	.string		"CTRLFCLR"
+	.section	.debug_info
+	.long		.Lname394
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #395: variable CTRLFSET
+	.section	.debug_info
+	.uleb128	395	; ref to abbrev 395
+	.section	.debug_abbrev
+	.uleb128	395
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname395:
+	.string		"CTRLFSET"
+	.section	.debug_info
+	.long		.Lname395
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #396: variable EVCTRL
+	.section	.debug_info
+	.uleb128	396	; ref to abbrev 396
+	.section	.debug_abbrev
+	.uleb128	396
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname396:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname396
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #397: variable INTCTRL
+	.section	.debug_info
+	.uleb128	397	; ref to abbrev 397
+	.section	.debug_abbrev
+	.uleb128	397
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname397:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname397
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #398: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	398	; ref to abbrev 398
+	.section	.debug_abbrev
+	.uleb128	398
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname398:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname398
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #399: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	399	; ref to abbrev 399
+	.section	.debug_abbrev
+	.uleb128	399
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname399:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname399
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #400: variable TEMP
+	.section	.debug_info
+	.uleb128	400	; ref to abbrev 400
+	.section	.debug_abbrev
+	.uleb128	400
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname400:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname400
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x0F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #401: variable CNT
+	.section	.debug_info
+	.uleb128	401	; ref to abbrev 401
+	.section	.debug_abbrev
+	.uleb128	401
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname401:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname401
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #402: variable PER
+	.section	.debug_info
+	.uleb128	402	; ref to abbrev 402
+	.section	.debug_abbrev
+	.uleb128	402
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname402:
+	.string		"PER"
+	.section	.debug_info
+	.long		.Lname402
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x26
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #403: variable CMP0
+	.section	.debug_info
+	.uleb128	403	; ref to abbrev 403
+	.section	.debug_abbrev
+	.uleb128	403
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname403:
+	.string		"CMP0"
+	.section	.debug_info
+	.long		.Lname403
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x28
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #404: variable CMP1
+	.section	.debug_info
+	.uleb128	404	; ref to abbrev 404
+	.section	.debug_abbrev
+	.uleb128	404
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname404:
+	.string		"CMP1"
+	.section	.debug_info
+	.long		.Lname404
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x2A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #405: variable CMP2
+	.section	.debug_info
+	.uleb128	405	; ref to abbrev 405
+	.section	.debug_abbrev
+	.uleb128	405
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname405:
+	.string		"CMP2"
+	.section	.debug_info
+	.long		.Lname405
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x2C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #406: variable PERBUF
+	.section	.debug_info
+	.uleb128	406	; ref to abbrev 406
+	.section	.debug_abbrev
+	.uleb128	406
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname406:
+	.string		"PERBUF"
+	.section	.debug_info
+	.long		.Lname406
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x36
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #407: variable CMP0BUF
+	.section	.debug_info
+	.uleb128	407	; ref to abbrev 407
+	.section	.debug_abbrev
+	.uleb128	407
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname407:
+	.string		"CMP0BUF"
+	.section	.debug_info
+	.long		.Lname407
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x38
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #408: variable CMP1BUF
+	.section	.debug_info
+	.uleb128	408	; ref to abbrev 408
+	.section	.debug_abbrev
+	.uleb128	408
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname408:
+	.string		"CMP1BUF"
+	.section	.debug_info
+	.long		.Lname408
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x3A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #409: variable CMP2BUF
+	.section	.debug_info
+	.uleb128	409	; ref to abbrev 409
+	.section	.debug_abbrev
+	.uleb128	409
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname409:
+	.string		"CMP2BUF"
+	.section	.debug_info
+	.long		.Lname409
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x3C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #410: variable CTRLA
+	.section	.debug_info
+	.uleb128	410	; ref to abbrev 410
+	.section	.debug_abbrev
+	.uleb128	410
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname410:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname410
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #411: variable CTRLB
+	.section	.debug_info
+	.uleb128	411	; ref to abbrev 411
+	.section	.debug_abbrev
+	.uleb128	411
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname411:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname411
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #412: variable CTRLC
+	.section	.debug_info
+	.uleb128	412	; ref to abbrev 412
+	.section	.debug_abbrev
+	.uleb128	412
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname412:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname412
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #413: variable CTRLD
+	.section	.debug_info
+	.uleb128	413	; ref to abbrev 413
+	.section	.debug_abbrev
+	.uleb128	413
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname413:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname413
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #414: variable CTRLECLR
+	.section	.debug_info
+	.uleb128	414	; ref to abbrev 414
+	.section	.debug_abbrev
+	.uleb128	414
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname414:
+	.string		"CTRLECLR"
+	.section	.debug_info
+	.long		.Lname414
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #415: variable CTRLESET
+	.section	.debug_info
+	.uleb128	415	; ref to abbrev 415
+	.section	.debug_abbrev
+	.uleb128	415
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname415:
+	.string		"CTRLESET"
+	.section	.debug_info
+	.long		.Lname415
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #416: variable INTCTRL
+	.section	.debug_info
+	.uleb128	416	; ref to abbrev 416
+	.section	.debug_abbrev
+	.uleb128	416
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname416:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname416
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #417: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	417	; ref to abbrev 417
+	.section	.debug_abbrev
+	.uleb128	417
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname417:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname417
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #418: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	418	; ref to abbrev 418
+	.section	.debug_abbrev
+	.uleb128	418
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname418:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname418
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #419: variable LCNT
+	.section	.debug_info
+	.uleb128	419	; ref to abbrev 419
+	.section	.debug_abbrev
+	.uleb128	419
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname419:
+	.string		"LCNT"
+	.section	.debug_info
+	.long		.Lname419
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #420: variable HCNT
+	.section	.debug_info
+	.uleb128	420	; ref to abbrev 420
+	.section	.debug_abbrev
+	.uleb128	420
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname420:
+	.string		"HCNT"
+	.section	.debug_info
+	.long		.Lname420
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x21
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #421: variable LPER
+	.section	.debug_info
+	.uleb128	421	; ref to abbrev 421
+	.section	.debug_abbrev
+	.uleb128	421
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname421:
+	.string		"LPER"
+	.section	.debug_info
+	.long		.Lname421
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x26
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #422: variable HPER
+	.section	.debug_info
+	.uleb128	422	; ref to abbrev 422
+	.section	.debug_abbrev
+	.uleb128	422
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname422:
+	.string		"HPER"
+	.section	.debug_info
+	.long		.Lname422
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x27
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #423: variable LCMP0
+	.section	.debug_info
+	.uleb128	423	; ref to abbrev 423
+	.section	.debug_abbrev
+	.uleb128	423
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname423:
+	.string		"LCMP0"
+	.section	.debug_info
+	.long		.Lname423
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x28
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #424: variable HCMP0
+	.section	.debug_info
+	.uleb128	424	; ref to abbrev 424
+	.section	.debug_abbrev
+	.uleb128	424
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname424:
+	.string		"HCMP0"
+	.section	.debug_info
+	.long		.Lname424
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x29
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #425: variable LCMP1
+	.section	.debug_info
+	.uleb128	425	; ref to abbrev 425
+	.section	.debug_abbrev
+	.uleb128	425
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname425:
+	.string		"LCMP1"
+	.section	.debug_info
+	.long		.Lname425
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x2A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #426: variable HCMP1
+	.section	.debug_info
+	.uleb128	426	; ref to abbrev 426
+	.section	.debug_abbrev
+	.uleb128	426
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname426:
+	.string		"HCMP1"
+	.section	.debug_info
+	.long		.Lname426
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x2B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #427: variable LCMP2
+	.section	.debug_info
+	.uleb128	427	; ref to abbrev 427
+	.section	.debug_abbrev
+	.uleb128	427
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname427:
+	.string		"LCMP2"
+	.section	.debug_info
+	.long		.Lname427
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x2C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #428: variable HCMP2
+	.section	.debug_info
+	.uleb128	428	; ref to abbrev 428
+	.section	.debug_abbrev
+	.uleb128	428
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname428:
+	.string		"HCMP2"
+	.section	.debug_info
+	.long		.Lname428
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0A40 + 0x2D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #429: variable CTRLA
+	.section	.debug_info
+	.uleb128	429	; ref to abbrev 429
+	.section	.debug_abbrev
+	.uleb128	429
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname429:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname429
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #430: variable CTRLB
+	.section	.debug_info
+	.uleb128	430	; ref to abbrev 430
+	.section	.debug_abbrev
+	.uleb128	430
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname430:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname430
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #431: variable EVCTRL
+	.section	.debug_info
+	.uleb128	431	; ref to abbrev 431
+	.section	.debug_abbrev
+	.uleb128	431
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname431:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname431
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #432: variable INTCTRL
+	.section	.debug_info
+	.uleb128	432	; ref to abbrev 432
+	.section	.debug_abbrev
+	.uleb128	432
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname432:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname432
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #433: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	433	; ref to abbrev 433
+	.section	.debug_abbrev
+	.uleb128	433
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname433:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname433
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #434: variable STATUS
+	.section	.debug_info
+	.uleb128	434	; ref to abbrev 434
+	.section	.debug_abbrev
+	.uleb128	434
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname434:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname434
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #435: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	435	; ref to abbrev 435
+	.section	.debug_abbrev
+	.uleb128	435
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname435:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname435
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #436: variable TEMP
+	.section	.debug_info
+	.uleb128	436	; ref to abbrev 436
+	.section	.debug_abbrev
+	.uleb128	436
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname436:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname436
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #437: variable CNT
+	.section	.debug_info
+	.uleb128	437	; ref to abbrev 437
+	.section	.debug_abbrev
+	.uleb128	437
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname437:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname437
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #438: variable CCMP
+	.section	.debug_info
+	.uleb128	438	; ref to abbrev 438
+	.section	.debug_abbrev
+	.uleb128	438
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname438:
+	.string		"CCMP"
+	.section	.debug_info
+	.long		.Lname438
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B00 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #439: variable CTRLA
+	.section	.debug_info
+	.uleb128	439	; ref to abbrev 439
+	.section	.debug_abbrev
+	.uleb128	439
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname439:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname439
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #440: variable CTRLB
+	.section	.debug_info
+	.uleb128	440	; ref to abbrev 440
+	.section	.debug_abbrev
+	.uleb128	440
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname440:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname440
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #441: variable EVCTRL
+	.section	.debug_info
+	.uleb128	441	; ref to abbrev 441
+	.section	.debug_abbrev
+	.uleb128	441
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname441:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname441
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #442: variable INTCTRL
+	.section	.debug_info
+	.uleb128	442	; ref to abbrev 442
+	.section	.debug_abbrev
+	.uleb128	442
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname442:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname442
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #443: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	443	; ref to abbrev 443
+	.section	.debug_abbrev
+	.uleb128	443
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname443:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname443
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #444: variable STATUS
+	.section	.debug_info
+	.uleb128	444	; ref to abbrev 444
+	.section	.debug_abbrev
+	.uleb128	444
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname444:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname444
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #445: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	445	; ref to abbrev 445
+	.section	.debug_abbrev
+	.uleb128	445
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname445:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname445
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #446: variable TEMP
+	.section	.debug_info
+	.uleb128	446	; ref to abbrev 446
+	.section	.debug_abbrev
+	.uleb128	446
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname446:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname446
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #447: variable CNT
+	.section	.debug_info
+	.uleb128	447	; ref to abbrev 447
+	.section	.debug_abbrev
+	.uleb128	447
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname447:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname447
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #448: variable CCMP
+	.section	.debug_info
+	.uleb128	448	; ref to abbrev 448
+	.section	.debug_abbrev
+	.uleb128	448
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname448:
+	.string		"CCMP"
+	.section	.debug_info
+	.long		.Lname448
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B10 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #449: variable CTRLA
+	.section	.debug_info
+	.uleb128	449	; ref to abbrev 449
+	.section	.debug_abbrev
+	.uleb128	449
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname449:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname449
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #450: variable CTRLB
+	.section	.debug_info
+	.uleb128	450	; ref to abbrev 450
+	.section	.debug_abbrev
+	.uleb128	450
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname450:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname450
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #451: variable EVCTRL
+	.section	.debug_info
+	.uleb128	451	; ref to abbrev 451
+	.section	.debug_abbrev
+	.uleb128	451
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname451:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname451
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #452: variable INTCTRL
+	.section	.debug_info
+	.uleb128	452	; ref to abbrev 452
+	.section	.debug_abbrev
+	.uleb128	452
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname452:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname452
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #453: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	453	; ref to abbrev 453
+	.section	.debug_abbrev
+	.uleb128	453
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname453:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname453
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #454: variable STATUS
+	.section	.debug_info
+	.uleb128	454	; ref to abbrev 454
+	.section	.debug_abbrev
+	.uleb128	454
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname454:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname454
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #455: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	455	; ref to abbrev 455
+	.section	.debug_abbrev
+	.uleb128	455
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname455:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname455
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #456: variable TEMP
+	.section	.debug_info
+	.uleb128	456	; ref to abbrev 456
+	.section	.debug_abbrev
+	.uleb128	456
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname456:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname456
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #457: variable CNT
+	.section	.debug_info
+	.uleb128	457	; ref to abbrev 457
+	.section	.debug_abbrev
+	.uleb128	457
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname457:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname457
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #458: variable CCMP
+	.section	.debug_info
+	.uleb128	458	; ref to abbrev 458
+	.section	.debug_abbrev
+	.uleb128	458
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname458:
+	.string		"CCMP"
+	.section	.debug_info
+	.long		.Lname458
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B20 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #459: variable CTRLA
+	.section	.debug_info
+	.uleb128	459	; ref to abbrev 459
+	.section	.debug_abbrev
+	.uleb128	459
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname459:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname459
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B30 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #460: variable CTRLB
+	.section	.debug_info
+	.uleb128	460	; ref to abbrev 460
+	.section	.debug_abbrev
+	.uleb128	460
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname460:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname460
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B30 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #461: variable EVCTRL
+	.section	.debug_info
+	.uleb128	461	; ref to abbrev 461
+	.section	.debug_abbrev
+	.uleb128	461
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname461:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname461
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B30 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #462: variable INTCTRL
+	.section	.debug_info
+	.uleb128	462	; ref to abbrev 462
+	.section	.debug_abbrev
+	.uleb128	462
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname462:
+	.string		"INTCTRL"
+	.section	.debug_info
+	.long		.Lname462
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B30 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #463: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	463	; ref to abbrev 463
+	.section	.debug_abbrev
+	.uleb128	463
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname463:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname463
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B30 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #464: variable STATUS
+	.section	.debug_info
+	.uleb128	464	; ref to abbrev 464
+	.section	.debug_abbrev
+	.uleb128	464
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname464:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname464
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B30 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #465: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	465	; ref to abbrev 465
+	.section	.debug_abbrev
+	.uleb128	465
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname465:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname465
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B30 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #466: variable TEMP
+	.section	.debug_info
+	.uleb128	466	; ref to abbrev 466
+	.section	.debug_abbrev
+	.uleb128	466
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname466:
+	.string		"TEMP"
+	.section	.debug_info
+	.long		.Lname466
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B30 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #467: variable CNT
+	.section	.debug_info
+	.uleb128	467	; ref to abbrev 467
+	.section	.debug_abbrev
+	.uleb128	467
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname467:
+	.string		"CNT"
+	.section	.debug_info
+	.long		.Lname467
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B30 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #468: variable CCMP
+	.section	.debug_info
+	.uleb128	468	; ref to abbrev 468
+	.section	.debug_abbrev
+	.uleb128	468
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname468:
+	.string		"CCMP"
+	.section	.debug_info
+	.long		.Lname468
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0B30 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #469: variable CTRLA
+	.section	.debug_info
+	.uleb128	469	; ref to abbrev 469
+	.section	.debug_abbrev
+	.uleb128	469
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname469:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname469
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #470: variable DUALCTRL
+	.section	.debug_info
+	.uleb128	470	; ref to abbrev 470
+	.section	.debug_abbrev
+	.uleb128	470
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname470:
+	.string		"DUALCTRL"
+	.section	.debug_info
+	.long		.Lname470
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #471: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	471	; ref to abbrev 471
+	.section	.debug_abbrev
+	.uleb128	471
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname471:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname471
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #472: variable MCTRLA
+	.section	.debug_info
+	.uleb128	472	; ref to abbrev 472
+	.section	.debug_abbrev
+	.uleb128	472
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname472:
+	.string		"MCTRLA"
+	.section	.debug_info
+	.long		.Lname472
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #473: variable MCTRLB
+	.section	.debug_info
+	.uleb128	473	; ref to abbrev 473
+	.section	.debug_abbrev
+	.uleb128	473
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname473:
+	.string		"MCTRLB"
+	.section	.debug_info
+	.long		.Lname473
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #474: variable MSTATUS
+	.section	.debug_info
+	.uleb128	474	; ref to abbrev 474
+	.section	.debug_abbrev
+	.uleb128	474
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname474:
+	.string		"MSTATUS"
+	.section	.debug_info
+	.long		.Lname474
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #475: variable MBAUD
+	.section	.debug_info
+	.uleb128	475	; ref to abbrev 475
+	.section	.debug_abbrev
+	.uleb128	475
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname475:
+	.string		"MBAUD"
+	.section	.debug_info
+	.long		.Lname475
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #476: variable MADDR
+	.section	.debug_info
+	.uleb128	476	; ref to abbrev 476
+	.section	.debug_abbrev
+	.uleb128	476
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname476:
+	.string		"MADDR"
+	.section	.debug_info
+	.long		.Lname476
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #477: variable MDATA
+	.section	.debug_info
+	.uleb128	477	; ref to abbrev 477
+	.section	.debug_abbrev
+	.uleb128	477
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname477:
+	.string		"MDATA"
+	.section	.debug_info
+	.long		.Lname477
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #478: variable SCTRLA
+	.section	.debug_info
+	.uleb128	478	; ref to abbrev 478
+	.section	.debug_abbrev
+	.uleb128	478
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname478:
+	.string		"SCTRLA"
+	.section	.debug_info
+	.long		.Lname478
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0x9
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #479: variable SCTRLB
+	.section	.debug_info
+	.uleb128	479	; ref to abbrev 479
+	.section	.debug_abbrev
+	.uleb128	479
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname479:
+	.string		"SCTRLB"
+	.section	.debug_info
+	.long		.Lname479
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #480: variable SSTATUS
+	.section	.debug_info
+	.uleb128	480	; ref to abbrev 480
+	.section	.debug_abbrev
+	.uleb128	480
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname480:
+	.string		"SSTATUS"
+	.section	.debug_info
+	.long		.Lname480
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #481: variable SADDR
+	.section	.debug_info
+	.uleb128	481	; ref to abbrev 481
+	.section	.debug_abbrev
+	.uleb128	481
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname481:
+	.string		"SADDR"
+	.section	.debug_info
+	.long		.Lname481
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #482: variable SDATA
+	.section	.debug_info
+	.uleb128	482	; ref to abbrev 482
+	.section	.debug_abbrev
+	.uleb128	482
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname482:
+	.string		"SDATA"
+	.section	.debug_info
+	.long		.Lname482
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xD
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #483: variable SADDRMASK
+	.section	.debug_info
+	.uleb128	483	; ref to abbrev 483
+	.section	.debug_abbrev
+	.uleb128	483
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname483:
+	.string		"SADDRMASK"
+	.section	.debug_info
+	.long		.Lname483
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0900 + 0xE
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #484: variable RXDATAL
+	.section	.debug_info
+	.uleb128	484	; ref to abbrev 484
+	.section	.debug_abbrev
+	.uleb128	484
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname484:
+	.string		"RXDATAL"
+	.section	.debug_info
+	.long		.Lname484
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #485: variable RXDATAH
+	.section	.debug_info
+	.uleb128	485	; ref to abbrev 485
+	.section	.debug_abbrev
+	.uleb128	485
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname485:
+	.string		"RXDATAH"
+	.section	.debug_info
+	.long		.Lname485
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #486: variable TXDATAL
+	.section	.debug_info
+	.uleb128	486	; ref to abbrev 486
+	.section	.debug_abbrev
+	.uleb128	486
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname486:
+	.string		"TXDATAL"
+	.section	.debug_info
+	.long		.Lname486
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #487: variable TXDATAH
+	.section	.debug_info
+	.uleb128	487	; ref to abbrev 487
+	.section	.debug_abbrev
+	.uleb128	487
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname487:
+	.string		"TXDATAH"
+	.section	.debug_info
+	.long		.Lname487
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #488: variable STATUS
+	.section	.debug_info
+	.uleb128	488	; ref to abbrev 488
+	.section	.debug_abbrev
+	.uleb128	488
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname488:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname488
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #489: variable CTRLA
+	.section	.debug_info
+	.uleb128	489	; ref to abbrev 489
+	.section	.debug_abbrev
+	.uleb128	489
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname489:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname489
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #490: variable CTRLB
+	.section	.debug_info
+	.uleb128	490	; ref to abbrev 490
+	.section	.debug_abbrev
+	.uleb128	490
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname490:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname490
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #491: variable CTRLC
+	.section	.debug_info
+	.uleb128	491	; ref to abbrev 491
+	.section	.debug_abbrev
+	.uleb128	491
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname491:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname491
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #492: variable BAUD
+	.section	.debug_info
+	.uleb128	492	; ref to abbrev 492
+	.section	.debug_abbrev
+	.uleb128	492
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname492:
+	.string		"BAUD"
+	.section	.debug_info
+	.long		.Lname492
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #493: variable CTRLD
+	.section	.debug_info
+	.uleb128	493	; ref to abbrev 493
+	.section	.debug_abbrev
+	.uleb128	493
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname493:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname493
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #494: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	494	; ref to abbrev 494
+	.section	.debug_abbrev
+	.uleb128	494
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname494:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname494
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #495: variable EVCTRL
+	.section	.debug_info
+	.uleb128	495	; ref to abbrev 495
+	.section	.debug_abbrev
+	.uleb128	495
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname495:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname495
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #496: variable TXPLCTRL
+	.section	.debug_info
+	.uleb128	496	; ref to abbrev 496
+	.section	.debug_abbrev
+	.uleb128	496
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname496:
+	.string		"TXPLCTRL"
+	.section	.debug_info
+	.long		.Lname496
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xD
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #497: variable RXPLCTRL
+	.section	.debug_info
+	.uleb128	497	; ref to abbrev 497
+	.section	.debug_abbrev
+	.uleb128	497
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname497:
+	.string		"RXPLCTRL"
+	.section	.debug_info
+	.long		.Lname497
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0800 + 0xE
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #498: variable RXDATAL
+	.section	.debug_info
+	.uleb128	498	; ref to abbrev 498
+	.section	.debug_abbrev
+	.uleb128	498
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname498:
+	.string		"RXDATAL"
+	.section	.debug_info
+	.long		.Lname498
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #499: variable RXDATAH
+	.section	.debug_info
+	.uleb128	499	; ref to abbrev 499
+	.section	.debug_abbrev
+	.uleb128	499
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname499:
+	.string		"RXDATAH"
+	.section	.debug_info
+	.long		.Lname499
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #500: variable TXDATAL
+	.section	.debug_info
+	.uleb128	500	; ref to abbrev 500
+	.section	.debug_abbrev
+	.uleb128	500
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname500:
+	.string		"TXDATAL"
+	.section	.debug_info
+	.long		.Lname500
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #501: variable TXDATAH
+	.section	.debug_info
+	.uleb128	501	; ref to abbrev 501
+	.section	.debug_abbrev
+	.uleb128	501
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname501:
+	.string		"TXDATAH"
+	.section	.debug_info
+	.long		.Lname501
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #502: variable STATUS
+	.section	.debug_info
+	.uleb128	502	; ref to abbrev 502
+	.section	.debug_abbrev
+	.uleb128	502
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname502:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname502
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #503: variable CTRLA
+	.section	.debug_info
+	.uleb128	503	; ref to abbrev 503
+	.section	.debug_abbrev
+	.uleb128	503
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname503:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname503
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #504: variable CTRLB
+	.section	.debug_info
+	.uleb128	504	; ref to abbrev 504
+	.section	.debug_abbrev
+	.uleb128	504
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname504:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname504
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #505: variable CTRLC
+	.section	.debug_info
+	.uleb128	505	; ref to abbrev 505
+	.section	.debug_abbrev
+	.uleb128	505
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname505:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname505
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #506: variable BAUD
+	.section	.debug_info
+	.uleb128	506	; ref to abbrev 506
+	.section	.debug_abbrev
+	.uleb128	506
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname506:
+	.string		"BAUD"
+	.section	.debug_info
+	.long		.Lname506
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #507: variable CTRLD
+	.section	.debug_info
+	.uleb128	507	; ref to abbrev 507
+	.section	.debug_abbrev
+	.uleb128	507
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname507:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname507
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #508: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	508	; ref to abbrev 508
+	.section	.debug_abbrev
+	.uleb128	508
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname508:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname508
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #509: variable EVCTRL
+	.section	.debug_info
+	.uleb128	509	; ref to abbrev 509
+	.section	.debug_abbrev
+	.uleb128	509
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname509:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname509
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #510: variable TXPLCTRL
+	.section	.debug_info
+	.uleb128	510	; ref to abbrev 510
+	.section	.debug_abbrev
+	.uleb128	510
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname510:
+	.string		"TXPLCTRL"
+	.section	.debug_info
+	.long		.Lname510
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0xD
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #511: variable RXPLCTRL
+	.section	.debug_info
+	.uleb128	511	; ref to abbrev 511
+	.section	.debug_abbrev
+	.uleb128	511
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname511:
+	.string		"RXPLCTRL"
+	.section	.debug_info
+	.long		.Lname511
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0820 + 0xE
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #512: variable RXDATAL
+	.section	.debug_info
+	.uleb128	512	; ref to abbrev 512
+	.section	.debug_abbrev
+	.uleb128	512
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname512:
+	.string		"RXDATAL"
+	.section	.debug_info
+	.long		.Lname512
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #513: variable RXDATAH
+	.section	.debug_info
+	.uleb128	513	; ref to abbrev 513
+	.section	.debug_abbrev
+	.uleb128	513
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname513:
+	.string		"RXDATAH"
+	.section	.debug_info
+	.long		.Lname513
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #514: variable TXDATAL
+	.section	.debug_info
+	.uleb128	514	; ref to abbrev 514
+	.section	.debug_abbrev
+	.uleb128	514
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname514:
+	.string		"TXDATAL"
+	.section	.debug_info
+	.long		.Lname514
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #515: variable TXDATAH
+	.section	.debug_info
+	.uleb128	515	; ref to abbrev 515
+	.section	.debug_abbrev
+	.uleb128	515
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname515:
+	.string		"TXDATAH"
+	.section	.debug_info
+	.long		.Lname515
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #516: variable STATUS
+	.section	.debug_info
+	.uleb128	516	; ref to abbrev 516
+	.section	.debug_abbrev
+	.uleb128	516
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname516:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname516
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #517: variable CTRLA
+	.section	.debug_info
+	.uleb128	517	; ref to abbrev 517
+	.section	.debug_abbrev
+	.uleb128	517
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname517:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname517
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x5
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #518: variable CTRLB
+	.section	.debug_info
+	.uleb128	518	; ref to abbrev 518
+	.section	.debug_abbrev
+	.uleb128	518
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname518:
+	.string		"CTRLB"
+	.section	.debug_info
+	.long		.Lname518
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x6
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #519: variable CTRLC
+	.section	.debug_info
+	.uleb128	519	; ref to abbrev 519
+	.section	.debug_abbrev
+	.uleb128	519
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname519:
+	.string		"CTRLC"
+	.section	.debug_info
+	.long		.Lname519
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x7
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #520: variable BAUD
+	.section	.debug_info
+	.uleb128	520	; ref to abbrev 520
+	.section	.debug_abbrev
+	.uleb128	520
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname520:
+	.string		"BAUD"
+	.section	.debug_info
+	.long		.Lname520
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint16_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0x8
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #521: variable CTRLD
+	.section	.debug_info
+	.uleb128	521	; ref to abbrev 521
+	.section	.debug_abbrev
+	.uleb128	521
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname521:
+	.string		"CTRLD"
+	.section	.debug_info
+	.long		.Lname521
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0xA
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #522: variable DBGCTRL
+	.section	.debug_info
+	.uleb128	522	; ref to abbrev 522
+	.section	.debug_abbrev
+	.uleb128	522
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname522:
+	.string		"DBGCTRL"
+	.section	.debug_info
+	.long		.Lname522
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0xB
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #523: variable EVCTRL
+	.section	.debug_info
+	.uleb128	523	; ref to abbrev 523
+	.section	.debug_abbrev
+	.uleb128	523
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname523:
+	.string		"EVCTRL"
+	.section	.debug_info
+	.long		.Lname523
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0xC
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #524: variable TXPLCTRL
+	.section	.debug_info
+	.uleb128	524	; ref to abbrev 524
+	.section	.debug_abbrev
+	.uleb128	524
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname524:
+	.string		"TXPLCTRL"
+	.section	.debug_info
+	.long		.Lname524
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0xD
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #525: variable RXPLCTRL
+	.section	.debug_info
+	.uleb128	525	; ref to abbrev 525
+	.section	.debug_abbrev
+	.uleb128	525
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname525:
+	.string		"RXPLCTRL"
+	.section	.debug_info
+	.long		.Lname525
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0840 + 0xE
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #526: variable USERROW0
+	.section	.debug_info
+	.uleb128	526	; ref to abbrev 526
+	.section	.debug_abbrev
+	.uleb128	526
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname526:
+	.string		"USERROW0"
+	.section	.debug_info
+	.long		.Lname526
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x00
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #527: variable USERROW1
+	.section	.debug_info
+	.uleb128	527	; ref to abbrev 527
+	.section	.debug_abbrev
+	.uleb128	527
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname527:
+	.string		"USERROW1"
+	.section	.debug_info
+	.long		.Lname527
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x01
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #528: variable USERROW2
+	.section	.debug_info
+	.uleb128	528	; ref to abbrev 528
+	.section	.debug_abbrev
+	.uleb128	528
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname528:
+	.string		"USERROW2"
+	.section	.debug_info
+	.long		.Lname528
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x02
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #529: variable USERROW3
+	.section	.debug_info
+	.uleb128	529	; ref to abbrev 529
+	.section	.debug_abbrev
+	.uleb128	529
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname529:
+	.string		"USERROW3"
+	.section	.debug_info
+	.long		.Lname529
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x03
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #530: variable USERROW4
+	.section	.debug_info
+	.uleb128	530	; ref to abbrev 530
+	.section	.debug_abbrev
+	.uleb128	530
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname530:
+	.string		"USERROW4"
+	.section	.debug_info
+	.long		.Lname530
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x04
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #531: variable USERROW5
+	.section	.debug_info
+	.uleb128	531	; ref to abbrev 531
+	.section	.debug_abbrev
+	.uleb128	531
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname531:
+	.string		"USERROW5"
+	.section	.debug_info
+	.long		.Lname531
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x05
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #532: variable USERROW6
+	.section	.debug_info
+	.uleb128	532	; ref to abbrev 532
+	.section	.debug_abbrev
+	.uleb128	532
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname532:
+	.string		"USERROW6"
+	.section	.debug_info
+	.long		.Lname532
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x06
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #533: variable USERROW7
+	.section	.debug_info
+	.uleb128	533	; ref to abbrev 533
+	.section	.debug_abbrev
+	.uleb128	533
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname533:
+	.string		"USERROW7"
+	.section	.debug_info
+	.long		.Lname533
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x07
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #534: variable USERROW8
+	.section	.debug_info
+	.uleb128	534	; ref to abbrev 534
+	.section	.debug_abbrev
+	.uleb128	534
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname534:
+	.string		"USERROW8"
+	.section	.debug_info
+	.long		.Lname534
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x08
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #535: variable USERROW9
+	.section	.debug_info
+	.uleb128	535	; ref to abbrev 535
+	.section	.debug_abbrev
+	.uleb128	535
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname535:
+	.string		"USERROW9"
+	.section	.debug_info
+	.long		.Lname535
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x09
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #536: variable USERROW10
+	.section	.debug_info
+	.uleb128	536	; ref to abbrev 536
+	.section	.debug_abbrev
+	.uleb128	536
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname536:
+	.string		"USERROW10"
+	.section	.debug_info
+	.long		.Lname536
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x0A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #537: variable USERROW11
+	.section	.debug_info
+	.uleb128	537	; ref to abbrev 537
+	.section	.debug_abbrev
+	.uleb128	537
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname537:
+	.string		"USERROW11"
+	.section	.debug_info
+	.long		.Lname537
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x0B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #538: variable USERROW12
+	.section	.debug_info
+	.uleb128	538	; ref to abbrev 538
+	.section	.debug_abbrev
+	.uleb128	538
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname538:
+	.string		"USERROW12"
+	.section	.debug_info
+	.long		.Lname538
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x0C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #539: variable USERROW13
+	.section	.debug_info
+	.uleb128	539	; ref to abbrev 539
+	.section	.debug_abbrev
+	.uleb128	539
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname539:
+	.string		"USERROW13"
+	.section	.debug_info
+	.long		.Lname539
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x0D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #540: variable USERROW14
+	.section	.debug_info
+	.uleb128	540	; ref to abbrev 540
+	.section	.debug_abbrev
+	.uleb128	540
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname540:
+	.string		"USERROW14"
+	.section	.debug_info
+	.long		.Lname540
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x0E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #541: variable USERROW15
+	.section	.debug_info
+	.uleb128	541	; ref to abbrev 541
+	.section	.debug_abbrev
+	.uleb128	541
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname541:
+	.string		"USERROW15"
+	.section	.debug_info
+	.long		.Lname541
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x0F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #542: variable USERROW16
+	.section	.debug_info
+	.uleb128	542	; ref to abbrev 542
+	.section	.debug_abbrev
+	.uleb128	542
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname542:
+	.string		"USERROW16"
+	.section	.debug_info
+	.long		.Lname542
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x10
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #543: variable USERROW17
+	.section	.debug_info
+	.uleb128	543	; ref to abbrev 543
+	.section	.debug_abbrev
+	.uleb128	543
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname543:
+	.string		"USERROW17"
+	.section	.debug_info
+	.long		.Lname543
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x11
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #544: variable USERROW18
+	.section	.debug_info
+	.uleb128	544	; ref to abbrev 544
+	.section	.debug_abbrev
+	.uleb128	544
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname544:
+	.string		"USERROW18"
+	.section	.debug_info
+	.long		.Lname544
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x12
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #545: variable USERROW19
+	.section	.debug_info
+	.uleb128	545	; ref to abbrev 545
+	.section	.debug_abbrev
+	.uleb128	545
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname545:
+	.string		"USERROW19"
+	.section	.debug_info
+	.long		.Lname545
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x13
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #546: variable USERROW20
+	.section	.debug_info
+	.uleb128	546	; ref to abbrev 546
+	.section	.debug_abbrev
+	.uleb128	546
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname546:
+	.string		"USERROW20"
+	.section	.debug_info
+	.long		.Lname546
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x14
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #547: variable USERROW21
+	.section	.debug_info
+	.uleb128	547	; ref to abbrev 547
+	.section	.debug_abbrev
+	.uleb128	547
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname547:
+	.string		"USERROW21"
+	.section	.debug_info
+	.long		.Lname547
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x15
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #548: variable USERROW22
+	.section	.debug_info
+	.uleb128	548	; ref to abbrev 548
+	.section	.debug_abbrev
+	.uleb128	548
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname548:
+	.string		"USERROW22"
+	.section	.debug_info
+	.long		.Lname548
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x16
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #549: variable USERROW23
+	.section	.debug_info
+	.uleb128	549	; ref to abbrev 549
+	.section	.debug_abbrev
+	.uleb128	549
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname549:
+	.string		"USERROW23"
+	.section	.debug_info
+	.long		.Lname549
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x17
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #550: variable USERROW24
+	.section	.debug_info
+	.uleb128	550	; ref to abbrev 550
+	.section	.debug_abbrev
+	.uleb128	550
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname550:
+	.string		"USERROW24"
+	.section	.debug_info
+	.long		.Lname550
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x18
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #551: variable USERROW25
+	.section	.debug_info
+	.uleb128	551	; ref to abbrev 551
+	.section	.debug_abbrev
+	.uleb128	551
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname551:
+	.string		"USERROW25"
+	.section	.debug_info
+	.long		.Lname551
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x19
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #552: variable USERROW26
+	.section	.debug_info
+	.uleb128	552	; ref to abbrev 552
+	.section	.debug_abbrev
+	.uleb128	552
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname552:
+	.string		"USERROW26"
+	.section	.debug_info
+	.long		.Lname552
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #553: variable USERROW27
+	.section	.debug_info
+	.uleb128	553	; ref to abbrev 553
+	.section	.debug_abbrev
+	.uleb128	553
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname553:
+	.string		"USERROW27"
+	.section	.debug_info
+	.long		.Lname553
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #554: variable USERROW28
+	.section	.debug_info
+	.uleb128	554	; ref to abbrev 554
+	.section	.debug_abbrev
+	.uleb128	554
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname554:
+	.string		"USERROW28"
+	.section	.debug_info
+	.long		.Lname554
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #555: variable USERROW29
+	.section	.debug_info
+	.uleb128	555	; ref to abbrev 555
+	.section	.debug_abbrev
+	.uleb128	555
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname555:
+	.string		"USERROW29"
+	.section	.debug_info
+	.long		.Lname555
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #556: variable USERROW30
+	.section	.debug_info
+	.uleb128	556	; ref to abbrev 556
+	.section	.debug_abbrev
+	.uleb128	556
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname556:
+	.string		"USERROW30"
+	.section	.debug_info
+	.long		.Lname556
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #557: variable USERROW31
+	.section	.debug_info
+	.uleb128	557	; ref to abbrev 557
+	.section	.debug_abbrev
+	.uleb128	557
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname557:
+	.string		"USERROW31"
+	.section	.debug_info
+	.long		.Lname557
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x1F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #558: variable USERROW32
+	.section	.debug_info
+	.uleb128	558	; ref to abbrev 558
+	.section	.debug_abbrev
+	.uleb128	558
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname558:
+	.string		"USERROW32"
+	.section	.debug_info
+	.long		.Lname558
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x20
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #559: variable USERROW33
+	.section	.debug_info
+	.uleb128	559	; ref to abbrev 559
+	.section	.debug_abbrev
+	.uleb128	559
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname559:
+	.string		"USERROW33"
+	.section	.debug_info
+	.long		.Lname559
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x21
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #560: variable USERROW34
+	.section	.debug_info
+	.uleb128	560	; ref to abbrev 560
+	.section	.debug_abbrev
+	.uleb128	560
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname560:
+	.string		"USERROW34"
+	.section	.debug_info
+	.long		.Lname560
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x22
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #561: variable USERROW35
+	.section	.debug_info
+	.uleb128	561	; ref to abbrev 561
+	.section	.debug_abbrev
+	.uleb128	561
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname561:
+	.string		"USERROW35"
+	.section	.debug_info
+	.long		.Lname561
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x23
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #562: variable USERROW36
+	.section	.debug_info
+	.uleb128	562	; ref to abbrev 562
+	.section	.debug_abbrev
+	.uleb128	562
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname562:
+	.string		"USERROW36"
+	.section	.debug_info
+	.long		.Lname562
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x24
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #563: variable USERROW37
+	.section	.debug_info
+	.uleb128	563	; ref to abbrev 563
+	.section	.debug_abbrev
+	.uleb128	563
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname563:
+	.string		"USERROW37"
+	.section	.debug_info
+	.long		.Lname563
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x25
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #564: variable USERROW38
+	.section	.debug_info
+	.uleb128	564	; ref to abbrev 564
+	.section	.debug_abbrev
+	.uleb128	564
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname564:
+	.string		"USERROW38"
+	.section	.debug_info
+	.long		.Lname564
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x26
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #565: variable USERROW39
+	.section	.debug_info
+	.uleb128	565	; ref to abbrev 565
+	.section	.debug_abbrev
+	.uleb128	565
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname565:
+	.string		"USERROW39"
+	.section	.debug_info
+	.long		.Lname565
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x27
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #566: variable USERROW40
+	.section	.debug_info
+	.uleb128	566	; ref to abbrev 566
+	.section	.debug_abbrev
+	.uleb128	566
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname566:
+	.string		"USERROW40"
+	.section	.debug_info
+	.long		.Lname566
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x28
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #567: variable USERROW41
+	.section	.debug_info
+	.uleb128	567	; ref to abbrev 567
+	.section	.debug_abbrev
+	.uleb128	567
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname567:
+	.string		"USERROW41"
+	.section	.debug_info
+	.long		.Lname567
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x29
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #568: variable USERROW42
+	.section	.debug_info
+	.uleb128	568	; ref to abbrev 568
+	.section	.debug_abbrev
+	.uleb128	568
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname568:
+	.string		"USERROW42"
+	.section	.debug_info
+	.long		.Lname568
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x2A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #569: variable USERROW43
+	.section	.debug_info
+	.uleb128	569	; ref to abbrev 569
+	.section	.debug_abbrev
+	.uleb128	569
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname569:
+	.string		"USERROW43"
+	.section	.debug_info
+	.long		.Lname569
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x2B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #570: variable USERROW44
+	.section	.debug_info
+	.uleb128	570	; ref to abbrev 570
+	.section	.debug_abbrev
+	.uleb128	570
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname570:
+	.string		"USERROW44"
+	.section	.debug_info
+	.long		.Lname570
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x2C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #571: variable USERROW45
+	.section	.debug_info
+	.uleb128	571	; ref to abbrev 571
+	.section	.debug_abbrev
+	.uleb128	571
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname571:
+	.string		"USERROW45"
+	.section	.debug_info
+	.long		.Lname571
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x2D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #572: variable USERROW46
+	.section	.debug_info
+	.uleb128	572	; ref to abbrev 572
+	.section	.debug_abbrev
+	.uleb128	572
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname572:
+	.string		"USERROW46"
+	.section	.debug_info
+	.long		.Lname572
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x2E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #573: variable USERROW47
+	.section	.debug_info
+	.uleb128	573	; ref to abbrev 573
+	.section	.debug_abbrev
+	.uleb128	573
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname573:
+	.string		"USERROW47"
+	.section	.debug_info
+	.long		.Lname573
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x2F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #574: variable USERROW48
+	.section	.debug_info
+	.uleb128	574	; ref to abbrev 574
+	.section	.debug_abbrev
+	.uleb128	574
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname574:
+	.string		"USERROW48"
+	.section	.debug_info
+	.long		.Lname574
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x30
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #575: variable USERROW49
+	.section	.debug_info
+	.uleb128	575	; ref to abbrev 575
+	.section	.debug_abbrev
+	.uleb128	575
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname575:
+	.string		"USERROW49"
+	.section	.debug_info
+	.long		.Lname575
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x31
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #576: variable USERROW50
+	.section	.debug_info
+	.uleb128	576	; ref to abbrev 576
+	.section	.debug_abbrev
+	.uleb128	576
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname576:
+	.string		"USERROW50"
+	.section	.debug_info
+	.long		.Lname576
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x32
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #577: variable USERROW51
+	.section	.debug_info
+	.uleb128	577	; ref to abbrev 577
+	.section	.debug_abbrev
+	.uleb128	577
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname577:
+	.string		"USERROW51"
+	.section	.debug_info
+	.long		.Lname577
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x33
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #578: variable USERROW52
+	.section	.debug_info
+	.uleb128	578	; ref to abbrev 578
+	.section	.debug_abbrev
+	.uleb128	578
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname578:
+	.string		"USERROW52"
+	.section	.debug_info
+	.long		.Lname578
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x34
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #579: variable USERROW53
+	.section	.debug_info
+	.uleb128	579	; ref to abbrev 579
+	.section	.debug_abbrev
+	.uleb128	579
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname579:
+	.string		"USERROW53"
+	.section	.debug_info
+	.long		.Lname579
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x35
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #580: variable USERROW54
+	.section	.debug_info
+	.uleb128	580	; ref to abbrev 580
+	.section	.debug_abbrev
+	.uleb128	580
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname580:
+	.string		"USERROW54"
+	.section	.debug_info
+	.long		.Lname580
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x36
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #581: variable USERROW55
+	.section	.debug_info
+	.uleb128	581	; ref to abbrev 581
+	.section	.debug_abbrev
+	.uleb128	581
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname581:
+	.string		"USERROW55"
+	.section	.debug_info
+	.long		.Lname581
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x37
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #582: variable USERROW56
+	.section	.debug_info
+	.uleb128	582	; ref to abbrev 582
+	.section	.debug_abbrev
+	.uleb128	582
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname582:
+	.string		"USERROW56"
+	.section	.debug_info
+	.long		.Lname582
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x38
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #583: variable USERROW57
+	.section	.debug_info
+	.uleb128	583	; ref to abbrev 583
+	.section	.debug_abbrev
+	.uleb128	583
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname583:
+	.string		"USERROW57"
+	.section	.debug_info
+	.long		.Lname583
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x39
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #584: variable USERROW58
+	.section	.debug_info
+	.uleb128	584	; ref to abbrev 584
+	.section	.debug_abbrev
+	.uleb128	584
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname584:
+	.string		"USERROW58"
+	.section	.debug_info
+	.long		.Lname584
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x3A
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #585: variable USERROW59
+	.section	.debug_info
+	.uleb128	585	; ref to abbrev 585
+	.section	.debug_abbrev
+	.uleb128	585
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname585:
+	.string		"USERROW59"
+	.section	.debug_info
+	.long		.Lname585
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x3B
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #586: variable USERROW60
+	.section	.debug_info
+	.uleb128	586	; ref to abbrev 586
+	.section	.debug_abbrev
+	.uleb128	586
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname586:
+	.string		"USERROW60"
+	.section	.debug_info
+	.long		.Lname586
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x3C
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #587: variable USERROW61
+	.section	.debug_info
+	.uleb128	587	; ref to abbrev 587
+	.section	.debug_abbrev
+	.uleb128	587
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname587:
+	.string		"USERROW61"
+	.section	.debug_info
+	.long		.Lname587
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x3D
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #588: variable USERROW62
+	.section	.debug_info
+	.uleb128	588	; ref to abbrev 588
+	.section	.debug_abbrev
+	.uleb128	588
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname588:
+	.string		"USERROW62"
+	.section	.debug_info
+	.long		.Lname588
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x3E
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #589: variable USERROW63
+	.section	.debug_info
+	.uleb128	589	; ref to abbrev 589
+	.section	.debug_abbrev
+	.uleb128	589
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname589:
+	.string		"USERROW63"
+	.section	.debug_info
+	.long		.Lname589
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x1080 + 0x3F
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #590: variable DIR
+	.section	.debug_info
+	.uleb128	590	; ref to abbrev 590
+	.section	.debug_abbrev
+	.uleb128	590
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname590:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname590
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0000 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #591: variable OUT
+	.section	.debug_info
+	.uleb128	591	; ref to abbrev 591
+	.section	.debug_abbrev
+	.uleb128	591
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname591:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname591
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0000 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #592: variable IN
+	.section	.debug_info
+	.uleb128	592	; ref to abbrev 592
+	.section	.debug_abbrev
+	.uleb128	592
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname592:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname592
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0000 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #593: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	593	; ref to abbrev 593
+	.section	.debug_abbrev
+	.uleb128	593
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname593:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname593
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0000 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #594: variable DIR
+	.section	.debug_info
+	.uleb128	594	; ref to abbrev 594
+	.section	.debug_abbrev
+	.uleb128	594
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname594:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname594
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0004 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #595: variable OUT
+	.section	.debug_info
+	.uleb128	595	; ref to abbrev 595
+	.section	.debug_abbrev
+	.uleb128	595
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname595:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname595
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0004 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #596: variable IN
+	.section	.debug_info
+	.uleb128	596	; ref to abbrev 596
+	.section	.debug_abbrev
+	.uleb128	596
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname596:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname596
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0004 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #597: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	597	; ref to abbrev 597
+	.section	.debug_abbrev
+	.uleb128	597
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname597:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname597
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0004 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #598: variable DIR
+	.section	.debug_info
+	.uleb128	598	; ref to abbrev 598
+	.section	.debug_abbrev
+	.uleb128	598
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname598:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname598
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0008 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #599: variable OUT
+	.section	.debug_info
+	.uleb128	599	; ref to abbrev 599
+	.section	.debug_abbrev
+	.uleb128	599
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname599:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname599
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0008 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #600: variable IN
+	.section	.debug_info
+	.uleb128	600	; ref to abbrev 600
+	.section	.debug_abbrev
+	.uleb128	600
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname600:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname600
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0008 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #601: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	601	; ref to abbrev 601
+	.section	.debug_abbrev
+	.uleb128	601
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname601:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname601
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0008 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #602: variable DIR
+	.section	.debug_info
+	.uleb128	602	; ref to abbrev 602
+	.section	.debug_abbrev
+	.uleb128	602
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname602:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname602
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x000C + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #603: variable OUT
+	.section	.debug_info
+	.uleb128	603	; ref to abbrev 603
+	.section	.debug_abbrev
+	.uleb128	603
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname603:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname603
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x000C + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #604: variable IN
+	.section	.debug_info
+	.uleb128	604	; ref to abbrev 604
+	.section	.debug_abbrev
+	.uleb128	604
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname604:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname604
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x000C + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #605: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	605	; ref to abbrev 605
+	.section	.debug_abbrev
+	.uleb128	605
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname605:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname605
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x000C + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #606: variable DIR
+	.section	.debug_info
+	.uleb128	606	; ref to abbrev 606
+	.section	.debug_abbrev
+	.uleb128	606
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname606:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname606
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0010 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #607: variable OUT
+	.section	.debug_info
+	.uleb128	607	; ref to abbrev 607
+	.section	.debug_abbrev
+	.uleb128	607
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname607:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname607
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0010 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #608: variable IN
+	.section	.debug_info
+	.uleb128	608	; ref to abbrev 608
+	.section	.debug_abbrev
+	.uleb128	608
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname608:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname608
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0010 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #609: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	609	; ref to abbrev 609
+	.section	.debug_abbrev
+	.uleb128	609
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname609:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname609
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0010 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #610: variable DIR
+	.section	.debug_info
+	.uleb128	610	; ref to abbrev 610
+	.section	.debug_abbrev
+	.uleb128	610
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname610:
+	.string		"DIR"
+	.section	.debug_info
+	.long		.Lname610
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0014 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #611: variable OUT
+	.section	.debug_info
+	.uleb128	611	; ref to abbrev 611
+	.section	.debug_abbrev
+	.uleb128	611
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname611:
+	.string		"OUT"
+	.section	.debug_info
+	.long		.Lname611
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0014 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #612: variable IN
+	.section	.debug_info
+	.uleb128	612	; ref to abbrev 612
+	.section	.debug_abbrev
+	.uleb128	612
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname612:
+	.string		"IN"
+	.section	.debug_info
+	.long		.Lname612
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0014 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #613: variable INTFLAGS
+	.section	.debug_info
+	.uleb128	613	; ref to abbrev 613
+	.section	.debug_abbrev
+	.uleb128	613
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname613:
+	.string		"INTFLAGS"
+	.section	.debug_info
+	.long		.Lname613
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0014 + 0x3
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #614: variable DAC0REF
+	.section	.debug_info
+	.uleb128	614	; ref to abbrev 614
+	.section	.debug_abbrev
+	.uleb128	614
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname614:
+	.string		"DAC0REF"
+	.section	.debug_info
+	.long		.Lname614
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00B0 + 0x2
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #615: variable ACREF
+	.section	.debug_info
+	.uleb128	615	; ref to abbrev 615
+	.section	.debug_abbrev
+	.uleb128	615
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname615:
+	.string		"ACREF"
+	.section	.debug_info
+	.long		.Lname615
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x00B0 + 0x4
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #616: variable CTRLA
+	.section	.debug_info
+	.uleb128	616	; ref to abbrev 616
+	.section	.debug_abbrev
+	.uleb128	616
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname616:
+	.string		"CTRLA"
+	.section	.debug_info
+	.long		.Lname616
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0100 + 0x0
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+;- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	;; DIE #617: variable STATUS
+	.section	.debug_info
+	.uleb128	617	; ref to abbrev 617
+	.section	.debug_abbrev
+	.uleb128	617
+	.uleb128	DW_TAG_variable
+	.byte		DW_CHILDREN_no
+
+	.uleb128	DW_AT_name
+	.uleb128	DW_FORM_strp
+	.section	.debug_str
+.Lname617:
+	.string		"STATUS"
+	.section	.debug_info
+	.long		.Lname617
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_file
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source file information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_decl_line
+	.uleb128	DW_FORM_data1
+	.section	.debug_info
+	.byte		0	; no source line information
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_type
+	.uleb128	DW_FORM_ref4
+	.section	.debug_info
+	.long		.Luint8_t - .Lssinfo
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_external
+	.uleb128	DW_FORM_flag
+	.section	.debug_info
+	.byte		1
+
+	.section	.debug_abbrev
+	.uleb128	DW_AT_location
+	.uleb128	DW_FORM_block1
+	.section	.debug_info
+	.byte		5	; length of block
+	.byte		DW_OP_addr
+	.long		0x800000 + 0x0100 + 0x1
+
+	.section	.debug_abbrev
+	.uleb128	0
+	.uleb128	0
+
+	;; trailer
+	.section	.debug_abbrev
+	.uleb128	0
+
+	.section	.debug_info
+	.uleb128	0
+.Leinfo:

--- a/devtools/gen-avr-lib-tree.sh.in
+++ b/devtools/gen-avr-lib-tree.sh.in
@@ -451,6 +451,22 @@ avr64dd28:crtavr64dd28.o:${DEV_DEFS}:${CFLAGS_SPACE}:${DEV_ASFLAGS};\
 avr64dd32:crtavr64dd32.o:${DEV_DEFS}:${CFLAGS_SPACE}:${DEV_ASFLAGS}\
 "
 
+AVREX_DEV_INFO="\
+avr16ea28:crtavr16ea28.o:${DEV_DEFS}:${CFLAGS_SPACE}:${DEV_ASFLAGS};\
+avr16ea32:crtavr16ea32.o:${DEV_DEFS}:${CFLAGS_SPACE}:${DEV_ASFLAGS};\
+avr16ea48:crtavr16ea48.o:${DEV_DEFS}:${CFLAGS_SPACE}:${DEV_ASFLAGS};\
+avr16eb14:crtavr16eb14.o:${DEV_DEFS}:${CFLAGS_SPACE}:${DEV_ASFLAGS};\
+avr16eb20:crtavr16eb20.o:${DEV_DEFS}:${CFLAGS_SPACE}:${DEV_ASFLAGS};\
+avr16eb28:crtavr16eb28.o:${DEV_DEFS}:${CFLAGS_SPACE}:${DEV_ASFLAGS};\
+avr16eb32:crtavr16eb32.o:${DEV_DEFS}:${CFLAGS_SPACE}:${DEV_ASFLAGS};\
+avr32ea28:crtavr32ea28.o:${DEV_DEFS}:${CFLAGS_SPACE}:${DEV_ASFLAGS};\
+avr32ea32:crtavr32ea32.o:${DEV_DEFS}:${CFLAGS_SPACE}:${DEV_ASFLAGS};\
+avr32ea48:crtavr32ea48.o:${DEV_DEFS}:${CFLAGS_SPACE}:${DEV_ASFLAGS};\
+avr64ea28:crtavr64ea28.o:${DEV_DEFS}:${CFLAGS_SPACE}:${DEV_ASFLAGS};\
+avr64ea32:crtavr64ea32.o:${DEV_DEFS}:${CFLAGS_SPACE}:${DEV_ASFLAGS};\
+avr64ea48:crtavr64ea48.o:${DEV_DEFS}:${CFLAGS_SPACE}:${DEV_ASFLAGS}\
+"
+
 # The "architectures" or "cores".  The second row only serves as a pointer
 # to all the supported devices as we iterate over AVR_ARH_INFO below.
 # Mentioning AVR25_DEV_INFO after avr25 only serves the purpose to include
@@ -479,7 +495,8 @@ avrxmega5:AVRXMEGA5_DEV_INFO:${LIB_DEFS}:${CFLAGS_BIG_MEMORY}:${DEV_ASFLAGS};\
 avrxmega6:AVRXMEGA6_DEV_INFO:${LIB_DEFS}:${CFLAGS_BIG_MEMORY}:${DEV_ASFLAGS};\
 avrxmega7:AVRXMEGA7_DEV_INFO:${LIB_DEFS}:${CFLAGS_BIG_MEMORY}:${DEV_ASFLAGS};\
 avrtiny:AVRTINY_DEV_INFO:${LIB_DEFS}:${CFLAGS_SPACE}:${DEV_ASFLAGS};\
-avrdx:AVRDX_DEV_INFO:${LIB_DEFS}:${CFLAGS_SPACE}:${DEV_ASFLAGS}\
+avrdx:AVRDX_DEV_INFO:${LIB_DEFS}:${CFLAGS_SPACE}:${DEV_ASFLAGS};\
+avrex:AVREX_DEV_INFO:${LIB_DEFS}:${CFLAGS_SPACE}:${DEV_ASFLAGS}\
 "
 
 # Make sure that we are the top-level of the source tree. We will look for the

--- a/devtools/generate_iosym.sh
+++ b/devtools/generate_iosym.sh
@@ -50,8 +50,8 @@ avr16dd32 avr32da28 avr32da32 avr32da48 avr32db28 avr32db32 avr32db48 \
 avr32dd14 avr32dd20 avr32dd28 avr32dd32 avr64da28 avr64da32 avr64da48 \
 avr64da64 avr64db28 avr64db32 avr64db48 avr64db64 avr64dd14 avr64dd20 \
 avr64dd28 avr64dd32 avr128da28 avr128da32 avr128da48 avr128da64 avr128db28 \
-avr128db32 avr128db48 avr128db64"
-
+avr128db32 avr128db48 avr128db64 avr16ea28 avr16ea32 avr16ea48 avr16eb14 \
+avr16eb20 avr16eb28 avr16eb32 avr32ea28 avr32ea32 avr32ea48 avr64ea28 avr64ea32 avr64ea48"
 
 if [ x"$ATDFDIR" = x ]
 then

--- a/include/avr/io.h
+++ b/include/avr/io.h
@@ -731,6 +731,32 @@
 #  include <avr/ioavr64dd28.h>
 #elif defined (__AVR_AVR64DD32__)
 #  include <avr/ioavr64dd32.h>
+#elif defined (__AVR_AVR16EA28__)
+#  include <avr/ioavr16ea28.h>
+#elif defined (__AVR_AVR16EA32__)
+#  include <avr/ioavr16ea32.h>
+#elif defined (__AVR_AVR16EA48__)
+#  include <avr/ioavr16ea48.h>
+#elif defined (__AVR_AVR16EB14__)
+#  include <avr/ioavr16eb14.h>
+#elif defined (__AVR_AVR16EB20__)
+#  include <avr/ioavr16eb20.h>
+#elif defined (__AVR_AVR16EB28__)
+#  include <avr/ioavr16eb28.h>
+#elif defined (__AVR_AVR16EB32__)
+#  include <avr/ioavr16eb32.h>
+#elif defined (__AVR_AVR32EA28__)
+#  include <avr/ioavr32ea28.h>
+#elif defined (__AVR_AVR32EA32__)
+#  include <avr/ioavr32ea32.h>
+#elif defined (__AVR_AVR32EA48__)
+#  include <avr/ioavr32ea48.h>
+#elif defined (__AVR_AVR64EA28__)
+#  include <avr/ioavr64ea28.h>
+#elif defined (__AVR_AVR64EA32__)
+#  include <avr/ioavr64ea32.h>
+#elif defined (__AVR_AVR64EA48__)
+#  include <avr/ioavr64ea48.h>
 #elif defined (__AVR_DEV_LIB_NAME__)
 #  define __concat__(a,b) a##b
 #  define __header1__(a,b) __concat__(a,b)

--- a/include/avr/ioavr16ea28.h
+++ b/include/avr/ioavr16ea28.h
@@ -1,0 +1,5800 @@
+/*
+ * Copyright (C) 2023, Microchip Technology Inc. and its subsidiaries ("Microchip")
+ * All rights reserved.
+ *
+ * This software is developed by Microchip Technology Inc. and its subsidiaries ("Microchip").
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other
+ *        materials provided with the distribution. Publication is not required when
+ *        this file is used in an embedded application.
+ *
+ *     3. Microchip's name may not be used to endorse or promote products derived from this
+ *        software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY MICROCHIP "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL MICROCHIP BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING BUT NOT LIMITED TO
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWSOEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _AVR_IO_H_
+#  error "Include <avr/io.h> instead of this file."
+#endif
+
+#ifndef _AVR_IOXXX_H_
+#  define _AVR_IOXXX_H_ "ioavr16ea28.h"
+#else
+#  error "Attempt to include more than one <avr/ioXXX.h> file."
+#endif
+
+#ifndef _AVR_AVR16EA28_H_INCLUDED
+#define _AVR_AVR16EA28_H_INCLUDED
+
+/* Ungrouped common registers */
+#define CCP  _SFR_MEM8(0x0034)  /* Configuration Change Protection */
+#define SP  _SFR_MEM16(0x003D)  /* Stack Pointer */
+#define SPL  _SFR_MEM8(0x003D)  /* Stack Pointer Low */
+#define SPH  _SFR_MEM8(0x003E)  /* Stack Pointer High */
+#define SREG  _SFR_MEM8(0x003F)  /* Status Register */
+
+/* C Language Only */
+#if !defined (__ASSEMBLER__)
+
+#include <stdint.h>
+
+typedef volatile uint8_t register8_t;
+typedef volatile uint16_t register16_t;
+typedef volatile uint32_t register32_t;
+
+
+#ifdef _WORDREGISTER
+#undef _WORDREGISTER
+#endif
+#define _WORDREGISTER(regname)   \
+    __extension__ union \
+    { \
+        register16_t regname; \
+        struct \
+        { \
+            register8_t regname ## L; \
+            register8_t regname ## H; \
+        }; \
+    }
+
+#ifdef _DWORDREGISTER
+#undef _DWORDREGISTER
+#endif
+#define _DWORDREGISTER(regname)  \
+    __extension__ union \
+    { \
+        register32_t regname; \
+        struct \
+        { \
+            register8_t regname ## 0; \
+            register8_t regname ## 1; \
+            register8_t regname ## 2; \
+            register8_t regname ## 3; \
+        }; \
+    }
+
+
+/*
+==========================================================================
+IO Module Structures
+==========================================================================
+*/
+
+
+/*
+--------------------------------------------------------------------------
+AC - Analog Comparator
+--------------------------------------------------------------------------
+*/
+
+/* Analog Comparator */
+typedef struct AC_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t MUXCTRL;  /* Mux Control A */
+    register8_t reserved_1[2];
+    register8_t DACREF;  /* DAC Voltage Reference */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t STATUS;  /* Status */
+} AC_t;
+
+/* Hysteresis Mode select */
+typedef enum AC_HYSMODE_enum
+{
+    AC_HYSMODE_NONE_gc = (0x00<<1),  /* No hysteresis */
+    AC_HYSMODE_SMALL_gc = (0x01<<1),  /* Small hysteresis */
+    AC_HYSMODE_MEDIUM_gc = (0x02<<1),  /* Medium hysteresis */
+    AC_HYSMODE_LARGE_gc = (0x03<<1)  /* Large hysteresis */
+} AC_HYSMODE_t;
+
+/* AC Output Initial Value select */
+typedef enum AC_INITVAL_enum
+{
+    AC_INITVAL_LOW_gc = (0x00<<6),  /* Output initialized to 0 */
+    AC_INITVAL_HIGH_gc = (0x01<<6)  /* Output initialized to 1 */
+} AC_INITVAL_t;
+
+/* Interrupt Mode select */
+typedef enum AC_INTMODE_NORMAL_enum
+{
+    AC_INTMODE_NORMAL_BOTHEDGE_gc = (0x00<<4),  /* Positive and negative inputs crosses */
+    AC_INTMODE_NORMAL_NEGEDGE_gc = (0x02<<4),  /* Positive input goes below negative input */
+    AC_INTMODE_NORMAL_POSEDGE_gc = (0x03<<4)  /* Positive input goes above negative input */
+} AC_INTMODE_NORMAL_t;
+
+/* Interrupt Mode select */
+typedef enum AC_INTMODE_WINDOW_enum
+{
+    AC_INTMODE_WINDOW_ABOVE_gc = (0x00<<4),  /* Window interrupt when input above both references */
+    AC_INTMODE_WINDOW_INSIDE_gc = (0x01<<4),  /* Window interrupt when input betweeen references */
+    AC_INTMODE_WINDOW_BELOW_gc = (0x02<<4),  /* Window interrupt when input below both references */
+    AC_INTMODE_WINDOW_OUTSIDE_gc = (0x03<<4)  /* Window interrupt when input outside reference */
+} AC_INTMODE_WINDOW_t;
+
+/* Negative Input MUX Selection */
+typedef enum AC_MUXNEG_enum
+{
+    AC_MUXNEG_AINN0_gc = (0x00<<0),  /* Negative Pin 0 */
+    AC_MUXNEG_AINN1_gc = (0x01<<0),  /* Negative Pin 1 */
+    AC_MUXNEG_AINN2_gc = (0x02<<0),  /* Negative Pin 2 */
+    AC_MUXNEG_AINN3_gc = (0x03<<0),  /* Negative Pin 3 */
+    AC_MUXNEG_DACREF_gc = (0x04<<0)  /* DAC Reference */
+} AC_MUXNEG_t;
+
+/* Positive Input MUX Selection */
+typedef enum AC_MUXPOS_enum
+{
+    AC_MUXPOS_AINP0_gc = (0x00<<3),  /* Positive Pin 0 */
+    AC_MUXPOS_AINP1_gc = (0x01<<3),  /* Positive Pin 1 */
+    AC_MUXPOS_AINP2_gc = (0x02<<3),  /* Positive Pin 2 */
+    AC_MUXPOS_AINP3_gc = (0x03<<3),  /* Positive Pin 3 */
+    AC_MUXPOS_AINP4_gc = (0x04<<3)  /* Positive Pin 4 */
+} AC_MUXPOS_t;
+
+/* Power profile select */
+typedef enum AC_POWER_enum
+{
+    AC_POWER_PROFILE0_gc = (0x00<<3),  /* Power profile 0, Fastest response time, highest consumption */
+    AC_POWER_PROFILE1_gc = (0x01<<3)  /* Power profile 1 */
+} AC_POWER_t;
+
+/* Window selection mode */
+typedef enum AC_WINSEL_enum
+{
+    AC_WINSEL_DISABLED_gc = (0x00<<0),  /* Window function disabled */
+    AC_WINSEL_UPSEL1_gc = (0x01<<0)  /* Select ACn+1 as upper limit in window compare */
+} AC_WINSEL_t;
+
+/* Analog Comparator Window State select */
+typedef enum AC_WINSTATE_enum
+{
+    AC_WINSTATE_ABOVE_gc = (0x00<<6),  /* Above window */
+    AC_WINSTATE_INSIDE_gc = (0x01<<6),  /* Inside window */
+    AC_WINSTATE_BELOW_gc = (0x02<<6)  /* Below window */
+} AC_WINSTATE_t;
+
+/*
+--------------------------------------------------------------------------
+ADC - Analog to Digital Converter
+--------------------------------------------------------------------------
+*/
+
+/* Analog to Digital Converter */
+typedef struct ADC_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    register8_t CTRLD;  /* Control D */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t STATUS;  /* Status register */
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t CTRLE;  /* Control E */
+    register8_t CTRLF;  /* Control F */
+    register8_t COMMAND;  /* Command register */
+    register8_t PGACTRL;  /* PGA Control */
+    register8_t MUXPOS;  /* Positive Input Multiplexer */
+    register8_t MUXNEG;  /* Negative Input Multiplexer */
+    register8_t reserved_1[2];
+    _DWORDREGISTER(RESULT);  /* Result */
+    _WORDREGISTER(SAMPLE);  /* Sample */
+    register8_t reserved_2[2];
+    register8_t TEMP0;  /* Temporary Data 0 */
+    register8_t TEMP1;  /* Temporary Data 1 */
+    register8_t TEMP2;  /* Temporary Data 2 */
+    register8_t reserved_3[1];
+    _WORDREGISTER(WINLT);  /* Window Low Threshold */
+    _WORDREGISTER(WINHT);  /* Window High Threshold */
+    register8_t reserved_4[32];
+} ADC_t;
+
+/* Sign Chopping select */
+typedef enum ADC_CHOPPING_enum
+{
+    ADC_CHOPPING_DISABLE_gc = (0x00<<6),  /* Sign Chopping Disabled */
+    ADC_CHOPPING_ENABLE_gc = (0x01<<6)  /* Sign Chopping Enabled */
+} ADC_CHOPPING_t;
+
+/* Gain select */
+typedef enum ADC_GAIN_enum
+{
+    ADC_GAIN_1X_gc = (0x00<<5),  /* 1x gain */
+    ADC_GAIN_2X_gc = (0x01<<5),  /* 2x gain */
+    ADC_GAIN_4X_gc = (0x02<<5),  /* 4x gain */
+    ADC_GAIN_8X_gc = (0x03<<5),  /* 8x gain */
+    ADC_GAIN_16X_gc = (0x04<<5)  /* 16x gain */
+} ADC_GAIN_t;
+
+/* Mode select */
+typedef enum ADC_MODE_enum
+{
+    ADC_MODE_SINGLE_8BIT_gc = (0x00<<4),  /* Single Conversion with 8-bit resolution */
+    ADC_MODE_SINGLE_12BIT_gc = (0x01<<4),  /* Single Conversion with 12-bit resolution */
+    ADC_MODE_SERIES_gc = (0x02<<4),  /* Series with accumulation, separate trigger for every 12-bit conversion */
+    ADC_MODE_SERIES_SCALING_gc = (0x03<<4),  /* Series with accumulation and scaling, separate trigger for every 12-bit conversion */
+    ADC_MODE_BURST_gc = (0x04<<4),  /* Burst with accumulation, one trigger will run SAMPNUM 12-bit conversions */
+    ADC_MODE_BURST_SCALING_gc = (0x05<<4)  /* Burst with accumulation and scaling, one trigger will run SAMPNUM 12-bit conversions */
+} ADC_MODE_t;
+
+/* Analog Channel Selection Bits */
+typedef enum ADC_MUXNEG_enum
+{
+    ADC_MUXNEG_AIN0_gc = (0x00<<0),  /* ADC input pin 0 */
+    ADC_MUXNEG_AIN1_gc = (0x01<<0),  /* ADC input pin 1 */
+    ADC_MUXNEG_AIN2_gc = (0x02<<0),  /* ADC input pin 2 */
+    ADC_MUXNEG_AIN3_gc = (0x03<<0),  /* ADC input pin 3 */
+    ADC_MUXNEG_AIN4_gc = (0x04<<0),  /* ADC input pin 4 */
+    ADC_MUXNEG_AIN5_gc = (0x05<<0),  /* ADC input pin 5 */
+    ADC_MUXNEG_AIN6_gc = (0x06<<0),  /* ADC input pin 6 */
+    ADC_MUXNEG_AIN7_gc = (0x07<<0),  /* ADC input pin 7 */
+    ADC_MUXNEG_AIN16_gc = (0x10<<0),  /* ADC input pin 16 */
+    ADC_MUXNEG_AIN17_gc = (0x11<<0),  /* ADC input pin 17 */
+    ADC_MUXNEG_AIN22_gc = (0x16<<0),  /* ADC input pin 22 */
+    ADC_MUXNEG_AIN23_gc = (0x17<<0),  /* ADC input pin 23 */
+    ADC_MUXNEG_AIN24_gc = (0x18<<0),  /* ADC input pin 24 */
+    ADC_MUXNEG_AIN25_gc = (0x19<<0),  /* ADC input pin 25 */
+    ADC_MUXNEG_AIN26_gc = (0x1A<<0),  /* ADC input pin 26 */
+    ADC_MUXNEG_AIN27_gc = (0x1B<<0),  /* ADC input pin 27 */
+    ADC_MUXNEG_AIN28_gc = (0x1C<<0),  /* ADC input pin 28 */
+    ADC_MUXNEG_AIN29_gc = (0x1D<<0),  /* ADC input pin 29 */
+    ADC_MUXNEG_AIN30_gc = (0x1E<<0),  /* ADC input pin 30 */
+    ADC_MUXNEG_AIN31_gc = (0x1F<<0),  /* ADC input pin 31 */
+    ADC_MUXNEG_GND_gc = (0x30<<0),  /* Ground */
+    ADC_MUXNEG_DAC0_gc = (0x38<<0),  /* Digital to Analog Converter 0 */
+    ADC_MUXNEG_DACREF0_gc = (0x39<<0),  /* AC0 DAC reference */
+    ADC_MUXNEG_DACREF1_gc = (0x3A<<0)  /* AC1 DAC reference */
+} ADC_MUXNEG_t;
+
+/* Analog Channel Selection Bits */
+typedef enum ADC_MUXPOS_enum
+{
+    ADC_MUXPOS_AIN0_gc = (0x00<<0),  /* ADC input pin 0 */
+    ADC_MUXPOS_AIN1_gc = (0x01<<0),  /* ADC input pin 1 */
+    ADC_MUXPOS_AIN2_gc = (0x02<<0),  /* ADC input pin 2 */
+    ADC_MUXPOS_AIN3_gc = (0x03<<0),  /* ADC input pin 3 */
+    ADC_MUXPOS_AIN4_gc = (0x04<<0),  /* ADC input pin 4 */
+    ADC_MUXPOS_AIN5_gc = (0x05<<0),  /* ADC input pin 5 */
+    ADC_MUXPOS_AIN6_gc = (0x06<<0),  /* ADC input pin 6 */
+    ADC_MUXPOS_AIN7_gc = (0x07<<0),  /* ADC input pin 7 */
+    ADC_MUXPOS_AIN16_gc = (0x10<<0),  /* ADC input pin 16 */
+    ADC_MUXPOS_AIN17_gc = (0x11<<0),  /* ADC input pin 17 */
+    ADC_MUXPOS_AIN22_gc = (0x16<<0),  /* ADC input pin 22 */
+    ADC_MUXPOS_AIN23_gc = (0x17<<0),  /* ADC input pin 23 */
+    ADC_MUXPOS_AIN24_gc = (0x18<<0),  /* ADC input pin 24 */
+    ADC_MUXPOS_AIN25_gc = (0x19<<0),  /* ADC input pin 25 */
+    ADC_MUXPOS_AIN26_gc = (0x1A<<0),  /* ADC input pin 26 */
+    ADC_MUXPOS_AIN27_gc = (0x1B<<0),  /* ADC input pin 27 */
+    ADC_MUXPOS_AIN28_gc = (0x1C<<0),  /* ADC input pin 28 */
+    ADC_MUXPOS_AIN29_gc = (0x1D<<0),  /* ADC input pin 29 */
+    ADC_MUXPOS_AIN30_gc = (0x1E<<0),  /* ADC input pin 30 */
+    ADC_MUXPOS_AIN31_gc = (0x1F<<0),  /* ADC input pin 31 */
+    ADC_MUXPOS_GND_gc = (0x30<<0),  /* Ground */
+    ADC_MUXPOS_VDD10_gc = (0x31<<0),  /* VDD Divided by 10 */
+    ADC_MUXPOS_TEMPSENSE_gc = (0x32<<0),  /* Temperature Sensor */
+    ADC_MUXPOS_DAC0_gc = (0x38<<0)  /* Digital to Analog Converter 0 */
+} ADC_MUXPOS_t;
+
+/* PGA BIAS Select */
+typedef enum ADC_PGABIASSEL_enum
+{
+    ADC_PGABIASSEL_100PCT_gc = (0x00<<3),  /* 100% BIAS current. */
+    ADC_PGABIASSEL_75PCT_gc = (0x01<<3),  /* 75% BIAS current. Usable for CLK_ADC<4.5MHz */
+    ADC_PGABIASSEL_50PCT_gc = (0x02<<3),  /* 50% BIAS current. Usable for CLK_ADC<3MHz */
+    ADC_PGABIASSEL_25PCT_gc = (0x03<<3)  /* 25% BIAS current. Usable for CLK_ADC<1.5MHz */
+} ADC_PGABIASSEL_t;
+
+/* Prescaler Value select */
+typedef enum ADC_PRESC_enum
+{
+    ADC_PRESC_DIV2_gc = (0x00<<0),  /* System clock divided by 2 */
+    ADC_PRESC_DIV4_gc = (0x01<<0),  /* System clock divided by 4 */
+    ADC_PRESC_DIV6_gc = (0x02<<0),  /* System clock divided by 6 */
+    ADC_PRESC_DIV8_gc = (0x03<<0),  /* System clock divided by 8 */
+    ADC_PRESC_DIV10_gc = (0x04<<0),  /* System clock divided by 10 */
+    ADC_PRESC_DIV12_gc = (0x05<<0),  /* System clock divided by 12 */
+    ADC_PRESC_DIV14_gc = (0x06<<0),  /* System clock divided by 14 */
+    ADC_PRESC_DIV16_gc = (0x07<<0),  /* System clock divided by 16 */
+    ADC_PRESC_DIV20_gc = (0x08<<0),  /* System clock divided by 20 */
+    ADC_PRESC_DIV24_gc = (0x09<<0),  /* System clock divided by 24 */
+    ADC_PRESC_DIV28_gc = (0x0A<<0),  /* System clock divided by 28 */
+    ADC_PRESC_DIV32_gc = (0x0B<<0),  /* System clock divided by 32 */
+    ADC_PRESC_DIV40_gc = (0x0C<<0),  /* System clock divided by 40 */
+    ADC_PRESC_DIV48_gc = (0x0D<<0),  /* System clock divided by 48 */
+    ADC_PRESC_DIV56_gc = (0x0E<<0),  /* System clock divided by 56 */
+    ADC_PRESC_DIV64_gc = (0x0F<<0)  /* System clock divided by 64 */
+} ADC_PRESC_t;
+
+/* Reference select */
+typedef enum ADC_REFSEL_enum
+{
+    ADC_REFSEL_VDD_gc = (0x00<<0),  /* VDD */
+    ADC_REFSEL_VREFA_gc = (0x02<<0),  /* External Reference */
+    ADC_REFSEL_1V024_gc = (0x04<<0),  /* Internal 1.024V Reference */
+    ADC_REFSEL_2V048_gc = (0x05<<0),  /* Internal 2.048V Reference */
+    ADC_REFSEL_4V096_gc = (0x06<<0),  /* Internal 4.096V Reference */
+    ADC_REFSEL_2V500_gc = (0x07<<0)  /* Internal 2.500V Reference */
+} ADC_REFSEL_t;
+
+/* Sample numbers select */
+typedef enum ADC_SAMPNUM_enum
+{
+    ADC_SAMPNUM_NONE_gc = (0x00<<0),  /* No accumulation */
+    ADC_SAMPNUM_ACC2_gc = (0x01<<0),  /* 2 samples accumulated */
+    ADC_SAMPNUM_ACC4_gc = (0x02<<0),  /* 4 samples accumulated */
+    ADC_SAMPNUM_ACC8_gc = (0x03<<0),  /* 8 samples accumulated */
+    ADC_SAMPNUM_ACC16_gc = (0x04<<0),  /* 16 samples accumulated */
+    ADC_SAMPNUM_ACC32_gc = (0x05<<0),  /* 32 samples accumulated */
+    ADC_SAMPNUM_ACC64_gc = (0x06<<0),  /* 64 samples accumulated */
+    ADC_SAMPNUM_ACC128_gc = (0x07<<0),  /* 128 samples accumulated */
+    ADC_SAMPNUM_ACC256_gc = (0x08<<0),  /* 256 samples accumulated */
+    ADC_SAMPNUM_ACC512_gc = (0x09<<0),  /* 512 samples accumulated */
+    ADC_SAMPNUM_ACC1024_gc = (0x0A<<0)  /* 1024 samples accumulated */
+} ADC_SAMPNUM_t;
+
+/* Start command select */
+typedef enum ADC_START_enum
+{
+    ADC_START_STOP_gc = (0x00<<0),  /* Stop an ongoing conversion */
+    ADC_START_IMMEDIATE_gc = (0x01<<0),  /* Start a conversion immediately. This will be set back to STOP when the first conversion is done, unless Free-Running mode is enabled */
+    ADC_START_MUXPOS_WRITE_gc = (0x02<<0),  /* Start when MUXPOS register is written */
+    ADC_START_MUXNEG_WRITE_gc = (0x03<<0),  /* Start when MUXNEG register is written */
+    ADC_START_EVENT_TRIGGER_gc = (0x04<<0)  /* Start when an event is received */
+} ADC_START_t;
+
+/* VIA select */
+typedef enum ADC_VIA_enum
+{
+    ADC_VIA_DIRECT_gc = (0x00<<6),  /* Inputs connected directly to ADC */
+    ADC_VIA_PGA_gc = (0x01<<6)  /* Inputs connected via PGA */
+} ADC_VIA_t;
+
+/* Window Comparator Mode select */
+typedef enum ADC_WINCM_enum
+{
+    ADC_WINCM_NONE_gc = (0x00<<0),  /* No Window Comparison */
+    ADC_WINCM_BELOW_gc = (0x01<<0),  /* Below Window */
+    ADC_WINCM_ABOVE_gc = (0x02<<0),  /* Above Window */
+    ADC_WINCM_INSIDE_gc = (0x03<<0),  /* Inside Window */
+    ADC_WINCM_OUTSIDE_gc = (0x04<<0)  /* Outside Window */
+} ADC_WINCM_t;
+
+/* Window Mode Source select */
+typedef enum ADC_WINSRC_enum
+{
+    ADC_WINSRC_RESULT_gc = (0x00<<3),  /* Result register used as Window Comparator Source */
+    ADC_WINSRC_SAMPLE_gc = (0x01<<3)  /* Sample register used as Window Comparator Source */
+} ADC_WINSRC_t;
+
+/*
+--------------------------------------------------------------------------
+BOD - Bod interface
+--------------------------------------------------------------------------
+*/
+
+/* Bod interface */
+typedef struct BOD_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t reserved_1[6];
+    register8_t VLMCTRLA;  /* Voltage level monitor Control */
+    register8_t INTCTRL;  /* Voltage level monitor interrupt Control */
+    register8_t INTFLAGS;  /* Voltage level monitor interrupt Flags */
+    register8_t STATUS;  /* Voltage level monitor status */
+    register8_t reserved_2[4];
+} BOD_t;
+
+/* Operation in active mode select */
+typedef enum BOD_ACTIVE_enum
+{
+    BOD_ACTIVE_DISABLE_gc = (0x00<<2),  /* Disabled */
+    BOD_ACTIVE_ENABLED_gc = (0x01<<2),  /* Enabled in continuous mode */
+    BOD_ACTIVE_SAMPLED_gc = (0x02<<2),  /* Enabled in sampled mode */
+    BOD_ACTIVE_ENABLEWAIT_gc = (0x03<<2)  /* Enabled in continuous mode. Execution halted at wake-up until BOD is running */
+} BOD_ACTIVE_t;
+
+/* Bod level select */
+typedef enum BOD_LVL_enum
+{
+    BOD_LVL_BODLEVEL0_gc = (0x00<<0),  /* BOD Disabled during normal operation */
+    BOD_LVL_BODLEVEL1_gc = (0x01<<0),  /* 1.9 V */
+    BOD_LVL_BODLEVEL2_gc = (0x02<<0),  /* 2.7 V */
+    BOD_LVL_BODLEVEL3_gc = (0x03<<0)  /* 4.5 V */
+} BOD_LVL_t;
+
+/* Sample frequency select */
+typedef enum BOD_SAMPFREQ_enum
+{
+    BOD_SAMPFREQ_128HZ_gc = (0x00<<4),  /* Sampling frequency is 128 Hz */
+    BOD_SAMPFREQ_32HZ_gc = (0x01<<4)  /* Sample frequency is 32 Hz */
+} BOD_SAMPFREQ_t;
+
+/* Operation in sleep mode select */
+typedef enum BOD_SLEEP_enum
+{
+    BOD_SLEEP_DISABLE_gc = (0x00<<0),  /* Disabled */
+    BOD_SLEEP_ENABLE_gc = (0x01<<0),  /* Enabled in continuous mode */
+    BOD_SLEEP_SAMPLE_gc = (0x02<<0)  /* Enabled in sampled mode */
+} BOD_SLEEP_t;
+
+/* Configuration select */
+typedef enum BOD_VLMCFG_enum
+{
+    BOD_VLMCFG_FALLING_gc = (0x00<<1),  /* VDD falls below VLM threshold */
+    BOD_VLMCFG_RISING_gc = (0x01<<1),  /* VDD rises above VLM threshold */
+    BOD_VLMCFG_BOTH_gc = (0x02<<1)  /* VDD crosses VLM threshold */
+} BOD_VLMCFG_t;
+
+/* voltage level monitor level select */
+typedef enum BOD_VLMLVL_enum
+{
+    BOD_VLMLVL_OFF_gc = (0x00<<0),  /* VLM Disabled */
+    BOD_VLMLVL_5ABOVE_gc = (0x01<<0),  /* VLM threshold 5% above BOD level */
+    BOD_VLMLVL_15ABOVE_gc = (0x02<<0),  /* VLM threshold 15% above BOD level */
+    BOD_VLMLVL_25ABOVE_gc = (0x03<<0)  /* VLM threshold 25% above BOD level */
+} BOD_VLMLVL_t;
+
+/* Voltage level monitor status select */
+typedef enum BOD_VLMS_enum
+{
+    BOD_VLMS_ABOVE_gc = (0x00<<0),  /* The voltage is above the VLM threshold level */
+    BOD_VLMS_BELOW_gc = (0x01<<0)  /* The voltage is below the VLM threshold level */
+} BOD_VLMS_t;
+
+/*
+--------------------------------------------------------------------------
+CCL - Configurable Custom Logic
+--------------------------------------------------------------------------
+*/
+
+/* Configurable Custom Logic */
+typedef struct CCL_struct
+{
+    register8_t CTRLA;  /* Control Register A */
+    register8_t SEQCTRL0;  /* Sequential Control 0 */
+    register8_t SEQCTRL1;  /* Sequential Control 1 */
+    register8_t reserved_1[2];
+    register8_t INTCTRL0;  /* Interrupt Control 0 */
+    register8_t reserved_2[1];
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t LUT0CTRLA;  /* LUT 0 Control A */
+    register8_t LUT0CTRLB;  /* LUT 0 Control B */
+    register8_t LUT0CTRLC;  /* LUT 0 Control C */
+    register8_t TRUTH0;  /* Truth 0 */
+    register8_t LUT1CTRLA;  /* LUT 1 Control A */
+    register8_t LUT1CTRLB;  /* LUT 1 Control B */
+    register8_t LUT1CTRLC;  /* LUT 1 Control C */
+    register8_t TRUTH1;  /* Truth 1 */
+    register8_t LUT2CTRLA;  /* LUT 2 Control A */
+    register8_t LUT2CTRLB;  /* LUT 2 Control B */
+    register8_t LUT2CTRLC;  /* LUT 2 Control C */
+    register8_t TRUTH2;  /* Truth 2 */
+    register8_t LUT3CTRLA;  /* LUT 3 Control A */
+    register8_t LUT3CTRLB;  /* LUT 3 Control B */
+    register8_t LUT3CTRLC;  /* LUT 3 Control C */
+    register8_t TRUTH3;  /* Truth 3 */
+    register8_t reserved_3[40];
+} CCL_t;
+
+/* Clock Source Selection */
+typedef enum CCL_CLKSRC_enum
+{
+    CCL_CLKSRC_CLKPER_gc = (0x00<<1),  /* Peripheral Clock */
+    CCL_CLKSRC_IN2_gc = (0x01<<1),  /* INSEL2 selection */
+    CCL_CLKSRC_OSCHF_gc = (0x04<<1),  /* Internal High Frequency oscillator */
+    CCL_CLKSRC_OSC32K_gc = (0x05<<1),  /* Internal 32.768 kHz oscillator */
+    CCL_CLKSRC_OSC1K_gc = (0x06<<1)  /* Internal 32.768 kHz oscillator divided by 32 */
+} CCL_CLKSRC_t;
+
+/* Edge Detection Enable select */
+typedef enum CCL_EDGEDET_enum
+{
+    CCL_EDGEDET_DIS_gc = (0x00<<7),  /* Edge detector is disabled */
+    CCL_EDGEDET_EN_gc = (0x01<<7)  /* Edge detector is enabled */
+} CCL_EDGEDET_t;
+
+/* Filter Selection */
+typedef enum CCL_FILTSEL_enum
+{
+    CCL_FILTSEL_DISABLE_gc = (0x00<<4),  /* Filter disabled */
+    CCL_FILTSEL_SYNCH_gc = (0x01<<4),  /* Synchronizer enabled */
+    CCL_FILTSEL_FILTER_gc = (0x02<<4)  /* Filter enabled */
+} CCL_FILTSEL_t;
+
+/* LUT Input 0 Source Selection */
+typedef enum CCL_INSEL0_enum
+{
+    CCL_INSEL0_MASK_gc = (0x00<<0),  /* Masked input */
+    CCL_INSEL0_FEEDBACK_gc = (0x01<<0),  /* Feedback input */
+    CCL_INSEL0_LINK_gc = (0x02<<0),  /* Output from LUT[n+1] as input source */
+    CCL_INSEL0_EVENTA_gc = (0x03<<0),  /* Event A as input source */
+    CCL_INSEL0_EVENTB_gc = (0x04<<0),  /* Event B as input source */
+    CCL_INSEL0_IO_gc = (0x05<<0),  /* IN0 input source */
+    CCL_INSEL0_AC0_gc = (0x06<<0),  /* AC0 output input source */
+    CCL_INSEL0_USART0_gc = (0x07<<0),  /* USART0 TxD input source */
+    CCL_INSEL0_SPI0_gc = (0x08<<0),  /* SPI0 MISO input source */
+    CCL_INSEL0_TCA0_gc = (0x09<<0),  /* TCA0 WO0 input source */
+    CCL_INSEL0_TCA1_gc = (0x0A<<0),  /* TCA1 WO0 input source */
+    CCL_INSEL0_TCB0_gc = (0x0B<<0)  /* TCB0 WO input source */
+} CCL_INSEL0_t;
+
+/* LUT Input 1 Source Selection */
+typedef enum CCL_INSEL1_enum
+{
+    CCL_INSEL1_MASK_gc = (0x00<<4),  /* Masked input */
+    CCL_INSEL1_FEEDBACK_gc = (0x01<<4),  /* Feedback input */
+    CCL_INSEL1_LINK_gc = (0x02<<4),  /* Output from LUT[n+1] as input source */
+    CCL_INSEL1_EVENTA_gc = (0x03<<4),  /* Event A as input source */
+    CCL_INSEL1_EVENTB_gc = (0x04<<4),  /* Event B as input source */
+    CCL_INSEL1_IO_gc = (0x05<<4),  /* IN0 input source */
+    CCL_INSEL1_AC1_gc = (0x06<<4),  /* AC1 output input source */
+    CCL_INSEL1_USART1_gc = (0x07<<4),  /* USART1 TxD input source */
+    CCL_INSEL1_SPI0_gc = (0x08<<4),  /* SPI0 MISO input source */
+    CCL_INSEL1_TCA0_gc = (0x09<<4),  /* TCA0 WO1 input source */
+    CCL_INSEL1_TCA1_gc = (0x0A<<4),  /* TCA1 WO1 input source */
+    CCL_INSEL1_TCB1_gc = (0x0B<<4)  /* TCB1 WO input source */
+} CCL_INSEL1_t;
+
+/* LUT Input 2 Source Selection */
+typedef enum CCL_INSEL2_enum
+{
+    CCL_INSEL2_MASK_gc = (0x00<<0),  /* Masked input */
+    CCL_INSEL2_FEEDBACK_gc = (0x01<<0),  /* Feedback input */
+    CCL_INSEL2_LINK_gc = (0x02<<0),  /* Output from LUT[n+1] as input source */
+    CCL_INSEL2_EVENTA_gc = (0x03<<0),  /* Event A as input source */
+    CCL_INSEL2_EVENTB_gc = (0x04<<0),  /* Event B as input source */
+    CCL_INSEL2_IO_gc = (0x05<<0),  /* IN0 input source */
+    CCL_INSEL2_AC1_gc = (0x06<<0),  /* AC1 output input source */
+    CCL_INSEL2_USART2_gc = (0x07<<0),  /* USART2 TxD input source */
+    CCL_INSEL2_SPI0_gc = (0x08<<0),  /* SPI0 MISO input source */
+    CCL_INSEL2_TCA0_gc = (0x09<<0),  /* TCA0 WO2 input source */
+    CCL_INSEL2_TCA1_gc = (0x0A<<0),  /* TCA1 WO2 input source */
+    CCL_INSEL2_TCB2_gc = (0x0B<<0)  /* TCB2 WO input source */
+} CCL_INSEL2_t;
+
+/* Interrupt Mode for LUT0 select */
+typedef enum CCL_INTMODE0_enum
+{
+    CCL_INTMODE0_INTDISABLE_gc = (0x00<<0),  /* Interrupt disabled */
+    CCL_INTMODE0_RISING_gc = (0x01<<0),  /* Sense rising edge */
+    CCL_INTMODE0_FALLING_gc = (0x02<<0),  /* Sense falling edge */
+    CCL_INTMODE0_BOTH_gc = (0x03<<0)  /* Sense both edges */
+} CCL_INTMODE0_t;
+
+/* Interrupt Mode for LUT1 select */
+typedef enum CCL_INTMODE1_enum
+{
+    CCL_INTMODE1_INTDISABLE_gc = (0x00<<2),  /* Interrupt disabled */
+    CCL_INTMODE1_RISING_gc = (0x01<<2),  /* Sense rising edge */
+    CCL_INTMODE1_FALLING_gc = (0x02<<2),  /* Sense falling edge */
+    CCL_INTMODE1_BOTH_gc = (0x03<<2)  /* Sense both edges */
+} CCL_INTMODE1_t;
+
+/* Interrupt Mode for LUT2 select */
+typedef enum CCL_INTMODE2_enum
+{
+    CCL_INTMODE2_INTDISABLE_gc = (0x00<<4),  /* Interrupt disabled */
+    CCL_INTMODE2_RISING_gc = (0x01<<4),  /* Sense rising edge */
+    CCL_INTMODE2_FALLING_gc = (0x02<<4),  /* Sense falling edge */
+    CCL_INTMODE2_BOTH_gc = (0x03<<4)  /* Sense both edges */
+} CCL_INTMODE2_t;
+
+/* Interrupt Mode for LUT3 select */
+typedef enum CCL_INTMODE3_enum
+{
+    CCL_INTMODE3_INTDISABLE_gc = (0x00<<6),  /* Interrupt disabled */
+    CCL_INTMODE3_RISING_gc = (0x01<<6),  /* Sense rising edge */
+    CCL_INTMODE3_FALLING_gc = (0x02<<6),  /* Sense falling edge */
+    CCL_INTMODE3_BOTH_gc = (0x03<<6)  /* Sense both edges */
+} CCL_INTMODE3_t;
+
+/* Sequential Selection */
+typedef enum CCL_SEQSEL_enum
+{
+    CCL_SEQSEL_DISABLE_gc = (0x00<<0),  /* Sequential logic disabled */
+    CCL_SEQSEL_DFF_gc = (0x01<<0),  /* D FlipFlop */
+    CCL_SEQSEL_JK_gc = (0x02<<0),  /* JK FlipFlop */
+    CCL_SEQSEL_LATCH_gc = (0x03<<0),  /* D Latch */
+    CCL_SEQSEL_RS_gc = (0x04<<0)  /* RS Latch */
+} CCL_SEQSEL_t;
+
+/*
+--------------------------------------------------------------------------
+CLKCTRL - Clock controller
+--------------------------------------------------------------------------
+*/
+
+/* Clock controller */
+typedef struct CLKCTRL_struct
+{
+    register8_t MCLKCTRLA;  /* MCLK Control A */
+    register8_t MCLKCTRLB;  /* MCLK Control B */
+    register8_t MCLKCTRLC;  /* MCLK Control C */
+    register8_t MCLKINTCTRL;  /* MCLK Interrupt Control */
+    register8_t MCLKINTFLAGS;  /* MCLK Interrupt Flags */
+    register8_t MCLKSTATUS;  /* MCLK Status */
+    register8_t MCLKTIMEBASE;  /* MCLK Timebase */
+    register8_t reserved_1[1];
+    register8_t OSCHFCTRLA;  /* OSCHF Control A */
+    register8_t OSCHFTUNE;  /* OSCHF Tune */
+    register8_t reserved_2[14];
+    register8_t OSC32KCTRLA;  /* OSC32K Control A */
+    register8_t reserved_3[3];
+    register8_t XOSC32KCTRLA;  /* XOSC32K Control A */
+    register8_t reserved_4[3];
+    register8_t XOSCHFCTRLA;  /* XOSCHF Control A */
+} CLKCTRL_t;
+
+/* Automatic Oscillator Tune select */
+typedef enum CLKCTRL_AUTOTUNE_enum
+{
+    CLKCTRL_AUTOTUNE_OFF_gc = (0x00<<0),  /* Disabled */
+    CLKCTRL_AUTOTUNE_XOSC32K_gc = (0x01<<0)  /* Tune against 32.768 kHz Crystal Oscillator */
+} CLKCTRL_AUTOTUNE_t;
+
+/* CFD Source select */
+typedef enum CLKCTRL_CFDSRC_enum
+{
+    CLKCTRL_CFDSRC_CLKMAIN_gc = (0x00<<2),  /* Main Clock */
+    CLKCTRL_CFDSRC_XOSCHF_gc = (0x01<<2),  /* High Frequency Crystal Oscillator */
+    CLKCTRL_CFDSRC_XOSC32K_gc = (0x02<<2)  /* 32.768 kHz Crystal Oscillator */
+} CLKCTRL_CFDSRC_t;
+
+/* Clock select */
+typedef enum CLKCTRL_CLKSEL_enum
+{
+    CLKCTRL_CLKSEL_OSCHF_gc = (0x00<<0),  /* Internal high-frequency oscillator */
+    CLKCTRL_CLKSEL_OSC32K_gc = (0x01<<0),  /* Internal 32.768 kHz oscillator */
+    CLKCTRL_CLKSEL_XOSC32K_gc = (0x02<<0),  /* 32.768 kHz crystal oscillator */
+    CLKCTRL_CLKSEL_EXTCLK_gc = (0x03<<0)  /* External clock */
+} CLKCTRL_CLKSEL_t;
+
+/* Crystal startup time select */
+typedef enum CLKCTRL_CSUT_enum
+{
+    CLKCTRL_CSUT_1K_gc = (0x00<<4),  /* 1k cycles */
+    CLKCTRL_CSUT_16K_gc = (0x01<<4),  /* 16k cycles */
+    CLKCTRL_CSUT_32K_gc = (0x02<<4),  /* 32k cycles */
+    CLKCTRL_CSUT_64K_gc = (0x03<<4)  /* 64k cycles */
+} CLKCTRL_CSUT_t;
+
+/* Start-Up Time select */
+typedef enum CLKCTRL_CSUTHF_enum
+{
+    CLKCTRL_CSUTHF_256CYC_gc = (0x00<<4),  /* 256 XOSCHF Cycles */
+    CLKCTRL_CSUTHF_1KCYC_gc = (0x01<<4),  /* 1K XOSCHF Cycles */
+    CLKCTRL_CSUTHF_4KCYC_gc = (0x02<<4)  /* 4K XOSCHF Cycles */
+} CLKCTRL_CSUTHF_t;
+
+/* Interrupt Type select */
+typedef enum CLKCTRL_INTTYPE_enum
+{
+    CLKCTRL_INTTYPE_INT_gc = (0x00<<7),  /* Regular interrupt */
+    CLKCTRL_INTTYPE_NMI_gc = (0x01<<7)  /* Non-maskable interrupt */
+} CLKCTRL_INTTYPE_t;
+
+/* Prescaler division select */
+typedef enum CLKCTRL_PDIV_enum
+{
+    CLKCTRL_PDIV_DIV2_gc = (0x00<<1),  /* Divide by 2 */
+    CLKCTRL_PDIV_DIV4_gc = (0x01<<1),  /* Divide by 4 */
+    CLKCTRL_PDIV_DIV8_gc = (0x02<<1),  /* Divide by 8 */
+    CLKCTRL_PDIV_DIV16_gc = (0x03<<1),  /* Divide by 16 */
+    CLKCTRL_PDIV_DIV32_gc = (0x04<<1),  /* Divide by 32 */
+    CLKCTRL_PDIV_DIV64_gc = (0x05<<1),  /* Divide by 64 */
+    CLKCTRL_PDIV_DIV6_gc = (0x08<<1),  /* Divide by 6 */
+    CLKCTRL_PDIV_DIV10_gc = (0x09<<1),  /* Divide by 10 */
+    CLKCTRL_PDIV_DIV12_gc = (0x0A<<1),  /* Divide by 12 */
+    CLKCTRL_PDIV_DIV24_gc = (0x0B<<1),  /* Divide by 24 */
+    CLKCTRL_PDIV_DIV48_gc = (0x0C<<1)  /* Divide by 48 */
+} CLKCTRL_PDIV_t;
+
+/* Source Select */
+typedef enum CLKCTRL_SELHF_enum
+{
+    CLKCTRL_SELHF_CRYSTAL_gc = (0x00<<1),  /* External Crystal */
+    CLKCTRL_SELHF_EXTCLK_gc = (0x01<<1)  /* Extenal Clock on XTALHF1 pin */
+} CLKCTRL_SELHF_t;
+
+/*
+--------------------------------------------------------------------------
+CPU - CPU
+--------------------------------------------------------------------------
+*/
+
+#define CORE_VERSION  V4S
+
+/* CCP signature select */
+typedef enum CCP_enum
+{
+    CCP_SPM_gc = (0x9D<<0),  /* SPM Instruction Protection */
+    CCP_IOREG_gc = (0xD8<<0)  /* IO Register Protection */
+} CCP_t;
+
+/*
+--------------------------------------------------------------------------
+CPUINT - Interrupt Controller
+--------------------------------------------------------------------------
+*/
+
+/* Interrupt Controller */
+typedef struct CPUINT_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t STATUS;  /* Status */
+    register8_t LVL0PRI;  /* Interrupt Level 0 Priority */
+    register8_t LVL1VEC;  /* Interrupt Level 1 Priority Vector */
+} CPUINT_t;
+
+
+/*
+--------------------------------------------------------------------------
+CRCSCAN - CRCSCAN
+--------------------------------------------------------------------------
+*/
+
+/* CRCSCAN */
+typedef struct CRCSCAN_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t STATUS;  /* Status */
+    register8_t reserved_1[13];
+} CRCSCAN_t;
+
+/* CRC Source select */
+typedef enum CRCSCAN_SRC_enum
+{
+    CRCSCAN_SRC_FLASH_gc = (0x00<<0),  /* CRC on entire flash */
+    CRCSCAN_SRC_APPLICATION_gc = (0x01<<0),  /* CRC on boot and appl section of flash */
+    CRCSCAN_SRC_BOOT_gc = (0x02<<0)  /* CRC on boot section of flash */
+} CRCSCAN_SRC_t;
+
+/*
+--------------------------------------------------------------------------
+DAC - Digital to Analog Converter
+--------------------------------------------------------------------------
+*/
+
+/* Digital to Analog Converter */
+typedef struct DAC_struct
+{
+    register8_t CTRLA;  /* Control Register A */
+    register8_t reserved_1[1];
+    _WORDREGISTER(DATA);  /* DATA Register */
+    register8_t reserved_2[12];
+} DAC_t;
+
+/* Output Buffer Range select */
+typedef enum DAC_OUTRANGE_enum
+{
+    DAC_OUTRANGE_AUTO_gc = (0x00<<4),  /* Output buffer automatically choose best range */
+    DAC_OUTRANGE_LOW_gc = (0x02<<4),  /* Output buffer configured to low range */
+    DAC_OUTRANGE_HIGH_gc = (0x03<<4)  /* Output buffer configured to high range */
+} DAC_OUTRANGE_t;
+
+/*
+--------------------------------------------------------------------------
+EVSYS - Event System
+--------------------------------------------------------------------------
+*/
+
+/* Event System */
+typedef struct EVSYS_struct
+{
+    register8_t SWEVENTA;  /* Software Event A */
+    register8_t reserved_1[15];
+    register8_t CHANNEL0;  /* Multiplexer Channel 0 */
+    register8_t CHANNEL1;  /* Multiplexer Channel 1 */
+    register8_t CHANNEL2;  /* Multiplexer Channel 2 */
+    register8_t CHANNEL3;  /* Multiplexer Channel 3 */
+    register8_t CHANNEL4;  /* Multiplexer Channel 4 */
+    register8_t CHANNEL5;  /* Multiplexer Channel 5 */
+    register8_t reserved_2[10];
+    register8_t USERCCLLUT0A;  /* CCL0 Event A */
+    register8_t USERCCLLUT0B;  /* CCL0 Event B */
+    register8_t USERCCLLUT1A;  /* CCL1 Event A */
+    register8_t USERCCLLUT1B;  /* CCL1 Event B */
+    register8_t USERCCLLUT2A;  /* CCL2 Event A */
+    register8_t USERCCLLUT2B;  /* CCL2 Event B */
+    register8_t USERCCLLUT3A;  /* CCL3 Event A */
+    register8_t USERCCLLUT3B;  /* CCL3 Event B */
+    register8_t USERADC0START;  /* ADC0 */
+    register8_t USEREVSYSEVOUTA;  /* EVOUTA */
+    register8_t reserved_3[1];
+    register8_t USEREVSYSEVOUTC;  /* EVOUTC */
+    register8_t USEREVSYSEVOUTD;  /* EVOUTD */
+    register8_t reserved_4[1];
+    register8_t USEREVSYSEVOUTF;  /* EVOUTF */
+    register8_t USERUSART0IRDA;  /* USART0 */
+    register8_t USERUSART1IRDA;  /* USART1 */
+    register8_t USERUSART2IRDA;  /* USART2 */
+    register8_t USERTCA0CNTA;  /* TCA0 Event A */
+    register8_t USERTCA0CNTB;  /* TCA0 Event B */
+    register8_t USERTCA1CNTA;  /* TCA1 Event A */
+    register8_t USERTCA1CNTB;  /* TCA1 Event B */
+    register8_t USERTCB0CAPT;  /* TCB0 Event A */
+    register8_t USERTCB0COUNT;  /* TCB0 Event B */
+    register8_t USERTCB1CAPT;  /* TCB1 Event A */
+    register8_t USERTCB1COUNT;  /* TCB1 Event B */
+    register8_t USERTCB2CAPT;  /* TCB2 Event A */
+    register8_t USERTCB2COUNT;  /* TCB2 Event B */
+    register8_t USERTCB3CAPT;  /* TCB3 Event A */
+    register8_t USERTCB3COUNT;  /* TCB3 Event B */
+    register8_t reserved_5[2];
+} EVSYS_t;
+
+/* Channel generator select */
+typedef enum EVSYS_CHANNEL_enum
+{
+    EVSYS_CHANNEL_OFF_gc = (0x00<<0),  /* Off */
+    EVSYS_CHANNEL_UPDI_SYNCH_gc = (0x01<<0),  /* UPDI SYNCH character */
+    EVSYS_CHANNEL_RTC_OVF_gc = (0x06<<0),  /* Real Time Counter overflow */
+    EVSYS_CHANNEL_RTC_CMP_gc = (0x07<<0),  /* Real Time Counter compare */
+    EVSYS_CHANNEL_RTC_PITEV0_gc = (0x08<<0),  /* Periodic Interrupt Timer Event 0 */
+    EVSYS_CHANNEL_RTC_PITEV1_gc = (0x09<<0),  /* Periodic Interrupt Timer Event 1 */
+    EVSYS_CHANNEL_CCL_LUT0_gc = (0x10<<0),  /* Configurable Custom Logic LUT0 */
+    EVSYS_CHANNEL_CCL_LUT1_gc = (0x11<<0),  /* Configurable Custom Logic LUT1 */
+    EVSYS_CHANNEL_CCL_LUT2_gc = (0x12<<0),  /* Configurable Custom Logic LUT2 */
+    EVSYS_CHANNEL_CCL_LUT3_gc = (0x13<<0),  /* Configurable Custom Logic LUT3 */
+    EVSYS_CHANNEL_AC0_OUT_gc = (0x20<<0),  /* Analog Comparator 0 out */
+    EVSYS_CHANNEL_AC1_OUT_gc = (0x21<<0),  /* Analog Comparator 1 out */
+    EVSYS_CHANNEL_ADC0_RES_gc = (0x24<<0),  /* ADC 0 Result Ready */
+    EVSYS_CHANNEL_ADC0_SAMP_gc = (0x25<<0),  /* ADC 0 Sample Ready */
+    EVSYS_CHANNEL_ADC0_WCMP_gc = (0x26<<0),  /* ADC 0 Window Compare */
+    EVSYS_CHANNEL_PORTA_EV0_gc = (0x40<<0),  /* Port A Event 0 */
+    EVSYS_CHANNEL_PORTA_EV1_gc = (0x41<<0),  /* Port A Event 1 */
+    EVSYS_CHANNEL_PORTC_EV0_gc = (0x44<<0),  /* Port C Event 0 */
+    EVSYS_CHANNEL_PORTC_EV1_gc = (0x45<<0),  /* Port C Event 1 */
+    EVSYS_CHANNEL_PORTD_EV0_gc = (0x46<<0),  /* Port D Event 0 */
+    EVSYS_CHANNEL_PORTD_EV1_gc = (0x47<<0),  /* Port D Event 1 */
+    EVSYS_CHANNEL_PORTF_EV0_gc = (0x4A<<0),  /* Port F Event 0 */
+    EVSYS_CHANNEL_PORTF_EV1_gc = (0x4B<<0),  /* Port F Event 1 */
+    EVSYS_CHANNEL_USART0_XCK_gc = (0x60<<0),  /* USART 0 XCK */
+    EVSYS_CHANNEL_USART1_XCK_gc = (0x61<<0),  /* USART 1 XCK */
+    EVSYS_CHANNEL_USART2_XCK_gc = (0x62<<0),  /* USART 2 XCK */
+    EVSYS_CHANNEL_SPI0_SCK_gc = (0x68<<0),  /* SPI 0 SCK */
+    EVSYS_CHANNEL_TCA0_OVF_LUNF_gc = (0x80<<0),  /* Timer/Counter A0 overflow / low byte timer underflow */
+    EVSYS_CHANNEL_TCA0_HUNF_gc = (0x81<<0),  /* Timer/Counter A0 high byte timer underflow */
+    EVSYS_CHANNEL_TCA0_CMP0_LCMP0_gc = (0x84<<0),  /* Timer/Counter A0 compare 0 / low byte timer compare 0 */
+    EVSYS_CHANNEL_TCA0_CMP1_LCMP1_gc = (0x85<<0),  /* Timer/Counter A0 compare 1 / low byte timer compare 1 */
+    EVSYS_CHANNEL_TCA0_CMP2_LCMP2_gc = (0x86<<0),  /* Timer/Counter A0 compare 2 / low byte timer compare 2 */
+    EVSYS_CHANNEL_TCA1_OVF_LUNF_gc = (0x88<<0),  /* Timer/Counter A1 overflow / low byte timer underflow */
+    EVSYS_CHANNEL_TCA1_HUNF_gc = (0x89<<0),  /* Timer/Counter A1 high byte timer underflow */
+    EVSYS_CHANNEL_TCA1_CMP0_LCMP0_gc = (0x8C<<0),  /* Timer/Counter A1 compare 0 / low byte timer compare 0 */
+    EVSYS_CHANNEL_TCA1_CMP1_LCMP1_gc = (0x8D<<0),  /* Timer/Counter A1 compare 1 / low byte timer compare 1 */
+    EVSYS_CHANNEL_TCA1_CMP2_LCMP2_gc = (0x8E<<0),  /* Timer/Counter A1 compare 2 / low byte timer compare 2 */
+    EVSYS_CHANNEL_TCB0_CAPT_gc = (0xA0<<0),  /* Timer/Counter B0 capture */
+    EVSYS_CHANNEL_TCB0_OVF_gc = (0xA1<<0),  /* Timer/Counter B0 overflow */
+    EVSYS_CHANNEL_TCB1_CAPT_gc = (0xA2<<0),  /* Timer/Counter B1 capture */
+    EVSYS_CHANNEL_TCB1_OVF_gc = (0xA3<<0),  /* Timer/Counter B1 overflow */
+    EVSYS_CHANNEL_TCB2_CAPT_gc = (0xA4<<0),  /* Timer/Counter B2 capture */
+    EVSYS_CHANNEL_TCB2_OVF_gc = (0xA5<<0),  /* Timer/Counter B2 overflow */
+    EVSYS_CHANNEL_TCB3_CAPT_gc = (0xA6<<0),  /* Timer/Counter B3 capture */
+    EVSYS_CHANNEL_TCB3_OVF_gc = (0xA7<<0)  /* Timer/Counter B3 overflow */
+} EVSYS_CHANNEL_t;
+
+/* Software event on channel select */
+typedef enum EVSYS_SWEVENTA_enum
+{
+    EVSYS_SWEVENTA_CH0_gc = (0x01<<0),  /* Software event on channel 0 */
+    EVSYS_SWEVENTA_CH1_gc = (0x02<<0),  /* Software event on channel 1 */
+    EVSYS_SWEVENTA_CH2_gc = (0x04<<0),  /* Software event on channel 2 */
+    EVSYS_SWEVENTA_CH3_gc = (0x08<<0),  /* Software event on channel 3 */
+    EVSYS_SWEVENTA_CH4_gc = (0x10<<0),  /* Software event on channel 4 */
+    EVSYS_SWEVENTA_CH5_gc = (0x20<<0),  /* Software event on channel 5 */
+    EVSYS_SWEVENTA_CH6_gc = (0x40<<0),  /* Software event on channel 6 */
+    EVSYS_SWEVENTA_CH7_gc = (0x80<<0)  /* Software event on channel 7 */
+} EVSYS_SWEVENTA_t;
+
+/* User channel select */
+typedef enum EVSYS_USER_enum
+{
+    EVSYS_USER_OFF_gc = (0x00<<0),  /* Off, No Eventsys Channel connected */
+    EVSYS_USER_CHANNEL0_gc = (0x01<<0),  /* Connect user to event channel 0 */
+    EVSYS_USER_CHANNEL1_gc = (0x02<<0),  /* Connect user to event channel 1 */
+    EVSYS_USER_CHANNEL2_gc = (0x03<<0),  /* Connect user to event channel 2 */
+    EVSYS_USER_CHANNEL3_gc = (0x04<<0),  /* Connect user to event channel 3 */
+    EVSYS_USER_CHANNEL4_gc = (0x05<<0),  /* Connect user to event channel 4 */
+    EVSYS_USER_CHANNEL5_gc = (0x06<<0)  /* Connect user to event channel 5 */
+} EVSYS_USER_t;
+
+/*
+--------------------------------------------------------------------------
+FUSE - Fuses
+--------------------------------------------------------------------------
+*/
+
+/* Fuses */
+typedef struct FUSE_struct
+{
+    register8_t WDTCFG;  /* Watchdog Configuration */
+    register8_t BODCFG;  /* BOD Configuration */
+    register8_t OSCCFG;  /* Oscillator Configuration */
+    register8_t reserved_1[2];
+    register8_t SYSCFG0;  /* System Configuration 0 */
+    register8_t SYSCFG1;  /* System Configuration 1 */
+    register8_t CODESIZE;  /* Code Section Size */
+    register8_t BOOTSIZE;  /* Boot Section Size */
+} FUSE_t;
+
+/* avr-libc typedef for avr/fuse.h */
+typedef FUSE_t NVM_FUSES_t;
+
+/* BOD Operation in Active Mode select */
+typedef enum ACTIVE_enum
+{
+    ACTIVE_DISABLE_gc = (0x00<<2),  /* Disabled */
+    ACTIVE_ENABLED_gc = (0x01<<2),  /* Enabled in continuous mode */
+    ACTIVE_SAMPLED_gc = (0x02<<2),  /* Enabled in sampled mode */
+    ACTIVE_ENABLEWAIT_gc = (0x03<<2)  /* Enabled in continuous mode. Execution halted at wake-up until BOD is running */
+} ACTIVE_t;
+
+/* CRC Select */
+typedef enum CRCSEL_enum
+{
+    CRCSEL_CRC16_gc = (0x00<<5),  /* Enable CRC16 */
+    CRCSEL_CRC32_gc = (0x01<<5)  /* Enable CRC32 */
+} CRCSEL_t;
+
+/* CRC Source select */
+typedef enum CRCSRC_enum
+{
+    CRCSRC_FLASH_gc = (0x00<<6),  /* CRC of full Flash (boot, application code and application data) */
+    CRCSRC_BOOT_gc = (0x01<<6),  /* CRC of boot section */
+    CRCSRC_BOOTAPP_gc = (0x02<<6),  /* CRC of application code and boot sections */
+    CRCSRC_NOCRC_gc = (0x03<<6)  /* No CRC */
+} CRCSRC_t;
+
+/* EEPROM Save select */
+typedef enum EESAVE_enum
+{
+    EESAVE_DISABLE_gc = (0x00<<0),  /* EEPROM content is erased during chip erase */
+    EESAVE_ENABLE_gc = (0x01<<0)  /* EEPROM content is preserved during chip erase */
+} EESAVE_t;
+
+/* BOD Level select */
+typedef enum LVL_enum
+{
+    LVL_BODLEVEL0_gc = (0x00<<5),  /* BOD Disabled during normal operation */
+    LVL_BODLEVEL1_gc = (0x01<<5),  /* 1.9 V */
+    LVL_BODLEVEL2_gc = (0x02<<5),  /* 2.7 V */
+    LVL_BODLEVEL3_gc = (0x03<<5)  /* 4.5 V */
+} LVL_t;
+
+/* High-frequency Oscillator Frequency select */
+typedef enum OSCHFFRQ_enum
+{
+    OSCHFFRQ_20M_gc = (0x00<<3),  /* OSCHF running at 20 MHz */
+    OSCHFFRQ_16M_gc = (0x01<<3)  /* OSCHF running at 16 MHz */
+} OSCHFFRQ_t;
+
+/* Watchdog Timeout Period select */
+typedef enum PERIOD_enum
+{
+    PERIOD_OFF_gc = (0x00<<0),  /* Watch-Dog timer Off */
+    PERIOD_8CLK_gc = (0x01<<0),  /* 8 cycles (8ms) */
+    PERIOD_16CLK_gc = (0x02<<0),  /* 16 cycles (16ms) */
+    PERIOD_32CLK_gc = (0x03<<0),  /* 32 cycles (32ms) */
+    PERIOD_64CLK_gc = (0x04<<0),  /* 64 cycles (64ms) */
+    PERIOD_128CLK_gc = (0x05<<0),  /* 128 cycles (0.128s) */
+    PERIOD_256CLK_gc = (0x06<<0),  /* 256 cycles (0.256s) */
+    PERIOD_512CLK_gc = (0x07<<0),  /* 512 cycles (0.512s) */
+    PERIOD_1KCLK_gc = (0x08<<0),  /* 1K cycles (1.0s) */
+    PERIOD_2KCLK_gc = (0x09<<0),  /* 2K cycles (2.0s) */
+    PERIOD_4KCLK_gc = (0x0A<<0),  /* 4K cycles (4.0s) */
+    PERIOD_8KCLK_gc = (0x0B<<0)  /* 8K cycles (8.0s) */
+} PERIOD_t;
+
+/* Reset Pin Configuration select */
+typedef enum RSTPINCFG_enum
+{
+    RSTPINCFG_NONE_gc = (0x00<<3),  /* No External Reset */
+    RSTPINCFG_RESET_gc = (0x01<<3)  /* PF6 configured as RESET pin */
+} RSTPINCFG_t;
+
+/* BOD Sample Frequency select */
+typedef enum SAMPFREQ_enum
+{
+    SAMPFREQ_128HZ_gc = (0x00<<4),  /* Sampling frequency is 128 Hz */
+    SAMPFREQ_32HZ_gc = (0x01<<4)  /* Sample frequency is 32 Hz */
+} SAMPFREQ_t;
+
+/* BOD Operation in Sleep Mode select */
+typedef enum SLEEP_enum
+{
+    SLEEP_DISABLE_gc = (0x00<<0),  /* Disabled */
+    SLEEP_ENABLE_gc = (0x01<<0),  /* Enabled in continuous mode */
+    SLEEP_SAMPLE_gc = (0x02<<0)  /* Enabled in sampled mode */
+} SLEEP_t;
+
+/* Startup Time select */
+typedef enum SUT_enum
+{
+    SUT_0MS_gc = (0x00<<0),  /* 0 ms */
+    SUT_1MS_gc = (0x01<<0),  /* 1 ms */
+    SUT_2MS_gc = (0x02<<0),  /* 2 ms */
+    SUT_4MS_gc = (0x03<<0),  /* 4 ms */
+    SUT_8MS_gc = (0x04<<0),  /* 8 ms */
+    SUT_16MS_gc = (0x05<<0),  /* 16 ms */
+    SUT_32MS_gc = (0x06<<0),  /* 32 ms */
+    SUT_64MS_gc = (0x07<<0)  /* 64 ms */
+} SUT_t;
+
+/* UPDI Pin Configuration select */
+typedef enum UPDIPINCFG_enum
+{
+    UPDIPINCFG_GPIO_gc = (0x00<<4),  /* PF7 Configured as GPIO pin */
+    UPDIPINCFG_UPDI_gc = (0x01<<4)  /* PF7 Configured as UPDI pin */
+} UPDIPINCFG_t;
+
+/* Watchdog Window Timeout Period select */
+typedef enum WINDOW_enum
+{
+    WINDOW_OFF_gc = (0x00<<4),  /* Window mode off */
+    WINDOW_8CLK_gc = (0x01<<4),  /* 8 cycles (8ms) */
+    WINDOW_16CLK_gc = (0x02<<4),  /* 16 cycles (16ms) */
+    WINDOW_32CLK_gc = (0x03<<4),  /* 32 cycles (32ms) */
+    WINDOW_64CLK_gc = (0x04<<4),  /* 64 cycles (64ms) */
+    WINDOW_128CLK_gc = (0x05<<4),  /* 128 cycles (0.128s) */
+    WINDOW_256CLK_gc = (0x06<<4),  /* 256 cycles (0.256s) */
+    WINDOW_512CLK_gc = (0x07<<4),  /* 512 cycles (0.512s) */
+    WINDOW_1KCLK_gc = (0x08<<4),  /* 1K cycles (1.0s) */
+    WINDOW_2KCLK_gc = (0x09<<4),  /* 2K cycles (2.0s) */
+    WINDOW_4KCLK_gc = (0x0A<<4),  /* 4K cycles (4.0s) */
+    WINDOW_8KCLK_gc = (0x0B<<4)  /* 8K cycles (8.0s) */
+} WINDOW_t;
+
+/*
+--------------------------------------------------------------------------
+GPR - General Purpose Registers
+--------------------------------------------------------------------------
+*/
+
+/* General Purpose Registers */
+typedef struct GPR_struct
+{
+    register8_t GPR0;  /* General Purpose Register 0 */
+    register8_t GPR1;  /* General Purpose Register 1 */
+    register8_t GPR2;  /* General Purpose Register 2 */
+    register8_t GPR3;  /* General Purpose Register 3 */
+} GPR_t;
+
+
+/*
+--------------------------------------------------------------------------
+LOCK - Lockbits
+--------------------------------------------------------------------------
+*/
+
+/* Lockbits */
+typedef struct LOCK_struct
+{
+    _DWORDREGISTER(KEY);  /* Lock Key Bits */
+} LOCK_t;
+
+/* Lock Key select */
+typedef enum LOCK_KEY_enum
+{
+    LOCK_KEY_NOLOCK_gc = (0x5CC5C55C<<0),  /* No locks */
+    LOCK_KEY_RWLOCK_gc = (0xA33A3AA3<<0)  /* Read and write lock */
+} LOCK_KEY_t;
+
+/*
+--------------------------------------------------------------------------
+NVMCTRL - Non-volatile Memory Controller
+--------------------------------------------------------------------------
+*/
+
+/* Non-volatile Memory Controller */
+typedef struct NVMCTRL_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t reserved_1[2];
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t STATUS;  /* Status */
+    register8_t reserved_2[1];
+    _WORDREGISTER(DATA);  /* Data */
+    register8_t reserved_3[2];
+    _DWORDREGISTER(ADDR);  /* Address */
+    register8_t reserved_4[48];
+} NVMCTRL_t;
+
+/* Command select */
+typedef enum NVMCTRL_CMD_enum
+{
+    NVMCTRL_CMD_NOCMD_gc = (0x00<<0),  /* No Command */
+    NVMCTRL_CMD_NOOP_gc = (0x01<<0),  /* No Operation */
+    NVMCTRL_CMD_FLPW_gc = (0x04<<0),  /* Flash Page Write */
+    NVMCTRL_CMD_FLPERW_gc = (0x05<<0),  /* Flash Page Erase and Write */
+    NVMCTRL_CMD_FLPER_gc = (0x08<<0),  /* Flash Page Erase */
+    NVMCTRL_CMD_FLMPER2_gc = (0x09<<0),  /* Flash 2-page erase enable */
+    NVMCTRL_CMD_FLMPER4_gc = (0x0A<<0),  /* Flash 4-page erase enable */
+    NVMCTRL_CMD_FLMPER8_gc = (0x0B<<0),  /* Flash 8-page erase enable */
+    NVMCTRL_CMD_FLMPER16_gc = (0x0C<<0),  /* Flash 16-page erase enable */
+    NVMCTRL_CMD_FLMPER32_gc = (0x0D<<0),  /* Flash 32-page erase enable */
+    NVMCTRL_CMD_FLPBCLR_gc = (0x0F<<0),  /* Flash Page Buffer Clear */
+    NVMCTRL_CMD_EEPW_gc = (0x14<<0),  /* EEPROM Page Write */
+    NVMCTRL_CMD_EEPERW_gc = (0x15<<0),  /* EEPROM Page Erase and Write */
+    NVMCTRL_CMD_EEPER_gc = (0x17<<0),  /* EEPROM Page Erase */
+    NVMCTRL_CMD_EEPBCLR_gc = (0x1F<<0),  /* EEPROM Page Buffer Clear */
+    NVMCTRL_CMD_CHER_gc = (0x20<<0),  /* Chip Erase Command (UPDI only) */
+    NVMCTRL_CMD_EECHER_gc = (0x30<<0)  /* EEPROM Erase Command (UPDI only) */
+} NVMCTRL_CMD_t;
+
+/* Write error select */
+typedef enum NVMCTRL_ERROR_enum
+{
+    NVMCTRL_ERROR_NOERROR_gc = (0x00<<4),  /* No Error */
+    NVMCTRL_ERROR_WRITEPROTECT_gc = (0x02<<4),  /* Attempt to program write protected area */
+    NVMCTRL_ERROR_CMDCOLLISION_gc = (0x03<<4),  /* Selecting new write command while write command already seleted */
+    NVMCTRL_ERROR_WRONGSECTION_gc = (0x04<<4)  /* Address cannot be written with selected command */
+} NVMCTRL_ERROR_t;
+
+/* Flash Mapping in Data space select */
+typedef enum NVMCTRL_FLMAP_enum
+{
+    NVMCTRL_FLMAP_SECTION0_gc = (0x00<<4),  /* Flash section 0, 0 - 32KB */
+    NVMCTRL_FLMAP_SECTION1_gc = (0x01<<4),  /* Flash section 1, 32 - 64KB */
+    NVMCTRL_FLMAP_SECTION2_gc = (0x02<<4),  /* Flash section 2, 64 - 96KB */
+    NVMCTRL_FLMAP_SECTION3_gc = (0x03<<4)  /* Flash section 3, 96 - 128KB */
+} NVMCTRL_FLMAP_t;
+
+/*
+--------------------------------------------------------------------------
+PORT - I/O Ports
+--------------------------------------------------------------------------
+*/
+
+/* I/O Ports */
+typedef struct PORT_struct
+{
+    register8_t DIR;  /* Data Direction */
+    register8_t DIRSET;  /* Data Direction Set */
+    register8_t DIRCLR;  /* Data Direction Clear */
+    register8_t DIRTGL;  /* Data Direction Toggle */
+    register8_t OUT;  /* Output Value */
+    register8_t OUTSET;  /* Output Value Set */
+    register8_t OUTCLR;  /* Output Value Clear */
+    register8_t OUTTGL;  /* Output Value Toggle */
+    register8_t IN;  /* Input Value */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t PORTCTRL;  /* Port Control */
+    register8_t PINCONFIG;  /* Pin Control Config */
+    register8_t PINCTRLUPD;  /* Pin Control Update */
+    register8_t PINCTRLSET;  /* Pin Control Set */
+    register8_t PINCTRLCLR;  /* Pin Control Clear */
+    register8_t reserved_1[1];
+    register8_t PIN0CTRL;  /* Pin 0 Control */
+    register8_t PIN1CTRL;  /* Pin 1 Control */
+    register8_t PIN2CTRL;  /* Pin 2 Control */
+    register8_t PIN3CTRL;  /* Pin 3 Control */
+    register8_t PIN4CTRL;  /* Pin 4 Control */
+    register8_t PIN5CTRL;  /* Pin 5 Control */
+    register8_t PIN6CTRL;  /* Pin 6 Control */
+    register8_t PIN7CTRL;  /* Pin 7 Control */
+    register8_t EVGENCTRL;  /* Event Generation Control */
+    register8_t reserved_2[7];
+} PORT_t;
+
+/* Event Generator 0 Select */
+typedef enum PORT_EVGEN0SEL_enum
+{
+    PORT_EVGEN0SEL_PIN0_gc = (0x00<<0),  /* Pin 0 used as event generator */
+    PORT_EVGEN0SEL_PIN1_gc = (0x01<<0),  /* Pin 1 used as event generator */
+    PORT_EVGEN0SEL_PIN2_gc = (0x02<<0),  /* Pin 2 used as event generator */
+    PORT_EVGEN0SEL_PIN3_gc = (0x03<<0),  /* Pin 3 used as event generator */
+    PORT_EVGEN0SEL_PIN4_gc = (0x04<<0),  /* Pin 4 used as event generator */
+    PORT_EVGEN0SEL_PIN5_gc = (0x05<<0),  /* Pin 5 used as event generator */
+    PORT_EVGEN0SEL_PIN6_gc = (0x06<<0),  /* Pin 6 used as event generator */
+    PORT_EVGEN0SEL_PIN7_gc = (0x07<<0)  /* Pin 7 used as event generator */
+} PORT_EVGEN0SEL_t;
+
+/* Event Generator 1 Select */
+typedef enum PORT_EVGEN1SEL_enum
+{
+    PORT_EVGEN1SEL_PIN0_gc = (0x00<<4),  /* Pin 0 used as event generator */
+    PORT_EVGEN1SEL_PIN1_gc = (0x01<<4),  /* Pin 1 used as event generator */
+    PORT_EVGEN1SEL_PIN2_gc = (0x02<<4),  /* Pin 2 used as event generator */
+    PORT_EVGEN1SEL_PIN3_gc = (0x03<<4),  /* Pin 3 used as event generator */
+    PORT_EVGEN1SEL_PIN4_gc = (0x04<<4),  /* Pin 4 used as event generator */
+    PORT_EVGEN1SEL_PIN5_gc = (0x05<<4),  /* Pin 5 used as event generator */
+    PORT_EVGEN1SEL_PIN6_gc = (0x06<<4),  /* Pin 6 used as event generator */
+    PORT_EVGEN1SEL_PIN7_gc = (0x07<<4)  /* Pin 7 used as event generator */
+} PORT_EVGEN1SEL_t;
+
+/* Input Level Select */
+typedef enum PORT_INLVL_enum
+{
+    PORT_INLVL_ST_gc = (0x00<<6),  /* Schmitt-Trigger input level */
+    PORT_INLVL_TTL_gc = (0x01<<6)  /* TTL Input level */
+} PORT_INLVL_t;
+
+/* Input/Sense Configuration select */
+typedef enum PORT_ISC_enum
+{
+    PORT_ISC_INTDISABLE_gc = (0x00<<0),  /* Interrupt disabled but input buffer enabled */
+    PORT_ISC_BOTHEDGES_gc = (0x01<<0),  /* Sense Both Edges */
+    PORT_ISC_RISING_gc = (0x02<<0),  /* Sense Rising Edge */
+    PORT_ISC_FALLING_gc = (0x03<<0),  /* Sense Falling Edge */
+    PORT_ISC_INPUT_DISABLE_gc = (0x04<<0),  /* Digital Input Buffer disabled */
+    PORT_ISC_LEVEL_gc = (0x05<<0)  /* Sense low Level */
+} PORT_ISC_t;
+
+/*
+--------------------------------------------------------------------------
+PORTMUX - Port Multiplexer
+--------------------------------------------------------------------------
+*/
+
+/* Port Multiplexer */
+typedef struct PORTMUX_struct
+{
+    register8_t EVSYSROUTEA;  /* EVSYS route A */
+    register8_t CCLROUTEA;  /* CCL route A */
+    register8_t USARTROUTEA;  /* USART route A */
+    register8_t USARTROUTEB;  /* USART route B */
+    register8_t reserved_1[1];
+    register8_t SPIROUTEA;  /* SPI route A */
+    register8_t TWIROUTEA;  /* TWI route A */
+    register8_t TCAROUTEA;  /* TCA route A */
+    register8_t TCBROUTEA;  /* TCB route A */
+    register8_t reserved_2[1];
+    register8_t ACROUTEA;  /* AC route A */
+    register8_t reserved_3[21];
+} PORTMUX_t;
+
+/* Analog Comparator 0 Output select */
+typedef enum PORTMUX_AC0_enum
+{
+    PORTMUX_AC0_DEFAULT_gc = (0x00<<0)  /* OUT: PA7 */
+} PORTMUX_AC0_t;
+
+/* Analog Comparator 1 Output select */
+typedef enum PORTMUX_AC1_enum
+{
+    PORTMUX_AC1_DEFAULT_gc = (0x00<<1)  /* OUT: PA7 */
+} PORTMUX_AC1_t;
+
+/* Event Output A select */
+typedef enum PORTMUX_EVOUTA_enum
+{
+    PORTMUX_EVOUTA_DEFAULT_gc = (0x00<<0),  /* EVOUTA: PA2 */
+    PORTMUX_EVOUTA_ALT1_gc = (0x01<<0)  /* EVOUTA: PA7 */
+} PORTMUX_EVOUTA_t;
+
+/* Event Output C select */
+typedef enum PORTMUX_EVOUTC_enum
+{
+    PORTMUX_EVOUTC_DEFAULT_gc = (0x00<<2)  /* EVOUTC: PC2 */
+} PORTMUX_EVOUTC_t;
+
+/* Event Output D select */
+typedef enum PORTMUX_EVOUTD_enum
+{
+    PORTMUX_EVOUTD_DEFAULT_gc = (0x00<<3),  /* EVOUTD: PD2 */
+    PORTMUX_EVOUTD_ALT1_gc = (0x01<<3)  /* EVOUTD: PD7 */
+} PORTMUX_EVOUTD_t;
+
+/* Event Output F select */
+typedef enum PORTMUX_EVOUTF_enum
+{
+    PORTMUX_EVOUTF_DEFAULT_gc = (0x00<<5),  /* Not connected to any pins */
+    PORTMUX_EVOUTF_ALT1_gc = (0x01<<5)  /* EVOUTF: PF7 */
+} PORTMUX_EVOUTF_t;
+
+/* CCL Look-Up Table 0 Signals select */
+typedef enum PORTMUX_LUT0_enum
+{
+    PORTMUX_LUT0_DEFAULT_gc = (0x00<<0),  /* In: PA0, PA1, PA2, Out: PA3 */
+    PORTMUX_LUT0_ALT1_gc = (0x01<<0)  /* In: PA0, PA1, PA2, Out: PA6 */
+} PORTMUX_LUT0_t;
+
+/* CCL Look-Up Table 1 Signals select */
+typedef enum PORTMUX_LUT1_enum
+{
+    PORTMUX_LUT1_DEFAULT_gc = (0x00<<1),  /* In: PC0, PC1, PC2, Out: PC3 */
+    PORTMUX_LUT1_ALT1_gc = (0x01<<1)  /* In: PC0, PC1, PC2, Out: - */
+} PORTMUX_LUT1_t;
+
+/* CCL Look-Up Table 2 Signals select */
+typedef enum PORTMUX_LUT2_enum
+{
+    PORTMUX_LUT2_DEFAULT_gc = (0x00<<2),  /* In: PD0, PD1, PD2, Out: PD3 */
+    PORTMUX_LUT2_ALT1_gc = (0x01<<2)  /* In: PD0, PD1, PD2, Out: PD6 */
+} PORTMUX_LUT2_t;
+
+/* SPI0 Signals select */
+typedef enum PORTMUX_SPI0_enum
+{
+    PORTMUX_SPI0_DEFAULT_gc = (0x00<<0),  /* MOSI: PA4, MISO: PA5, SCK: PA6, SS: PA7 */
+    PORTMUX_SPI0_ALT3_gc = (0x03<<0),  /* MOSI: PA0, MISO: PA1, SCK: PC0, SS: PC1 */
+    PORTMUX_SPI0_ALT4_gc = (0x04<<0),  /* MOSI: PD4, MISO: PD5, SCK: PD6, SS: PD7 */
+    PORTMUX_SPI0_ALT5_gc = (0x05<<0),  /* MOSI: PC0, MISO: PC1, SCK: PC2, SS: PC3 */
+    PORTMUX_SPI0_ALT6_gc = (0x06<<0),  /* MOSI: PC1, MISO: PC2, SCK: PC3, SS: PF7 */
+    PORTMUX_SPI0_NONE_gc = (0x07<<0)  /* Not connected to any pins, SS set to 1 */
+} PORTMUX_SPI0_t;
+
+/* TCA0 Signals select */
+typedef enum PORTMUX_TCA0_enum
+{
+    PORTMUX_TCA0_PORTA_gc = (0x00<<0),  /* WOn: PA0, PA1, PA2, PA3, PA4, PA5 */
+    PORTMUX_TCA0_PORTC_gc = (0x02<<0),  /* WOn: PC0, PC1, PC2, PC3, -, - */
+    PORTMUX_TCA0_PORTD_gc = (0x03<<0),  /* WOn: PD0, PD1, PD2, PD3, PD4, PD5 */
+    PORTMUX_TCA0_PORTF_gc = (0x05<<0)  /* WOn: PF0, PF1, -, -, -, - */
+} PORTMUX_TCA0_t;
+
+/* TCA1 Signals select */
+typedef enum PORTMUX_TCA1_enum
+{
+    PORTMUX_TCA1_PORTB_gc = (0x00<<3),  /* Not connected to any pins */
+    PORTMUX_TCA1_PORTA_gc = (0x04<<3),  /* WOn: PA4, PA5, PA6, -, -, - */
+    PORTMUX_TCA1_PORTD_gc = (0x05<<3)  /* WOn: PD4, PD5, PD6, -, -, - */
+} PORTMUX_TCA1_t;
+
+/* TCB0 Output select */
+typedef enum PORTMUX_TCB0_enum
+{
+    PORTMUX_TCB0_DEFAULT_gc = (0x00<<0)  /* WO: PA2 */
+} PORTMUX_TCB0_t;
+
+/* TCB1 Output select */
+typedef enum PORTMUX_TCB1_enum
+{
+    PORTMUX_TCB1_DEFAULT_gc = (0x00<<1)  /* WO: PA3 */
+} PORTMUX_TCB1_t;
+
+/* TCB2 Output select */
+typedef enum PORTMUX_TCB2_enum
+{
+    PORTMUX_TCB2_DEFAULT_gc = (0x00<<2)  /* WO: PC0 */
+} PORTMUX_TCB2_t;
+
+/* TCB3 Output select */
+typedef enum PORTMUX_TCB3_enum
+{
+    PORTMUX_TCB3_DEFAULT_gc = (0x00<<3),  /* Not connected to any pins */
+    PORTMUX_TCB3_ALT1_gc = (0x01<<3)  /* WO: PC1 */
+} PORTMUX_TCB3_t;
+
+/* TWI0 Signals select */
+typedef enum PORTMUX_TWI0_enum
+{
+    PORTMUX_TWI0_DEFAULT_gc = (0x00<<0),  /* SDA: PA2, SCL: PA3. Dual mode: SDA: PC2, SCL: PC3 */
+    PORTMUX_TWI0_ALT1_gc = (0x01<<0),  /* SDA: PA2, SCL: PA3. Dual mode: SDA: -, SCL: - */
+    PORTMUX_TWI0_ALT2_gc = (0x02<<0),  /* SDA: PC2, SCL: PC3. Dual mode: SDA: -, SCL: - */
+    PORTMUX_TWI0_ALT3_gc = (0x03<<0)  /* SDA: PA0, SCL: PA1. Dual mode: SDA: PC2, SCL: PC3 */
+} PORTMUX_TWI0_t;
+
+/* USART0 Routing select */
+typedef enum PORTMUX_USART0_enum
+{
+    PORTMUX_USART0_DEFAULT_gc = (0x00<<0),  /* TxD: PA0, RxD: PA1, XCK: PA2, XDIR: PA3 */
+    PORTMUX_USART0_ALT1_gc = (0x01<<0),  /* TxD: PA4, RxD: PA5, XCK: PA6, XDIR: PA7 */
+    PORTMUX_USART0_ALT2_gc = (0x02<<0),  /* TxD: PA2, RxD: PA3, XCK: -, XDIR: - */
+    PORTMUX_USART0_ALT3_gc = (0x03<<0),  /* TxD: PD4, RxD: PD5, XCK: PD6, XDIR: PD7 */
+    PORTMUX_USART0_ALT4_gc = (0x04<<0),  /* TxD: PC1, RxD: PC2, XCK: PC3, XDIR: - */
+    PORTMUX_USART0_NONE_gc = (0x05<<0)  /* Not connected to any pins */
+} PORTMUX_USART0_t;
+
+/* USART1 Routing select */
+typedef enum PORTMUX_USART1_enum
+{
+    PORTMUX_USART1_DEFAULT_gc = (0x00<<3),  /* TxD: PC0, RxD: PC1, XCK: PC2, XDIR: PC3 */
+    PORTMUX_USART1_ALT2_gc = (0x02<<3),  /* TxD: PD6, RxD: PD7, XCK: -, XDIR: - */
+    PORTMUX_USART1_NONE_gc = (0x03<<3)  /* Not connected to any pins */
+} PORTMUX_USART1_t;
+
+/* USART2 Routing select */
+typedef enum PORTMUX_USART2_enum
+{
+    PORTMUX_USART2_DEFAULT_gc = (0x00<<0),  /* TxD: PF0, RxD: PF1, XCK: -, XDIR: - */
+    PORTMUX_USART2_NONE_gc = (0x03<<0)  /* Not connected to any pins */
+} PORTMUX_USART2_t;
+
+/*
+--------------------------------------------------------------------------
+RSTCTRL - Reset controller
+--------------------------------------------------------------------------
+*/
+
+/* Reset controller */
+typedef struct RSTCTRL_struct
+{
+    register8_t RSTFR;  /* Reset Flags */
+    register8_t SWRR;  /* Software Reset */
+    register8_t reserved_1[14];
+} RSTCTRL_t;
+
+
+/*
+--------------------------------------------------------------------------
+RTC - Real-Time Counter
+--------------------------------------------------------------------------
+*/
+
+/* Real-Time Counter */
+typedef struct RTC_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t STATUS;  /* Status */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t TEMP;  /* Temporary */
+    register8_t DBGCTRL;  /* Debug control */
+    register8_t CALIB;  /* Calibration */
+    register8_t CLKSEL;  /* Clock Select */
+    _WORDREGISTER(CNT);  /* Counter */
+    _WORDREGISTER(PER);  /* Period */
+    _WORDREGISTER(CMP);  /* Compare */
+    register8_t reserved_1[2];
+    register8_t PITCTRLA;  /* PIT Control A */
+    register8_t PITSTATUS;  /* PIT Status */
+    register8_t PITINTCTRL;  /* PIT Interrupt Control */
+    register8_t PITINTFLAGS;  /* PIT Interrupt Flags */
+    register8_t reserved_2[1];
+    register8_t PITDBGCTRL;  /* PIT Debug control */
+    register8_t PITEVGENCTRLA;  /* PIT Event Generation Control A */
+    register8_t reserved_3[9];
+} RTC_t;
+
+/* Clock Select */
+typedef enum RTC_CLKSEL_enum
+{
+    RTC_CLKSEL_OSC32K_gc = (0x00<<0),  /* Internal 32.768 kHz Oscillator */
+    RTC_CLKSEL_OSC1K_gc = (0x01<<0),  /* Internal 32.768 kHz Oscillator Divided by 32 */
+    RTC_CLKSEL_XOSC32K_gc = (0x02<<0),  /* 32.768 kHz Crystal Oscillator */
+    RTC_CLKSEL_EXTCLK_gc = (0x03<<0)  /* External Clock */
+} RTC_CLKSEL_t;
+
+/* Event Generation 0 Select */
+typedef enum RTC_EVGEN0SEL_enum
+{
+    RTC_EVGEN0SEL_OFF_gc = (0x00<<0),  /* No Event Generated */
+    RTC_EVGEN0SEL_DIV4_gc = (0x01<<0),  /* CLK_RTC divided by 4 */
+    RTC_EVGEN0SEL_DIV8_gc = (0x02<<0),  /* CLK_RTC divided by 8 */
+    RTC_EVGEN0SEL_DIV16_gc = (0x03<<0),  /* CLK_RTC divided by 16 */
+    RTC_EVGEN0SEL_DIV32_gc = (0x04<<0),  /* CLK_RTC divided by 32 */
+    RTC_EVGEN0SEL_DIV64_gc = (0x05<<0),  /* CLK_RTC divided by 64 */
+    RTC_EVGEN0SEL_DIV128_gc = (0x06<<0),  /* CLK_RTC divided by 128 */
+    RTC_EVGEN0SEL_DIV256_gc = (0x07<<0),  /* CLK_RTC divided by 256 */
+    RTC_EVGEN0SEL_DIV512_gc = (0x08<<0),  /* CLK_RTC divided by 512 */
+    RTC_EVGEN0SEL_DIV1024_gc = (0x09<<0),  /* CLK_RTC divided by 1024 */
+    RTC_EVGEN0SEL_DIV2048_gc = (0x0A<<0),  /* CLK_RTC divided by 2048 */
+    RTC_EVGEN0SEL_DIV4096_gc = (0x0B<<0),  /* CLK_RTC divided by 4096 */
+    RTC_EVGEN0SEL_DIV8192_gc = (0x0C<<0),  /* CLK_RTC divided by 8192 */
+    RTC_EVGEN0SEL_DIV16384_gc = (0x0D<<0),  /* CLK_RTC divided by 16384 */
+    RTC_EVGEN0SEL_DIV32768_gc = (0x0E<<0)  /* CLK_RTC divided by 32768 */
+} RTC_EVGEN0SEL_t;
+
+/* Event Generation 1 Select */
+typedef enum RTC_EVGEN1SEL_enum
+{
+    RTC_EVGEN1SEL_OFF_gc = (0x00<<4),  /* No Event Generated */
+    RTC_EVGEN1SEL_DIV4_gc = (0x01<<4),  /* CLK_RTC divided by 4 */
+    RTC_EVGEN1SEL_DIV8_gc = (0x02<<4),  /* CLK_RTC divided by 8 */
+    RTC_EVGEN1SEL_DIV16_gc = (0x03<<4),  /* CLK_RTC divided by 16 */
+    RTC_EVGEN1SEL_DIV32_gc = (0x04<<4),  /* CLK_RTC divided by 32 */
+    RTC_EVGEN1SEL_DIV64_gc = (0x05<<4),  /* CLK_RTC divided by 64 */
+    RTC_EVGEN1SEL_DIV128_gc = (0x06<<4),  /* CLK_RTC divided by 128 */
+    RTC_EVGEN1SEL_DIV256_gc = (0x07<<4),  /* CLK_RTC divided by 256 */
+    RTC_EVGEN1SEL_DIV512_gc = (0x08<<4),  /* CLK_RTC divided by 512 */
+    RTC_EVGEN1SEL_DIV1024_gc = (0x09<<4),  /* CLK_RTC divided by 1024 */
+    RTC_EVGEN1SEL_DIV2048_gc = (0x0A<<4),  /* CLK_RTC divided by 2048 */
+    RTC_EVGEN1SEL_DIV4096_gc = (0x0B<<4),  /* CLK_RTC divided by 4096 */
+    RTC_EVGEN1SEL_DIV8192_gc = (0x0C<<4),  /* CLK_RTC divided by 8192 */
+    RTC_EVGEN1SEL_DIV16384_gc = (0x0D<<4),  /* CLK_RTC divided by 16384 */
+    RTC_EVGEN1SEL_DIV32768_gc = (0x0E<<4)  /* CLK_RTC divided by 32768 */
+} RTC_EVGEN1SEL_t;
+
+/* Period select */
+typedef enum RTC_PERIOD_enum
+{
+    RTC_PERIOD_OFF_gc = (0x00<<3),  /* Off */
+    RTC_PERIOD_CYC4_gc = (0x01<<3),  /* RTC Clock Cycles 4 */
+    RTC_PERIOD_CYC8_gc = (0x02<<3),  /* RTC Clock Cycles 8 */
+    RTC_PERIOD_CYC16_gc = (0x03<<3),  /* RTC Clock Cycles 16 */
+    RTC_PERIOD_CYC32_gc = (0x04<<3),  /* RTC Clock Cycles 32 */
+    RTC_PERIOD_CYC64_gc = (0x05<<3),  /* RTC Clock Cycles 64 */
+    RTC_PERIOD_CYC128_gc = (0x06<<3),  /* RTC Clock Cycles 128 */
+    RTC_PERIOD_CYC256_gc = (0x07<<3),  /* RTC Clock Cycles 256 */
+    RTC_PERIOD_CYC512_gc = (0x08<<3),  /* RTC Clock Cycles 512 */
+    RTC_PERIOD_CYC1024_gc = (0x09<<3),  /* RTC Clock Cycles 1024 */
+    RTC_PERIOD_CYC2048_gc = (0x0A<<3),  /* RTC Clock Cycles 2048 */
+    RTC_PERIOD_CYC4096_gc = (0x0B<<3),  /* RTC Clock Cycles 4096 */
+    RTC_PERIOD_CYC8192_gc = (0x0C<<3),  /* RTC Clock Cycles 8192 */
+    RTC_PERIOD_CYC16384_gc = (0x0D<<3),  /* RTC Clock Cycles 16384 */
+    RTC_PERIOD_CYC32768_gc = (0x0E<<3)  /* RTC Clock Cycles 32768 */
+} RTC_PERIOD_t;
+
+/* Prescaling Factor select */
+typedef enum RTC_PRESCALER_enum
+{
+    RTC_PRESCALER_DIV1_gc = (0x00<<3),  /* RTC Clock / 1 */
+    RTC_PRESCALER_DIV2_gc = (0x01<<3),  /* RTC Clock / 2 */
+    RTC_PRESCALER_DIV4_gc = (0x02<<3),  /* RTC Clock / 4 */
+    RTC_PRESCALER_DIV8_gc = (0x03<<3),  /* RTC Clock / 8 */
+    RTC_PRESCALER_DIV16_gc = (0x04<<3),  /* RTC Clock / 16 */
+    RTC_PRESCALER_DIV32_gc = (0x05<<3),  /* RTC Clock / 32 */
+    RTC_PRESCALER_DIV64_gc = (0x06<<3),  /* RTC Clock / 64 */
+    RTC_PRESCALER_DIV128_gc = (0x07<<3),  /* RTC Clock / 128 */
+    RTC_PRESCALER_DIV256_gc = (0x08<<3),  /* RTC Clock / 256 */
+    RTC_PRESCALER_DIV512_gc = (0x09<<3),  /* RTC Clock / 512 */
+    RTC_PRESCALER_DIV1024_gc = (0x0A<<3),  /* RTC Clock / 1024 */
+    RTC_PRESCALER_DIV2048_gc = (0x0B<<3),  /* RTC Clock / 2048 */
+    RTC_PRESCALER_DIV4096_gc = (0x0C<<3),  /* RTC Clock / 4096 */
+    RTC_PRESCALER_DIV8192_gc = (0x0D<<3),  /* RTC Clock / 8192 */
+    RTC_PRESCALER_DIV16384_gc = (0x0E<<3),  /* RTC Clock / 16384 */
+    RTC_PRESCALER_DIV32768_gc = (0x0F<<3)  /* RTC Clock / 32768 */
+} RTC_PRESCALER_t;
+
+/*
+--------------------------------------------------------------------------
+SIGROW - Signature row
+--------------------------------------------------------------------------
+*/
+
+/* Signature row */
+typedef struct SIGROW_struct
+{
+    register8_t DEVICEID0;  /* Device ID Byte 0 */
+    register8_t DEVICEID1;  /* Device ID Byte 1 */
+    register8_t DEVICEID2;  /* Device ID Byte 2 */
+    register8_t reserved_1[1];
+    _WORDREGISTER(TEMPSENSE0);  /* Temperature Calibration 0 */
+    _WORDREGISTER(TEMPSENSE1);  /* Temperature Calibration 1 */
+    register8_t reserved_2[8];
+    register8_t SERNUM0;  /* Serial Number Byte 0 */
+    register8_t SERNUM1;  /* Serial Number Byte 1 */
+    register8_t SERNUM2;  /* Serial Number Byte 2 */
+    register8_t SERNUM3;  /* Serial Number Byte 3 */
+    register8_t SERNUM4;  /* Serial Number Byte 4 */
+    register8_t SERNUM5;  /* Serial Number Byte 5 */
+    register8_t SERNUM6;  /* Serial Number Byte 6 */
+    register8_t SERNUM7;  /* Serial Number Byte 7 */
+    register8_t SERNUM8;  /* Serial Number Byte 8 */
+    register8_t SERNUM9;  /* Serial Number Byte 9 */
+    register8_t SERNUM10;  /* Serial Number Byte 10 */
+    register8_t SERNUM11;  /* Serial Number Byte 11 */
+    register8_t SERNUM12;  /* Serial Number Byte 12 */
+    register8_t SERNUM13;  /* Serial Number Byte 13 */
+    register8_t SERNUM14;  /* Serial Number Byte 14 */
+    register8_t SERNUM15;  /* Serial Number Byte 15 */
+    register8_t reserved_3[32];
+} SIGROW_t;
+
+
+/*
+--------------------------------------------------------------------------
+SLPCTRL - Sleep Controller
+--------------------------------------------------------------------------
+*/
+
+/* Sleep Controller */
+typedef struct SLPCTRL_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t reserved_1[1];
+} SLPCTRL_t;
+
+/* Sleep mode select */
+typedef enum SLPCTRL_SMODE_enum
+{
+    SLPCTRL_SMODE_IDLE_gc = (0x00<<1),  /* Idle mode */
+    SLPCTRL_SMODE_STDBY_gc = (0x01<<1),  /* Standby Mode */
+    SLPCTRL_SMODE_PDOWN_gc = (0x02<<1)  /* Power-down Mode */
+} SLPCTRL_SMODE_t;
+
+#define SLEEP_MODE_IDLE (0x00<<1)
+#define SLEEP_MODE_STANDBY (0x01<<1)
+#define SLEEP_MODE_PWR_DOWN (0x02<<1)
+/*
+--------------------------------------------------------------------------
+SPI - Serial Peripheral Interface
+--------------------------------------------------------------------------
+*/
+
+/* Serial Peripheral Interface */
+typedef struct SPI_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t DATA;  /* Data */
+    register8_t reserved_1[3];
+} SPI_t;
+
+/* SPI Mode select */
+typedef enum SPI_MODE_enum
+{
+    SPI_MODE_0_gc = (0x00<<0),  /* SPI Mode 0 */
+    SPI_MODE_1_gc = (0x01<<0),  /* SPI Mode 1 */
+    SPI_MODE_2_gc = (0x02<<0),  /* SPI Mode 2 */
+    SPI_MODE_3_gc = (0x03<<0)  /* SPI Mode 3 */
+} SPI_MODE_t;
+
+/* Prescaler select */
+typedef enum SPI_PRESC_enum
+{
+    SPI_PRESC_DIV4_gc = (0x00<<1),  /* CLK_PER / 4 */
+    SPI_PRESC_DIV16_gc = (0x01<<1),  /* CLK_PER / 16 */
+    SPI_PRESC_DIV64_gc = (0x02<<1),  /* CLK_PER / 64 */
+    SPI_PRESC_DIV128_gc = (0x03<<1)  /* CLK_PER / 128 */
+} SPI_PRESC_t;
+
+/*
+--------------------------------------------------------------------------
+SYSCFG - System Configuration Registers
+--------------------------------------------------------------------------
+*/
+
+/* System Configuration Registers */
+typedef struct SYSCFG_struct
+{
+    register8_t reserved_1[1];
+    register8_t REVID;  /* Revision ID */
+    register8_t reserved_2[2];
+    register8_t OCDMCTRL;  /* OCD Message Control */
+    register8_t OCDMSTATUS;  /* OCD Message Status */
+    register8_t reserved_3[26];
+} SYSCFG_t;
+
+
+/*
+--------------------------------------------------------------------------
+TCA - 16-bit Timer/Counter Type A
+--------------------------------------------------------------------------
+*/
+
+/* 16-bit Timer/Counter Type A - Single Mode */
+typedef struct TCA_SINGLE_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    register8_t CTRLD;  /* Control D */
+    register8_t CTRLECLR;  /* Control E Clear */
+    register8_t CTRLESET;  /* Control E Set */
+    register8_t CTRLFCLR;  /* Control F Clear */
+    register8_t CTRLFSET;  /* Control F Set */
+    register8_t reserved_1[1];
+    register8_t EVCTRL;  /* Event Control */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t reserved_2[2];
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t TEMP;  /* Temporary data for 16-bit Access */
+    register8_t reserved_3[16];
+    _WORDREGISTER(CNT);  /* Count */
+    register8_t reserved_4[4];
+    _WORDREGISTER(PER);  /* Period */
+    _WORDREGISTER(CMP0);  /* Compare 0 */
+    _WORDREGISTER(CMP1);  /* Compare 1 */
+    _WORDREGISTER(CMP2);  /* Compare 2 */
+    register8_t reserved_5[8];
+    _WORDREGISTER(PERBUF);  /* Period Buffer */
+    _WORDREGISTER(CMP0BUF);  /* Compare 0 Buffer */
+    _WORDREGISTER(CMP1BUF);  /* Compare 1 Buffer */
+    _WORDREGISTER(CMP2BUF);  /* Compare 2 Buffer */
+    register8_t reserved_6[2];
+} TCA_SINGLE_t;
+
+/* 16-bit Timer/Counter Type A - Split Mode */
+typedef struct TCA_SPLIT_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    register8_t CTRLD;  /* Control D */
+    register8_t CTRLECLR;  /* Control E Clear */
+    register8_t CTRLESET;  /* Control E Set */
+    register8_t reserved_1[4];
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t reserved_2[2];
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t reserved_3[17];
+    register8_t LCNT;  /* Low Count */
+    register8_t HCNT;  /* High Count */
+    register8_t reserved_4[4];
+    register8_t LPER;  /* Low Period */
+    register8_t HPER;  /* High Period */
+    register8_t LCMP0;  /* Low Compare */
+    register8_t HCMP0;  /* High Compare */
+    register8_t LCMP1;  /* Low Compare */
+    register8_t HCMP1;  /* High Compare */
+    register8_t LCMP2;  /* Low Compare */
+    register8_t HCMP2;  /* High Compare */
+    register8_t reserved_5[18];
+} TCA_SPLIT_t;
+
+/* 16-bit Timer/Counter Type A */
+typedef union TCA_union
+{
+    TCA_SINGLE_t SINGLE;  /* Single Mode */
+    TCA_SPLIT_t SPLIT;  /* Split Mode */
+} TCA_t;
+
+/* Clock Selection */
+typedef enum TCA_SINGLE_CLKSEL_enum
+{
+    TCA_SINGLE_CLKSEL_DIV1_gc = (0x00<<1),  /* CLK_PER */
+    TCA_SINGLE_CLKSEL_DIV2_gc = (0x01<<1),  /* CLK_PER / 2 */
+    TCA_SINGLE_CLKSEL_DIV4_gc = (0x02<<1),  /* CLK_PER / 4 */
+    TCA_SINGLE_CLKSEL_DIV8_gc = (0x03<<1),  /* CLK_PER / 8 */
+    TCA_SINGLE_CLKSEL_DIV16_gc = (0x04<<1),  /* CLK_PER / 16 */
+    TCA_SINGLE_CLKSEL_DIV64_gc = (0x05<<1),  /* CLK_PER / 64 */
+    TCA_SINGLE_CLKSEL_DIV256_gc = (0x06<<1),  /* CLK_PER / 256 */
+    TCA_SINGLE_CLKSEL_DIV1024_gc = (0x07<<1)  /* CLK_PER / 1024 */
+} TCA_SINGLE_CLKSEL_t;
+
+/* Command select */
+typedef enum TCA_SINGLE_CMD_enum
+{
+    TCA_SINGLE_CMD_NONE_gc = (0x00<<2),  /* No Command */
+    TCA_SINGLE_CMD_UPDATE_gc = (0x01<<2),  /* Force Update */
+    TCA_SINGLE_CMD_RESTART_gc = (0x02<<2),  /* Force Restart */
+    TCA_SINGLE_CMD_RESET_gc = (0x03<<2)  /* Force Hard Reset */
+} TCA_SINGLE_CMD_t;
+
+/* Direction select */
+typedef enum TCA_SINGLE_DIR_enum
+{
+    TCA_SINGLE_DIR_UP_gc = (0x00<<0),  /* Count up */
+    TCA_SINGLE_DIR_DOWN_gc = (0x01<<0)  /* Count down */
+} TCA_SINGLE_DIR_t;
+
+/* Event Action A select */
+typedef enum TCA_SINGLE_EVACTA_enum
+{
+    TCA_SINGLE_EVACTA_CNT_POSEDGE_gc = (0x00<<1),  /* Count on positive edge event */
+    TCA_SINGLE_EVACTA_CNT_ANYEDGE_gc = (0x01<<1),  /* Count on any edge event */
+    TCA_SINGLE_EVACTA_CNT_HIGHLVL_gc = (0x02<<1),  /* Count on prescaled clock while event line is 1. */
+    TCA_SINGLE_EVACTA_UPDOWN_gc = (0x03<<1)  /* Count on prescaled clock. Event controls count direction. Up-count when event line is 0, down-count when event line is 1. */
+} TCA_SINGLE_EVACTA_t;
+
+/* Event Action B select */
+typedef enum TCA_SINGLE_EVACTB_enum
+{
+    TCA_SINGLE_EVACTB_NONE_gc = (0x00<<5),  /* No Action */
+    TCA_SINGLE_EVACTB_UPDOWN_gc = (0x03<<5),  /* Count on prescaled clock. Event controls count direction. Up-count when event line is 0, down-count when event line is 1. */
+    TCA_SINGLE_EVACTB_RESTART_POSEDGE_gc = (0x04<<5),  /* Restart counter at positive edge event */
+    TCA_SINGLE_EVACTB_RESTART_ANYEDGE_gc = (0x05<<5),  /* Restart counter on any edge event */
+    TCA_SINGLE_EVACTB_RESTART_HIGHLVL_gc = (0x06<<5)  /* Restart counter while event line is 1. */
+} TCA_SINGLE_EVACTB_t;
+
+/* Waveform generation mode select */
+typedef enum TCA_SINGLE_WGMODE_enum
+{
+    TCA_SINGLE_WGMODE_NORMAL_gc = (0x00<<0),  /* Normal Mode */
+    TCA_SINGLE_WGMODE_FRQ_gc = (0x01<<0),  /* Frequency Generation Mode */
+    TCA_SINGLE_WGMODE_SINGLESLOPE_gc = (0x03<<0),  /* Single Slope PWM */
+    TCA_SINGLE_WGMODE_DSTOP_gc = (0x05<<0),  /* Dual Slope PWM, overflow on TOP */
+    TCA_SINGLE_WGMODE_DSBOTH_gc = (0x06<<0),  /* Dual Slope PWM, overflow on TOP and BOTTOM */
+    TCA_SINGLE_WGMODE_DSBOTTOM_gc = (0x07<<0)  /* Dual Slope PWM, overflow on BOTTOM */
+} TCA_SINGLE_WGMODE_t;
+
+/* Clock Selection */
+typedef enum TCA_SPLIT_CLKSEL_enum
+{
+    TCA_SPLIT_CLKSEL_DIV1_gc = (0x00<<1),  /* CLK_PER */
+    TCA_SPLIT_CLKSEL_DIV2_gc = (0x01<<1),  /* CLK_PER / 2 */
+    TCA_SPLIT_CLKSEL_DIV4_gc = (0x02<<1),  /* CLK_PER / 4 */
+    TCA_SPLIT_CLKSEL_DIV8_gc = (0x03<<1),  /* CLK_PER / 8 */
+    TCA_SPLIT_CLKSEL_DIV16_gc = (0x04<<1),  /* CLK_PER / 16 */
+    TCA_SPLIT_CLKSEL_DIV64_gc = (0x05<<1),  /* CLK_PER / 64 */
+    TCA_SPLIT_CLKSEL_DIV256_gc = (0x06<<1),  /* CLK_PER / 256 */
+    TCA_SPLIT_CLKSEL_DIV1024_gc = (0x07<<1)  /* CLK_PER / 1024 */
+} TCA_SPLIT_CLKSEL_t;
+
+/* Command select */
+typedef enum TCA_SPLIT_CMD_enum
+{
+    TCA_SPLIT_CMD_NONE_gc = (0x00<<2),  /* No Command */
+    TCA_SPLIT_CMD_UPDATE_gc = (0x01<<2),  /* Force Update */
+    TCA_SPLIT_CMD_RESTART_gc = (0x02<<2),  /* Force Restart */
+    TCA_SPLIT_CMD_RESET_gc = (0x03<<2)  /* Force Hard Reset */
+} TCA_SPLIT_CMD_t;
+
+/* Command Enable select */
+typedef enum TCA_SPLIT_CMDEN_enum
+{
+    TCA_SPLIT_CMDEN_NONE_gc = (0x00<<0),  /* None */
+    TCA_SPLIT_CMDEN_BOTH_gc = (0x03<<0)  /* Both low byte and high byte counter */
+} TCA_SPLIT_CMDEN_t;
+
+/*
+--------------------------------------------------------------------------
+TCB - 16-bit Timer Type B
+--------------------------------------------------------------------------
+*/
+
+/* 16-bit Timer Type B */
+typedef struct TCB_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control Register B */
+    register8_t reserved_1[2];
+    register8_t EVCTRL;  /* Event Control */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t STATUS;  /* Status */
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t TEMP;  /* Temporary Value */
+    _WORDREGISTER(CNT);  /* Count */
+    _WORDREGISTER(CCMP);  /* Compare or Capture */
+    register8_t reserved_2[2];
+} TCB_t;
+
+/* Clock Select */
+typedef enum TCB_CLKSEL_enum
+{
+    TCB_CLKSEL_DIV1_gc = (0x00<<1),  /* CLK_PER */
+    TCB_CLKSEL_DIV2_gc = (0x01<<1),  /* CLK_PER/2 */
+    TCB_CLKSEL_TCA0_gc = (0x02<<1),  /* Use CLK_TCA from TCA0 */
+    TCB_CLKSEL_TCA1_gc = (0x03<<1),  /* Use CLK_TCA from TCA1 */
+    TCB_CLKSEL_EVENT_gc = (0x07<<1)  /* Count on event edge */
+} TCB_CLKSEL_t;
+
+/* Timer Mode select */
+typedef enum TCB_CNTMODE_enum
+{
+    TCB_CNTMODE_INT_gc = (0x00<<0),  /* Periodic Interrupt */
+    TCB_CNTMODE_TIMEOUT_gc = (0x01<<0),  /* Periodic Timeout */
+    TCB_CNTMODE_CAPT_gc = (0x02<<0),  /* Input Capture Event */
+    TCB_CNTMODE_FRQ_gc = (0x03<<0),  /* Input Capture Frequency measurement */
+    TCB_CNTMODE_PW_gc = (0x04<<0),  /* Input Capture Pulse-Width measurement */
+    TCB_CNTMODE_FRQPW_gc = (0x05<<0),  /* Input Capture Frequency and Pulse-Width measurement */
+    TCB_CNTMODE_SINGLE_gc = (0x06<<0),  /* Single Shot */
+    TCB_CNTMODE_PWM8_gc = (0x07<<0)  /* 8-bit PWM */
+} TCB_CNTMODE_t;
+
+/*
+--------------------------------------------------------------------------
+TWI - Two-Wire Interface
+--------------------------------------------------------------------------
+*/
+
+/* Two-Wire Interface */
+typedef struct TWI_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t DUALCTRL;  /* Dual Mode Control */
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t MCTRLA;  /* Host Control A */
+    register8_t MCTRLB;  /* Host Control B */
+    register8_t MSTATUS;  /* Host STATUS */
+    register8_t MBAUD;  /* Host Baud Rate */
+    register8_t MADDR;  /* Host Address */
+    register8_t MDATA;  /* Host Data */
+    register8_t SCTRLA;  /* Client Control A */
+    register8_t SCTRLB;  /* Client Control B */
+    register8_t SSTATUS;  /* Client Status */
+    register8_t SADDR;  /* Client Address */
+    register8_t SDATA;  /* Client Data */
+    register8_t SADDRMASK;  /* Client Address Mask */
+    register8_t reserved_1[1];
+} TWI_t;
+
+/* Acknowledge Action select */
+typedef enum TWI_ACKACT_enum
+{
+    TWI_ACKACT_ACK_gc = (0x00<<2),  /* Send ACK */
+    TWI_ACKACT_NACK_gc = (0x01<<2)  /* Send NACK */
+} TWI_ACKACT_t;
+
+/* Address or Stop select */
+typedef enum TWI_AP_enum
+{
+    TWI_AP_STOP_gc = (0x00<<0),  /* A Stop condition generated the interrupt on APIF flag */
+    TWI_AP_ADR_gc = (0x01<<0)  /* Address detection generated the interrupt on APIF flag */
+} TWI_AP_t;
+
+/* Bus State select */
+typedef enum TWI_BUSSTATE_enum
+{
+    TWI_BUSSTATE_UNKNOWN_gc = (0x00<<0),  /* Unknown bus state */
+    TWI_BUSSTATE_IDLE_gc = (0x01<<0),  /* Bus is idle */
+    TWI_BUSSTATE_OWNER_gc = (0x02<<0),  /* This TWI controls the bus */
+    TWI_BUSSTATE_BUSY_gc = (0x03<<0)  /* The bus is busy */
+} TWI_BUSSTATE_t;
+
+/* Debug Run select */
+typedef enum TWI_DBGRUN_enum
+{
+    TWI_DBGRUN_HALT_gc = (0x00<<0),  /* The peripheral is halted in Break Debug mode and ignores events */
+    TWI_DBGRUN_RUN_gc = (0x01<<0)  /* The peripheral will continue to run in Break Debug mode when the CPU is halted */
+} TWI_DBGRUN_t;
+
+/* Fast-mode Enable select */
+typedef enum TWI_FMEN_enum
+{
+    TWI_FMEN_OFF_gc = (0x00<<0),  /* SCL duty cycle operating according to Sm specification */
+    TWI_FMEN_ON_gc = (0x01<<0)  /* SCL duty cycle operating according to Fm specification */
+} TWI_FMEN_t;
+
+/* Fast-mode Plus Enable select */
+typedef enum TWI_FMPEN_enum
+{
+    TWI_FMPEN_OFF_gc = (0x00<<1),  /* Operating in Standard-mode or Fast-mode */
+    TWI_FMPEN_ON_gc = (0x01<<1)  /* Operating in Fast-mode Plus */
+} TWI_FMPEN_t;
+
+/* Input voltage transition level select */
+typedef enum TWI_INPUTLVL_enum
+{
+    TWI_INPUTLVL_I2C_gc = (0x00<<6),  /* I2C input voltage transition level */
+    TWI_INPUTLVL_SMBUS_gc = (0x01<<6)  /* SMBus 3.0 input voltage transition level */
+} TWI_INPUTLVL_t;
+
+/* Command select */
+typedef enum TWI_MCMD_enum
+{
+    TWI_MCMD_NOACT_gc = (0x00<<0),  /* No action */
+    TWI_MCMD_REPSTART_gc = (0x01<<0),  /* Execute Acknowledge Action followed by repeated Start. */
+    TWI_MCMD_RECVTRANS_gc = (0x02<<0),  /* Execute Acknowledge Action followed by a byte read/write operation. Read/write is defined by DIR. */
+    TWI_MCMD_STOP_gc = (0x03<<0)  /* Execute Acknowledge Action followed by issuing a Stop condition. */
+} TWI_MCMD_t;
+
+/* Command select */
+typedef enum TWI_SCMD_enum
+{
+    TWI_SCMD_NOACT_gc = (0x00<<0),  /* No Action */
+    TWI_SCMD_COMPTRANS_gc = (0x02<<0),  /* Complete transaction */
+    TWI_SCMD_RESPONSE_gc = (0x03<<0)  /* Used in response to an interrupt */
+} TWI_SCMD_t;
+
+/* SDA Hold Time select */
+typedef enum TWI_SDAHOLD_enum
+{
+    TWI_SDAHOLD_OFF_gc = (0x00<<2),  /* No SDA Hold Delay */
+    TWI_SDAHOLD_50NS_gc = (0x01<<2),  /* Short SDA hold time */
+    TWI_SDAHOLD_300NS_gc = (0x02<<2),  /* Meets SMBUS 2.0 specification under typical conditions */
+    TWI_SDAHOLD_500NS_gc = (0x03<<2)  /* Meets SMBUS 2.0 specificaiton across all corners */
+} TWI_SDAHOLD_t;
+
+/* SDA Setup Time select */
+typedef enum TWI_SDASETUP_enum
+{
+    TWI_SDASETUP_4CYC_gc = (0x00<<4),  /* SDA setup time is four clock cycles */
+    TWI_SDASETUP_8CYC_gc = (0x01<<4)  /* SDA setup time is eight clock cycle */
+} TWI_SDASETUP_t;
+
+/* Inactive Bus Time-Out select */
+typedef enum TWI_TIMEOUT_enum
+{
+    TWI_TIMEOUT_DISABLED_gc = (0x00<<2),  /* Bus time-out disabled. I2C. */
+    TWI_TIMEOUT_50US_gc = (0x01<<2),  /* 50us - SMBus */
+    TWI_TIMEOUT_100US_gc = (0x02<<2),  /* 100us */
+    TWI_TIMEOUT_200US_gc = (0x03<<2)  /* 200us */
+} TWI_TIMEOUT_t;
+
+/*
+--------------------------------------------------------------------------
+USART - Universal Synchronous and Asynchronous Receiver and Transmitter
+--------------------------------------------------------------------------
+*/
+
+/* Universal Synchronous and Asynchronous Receiver and Transmitter */
+typedef struct USART_struct
+{
+    register8_t RXDATAL;  /* Receive Data Low Byte */
+    register8_t RXDATAH;  /* Receive Data High Byte */
+    register8_t TXDATAL;  /* Transmit Data Low Byte */
+    register8_t TXDATAH;  /* Transmit Data High Byte */
+    register8_t STATUS;  /* Status */
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    _WORDREGISTER(BAUD);  /* Baud Rate */
+    register8_t CTRLD;  /* Control D */
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t EVCTRL;  /* Event Control */
+    register8_t TXPLCTRL;  /* IRCOM Transmitter Pulse Length Control */
+    register8_t RXPLCTRL;  /* IRCOM Receiver Pulse Length Control */
+    register8_t reserved_1[1];
+} USART_t;
+
+/* Auto Baud Window select */
+typedef enum USART_ABW_enum
+{
+    USART_ABW_WDW0_gc = (0x00<<6),  /* 18% tolerance */
+    USART_ABW_WDW1_gc = (0x01<<6),  /* 15% tolerance */
+    USART_ABW_WDW2_gc = (0x02<<6),  /* 21% tolerance */
+    USART_ABW_WDW3_gc = (0x03<<6)  /* 25% tolerance */
+} USART_ABW_t;
+
+/* Character Size select */
+typedef enum USART_CHSIZE_enum
+{
+    USART_CHSIZE_5BIT_gc = (0x00<<0),  /* Character size: 5 bit */
+    USART_CHSIZE_6BIT_gc = (0x01<<0),  /* Character size: 6 bit */
+    USART_CHSIZE_7BIT_gc = (0x02<<0),  /* Character size: 7 bit */
+    USART_CHSIZE_8BIT_gc = (0x03<<0),  /* Character size: 8 bit */
+    USART_CHSIZE_9BITL_gc = (0x06<<0),  /* Character size: 9 bit read low byte first */
+    USART_CHSIZE_9BITH_gc = (0x07<<0)  /* Character size: 9 bit read high byte first */
+} USART_CHSIZE_t;
+
+/* Communication Mode select */
+typedef enum USART_CMODE_enum
+{
+    USART_CMODE_ASYNCHRONOUS_gc = (0x00<<6),  /* Asynchronous Mode */
+    USART_CMODE_SYNCHRONOUS_gc = (0x01<<6),  /* Synchronous Mode */
+    USART_CMODE_IRCOM_gc = (0x02<<6),  /* Infrared Communication */
+    USART_CMODE_MSPI_gc = (0x03<<6)  /* SPI Host Mode */
+} USART_CMODE_t;
+
+/* Parity Mode select */
+typedef enum USART_PMODE_enum
+{
+    USART_PMODE_DISABLED_gc = (0x00<<4),  /* No Parity */
+    USART_PMODE_EVEN_gc = (0x02<<4),  /* Even Parity */
+    USART_PMODE_ODD_gc = (0x03<<4)  /* Odd Parity */
+} USART_PMODE_t;
+
+/* RS485 Mode internal transmitter select */
+typedef enum USART_RS485_enum
+{
+    USART_RS485_DISABLE_gc = (0x00<<0),  /* RS485 Mode disabled */
+    USART_RS485_ENABLE_gc = (0x01<<0)  /* RS485 Mode enabled */
+} USART_RS485_t;
+
+/* Receiver Mode select */
+typedef enum USART_RXMODE_enum
+{
+    USART_RXMODE_NORMAL_gc = (0x00<<1),  /* Normal mode */
+    USART_RXMODE_CLK2X_gc = (0x01<<1),  /* CLK2x mode */
+    USART_RXMODE_GENAUTO_gc = (0x02<<1),  /* Generic autobaud mode */
+    USART_RXMODE_LINAUTO_gc = (0x03<<1)  /* LIN constrained autobaud mode */
+} USART_RXMODE_t;
+
+/* Stop Bit Mode select */
+typedef enum USART_SBMODE_enum
+{
+    USART_SBMODE_1BIT_gc = (0x00<<3),  /* 1 stop bit */
+    USART_SBMODE_2BIT_gc = (0x01<<3)  /* 2 stop bits */
+} USART_SBMODE_t;
+
+/*
+--------------------------------------------------------------------------
+USERROW - User Row
+--------------------------------------------------------------------------
+*/
+
+/* User Row */
+typedef struct USERROW_struct
+{
+    register8_t USERROW0;  /* User Row Byte 0 */
+    register8_t USERROW1;  /* User Row Byte 1 */
+    register8_t USERROW2;  /* User Row Byte 2 */
+    register8_t USERROW3;  /* User Row Byte 3 */
+    register8_t USERROW4;  /* User Row Byte 4 */
+    register8_t USERROW5;  /* User Row Byte 5 */
+    register8_t USERROW6;  /* User Row Byte 6 */
+    register8_t USERROW7;  /* User Row Byte 7 */
+    register8_t USERROW8;  /* User Row Byte 8 */
+    register8_t USERROW9;  /* User Row Byte 9 */
+    register8_t USERROW10;  /* User Row Byte 10 */
+    register8_t USERROW11;  /* User Row Byte 11 */
+    register8_t USERROW12;  /* User Row Byte 12 */
+    register8_t USERROW13;  /* User Row Byte 13 */
+    register8_t USERROW14;  /* User Row Byte 14 */
+    register8_t USERROW15;  /* User Row Byte 15 */
+    register8_t USERROW16;  /* User Row Byte 16 */
+    register8_t USERROW17;  /* User Row Byte 17 */
+    register8_t USERROW18;  /* User Row Byte 18 */
+    register8_t USERROW19;  /* User Row Byte 19 */
+    register8_t USERROW20;  /* User Row Byte 20 */
+    register8_t USERROW21;  /* User Row Byte 21 */
+    register8_t USERROW22;  /* User Row Byte 22 */
+    register8_t USERROW23;  /* User Row Byte 23 */
+    register8_t USERROW24;  /* User Row Byte 24 */
+    register8_t USERROW25;  /* User Row Byte 25 */
+    register8_t USERROW26;  /* User Row Byte 26 */
+    register8_t USERROW27;  /* User Row Byte 27 */
+    register8_t USERROW28;  /* User Row Byte 28 */
+    register8_t USERROW29;  /* User Row Byte 29 */
+    register8_t USERROW30;  /* User Row Byte 30 */
+    register8_t USERROW31;  /* User Row Byte 31 */
+    register8_t USERROW32;  /* User Row Byte 32 */
+    register8_t USERROW33;  /* User Row Byte 33 */
+    register8_t USERROW34;  /* User Row Byte 34 */
+    register8_t USERROW35;  /* User Row Byte 35 */
+    register8_t USERROW36;  /* User Row Byte 36 */
+    register8_t USERROW37;  /* User Row Byte 37 */
+    register8_t USERROW38;  /* User Row Byte 38 */
+    register8_t USERROW39;  /* User Row Byte 39 */
+    register8_t USERROW40;  /* User Row Byte 40 */
+    register8_t USERROW41;  /* User Row Byte 41 */
+    register8_t USERROW42;  /* User Row Byte 42 */
+    register8_t USERROW43;  /* User Row Byte 43 */
+    register8_t USERROW44;  /* User Row Byte 44 */
+    register8_t USERROW45;  /* User Row Byte 45 */
+    register8_t USERROW46;  /* User Row Byte 46 */
+    register8_t USERROW47;  /* User Row Byte 47 */
+    register8_t USERROW48;  /* User Row Byte 48 */
+    register8_t USERROW49;  /* User Row Byte 49 */
+    register8_t USERROW50;  /* User Row Byte 50 */
+    register8_t USERROW51;  /* User Row Byte 51 */
+    register8_t USERROW52;  /* User Row Byte 52 */
+    register8_t USERROW53;  /* User Row Byte 53 */
+    register8_t USERROW54;  /* User Row Byte 54 */
+    register8_t USERROW55;  /* User Row Byte 55 */
+    register8_t USERROW56;  /* User Row Byte 56 */
+    register8_t USERROW57;  /* User Row Byte 57 */
+    register8_t USERROW58;  /* User Row Byte 58 */
+    register8_t USERROW59;  /* User Row Byte 59 */
+    register8_t USERROW60;  /* User Row Byte 60 */
+    register8_t USERROW61;  /* User Row Byte 61 */
+    register8_t USERROW62;  /* User Row Byte 62 */
+    register8_t USERROW63;  /* User Row Byte 63 */
+} USERROW_t;
+
+
+/*
+--------------------------------------------------------------------------
+VPORT - Virtual Ports
+--------------------------------------------------------------------------
+*/
+
+/* Virtual Ports */
+typedef struct VPORT_struct
+{
+    register8_t DIR;  /* Data Direction */
+    register8_t OUT;  /* Output Value */
+    register8_t IN;  /* Input Value */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+} VPORT_t;
+
+
+/*
+--------------------------------------------------------------------------
+VREF - Voltage reference
+--------------------------------------------------------------------------
+*/
+
+/* Voltage reference */
+typedef struct VREF_struct
+{
+    register8_t reserved_1[2];
+    register8_t DAC0REF;  /* DAC0 Reference */
+    register8_t reserved_2[1];
+    register8_t ACREF;  /* AC Reference */
+} VREF_t;
+
+/* Reference select */
+typedef enum VREF_REFSEL_enum
+{
+    VREF_REFSEL_1V024_gc = (0x00<<0),  /* Internal 1.024V reference */
+    VREF_REFSEL_2V048_gc = (0x01<<0),  /* Internal 2.048V reference */
+    VREF_REFSEL_4V096_gc = (0x02<<0),  /* Internal 4.096V reference */
+    VREF_REFSEL_2V500_gc = (0x03<<0),  /* Internal 2.500V reference */
+    VREF_REFSEL_VDD_gc = (0x05<<0),  /* VDD as reference */
+    VREF_REFSEL_VREFA_gc = (0x06<<0)  /* External reference on VREFA pin */
+} VREF_REFSEL_t;
+
+/*
+--------------------------------------------------------------------------
+WDT - Watch-Dog Timer
+--------------------------------------------------------------------------
+*/
+
+/* Watch-Dog Timer */
+typedef struct WDT_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t STATUS;  /* Status */
+    register8_t reserved_1[14];
+} WDT_t;
+
+/* Period select */
+typedef enum WDT_PERIOD_enum
+{
+    WDT_PERIOD_OFF_gc = (0x00<<0),  /* Off */
+    WDT_PERIOD_8CLK_gc = (0x01<<0),  /* 8 cycles (8ms) */
+    WDT_PERIOD_16CLK_gc = (0x02<<0),  /* 16 cycles (16ms) */
+    WDT_PERIOD_32CLK_gc = (0x03<<0),  /* 32 cycles (32ms) */
+    WDT_PERIOD_64CLK_gc = (0x04<<0),  /* 64 cycles (64ms) */
+    WDT_PERIOD_128CLK_gc = (0x05<<0),  /* 128 cycles (0.128s) */
+    WDT_PERIOD_256CLK_gc = (0x06<<0),  /* 256 cycles (0.256s) */
+    WDT_PERIOD_512CLK_gc = (0x07<<0),  /* 512 cycles (0.512s) */
+    WDT_PERIOD_1KCLK_gc = (0x08<<0),  /* 1K cycles (1.0s) */
+    WDT_PERIOD_2KCLK_gc = (0x09<<0),  /* 2K cycles (2.0s) */
+    WDT_PERIOD_4KCLK_gc = (0x0A<<0),  /* 4K cycles (4.1s) */
+    WDT_PERIOD_8KCLK_gc = (0x0B<<0)  /* 8K cycles (8.2s) */
+} WDT_PERIOD_t;
+
+/* Window select */
+typedef enum WDT_WINDOW_enum
+{
+    WDT_WINDOW_OFF_gc = (0x00<<4),  /* Off */
+    WDT_WINDOW_8CLK_gc = (0x01<<4),  /* 8 cycles (8ms) */
+    WDT_WINDOW_16CLK_gc = (0x02<<4),  /* 16 cycles (16ms) */
+    WDT_WINDOW_32CLK_gc = (0x03<<4),  /* 32 cycles (32ms) */
+    WDT_WINDOW_64CLK_gc = (0x04<<4),  /* 64 cycles (64ms) */
+    WDT_WINDOW_128CLK_gc = (0x05<<4),  /* 128 cycles (0.128s) */
+    WDT_WINDOW_256CLK_gc = (0x06<<4),  /* 256 cycles (0.256s) */
+    WDT_WINDOW_512CLK_gc = (0x07<<4),  /* 512 cycles (0.512s) */
+    WDT_WINDOW_1KCLK_gc = (0x08<<4),  /* 1K cycles (1.0s) */
+    WDT_WINDOW_2KCLK_gc = (0x09<<4),  /* 2K cycles (2.0s) */
+    WDT_WINDOW_4KCLK_gc = (0x0A<<4),  /* 4K cycles (4.1s) */
+    WDT_WINDOW_8KCLK_gc = (0x0B<<4)  /* 8K cycles (8.2s) */
+} WDT_WINDOW_t;
+/*
+==========================================================================
+IO Module Instances. Mapped to memory.
+==========================================================================
+*/
+
+#define VPORTA              (*(VPORT_t *) 0x0000) /* Virtual Ports */
+#define VPORTC              (*(VPORT_t *) 0x0008) /* Virtual Ports */
+#define VPORTD              (*(VPORT_t *) 0x000C) /* Virtual Ports */
+#define VPORTF              (*(VPORT_t *) 0x0014) /* Virtual Ports */
+#define GPR                   (*(GPR_t *) 0x001C) /* General Purpose Registers */
+#define RSTCTRL           (*(RSTCTRL_t *) 0x0040) /* Reset controller */
+#define SLPCTRL           (*(SLPCTRL_t *) 0x0050) /* Sleep Controller */
+#define CLKCTRL           (*(CLKCTRL_t *) 0x0060) /* Clock controller */
+#define BOD                   (*(BOD_t *) 0x00A0) /* Bod interface */
+#define VREF                 (*(VREF_t *) 0x00B0) /* Voltage reference */
+#define WDT                   (*(WDT_t *) 0x0100) /* Watch-Dog Timer */
+#define CPUINT             (*(CPUINT_t *) 0x0110) /* Interrupt Controller */
+#define CRCSCAN           (*(CRCSCAN_t *) 0x0120) /* CRCSCAN */
+#define RTC                   (*(RTC_t *) 0x0140) /* Real-Time Counter */
+#define CCL                   (*(CCL_t *) 0x01C0) /* Configurable Custom Logic */
+#define EVSYS               (*(EVSYS_t *) 0x0200) /* Event System */
+#define PORTA                (*(PORT_t *) 0x0400) /* I/O Ports */
+#define PORTC                (*(PORT_t *) 0x0440) /* I/O Ports */
+#define PORTD                (*(PORT_t *) 0x0460) /* I/O Ports */
+#define PORTF                (*(PORT_t *) 0x04A0) /* I/O Ports */
+#define PORTMUX           (*(PORTMUX_t *) 0x05E0) /* Port Multiplexer */
+#define ADC0                  (*(ADC_t *) 0x0600) /* Analog to Digital Converter */
+#define AC0                    (*(AC_t *) 0x0680) /* Analog Comparator */
+#define AC1                    (*(AC_t *) 0x0688) /* Analog Comparator */
+#define DAC0                  (*(DAC_t *) 0x06A0) /* Digital to Analog Converter */
+#define USART0              (*(USART_t *) 0x0800) /* Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define USART1              (*(USART_t *) 0x0820) /* Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define USART2              (*(USART_t *) 0x0840) /* Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define TWI0                  (*(TWI_t *) 0x0900) /* Two-Wire Interface */
+#define SPI0                  (*(SPI_t *) 0x0940) /* Serial Peripheral Interface */
+#define TCA0                  (*(TCA_t *) 0x0A00) /* 16-bit Timer/Counter Type A */
+#define TCB0                  (*(TCB_t *) 0x0B00) /* 16-bit Timer Type B */
+#define TCB1                  (*(TCB_t *) 0x0B10) /* 16-bit Timer Type B */
+#define TCB2                  (*(TCB_t *) 0x0B20) /* 16-bit Timer Type B */
+#define SYSCFG             (*(SYSCFG_t *) 0x0F00) /* System Configuration Registers */
+#define NVMCTRL           (*(NVMCTRL_t *) 0x1000) /* Non-volatile Memory Controller */
+#define LOCK                 (*(LOCK_t *) 0x1040) /* Lockbits */
+#define FUSE                 (*(FUSE_t *) 0x1050) /* Fuses */
+#define USERROW           (*(USERROW_t *) 0x1080) /* User Row */
+#define SIGROW             (*(SIGROW_t *) 0x1100) /* Signature row */
+
+#endif /* !defined (__ASSEMBLER__) */
+
+
+/* ========== Flattened fully qualified IO register names ========== */
+
+
+/* VPORT (VPORTA) - Virtual Ports */
+#define VPORTA_DIR  _SFR_MEM8(0x0000)
+#define VPORTA_OUT  _SFR_MEM8(0x0001)
+#define VPORTA_IN  _SFR_MEM8(0x0002)
+#define VPORTA_INTFLAGS  _SFR_MEM8(0x0003)
+
+
+/* VPORT (VPORTC) - Virtual Ports */
+#define VPORTC_DIR  _SFR_MEM8(0x0008)
+#define VPORTC_OUT  _SFR_MEM8(0x0009)
+#define VPORTC_IN  _SFR_MEM8(0x000A)
+#define VPORTC_INTFLAGS  _SFR_MEM8(0x000B)
+
+
+/* VPORT (VPORTD) - Virtual Ports */
+#define VPORTD_DIR  _SFR_MEM8(0x000C)
+#define VPORTD_OUT  _SFR_MEM8(0x000D)
+#define VPORTD_IN  _SFR_MEM8(0x000E)
+#define VPORTD_INTFLAGS  _SFR_MEM8(0x000F)
+
+
+/* VPORT (VPORTF) - Virtual Ports */
+#define VPORTF_DIR  _SFR_MEM8(0x0014)
+#define VPORTF_OUT  _SFR_MEM8(0x0015)
+#define VPORTF_IN  _SFR_MEM8(0x0016)
+#define VPORTF_INTFLAGS  _SFR_MEM8(0x0017)
+
+
+/* GPR - General Purpose Registers */
+#define GPR_GPR0  _SFR_MEM8(0x001C)
+#define GPR_GPR1  _SFR_MEM8(0x001D)
+#define GPR_GPR2  _SFR_MEM8(0x001E)
+#define GPR_GPR3  _SFR_MEM8(0x001F)
+
+
+/* CPU - CPU */
+#define CPU_CCP  _SFR_MEM8(0x0034)
+#define CPU_SP  _SFR_MEM16(0x003D)
+#define CPU_SPL  _SFR_MEM8(0x003D)
+#define CPU_SPH  _SFR_MEM8(0x003E)
+#define CPU_SREG  _SFR_MEM8(0x003F)
+
+
+/* RSTCTRL - Reset controller */
+#define RSTCTRL_RSTFR  _SFR_MEM8(0x0040)
+#define RSTCTRL_SWRR  _SFR_MEM8(0x0041)
+
+
+/* SLPCTRL - Sleep Controller */
+#define SLPCTRL_CTRLA  _SFR_MEM8(0x0050)
+
+
+/* CLKCTRL - Clock controller */
+#define CLKCTRL_MCLKCTRLA  _SFR_MEM8(0x0060)
+#define CLKCTRL_MCLKCTRLB  _SFR_MEM8(0x0061)
+#define CLKCTRL_MCLKCTRLC  _SFR_MEM8(0x0062)
+#define CLKCTRL_MCLKINTCTRL  _SFR_MEM8(0x0063)
+#define CLKCTRL_MCLKINTFLAGS  _SFR_MEM8(0x0064)
+#define CLKCTRL_MCLKSTATUS  _SFR_MEM8(0x0065)
+#define CLKCTRL_MCLKTIMEBASE  _SFR_MEM8(0x0066)
+#define CLKCTRL_OSCHFCTRLA  _SFR_MEM8(0x0068)
+#define CLKCTRL_OSCHFTUNE  _SFR_MEM8(0x0069)
+#define CLKCTRL_OSC32KCTRLA  _SFR_MEM8(0x0078)
+#define CLKCTRL_XOSC32KCTRLA  _SFR_MEM8(0x007C)
+#define CLKCTRL_XOSCHFCTRLA  _SFR_MEM8(0x0080)
+
+
+/* BOD - Bod interface */
+#define BOD_CTRLA  _SFR_MEM8(0x00A0)
+#define BOD_CTRLB  _SFR_MEM8(0x00A1)
+#define BOD_VLMCTRLA  _SFR_MEM8(0x00A8)
+#define BOD_INTCTRL  _SFR_MEM8(0x00A9)
+#define BOD_INTFLAGS  _SFR_MEM8(0x00AA)
+#define BOD_STATUS  _SFR_MEM8(0x00AB)
+
+
+/* VREF - Voltage reference */
+#define VREF_DAC0REF  _SFR_MEM8(0x00B2)
+#define VREF_ACREF  _SFR_MEM8(0x00B4)
+
+
+/* WDT - Watch-Dog Timer */
+#define WDT_CTRLA  _SFR_MEM8(0x0100)
+#define WDT_STATUS  _SFR_MEM8(0x0101)
+
+
+/* CPUINT - Interrupt Controller */
+#define CPUINT_CTRLA  _SFR_MEM8(0x0110)
+#define CPUINT_STATUS  _SFR_MEM8(0x0111)
+#define CPUINT_LVL0PRI  _SFR_MEM8(0x0112)
+#define CPUINT_LVL1VEC  _SFR_MEM8(0x0113)
+
+
+/* CRCSCAN - CRCSCAN */
+#define CRCSCAN_CTRLA  _SFR_MEM8(0x0120)
+#define CRCSCAN_CTRLB  _SFR_MEM8(0x0121)
+#define CRCSCAN_STATUS  _SFR_MEM8(0x0122)
+
+
+/* RTC - Real-Time Counter */
+#define RTC_CTRLA  _SFR_MEM8(0x0140)
+#define RTC_STATUS  _SFR_MEM8(0x0141)
+#define RTC_INTCTRL  _SFR_MEM8(0x0142)
+#define RTC_INTFLAGS  _SFR_MEM8(0x0143)
+#define RTC_TEMP  _SFR_MEM8(0x0144)
+#define RTC_DBGCTRL  _SFR_MEM8(0x0145)
+#define RTC_CALIB  _SFR_MEM8(0x0146)
+#define RTC_CLKSEL  _SFR_MEM8(0x0147)
+#define RTC_CNT  _SFR_MEM16(0x0148)
+#define RTC_CNTL  _SFR_MEM8(0x0148)
+#define RTC_CNTH  _SFR_MEM8(0x0149)
+#define RTC_PER  _SFR_MEM16(0x014A)
+#define RTC_PERL  _SFR_MEM8(0x014A)
+#define RTC_PERH  _SFR_MEM8(0x014B)
+#define RTC_CMP  _SFR_MEM16(0x014C)
+#define RTC_CMPL  _SFR_MEM8(0x014C)
+#define RTC_CMPH  _SFR_MEM8(0x014D)
+#define RTC_PITCTRLA  _SFR_MEM8(0x0150)
+#define RTC_PITSTATUS  _SFR_MEM8(0x0151)
+#define RTC_PITINTCTRL  _SFR_MEM8(0x0152)
+#define RTC_PITINTFLAGS  _SFR_MEM8(0x0153)
+#define RTC_PITDBGCTRL  _SFR_MEM8(0x0155)
+#define RTC_PITEVGENCTRLA  _SFR_MEM8(0x0156)
+
+
+/* CCL - Configurable Custom Logic */
+#define CCL_CTRLA  _SFR_MEM8(0x01C0)
+#define CCL_SEQCTRL0  _SFR_MEM8(0x01C1)
+#define CCL_SEQCTRL1  _SFR_MEM8(0x01C2)
+#define CCL_INTCTRL0  _SFR_MEM8(0x01C5)
+#define CCL_INTFLAGS  _SFR_MEM8(0x01C7)
+#define CCL_LUT0CTRLA  _SFR_MEM8(0x01C8)
+#define CCL_LUT0CTRLB  _SFR_MEM8(0x01C9)
+#define CCL_LUT0CTRLC  _SFR_MEM8(0x01CA)
+#define CCL_TRUTH0  _SFR_MEM8(0x01CB)
+#define CCL_LUT1CTRLA  _SFR_MEM8(0x01CC)
+#define CCL_LUT1CTRLB  _SFR_MEM8(0x01CD)
+#define CCL_LUT1CTRLC  _SFR_MEM8(0x01CE)
+#define CCL_TRUTH1  _SFR_MEM8(0x01CF)
+#define CCL_LUT2CTRLA  _SFR_MEM8(0x01D0)
+#define CCL_LUT2CTRLB  _SFR_MEM8(0x01D1)
+#define CCL_LUT2CTRLC  _SFR_MEM8(0x01D2)
+#define CCL_TRUTH2  _SFR_MEM8(0x01D3)
+#define CCL_LUT3CTRLA  _SFR_MEM8(0x01D4)
+#define CCL_LUT3CTRLB  _SFR_MEM8(0x01D5)
+#define CCL_LUT3CTRLC  _SFR_MEM8(0x01D6)
+#define CCL_TRUTH3  _SFR_MEM8(0x01D7)
+
+
+/* EVSYS - Event System */
+#define EVSYS_SWEVENTA  _SFR_MEM8(0x0200)
+#define EVSYS_CHANNEL0  _SFR_MEM8(0x0210)
+#define EVSYS_CHANNEL1  _SFR_MEM8(0x0211)
+#define EVSYS_CHANNEL2  _SFR_MEM8(0x0212)
+#define EVSYS_CHANNEL3  _SFR_MEM8(0x0213)
+#define EVSYS_CHANNEL4  _SFR_MEM8(0x0214)
+#define EVSYS_CHANNEL5  _SFR_MEM8(0x0215)
+#define EVSYS_USERCCLLUT0A  _SFR_MEM8(0x0220)
+#define EVSYS_USERCCLLUT0B  _SFR_MEM8(0x0221)
+#define EVSYS_USERCCLLUT1A  _SFR_MEM8(0x0222)
+#define EVSYS_USERCCLLUT1B  _SFR_MEM8(0x0223)
+#define EVSYS_USERCCLLUT2A  _SFR_MEM8(0x0224)
+#define EVSYS_USERCCLLUT2B  _SFR_MEM8(0x0225)
+#define EVSYS_USERCCLLUT3A  _SFR_MEM8(0x0226)
+#define EVSYS_USERCCLLUT3B  _SFR_MEM8(0x0227)
+#define EVSYS_USERADC0START  _SFR_MEM8(0x0228)
+#define EVSYS_USEREVSYSEVOUTA  _SFR_MEM8(0x0229)
+#define EVSYS_USEREVSYSEVOUTC  _SFR_MEM8(0x022B)
+#define EVSYS_USEREVSYSEVOUTD  _SFR_MEM8(0x022C)
+#define EVSYS_USEREVSYSEVOUTF  _SFR_MEM8(0x022E)
+#define EVSYS_USERUSART0IRDA  _SFR_MEM8(0x022F)
+#define EVSYS_USERUSART1IRDA  _SFR_MEM8(0x0230)
+#define EVSYS_USERUSART2IRDA  _SFR_MEM8(0x0231)
+#define EVSYS_USERTCA0CNTA  _SFR_MEM8(0x0232)
+#define EVSYS_USERTCA0CNTB  _SFR_MEM8(0x0233)
+#define EVSYS_USERTCA1CNTA  _SFR_MEM8(0x0234)
+#define EVSYS_USERTCA1CNTB  _SFR_MEM8(0x0235)
+#define EVSYS_USERTCB0CAPT  _SFR_MEM8(0x0236)
+#define EVSYS_USERTCB0COUNT  _SFR_MEM8(0x0237)
+#define EVSYS_USERTCB1CAPT  _SFR_MEM8(0x0238)
+#define EVSYS_USERTCB1COUNT  _SFR_MEM8(0x0239)
+#define EVSYS_USERTCB2CAPT  _SFR_MEM8(0x023A)
+#define EVSYS_USERTCB2COUNT  _SFR_MEM8(0x023B)
+#define EVSYS_USERTCB3CAPT  _SFR_MEM8(0x023C)
+#define EVSYS_USERTCB3COUNT  _SFR_MEM8(0x023D)
+
+
+/* PORT (PORTA) - I/O Ports */
+#define PORTA_DIR  _SFR_MEM8(0x0400)
+#define PORTA_DIRSET  _SFR_MEM8(0x0401)
+#define PORTA_DIRCLR  _SFR_MEM8(0x0402)
+#define PORTA_DIRTGL  _SFR_MEM8(0x0403)
+#define PORTA_OUT  _SFR_MEM8(0x0404)
+#define PORTA_OUTSET  _SFR_MEM8(0x0405)
+#define PORTA_OUTCLR  _SFR_MEM8(0x0406)
+#define PORTA_OUTTGL  _SFR_MEM8(0x0407)
+#define PORTA_IN  _SFR_MEM8(0x0408)
+#define PORTA_INTFLAGS  _SFR_MEM8(0x0409)
+#define PORTA_PORTCTRL  _SFR_MEM8(0x040A)
+#define PORTA_PINCONFIG  _SFR_MEM8(0x040B)
+#define PORTA_PINCTRLUPD  _SFR_MEM8(0x040C)
+#define PORTA_PINCTRLSET  _SFR_MEM8(0x040D)
+#define PORTA_PINCTRLCLR  _SFR_MEM8(0x040E)
+#define PORTA_PIN0CTRL  _SFR_MEM8(0x0410)
+#define PORTA_PIN1CTRL  _SFR_MEM8(0x0411)
+#define PORTA_PIN2CTRL  _SFR_MEM8(0x0412)
+#define PORTA_PIN3CTRL  _SFR_MEM8(0x0413)
+#define PORTA_PIN4CTRL  _SFR_MEM8(0x0414)
+#define PORTA_PIN5CTRL  _SFR_MEM8(0x0415)
+#define PORTA_PIN6CTRL  _SFR_MEM8(0x0416)
+#define PORTA_PIN7CTRL  _SFR_MEM8(0x0417)
+#define PORTA_EVGENCTRL  _SFR_MEM8(0x0418)
+
+
+/* PORT (PORTC) - I/O Ports */
+#define PORTC_DIR  _SFR_MEM8(0x0440)
+#define PORTC_DIRSET  _SFR_MEM8(0x0441)
+#define PORTC_DIRCLR  _SFR_MEM8(0x0442)
+#define PORTC_DIRTGL  _SFR_MEM8(0x0443)
+#define PORTC_OUT  _SFR_MEM8(0x0444)
+#define PORTC_OUTSET  _SFR_MEM8(0x0445)
+#define PORTC_OUTCLR  _SFR_MEM8(0x0446)
+#define PORTC_OUTTGL  _SFR_MEM8(0x0447)
+#define PORTC_IN  _SFR_MEM8(0x0448)
+#define PORTC_INTFLAGS  _SFR_MEM8(0x0449)
+#define PORTC_PORTCTRL  _SFR_MEM8(0x044A)
+#define PORTC_PINCONFIG  _SFR_MEM8(0x044B)
+#define PORTC_PINCTRLUPD  _SFR_MEM8(0x044C)
+#define PORTC_PINCTRLSET  _SFR_MEM8(0x044D)
+#define PORTC_PINCTRLCLR  _SFR_MEM8(0x044E)
+#define PORTC_PIN0CTRL  _SFR_MEM8(0x0450)
+#define PORTC_PIN1CTRL  _SFR_MEM8(0x0451)
+#define PORTC_PIN2CTRL  _SFR_MEM8(0x0452)
+#define PORTC_PIN3CTRL  _SFR_MEM8(0x0453)
+#define PORTC_PIN4CTRL  _SFR_MEM8(0x0454)
+#define PORTC_PIN5CTRL  _SFR_MEM8(0x0455)
+#define PORTC_PIN6CTRL  _SFR_MEM8(0x0456)
+#define PORTC_PIN7CTRL  _SFR_MEM8(0x0457)
+#define PORTC_EVGENCTRL  _SFR_MEM8(0x0458)
+
+
+/* PORT (PORTD) - I/O Ports */
+#define PORTD_DIR  _SFR_MEM8(0x0460)
+#define PORTD_DIRSET  _SFR_MEM8(0x0461)
+#define PORTD_DIRCLR  _SFR_MEM8(0x0462)
+#define PORTD_DIRTGL  _SFR_MEM8(0x0463)
+#define PORTD_OUT  _SFR_MEM8(0x0464)
+#define PORTD_OUTSET  _SFR_MEM8(0x0465)
+#define PORTD_OUTCLR  _SFR_MEM8(0x0466)
+#define PORTD_OUTTGL  _SFR_MEM8(0x0467)
+#define PORTD_IN  _SFR_MEM8(0x0468)
+#define PORTD_INTFLAGS  _SFR_MEM8(0x0469)
+#define PORTD_PORTCTRL  _SFR_MEM8(0x046A)
+#define PORTD_PINCONFIG  _SFR_MEM8(0x046B)
+#define PORTD_PINCTRLUPD  _SFR_MEM8(0x046C)
+#define PORTD_PINCTRLSET  _SFR_MEM8(0x046D)
+#define PORTD_PINCTRLCLR  _SFR_MEM8(0x046E)
+#define PORTD_PIN0CTRL  _SFR_MEM8(0x0470)
+#define PORTD_PIN1CTRL  _SFR_MEM8(0x0471)
+#define PORTD_PIN2CTRL  _SFR_MEM8(0x0472)
+#define PORTD_PIN3CTRL  _SFR_MEM8(0x0473)
+#define PORTD_PIN4CTRL  _SFR_MEM8(0x0474)
+#define PORTD_PIN5CTRL  _SFR_MEM8(0x0475)
+#define PORTD_PIN6CTRL  _SFR_MEM8(0x0476)
+#define PORTD_PIN7CTRL  _SFR_MEM8(0x0477)
+#define PORTD_EVGENCTRL  _SFR_MEM8(0x0478)
+
+
+/* PORT (PORTF) - I/O Ports */
+#define PORTF_DIR  _SFR_MEM8(0x04A0)
+#define PORTF_DIRSET  _SFR_MEM8(0x04A1)
+#define PORTF_DIRCLR  _SFR_MEM8(0x04A2)
+#define PORTF_DIRTGL  _SFR_MEM8(0x04A3)
+#define PORTF_OUT  _SFR_MEM8(0x04A4)
+#define PORTF_OUTSET  _SFR_MEM8(0x04A5)
+#define PORTF_OUTCLR  _SFR_MEM8(0x04A6)
+#define PORTF_OUTTGL  _SFR_MEM8(0x04A7)
+#define PORTF_IN  _SFR_MEM8(0x04A8)
+#define PORTF_INTFLAGS  _SFR_MEM8(0x04A9)
+#define PORTF_PORTCTRL  _SFR_MEM8(0x04AA)
+#define PORTF_PINCONFIG  _SFR_MEM8(0x04AB)
+#define PORTF_PINCTRLUPD  _SFR_MEM8(0x04AC)
+#define PORTF_PINCTRLSET  _SFR_MEM8(0x04AD)
+#define PORTF_PINCTRLCLR  _SFR_MEM8(0x04AE)
+#define PORTF_PIN0CTRL  _SFR_MEM8(0x04B0)
+#define PORTF_PIN1CTRL  _SFR_MEM8(0x04B1)
+#define PORTF_PIN2CTRL  _SFR_MEM8(0x04B2)
+#define PORTF_PIN3CTRL  _SFR_MEM8(0x04B3)
+#define PORTF_PIN4CTRL  _SFR_MEM8(0x04B4)
+#define PORTF_PIN5CTRL  _SFR_MEM8(0x04B5)
+#define PORTF_PIN6CTRL  _SFR_MEM8(0x04B6)
+#define PORTF_PIN7CTRL  _SFR_MEM8(0x04B7)
+#define PORTF_EVGENCTRL  _SFR_MEM8(0x04B8)
+
+
+/* PORTMUX - Port Multiplexer */
+#define PORTMUX_EVSYSROUTEA  _SFR_MEM8(0x05E0)
+#define PORTMUX_CCLROUTEA  _SFR_MEM8(0x05E1)
+#define PORTMUX_USARTROUTEA  _SFR_MEM8(0x05E2)
+#define PORTMUX_USARTROUTEB  _SFR_MEM8(0x05E3)
+#define PORTMUX_SPIROUTEA  _SFR_MEM8(0x05E5)
+#define PORTMUX_TWIROUTEA  _SFR_MEM8(0x05E6)
+#define PORTMUX_TCAROUTEA  _SFR_MEM8(0x05E7)
+#define PORTMUX_TCBROUTEA  _SFR_MEM8(0x05E8)
+#define PORTMUX_ACROUTEA  _SFR_MEM8(0x05EA)
+
+
+/* ADC (ADC0) - Analog to Digital Converter */
+#define ADC0_CTRLA  _SFR_MEM8(0x0600)
+#define ADC0_CTRLB  _SFR_MEM8(0x0601)
+#define ADC0_CTRLC  _SFR_MEM8(0x0602)
+#define ADC0_CTRLD  _SFR_MEM8(0x0603)
+#define ADC0_INTCTRL  _SFR_MEM8(0x0604)
+#define ADC0_INTFLAGS  _SFR_MEM8(0x0605)
+#define ADC0_STATUS  _SFR_MEM8(0x0606)
+#define ADC0_DBGCTRL  _SFR_MEM8(0x0607)
+#define ADC0_CTRLE  _SFR_MEM8(0x0608)
+#define ADC0_CTRLF  _SFR_MEM8(0x0609)
+#define ADC0_COMMAND  _SFR_MEM8(0x060A)
+#define ADC0_PGACTRL  _SFR_MEM8(0x060B)
+#define ADC0_MUXPOS  _SFR_MEM8(0x060C)
+#define ADC0_MUXNEG  _SFR_MEM8(0x060D)
+#define ADC0_RESULT  _SFR_MEM32(0x0610)
+#define ADC0_RESULT0  _SFR_MEM8(0x0610)
+#define ADC0_RESULT1  _SFR_MEM8(0x0611)
+#define ADC0_RESULT2  _SFR_MEM8(0x0612)
+#define ADC0_RESULT3  _SFR_MEM8(0x0613)
+#define ADC0_SAMPLE  _SFR_MEM16(0x0614)
+#define ADC0_SAMPLEL  _SFR_MEM8(0x0614)
+#define ADC0_SAMPLEH  _SFR_MEM8(0x0615)
+#define ADC0_TEMP0  _SFR_MEM8(0x0618)
+#define ADC0_TEMP1  _SFR_MEM8(0x0619)
+#define ADC0_TEMP2  _SFR_MEM8(0x061A)
+#define ADC0_WINLT  _SFR_MEM16(0x061C)
+#define ADC0_WINLTL  _SFR_MEM8(0x061C)
+#define ADC0_WINLTH  _SFR_MEM8(0x061D)
+#define ADC0_WINHT  _SFR_MEM16(0x061E)
+#define ADC0_WINHTL  _SFR_MEM8(0x061E)
+#define ADC0_WINHTH  _SFR_MEM8(0x061F)
+
+
+/* AC (AC0) - Analog Comparator */
+#define AC0_CTRLA  _SFR_MEM8(0x0680)
+#define AC0_CTRLB  _SFR_MEM8(0x0681)
+#define AC0_MUXCTRL  _SFR_MEM8(0x0682)
+#define AC0_DACREF  _SFR_MEM8(0x0685)
+#define AC0_INTCTRL  _SFR_MEM8(0x0686)
+#define AC0_STATUS  _SFR_MEM8(0x0687)
+
+
+/* AC (AC1) - Analog Comparator */
+#define AC1_CTRLA  _SFR_MEM8(0x0688)
+#define AC1_CTRLB  _SFR_MEM8(0x0689)
+#define AC1_MUXCTRL  _SFR_MEM8(0x068A)
+#define AC1_DACREF  _SFR_MEM8(0x068D)
+#define AC1_INTCTRL  _SFR_MEM8(0x068E)
+#define AC1_STATUS  _SFR_MEM8(0x068F)
+
+
+/* DAC (DAC0) - Digital to Analog Converter */
+#define DAC0_CTRLA  _SFR_MEM8(0x06A0)
+#define DAC0_DATA  _SFR_MEM16(0x06A2)
+#define DAC0_DATAL  _SFR_MEM8(0x06A2)
+#define DAC0_DATAH  _SFR_MEM8(0x06A3)
+
+
+/* USART (USART0) - Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define USART0_RXDATAL  _SFR_MEM8(0x0800)
+#define USART0_RXDATAH  _SFR_MEM8(0x0801)
+#define USART0_TXDATAL  _SFR_MEM8(0x0802)
+#define USART0_TXDATAH  _SFR_MEM8(0x0803)
+#define USART0_STATUS  _SFR_MEM8(0x0804)
+#define USART0_CTRLA  _SFR_MEM8(0x0805)
+#define USART0_CTRLB  _SFR_MEM8(0x0806)
+#define USART0_CTRLC  _SFR_MEM8(0x0807)
+#define USART0_BAUD  _SFR_MEM16(0x0808)
+#define USART0_BAUDL  _SFR_MEM8(0x0808)
+#define USART0_BAUDH  _SFR_MEM8(0x0809)
+#define USART0_CTRLD  _SFR_MEM8(0x080A)
+#define USART0_DBGCTRL  _SFR_MEM8(0x080B)
+#define USART0_EVCTRL  _SFR_MEM8(0x080C)
+#define USART0_TXPLCTRL  _SFR_MEM8(0x080D)
+#define USART0_RXPLCTRL  _SFR_MEM8(0x080E)
+
+
+/* USART (USART1) - Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define USART1_RXDATAL  _SFR_MEM8(0x0820)
+#define USART1_RXDATAH  _SFR_MEM8(0x0821)
+#define USART1_TXDATAL  _SFR_MEM8(0x0822)
+#define USART1_TXDATAH  _SFR_MEM8(0x0823)
+#define USART1_STATUS  _SFR_MEM8(0x0824)
+#define USART1_CTRLA  _SFR_MEM8(0x0825)
+#define USART1_CTRLB  _SFR_MEM8(0x0826)
+#define USART1_CTRLC  _SFR_MEM8(0x0827)
+#define USART1_BAUD  _SFR_MEM16(0x0828)
+#define USART1_BAUDL  _SFR_MEM8(0x0828)
+#define USART1_BAUDH  _SFR_MEM8(0x0829)
+#define USART1_CTRLD  _SFR_MEM8(0x082A)
+#define USART1_DBGCTRL  _SFR_MEM8(0x082B)
+#define USART1_EVCTRL  _SFR_MEM8(0x082C)
+#define USART1_TXPLCTRL  _SFR_MEM8(0x082D)
+#define USART1_RXPLCTRL  _SFR_MEM8(0x082E)
+
+
+/* USART (USART2) - Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define USART2_RXDATAL  _SFR_MEM8(0x0840)
+#define USART2_RXDATAH  _SFR_MEM8(0x0841)
+#define USART2_TXDATAL  _SFR_MEM8(0x0842)
+#define USART2_TXDATAH  _SFR_MEM8(0x0843)
+#define USART2_STATUS  _SFR_MEM8(0x0844)
+#define USART2_CTRLA  _SFR_MEM8(0x0845)
+#define USART2_CTRLB  _SFR_MEM8(0x0846)
+#define USART2_CTRLC  _SFR_MEM8(0x0847)
+#define USART2_BAUD  _SFR_MEM16(0x0848)
+#define USART2_BAUDL  _SFR_MEM8(0x0848)
+#define USART2_BAUDH  _SFR_MEM8(0x0849)
+#define USART2_CTRLD  _SFR_MEM8(0x084A)
+#define USART2_DBGCTRL  _SFR_MEM8(0x084B)
+#define USART2_EVCTRL  _SFR_MEM8(0x084C)
+#define USART2_TXPLCTRL  _SFR_MEM8(0x084D)
+#define USART2_RXPLCTRL  _SFR_MEM8(0x084E)
+
+
+/* TWI (TWI0) - Two-Wire Interface */
+#define TWI0_CTRLA  _SFR_MEM8(0x0900)
+#define TWI0_DUALCTRL  _SFR_MEM8(0x0901)
+#define TWI0_DBGCTRL  _SFR_MEM8(0x0902)
+#define TWI0_MCTRLA  _SFR_MEM8(0x0903)
+#define TWI0_MCTRLB  _SFR_MEM8(0x0904)
+#define TWI0_MSTATUS  _SFR_MEM8(0x0905)
+#define TWI0_MBAUD  _SFR_MEM8(0x0906)
+#define TWI0_MADDR  _SFR_MEM8(0x0907)
+#define TWI0_MDATA  _SFR_MEM8(0x0908)
+#define TWI0_SCTRLA  _SFR_MEM8(0x0909)
+#define TWI0_SCTRLB  _SFR_MEM8(0x090A)
+#define TWI0_SSTATUS  _SFR_MEM8(0x090B)
+#define TWI0_SADDR  _SFR_MEM8(0x090C)
+#define TWI0_SDATA  _SFR_MEM8(0x090D)
+#define TWI0_SADDRMASK  _SFR_MEM8(0x090E)
+
+
+/* SPI (SPI0) - Serial Peripheral Interface */
+#define SPI0_CTRLA  _SFR_MEM8(0x0940)
+#define SPI0_CTRLB  _SFR_MEM8(0x0941)
+#define SPI0_INTCTRL  _SFR_MEM8(0x0942)
+#define SPI0_INTFLAGS  _SFR_MEM8(0x0943)
+#define SPI0_DATA  _SFR_MEM8(0x0944)
+
+
+/* TCA (TCA0) - 16-bit Timer/Counter Type A - Single Mode */
+#define TCA0_SINGLE_CTRLA  _SFR_MEM8(0x0A00)
+#define TCA0_SINGLE_CTRLB  _SFR_MEM8(0x0A01)
+#define TCA0_SINGLE_CTRLC  _SFR_MEM8(0x0A02)
+#define TCA0_SINGLE_CTRLD  _SFR_MEM8(0x0A03)
+#define TCA0_SINGLE_CTRLECLR  _SFR_MEM8(0x0A04)
+#define TCA0_SINGLE_CTRLESET  _SFR_MEM8(0x0A05)
+#define TCA0_SINGLE_CTRLFCLR  _SFR_MEM8(0x0A06)
+#define TCA0_SINGLE_CTRLFSET  _SFR_MEM8(0x0A07)
+#define TCA0_SINGLE_EVCTRL  _SFR_MEM8(0x0A09)
+#define TCA0_SINGLE_INTCTRL  _SFR_MEM8(0x0A0A)
+#define TCA0_SINGLE_INTFLAGS  _SFR_MEM8(0x0A0B)
+#define TCA0_SINGLE_DBGCTRL  _SFR_MEM8(0x0A0E)
+#define TCA0_SINGLE_TEMP  _SFR_MEM8(0x0A0F)
+#define TCA0_SINGLE_CNT  _SFR_MEM16(0x0A20)
+#define TCA0_SINGLE_CNTL  _SFR_MEM8(0x0A20)
+#define TCA0_SINGLE_CNTH  _SFR_MEM8(0x0A21)
+#define TCA0_SINGLE_PER  _SFR_MEM16(0x0A26)
+#define TCA0_SINGLE_PERL  _SFR_MEM8(0x0A26)
+#define TCA0_SINGLE_PERH  _SFR_MEM8(0x0A27)
+#define TCA0_SINGLE_CMP0  _SFR_MEM16(0x0A28)
+#define TCA0_SINGLE_CMP0L  _SFR_MEM8(0x0A28)
+#define TCA0_SINGLE_CMP0H  _SFR_MEM8(0x0A29)
+#define TCA0_SINGLE_CMP1  _SFR_MEM16(0x0A2A)
+#define TCA0_SINGLE_CMP1L  _SFR_MEM8(0x0A2A)
+#define TCA0_SINGLE_CMP1H  _SFR_MEM8(0x0A2B)
+#define TCA0_SINGLE_CMP2  _SFR_MEM16(0x0A2C)
+#define TCA0_SINGLE_CMP2L  _SFR_MEM8(0x0A2C)
+#define TCA0_SINGLE_CMP2H  _SFR_MEM8(0x0A2D)
+#define TCA0_SINGLE_PERBUF  _SFR_MEM16(0x0A36)
+#define TCA0_SINGLE_PERBUFL  _SFR_MEM8(0x0A36)
+#define TCA0_SINGLE_PERBUFH  _SFR_MEM8(0x0A37)
+#define TCA0_SINGLE_CMP0BUF  _SFR_MEM16(0x0A38)
+#define TCA0_SINGLE_CMP0BUFL  _SFR_MEM8(0x0A38)
+#define TCA0_SINGLE_CMP0BUFH  _SFR_MEM8(0x0A39)
+#define TCA0_SINGLE_CMP1BUF  _SFR_MEM16(0x0A3A)
+#define TCA0_SINGLE_CMP1BUFL  _SFR_MEM8(0x0A3A)
+#define TCA0_SINGLE_CMP1BUFH  _SFR_MEM8(0x0A3B)
+#define TCA0_SINGLE_CMP2BUF  _SFR_MEM16(0x0A3C)
+#define TCA0_SINGLE_CMP2BUFL  _SFR_MEM8(0x0A3C)
+#define TCA0_SINGLE_CMP2BUFH  _SFR_MEM8(0x0A3D)
+
+
+/* TCA (TCA0) - 16-bit Timer/Counter Type A - Split Mode */
+#define TCA0_SPLIT_CTRLA  _SFR_MEM8(0x0A00)
+#define TCA0_SPLIT_CTRLB  _SFR_MEM8(0x0A01)
+#define TCA0_SPLIT_CTRLC  _SFR_MEM8(0x0A02)
+#define TCA0_SPLIT_CTRLD  _SFR_MEM8(0x0A03)
+#define TCA0_SPLIT_CTRLECLR  _SFR_MEM8(0x0A04)
+#define TCA0_SPLIT_CTRLESET  _SFR_MEM8(0x0A05)
+#define TCA0_SPLIT_INTCTRL  _SFR_MEM8(0x0A0A)
+#define TCA0_SPLIT_INTFLAGS  _SFR_MEM8(0x0A0B)
+#define TCA0_SPLIT_DBGCTRL  _SFR_MEM8(0x0A0E)
+#define TCA0_SPLIT_LCNT  _SFR_MEM8(0x0A20)
+#define TCA0_SPLIT_HCNT  _SFR_MEM8(0x0A21)
+#define TCA0_SPLIT_LPER  _SFR_MEM8(0x0A26)
+#define TCA0_SPLIT_HPER  _SFR_MEM8(0x0A27)
+#define TCA0_SPLIT_LCMP0  _SFR_MEM8(0x0A28)
+#define TCA0_SPLIT_HCMP0  _SFR_MEM8(0x0A29)
+#define TCA0_SPLIT_LCMP1  _SFR_MEM8(0x0A2A)
+#define TCA0_SPLIT_HCMP1  _SFR_MEM8(0x0A2B)
+#define TCA0_SPLIT_LCMP2  _SFR_MEM8(0x0A2C)
+#define TCA0_SPLIT_HCMP2  _SFR_MEM8(0x0A2D)
+
+
+/* TCB (TCB0) - 16-bit Timer Type B */
+#define TCB0_CTRLA  _SFR_MEM8(0x0B00)
+#define TCB0_CTRLB  _SFR_MEM8(0x0B01)
+#define TCB0_EVCTRL  _SFR_MEM8(0x0B04)
+#define TCB0_INTCTRL  _SFR_MEM8(0x0B05)
+#define TCB0_INTFLAGS  _SFR_MEM8(0x0B06)
+#define TCB0_STATUS  _SFR_MEM8(0x0B07)
+#define TCB0_DBGCTRL  _SFR_MEM8(0x0B08)
+#define TCB0_TEMP  _SFR_MEM8(0x0B09)
+#define TCB0_CNT  _SFR_MEM16(0x0B0A)
+#define TCB0_CNTL  _SFR_MEM8(0x0B0A)
+#define TCB0_CNTH  _SFR_MEM8(0x0B0B)
+#define TCB0_CCMP  _SFR_MEM16(0x0B0C)
+#define TCB0_CCMPL  _SFR_MEM8(0x0B0C)
+#define TCB0_CCMPH  _SFR_MEM8(0x0B0D)
+
+
+/* TCB (TCB1) - 16-bit Timer Type B */
+#define TCB1_CTRLA  _SFR_MEM8(0x0B10)
+#define TCB1_CTRLB  _SFR_MEM8(0x0B11)
+#define TCB1_EVCTRL  _SFR_MEM8(0x0B14)
+#define TCB1_INTCTRL  _SFR_MEM8(0x0B15)
+#define TCB1_INTFLAGS  _SFR_MEM8(0x0B16)
+#define TCB1_STATUS  _SFR_MEM8(0x0B17)
+#define TCB1_DBGCTRL  _SFR_MEM8(0x0B18)
+#define TCB1_TEMP  _SFR_MEM8(0x0B19)
+#define TCB1_CNT  _SFR_MEM16(0x0B1A)
+#define TCB1_CNTL  _SFR_MEM8(0x0B1A)
+#define TCB1_CNTH  _SFR_MEM8(0x0B1B)
+#define TCB1_CCMP  _SFR_MEM16(0x0B1C)
+#define TCB1_CCMPL  _SFR_MEM8(0x0B1C)
+#define TCB1_CCMPH  _SFR_MEM8(0x0B1D)
+
+
+/* TCB (TCB2) - 16-bit Timer Type B */
+#define TCB2_CTRLA  _SFR_MEM8(0x0B20)
+#define TCB2_CTRLB  _SFR_MEM8(0x0B21)
+#define TCB2_EVCTRL  _SFR_MEM8(0x0B24)
+#define TCB2_INTCTRL  _SFR_MEM8(0x0B25)
+#define TCB2_INTFLAGS  _SFR_MEM8(0x0B26)
+#define TCB2_STATUS  _SFR_MEM8(0x0B27)
+#define TCB2_DBGCTRL  _SFR_MEM8(0x0B28)
+#define TCB2_TEMP  _SFR_MEM8(0x0B29)
+#define TCB2_CNT  _SFR_MEM16(0x0B2A)
+#define TCB2_CNTL  _SFR_MEM8(0x0B2A)
+#define TCB2_CNTH  _SFR_MEM8(0x0B2B)
+#define TCB2_CCMP  _SFR_MEM16(0x0B2C)
+#define TCB2_CCMPL  _SFR_MEM8(0x0B2C)
+#define TCB2_CCMPH  _SFR_MEM8(0x0B2D)
+
+
+/* SYSCFG - System Configuration Registers */
+#define SYSCFG_REVID  _SFR_MEM8(0x0F01)
+#define SYSCFG_OCDMCTRL  _SFR_MEM8(0x0F04)
+#define SYSCFG_OCDMSTATUS  _SFR_MEM8(0x0F05)
+
+
+/* NVMCTRL - Non-volatile Memory Controller */
+#define NVMCTRL_CTRLA  _SFR_MEM8(0x1000)
+#define NVMCTRL_CTRLB  _SFR_MEM8(0x1001)
+#define NVMCTRL_INTCTRL  _SFR_MEM8(0x1004)
+#define NVMCTRL_INTFLAGS  _SFR_MEM8(0x1005)
+#define NVMCTRL_STATUS  _SFR_MEM8(0x1006)
+#define NVMCTRL_DATA  _SFR_MEM16(0x1008)
+#define NVMCTRL_DATAL  _SFR_MEM8(0x1008)
+#define NVMCTRL_DATAH  _SFR_MEM8(0x1009)
+#define NVMCTRL_ADDR  _SFR_MEM32(0x100C)
+#define NVMCTRL_ADDR0  _SFR_MEM8(0x100C)
+#define NVMCTRL_ADDR1  _SFR_MEM8(0x100D)
+#define NVMCTRL_ADDR2  _SFR_MEM8(0x100E)
+#define NVMCTRL_ADDR3  _SFR_MEM8(0x100F)
+
+
+/* LOCK - Lockbits */
+#define LOCK_KEY  _SFR_MEM32(0x1040)
+#define LOCK_KEY0  _SFR_MEM8(0x1040)
+#define LOCK_KEY1  _SFR_MEM8(0x1041)
+#define LOCK_KEY2  _SFR_MEM8(0x1042)
+#define LOCK_KEY3  _SFR_MEM8(0x1043)
+
+
+/* FUSE - Fuses */
+#define FUSE_WDTCFG  _SFR_MEM8(0x1050)
+#define FUSE_BODCFG  _SFR_MEM8(0x1051)
+#define FUSE_OSCCFG  _SFR_MEM8(0x1052)
+#define FUSE_SYSCFG0  _SFR_MEM8(0x1055)
+#define FUSE_SYSCFG1  _SFR_MEM8(0x1056)
+#define FUSE_CODESIZE  _SFR_MEM8(0x1057)
+#define FUSE_BOOTSIZE  _SFR_MEM8(0x1058)
+
+
+/* USERROW - User Row */
+#define USERROW_USERROW0  _SFR_MEM8(0x1080)
+#define USERROW_USERROW1  _SFR_MEM8(0x1081)
+#define USERROW_USERROW2  _SFR_MEM8(0x1082)
+#define USERROW_USERROW3  _SFR_MEM8(0x1083)
+#define USERROW_USERROW4  _SFR_MEM8(0x1084)
+#define USERROW_USERROW5  _SFR_MEM8(0x1085)
+#define USERROW_USERROW6  _SFR_MEM8(0x1086)
+#define USERROW_USERROW7  _SFR_MEM8(0x1087)
+#define USERROW_USERROW8  _SFR_MEM8(0x1088)
+#define USERROW_USERROW9  _SFR_MEM8(0x1089)
+#define USERROW_USERROW10  _SFR_MEM8(0x108A)
+#define USERROW_USERROW11  _SFR_MEM8(0x108B)
+#define USERROW_USERROW12  _SFR_MEM8(0x108C)
+#define USERROW_USERROW13  _SFR_MEM8(0x108D)
+#define USERROW_USERROW14  _SFR_MEM8(0x108E)
+#define USERROW_USERROW15  _SFR_MEM8(0x108F)
+#define USERROW_USERROW16  _SFR_MEM8(0x1090)
+#define USERROW_USERROW17  _SFR_MEM8(0x1091)
+#define USERROW_USERROW18  _SFR_MEM8(0x1092)
+#define USERROW_USERROW19  _SFR_MEM8(0x1093)
+#define USERROW_USERROW20  _SFR_MEM8(0x1094)
+#define USERROW_USERROW21  _SFR_MEM8(0x1095)
+#define USERROW_USERROW22  _SFR_MEM8(0x1096)
+#define USERROW_USERROW23  _SFR_MEM8(0x1097)
+#define USERROW_USERROW24  _SFR_MEM8(0x1098)
+#define USERROW_USERROW25  _SFR_MEM8(0x1099)
+#define USERROW_USERROW26  _SFR_MEM8(0x109A)
+#define USERROW_USERROW27  _SFR_MEM8(0x109B)
+#define USERROW_USERROW28  _SFR_MEM8(0x109C)
+#define USERROW_USERROW29  _SFR_MEM8(0x109D)
+#define USERROW_USERROW30  _SFR_MEM8(0x109E)
+#define USERROW_USERROW31  _SFR_MEM8(0x109F)
+#define USERROW_USERROW32  _SFR_MEM8(0x10A0)
+#define USERROW_USERROW33  _SFR_MEM8(0x10A1)
+#define USERROW_USERROW34  _SFR_MEM8(0x10A2)
+#define USERROW_USERROW35  _SFR_MEM8(0x10A3)
+#define USERROW_USERROW36  _SFR_MEM8(0x10A4)
+#define USERROW_USERROW37  _SFR_MEM8(0x10A5)
+#define USERROW_USERROW38  _SFR_MEM8(0x10A6)
+#define USERROW_USERROW39  _SFR_MEM8(0x10A7)
+#define USERROW_USERROW40  _SFR_MEM8(0x10A8)
+#define USERROW_USERROW41  _SFR_MEM8(0x10A9)
+#define USERROW_USERROW42  _SFR_MEM8(0x10AA)
+#define USERROW_USERROW43  _SFR_MEM8(0x10AB)
+#define USERROW_USERROW44  _SFR_MEM8(0x10AC)
+#define USERROW_USERROW45  _SFR_MEM8(0x10AD)
+#define USERROW_USERROW46  _SFR_MEM8(0x10AE)
+#define USERROW_USERROW47  _SFR_MEM8(0x10AF)
+#define USERROW_USERROW48  _SFR_MEM8(0x10B0)
+#define USERROW_USERROW49  _SFR_MEM8(0x10B1)
+#define USERROW_USERROW50  _SFR_MEM8(0x10B2)
+#define USERROW_USERROW51  _SFR_MEM8(0x10B3)
+#define USERROW_USERROW52  _SFR_MEM8(0x10B4)
+#define USERROW_USERROW53  _SFR_MEM8(0x10B5)
+#define USERROW_USERROW54  _SFR_MEM8(0x10B6)
+#define USERROW_USERROW55  _SFR_MEM8(0x10B7)
+#define USERROW_USERROW56  _SFR_MEM8(0x10B8)
+#define USERROW_USERROW57  _SFR_MEM8(0x10B9)
+#define USERROW_USERROW58  _SFR_MEM8(0x10BA)
+#define USERROW_USERROW59  _SFR_MEM8(0x10BB)
+#define USERROW_USERROW60  _SFR_MEM8(0x10BC)
+#define USERROW_USERROW61  _SFR_MEM8(0x10BD)
+#define USERROW_USERROW62  _SFR_MEM8(0x10BE)
+#define USERROW_USERROW63  _SFR_MEM8(0x10BF)
+
+
+/* SIGROW - Signature row */
+#define SIGROW_DEVICEID0  _SFR_MEM8(0x1100)
+#define SIGROW_DEVICEID1  _SFR_MEM8(0x1101)
+#define SIGROW_DEVICEID2  _SFR_MEM8(0x1102)
+#define SIGROW_TEMPSENSE0  _SFR_MEM16(0x1104)
+#define SIGROW_TEMPSENSE0L  _SFR_MEM8(0x1104)
+#define SIGROW_TEMPSENSE0H  _SFR_MEM8(0x1105)
+#define SIGROW_TEMPSENSE1  _SFR_MEM16(0x1106)
+#define SIGROW_TEMPSENSE1L  _SFR_MEM8(0x1106)
+#define SIGROW_TEMPSENSE1H  _SFR_MEM8(0x1107)
+#define SIGROW_SERNUM0  _SFR_MEM8(0x1110)
+#define SIGROW_SERNUM1  _SFR_MEM8(0x1111)
+#define SIGROW_SERNUM2  _SFR_MEM8(0x1112)
+#define SIGROW_SERNUM3  _SFR_MEM8(0x1113)
+#define SIGROW_SERNUM4  _SFR_MEM8(0x1114)
+#define SIGROW_SERNUM5  _SFR_MEM8(0x1115)
+#define SIGROW_SERNUM6  _SFR_MEM8(0x1116)
+#define SIGROW_SERNUM7  _SFR_MEM8(0x1117)
+#define SIGROW_SERNUM8  _SFR_MEM8(0x1118)
+#define SIGROW_SERNUM9  _SFR_MEM8(0x1119)
+#define SIGROW_SERNUM10  _SFR_MEM8(0x111A)
+#define SIGROW_SERNUM11  _SFR_MEM8(0x111B)
+#define SIGROW_SERNUM12  _SFR_MEM8(0x111C)
+#define SIGROW_SERNUM13  _SFR_MEM8(0x111D)
+#define SIGROW_SERNUM14  _SFR_MEM8(0x111E)
+#define SIGROW_SERNUM15  _SFR_MEM8(0x111F)
+
+
+
+/*================== Bitfield Definitions ================== */
+
+/* AC - Analog Comparator */
+/* AC.CTRLA  bit masks and bit positions */
+#define AC_ENABLE_bm  0x01  /* Enable bit mask. */
+#define AC_ENABLE_bp  0  /* Enable bit position. */
+#define AC_HYSMODE_gm  0x06  /* Hysteresis Mode group mask. */
+#define AC_HYSMODE_gp  1  /* Hysteresis Mode group position. */
+#define AC_HYSMODE_0_bm  (1<<1)  /* Hysteresis Mode bit 0 mask. */
+#define AC_HYSMODE_0_bp  1  /* Hysteresis Mode bit 0 position. */
+#define AC_HYSMODE_1_bm  (1<<2)  /* Hysteresis Mode bit 1 mask. */
+#define AC_HYSMODE_1_bp  2  /* Hysteresis Mode bit 1 position. */
+#define AC_POWER_gm  0x18  /* Power profile group mask. */
+#define AC_POWER_gp  3  /* Power profile group position. */
+#define AC_POWER_0_bm  (1<<3)  /* Power profile bit 0 mask. */
+#define AC_POWER_0_bp  3  /* Power profile bit 0 position. */
+#define AC_POWER_1_bm  (1<<4)  /* Power profile bit 1 mask. */
+#define AC_POWER_1_bp  4  /* Power profile bit 1 position. */
+#define AC_OUTEN_bm  0x40  /* Output Pad Enable bit mask. */
+#define AC_OUTEN_bp  6  /* Output Pad Enable bit position. */
+#define AC_RUNSTDBY_bm  0x80  /* Run in Standby Mode bit mask. */
+#define AC_RUNSTDBY_bp  7  /* Run in Standby Mode bit position. */
+
+/* AC.CTRLB  bit masks and bit positions */
+#define AC_WINSEL_gm  0x03  /* Window selection mode group mask. */
+#define AC_WINSEL_gp  0  /* Window selection mode group position. */
+#define AC_WINSEL_0_bm  (1<<0)  /* Window selection mode bit 0 mask. */
+#define AC_WINSEL_0_bp  0  /* Window selection mode bit 0 position. */
+#define AC_WINSEL_1_bm  (1<<1)  /* Window selection mode bit 1 mask. */
+#define AC_WINSEL_1_bp  1  /* Window selection mode bit 1 position. */
+
+/* AC.MUXCTRL  bit masks and bit positions */
+#define AC_MUXNEG_gm  0x07  /* Negative Input MUX Selection group mask. */
+#define AC_MUXNEG_gp  0  /* Negative Input MUX Selection group position. */
+#define AC_MUXNEG_0_bm  (1<<0)  /* Negative Input MUX Selection bit 0 mask. */
+#define AC_MUXNEG_0_bp  0  /* Negative Input MUX Selection bit 0 position. */
+#define AC_MUXNEG_1_bm  (1<<1)  /* Negative Input MUX Selection bit 1 mask. */
+#define AC_MUXNEG_1_bp  1  /* Negative Input MUX Selection bit 1 position. */
+#define AC_MUXNEG_2_bm  (1<<2)  /* Negative Input MUX Selection bit 2 mask. */
+#define AC_MUXNEG_2_bp  2  /* Negative Input MUX Selection bit 2 position. */
+#define AC_MUXPOS_gm  0x38  /* Positive Input MUX Selection group mask. */
+#define AC_MUXPOS_gp  3  /* Positive Input MUX Selection group position. */
+#define AC_MUXPOS_0_bm  (1<<3)  /* Positive Input MUX Selection bit 0 mask. */
+#define AC_MUXPOS_0_bp  3  /* Positive Input MUX Selection bit 0 position. */
+#define AC_MUXPOS_1_bm  (1<<4)  /* Positive Input MUX Selection bit 1 mask. */
+#define AC_MUXPOS_1_bp  4  /* Positive Input MUX Selection bit 1 position. */
+#define AC_MUXPOS_2_bm  (1<<5)  /* Positive Input MUX Selection bit 2 mask. */
+#define AC_MUXPOS_2_bp  5  /* Positive Input MUX Selection bit 2 position. */
+#define AC_INITVAL_bm  0x40  /* AC Output Initial Value bit mask. */
+#define AC_INITVAL_bp  6  /* AC Output Initial Value bit position. */
+#define AC_INVERT_bm  0x80  /* Invert AC Output bit mask. */
+#define AC_INVERT_bp  7  /* Invert AC Output bit position. */
+
+/* AC.DACREF  bit masks and bit positions */
+#define AC_DACREF_gm  0xFF  /* DACREF group mask. */
+#define AC_DACREF_gp  0  /* DACREF group position. */
+#define AC_DACREF_0_bm  (1<<0)  /* DACREF bit 0 mask. */
+#define AC_DACREF_0_bp  0  /* DACREF bit 0 position. */
+#define AC_DACREF_1_bm  (1<<1)  /* DACREF bit 1 mask. */
+#define AC_DACREF_1_bp  1  /* DACREF bit 1 position. */
+#define AC_DACREF_2_bm  (1<<2)  /* DACREF bit 2 mask. */
+#define AC_DACREF_2_bp  2  /* DACREF bit 2 position. */
+#define AC_DACREF_3_bm  (1<<3)  /* DACREF bit 3 mask. */
+#define AC_DACREF_3_bp  3  /* DACREF bit 3 position. */
+#define AC_DACREF_4_bm  (1<<4)  /* DACREF bit 4 mask. */
+#define AC_DACREF_4_bp  4  /* DACREF bit 4 position. */
+#define AC_DACREF_5_bm  (1<<5)  /* DACREF bit 5 mask. */
+#define AC_DACREF_5_bp  5  /* DACREF bit 5 position. */
+#define AC_DACREF_6_bm  (1<<6)  /* DACREF bit 6 mask. */
+#define AC_DACREF_6_bp  6  /* DACREF bit 6 position. */
+#define AC_DACREF_7_bm  (1<<7)  /* DACREF bit 7 mask. */
+#define AC_DACREF_7_bp  7  /* DACREF bit 7 position. */
+
+/* AC.INTCTRL  bit masks and bit positions */
+#define AC_CMP_bm  0x01  /* Interrupt Enable bit mask. */
+#define AC_CMP_bp  0  /* Interrupt Enable bit position. */
+#define AC_INTMODE_NORMAL_gm  0x30  /* Interrupt Mode group mask. */
+#define AC_INTMODE_NORMAL_gp  4  /* Interrupt Mode group position. */
+#define AC_INTMODE_NORMAL_0_bm  (1<<4)  /* Interrupt Mode bit 0 mask. */
+#define AC_INTMODE_NORMAL_0_bp  4  /* Interrupt Mode bit 0 position. */
+#define AC_INTMODE_NORMAL_1_bm  (1<<5)  /* Interrupt Mode bit 1 mask. */
+#define AC_INTMODE_NORMAL_1_bp  5  /* Interrupt Mode bit 1 position. */
+#define AC_INTMODE_WINDOW_gm  0x30  /* Interrupt Mode group mask. */
+#define AC_INTMODE_WINDOW_gp  4  /* Interrupt Mode group position. */
+#define AC_INTMODE_WINDOW_0_bm  (1<<4)  /* Interrupt Mode bit 0 mask. */
+#define AC_INTMODE_WINDOW_0_bp  4  /* Interrupt Mode bit 0 position. */
+#define AC_INTMODE_WINDOW_1_bm  (1<<5)  /* Interrupt Mode bit 1 mask. */
+#define AC_INTMODE_WINDOW_1_bp  5  /* Interrupt Mode bit 1 position. */
+
+/* AC.STATUS  bit masks and bit positions */
+#define AC_CMPIF_bm  0x01  /* Analog Comparator Interrupt Flag bit mask. */
+#define AC_CMPIF_bp  0  /* Analog Comparator Interrupt Flag bit position. */
+#define AC_CMPSTATE_bm  0x10  /* Analog Comparator State bit mask. */
+#define AC_CMPSTATE_bp  4  /* Analog Comparator State bit position. */
+#define AC_WINSTATE_gm  0xC0  /* Analog Comparator Window State group mask. */
+#define AC_WINSTATE_gp  6  /* Analog Comparator Window State group position. */
+#define AC_WINSTATE_0_bm  (1<<6)  /* Analog Comparator Window State bit 0 mask. */
+#define AC_WINSTATE_0_bp  6  /* Analog Comparator Window State bit 0 position. */
+#define AC_WINSTATE_1_bm  (1<<7)  /* Analog Comparator Window State bit 1 mask. */
+#define AC_WINSTATE_1_bp  7  /* Analog Comparator Window State bit 1 position. */
+
+
+/* ADC - Analog to Digital Converter */
+/* ADC.CTRLA  bit masks and bit positions */
+#define ADC_ENABLE_bm  0x01  /* ADC Enable bit mask. */
+#define ADC_ENABLE_bp  0  /* ADC Enable bit position. */
+#define ADC_LOWLAT_bm  0x20  /* Low Latency bit mask. */
+#define ADC_LOWLAT_bp  5  /* Low Latency bit position. */
+#define ADC_RUNSTDBY_bm  0x80  /* Run in Standby bit mask. */
+#define ADC_RUNSTDBY_bp  7  /* Run in Standby bit position. */
+
+/* ADC.CTRLB  bit masks and bit positions */
+#define ADC_PRESC_gm  0x0F  /* Prescaler Value group mask. */
+#define ADC_PRESC_gp  0  /* Prescaler Value group position. */
+#define ADC_PRESC_0_bm  (1<<0)  /* Prescaler Value bit 0 mask. */
+#define ADC_PRESC_0_bp  0  /* Prescaler Value bit 0 position. */
+#define ADC_PRESC_1_bm  (1<<1)  /* Prescaler Value bit 1 mask. */
+#define ADC_PRESC_1_bp  1  /* Prescaler Value bit 1 position. */
+#define ADC_PRESC_2_bm  (1<<2)  /* Prescaler Value bit 2 mask. */
+#define ADC_PRESC_2_bp  2  /* Prescaler Value bit 2 position. */
+#define ADC_PRESC_3_bm  (1<<3)  /* Prescaler Value bit 3 mask. */
+#define ADC_PRESC_3_bp  3  /* Prescaler Value bit 3 position. */
+
+/* ADC.CTRLC  bit masks and bit positions */
+#define ADC_REFSEL_gm  0x07  /* Reference select group mask. */
+#define ADC_REFSEL_gp  0  /* Reference select group position. */
+#define ADC_REFSEL_0_bm  (1<<0)  /* Reference select bit 0 mask. */
+#define ADC_REFSEL_0_bp  0  /* Reference select bit 0 position. */
+#define ADC_REFSEL_1_bm  (1<<1)  /* Reference select bit 1 mask. */
+#define ADC_REFSEL_1_bp  1  /* Reference select bit 1 position. */
+#define ADC_REFSEL_2_bm  (1<<2)  /* Reference select bit 2 mask. */
+#define ADC_REFSEL_2_bp  2  /* Reference select bit 2 position. */
+
+/* ADC.CTRLD  bit masks and bit positions */
+#define ADC_WINCM_gm  0x07  /* Window Comparator Mode group mask. */
+#define ADC_WINCM_gp  0  /* Window Comparator Mode group position. */
+#define ADC_WINCM_0_bm  (1<<0)  /* Window Comparator Mode bit 0 mask. */
+#define ADC_WINCM_0_bp  0  /* Window Comparator Mode bit 0 position. */
+#define ADC_WINCM_1_bm  (1<<1)  /* Window Comparator Mode bit 1 mask. */
+#define ADC_WINCM_1_bp  1  /* Window Comparator Mode bit 1 position. */
+#define ADC_WINCM_2_bm  (1<<2)  /* Window Comparator Mode bit 2 mask. */
+#define ADC_WINCM_2_bp  2  /* Window Comparator Mode bit 2 position. */
+#define ADC_WINSRC_bm  0x08  /* Window Mode Source bit mask. */
+#define ADC_WINSRC_bp  3  /* Window Mode Source bit position. */
+
+/* ADC.INTCTRL  bit masks and bit positions */
+#define ADC_RESRDY_bm  0x01  /* Result Ready Interrupt Enable bit mask. */
+#define ADC_RESRDY_bp  0  /* Result Ready Interrupt Enable bit position. */
+#define ADC_SAMPRDY_bm  0x02  /* Sample Ready Interrupt Enable bit mask. */
+#define ADC_SAMPRDY_bp  1  /* Sample Ready Interrupt Enable bit position. */
+#define ADC_WCMP_bm  0x04  /* Window Comparator Interrupt Enable bit mask. */
+#define ADC_WCMP_bp  2  /* Window Comparator Interrupt Enable bit position. */
+#define ADC_RESOVR_bm  0x08  /* Result Overwrite Interrupt Enable bit mask. */
+#define ADC_RESOVR_bp  3  /* Result Overwrite Interrupt Enable bit position. */
+#define ADC_SAMPOVR_bm  0x10  /* Sample Overwrite Interrupt Enable bit mask. */
+#define ADC_SAMPOVR_bp  4  /* Sample Overwrite Interrupt Enable bit position. */
+#define ADC_TRIGOVR_bm  0x20  /* Trigger Overrun Interrupt Enable bit mask. */
+#define ADC_TRIGOVR_bp  5  /* Trigger Overrun Interrupt Enable bit position. */
+
+/* ADC.INTFLAGS  bit masks and bit positions */
+/* ADC_RESRDY  is already defined. */
+/* ADC_SAMPRDY  is already defined. */
+/* ADC_WCMP  is already defined. */
+/* ADC_RESOVR  is already defined. */
+/* ADC_SAMPOVR  is already defined. */
+/* ADC_TRIGOVR  is already defined. */
+
+/* ADC.STATUS  bit masks and bit positions */
+#define ADC_ADCBUSY_bm  0x01  /* ADC Busy bit mask. */
+#define ADC_ADCBUSY_bp  0  /* ADC Busy bit position. */
+
+/* ADC.DBGCTRL  bit masks and bit positions */
+#define ADC_DBGRUN_bm  0x01  /* Run in Debug Mode bit mask. */
+#define ADC_DBGRUN_bp  0  /* Run in Debug Mode bit position. */
+
+/* ADC.CTRLE  bit masks and bit positions */
+#define ADC_SAMPDUR_gm  0xFF  /* Sample Duration group mask. */
+#define ADC_SAMPDUR_gp  0  /* Sample Duration group position. */
+#define ADC_SAMPDUR_0_bm  (1<<0)  /* Sample Duration bit 0 mask. */
+#define ADC_SAMPDUR_0_bp  0  /* Sample Duration bit 0 position. */
+#define ADC_SAMPDUR_1_bm  (1<<1)  /* Sample Duration bit 1 mask. */
+#define ADC_SAMPDUR_1_bp  1  /* Sample Duration bit 1 position. */
+#define ADC_SAMPDUR_2_bm  (1<<2)  /* Sample Duration bit 2 mask. */
+#define ADC_SAMPDUR_2_bp  2  /* Sample Duration bit 2 position. */
+#define ADC_SAMPDUR_3_bm  (1<<3)  /* Sample Duration bit 3 mask. */
+#define ADC_SAMPDUR_3_bp  3  /* Sample Duration bit 3 position. */
+#define ADC_SAMPDUR_4_bm  (1<<4)  /* Sample Duration bit 4 mask. */
+#define ADC_SAMPDUR_4_bp  4  /* Sample Duration bit 4 position. */
+#define ADC_SAMPDUR_5_bm  (1<<5)  /* Sample Duration bit 5 mask. */
+#define ADC_SAMPDUR_5_bp  5  /* Sample Duration bit 5 position. */
+#define ADC_SAMPDUR_6_bm  (1<<6)  /* Sample Duration bit 6 mask. */
+#define ADC_SAMPDUR_6_bp  6  /* Sample Duration bit 6 position. */
+#define ADC_SAMPDUR_7_bm  (1<<7)  /* Sample Duration bit 7 mask. */
+#define ADC_SAMPDUR_7_bp  7  /* Sample Duration bit 7 position. */
+
+/* ADC.CTRLF  bit masks and bit positions */
+#define ADC_SAMPNUM_gm  0x0F  /* Sample numbers group mask. */
+#define ADC_SAMPNUM_gp  0  /* Sample numbers group position. */
+#define ADC_SAMPNUM_0_bm  (1<<0)  /* Sample numbers bit 0 mask. */
+#define ADC_SAMPNUM_0_bp  0  /* Sample numbers bit 0 position. */
+#define ADC_SAMPNUM_1_bm  (1<<1)  /* Sample numbers bit 1 mask. */
+#define ADC_SAMPNUM_1_bp  1  /* Sample numbers bit 1 position. */
+#define ADC_SAMPNUM_2_bm  (1<<2)  /* Sample numbers bit 2 mask. */
+#define ADC_SAMPNUM_2_bp  2  /* Sample numbers bit 2 position. */
+#define ADC_SAMPNUM_3_bm  (1<<3)  /* Sample numbers bit 3 mask. */
+#define ADC_SAMPNUM_3_bp  3  /* Sample numbers bit 3 position. */
+#define ADC_LEFTADJ_bm  0x10  /* Left Adjust bit mask. */
+#define ADC_LEFTADJ_bp  4  /* Left Adjust bit position. */
+#define ADC_FREERUN_bm  0x20  /* Free-Running mode bit mask. */
+#define ADC_FREERUN_bp  5  /* Free-Running mode bit position. */
+#define ADC_CHOPPING_bm  0x40  /* Sign Chopping bit mask. */
+#define ADC_CHOPPING_bp  6  /* Sign Chopping bit position. */
+
+/* ADC.COMMAND  bit masks and bit positions */
+#define ADC_START_gm  0x07  /* Start command group mask. */
+#define ADC_START_gp  0  /* Start command group position. */
+#define ADC_START_0_bm  (1<<0)  /* Start command bit 0 mask. */
+#define ADC_START_0_bp  0  /* Start command bit 0 position. */
+#define ADC_START_1_bm  (1<<1)  /* Start command bit 1 mask. */
+#define ADC_START_1_bp  1  /* Start command bit 1 position. */
+#define ADC_START_2_bm  (1<<2)  /* Start command bit 2 mask. */
+#define ADC_START_2_bp  2  /* Start command bit 2 position. */
+#define ADC_MODE_gm  0x70  /* Mode group mask. */
+#define ADC_MODE_gp  4  /* Mode group position. */
+#define ADC_MODE_0_bm  (1<<4)  /* Mode bit 0 mask. */
+#define ADC_MODE_0_bp  4  /* Mode bit 0 position. */
+#define ADC_MODE_1_bm  (1<<5)  /* Mode bit 1 mask. */
+#define ADC_MODE_1_bp  5  /* Mode bit 1 position. */
+#define ADC_MODE_2_bm  (1<<6)  /* Mode bit 2 mask. */
+#define ADC_MODE_2_bp  6  /* Mode bit 2 position. */
+#define ADC_DIFF_bm  0x80  /* Differential mode bit mask. */
+#define ADC_DIFF_bp  7  /* Differential mode bit position. */
+
+/* ADC.PGACTRL  bit masks and bit positions */
+#define ADC_PGAEN_bm  0x01  /* PGA Enable bit mask. */
+#define ADC_PGAEN_bp  0  /* PGA Enable bit position. */
+#define ADC_PGABIASSEL_gm  0x18  /* PGA BIAS Select group mask. */
+#define ADC_PGABIASSEL_gp  3  /* PGA BIAS Select group position. */
+#define ADC_PGABIASSEL_0_bm  (1<<3)  /* PGA BIAS Select bit 0 mask. */
+#define ADC_PGABIASSEL_0_bp  3  /* PGA BIAS Select bit 0 position. */
+#define ADC_PGABIASSEL_1_bm  (1<<4)  /* PGA BIAS Select bit 1 mask. */
+#define ADC_PGABIASSEL_1_bp  4  /* PGA BIAS Select bit 1 position. */
+#define ADC_GAIN_gm  0xE0  /* Gain group mask. */
+#define ADC_GAIN_gp  5  /* Gain group position. */
+#define ADC_GAIN_0_bm  (1<<5)  /* Gain bit 0 mask. */
+#define ADC_GAIN_0_bp  5  /* Gain bit 0 position. */
+#define ADC_GAIN_1_bm  (1<<6)  /* Gain bit 1 mask. */
+#define ADC_GAIN_1_bp  6  /* Gain bit 1 position. */
+#define ADC_GAIN_2_bm  (1<<7)  /* Gain bit 2 mask. */
+#define ADC_GAIN_2_bp  7  /* Gain bit 2 position. */
+
+/* ADC.MUXPOS  bit masks and bit positions */
+#define ADC_MUXPOS_gm  0x3F  /* Analog Channel Selection Bits group mask. */
+#define ADC_MUXPOS_gp  0  /* Analog Channel Selection Bits group position. */
+#define ADC_MUXPOS_0_bm  (1<<0)  /* Analog Channel Selection Bits bit 0 mask. */
+#define ADC_MUXPOS_0_bp  0  /* Analog Channel Selection Bits bit 0 position. */
+#define ADC_MUXPOS_1_bm  (1<<1)  /* Analog Channel Selection Bits bit 1 mask. */
+#define ADC_MUXPOS_1_bp  1  /* Analog Channel Selection Bits bit 1 position. */
+#define ADC_MUXPOS_2_bm  (1<<2)  /* Analog Channel Selection Bits bit 2 mask. */
+#define ADC_MUXPOS_2_bp  2  /* Analog Channel Selection Bits bit 2 position. */
+#define ADC_MUXPOS_3_bm  (1<<3)  /* Analog Channel Selection Bits bit 3 mask. */
+#define ADC_MUXPOS_3_bp  3  /* Analog Channel Selection Bits bit 3 position. */
+#define ADC_MUXPOS_4_bm  (1<<4)  /* Analog Channel Selection Bits bit 4 mask. */
+#define ADC_MUXPOS_4_bp  4  /* Analog Channel Selection Bits bit 4 position. */
+#define ADC_MUXPOS_5_bm  (1<<5)  /* Analog Channel Selection Bits bit 5 mask. */
+#define ADC_MUXPOS_5_bp  5  /* Analog Channel Selection Bits bit 5 position. */
+#define ADC_VIA_gm  0xC0  /* VIA group mask. */
+#define ADC_VIA_gp  6  /* VIA group position. */
+#define ADC_VIA_0_bm  (1<<6)  /* VIA bit 0 mask. */
+#define ADC_VIA_0_bp  6  /* VIA bit 0 position. */
+#define ADC_VIA_1_bm  (1<<7)  /* VIA bit 1 mask. */
+#define ADC_VIA_1_bp  7  /* VIA bit 1 position. */
+
+/* ADC.MUXNEG  bit masks and bit positions */
+#define ADC_MUXNEG_gm  0x3F  /* Analog Channel Selection Bits group mask. */
+#define ADC_MUXNEG_gp  0  /* Analog Channel Selection Bits group position. */
+#define ADC_MUXNEG_0_bm  (1<<0)  /* Analog Channel Selection Bits bit 0 mask. */
+#define ADC_MUXNEG_0_bp  0  /* Analog Channel Selection Bits bit 0 position. */
+#define ADC_MUXNEG_1_bm  (1<<1)  /* Analog Channel Selection Bits bit 1 mask. */
+#define ADC_MUXNEG_1_bp  1  /* Analog Channel Selection Bits bit 1 position. */
+#define ADC_MUXNEG_2_bm  (1<<2)  /* Analog Channel Selection Bits bit 2 mask. */
+#define ADC_MUXNEG_2_bp  2  /* Analog Channel Selection Bits bit 2 position. */
+#define ADC_MUXNEG_3_bm  (1<<3)  /* Analog Channel Selection Bits bit 3 mask. */
+#define ADC_MUXNEG_3_bp  3  /* Analog Channel Selection Bits bit 3 position. */
+#define ADC_MUXNEG_4_bm  (1<<4)  /* Analog Channel Selection Bits bit 4 mask. */
+#define ADC_MUXNEG_4_bp  4  /* Analog Channel Selection Bits bit 4 position. */
+#define ADC_MUXNEG_5_bm  (1<<5)  /* Analog Channel Selection Bits bit 5 mask. */
+#define ADC_MUXNEG_5_bp  5  /* Analog Channel Selection Bits bit 5 position. */
+/* ADC_VIA  is already defined. */
+
+
+/* BOD - Bod interface */
+/* BOD.CTRLA  bit masks and bit positions */
+#define BOD_SLEEP_gm  0x03  /* Operation in sleep mode group mask. */
+#define BOD_SLEEP_gp  0  /* Operation in sleep mode group position. */
+#define BOD_SLEEP_0_bm  (1<<0)  /* Operation in sleep mode bit 0 mask. */
+#define BOD_SLEEP_0_bp  0  /* Operation in sleep mode bit 0 position. */
+#define BOD_SLEEP_1_bm  (1<<1)  /* Operation in sleep mode bit 1 mask. */
+#define BOD_SLEEP_1_bp  1  /* Operation in sleep mode bit 1 position. */
+#define BOD_ACTIVE_gm  0x0C  /* Operation in active mode group mask. */
+#define BOD_ACTIVE_gp  2  /* Operation in active mode group position. */
+#define BOD_ACTIVE_0_bm  (1<<2)  /* Operation in active mode bit 0 mask. */
+#define BOD_ACTIVE_0_bp  2  /* Operation in active mode bit 0 position. */
+#define BOD_ACTIVE_1_bm  (1<<3)  /* Operation in active mode bit 1 mask. */
+#define BOD_ACTIVE_1_bp  3  /* Operation in active mode bit 1 position. */
+#define BOD_SAMPFREQ_bm  0x10  /* Sample frequency bit mask. */
+#define BOD_SAMPFREQ_bp  4  /* Sample frequency bit position. */
+
+/* BOD.CTRLB  bit masks and bit positions */
+#define BOD_LVL_gm  0x07  /* Bod level group mask. */
+#define BOD_LVL_gp  0  /* Bod level group position. */
+#define BOD_LVL_0_bm  (1<<0)  /* Bod level bit 0 mask. */
+#define BOD_LVL_0_bp  0  /* Bod level bit 0 position. */
+#define BOD_LVL_1_bm  (1<<1)  /* Bod level bit 1 mask. */
+#define BOD_LVL_1_bp  1  /* Bod level bit 1 position. */
+#define BOD_LVL_2_bm  (1<<2)  /* Bod level bit 2 mask. */
+#define BOD_LVL_2_bp  2  /* Bod level bit 2 position. */
+
+/* BOD.VLMCTRLA  bit masks and bit positions */
+#define BOD_VLMLVL_gm  0x03  /* voltage level monitor level group mask. */
+#define BOD_VLMLVL_gp  0  /* voltage level monitor level group position. */
+#define BOD_VLMLVL_0_bm  (1<<0)  /* voltage level monitor level bit 0 mask. */
+#define BOD_VLMLVL_0_bp  0  /* voltage level monitor level bit 0 position. */
+#define BOD_VLMLVL_1_bm  (1<<1)  /* voltage level monitor level bit 1 mask. */
+#define BOD_VLMLVL_1_bp  1  /* voltage level monitor level bit 1 position. */
+
+/* BOD.INTCTRL  bit masks and bit positions */
+#define BOD_VLMIE_bm  0x01  /* voltage level monitor interrrupt enable bit mask. */
+#define BOD_VLMIE_bp  0  /* voltage level monitor interrrupt enable bit position. */
+#define BOD_VLMCFG_gm  0x06  /* Configuration group mask. */
+#define BOD_VLMCFG_gp  1  /* Configuration group position. */
+#define BOD_VLMCFG_0_bm  (1<<1)  /* Configuration bit 0 mask. */
+#define BOD_VLMCFG_0_bp  1  /* Configuration bit 0 position. */
+#define BOD_VLMCFG_1_bm  (1<<2)  /* Configuration bit 1 mask. */
+#define BOD_VLMCFG_1_bp  2  /* Configuration bit 1 position. */
+
+/* BOD.INTFLAGS  bit masks and bit positions */
+#define BOD_VLMIF_bm  0x01  /* Voltage level monitor interrupt flag bit mask. */
+#define BOD_VLMIF_bp  0  /* Voltage level monitor interrupt flag bit position. */
+
+/* BOD.STATUS  bit masks and bit positions */
+#define BOD_VLMS_bm  0x01  /* Voltage level monitor status bit mask. */
+#define BOD_VLMS_bp  0  /* Voltage level monitor status bit position. */
+
+
+/* CCL - Configurable Custom Logic */
+/* CCL.CTRLA  bit masks and bit positions */
+#define CCL_ENABLE_bm  0x01  /* Enable bit mask. */
+#define CCL_ENABLE_bp  0  /* Enable bit position. */
+#define CCL_RUNSTDBY_bm  0x40  /* Run in Standby bit mask. */
+#define CCL_RUNSTDBY_bp  6  /* Run in Standby bit position. */
+
+/* CCL.SEQCTRL0  bit masks and bit positions */
+#define CCL_SEQSEL_gm  0x07  /* Sequential Selection group mask. */
+#define CCL_SEQSEL_gp  0  /* Sequential Selection group position. */
+#define CCL_SEQSEL_0_bm  (1<<0)  /* Sequential Selection bit 0 mask. */
+#define CCL_SEQSEL_0_bp  0  /* Sequential Selection bit 0 position. */
+#define CCL_SEQSEL_1_bm  (1<<1)  /* Sequential Selection bit 1 mask. */
+#define CCL_SEQSEL_1_bp  1  /* Sequential Selection bit 1 position. */
+#define CCL_SEQSEL_2_bm  (1<<2)  /* Sequential Selection bit 2 mask. */
+#define CCL_SEQSEL_2_bp  2  /* Sequential Selection bit 2 position. */
+
+/* CCL.SEQCTRL1  bit masks and bit positions */
+/* CCL_SEQSEL  is already defined. */
+
+/* CCL.INTCTRL0  bit masks and bit positions */
+#define CCL_INTMODE0_gm  0x03  /* Interrupt Mode for LUT0 group mask. */
+#define CCL_INTMODE0_gp  0  /* Interrupt Mode for LUT0 group position. */
+#define CCL_INTMODE0_0_bm  (1<<0)  /* Interrupt Mode for LUT0 bit 0 mask. */
+#define CCL_INTMODE0_0_bp  0  /* Interrupt Mode for LUT0 bit 0 position. */
+#define CCL_INTMODE0_1_bm  (1<<1)  /* Interrupt Mode for LUT0 bit 1 mask. */
+#define CCL_INTMODE0_1_bp  1  /* Interrupt Mode for LUT0 bit 1 position. */
+#define CCL_INTMODE1_gm  0x0C  /* Interrupt Mode for LUT1 group mask. */
+#define CCL_INTMODE1_gp  2  /* Interrupt Mode for LUT1 group position. */
+#define CCL_INTMODE1_0_bm  (1<<2)  /* Interrupt Mode for LUT1 bit 0 mask. */
+#define CCL_INTMODE1_0_bp  2  /* Interrupt Mode for LUT1 bit 0 position. */
+#define CCL_INTMODE1_1_bm  (1<<3)  /* Interrupt Mode for LUT1 bit 1 mask. */
+#define CCL_INTMODE1_1_bp  3  /* Interrupt Mode for LUT1 bit 1 position. */
+#define CCL_INTMODE2_gm  0x30  /* Interrupt Mode for LUT2 group mask. */
+#define CCL_INTMODE2_gp  4  /* Interrupt Mode for LUT2 group position. */
+#define CCL_INTMODE2_0_bm  (1<<4)  /* Interrupt Mode for LUT2 bit 0 mask. */
+#define CCL_INTMODE2_0_bp  4  /* Interrupt Mode for LUT2 bit 0 position. */
+#define CCL_INTMODE2_1_bm  (1<<5)  /* Interrupt Mode for LUT2 bit 1 mask. */
+#define CCL_INTMODE2_1_bp  5  /* Interrupt Mode for LUT2 bit 1 position. */
+#define CCL_INTMODE3_gm  0xC0  /* Interrupt Mode for LUT3 group mask. */
+#define CCL_INTMODE3_gp  6  /* Interrupt Mode for LUT3 group position. */
+#define CCL_INTMODE3_0_bm  (1<<6)  /* Interrupt Mode for LUT3 bit 0 mask. */
+#define CCL_INTMODE3_0_bp  6  /* Interrupt Mode for LUT3 bit 0 position. */
+#define CCL_INTMODE3_1_bm  (1<<7)  /* Interrupt Mode for LUT3 bit 1 mask. */
+#define CCL_INTMODE3_1_bp  7  /* Interrupt Mode for LUT3 bit 1 position. */
+
+/* CCL.INTFLAGS  bit masks and bit positions */
+#define CCL_INT_gm  0x0F  /* Interrupt Flag group mask. */
+#define CCL_INT_gp  0  /* Interrupt Flag group position. */
+#define CCL_INT_0_bm  (1<<0)  /* Interrupt Flag bit 0 mask. */
+#define CCL_INT_0_bp  0  /* Interrupt Flag bit 0 position. */
+#define CCL_INT0_bm  CCL_INT_0_bm  /* This define is deprecated and should not be used */
+#define CCL_INT0_bp  CCL_INT_0_bp  /* This define is deprecated and should not be used */
+#define CCL_INT_1_bm  (1<<1)  /* Interrupt Flag bit 1 mask. */
+#define CCL_INT_1_bp  1  /* Interrupt Flag bit 1 position. */
+#define CCL_INT1_bm  CCL_INT_1_bm  /* This define is deprecated and should not be used */
+#define CCL_INT1_bp  CCL_INT_1_bp  /* This define is deprecated and should not be used */
+#define CCL_INT_2_bm  (1<<2)  /* Interrupt Flag bit 2 mask. */
+#define CCL_INT_2_bp  2  /* Interrupt Flag bit 2 position. */
+#define CCL_INT2_bm  CCL_INT_2_bm  /* This define is deprecated and should not be used */
+#define CCL_INT2_bp  CCL_INT_2_bp  /* This define is deprecated and should not be used */
+#define CCL_INT_3_bm  (1<<3)  /* Interrupt Flag bit 3 mask. */
+#define CCL_INT_3_bp  3  /* Interrupt Flag bit 3 position. */
+#define CCL_INT3_bm  CCL_INT_3_bm  /* This define is deprecated and should not be used */
+#define CCL_INT3_bp  CCL_INT_3_bp  /* This define is deprecated and should not be used */
+
+/* CCL.LUT0CTRLA  bit masks and bit positions */
+/* CCL_ENABLE  is already defined. */
+#define CCL_CLKSRC_gm  0x0E  /* Clock Source Selection group mask. */
+#define CCL_CLKSRC_gp  1  /* Clock Source Selection group position. */
+#define CCL_CLKSRC_0_bm  (1<<1)  /* Clock Source Selection bit 0 mask. */
+#define CCL_CLKSRC_0_bp  1  /* Clock Source Selection bit 0 position. */
+#define CCL_CLKSRC_1_bm  (1<<2)  /* Clock Source Selection bit 1 mask. */
+#define CCL_CLKSRC_1_bp  2  /* Clock Source Selection bit 1 position. */
+#define CCL_CLKSRC_2_bm  (1<<3)  /* Clock Source Selection bit 2 mask. */
+#define CCL_CLKSRC_2_bp  3  /* Clock Source Selection bit 2 position. */
+#define CCL_FILTSEL_gm  0x30  /* Filter Selection group mask. */
+#define CCL_FILTSEL_gp  4  /* Filter Selection group position. */
+#define CCL_FILTSEL_0_bm  (1<<4)  /* Filter Selection bit 0 mask. */
+#define CCL_FILTSEL_0_bp  4  /* Filter Selection bit 0 position. */
+#define CCL_FILTSEL_1_bm  (1<<5)  /* Filter Selection bit 1 mask. */
+#define CCL_FILTSEL_1_bp  5  /* Filter Selection bit 1 position. */
+#define CCL_OUTEN_bm  0x40  /* Output Enable bit mask. */
+#define CCL_OUTEN_bp  6  /* Output Enable bit position. */
+#define CCL_EDGEDET_bm  0x80  /* Edge Detection Enable bit mask. */
+#define CCL_EDGEDET_bp  7  /* Edge Detection Enable bit position. */
+
+/* CCL.LUT0CTRLB  bit masks and bit positions */
+#define CCL_INSEL0_gm  0x0F  /* LUT Input 0 Source Selection group mask. */
+#define CCL_INSEL0_gp  0  /* LUT Input 0 Source Selection group position. */
+#define CCL_INSEL0_0_bm  (1<<0)  /* LUT Input 0 Source Selection bit 0 mask. */
+#define CCL_INSEL0_0_bp  0  /* LUT Input 0 Source Selection bit 0 position. */
+#define CCL_INSEL0_1_bm  (1<<1)  /* LUT Input 0 Source Selection bit 1 mask. */
+#define CCL_INSEL0_1_bp  1  /* LUT Input 0 Source Selection bit 1 position. */
+#define CCL_INSEL0_2_bm  (1<<2)  /* LUT Input 0 Source Selection bit 2 mask. */
+#define CCL_INSEL0_2_bp  2  /* LUT Input 0 Source Selection bit 2 position. */
+#define CCL_INSEL0_3_bm  (1<<3)  /* LUT Input 0 Source Selection bit 3 mask. */
+#define CCL_INSEL0_3_bp  3  /* LUT Input 0 Source Selection bit 3 position. */
+#define CCL_INSEL1_gm  0xF0  /* LUT Input 1 Source Selection group mask. */
+#define CCL_INSEL1_gp  4  /* LUT Input 1 Source Selection group position. */
+#define CCL_INSEL1_0_bm  (1<<4)  /* LUT Input 1 Source Selection bit 0 mask. */
+#define CCL_INSEL1_0_bp  4  /* LUT Input 1 Source Selection bit 0 position. */
+#define CCL_INSEL1_1_bm  (1<<5)  /* LUT Input 1 Source Selection bit 1 mask. */
+#define CCL_INSEL1_1_bp  5  /* LUT Input 1 Source Selection bit 1 position. */
+#define CCL_INSEL1_2_bm  (1<<6)  /* LUT Input 1 Source Selection bit 2 mask. */
+#define CCL_INSEL1_2_bp  6  /* LUT Input 1 Source Selection bit 2 position. */
+#define CCL_INSEL1_3_bm  (1<<7)  /* LUT Input 1 Source Selection bit 3 mask. */
+#define CCL_INSEL1_3_bp  7  /* LUT Input 1 Source Selection bit 3 position. */
+
+/* CCL.LUT0CTRLC  bit masks and bit positions */
+#define CCL_INSEL2_gm  0x0F  /* LUT Input 2 Source Selection group mask. */
+#define CCL_INSEL2_gp  0  /* LUT Input 2 Source Selection group position. */
+#define CCL_INSEL2_0_bm  (1<<0)  /* LUT Input 2 Source Selection bit 0 mask. */
+#define CCL_INSEL2_0_bp  0  /* LUT Input 2 Source Selection bit 0 position. */
+#define CCL_INSEL2_1_bm  (1<<1)  /* LUT Input 2 Source Selection bit 1 mask. */
+#define CCL_INSEL2_1_bp  1  /* LUT Input 2 Source Selection bit 1 position. */
+#define CCL_INSEL2_2_bm  (1<<2)  /* LUT Input 2 Source Selection bit 2 mask. */
+#define CCL_INSEL2_2_bp  2  /* LUT Input 2 Source Selection bit 2 position. */
+#define CCL_INSEL2_3_bm  (1<<3)  /* LUT Input 2 Source Selection bit 3 mask. */
+#define CCL_INSEL2_3_bp  3  /* LUT Input 2 Source Selection bit 3 position. */
+
+/* CCL.TRUTH0  bit masks and bit positions */
+#define CCL_TRUTH_gm  0xFF  /* Truth Table group mask. */
+#define CCL_TRUTH_gp  0  /* Truth Table group position. */
+#define CCL_TRUTH_0_bm  (1<<0)  /* Truth Table bit 0 mask. */
+#define CCL_TRUTH_0_bp  0  /* Truth Table bit 0 position. */
+#define CCL_TRUTH_1_bm  (1<<1)  /* Truth Table bit 1 mask. */
+#define CCL_TRUTH_1_bp  1  /* Truth Table bit 1 position. */
+#define CCL_TRUTH_2_bm  (1<<2)  /* Truth Table bit 2 mask. */
+#define CCL_TRUTH_2_bp  2  /* Truth Table bit 2 position. */
+#define CCL_TRUTH_3_bm  (1<<3)  /* Truth Table bit 3 mask. */
+#define CCL_TRUTH_3_bp  3  /* Truth Table bit 3 position. */
+#define CCL_TRUTH_4_bm  (1<<4)  /* Truth Table bit 4 mask. */
+#define CCL_TRUTH_4_bp  4  /* Truth Table bit 4 position. */
+#define CCL_TRUTH_5_bm  (1<<5)  /* Truth Table bit 5 mask. */
+#define CCL_TRUTH_5_bp  5  /* Truth Table bit 5 position. */
+#define CCL_TRUTH_6_bm  (1<<6)  /* Truth Table bit 6 mask. */
+#define CCL_TRUTH_6_bp  6  /* Truth Table bit 6 position. */
+#define CCL_TRUTH_7_bm  (1<<7)  /* Truth Table bit 7 mask. */
+#define CCL_TRUTH_7_bp  7  /* Truth Table bit 7 position. */
+
+/* CCL.LUT1CTRLA  bit masks and bit positions */
+/* CCL_ENABLE  is already defined. */
+/* CCL_CLKSRC  is already defined. */
+/* CCL_FILTSEL  is already defined. */
+/* CCL_OUTEN  is already defined. */
+/* CCL_EDGEDET  is already defined. */
+
+/* CCL.LUT1CTRLB  bit masks and bit positions */
+/* CCL_INSEL0  is already defined. */
+/* CCL_INSEL1  is already defined. */
+
+/* CCL.LUT1CTRLC  bit masks and bit positions */
+/* CCL_INSEL2  is already defined. */
+
+/* CCL.TRUTH1  bit masks and bit positions */
+/* CCL_TRUTH  is already defined. */
+
+/* CCL.LUT2CTRLA  bit masks and bit positions */
+/* CCL_ENABLE  is already defined. */
+/* CCL_CLKSRC  is already defined. */
+/* CCL_FILTSEL  is already defined. */
+/* CCL_OUTEN  is already defined. */
+/* CCL_EDGEDET  is already defined. */
+
+/* CCL.LUT2CTRLB  bit masks and bit positions */
+/* CCL_INSEL0  is already defined. */
+/* CCL_INSEL1  is already defined. */
+
+/* CCL.LUT2CTRLC  bit masks and bit positions */
+/* CCL_INSEL2  is already defined. */
+
+/* CCL.TRUTH2  bit masks and bit positions */
+/* CCL_TRUTH  is already defined. */
+
+/* CCL.LUT3CTRLA  bit masks and bit positions */
+/* CCL_ENABLE  is already defined. */
+/* CCL_CLKSRC  is already defined. */
+/* CCL_FILTSEL  is already defined. */
+/* CCL_OUTEN  is already defined. */
+/* CCL_EDGEDET  is already defined. */
+
+/* CCL.LUT3CTRLB  bit masks and bit positions */
+/* CCL_INSEL0  is already defined. */
+/* CCL_INSEL1  is already defined. */
+
+/* CCL.LUT3CTRLC  bit masks and bit positions */
+/* CCL_INSEL2  is already defined. */
+
+/* CCL.TRUTH3  bit masks and bit positions */
+/* CCL_TRUTH  is already defined. */
+
+
+/* CLKCTRL - Clock controller */
+/* CLKCTRL.MCLKCTRLA  bit masks and bit positions */
+#define CLKCTRL_CLKSEL_gm  0x07  /* Clock select group mask. */
+#define CLKCTRL_CLKSEL_gp  0  /* Clock select group position. */
+#define CLKCTRL_CLKSEL_0_bm  (1<<0)  /* Clock select bit 0 mask. */
+#define CLKCTRL_CLKSEL_0_bp  0  /* Clock select bit 0 position. */
+#define CLKCTRL_CLKSEL_1_bm  (1<<1)  /* Clock select bit 1 mask. */
+#define CLKCTRL_CLKSEL_1_bp  1  /* Clock select bit 1 position. */
+#define CLKCTRL_CLKSEL_2_bm  (1<<2)  /* Clock select bit 2 mask. */
+#define CLKCTRL_CLKSEL_2_bp  2  /* Clock select bit 2 position. */
+#define CLKCTRL_CLKOUT_bm  0x80  /* System clock out bit mask. */
+#define CLKCTRL_CLKOUT_bp  7  /* System clock out bit position. */
+
+/* CLKCTRL.MCLKCTRLB  bit masks and bit positions */
+#define CLKCTRL_PEN_bm  0x01  /* Prescaler enable bit mask. */
+#define CLKCTRL_PEN_bp  0  /* Prescaler enable bit position. */
+#define CLKCTRL_PDIV_gm  0x1E  /* Prescaler division group mask. */
+#define CLKCTRL_PDIV_gp  1  /* Prescaler division group position. */
+#define CLKCTRL_PDIV_0_bm  (1<<1)  /* Prescaler division bit 0 mask. */
+#define CLKCTRL_PDIV_0_bp  1  /* Prescaler division bit 0 position. */
+#define CLKCTRL_PDIV_1_bm  (1<<2)  /* Prescaler division bit 1 mask. */
+#define CLKCTRL_PDIV_1_bp  2  /* Prescaler division bit 1 position. */
+#define CLKCTRL_PDIV_2_bm  (1<<3)  /* Prescaler division bit 2 mask. */
+#define CLKCTRL_PDIV_2_bp  3  /* Prescaler division bit 2 position. */
+#define CLKCTRL_PDIV_3_bm  (1<<4)  /* Prescaler division bit 3 mask. */
+#define CLKCTRL_PDIV_3_bp  4  /* Prescaler division bit 3 position. */
+
+/* CLKCTRL.MCLKCTRLC  bit masks and bit positions */
+#define CLKCTRL_CFDEN_bm  0x01  /* Clock Failure Detect Enable bit mask. */
+#define CLKCTRL_CFDEN_bp  0  /* Clock Failure Detect Enable bit position. */
+#define CLKCTRL_CFDTST_bm  0x02  /* CFD Test bit mask. */
+#define CLKCTRL_CFDTST_bp  1  /* CFD Test bit position. */
+#define CLKCTRL_CFDSRC_gm  0x0C  /* CFD Source group mask. */
+#define CLKCTRL_CFDSRC_gp  2  /* CFD Source group position. */
+#define CLKCTRL_CFDSRC_0_bm  (1<<2)  /* CFD Source bit 0 mask. */
+#define CLKCTRL_CFDSRC_0_bp  2  /* CFD Source bit 0 position. */
+#define CLKCTRL_CFDSRC_1_bm  (1<<3)  /* CFD Source bit 1 mask. */
+#define CLKCTRL_CFDSRC_1_bp  3  /* CFD Source bit 1 position. */
+
+/* CLKCTRL.MCLKINTCTRL  bit masks and bit positions */
+#define CLKCTRL_CFD_bm  0x01  /* Interrupt Enable bit mask. */
+#define CLKCTRL_CFD_bp  0  /* Interrupt Enable bit position. */
+#define CLKCTRL_INTTYPE_bm  0x80  /* Interrupt Type bit mask. */
+#define CLKCTRL_INTTYPE_bp  7  /* Interrupt Type bit position. */
+
+/* CLKCTRL.MCLKINTFLAGS  bit masks and bit positions */
+/* CLKCTRL_CFD  is already defined. */
+
+/* CLKCTRL.MCLKSTATUS  bit masks and bit positions */
+#define CLKCTRL_SOSC_bm  0x01  /* System Oscillator changing bit mask. */
+#define CLKCTRL_SOSC_bp  0  /* System Oscillator changing bit position. */
+#define CLKCTRL_OSCHFS_bm  0x02  /* High frequency oscillator status bit mask. */
+#define CLKCTRL_OSCHFS_bp  1  /* High frequency oscillator status bit position. */
+#define CLKCTRL_OSC32KS_bm  0x04  /* 32KHz oscillator status bit mask. */
+#define CLKCTRL_OSC32KS_bp  2  /* 32KHz oscillator status bit position. */
+#define CLKCTRL_XOSC32KS_bm  0x08  /* 32.768 kHz Crystal Oscillator status bit mask. */
+#define CLKCTRL_XOSC32KS_bp  3  /* 32.768 kHz Crystal Oscillator status bit position. */
+#define CLKCTRL_EXTS_bm  0x10  /* External Clock status / XOSCHF status bit mask. */
+#define CLKCTRL_EXTS_bp  4  /* External Clock status / XOSCHF status bit position. */
+
+/* CLKCTRL.MCLKTIMEBASE  bit masks and bit positions */
+#define CLKCTRL_TIMEBASE_gm  0x1F  /* Timebase group mask. */
+#define CLKCTRL_TIMEBASE_gp  0  /* Timebase group position. */
+#define CLKCTRL_TIMEBASE_0_bm  (1<<0)  /* Timebase bit 0 mask. */
+#define CLKCTRL_TIMEBASE_0_bp  0  /* Timebase bit 0 position. */
+#define CLKCTRL_TIMEBASE_1_bm  (1<<1)  /* Timebase bit 1 mask. */
+#define CLKCTRL_TIMEBASE_1_bp  1  /* Timebase bit 1 position. */
+#define CLKCTRL_TIMEBASE_2_bm  (1<<2)  /* Timebase bit 2 mask. */
+#define CLKCTRL_TIMEBASE_2_bp  2  /* Timebase bit 2 position. */
+#define CLKCTRL_TIMEBASE_3_bm  (1<<3)  /* Timebase bit 3 mask. */
+#define CLKCTRL_TIMEBASE_3_bp  3  /* Timebase bit 3 position. */
+#define CLKCTRL_TIMEBASE_4_bm  (1<<4)  /* Timebase bit 4 mask. */
+#define CLKCTRL_TIMEBASE_4_bp  4  /* Timebase bit 4 position. */
+
+/* CLKCTRL.OSCHFCTRLA  bit masks and bit positions */
+#define CLKCTRL_AUTOTUNE_gm  0x03  /* Automatic Oscillator Tune group mask. */
+#define CLKCTRL_AUTOTUNE_gp  0  /* Automatic Oscillator Tune group position. */
+#define CLKCTRL_AUTOTUNE_0_bm  (1<<0)  /* Automatic Oscillator Tune bit 0 mask. */
+#define CLKCTRL_AUTOTUNE_0_bp  0  /* Automatic Oscillator Tune bit 0 position. */
+#define CLKCTRL_AUTOTUNE_1_bm  (1<<1)  /* Automatic Oscillator Tune bit 1 mask. */
+#define CLKCTRL_AUTOTUNE_1_bp  1  /* Automatic Oscillator Tune bit 1 position. */
+#define CLKCTRL_RUNSTDBY_bm  0x80  /* Run in standby bit mask. */
+#define CLKCTRL_RUNSTDBY_bp  7  /* Run in standby bit position. */
+
+/* CLKCTRL.OSCHFTUNE  bit masks and bit positions */
+#define CLKCTRL_TUNE_gm  0xFF  /* Oscillator Tune group mask. */
+#define CLKCTRL_TUNE_gp  0  /* Oscillator Tune group position. */
+#define CLKCTRL_TUNE_0_bm  (1<<0)  /* Oscillator Tune bit 0 mask. */
+#define CLKCTRL_TUNE_0_bp  0  /* Oscillator Tune bit 0 position. */
+#define CLKCTRL_TUNE_1_bm  (1<<1)  /* Oscillator Tune bit 1 mask. */
+#define CLKCTRL_TUNE_1_bp  1  /* Oscillator Tune bit 1 position. */
+#define CLKCTRL_TUNE_2_bm  (1<<2)  /* Oscillator Tune bit 2 mask. */
+#define CLKCTRL_TUNE_2_bp  2  /* Oscillator Tune bit 2 position. */
+#define CLKCTRL_TUNE_3_bm  (1<<3)  /* Oscillator Tune bit 3 mask. */
+#define CLKCTRL_TUNE_3_bp  3  /* Oscillator Tune bit 3 position. */
+#define CLKCTRL_TUNE_4_bm  (1<<4)  /* Oscillator Tune bit 4 mask. */
+#define CLKCTRL_TUNE_4_bp  4  /* Oscillator Tune bit 4 position. */
+#define CLKCTRL_TUNE_5_bm  (1<<5)  /* Oscillator Tune bit 5 mask. */
+#define CLKCTRL_TUNE_5_bp  5  /* Oscillator Tune bit 5 position. */
+#define CLKCTRL_TUNE_6_bm  (1<<6)  /* Oscillator Tune bit 6 mask. */
+#define CLKCTRL_TUNE_6_bp  6  /* Oscillator Tune bit 6 position. */
+#define CLKCTRL_TUNE_7_bm  (1<<7)  /* Oscillator Tune bit 7 mask. */
+#define CLKCTRL_TUNE_7_bp  7  /* Oscillator Tune bit 7 position. */
+
+/* CLKCTRL.OSC32KCTRLA  bit masks and bit positions */
+/* CLKCTRL_RUNSTDBY  is already defined. */
+
+/* CLKCTRL.XOSC32KCTRLA  bit masks and bit positions */
+#define CLKCTRL_ENABLE_bm  0x01  /* Enable bit mask. */
+#define CLKCTRL_ENABLE_bp  0  /* Enable bit position. */
+#define CLKCTRL_LPMODE_bm  0x02  /* Low power mode bit mask. */
+#define CLKCTRL_LPMODE_bp  1  /* Low power mode bit position. */
+#define CLKCTRL_SEL_bm  0x04  /* Select bit mask. */
+#define CLKCTRL_SEL_bp  2  /* Select bit position. */
+#define CLKCTRL_CSUT_gm  0x30  /* Crystal startup time group mask. */
+#define CLKCTRL_CSUT_gp  4  /* Crystal startup time group position. */
+#define CLKCTRL_CSUT_0_bm  (1<<4)  /* Crystal startup time bit 0 mask. */
+#define CLKCTRL_CSUT_0_bp  4  /* Crystal startup time bit 0 position. */
+#define CLKCTRL_CSUT_1_bm  (1<<5)  /* Crystal startup time bit 1 mask. */
+#define CLKCTRL_CSUT_1_bp  5  /* Crystal startup time bit 1 position. */
+/* CLKCTRL_RUNSTDBY  is already defined. */
+
+/* CLKCTRL.XOSCHFCTRLA  bit masks and bit positions */
+/* CLKCTRL_ENABLE  is already defined. */
+#define CLKCTRL_SELHF_bm  0x02  /* Source Select bit mask. */
+#define CLKCTRL_SELHF_bp  1  /* Source Select bit position. */
+#define CLKCTRL_CSUTHF_gm  0x30  /* Start-Up Time group mask. */
+#define CLKCTRL_CSUTHF_gp  4  /* Start-Up Time group position. */
+#define CLKCTRL_CSUTHF_0_bm  (1<<4)  /* Start-Up Time bit 0 mask. */
+#define CLKCTRL_CSUTHF_0_bp  4  /* Start-Up Time bit 0 position. */
+#define CLKCTRL_CSUTHF_1_bm  (1<<5)  /* Start-Up Time bit 1 mask. */
+#define CLKCTRL_CSUTHF_1_bp  5  /* Start-Up Time bit 1 position. */
+/* CLKCTRL_RUNSTDBY  is already defined. */
+
+
+/* CPU - CPU */
+/* CPU.CCP  bit masks and bit positions */
+#define CPU_CCP_gm  0xFF  /* CCP signature group mask. */
+#define CPU_CCP_gp  0  /* CCP signature group position. */
+#define CPU_CCP_0_bm  (1<<0)  /* CCP signature bit 0 mask. */
+#define CPU_CCP_0_bp  0  /* CCP signature bit 0 position. */
+#define CPU_CCP_1_bm  (1<<1)  /* CCP signature bit 1 mask. */
+#define CPU_CCP_1_bp  1  /* CCP signature bit 1 position. */
+#define CPU_CCP_2_bm  (1<<2)  /* CCP signature bit 2 mask. */
+#define CPU_CCP_2_bp  2  /* CCP signature bit 2 position. */
+#define CPU_CCP_3_bm  (1<<3)  /* CCP signature bit 3 mask. */
+#define CPU_CCP_3_bp  3  /* CCP signature bit 3 position. */
+#define CPU_CCP_4_bm  (1<<4)  /* CCP signature bit 4 mask. */
+#define CPU_CCP_4_bp  4  /* CCP signature bit 4 position. */
+#define CPU_CCP_5_bm  (1<<5)  /* CCP signature bit 5 mask. */
+#define CPU_CCP_5_bp  5  /* CCP signature bit 5 position. */
+#define CPU_CCP_6_bm  (1<<6)  /* CCP signature bit 6 mask. */
+#define CPU_CCP_6_bp  6  /* CCP signature bit 6 position. */
+#define CPU_CCP_7_bm  (1<<7)  /* CCP signature bit 7 mask. */
+#define CPU_CCP_7_bp  7  /* CCP signature bit 7 position. */
+
+/* CPU.SREG  bit masks and bit positions */
+#define CPU_C_bm  0x01  /* Carry Flag bit mask. */
+#define CPU_C_bp  0  /* Carry Flag bit position. */
+#define CPU_Z_bm  0x02  /* Zero Flag bit mask. */
+#define CPU_Z_bp  1  /* Zero Flag bit position. */
+#define CPU_N_bm  0x04  /* Negative Flag bit mask. */
+#define CPU_N_bp  2  /* Negative Flag bit position. */
+#define CPU_V_bm  0x08  /* Two's Complement Overflow Flag bit mask. */
+#define CPU_V_bp  3  /* Two's Complement Overflow Flag bit position. */
+#define CPU_S_bm  0x10  /* N Exclusive Or V Flag bit mask. */
+#define CPU_S_bp  4  /* N Exclusive Or V Flag bit position. */
+#define CPU_H_bm  0x20  /* Half Carry Flag bit mask. */
+#define CPU_H_bp  5  /* Half Carry Flag bit position. */
+#define CPU_T_bm  0x40  /* Transfer Bit bit mask. */
+#define CPU_T_bp  6  /* Transfer Bit bit position. */
+#define CPU_I_bm  0x80  /* Global Interrupt Enable Flag bit mask. */
+#define CPU_I_bp  7  /* Global Interrupt Enable Flag bit position. */
+
+
+/* CPUINT - Interrupt Controller */
+/* CPUINT.CTRLA  bit masks and bit positions */
+#define CPUINT_LVL0RR_bm  0x01  /* Round-robin Scheduling Enable bit mask. */
+#define CPUINT_LVL0RR_bp  0  /* Round-robin Scheduling Enable bit position. */
+#define CPUINT_CVT_bm  0x20  /* Compact Vector Table bit mask. */
+#define CPUINT_CVT_bp  5  /* Compact Vector Table bit position. */
+#define CPUINT_IVSEL_bm  0x40  /* Interrupt Vector Select bit mask. */
+#define CPUINT_IVSEL_bp  6  /* Interrupt Vector Select bit position. */
+
+/* CPUINT.STATUS  bit masks and bit positions */
+#define CPUINT_LVL0EX_bm  0x01  /* Level 0 Interrupt Executing bit mask. */
+#define CPUINT_LVL0EX_bp  0  /* Level 0 Interrupt Executing bit position. */
+#define CPUINT_LVL1EX_bm  0x02  /* Level 1 Interrupt Executing bit mask. */
+#define CPUINT_LVL1EX_bp  1  /* Level 1 Interrupt Executing bit position. */
+#define CPUINT_NMIEX_bm  0x80  /* Non-maskable Interrupt Executing bit mask. */
+#define CPUINT_NMIEX_bp  7  /* Non-maskable Interrupt Executing bit position. */
+
+/* CPUINT.LVL0PRI  bit masks and bit positions */
+#define CPUINT_LVL0PRI_gm  0xFF  /* Interrupt Level Priority group mask. */
+#define CPUINT_LVL0PRI_gp  0  /* Interrupt Level Priority group position. */
+#define CPUINT_LVL0PRI_0_bm  (1<<0)  /* Interrupt Level Priority bit 0 mask. */
+#define CPUINT_LVL0PRI_0_bp  0  /* Interrupt Level Priority bit 0 position. */
+#define CPUINT_LVL0PRI_1_bm  (1<<1)  /* Interrupt Level Priority bit 1 mask. */
+#define CPUINT_LVL0PRI_1_bp  1  /* Interrupt Level Priority bit 1 position. */
+#define CPUINT_LVL0PRI_2_bm  (1<<2)  /* Interrupt Level Priority bit 2 mask. */
+#define CPUINT_LVL0PRI_2_bp  2  /* Interrupt Level Priority bit 2 position. */
+#define CPUINT_LVL0PRI_3_bm  (1<<3)  /* Interrupt Level Priority bit 3 mask. */
+#define CPUINT_LVL0PRI_3_bp  3  /* Interrupt Level Priority bit 3 position. */
+#define CPUINT_LVL0PRI_4_bm  (1<<4)  /* Interrupt Level Priority bit 4 mask. */
+#define CPUINT_LVL0PRI_4_bp  4  /* Interrupt Level Priority bit 4 position. */
+#define CPUINT_LVL0PRI_5_bm  (1<<5)  /* Interrupt Level Priority bit 5 mask. */
+#define CPUINT_LVL0PRI_5_bp  5  /* Interrupt Level Priority bit 5 position. */
+#define CPUINT_LVL0PRI_6_bm  (1<<6)  /* Interrupt Level Priority bit 6 mask. */
+#define CPUINT_LVL0PRI_6_bp  6  /* Interrupt Level Priority bit 6 position. */
+#define CPUINT_LVL0PRI_7_bm  (1<<7)  /* Interrupt Level Priority bit 7 mask. */
+#define CPUINT_LVL0PRI_7_bp  7  /* Interrupt Level Priority bit 7 position. */
+
+/* CPUINT.LVL1VEC  bit masks and bit positions */
+#define CPUINT_LVL1VEC_gm  0xFF  /* Interrupt Vector with High Priority group mask. */
+#define CPUINT_LVL1VEC_gp  0  /* Interrupt Vector with High Priority group position. */
+#define CPUINT_LVL1VEC_0_bm  (1<<0)  /* Interrupt Vector with High Priority bit 0 mask. */
+#define CPUINT_LVL1VEC_0_bp  0  /* Interrupt Vector with High Priority bit 0 position. */
+#define CPUINT_LVL1VEC_1_bm  (1<<1)  /* Interrupt Vector with High Priority bit 1 mask. */
+#define CPUINT_LVL1VEC_1_bp  1  /* Interrupt Vector with High Priority bit 1 position. */
+#define CPUINT_LVL1VEC_2_bm  (1<<2)  /* Interrupt Vector with High Priority bit 2 mask. */
+#define CPUINT_LVL1VEC_2_bp  2  /* Interrupt Vector with High Priority bit 2 position. */
+#define CPUINT_LVL1VEC_3_bm  (1<<3)  /* Interrupt Vector with High Priority bit 3 mask. */
+#define CPUINT_LVL1VEC_3_bp  3  /* Interrupt Vector with High Priority bit 3 position. */
+#define CPUINT_LVL1VEC_4_bm  (1<<4)  /* Interrupt Vector with High Priority bit 4 mask. */
+#define CPUINT_LVL1VEC_4_bp  4  /* Interrupt Vector with High Priority bit 4 position. */
+#define CPUINT_LVL1VEC_5_bm  (1<<5)  /* Interrupt Vector with High Priority bit 5 mask. */
+#define CPUINT_LVL1VEC_5_bp  5  /* Interrupt Vector with High Priority bit 5 position. */
+#define CPUINT_LVL1VEC_6_bm  (1<<6)  /* Interrupt Vector with High Priority bit 6 mask. */
+#define CPUINT_LVL1VEC_6_bp  6  /* Interrupt Vector with High Priority bit 6 position. */
+#define CPUINT_LVL1VEC_7_bm  (1<<7)  /* Interrupt Vector with High Priority bit 7 mask. */
+#define CPUINT_LVL1VEC_7_bp  7  /* Interrupt Vector with High Priority bit 7 position. */
+
+
+/* CRCSCAN - CRCSCAN */
+/* CRCSCAN.CTRLA  bit masks and bit positions */
+#define CRCSCAN_ENABLE_bm  0x01  /* Enable CRC scan bit mask. */
+#define CRCSCAN_ENABLE_bp  0  /* Enable CRC scan bit position. */
+#define CRCSCAN_NMIEN_bm  0x02  /* Enable NMI Trigger bit mask. */
+#define CRCSCAN_NMIEN_bp  1  /* Enable NMI Trigger bit position. */
+#define CRCSCAN_RESET_bm  0x80  /* Reset CRC scan bit mask. */
+#define CRCSCAN_RESET_bp  7  /* Reset CRC scan bit position. */
+
+/* CRCSCAN.CTRLB  bit masks and bit positions */
+#define CRCSCAN_SRC_gm  0x03  /* CRC Source group mask. */
+#define CRCSCAN_SRC_gp  0  /* CRC Source group position. */
+#define CRCSCAN_SRC_0_bm  (1<<0)  /* CRC Source bit 0 mask. */
+#define CRCSCAN_SRC_0_bp  0  /* CRC Source bit 0 position. */
+#define CRCSCAN_SRC_1_bm  (1<<1)  /* CRC Source bit 1 mask. */
+#define CRCSCAN_SRC_1_bp  1  /* CRC Source bit 1 position. */
+
+/* CRCSCAN.STATUS  bit masks and bit positions */
+#define CRCSCAN_BUSY_bm  0x01  /* CRC Busy bit mask. */
+#define CRCSCAN_BUSY_bp  0  /* CRC Busy bit position. */
+#define CRCSCAN_OK_bm  0x02  /* CRC Ok bit mask. */
+#define CRCSCAN_OK_bp  1  /* CRC Ok bit position. */
+
+
+/* DAC - Digital to Analog Converter */
+/* DAC.CTRLA  bit masks and bit positions */
+#define DAC_ENABLE_bm  0x01  /* DAC Enable bit mask. */
+#define DAC_ENABLE_bp  0  /* DAC Enable bit position. */
+#define DAC_OUTRANGE_gm  0x30  /* Output Buffer Range group mask. */
+#define DAC_OUTRANGE_gp  4  /* Output Buffer Range group position. */
+#define DAC_OUTRANGE_0_bm  (1<<4)  /* Output Buffer Range bit 0 mask. */
+#define DAC_OUTRANGE_0_bp  4  /* Output Buffer Range bit 0 position. */
+#define DAC_OUTRANGE_1_bm  (1<<5)  /* Output Buffer Range bit 1 mask. */
+#define DAC_OUTRANGE_1_bp  5  /* Output Buffer Range bit 1 position. */
+#define DAC_OUTEN_bm  0x40  /* Output Buffer Enable bit mask. */
+#define DAC_OUTEN_bp  6  /* Output Buffer Enable bit position. */
+#define DAC_RUNSTDBY_bm  0x80  /* Run in Standby Mode bit mask. */
+#define DAC_RUNSTDBY_bp  7  /* Run in Standby Mode bit position. */
+
+/* DAC.DATA  bit masks and bit positions */
+#define DAC_DATA_gm  0xFFC0  /* Data group mask. */
+#define DAC_DATA_gp  6  /* Data group position. */
+#define DAC_DATA_0_bm  (1<<6)  /* Data bit 0 mask. */
+#define DAC_DATA_0_bp  6  /* Data bit 0 position. */
+#define DAC_DATA_1_bm  (1<<7)  /* Data bit 1 mask. */
+#define DAC_DATA_1_bp  7  /* Data bit 1 position. */
+#define DAC_DATA_2_bm  (1<<8)  /* Data bit 2 mask. */
+#define DAC_DATA_2_bp  8  /* Data bit 2 position. */
+#define DAC_DATA_3_bm  (1<<9)  /* Data bit 3 mask. */
+#define DAC_DATA_3_bp  9  /* Data bit 3 position. */
+#define DAC_DATA_4_bm  (1<<10)  /* Data bit 4 mask. */
+#define DAC_DATA_4_bp  10  /* Data bit 4 position. */
+#define DAC_DATA_5_bm  (1<<11)  /* Data bit 5 mask. */
+#define DAC_DATA_5_bp  11  /* Data bit 5 position. */
+#define DAC_DATA_6_bm  (1<<12)  /* Data bit 6 mask. */
+#define DAC_DATA_6_bp  12  /* Data bit 6 position. */
+#define DAC_DATA_7_bm  (1<<13)  /* Data bit 7 mask. */
+#define DAC_DATA_7_bp  13  /* Data bit 7 position. */
+#define DAC_DATA_8_bm  (1<<14)  /* Data bit 8 mask. */
+#define DAC_DATA_8_bp  14  /* Data bit 8 position. */
+#define DAC_DATA_9_bm  (1<<15)  /* Data bit 9 mask. */
+#define DAC_DATA_9_bp  15  /* Data bit 9 position. */
+
+
+/* EVSYS - Event System */
+/* EVSYS.SWEVENTA  bit masks and bit positions */
+#define EVSYS_SWEVENTA_gm  0xFF  /* Software event on channel select group mask. */
+#define EVSYS_SWEVENTA_gp  0  /* Software event on channel select group position. */
+#define EVSYS_SWEVENTA_0_bm  (1<<0)  /* Software event on channel select bit 0 mask. */
+#define EVSYS_SWEVENTA_0_bp  0  /* Software event on channel select bit 0 position. */
+#define EVSYS_SWEVENTA_1_bm  (1<<1)  /* Software event on channel select bit 1 mask. */
+#define EVSYS_SWEVENTA_1_bp  1  /* Software event on channel select bit 1 position. */
+#define EVSYS_SWEVENTA_2_bm  (1<<2)  /* Software event on channel select bit 2 mask. */
+#define EVSYS_SWEVENTA_2_bp  2  /* Software event on channel select bit 2 position. */
+#define EVSYS_SWEVENTA_3_bm  (1<<3)  /* Software event on channel select bit 3 mask. */
+#define EVSYS_SWEVENTA_3_bp  3  /* Software event on channel select bit 3 position. */
+#define EVSYS_SWEVENTA_4_bm  (1<<4)  /* Software event on channel select bit 4 mask. */
+#define EVSYS_SWEVENTA_4_bp  4  /* Software event on channel select bit 4 position. */
+#define EVSYS_SWEVENTA_5_bm  (1<<5)  /* Software event on channel select bit 5 mask. */
+#define EVSYS_SWEVENTA_5_bp  5  /* Software event on channel select bit 5 position. */
+#define EVSYS_SWEVENTA_6_bm  (1<<6)  /* Software event on channel select bit 6 mask. */
+#define EVSYS_SWEVENTA_6_bp  6  /* Software event on channel select bit 6 position. */
+#define EVSYS_SWEVENTA_7_bm  (1<<7)  /* Software event on channel select bit 7 mask. */
+#define EVSYS_SWEVENTA_7_bp  7  /* Software event on channel select bit 7 position. */
+
+/* EVSYS.CHANNEL0  bit masks and bit positions */
+#define EVSYS_CHANNEL_gm  0xFF  /* Channel generator select group mask. */
+#define EVSYS_CHANNEL_gp  0  /* Channel generator select group position. */
+#define EVSYS_CHANNEL_0_bm  (1<<0)  /* Channel generator select bit 0 mask. */
+#define EVSYS_CHANNEL_0_bp  0  /* Channel generator select bit 0 position. */
+#define EVSYS_CHANNEL_1_bm  (1<<1)  /* Channel generator select bit 1 mask. */
+#define EVSYS_CHANNEL_1_bp  1  /* Channel generator select bit 1 position. */
+#define EVSYS_CHANNEL_2_bm  (1<<2)  /* Channel generator select bit 2 mask. */
+#define EVSYS_CHANNEL_2_bp  2  /* Channel generator select bit 2 position. */
+#define EVSYS_CHANNEL_3_bm  (1<<3)  /* Channel generator select bit 3 mask. */
+#define EVSYS_CHANNEL_3_bp  3  /* Channel generator select bit 3 position. */
+#define EVSYS_CHANNEL_4_bm  (1<<4)  /* Channel generator select bit 4 mask. */
+#define EVSYS_CHANNEL_4_bp  4  /* Channel generator select bit 4 position. */
+#define EVSYS_CHANNEL_5_bm  (1<<5)  /* Channel generator select bit 5 mask. */
+#define EVSYS_CHANNEL_5_bp  5  /* Channel generator select bit 5 position. */
+#define EVSYS_CHANNEL_6_bm  (1<<6)  /* Channel generator select bit 6 mask. */
+#define EVSYS_CHANNEL_6_bp  6  /* Channel generator select bit 6 position. */
+#define EVSYS_CHANNEL_7_bm  (1<<7)  /* Channel generator select bit 7 mask. */
+#define EVSYS_CHANNEL_7_bp  7  /* Channel generator select bit 7 position. */
+
+/* EVSYS.CHANNEL1  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.CHANNEL2  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.CHANNEL3  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.CHANNEL4  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.CHANNEL5  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.USERCCLLUT0A  bit masks and bit positions */
+#define EVSYS_USER_gm  0xFF  /* User channel select group mask. */
+#define EVSYS_USER_gp  0  /* User channel select group position. */
+#define EVSYS_USER_0_bm  (1<<0)  /* User channel select bit 0 mask. */
+#define EVSYS_USER_0_bp  0  /* User channel select bit 0 position. */
+#define EVSYS_USER_1_bm  (1<<1)  /* User channel select bit 1 mask. */
+#define EVSYS_USER_1_bp  1  /* User channel select bit 1 position. */
+#define EVSYS_USER_2_bm  (1<<2)  /* User channel select bit 2 mask. */
+#define EVSYS_USER_2_bp  2  /* User channel select bit 2 position. */
+#define EVSYS_USER_3_bm  (1<<3)  /* User channel select bit 3 mask. */
+#define EVSYS_USER_3_bp  3  /* User channel select bit 3 position. */
+#define EVSYS_USER_4_bm  (1<<4)  /* User channel select bit 4 mask. */
+#define EVSYS_USER_4_bp  4  /* User channel select bit 4 position. */
+#define EVSYS_USER_5_bm  (1<<5)  /* User channel select bit 5 mask. */
+#define EVSYS_USER_5_bp  5  /* User channel select bit 5 position. */
+#define EVSYS_USER_6_bm  (1<<6)  /* User channel select bit 6 mask. */
+#define EVSYS_USER_6_bp  6  /* User channel select bit 6 position. */
+#define EVSYS_USER_7_bm  (1<<7)  /* User channel select bit 7 mask. */
+#define EVSYS_USER_7_bp  7  /* User channel select bit 7 position. */
+
+/* EVSYS.USERCCLLUT0B  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT1A  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT1B  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT2A  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT2B  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT3A  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT3B  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERADC0START  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTC  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTD  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTF  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERUSART0IRDA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERUSART1IRDA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERUSART2IRDA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCA0CNTA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCA0CNTB  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCA1CNTA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCA1CNTB  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB0CAPT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB0COUNT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB1CAPT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB1COUNT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB2CAPT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB2COUNT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB3CAPT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB3COUNT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+
+/* FUSE - Fuses */
+/* FUSE.WDTCFG  bit masks and bit positions */
+#define FUSE_PERIOD_gm  0x0F  /* Watchdog Timeout Period group mask. */
+#define FUSE_PERIOD_gp  0  /* Watchdog Timeout Period group position. */
+#define FUSE_PERIOD_0_bm  (1<<0)  /* Watchdog Timeout Period bit 0 mask. */
+#define FUSE_PERIOD_0_bp  0  /* Watchdog Timeout Period bit 0 position. */
+#define FUSE_PERIOD_1_bm  (1<<1)  /* Watchdog Timeout Period bit 1 mask. */
+#define FUSE_PERIOD_1_bp  1  /* Watchdog Timeout Period bit 1 position. */
+#define FUSE_PERIOD_2_bm  (1<<2)  /* Watchdog Timeout Period bit 2 mask. */
+#define FUSE_PERIOD_2_bp  2  /* Watchdog Timeout Period bit 2 position. */
+#define FUSE_PERIOD_3_bm  (1<<3)  /* Watchdog Timeout Period bit 3 mask. */
+#define FUSE_PERIOD_3_bp  3  /* Watchdog Timeout Period bit 3 position. */
+#define FUSE_WINDOW_gm  0xF0  /* Watchdog Window Timeout Period group mask. */
+#define FUSE_WINDOW_gp  4  /* Watchdog Window Timeout Period group position. */
+#define FUSE_WINDOW_0_bm  (1<<4)  /* Watchdog Window Timeout Period bit 0 mask. */
+#define FUSE_WINDOW_0_bp  4  /* Watchdog Window Timeout Period bit 0 position. */
+#define FUSE_WINDOW_1_bm  (1<<5)  /* Watchdog Window Timeout Period bit 1 mask. */
+#define FUSE_WINDOW_1_bp  5  /* Watchdog Window Timeout Period bit 1 position. */
+#define FUSE_WINDOW_2_bm  (1<<6)  /* Watchdog Window Timeout Period bit 2 mask. */
+#define FUSE_WINDOW_2_bp  6  /* Watchdog Window Timeout Period bit 2 position. */
+#define FUSE_WINDOW_3_bm  (1<<7)  /* Watchdog Window Timeout Period bit 3 mask. */
+#define FUSE_WINDOW_3_bp  7  /* Watchdog Window Timeout Period bit 3 position. */
+
+/* FUSE.BODCFG  bit masks and bit positions */
+#define FUSE_SLEEP_gm  0x03  /* BOD Operation in Sleep Mode group mask. */
+#define FUSE_SLEEP_gp  0  /* BOD Operation in Sleep Mode group position. */
+#define FUSE_SLEEP_0_bm  (1<<0)  /* BOD Operation in Sleep Mode bit 0 mask. */
+#define FUSE_SLEEP_0_bp  0  /* BOD Operation in Sleep Mode bit 0 position. */
+#define FUSE_SLEEP_1_bm  (1<<1)  /* BOD Operation in Sleep Mode bit 1 mask. */
+#define FUSE_SLEEP_1_bp  1  /* BOD Operation in Sleep Mode bit 1 position. */
+#define FUSE_ACTIVE_gm  0x0C  /* BOD Operation in Active Mode group mask. */
+#define FUSE_ACTIVE_gp  2  /* BOD Operation in Active Mode group position. */
+#define FUSE_ACTIVE_0_bm  (1<<2)  /* BOD Operation in Active Mode bit 0 mask. */
+#define FUSE_ACTIVE_0_bp  2  /* BOD Operation in Active Mode bit 0 position. */
+#define FUSE_ACTIVE_1_bm  (1<<3)  /* BOD Operation in Active Mode bit 1 mask. */
+#define FUSE_ACTIVE_1_bp  3  /* BOD Operation in Active Mode bit 1 position. */
+#define FUSE_SAMPFREQ_bm  0x10  /* BOD Sample Frequency bit mask. */
+#define FUSE_SAMPFREQ_bp  4  /* BOD Sample Frequency bit position. */
+#define FUSE_LVL_gm  0xE0  /* BOD Level group mask. */
+#define FUSE_LVL_gp  5  /* BOD Level group position. */
+#define FUSE_LVL_0_bm  (1<<5)  /* BOD Level bit 0 mask. */
+#define FUSE_LVL_0_bp  5  /* BOD Level bit 0 position. */
+#define FUSE_LVL_1_bm  (1<<6)  /* BOD Level bit 1 mask. */
+#define FUSE_LVL_1_bp  6  /* BOD Level bit 1 position. */
+#define FUSE_LVL_2_bm  (1<<7)  /* BOD Level bit 2 mask. */
+#define FUSE_LVL_2_bp  7  /* BOD Level bit 2 position. */
+
+/* FUSE.OSCCFG  bit masks and bit positions */
+#define FUSE_OSCHFFRQ_bm  0x08  /* High-frequency Oscillator Frequency bit mask. */
+#define FUSE_OSCHFFRQ_bp  3  /* High-frequency Oscillator Frequency bit position. */
+
+/* FUSE.SYSCFG0  bit masks and bit positions */
+#define FUSE_EESAVE_bm  0x01  /* EEPROM Save bit mask. */
+#define FUSE_EESAVE_bp  0  /* EEPROM Save bit position. */
+#define FUSE_RSTPINCFG_bm  0x08  /* Reset Pin Configuration bit mask. */
+#define FUSE_RSTPINCFG_bp  3  /* Reset Pin Configuration bit position. */
+#define FUSE_UPDIPINCFG_bm  0x10  /* UPDI Pin Configuration bit mask. */
+#define FUSE_UPDIPINCFG_bp  4  /* UPDI Pin Configuration bit position. */
+#define FUSE_CRCSEL_bm  0x20  /* CRC Select bit mask. */
+#define FUSE_CRCSEL_bp  5  /* CRC Select bit position. */
+#define FUSE_CRCSRC_gm  0xC0  /* CRC Source group mask. */
+#define FUSE_CRCSRC_gp  6  /* CRC Source group position. */
+#define FUSE_CRCSRC_0_bm  (1<<6)  /* CRC Source bit 0 mask. */
+#define FUSE_CRCSRC_0_bp  6  /* CRC Source bit 0 position. */
+#define FUSE_CRCSRC_1_bm  (1<<7)  /* CRC Source bit 1 mask. */
+#define FUSE_CRCSRC_1_bp  7  /* CRC Source bit 1 position. */
+
+/* FUSE.SYSCFG1  bit masks and bit positions */
+#define FUSE_SUT_gm  0x07  /* Startup Time group mask. */
+#define FUSE_SUT_gp  0  /* Startup Time group position. */
+#define FUSE_SUT_0_bm  (1<<0)  /* Startup Time bit 0 mask. */
+#define FUSE_SUT_0_bp  0  /* Startup Time bit 0 position. */
+#define FUSE_SUT_1_bm  (1<<1)  /* Startup Time bit 1 mask. */
+#define FUSE_SUT_1_bp  1  /* Startup Time bit 1 position. */
+#define FUSE_SUT_2_bm  (1<<2)  /* Startup Time bit 2 mask. */
+#define FUSE_SUT_2_bp  2  /* Startup Time bit 2 position. */
+
+
+
+/* LOCK - Lockbits */
+/* LOCK.KEY  bit masks and bit positions */
+#define LOCK_KEY_gm  0xFFFFFFFF  /* Lock Key group mask. */
+#define LOCK_KEY_gp  0  /* Lock Key group position. */
+#define LOCK_KEY_0_bm  (1<<0)  /* Lock Key bit 0 mask. */
+#define LOCK_KEY_0_bp  0  /* Lock Key bit 0 position. */
+#define LOCK_KEY_1_bm  (1<<1)  /* Lock Key bit 1 mask. */
+#define LOCK_KEY_1_bp  1  /* Lock Key bit 1 position. */
+#define LOCK_KEY_2_bm  (1<<2)  /* Lock Key bit 2 mask. */
+#define LOCK_KEY_2_bp  2  /* Lock Key bit 2 position. */
+#define LOCK_KEY_3_bm  (1<<3)  /* Lock Key bit 3 mask. */
+#define LOCK_KEY_3_bp  3  /* Lock Key bit 3 position. */
+#define LOCK_KEY_4_bm  (1<<4)  /* Lock Key bit 4 mask. */
+#define LOCK_KEY_4_bp  4  /* Lock Key bit 4 position. */
+#define LOCK_KEY_5_bm  (1<<5)  /* Lock Key bit 5 mask. */
+#define LOCK_KEY_5_bp  5  /* Lock Key bit 5 position. */
+#define LOCK_KEY_6_bm  (1<<6)  /* Lock Key bit 6 mask. */
+#define LOCK_KEY_6_bp  6  /* Lock Key bit 6 position. */
+#define LOCK_KEY_7_bm  (1<<7)  /* Lock Key bit 7 mask. */
+#define LOCK_KEY_7_bp  7  /* Lock Key bit 7 position. */
+#define LOCK_KEY_8_bm  (1<<8)  /* Lock Key bit 8 mask. */
+#define LOCK_KEY_8_bp  8  /* Lock Key bit 8 position. */
+#define LOCK_KEY_9_bm  (1<<9)  /* Lock Key bit 9 mask. */
+#define LOCK_KEY_9_bp  9  /* Lock Key bit 9 position. */
+#define LOCK_KEY_10_bm  (1<<10)  /* Lock Key bit 10 mask. */
+#define LOCK_KEY_10_bp  10  /* Lock Key bit 10 position. */
+#define LOCK_KEY_11_bm  (1<<11)  /* Lock Key bit 11 mask. */
+#define LOCK_KEY_11_bp  11  /* Lock Key bit 11 position. */
+#define LOCK_KEY_12_bm  (1<<12)  /* Lock Key bit 12 mask. */
+#define LOCK_KEY_12_bp  12  /* Lock Key bit 12 position. */
+#define LOCK_KEY_13_bm  (1<<13)  /* Lock Key bit 13 mask. */
+#define LOCK_KEY_13_bp  13  /* Lock Key bit 13 position. */
+#define LOCK_KEY_14_bm  (1<<14)  /* Lock Key bit 14 mask. */
+#define LOCK_KEY_14_bp  14  /* Lock Key bit 14 position. */
+#define LOCK_KEY_15_bm  (1<<15)  /* Lock Key bit 15 mask. */
+#define LOCK_KEY_15_bp  15  /* Lock Key bit 15 position. */
+#define LOCK_KEY_16_bm  (1<<16)  /* Lock Key bit 16 mask. */
+#define LOCK_KEY_16_bp  16  /* Lock Key bit 16 position. */
+#define LOCK_KEY_17_bm  (1<<17)  /* Lock Key bit 17 mask. */
+#define LOCK_KEY_17_bp  17  /* Lock Key bit 17 position. */
+#define LOCK_KEY_18_bm  (1<<18)  /* Lock Key bit 18 mask. */
+#define LOCK_KEY_18_bp  18  /* Lock Key bit 18 position. */
+#define LOCK_KEY_19_bm  (1<<19)  /* Lock Key bit 19 mask. */
+#define LOCK_KEY_19_bp  19  /* Lock Key bit 19 position. */
+#define LOCK_KEY_20_bm  (1<<20)  /* Lock Key bit 20 mask. */
+#define LOCK_KEY_20_bp  20  /* Lock Key bit 20 position. */
+#define LOCK_KEY_21_bm  (1<<21)  /* Lock Key bit 21 mask. */
+#define LOCK_KEY_21_bp  21  /* Lock Key bit 21 position. */
+#define LOCK_KEY_22_bm  (1<<22)  /* Lock Key bit 22 mask. */
+#define LOCK_KEY_22_bp  22  /* Lock Key bit 22 position. */
+#define LOCK_KEY_23_bm  (1<<23)  /* Lock Key bit 23 mask. */
+#define LOCK_KEY_23_bp  23  /* Lock Key bit 23 position. */
+#define LOCK_KEY_24_bm  (1<<24)  /* Lock Key bit 24 mask. */
+#define LOCK_KEY_24_bp  24  /* Lock Key bit 24 position. */
+#define LOCK_KEY_25_bm  (1<<25)  /* Lock Key bit 25 mask. */
+#define LOCK_KEY_25_bp  25  /* Lock Key bit 25 position. */
+#define LOCK_KEY_26_bm  (1<<26)  /* Lock Key bit 26 mask. */
+#define LOCK_KEY_26_bp  26  /* Lock Key bit 26 position. */
+#define LOCK_KEY_27_bm  (1<<27)  /* Lock Key bit 27 mask. */
+#define LOCK_KEY_27_bp  27  /* Lock Key bit 27 position. */
+#define LOCK_KEY_28_bm  (1<<28)  /* Lock Key bit 28 mask. */
+#define LOCK_KEY_28_bp  28  /* Lock Key bit 28 position. */
+#define LOCK_KEY_29_bm  (1<<29)  /* Lock Key bit 29 mask. */
+#define LOCK_KEY_29_bp  29  /* Lock Key bit 29 position. */
+#define LOCK_KEY_30_bm  (1<<30)  /* Lock Key bit 30 mask. */
+#define LOCK_KEY_30_bp  30  /* Lock Key bit 30 position. */
+#define LOCK_KEY_31_bm  (1<<31)  /* Lock Key bit 31 mask. */
+#define LOCK_KEY_31_bp  31  /* Lock Key bit 31 position. */
+
+
+/* NVMCTRL - Non-volatile Memory Controller */
+/* NVMCTRL.CTRLA  bit masks and bit positions */
+#define NVMCTRL_CMD_gm  0x7F  /* Command group mask. */
+#define NVMCTRL_CMD_gp  0  /* Command group position. */
+#define NVMCTRL_CMD_0_bm  (1<<0)  /* Command bit 0 mask. */
+#define NVMCTRL_CMD_0_bp  0  /* Command bit 0 position. */
+#define NVMCTRL_CMD_1_bm  (1<<1)  /* Command bit 1 mask. */
+#define NVMCTRL_CMD_1_bp  1  /* Command bit 1 position. */
+#define NVMCTRL_CMD_2_bm  (1<<2)  /* Command bit 2 mask. */
+#define NVMCTRL_CMD_2_bp  2  /* Command bit 2 position. */
+#define NVMCTRL_CMD_3_bm  (1<<3)  /* Command bit 3 mask. */
+#define NVMCTRL_CMD_3_bp  3  /* Command bit 3 position. */
+#define NVMCTRL_CMD_4_bm  (1<<4)  /* Command bit 4 mask. */
+#define NVMCTRL_CMD_4_bp  4  /* Command bit 4 position. */
+#define NVMCTRL_CMD_5_bm  (1<<5)  /* Command bit 5 mask. */
+#define NVMCTRL_CMD_5_bp  5  /* Command bit 5 position. */
+#define NVMCTRL_CMD_6_bm  (1<<6)  /* Command bit 6 mask. */
+#define NVMCTRL_CMD_6_bp  6  /* Command bit 6 position. */
+
+/* NVMCTRL.CTRLB  bit masks and bit positions */
+#define NVMCTRL_APPCODEWP_bm  0x01  /* Application Code Write Protect bit mask. */
+#define NVMCTRL_APPCODEWP_bp  0  /* Application Code Write Protect bit position. */
+#define NVMCTRL_BOOTRP_bm  0x02  /* Boot Read Protect bit mask. */
+#define NVMCTRL_BOOTRP_bp  1  /* Boot Read Protect bit position. */
+#define NVMCTRL_APPDATAWP_bm  0x04  /* Application Data Write Protect bit mask. */
+#define NVMCTRL_APPDATAWP_bp  2  /* Application Data Write Protect bit position. */
+#define NVMCTRL_EEWP_bm  0x08  /* EEPROM Write Protect bit mask. */
+#define NVMCTRL_EEWP_bp  3  /* EEPROM Write Protect bit position. */
+#define NVMCTRL_FLMAP_gm  0x30  /* Flash Mapping in Data space group mask. */
+#define NVMCTRL_FLMAP_gp  4  /* Flash Mapping in Data space group position. */
+#define NVMCTRL_FLMAP_0_bm  (1<<4)  /* Flash Mapping in Data space bit 0 mask. */
+#define NVMCTRL_FLMAP_0_bp  4  /* Flash Mapping in Data space bit 0 position. */
+#define NVMCTRL_FLMAP_1_bm  (1<<5)  /* Flash Mapping in Data space bit 1 mask. */
+#define NVMCTRL_FLMAP_1_bp  5  /* Flash Mapping in Data space bit 1 position. */
+#define NVMCTRL_FLMAPLOCK_bm  0x80  /* Flash Mapping Lock bit mask. */
+#define NVMCTRL_FLMAPLOCK_bp  7  /* Flash Mapping Lock bit position. */
+
+/* NVMCTRL.INTCTRL  bit masks and bit positions */
+#define NVMCTRL_EEREADY_bm  0x01  /* EEPROM Ready bit mask. */
+#define NVMCTRL_EEREADY_bp  0  /* EEPROM Ready bit position. */
+#define NVMCTRL_FLREADY_bm  0x02  /* Flash Ready bit mask. */
+#define NVMCTRL_FLREADY_bp  1  /* Flash Ready bit position. */
+
+/* NVMCTRL.INTFLAGS  bit masks and bit positions */
+/* NVMCTRL_EEREADY  is already defined. */
+/* NVMCTRL_FLREADY  is already defined. */
+
+/* NVMCTRL.STATUS  bit masks and bit positions */
+#define NVMCTRL_EEBUSY_bm  0x01  /* EEPROM busy bit mask. */
+#define NVMCTRL_EEBUSY_bp  0  /* EEPROM busy bit position. */
+#define NVMCTRL_FLBUSY_bm  0x02  /* Flash busy bit mask. */
+#define NVMCTRL_FLBUSY_bp  1  /* Flash busy bit position. */
+#define NVMCTRL_ERROR_gm  0x70  /* Write error group mask. */
+#define NVMCTRL_ERROR_gp  4  /* Write error group position. */
+#define NVMCTRL_ERROR_0_bm  (1<<4)  /* Write error bit 0 mask. */
+#define NVMCTRL_ERROR_0_bp  4  /* Write error bit 0 position. */
+#define NVMCTRL_ERROR_1_bm  (1<<5)  /* Write error bit 1 mask. */
+#define NVMCTRL_ERROR_1_bp  5  /* Write error bit 1 position. */
+#define NVMCTRL_ERROR_2_bm  (1<<6)  /* Write error bit 2 mask. */
+#define NVMCTRL_ERROR_2_bp  6  /* Write error bit 2 position. */
+
+
+/* PORT - I/O Ports */
+/* PORT.INTFLAGS  bit masks and bit positions */
+#define PORT_INT_gm  0xFF  /* Pin Interrupt Flag group mask. */
+#define PORT_INT_gp  0  /* Pin Interrupt Flag group position. */
+#define PORT_INT_0_bm  (1<<0)  /* Pin Interrupt Flag bit 0 mask. */
+#define PORT_INT_0_bp  0  /* Pin Interrupt Flag bit 0 position. */
+#define PORT_INT0_bm  PORT_INT_0_bm  /* This define is deprecated and should not be used */
+#define PORT_INT0_bp  PORT_INT_0_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_1_bm  (1<<1)  /* Pin Interrupt Flag bit 1 mask. */
+#define PORT_INT_1_bp  1  /* Pin Interrupt Flag bit 1 position. */
+#define PORT_INT1_bm  PORT_INT_1_bm  /* This define is deprecated and should not be used */
+#define PORT_INT1_bp  PORT_INT_1_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_2_bm  (1<<2)  /* Pin Interrupt Flag bit 2 mask. */
+#define PORT_INT_2_bp  2  /* Pin Interrupt Flag bit 2 position. */
+#define PORT_INT2_bm  PORT_INT_2_bm  /* This define is deprecated and should not be used */
+#define PORT_INT2_bp  PORT_INT_2_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_3_bm  (1<<3)  /* Pin Interrupt Flag bit 3 mask. */
+#define PORT_INT_3_bp  3  /* Pin Interrupt Flag bit 3 position. */
+#define PORT_INT3_bm  PORT_INT_3_bm  /* This define is deprecated and should not be used */
+#define PORT_INT3_bp  PORT_INT_3_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_4_bm  (1<<4)  /* Pin Interrupt Flag bit 4 mask. */
+#define PORT_INT_4_bp  4  /* Pin Interrupt Flag bit 4 position. */
+#define PORT_INT4_bm  PORT_INT_4_bm  /* This define is deprecated and should not be used */
+#define PORT_INT4_bp  PORT_INT_4_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_5_bm  (1<<5)  /* Pin Interrupt Flag bit 5 mask. */
+#define PORT_INT_5_bp  5  /* Pin Interrupt Flag bit 5 position. */
+#define PORT_INT5_bm  PORT_INT_5_bm  /* This define is deprecated and should not be used */
+#define PORT_INT5_bp  PORT_INT_5_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_6_bm  (1<<6)  /* Pin Interrupt Flag bit 6 mask. */
+#define PORT_INT_6_bp  6  /* Pin Interrupt Flag bit 6 position. */
+#define PORT_INT6_bm  PORT_INT_6_bm  /* This define is deprecated and should not be used */
+#define PORT_INT6_bp  PORT_INT_6_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_7_bm  (1<<7)  /* Pin Interrupt Flag bit 7 mask. */
+#define PORT_INT_7_bp  7  /* Pin Interrupt Flag bit 7 position. */
+#define PORT_INT7_bm  PORT_INT_7_bm  /* This define is deprecated and should not be used */
+#define PORT_INT7_bp  PORT_INT_7_bp  /* This define is deprecated and should not be used */
+
+/* PORT.PORTCTRL  bit masks and bit positions */
+#define PORT_SRL_bm  0x01  /* Slew Rate Limit Enable bit mask. */
+#define PORT_SRL_bp  0  /* Slew Rate Limit Enable bit position. */
+
+/* PORT.PINCONFIG  bit masks and bit positions */
+#define PORT_ISC_gm  0x07  /* Input/Sense Configuration group mask. */
+#define PORT_ISC_gp  0  /* Input/Sense Configuration group position. */
+#define PORT_ISC_0_bm  (1<<0)  /* Input/Sense Configuration bit 0 mask. */
+#define PORT_ISC_0_bp  0  /* Input/Sense Configuration bit 0 position. */
+#define PORT_ISC_1_bm  (1<<1)  /* Input/Sense Configuration bit 1 mask. */
+#define PORT_ISC_1_bp  1  /* Input/Sense Configuration bit 1 position. */
+#define PORT_ISC_2_bm  (1<<2)  /* Input/Sense Configuration bit 2 mask. */
+#define PORT_ISC_2_bp  2  /* Input/Sense Configuration bit 2 position. */
+#define PORT_PULLUPEN_bm  0x08  /* Pullup enable bit mask. */
+#define PORT_PULLUPEN_bp  3  /* Pullup enable bit position. */
+#define PORT_INLVL_bm  0x40  /* Input Level Select bit mask. */
+#define PORT_INLVL_bp  6  /* Input Level Select bit position. */
+#define PORT_INVEN_bm  0x80  /* Inverted I/O Enable bit mask. */
+#define PORT_INVEN_bp  7  /* Inverted I/O Enable bit position. */
+
+/* PORT.PIN0CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN1CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN2CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN3CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN4CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN5CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN6CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN7CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.EVGENCTRL  bit masks and bit positions */
+#define PORT_EVGEN0SEL_gm  0x07  /* Event Generator 0 Select group mask. */
+#define PORT_EVGEN0SEL_gp  0  /* Event Generator 0 Select group position. */
+#define PORT_EVGEN0SEL_0_bm  (1<<0)  /* Event Generator 0 Select bit 0 mask. */
+#define PORT_EVGEN0SEL_0_bp  0  /* Event Generator 0 Select bit 0 position. */
+#define PORT_EVGEN0SEL_1_bm  (1<<1)  /* Event Generator 0 Select bit 1 mask. */
+#define PORT_EVGEN0SEL_1_bp  1  /* Event Generator 0 Select bit 1 position. */
+#define PORT_EVGEN0SEL_2_bm  (1<<2)  /* Event Generator 0 Select bit 2 mask. */
+#define PORT_EVGEN0SEL_2_bp  2  /* Event Generator 0 Select bit 2 position. */
+#define PORT_EVGEN1SEL_gm  0x70  /* Event Generator 1 Select group mask. */
+#define PORT_EVGEN1SEL_gp  4  /* Event Generator 1 Select group position. */
+#define PORT_EVGEN1SEL_0_bm  (1<<4)  /* Event Generator 1 Select bit 0 mask. */
+#define PORT_EVGEN1SEL_0_bp  4  /* Event Generator 1 Select bit 0 position. */
+#define PORT_EVGEN1SEL_1_bm  (1<<5)  /* Event Generator 1 Select bit 1 mask. */
+#define PORT_EVGEN1SEL_1_bp  5  /* Event Generator 1 Select bit 1 position. */
+#define PORT_EVGEN1SEL_2_bm  (1<<6)  /* Event Generator 1 Select bit 2 mask. */
+#define PORT_EVGEN1SEL_2_bp  6  /* Event Generator 1 Select bit 2 position. */
+
+
+/* PORTMUX - Port Multiplexer */
+/* PORTMUX.EVSYSROUTEA  bit masks and bit positions */
+#define PORTMUX_EVOUTA_bm  0x01  /* Event Output A bit mask. */
+#define PORTMUX_EVOUTA_bp  0  /* Event Output A bit position. */
+#define PORTMUX_EVOUTC_bm  0x04  /* Event Output C bit mask. */
+#define PORTMUX_EVOUTC_bp  2  /* Event Output C bit position. */
+#define PORTMUX_EVOUTD_bm  0x08  /* Event Output D bit mask. */
+#define PORTMUX_EVOUTD_bp  3  /* Event Output D bit position. */
+#define PORTMUX_EVOUTF_bm  0x20  /* Event Output F bit mask. */
+#define PORTMUX_EVOUTF_bp  5  /* Event Output F bit position. */
+
+/* PORTMUX.CCLROUTEA  bit masks and bit positions */
+#define PORTMUX_LUT0_bm  0x01  /* CCL Look-Up Table 0 Signals bit mask. */
+#define PORTMUX_LUT0_bp  0  /* CCL Look-Up Table 0 Signals bit position. */
+#define PORTMUX_LUT1_bm  0x02  /* CCL Look-Up Table 1 Signals bit mask. */
+#define PORTMUX_LUT1_bp  1  /* CCL Look-Up Table 1 Signals bit position. */
+#define PORTMUX_LUT2_bm  0x04  /* CCL Look-Up Table 2 Signals bit mask. */
+#define PORTMUX_LUT2_bp  2  /* CCL Look-Up Table 2 Signals bit position. */
+
+/* PORTMUX.USARTROUTEA  bit masks and bit positions */
+#define PORTMUX_USART0_gm  0x07  /* USART0 Routing group mask. */
+#define PORTMUX_USART0_gp  0  /* USART0 Routing group position. */
+#define PORTMUX_USART0_0_bm  (1<<0)  /* USART0 Routing bit 0 mask. */
+#define PORTMUX_USART0_0_bp  0  /* USART0 Routing bit 0 position. */
+#define PORTMUX_USART0_1_bm  (1<<1)  /* USART0 Routing bit 1 mask. */
+#define PORTMUX_USART0_1_bp  1  /* USART0 Routing bit 1 position. */
+#define PORTMUX_USART0_2_bm  (1<<2)  /* USART0 Routing bit 2 mask. */
+#define PORTMUX_USART0_2_bp  2  /* USART0 Routing bit 2 position. */
+#define PORTMUX_USART1_gm  0x18  /* USART1 Routing group mask. */
+#define PORTMUX_USART1_gp  3  /* USART1 Routing group position. */
+#define PORTMUX_USART1_0_bm  (1<<3)  /* USART1 Routing bit 0 mask. */
+#define PORTMUX_USART1_0_bp  3  /* USART1 Routing bit 0 position. */
+#define PORTMUX_USART1_1_bm  (1<<4)  /* USART1 Routing bit 1 mask. */
+#define PORTMUX_USART1_1_bp  4  /* USART1 Routing bit 1 position. */
+
+/* PORTMUX.USARTROUTEB  bit masks and bit positions */
+#define PORTMUX_USART2_gm  0x03  /* USART2 Routing group mask. */
+#define PORTMUX_USART2_gp  0  /* USART2 Routing group position. */
+#define PORTMUX_USART2_0_bm  (1<<0)  /* USART2 Routing bit 0 mask. */
+#define PORTMUX_USART2_0_bp  0  /* USART2 Routing bit 0 position. */
+#define PORTMUX_USART2_1_bm  (1<<1)  /* USART2 Routing bit 1 mask. */
+#define PORTMUX_USART2_1_bp  1  /* USART2 Routing bit 1 position. */
+
+/* PORTMUX.SPIROUTEA  bit masks and bit positions */
+#define PORTMUX_SPI0_gm  0x07  /* SPI0 Signals group mask. */
+#define PORTMUX_SPI0_gp  0  /* SPI0 Signals group position. */
+#define PORTMUX_SPI0_0_bm  (1<<0)  /* SPI0 Signals bit 0 mask. */
+#define PORTMUX_SPI0_0_bp  0  /* SPI0 Signals bit 0 position. */
+#define PORTMUX_SPI0_1_bm  (1<<1)  /* SPI0 Signals bit 1 mask. */
+#define PORTMUX_SPI0_1_bp  1  /* SPI0 Signals bit 1 position. */
+#define PORTMUX_SPI0_2_bm  (1<<2)  /* SPI0 Signals bit 2 mask. */
+#define PORTMUX_SPI0_2_bp  2  /* SPI0 Signals bit 2 position. */
+
+/* PORTMUX.TWIROUTEA  bit masks and bit positions */
+#define PORTMUX_TWI0_gm  0x03  /* TWI0 Signals group mask. */
+#define PORTMUX_TWI0_gp  0  /* TWI0 Signals group position. */
+#define PORTMUX_TWI0_0_bm  (1<<0)  /* TWI0 Signals bit 0 mask. */
+#define PORTMUX_TWI0_0_bp  0  /* TWI0 Signals bit 0 position. */
+#define PORTMUX_TWI0_1_bm  (1<<1)  /* TWI0 Signals bit 1 mask. */
+#define PORTMUX_TWI0_1_bp  1  /* TWI0 Signals bit 1 position. */
+
+/* PORTMUX.TCAROUTEA  bit masks and bit positions */
+#define PORTMUX_TCA0_gm  0x07  /* TCA0 Signals group mask. */
+#define PORTMUX_TCA0_gp  0  /* TCA0 Signals group position. */
+#define PORTMUX_TCA0_0_bm  (1<<0)  /* TCA0 Signals bit 0 mask. */
+#define PORTMUX_TCA0_0_bp  0  /* TCA0 Signals bit 0 position. */
+#define PORTMUX_TCA0_1_bm  (1<<1)  /* TCA0 Signals bit 1 mask. */
+#define PORTMUX_TCA0_1_bp  1  /* TCA0 Signals bit 1 position. */
+#define PORTMUX_TCA0_2_bm  (1<<2)  /* TCA0 Signals bit 2 mask. */
+#define PORTMUX_TCA0_2_bp  2  /* TCA0 Signals bit 2 position. */
+#define PORTMUX_TCA1_gm  0x38  /* TCA1 Signals group mask. */
+#define PORTMUX_TCA1_gp  3  /* TCA1 Signals group position. */
+#define PORTMUX_TCA1_0_bm  (1<<3)  /* TCA1 Signals bit 0 mask. */
+#define PORTMUX_TCA1_0_bp  3  /* TCA1 Signals bit 0 position. */
+#define PORTMUX_TCA1_1_bm  (1<<4)  /* TCA1 Signals bit 1 mask. */
+#define PORTMUX_TCA1_1_bp  4  /* TCA1 Signals bit 1 position. */
+#define PORTMUX_TCA1_2_bm  (1<<5)  /* TCA1 Signals bit 2 mask. */
+#define PORTMUX_TCA1_2_bp  5  /* TCA1 Signals bit 2 position. */
+
+/* PORTMUX.TCBROUTEA  bit masks and bit positions */
+#define PORTMUX_TCB0_bm  0x01  /* TCB0 Output bit mask. */
+#define PORTMUX_TCB0_bp  0  /* TCB0 Output bit position. */
+#define PORTMUX_TCB1_bm  0x02  /* TCB1 Output bit mask. */
+#define PORTMUX_TCB1_bp  1  /* TCB1 Output bit position. */
+#define PORTMUX_TCB2_bm  0x04  /* TCB2 Output bit mask. */
+#define PORTMUX_TCB2_bp  2  /* TCB2 Output bit position. */
+#define PORTMUX_TCB3_bm  0x08  /* TCB3 Output bit mask. */
+#define PORTMUX_TCB3_bp  3  /* TCB3 Output bit position. */
+
+/* PORTMUX.ACROUTEA  bit masks and bit positions */
+#define PORTMUX_AC0_bm  0x01  /* Analog Comparator 0 Output bit mask. */
+#define PORTMUX_AC0_bp  0  /* Analog Comparator 0 Output bit position. */
+#define PORTMUX_AC1_bm  0x02  /* Analog Comparator 1 Output bit mask. */
+#define PORTMUX_AC1_bp  1  /* Analog Comparator 1 Output bit position. */
+
+
+/* RSTCTRL - Reset controller */
+/* RSTCTRL.RSTFR  bit masks and bit positions */
+#define RSTCTRL_PORF_bm  0x01  /* Power on Reset flag bit mask. */
+#define RSTCTRL_PORF_bp  0  /* Power on Reset flag bit position. */
+#define RSTCTRL_BORF_bm  0x02  /* Brown out detector Reset flag bit mask. */
+#define RSTCTRL_BORF_bp  1  /* Brown out detector Reset flag bit position. */
+#define RSTCTRL_EXTRF_bm  0x04  /* External Reset flag bit mask. */
+#define RSTCTRL_EXTRF_bp  2  /* External Reset flag bit position. */
+#define RSTCTRL_WDRF_bm  0x08  /* Watch dog Reset flag bit mask. */
+#define RSTCTRL_WDRF_bp  3  /* Watch dog Reset flag bit position. */
+#define RSTCTRL_SWRF_bm  0x10  /* Software Reset flag bit mask. */
+#define RSTCTRL_SWRF_bp  4  /* Software Reset flag bit position. */
+#define RSTCTRL_UPDIRF_bm  0x20  /* UPDI Reset flag bit mask. */
+#define RSTCTRL_UPDIRF_bp  5  /* UPDI Reset flag bit position. */
+
+/* RSTCTRL.SWRR  bit masks and bit positions */
+#define RSTCTRL_SWRE_bm  0x01  /* Software Reset Enable bit mask. */
+#define RSTCTRL_SWRE_bp  0  /* Software Reset Enable bit position. */
+
+
+/* RTC - Real-Time Counter */
+/* RTC.CTRLA  bit masks and bit positions */
+#define RTC_RTCEN_bm  0x01  /* Enable bit mask. */
+#define RTC_RTCEN_bp  0  /* Enable bit position. */
+#define RTC_CORREN_bm  0x04  /* Correction enable bit mask. */
+#define RTC_CORREN_bp  2  /* Correction enable bit position. */
+#define RTC_PRESCALER_gm  0x78  /* Prescaling Factor group mask. */
+#define RTC_PRESCALER_gp  3  /* Prescaling Factor group position. */
+#define RTC_PRESCALER_0_bm  (1<<3)  /* Prescaling Factor bit 0 mask. */
+#define RTC_PRESCALER_0_bp  3  /* Prescaling Factor bit 0 position. */
+#define RTC_PRESCALER_1_bm  (1<<4)  /* Prescaling Factor bit 1 mask. */
+#define RTC_PRESCALER_1_bp  4  /* Prescaling Factor bit 1 position. */
+#define RTC_PRESCALER_2_bm  (1<<5)  /* Prescaling Factor bit 2 mask. */
+#define RTC_PRESCALER_2_bp  5  /* Prescaling Factor bit 2 position. */
+#define RTC_PRESCALER_3_bm  (1<<6)  /* Prescaling Factor bit 3 mask. */
+#define RTC_PRESCALER_3_bp  6  /* Prescaling Factor bit 3 position. */
+#define RTC_RUNSTDBY_bm  0x80  /* Run In Standby bit mask. */
+#define RTC_RUNSTDBY_bp  7  /* Run In Standby bit position. */
+
+/* RTC.STATUS  bit masks and bit positions */
+#define RTC_CTRLABUSY_bm  0x01  /* CTRLA Synchronization Busy Flag bit mask. */
+#define RTC_CTRLABUSY_bp  0  /* CTRLA Synchronization Busy Flag bit position. */
+#define RTC_CNTBUSY_bm  0x02  /* Count Synchronization Busy Flag bit mask. */
+#define RTC_CNTBUSY_bp  1  /* Count Synchronization Busy Flag bit position. */
+#define RTC_PERBUSY_bm  0x04  /* Period Synchronization Busy Flag bit mask. */
+#define RTC_PERBUSY_bp  2  /* Period Synchronization Busy Flag bit position. */
+#define RTC_CMPBUSY_bm  0x08  /* Comparator Synchronization Busy Flag bit mask. */
+#define RTC_CMPBUSY_bp  3  /* Comparator Synchronization Busy Flag bit position. */
+
+/* RTC.INTCTRL  bit masks and bit positions */
+#define RTC_OVF_bm  0x01  /* Overflow Interrupt enable bit mask. */
+#define RTC_OVF_bp  0  /* Overflow Interrupt enable bit position. */
+#define RTC_CMP_bm  0x02  /* Compare Match Interrupt enable bit mask. */
+#define RTC_CMP_bp  1  /* Compare Match Interrupt enable bit position. */
+
+/* RTC.INTFLAGS  bit masks and bit positions */
+/* RTC_OVF  is already defined. */
+/* RTC_CMP  is already defined. */
+
+/* RTC.DBGCTRL  bit masks and bit positions */
+#define RTC_DBGRUN_bm  0x01  /* Run in debug bit mask. */
+#define RTC_DBGRUN_bp  0  /* Run in debug bit position. */
+
+/* RTC.CALIB  bit masks and bit positions */
+#define RTC_ERROR_gm  0x7F  /* Error Correction Value group mask. */
+#define RTC_ERROR_gp  0  /* Error Correction Value group position. */
+#define RTC_ERROR_0_bm  (1<<0)  /* Error Correction Value bit 0 mask. */
+#define RTC_ERROR_0_bp  0  /* Error Correction Value bit 0 position. */
+#define RTC_ERROR_1_bm  (1<<1)  /* Error Correction Value bit 1 mask. */
+#define RTC_ERROR_1_bp  1  /* Error Correction Value bit 1 position. */
+#define RTC_ERROR_2_bm  (1<<2)  /* Error Correction Value bit 2 mask. */
+#define RTC_ERROR_2_bp  2  /* Error Correction Value bit 2 position. */
+#define RTC_ERROR_3_bm  (1<<3)  /* Error Correction Value bit 3 mask. */
+#define RTC_ERROR_3_bp  3  /* Error Correction Value bit 3 position. */
+#define RTC_ERROR_4_bm  (1<<4)  /* Error Correction Value bit 4 mask. */
+#define RTC_ERROR_4_bp  4  /* Error Correction Value bit 4 position. */
+#define RTC_ERROR_5_bm  (1<<5)  /* Error Correction Value bit 5 mask. */
+#define RTC_ERROR_5_bp  5  /* Error Correction Value bit 5 position. */
+#define RTC_ERROR_6_bm  (1<<6)  /* Error Correction Value bit 6 mask. */
+#define RTC_ERROR_6_bp  6  /* Error Correction Value bit 6 position. */
+#define RTC_SIGN_bm  0x80  /* Error Correction Sign Bit bit mask. */
+#define RTC_SIGN_bp  7  /* Error Correction Sign Bit bit position. */
+
+/* RTC.CLKSEL  bit masks and bit positions */
+#define RTC_CLKSEL_gm  0x03  /* Clock Select group mask. */
+#define RTC_CLKSEL_gp  0  /* Clock Select group position. */
+#define RTC_CLKSEL_0_bm  (1<<0)  /* Clock Select bit 0 mask. */
+#define RTC_CLKSEL_0_bp  0  /* Clock Select bit 0 position. */
+#define RTC_CLKSEL_1_bm  (1<<1)  /* Clock Select bit 1 mask. */
+#define RTC_CLKSEL_1_bp  1  /* Clock Select bit 1 position. */
+
+/* RTC.PITCTRLA  bit masks and bit positions */
+#define RTC_PITEN_bm  0x01  /* Enable bit mask. */
+#define RTC_PITEN_bp  0  /* Enable bit position. */
+#define RTC_PERIOD_gm  0x78  /* Period group mask. */
+#define RTC_PERIOD_gp  3  /* Period group position. */
+#define RTC_PERIOD_0_bm  (1<<3)  /* Period bit 0 mask. */
+#define RTC_PERIOD_0_bp  3  /* Period bit 0 position. */
+#define RTC_PERIOD_1_bm  (1<<4)  /* Period bit 1 mask. */
+#define RTC_PERIOD_1_bp  4  /* Period bit 1 position. */
+#define RTC_PERIOD_2_bm  (1<<5)  /* Period bit 2 mask. */
+#define RTC_PERIOD_2_bp  5  /* Period bit 2 position. */
+#define RTC_PERIOD_3_bm  (1<<6)  /* Period bit 3 mask. */
+#define RTC_PERIOD_3_bp  6  /* Period bit 3 position. */
+
+/* RTC.PITSTATUS  bit masks and bit positions */
+#define RTC_CTRLBUSY_bm  0x01  /* CTRLA Synchronization Busy Flag bit mask. */
+#define RTC_CTRLBUSY_bp  0  /* CTRLA Synchronization Busy Flag bit position. */
+
+/* RTC.PITINTCTRL  bit masks and bit positions */
+#define RTC_PI_bm  0x01  /* Periodic Interrupt bit mask. */
+#define RTC_PI_bp  0  /* Periodic Interrupt bit position. */
+
+/* RTC.PITINTFLAGS  bit masks and bit positions */
+/* RTC_PI  is already defined. */
+
+/* RTC.PITDBGCTRL  bit masks and bit positions */
+/* RTC_DBGRUN  is already defined. */
+
+/* RTC.PITEVGENCTRLA  bit masks and bit positions */
+#define RTC_EVGEN0SEL_gm  0x0F  /* Event Generation 0 Select group mask. */
+#define RTC_EVGEN0SEL_gp  0  /* Event Generation 0 Select group position. */
+#define RTC_EVGEN0SEL_0_bm  (1<<0)  /* Event Generation 0 Select bit 0 mask. */
+#define RTC_EVGEN0SEL_0_bp  0  /* Event Generation 0 Select bit 0 position. */
+#define RTC_EVGEN0SEL_1_bm  (1<<1)  /* Event Generation 0 Select bit 1 mask. */
+#define RTC_EVGEN0SEL_1_bp  1  /* Event Generation 0 Select bit 1 position. */
+#define RTC_EVGEN0SEL_2_bm  (1<<2)  /* Event Generation 0 Select bit 2 mask. */
+#define RTC_EVGEN0SEL_2_bp  2  /* Event Generation 0 Select bit 2 position. */
+#define RTC_EVGEN0SEL_3_bm  (1<<3)  /* Event Generation 0 Select bit 3 mask. */
+#define RTC_EVGEN0SEL_3_bp  3  /* Event Generation 0 Select bit 3 position. */
+#define RTC_EVGEN1SEL_gm  0xF0  /* Event Generation 1 Select group mask. */
+#define RTC_EVGEN1SEL_gp  4  /* Event Generation 1 Select group position. */
+#define RTC_EVGEN1SEL_0_bm  (1<<4)  /* Event Generation 1 Select bit 0 mask. */
+#define RTC_EVGEN1SEL_0_bp  4  /* Event Generation 1 Select bit 0 position. */
+#define RTC_EVGEN1SEL_1_bm  (1<<5)  /* Event Generation 1 Select bit 1 mask. */
+#define RTC_EVGEN1SEL_1_bp  5  /* Event Generation 1 Select bit 1 position. */
+#define RTC_EVGEN1SEL_2_bm  (1<<6)  /* Event Generation 1 Select bit 2 mask. */
+#define RTC_EVGEN1SEL_2_bp  6  /* Event Generation 1 Select bit 2 position. */
+#define RTC_EVGEN1SEL_3_bm  (1<<7)  /* Event Generation 1 Select bit 3 mask. */
+#define RTC_EVGEN1SEL_3_bp  7  /* Event Generation 1 Select bit 3 position. */
+
+
+
+/* SLPCTRL - Sleep Controller */
+/* SLPCTRL.CTRLA  bit masks and bit positions */
+#define SLPCTRL_SEN_bm  0x01  /* Sleep enable bit mask. */
+#define SLPCTRL_SEN_bp  0  /* Sleep enable bit position. */
+#define SLPCTRL_SMODE_gm  0x06  /* Sleep mode group mask. */
+#define SLPCTRL_SMODE_gp  1  /* Sleep mode group position. */
+#define SLPCTRL_SMODE_0_bm  (1<<1)  /* Sleep mode bit 0 mask. */
+#define SLPCTRL_SMODE_0_bp  1  /* Sleep mode bit 0 position. */
+#define SLPCTRL_SMODE_1_bm  (1<<2)  /* Sleep mode bit 1 mask. */
+#define SLPCTRL_SMODE_1_bp  2  /* Sleep mode bit 1 position. */
+
+
+/* SPI - Serial Peripheral Interface */
+/* SPI.CTRLA  bit masks and bit positions */
+#define SPI_ENABLE_bm  0x01  /* Enable Module bit mask. */
+#define SPI_ENABLE_bp  0  /* Enable Module bit position. */
+#define SPI_PRESC_gm  0x06  /* Prescaler group mask. */
+#define SPI_PRESC_gp  1  /* Prescaler group position. */
+#define SPI_PRESC_0_bm  (1<<1)  /* Prescaler bit 0 mask. */
+#define SPI_PRESC_0_bp  1  /* Prescaler bit 0 position. */
+#define SPI_PRESC_1_bm  (1<<2)  /* Prescaler bit 1 mask. */
+#define SPI_PRESC_1_bp  2  /* Prescaler bit 1 position. */
+#define SPI_CLK2X_bm  0x10  /* Enable Double Speed bit mask. */
+#define SPI_CLK2X_bp  4  /* Enable Double Speed bit position. */
+#define SPI_MASTER_bm  0x20  /* Host Operation Enable bit mask. */
+#define SPI_MASTER_bp  5  /* Host Operation Enable bit position. */
+#define SPI_DORD_bm  0x40  /* Data Order Setting bit mask. */
+#define SPI_DORD_bp  6  /* Data Order Setting bit position. */
+
+/* SPI.CTRLB  bit masks and bit positions */
+#define SPI_MODE_gm  0x03  /* SPI Mode group mask. */
+#define SPI_MODE_gp  0  /* SPI Mode group position. */
+#define SPI_MODE_0_bm  (1<<0)  /* SPI Mode bit 0 mask. */
+#define SPI_MODE_0_bp  0  /* SPI Mode bit 0 position. */
+#define SPI_MODE_1_bm  (1<<1)  /* SPI Mode bit 1 mask. */
+#define SPI_MODE_1_bp  1  /* SPI Mode bit 1 position. */
+#define SPI_SSD_bm  0x04  /* SPI Select Disable bit mask. */
+#define SPI_SSD_bp  2  /* SPI Select Disable bit position. */
+#define SPI_BUFWR_bm  0x40  /* Buffer Mode Wait for Receive bit mask. */
+#define SPI_BUFWR_bp  6  /* Buffer Mode Wait for Receive bit position. */
+#define SPI_BUFEN_bm  0x80  /* Buffer Mode Enable bit mask. */
+#define SPI_BUFEN_bp  7  /* Buffer Mode Enable bit position. */
+
+/* SPI.INTCTRL  bit masks and bit positions */
+#define SPI_IE_bm  0x01  /* Interrupt Enable bit mask. */
+#define SPI_IE_bp  0  /* Interrupt Enable bit position. */
+#define SPI_SSIE_bm  0x10  /* SPI Select Trigger Interrupt Enable bit mask. */
+#define SPI_SSIE_bp  4  /* SPI Select Trigger Interrupt Enable bit position. */
+#define SPI_DREIE_bm  0x20  /* Data Register Empty Interrupt Enable bit mask. */
+#define SPI_DREIE_bp  5  /* Data Register Empty Interrupt Enable bit position. */
+#define SPI_TXCIE_bm  0x40  /* Transfer Complete Interrupt Enable bit mask. */
+#define SPI_TXCIE_bp  6  /* Transfer Complete Interrupt Enable bit position. */
+#define SPI_RXCIE_bm  0x80  /* Receive Complete Interrupt Enable bit mask. */
+#define SPI_RXCIE_bp  7  /* Receive Complete Interrupt Enable bit position. */
+
+/* SPI.INTFLAGS  bit masks and bit positions */
+#define SPI_BUFOVF_bm  0x01  /* Buffer Overflow bit mask. */
+#define SPI_BUFOVF_bp  0  /* Buffer Overflow bit position. */
+#define SPI_SSIF_bm  0x10  /* SPI Select Trigger Interrupt Flag bit mask. */
+#define SPI_SSIF_bp  4  /* SPI Select Trigger Interrupt Flag bit position. */
+#define SPI_DREIF_bm  0x20  /* Data Register Empty Interrupt Flag bit mask. */
+#define SPI_DREIF_bp  5  /* Data Register Empty Interrupt Flag bit position. */
+#define SPI_TXCIF_bm  0x40  /* Transfer Complete Interrupt Flag bit mask. */
+#define SPI_TXCIF_bp  6  /* Transfer Complete Interrupt Flag bit position. */
+#define SPI_WRCOL_bm  0x40  /* Write Collision bit mask. */
+#define SPI_WRCOL_bp  6  /* Write Collision bit position. */
+#define SPI_RXCIF_bm  0x80  /* Receive Complete Interrupt Flag bit mask. */
+#define SPI_RXCIF_bp  7  /* Receive Complete Interrupt Flag bit position. */
+#define SPI_IF_bm  0x80  /* Interrupt Flag bit mask. */
+#define SPI_IF_bp  7  /* Interrupt Flag bit position. */
+
+
+/* SYSCFG - System Configuration Registers */
+/* SYSCFG.REVID  bit masks and bit positions */
+#define SYSCFG_MINOR_gm  0x0F  /* Minor Revision group mask. */
+#define SYSCFG_MINOR_gp  0  /* Minor Revision group position. */
+#define SYSCFG_MINOR_0_bm  (1<<0)  /* Minor Revision bit 0 mask. */
+#define SYSCFG_MINOR_0_bp  0  /* Minor Revision bit 0 position. */
+#define SYSCFG_MINOR_1_bm  (1<<1)  /* Minor Revision bit 1 mask. */
+#define SYSCFG_MINOR_1_bp  1  /* Minor Revision bit 1 position. */
+#define SYSCFG_MINOR_2_bm  (1<<2)  /* Minor Revision bit 2 mask. */
+#define SYSCFG_MINOR_2_bp  2  /* Minor Revision bit 2 position. */
+#define SYSCFG_MINOR_3_bm  (1<<3)  /* Minor Revision bit 3 mask. */
+#define SYSCFG_MINOR_3_bp  3  /* Minor Revision bit 3 position. */
+#define SYSCFG_MAJOR_gm  0xF0  /* Major Revision group mask. */
+#define SYSCFG_MAJOR_gp  4  /* Major Revision group position. */
+#define SYSCFG_MAJOR_0_bm  (1<<4)  /* Major Revision bit 0 mask. */
+#define SYSCFG_MAJOR_0_bp  4  /* Major Revision bit 0 position. */
+#define SYSCFG_MAJOR_1_bm  (1<<5)  /* Major Revision bit 1 mask. */
+#define SYSCFG_MAJOR_1_bp  5  /* Major Revision bit 1 position. */
+#define SYSCFG_MAJOR_2_bm  (1<<6)  /* Major Revision bit 2 mask. */
+#define SYSCFG_MAJOR_2_bp  6  /* Major Revision bit 2 position. */
+#define SYSCFG_MAJOR_3_bm  (1<<7)  /* Major Revision bit 3 mask. */
+#define SYSCFG_MAJOR_3_bp  7  /* Major Revision bit 3 position. */
+
+/* SYSCFG.OCDMCTRL  bit masks and bit positions */
+#define SYSCFG_OCDM_gm  0xFF  /* OCD Message group mask. */
+#define SYSCFG_OCDM_gp  0  /* OCD Message group position. */
+#define SYSCFG_OCDM_0_bm  (1<<0)  /* OCD Message bit 0 mask. */
+#define SYSCFG_OCDM_0_bp  0  /* OCD Message bit 0 position. */
+#define SYSCFG_OCDM_1_bm  (1<<1)  /* OCD Message bit 1 mask. */
+#define SYSCFG_OCDM_1_bp  1  /* OCD Message bit 1 position. */
+#define SYSCFG_OCDM_2_bm  (1<<2)  /* OCD Message bit 2 mask. */
+#define SYSCFG_OCDM_2_bp  2  /* OCD Message bit 2 position. */
+#define SYSCFG_OCDM_3_bm  (1<<3)  /* OCD Message bit 3 mask. */
+#define SYSCFG_OCDM_3_bp  3  /* OCD Message bit 3 position. */
+#define SYSCFG_OCDM_4_bm  (1<<4)  /* OCD Message bit 4 mask. */
+#define SYSCFG_OCDM_4_bp  4  /* OCD Message bit 4 position. */
+#define SYSCFG_OCDM_5_bm  (1<<5)  /* OCD Message bit 5 mask. */
+#define SYSCFG_OCDM_5_bp  5  /* OCD Message bit 5 position. */
+#define SYSCFG_OCDM_6_bm  (1<<6)  /* OCD Message bit 6 mask. */
+#define SYSCFG_OCDM_6_bp  6  /* OCD Message bit 6 position. */
+#define SYSCFG_OCDM_7_bm  (1<<7)  /* OCD Message bit 7 mask. */
+#define SYSCFG_OCDM_7_bp  7  /* OCD Message bit 7 position. */
+
+/* SYSCFG.OCDMSTATUS  bit masks and bit positions */
+#define SYSCFG_VALID_bm  0x01  /* OCD Message Valid bit mask. */
+#define SYSCFG_VALID_bp  0  /* OCD Message Valid bit position. */
+
+
+/* TCA - 16-bit Timer/Counter Type A */
+/* TCA_SINGLE.CTRLA  bit masks and bit positions */
+#define TCA_SINGLE_ENABLE_bm  0x01  /* Module Enable bit mask. */
+#define TCA_SINGLE_ENABLE_bp  0  /* Module Enable bit position. */
+#define TCA_SINGLE_CLKSEL_gm  0x0E  /* Clock Selection group mask. */
+#define TCA_SINGLE_CLKSEL_gp  1  /* Clock Selection group position. */
+#define TCA_SINGLE_CLKSEL_0_bm  (1<<1)  /* Clock Selection bit 0 mask. */
+#define TCA_SINGLE_CLKSEL_0_bp  1  /* Clock Selection bit 0 position. */
+#define TCA_SINGLE_CLKSEL_1_bm  (1<<2)  /* Clock Selection bit 1 mask. */
+#define TCA_SINGLE_CLKSEL_1_bp  2  /* Clock Selection bit 1 position. */
+#define TCA_SINGLE_CLKSEL_2_bm  (1<<3)  /* Clock Selection bit 2 mask. */
+#define TCA_SINGLE_CLKSEL_2_bp  3  /* Clock Selection bit 2 position. */
+#define TCA_SINGLE_RUNSTDBY_bm  0x80  /* Run in Standby bit mask. */
+#define TCA_SINGLE_RUNSTDBY_bp  7  /* Run in Standby bit position. */
+
+/* TCA_SINGLE.CTRLB  bit masks and bit positions */
+#define TCA_SINGLE_WGMODE_gm  0x07  /* Waveform generation mode group mask. */
+#define TCA_SINGLE_WGMODE_gp  0  /* Waveform generation mode group position. */
+#define TCA_SINGLE_WGMODE_0_bm  (1<<0)  /* Waveform generation mode bit 0 mask. */
+#define TCA_SINGLE_WGMODE_0_bp  0  /* Waveform generation mode bit 0 position. */
+#define TCA_SINGLE_WGMODE_1_bm  (1<<1)  /* Waveform generation mode bit 1 mask. */
+#define TCA_SINGLE_WGMODE_1_bp  1  /* Waveform generation mode bit 1 position. */
+#define TCA_SINGLE_WGMODE_2_bm  (1<<2)  /* Waveform generation mode bit 2 mask. */
+#define TCA_SINGLE_WGMODE_2_bp  2  /* Waveform generation mode bit 2 position. */
+#define TCA_SINGLE_ALUPD_bm  0x08  /* Auto Lock Update bit mask. */
+#define TCA_SINGLE_ALUPD_bp  3  /* Auto Lock Update bit position. */
+#define TCA_SINGLE_CMP0EN_bm  0x10  /* Compare 0 Enable bit mask. */
+#define TCA_SINGLE_CMP0EN_bp  4  /* Compare 0 Enable bit position. */
+#define TCA_SINGLE_CMP1EN_bm  0x20  /* Compare 1 Enable bit mask. */
+#define TCA_SINGLE_CMP1EN_bp  5  /* Compare 1 Enable bit position. */
+#define TCA_SINGLE_CMP2EN_bm  0x40  /* Compare 2 Enable bit mask. */
+#define TCA_SINGLE_CMP2EN_bp  6  /* Compare 2 Enable bit position. */
+
+/* TCA_SINGLE.CTRLC  bit masks and bit positions */
+#define TCA_SINGLE_CMP0OV_bm  0x01  /* Compare 0 Waveform Output Value bit mask. */
+#define TCA_SINGLE_CMP0OV_bp  0  /* Compare 0 Waveform Output Value bit position. */
+#define TCA_SINGLE_CMP1OV_bm  0x02  /* Compare 1 Waveform Output Value bit mask. */
+#define TCA_SINGLE_CMP1OV_bp  1  /* Compare 1 Waveform Output Value bit position. */
+#define TCA_SINGLE_CMP2OV_bm  0x04  /* Compare 2 Waveform Output Value bit mask. */
+#define TCA_SINGLE_CMP2OV_bp  2  /* Compare 2 Waveform Output Value bit position. */
+
+/* TCA_SINGLE.CTRLD  bit masks and bit positions */
+#define TCA_SINGLE_SPLITM_bm  0x01  /* Split Mode Enable bit mask. */
+#define TCA_SINGLE_SPLITM_bp  0  /* Split Mode Enable bit position. */
+
+/* TCA_SINGLE.CTRLECLR  bit masks and bit positions */
+#define TCA_SINGLE_DIR_bm  0x01  /* Direction bit mask. */
+#define TCA_SINGLE_DIR_bp  0  /* Direction bit position. */
+#define TCA_SINGLE_LUPD_bm  0x02  /* Lock Update bit mask. */
+#define TCA_SINGLE_LUPD_bp  1  /* Lock Update bit position. */
+#define TCA_SINGLE_CMD_gm  0x0C  /* Command group mask. */
+#define TCA_SINGLE_CMD_gp  2  /* Command group position. */
+#define TCA_SINGLE_CMD_0_bm  (1<<2)  /* Command bit 0 mask. */
+#define TCA_SINGLE_CMD_0_bp  2  /* Command bit 0 position. */
+#define TCA_SINGLE_CMD_1_bm  (1<<3)  /* Command bit 1 mask. */
+#define TCA_SINGLE_CMD_1_bp  3  /* Command bit 1 position. */
+
+/* TCA_SINGLE.CTRLESET  bit masks and bit positions */
+/* TCA_SINGLE_DIR  is already defined. */
+/* TCA_SINGLE_LUPD  is already defined. */
+/* TCA_SINGLE_CMD  is already defined. */
+
+/* TCA_SINGLE.CTRLFCLR  bit masks and bit positions */
+#define TCA_SINGLE_PERBV_bm  0x01  /* Period Buffer Valid bit mask. */
+#define TCA_SINGLE_PERBV_bp  0  /* Period Buffer Valid bit position. */
+#define TCA_SINGLE_CMP0BV_bm  0x02  /* Compare 0 Buffer Valid bit mask. */
+#define TCA_SINGLE_CMP0BV_bp  1  /* Compare 0 Buffer Valid bit position. */
+#define TCA_SINGLE_CMP1BV_bm  0x04  /* Compare 1 Buffer Valid bit mask. */
+#define TCA_SINGLE_CMP1BV_bp  2  /* Compare 1 Buffer Valid bit position. */
+#define TCA_SINGLE_CMP2BV_bm  0x08  /* Compare 2 Buffer Valid bit mask. */
+#define TCA_SINGLE_CMP2BV_bp  3  /* Compare 2 Buffer Valid bit position. */
+
+/* TCA_SINGLE.CTRLFSET  bit masks and bit positions */
+/* TCA_SINGLE_PERBV  is already defined. */
+/* TCA_SINGLE_CMP0BV  is already defined. */
+/* TCA_SINGLE_CMP1BV  is already defined. */
+/* TCA_SINGLE_CMP2BV  is already defined. */
+
+/* TCA_SINGLE.EVCTRL  bit masks and bit positions */
+#define TCA_SINGLE_CNTAEI_bm  0x01  /* Count on Event Input A bit mask. */
+#define TCA_SINGLE_CNTAEI_bp  0  /* Count on Event Input A bit position. */
+#define TCA_SINGLE_EVACTA_gm  0x0E  /* Event Action A group mask. */
+#define TCA_SINGLE_EVACTA_gp  1  /* Event Action A group position. */
+#define TCA_SINGLE_EVACTA_0_bm  (1<<1)  /* Event Action A bit 0 mask. */
+#define TCA_SINGLE_EVACTA_0_bp  1  /* Event Action A bit 0 position. */
+#define TCA_SINGLE_EVACTA_1_bm  (1<<2)  /* Event Action A bit 1 mask. */
+#define TCA_SINGLE_EVACTA_1_bp  2  /* Event Action A bit 1 position. */
+#define TCA_SINGLE_EVACTA_2_bm  (1<<3)  /* Event Action A bit 2 mask. */
+#define TCA_SINGLE_EVACTA_2_bp  3  /* Event Action A bit 2 position. */
+#define TCA_SINGLE_CNTBEI_bm  0x10  /* Count on Event Input B bit mask. */
+#define TCA_SINGLE_CNTBEI_bp  4  /* Count on Event Input B bit position. */
+#define TCA_SINGLE_EVACTB_gm  0xE0  /* Event Action B group mask. */
+#define TCA_SINGLE_EVACTB_gp  5  /* Event Action B group position. */
+#define TCA_SINGLE_EVACTB_0_bm  (1<<5)  /* Event Action B bit 0 mask. */
+#define TCA_SINGLE_EVACTB_0_bp  5  /* Event Action B bit 0 position. */
+#define TCA_SINGLE_EVACTB_1_bm  (1<<6)  /* Event Action B bit 1 mask. */
+#define TCA_SINGLE_EVACTB_1_bp  6  /* Event Action B bit 1 position. */
+#define TCA_SINGLE_EVACTB_2_bm  (1<<7)  /* Event Action B bit 2 mask. */
+#define TCA_SINGLE_EVACTB_2_bp  7  /* Event Action B bit 2 position. */
+
+/* TCA_SINGLE.INTCTRL  bit masks and bit positions */
+#define TCA_SINGLE_OVF_bm  0x01  /* Overflow Interrupt bit mask. */
+#define TCA_SINGLE_OVF_bp  0  /* Overflow Interrupt bit position. */
+#define TCA_SINGLE_CMP0_bm  0x10  /* Compare 0 Interrupt bit mask. */
+#define TCA_SINGLE_CMP0_bp  4  /* Compare 0 Interrupt bit position. */
+#define TCA_SINGLE_CMP1_bm  0x20  /* Compare 1 Interrupt bit mask. */
+#define TCA_SINGLE_CMP1_bp  5  /* Compare 1 Interrupt bit position. */
+#define TCA_SINGLE_CMP2_bm  0x40  /* Compare 2 Interrupt bit mask. */
+#define TCA_SINGLE_CMP2_bp  6  /* Compare 2 Interrupt bit position. */
+
+/* TCA_SINGLE.INTFLAGS  bit masks and bit positions */
+/* TCA_SINGLE_OVF  is already defined. */
+/* TCA_SINGLE_CMP0  is already defined. */
+/* TCA_SINGLE_CMP1  is already defined. */
+/* TCA_SINGLE_CMP2  is already defined. */
+
+/* TCA_SINGLE.DBGCTRL  bit masks and bit positions */
+#define TCA_SINGLE_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define TCA_SINGLE_DBGRUN_bp  0  /* Debug Run bit position. */
+
+/* TCA_SPLIT.CTRLA  bit masks and bit positions */
+#define TCA_SPLIT_ENABLE_bm  0x01  /* Module Enable bit mask. */
+#define TCA_SPLIT_ENABLE_bp  0  /* Module Enable bit position. */
+#define TCA_SPLIT_CLKSEL_gm  0x0E  /* Clock Selection group mask. */
+#define TCA_SPLIT_CLKSEL_gp  1  /* Clock Selection group position. */
+#define TCA_SPLIT_CLKSEL_0_bm  (1<<1)  /* Clock Selection bit 0 mask. */
+#define TCA_SPLIT_CLKSEL_0_bp  1  /* Clock Selection bit 0 position. */
+#define TCA_SPLIT_CLKSEL_1_bm  (1<<2)  /* Clock Selection bit 1 mask. */
+#define TCA_SPLIT_CLKSEL_1_bp  2  /* Clock Selection bit 1 position. */
+#define TCA_SPLIT_CLKSEL_2_bm  (1<<3)  /* Clock Selection bit 2 mask. */
+#define TCA_SPLIT_CLKSEL_2_bp  3  /* Clock Selection bit 2 position. */
+#define TCA_SPLIT_RUNSTDBY_bm  0x80  /* Run in Standby bit mask. */
+#define TCA_SPLIT_RUNSTDBY_bp  7  /* Run in Standby bit position. */
+
+/* TCA_SPLIT.CTRLB  bit masks and bit positions */
+#define TCA_SPLIT_LCMP0EN_bm  0x01  /* Low Compare 0 Enable bit mask. */
+#define TCA_SPLIT_LCMP0EN_bp  0  /* Low Compare 0 Enable bit position. */
+#define TCA_SPLIT_LCMP1EN_bm  0x02  /* Low Compare 1 Enable bit mask. */
+#define TCA_SPLIT_LCMP1EN_bp  1  /* Low Compare 1 Enable bit position. */
+#define TCA_SPLIT_LCMP2EN_bm  0x04  /* Low Compare 2 Enable bit mask. */
+#define TCA_SPLIT_LCMP2EN_bp  2  /* Low Compare 2 Enable bit position. */
+#define TCA_SPLIT_HCMP0EN_bm  0x10  /* High Compare 0 Enable bit mask. */
+#define TCA_SPLIT_HCMP0EN_bp  4  /* High Compare 0 Enable bit position. */
+#define TCA_SPLIT_HCMP1EN_bm  0x20  /* High Compare 1 Enable bit mask. */
+#define TCA_SPLIT_HCMP1EN_bp  5  /* High Compare 1 Enable bit position. */
+#define TCA_SPLIT_HCMP2EN_bm  0x40  /* High Compare 2 Enable bit mask. */
+#define TCA_SPLIT_HCMP2EN_bp  6  /* High Compare 2 Enable bit position. */
+
+/* TCA_SPLIT.CTRLC  bit masks and bit positions */
+#define TCA_SPLIT_LCMP0OV_bm  0x01  /* Low Compare 0 Output Value bit mask. */
+#define TCA_SPLIT_LCMP0OV_bp  0  /* Low Compare 0 Output Value bit position. */
+#define TCA_SPLIT_LCMP1OV_bm  0x02  /* Low Compare 1 Output Value bit mask. */
+#define TCA_SPLIT_LCMP1OV_bp  1  /* Low Compare 1 Output Value bit position. */
+#define TCA_SPLIT_LCMP2OV_bm  0x04  /* Low Compare 2 Output Value bit mask. */
+#define TCA_SPLIT_LCMP2OV_bp  2  /* Low Compare 2 Output Value bit position. */
+#define TCA_SPLIT_HCMP0OV_bm  0x10  /* High Compare 0 Output Value bit mask. */
+#define TCA_SPLIT_HCMP0OV_bp  4  /* High Compare 0 Output Value bit position. */
+#define TCA_SPLIT_HCMP1OV_bm  0x20  /* High Compare 1 Output Value bit mask. */
+#define TCA_SPLIT_HCMP1OV_bp  5  /* High Compare 1 Output Value bit position. */
+#define TCA_SPLIT_HCMP2OV_bm  0x40  /* High Compare 2 Output Value bit mask. */
+#define TCA_SPLIT_HCMP2OV_bp  6  /* High Compare 2 Output Value bit position. */
+
+/* TCA_SPLIT.CTRLD  bit masks and bit positions */
+#define TCA_SPLIT_SPLITM_bm  0x01  /* Split Mode Enable bit mask. */
+#define TCA_SPLIT_SPLITM_bp  0  /* Split Mode Enable bit position. */
+
+/* TCA_SPLIT.CTRLECLR  bit masks and bit positions */
+#define TCA_SPLIT_CMDEN_gm  0x03  /* Command Enable group mask. */
+#define TCA_SPLIT_CMDEN_gp  0  /* Command Enable group position. */
+#define TCA_SPLIT_CMDEN_0_bm  (1<<0)  /* Command Enable bit 0 mask. */
+#define TCA_SPLIT_CMDEN_0_bp  0  /* Command Enable bit 0 position. */
+#define TCA_SPLIT_CMDEN_1_bm  (1<<1)  /* Command Enable bit 1 mask. */
+#define TCA_SPLIT_CMDEN_1_bp  1  /* Command Enable bit 1 position. */
+#define TCA_SPLIT_CMD_gm  0x0C  /* Command group mask. */
+#define TCA_SPLIT_CMD_gp  2  /* Command group position. */
+#define TCA_SPLIT_CMD_0_bm  (1<<2)  /* Command bit 0 mask. */
+#define TCA_SPLIT_CMD_0_bp  2  /* Command bit 0 position. */
+#define TCA_SPLIT_CMD_1_bm  (1<<3)  /* Command bit 1 mask. */
+#define TCA_SPLIT_CMD_1_bp  3  /* Command bit 1 position. */
+
+/* TCA_SPLIT.CTRLESET  bit masks and bit positions */
+/* TCA_SPLIT_CMDEN  is already defined. */
+/* TCA_SPLIT_CMD  is already defined. */
+
+/* TCA_SPLIT.INTCTRL  bit masks and bit positions */
+#define TCA_SPLIT_LUNF_bm  0x01  /* Low Underflow Interrupt Enable bit mask. */
+#define TCA_SPLIT_LUNF_bp  0  /* Low Underflow Interrupt Enable bit position. */
+#define TCA_SPLIT_HUNF_bm  0x02  /* High Underflow Interrupt Enable bit mask. */
+#define TCA_SPLIT_HUNF_bp  1  /* High Underflow Interrupt Enable bit position. */
+#define TCA_SPLIT_LCMP0_bm  0x10  /* Low Compare 0 Interrupt Enable bit mask. */
+#define TCA_SPLIT_LCMP0_bp  4  /* Low Compare 0 Interrupt Enable bit position. */
+#define TCA_SPLIT_LCMP1_bm  0x20  /* Low Compare 1 Interrupt Enable bit mask. */
+#define TCA_SPLIT_LCMP1_bp  5  /* Low Compare 1 Interrupt Enable bit position. */
+#define TCA_SPLIT_LCMP2_bm  0x40  /* Low Compare 2 Interrupt Enable bit mask. */
+#define TCA_SPLIT_LCMP2_bp  6  /* Low Compare 2 Interrupt Enable bit position. */
+
+/* TCA_SPLIT.INTFLAGS  bit masks and bit positions */
+/* TCA_SPLIT_LUNF  is already defined. */
+/* TCA_SPLIT_HUNF  is already defined. */
+/* TCA_SPLIT_LCMP0  is already defined. */
+/* TCA_SPLIT_LCMP1  is already defined. */
+/* TCA_SPLIT_LCMP2  is already defined. */
+
+/* TCA_SPLIT.DBGCTRL  bit masks and bit positions */
+#define TCA_SPLIT_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define TCA_SPLIT_DBGRUN_bp  0  /* Debug Run bit position. */
+
+
+/* TCB - 16-bit Timer Type B */
+/* TCB.CTRLA  bit masks and bit positions */
+#define TCB_ENABLE_bm  0x01  /* Enable bit mask. */
+#define TCB_ENABLE_bp  0  /* Enable bit position. */
+#define TCB_CLKSEL_gm  0x0E  /* Clock Select group mask. */
+#define TCB_CLKSEL_gp  1  /* Clock Select group position. */
+#define TCB_CLKSEL_0_bm  (1<<1)  /* Clock Select bit 0 mask. */
+#define TCB_CLKSEL_0_bp  1  /* Clock Select bit 0 position. */
+#define TCB_CLKSEL_1_bm  (1<<2)  /* Clock Select bit 1 mask. */
+#define TCB_CLKSEL_1_bp  2  /* Clock Select bit 1 position. */
+#define TCB_CLKSEL_2_bm  (1<<3)  /* Clock Select bit 2 mask. */
+#define TCB_CLKSEL_2_bp  3  /* Clock Select bit 2 position. */
+#define TCB_SYNCUPD_bm  0x10  /* Synchronize Update bit mask. */
+#define TCB_SYNCUPD_bp  4  /* Synchronize Update bit position. */
+#define TCB_CASCADE_bm  0x20  /* Cascade two timers bit mask. */
+#define TCB_CASCADE_bp  5  /* Cascade two timers bit position. */
+#define TCB_RUNSTDBY_bm  0x40  /* Run Standby bit mask. */
+#define TCB_RUNSTDBY_bp  6  /* Run Standby bit position. */
+
+/* TCB.CTRLB  bit masks and bit positions */
+#define TCB_CNTMODE_gm  0x07  /* Timer Mode group mask. */
+#define TCB_CNTMODE_gp  0  /* Timer Mode group position. */
+#define TCB_CNTMODE_0_bm  (1<<0)  /* Timer Mode bit 0 mask. */
+#define TCB_CNTMODE_0_bp  0  /* Timer Mode bit 0 position. */
+#define TCB_CNTMODE_1_bm  (1<<1)  /* Timer Mode bit 1 mask. */
+#define TCB_CNTMODE_1_bp  1  /* Timer Mode bit 1 position. */
+#define TCB_CNTMODE_2_bm  (1<<2)  /* Timer Mode bit 2 mask. */
+#define TCB_CNTMODE_2_bp  2  /* Timer Mode bit 2 position. */
+#define TCB_CCMPEN_bm  0x10  /* Pin Output Enable bit mask. */
+#define TCB_CCMPEN_bp  4  /* Pin Output Enable bit position. */
+#define TCB_CCMPINIT_bm  0x20  /* Pin Initial State bit mask. */
+#define TCB_CCMPINIT_bp  5  /* Pin Initial State bit position. */
+#define TCB_ASYNC_bm  0x40  /* Asynchronous Enable bit mask. */
+#define TCB_ASYNC_bp  6  /* Asynchronous Enable bit position. */
+
+/* TCB.EVCTRL  bit masks and bit positions */
+#define TCB_CAPTEI_bm  0x01  /* Event Input Enable bit mask. */
+#define TCB_CAPTEI_bp  0  /* Event Input Enable bit position. */
+#define TCB_EDGE_bm  0x10  /* Event Edge bit mask. */
+#define TCB_EDGE_bp  4  /* Event Edge bit position. */
+#define TCB_FILTER_bm  0x40  /* Input Capture Noise Cancellation Filter bit mask. */
+#define TCB_FILTER_bp  6  /* Input Capture Noise Cancellation Filter bit position. */
+
+/* TCB.INTCTRL  bit masks and bit positions */
+#define TCB_CAPT_bm  0x01  /* Capture or Timeout bit mask. */
+#define TCB_CAPT_bp  0  /* Capture or Timeout bit position. */
+#define TCB_OVF_bm  0x02  /* Overflow bit mask. */
+#define TCB_OVF_bp  1  /* Overflow bit position. */
+
+/* TCB.INTFLAGS  bit masks and bit positions */
+/* TCB_CAPT  is already defined. */
+/* TCB_OVF  is already defined. */
+
+/* TCB.STATUS  bit masks and bit positions */
+#define TCB_RUN_bm  0x01  /* Run bit mask. */
+#define TCB_RUN_bp  0  /* Run bit position. */
+
+/* TCB.DBGCTRL  bit masks and bit positions */
+#define TCB_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define TCB_DBGRUN_bp  0  /* Debug Run bit position. */
+
+
+/* TWI - Two-Wire Interface */
+/* TWI.CTRLA  bit masks and bit positions */
+#define TWI_FMEN_bm  0x01  /* Fast-mode Enable bit mask. */
+#define TWI_FMEN_bp  0  /* Fast-mode Enable bit position. */
+#define TWI_FMPEN_bm  0x02  /* Fast-mode Plus Enable bit mask. */
+#define TWI_FMPEN_bp  1  /* Fast-mode Plus Enable bit position. */
+#define TWI_SDAHOLD_gm  0x0C  /* SDA Hold Time group mask. */
+#define TWI_SDAHOLD_gp  2  /* SDA Hold Time group position. */
+#define TWI_SDAHOLD_0_bm  (1<<2)  /* SDA Hold Time bit 0 mask. */
+#define TWI_SDAHOLD_0_bp  2  /* SDA Hold Time bit 0 position. */
+#define TWI_SDAHOLD_1_bm  (1<<3)  /* SDA Hold Time bit 1 mask. */
+#define TWI_SDAHOLD_1_bp  3  /* SDA Hold Time bit 1 position. */
+#define TWI_SDASETUP_bm  0x10  /* SDA Setup Time bit mask. */
+#define TWI_SDASETUP_bp  4  /* SDA Setup Time bit position. */
+#define TWI_INPUTLVL_bm  0x40  /* Input voltage transition level bit mask. */
+#define TWI_INPUTLVL_bp  6  /* Input voltage transition level bit position. */
+
+/* TWI.DUALCTRL  bit masks and bit positions */
+#define TWI_ENABLE_bm  0x01  /* Enable bit mask. */
+#define TWI_ENABLE_bp  0  /* Enable bit position. */
+/* TWI_FMPEN  is already defined. */
+/* TWI_SDAHOLD  is already defined. */
+/* TWI_INPUTLVL  is already defined. */
+
+/* TWI.DBGCTRL  bit masks and bit positions */
+#define TWI_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define TWI_DBGRUN_bp  0  /* Debug Run bit position. */
+
+/* TWI.MCTRLA  bit masks and bit positions */
+/* TWI_ENABLE  is already defined. */
+#define TWI_SMEN_bm  0x02  /* Smart Mode Enable bit mask. */
+#define TWI_SMEN_bp  1  /* Smart Mode Enable bit position. */
+#define TWI_TIMEOUT_gm  0x0C  /* Inactive Bus Time-Out group mask. */
+#define TWI_TIMEOUT_gp  2  /* Inactive Bus Time-Out group position. */
+#define TWI_TIMEOUT_0_bm  (1<<2)  /* Inactive Bus Time-Out bit 0 mask. */
+#define TWI_TIMEOUT_0_bp  2  /* Inactive Bus Time-Out bit 0 position. */
+#define TWI_TIMEOUT_1_bm  (1<<3)  /* Inactive Bus Time-Out bit 1 mask. */
+#define TWI_TIMEOUT_1_bp  3  /* Inactive Bus Time-Out bit 1 position. */
+#define TWI_QCEN_bm  0x10  /* Quick Command Enable bit mask. */
+#define TWI_QCEN_bp  4  /* Quick Command Enable bit position. */
+#define TWI_WIEN_bm  0x40  /* Write Interrupt Enable bit mask. */
+#define TWI_WIEN_bp  6  /* Write Interrupt Enable bit position. */
+#define TWI_RIEN_bm  0x80  /* Read Interrupt Enable bit mask. */
+#define TWI_RIEN_bp  7  /* Read Interrupt Enable bit position. */
+
+/* TWI.MCTRLB  bit masks and bit positions */
+#define TWI_MCMD_gm  0x03  /* Command group mask. */
+#define TWI_MCMD_gp  0  /* Command group position. */
+#define TWI_MCMD_0_bm  (1<<0)  /* Command bit 0 mask. */
+#define TWI_MCMD_0_bp  0  /* Command bit 0 position. */
+#define TWI_MCMD_1_bm  (1<<1)  /* Command bit 1 mask. */
+#define TWI_MCMD_1_bp  1  /* Command bit 1 position. */
+#define TWI_ACKACT_bm  0x04  /* Acknowledge Action bit mask. */
+#define TWI_ACKACT_bp  2  /* Acknowledge Action bit position. */
+#define TWI_FLUSH_bm  0x08  /* Flush bit mask. */
+#define TWI_FLUSH_bp  3  /* Flush bit position. */
+
+/* TWI.MSTATUS  bit masks and bit positions */
+#define TWI_BUSSTATE_gm  0x03  /* Bus State group mask. */
+#define TWI_BUSSTATE_gp  0  /* Bus State group position. */
+#define TWI_BUSSTATE_0_bm  (1<<0)  /* Bus State bit 0 mask. */
+#define TWI_BUSSTATE_0_bp  0  /* Bus State bit 0 position. */
+#define TWI_BUSSTATE_1_bm  (1<<1)  /* Bus State bit 1 mask. */
+#define TWI_BUSSTATE_1_bp  1  /* Bus State bit 1 position. */
+#define TWI_BUSERR_bm  0x04  /* Bus Error bit mask. */
+#define TWI_BUSERR_bp  2  /* Bus Error bit position. */
+#define TWI_ARBLOST_bm  0x08  /* Arbitration Lost bit mask. */
+#define TWI_ARBLOST_bp  3  /* Arbitration Lost bit position. */
+#define TWI_RXACK_bm  0x10  /* Received Acknowledge bit mask. */
+#define TWI_RXACK_bp  4  /* Received Acknowledge bit position. */
+#define TWI_CLKHOLD_bm  0x20  /* Clock Hold bit mask. */
+#define TWI_CLKHOLD_bp  5  /* Clock Hold bit position. */
+#define TWI_WIF_bm  0x40  /* Write Interrupt Flag bit mask. */
+#define TWI_WIF_bp  6  /* Write Interrupt Flag bit position. */
+#define TWI_RIF_bm  0x80  /* Read Interrupt Flag bit mask. */
+#define TWI_RIF_bp  7  /* Read Interrupt Flag bit position. */
+
+/* TWI.MBAUD  bit masks and bit positions */
+#define TWI_BAUD_gm  0xFF  /* Baud Rate group mask. */
+#define TWI_BAUD_gp  0  /* Baud Rate group position. */
+#define TWI_BAUD_0_bm  (1<<0)  /* Baud Rate bit 0 mask. */
+#define TWI_BAUD_0_bp  0  /* Baud Rate bit 0 position. */
+#define TWI_BAUD_1_bm  (1<<1)  /* Baud Rate bit 1 mask. */
+#define TWI_BAUD_1_bp  1  /* Baud Rate bit 1 position. */
+#define TWI_BAUD_2_bm  (1<<2)  /* Baud Rate bit 2 mask. */
+#define TWI_BAUD_2_bp  2  /* Baud Rate bit 2 position. */
+#define TWI_BAUD_3_bm  (1<<3)  /* Baud Rate bit 3 mask. */
+#define TWI_BAUD_3_bp  3  /* Baud Rate bit 3 position. */
+#define TWI_BAUD_4_bm  (1<<4)  /* Baud Rate bit 4 mask. */
+#define TWI_BAUD_4_bp  4  /* Baud Rate bit 4 position. */
+#define TWI_BAUD_5_bm  (1<<5)  /* Baud Rate bit 5 mask. */
+#define TWI_BAUD_5_bp  5  /* Baud Rate bit 5 position. */
+#define TWI_BAUD_6_bm  (1<<6)  /* Baud Rate bit 6 mask. */
+#define TWI_BAUD_6_bp  6  /* Baud Rate bit 6 position. */
+#define TWI_BAUD_7_bm  (1<<7)  /* Baud Rate bit 7 mask. */
+#define TWI_BAUD_7_bp  7  /* Baud Rate bit 7 position. */
+
+/* TWI.MADDR  bit masks and bit positions */
+#define TWI_ADDR_gm  0xFF  /* Address group mask. */
+#define TWI_ADDR_gp  0  /* Address group position. */
+#define TWI_ADDR_0_bm  (1<<0)  /* Address bit 0 mask. */
+#define TWI_ADDR_0_bp  0  /* Address bit 0 position. */
+#define TWI_ADDR_1_bm  (1<<1)  /* Address bit 1 mask. */
+#define TWI_ADDR_1_bp  1  /* Address bit 1 position. */
+#define TWI_ADDR_2_bm  (1<<2)  /* Address bit 2 mask. */
+#define TWI_ADDR_2_bp  2  /* Address bit 2 position. */
+#define TWI_ADDR_3_bm  (1<<3)  /* Address bit 3 mask. */
+#define TWI_ADDR_3_bp  3  /* Address bit 3 position. */
+#define TWI_ADDR_4_bm  (1<<4)  /* Address bit 4 mask. */
+#define TWI_ADDR_4_bp  4  /* Address bit 4 position. */
+#define TWI_ADDR_5_bm  (1<<5)  /* Address bit 5 mask. */
+#define TWI_ADDR_5_bp  5  /* Address bit 5 position. */
+#define TWI_ADDR_6_bm  (1<<6)  /* Address bit 6 mask. */
+#define TWI_ADDR_6_bp  6  /* Address bit 6 position. */
+#define TWI_ADDR_7_bm  (1<<7)  /* Address bit 7 mask. */
+#define TWI_ADDR_7_bp  7  /* Address bit 7 position. */
+
+/* TWI.MDATA  bit masks and bit positions */
+#define TWI_DATA_gm  0xFF  /* Data group mask. */
+#define TWI_DATA_gp  0  /* Data group position. */
+#define TWI_DATA_0_bm  (1<<0)  /* Data bit 0 mask. */
+#define TWI_DATA_0_bp  0  /* Data bit 0 position. */
+#define TWI_DATA_1_bm  (1<<1)  /* Data bit 1 mask. */
+#define TWI_DATA_1_bp  1  /* Data bit 1 position. */
+#define TWI_DATA_2_bm  (1<<2)  /* Data bit 2 mask. */
+#define TWI_DATA_2_bp  2  /* Data bit 2 position. */
+#define TWI_DATA_3_bm  (1<<3)  /* Data bit 3 mask. */
+#define TWI_DATA_3_bp  3  /* Data bit 3 position. */
+#define TWI_DATA_4_bm  (1<<4)  /* Data bit 4 mask. */
+#define TWI_DATA_4_bp  4  /* Data bit 4 position. */
+#define TWI_DATA_5_bm  (1<<5)  /* Data bit 5 mask. */
+#define TWI_DATA_5_bp  5  /* Data bit 5 position. */
+#define TWI_DATA_6_bm  (1<<6)  /* Data bit 6 mask. */
+#define TWI_DATA_6_bp  6  /* Data bit 6 position. */
+#define TWI_DATA_7_bm  (1<<7)  /* Data bit 7 mask. */
+#define TWI_DATA_7_bp  7  /* Data bit 7 position. */
+
+/* TWI.SCTRLA  bit masks and bit positions */
+/* TWI_ENABLE  is already defined. */
+/* TWI_SMEN  is already defined. */
+#define TWI_PMEN_bm  0x04  /* Address Recognition Mode bit mask. */
+#define TWI_PMEN_bp  2  /* Address Recognition Mode bit position. */
+#define TWI_PIEN_bm  0x20  /* Stop Interrupt Enable bit mask. */
+#define TWI_PIEN_bp  5  /* Stop Interrupt Enable bit position. */
+#define TWI_APIEN_bm  0x40  /* Address or Stop Interrupt Enable bit mask. */
+#define TWI_APIEN_bp  6  /* Address or Stop Interrupt Enable bit position. */
+#define TWI_DIEN_bm  0x80  /* Data Interrupt Enable bit mask. */
+#define TWI_DIEN_bp  7  /* Data Interrupt Enable bit position. */
+
+/* TWI.SCTRLB  bit masks and bit positions */
+#define TWI_SCMD_gm  0x03  /* Command group mask. */
+#define TWI_SCMD_gp  0  /* Command group position. */
+#define TWI_SCMD_0_bm  (1<<0)  /* Command bit 0 mask. */
+#define TWI_SCMD_0_bp  0  /* Command bit 0 position. */
+#define TWI_SCMD_1_bm  (1<<1)  /* Command bit 1 mask. */
+#define TWI_SCMD_1_bp  1  /* Command bit 1 position. */
+/* TWI_ACKACT  is already defined. */
+
+/* TWI.SSTATUS  bit masks and bit positions */
+#define TWI_AP_bm  0x01  /* Address or Stop bit mask. */
+#define TWI_AP_bp  0  /* Address or Stop bit position. */
+#define TWI_DIR_bm  0x02  /* Read/Write Direction bit mask. */
+#define TWI_DIR_bp  1  /* Read/Write Direction bit position. */
+/* TWI_BUSERR  is already defined. */
+#define TWI_COLL_bm  0x08  /* Collision bit mask. */
+#define TWI_COLL_bp  3  /* Collision bit position. */
+/* TWI_RXACK  is already defined. */
+/* TWI_CLKHOLD  is already defined. */
+#define TWI_APIF_bm  0x40  /* Address or Stop Interrupt Flag bit mask. */
+#define TWI_APIF_bp  6  /* Address or Stop Interrupt Flag bit position. */
+#define TWI_DIF_bm  0x80  /* Data Interrupt Flag bit mask. */
+#define TWI_DIF_bp  7  /* Data Interrupt Flag bit position. */
+
+/* TWI.SADDR  bit masks and bit positions */
+/* TWI_ADDR  is already defined. */
+
+/* TWI.SDATA  bit masks and bit positions */
+/* TWI_DATA  is already defined. */
+
+/* TWI.SADDRMASK  bit masks and bit positions */
+#define TWI_ADDREN_bm  0x01  /* Address Mask Enable bit mask. */
+#define TWI_ADDREN_bp  0  /* Address Mask Enable bit position. */
+#define TWI_ADDRMASK_gm  0xFE  /* Address Mask group mask. */
+#define TWI_ADDRMASK_gp  1  /* Address Mask group position. */
+#define TWI_ADDRMASK_0_bm  (1<<1)  /* Address Mask bit 0 mask. */
+#define TWI_ADDRMASK_0_bp  1  /* Address Mask bit 0 position. */
+#define TWI_ADDRMASK_1_bm  (1<<2)  /* Address Mask bit 1 mask. */
+#define TWI_ADDRMASK_1_bp  2  /* Address Mask bit 1 position. */
+#define TWI_ADDRMASK_2_bm  (1<<3)  /* Address Mask bit 2 mask. */
+#define TWI_ADDRMASK_2_bp  3  /* Address Mask bit 2 position. */
+#define TWI_ADDRMASK_3_bm  (1<<4)  /* Address Mask bit 3 mask. */
+#define TWI_ADDRMASK_3_bp  4  /* Address Mask bit 3 position. */
+#define TWI_ADDRMASK_4_bm  (1<<5)  /* Address Mask bit 4 mask. */
+#define TWI_ADDRMASK_4_bp  5  /* Address Mask bit 4 position. */
+#define TWI_ADDRMASK_5_bm  (1<<6)  /* Address Mask bit 5 mask. */
+#define TWI_ADDRMASK_5_bp  6  /* Address Mask bit 5 position. */
+#define TWI_ADDRMASK_6_bm  (1<<7)  /* Address Mask bit 6 mask. */
+#define TWI_ADDRMASK_6_bp  7  /* Address Mask bit 6 position. */
+
+
+/* USART - Universal Synchronous and Asynchronous Receiver and Transmitter */
+/* USART.RXDATAL  bit masks and bit positions */
+#define USART_DATA_gm  0xFF  /* RX Data group mask. */
+#define USART_DATA_gp  0  /* RX Data group position. */
+#define USART_DATA_0_bm  (1<<0)  /* RX Data bit 0 mask. */
+#define USART_DATA_0_bp  0  /* RX Data bit 0 position. */
+#define USART_DATA_1_bm  (1<<1)  /* RX Data bit 1 mask. */
+#define USART_DATA_1_bp  1  /* RX Data bit 1 position. */
+#define USART_DATA_2_bm  (1<<2)  /* RX Data bit 2 mask. */
+#define USART_DATA_2_bp  2  /* RX Data bit 2 position. */
+#define USART_DATA_3_bm  (1<<3)  /* RX Data bit 3 mask. */
+#define USART_DATA_3_bp  3  /* RX Data bit 3 position. */
+#define USART_DATA_4_bm  (1<<4)  /* RX Data bit 4 mask. */
+#define USART_DATA_4_bp  4  /* RX Data bit 4 position. */
+#define USART_DATA_5_bm  (1<<5)  /* RX Data bit 5 mask. */
+#define USART_DATA_5_bp  5  /* RX Data bit 5 position. */
+#define USART_DATA_6_bm  (1<<6)  /* RX Data bit 6 mask. */
+#define USART_DATA_6_bp  6  /* RX Data bit 6 position. */
+#define USART_DATA_7_bm  (1<<7)  /* RX Data bit 7 mask. */
+#define USART_DATA_7_bp  7  /* RX Data bit 7 position. */
+
+/* USART.RXDATAH  bit masks and bit positions */
+#define USART_DATA8_bm  0x01  /* Receiver Data Register bit mask. */
+#define USART_DATA8_bp  0  /* Receiver Data Register bit position. */
+#define USART_PERR_bm  0x02  /* Parity Error bit mask. */
+#define USART_PERR_bp  1  /* Parity Error bit position. */
+#define USART_FERR_bm  0x04  /* Frame Error bit mask. */
+#define USART_FERR_bp  2  /* Frame Error bit position. */
+#define USART_BUFOVF_bm  0x40  /* Buffer Overflow bit mask. */
+#define USART_BUFOVF_bp  6  /* Buffer Overflow bit position. */
+#define USART_RXCIF_bm  0x80  /* Receive Complete Interrupt Flag bit mask. */
+#define USART_RXCIF_bp  7  /* Receive Complete Interrupt Flag bit position. */
+
+/* USART.TXDATAL  bit masks and bit positions */
+/* USART_DATA  is already defined. */
+
+/* USART.TXDATAH  bit masks and bit positions */
+/* USART_DATA8  is already defined. */
+
+/* USART.STATUS  bit masks and bit positions */
+#define USART_WFB_bm  0x01  /* Wait For Break bit mask. */
+#define USART_WFB_bp  0  /* Wait For Break bit position. */
+#define USART_BDF_bm  0x02  /* Break Detected Flag bit mask. */
+#define USART_BDF_bp  1  /* Break Detected Flag bit position. */
+#define USART_ISFIF_bm  0x08  /* Inconsistent Sync Field Interrupt Flag bit mask. */
+#define USART_ISFIF_bp  3  /* Inconsistent Sync Field Interrupt Flag bit position. */
+#define USART_RXSIF_bm  0x10  /* Receive Start Interrupt bit mask. */
+#define USART_RXSIF_bp  4  /* Receive Start Interrupt bit position. */
+#define USART_DREIF_bm  0x20  /* Data Register Empty Flag bit mask. */
+#define USART_DREIF_bp  5  /* Data Register Empty Flag bit position. */
+#define USART_TXCIF_bm  0x40  /* Transmit Interrupt Flag bit mask. */
+#define USART_TXCIF_bp  6  /* Transmit Interrupt Flag bit position. */
+/* USART_RXCIF  is already defined. */
+
+/* USART.CTRLA  bit masks and bit positions */
+#define USART_RS485_bm  0x01  /* RS485 Mode internal transmitter bit mask. */
+#define USART_RS485_bp  0  /* RS485 Mode internal transmitter bit position. */
+#define USART_ABEIE_bm  0x04  /* Auto-baud Error Interrupt Enable bit mask. */
+#define USART_ABEIE_bp  2  /* Auto-baud Error Interrupt Enable bit position. */
+#define USART_LBME_bm  0x08  /* Loop-back Mode Enable bit mask. */
+#define USART_LBME_bp  3  /* Loop-back Mode Enable bit position. */
+#define USART_RXSIE_bm  0x10  /* Receiver Start Frame Interrupt Enable bit mask. */
+#define USART_RXSIE_bp  4  /* Receiver Start Frame Interrupt Enable bit position. */
+#define USART_DREIE_bm  0x20  /* Data Register Empty Interrupt Enable bit mask. */
+#define USART_DREIE_bp  5  /* Data Register Empty Interrupt Enable bit position. */
+#define USART_TXCIE_bm  0x40  /* Transmit Complete Interrupt Enable bit mask. */
+#define USART_TXCIE_bp  6  /* Transmit Complete Interrupt Enable bit position. */
+#define USART_RXCIE_bm  0x80  /* Receive Complete Interrupt Enable bit mask. */
+#define USART_RXCIE_bp  7  /* Receive Complete Interrupt Enable bit position. */
+
+/* USART.CTRLB  bit masks and bit positions */
+#define USART_MPCM_bm  0x01  /* Multi-processor Communication Mode bit mask. */
+#define USART_MPCM_bp  0  /* Multi-processor Communication Mode bit position. */
+#define USART_RXMODE_gm  0x06  /* Receiver Mode group mask. */
+#define USART_RXMODE_gp  1  /* Receiver Mode group position. */
+#define USART_RXMODE_0_bm  (1<<1)  /* Receiver Mode bit 0 mask. */
+#define USART_RXMODE_0_bp  1  /* Receiver Mode bit 0 position. */
+#define USART_RXMODE_1_bm  (1<<2)  /* Receiver Mode bit 1 mask. */
+#define USART_RXMODE_1_bp  2  /* Receiver Mode bit 1 position. */
+#define USART_ODME_bm  0x08  /* Open Drain Mode Enable bit mask. */
+#define USART_ODME_bp  3  /* Open Drain Mode Enable bit position. */
+#define USART_SFDEN_bm  0x10  /* Start Frame Detection Enable bit mask. */
+#define USART_SFDEN_bp  4  /* Start Frame Detection Enable bit position. */
+#define USART_TXEN_bm  0x40  /* Transmitter Enable bit mask. */
+#define USART_TXEN_bp  6  /* Transmitter Enable bit position. */
+#define USART_RXEN_bm  0x80  /* Reciever enable bit mask. */
+#define USART_RXEN_bp  7  /* Reciever enable bit position. */
+
+/* USART.CTRLC  bit masks and bit positions */
+#define USART_UCPHA_bm  0x02  /* SPI Host Mode, Clock Phase bit mask. */
+#define USART_UCPHA_bp  1  /* SPI Host Mode, Clock Phase bit position. */
+#define USART_UDORD_bm  0x04  /* SPI Host Mode, Data Order bit mask. */
+#define USART_UDORD_bp  2  /* SPI Host Mode, Data Order bit position. */
+#define USART_CHSIZE_gm  0x07  /* Character Size group mask. */
+#define USART_CHSIZE_gp  0  /* Character Size group position. */
+#define USART_CHSIZE_0_bm  (1<<0)  /* Character Size bit 0 mask. */
+#define USART_CHSIZE_0_bp  0  /* Character Size bit 0 position. */
+#define USART_CHSIZE_1_bm  (1<<1)  /* Character Size bit 1 mask. */
+#define USART_CHSIZE_1_bp  1  /* Character Size bit 1 position. */
+#define USART_CHSIZE_2_bm  (1<<2)  /* Character Size bit 2 mask. */
+#define USART_CHSIZE_2_bp  2  /* Character Size bit 2 position. */
+#define USART_SBMODE_bm  0x08  /* Stop Bit Mode bit mask. */
+#define USART_SBMODE_bp  3  /* Stop Bit Mode bit position. */
+#define USART_PMODE_gm  0x30  /* Parity Mode group mask. */
+#define USART_PMODE_gp  4  /* Parity Mode group position. */
+#define USART_PMODE_0_bm  (1<<4)  /* Parity Mode bit 0 mask. */
+#define USART_PMODE_0_bp  4  /* Parity Mode bit 0 position. */
+#define USART_PMODE_1_bm  (1<<5)  /* Parity Mode bit 1 mask. */
+#define USART_PMODE_1_bp  5  /* Parity Mode bit 1 position. */
+#define USART_CMODE_gm  0xC0  /* Communication Mode group mask. */
+#define USART_CMODE_gp  6  /* Communication Mode group position. */
+#define USART_CMODE_0_bm  (1<<6)  /* Communication Mode bit 0 mask. */
+#define USART_CMODE_0_bp  6  /* Communication Mode bit 0 position. */
+#define USART_CMODE_1_bm  (1<<7)  /* Communication Mode bit 1 mask. */
+#define USART_CMODE_1_bp  7  /* Communication Mode bit 1 position. */
+
+/* USART.CTRLD  bit masks and bit positions */
+#define USART_ABW_gm  0xC0  /* Auto Baud Window group mask. */
+#define USART_ABW_gp  6  /* Auto Baud Window group position. */
+#define USART_ABW_0_bm  (1<<6)  /* Auto Baud Window bit 0 mask. */
+#define USART_ABW_0_bp  6  /* Auto Baud Window bit 0 position. */
+#define USART_ABW_1_bm  (1<<7)  /* Auto Baud Window bit 1 mask. */
+#define USART_ABW_1_bp  7  /* Auto Baud Window bit 1 position. */
+
+/* USART.DBGCTRL  bit masks and bit positions */
+#define USART_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define USART_DBGRUN_bp  0  /* Debug Run bit position. */
+
+/* USART.EVCTRL  bit masks and bit positions */
+#define USART_IREI_bm  0x01  /* IrDA Event Input Enable bit mask. */
+#define USART_IREI_bp  0  /* IrDA Event Input Enable bit position. */
+
+/* USART.TXPLCTRL  bit masks and bit positions */
+#define USART_TXPL_gm  0xFF  /* Transmit pulse length group mask. */
+#define USART_TXPL_gp  0  /* Transmit pulse length group position. */
+#define USART_TXPL_0_bm  (1<<0)  /* Transmit pulse length bit 0 mask. */
+#define USART_TXPL_0_bp  0  /* Transmit pulse length bit 0 position. */
+#define USART_TXPL_1_bm  (1<<1)  /* Transmit pulse length bit 1 mask. */
+#define USART_TXPL_1_bp  1  /* Transmit pulse length bit 1 position. */
+#define USART_TXPL_2_bm  (1<<2)  /* Transmit pulse length bit 2 mask. */
+#define USART_TXPL_2_bp  2  /* Transmit pulse length bit 2 position. */
+#define USART_TXPL_3_bm  (1<<3)  /* Transmit pulse length bit 3 mask. */
+#define USART_TXPL_3_bp  3  /* Transmit pulse length bit 3 position. */
+#define USART_TXPL_4_bm  (1<<4)  /* Transmit pulse length bit 4 mask. */
+#define USART_TXPL_4_bp  4  /* Transmit pulse length bit 4 position. */
+#define USART_TXPL_5_bm  (1<<5)  /* Transmit pulse length bit 5 mask. */
+#define USART_TXPL_5_bp  5  /* Transmit pulse length bit 5 position. */
+#define USART_TXPL_6_bm  (1<<6)  /* Transmit pulse length bit 6 mask. */
+#define USART_TXPL_6_bp  6  /* Transmit pulse length bit 6 position. */
+#define USART_TXPL_7_bm  (1<<7)  /* Transmit pulse length bit 7 mask. */
+#define USART_TXPL_7_bp  7  /* Transmit pulse length bit 7 position. */
+
+/* USART.RXPLCTRL  bit masks and bit positions */
+#define USART_RXPL_gm  0x7F  /* Receiver Pulse Lenght group mask. */
+#define USART_RXPL_gp  0  /* Receiver Pulse Lenght group position. */
+#define USART_RXPL_0_bm  (1<<0)  /* Receiver Pulse Lenght bit 0 mask. */
+#define USART_RXPL_0_bp  0  /* Receiver Pulse Lenght bit 0 position. */
+#define USART_RXPL_1_bm  (1<<1)  /* Receiver Pulse Lenght bit 1 mask. */
+#define USART_RXPL_1_bp  1  /* Receiver Pulse Lenght bit 1 position. */
+#define USART_RXPL_2_bm  (1<<2)  /* Receiver Pulse Lenght bit 2 mask. */
+#define USART_RXPL_2_bp  2  /* Receiver Pulse Lenght bit 2 position. */
+#define USART_RXPL_3_bm  (1<<3)  /* Receiver Pulse Lenght bit 3 mask. */
+#define USART_RXPL_3_bp  3  /* Receiver Pulse Lenght bit 3 position. */
+#define USART_RXPL_4_bm  (1<<4)  /* Receiver Pulse Lenght bit 4 mask. */
+#define USART_RXPL_4_bp  4  /* Receiver Pulse Lenght bit 4 position. */
+#define USART_RXPL_5_bm  (1<<5)  /* Receiver Pulse Lenght bit 5 mask. */
+#define USART_RXPL_5_bp  5  /* Receiver Pulse Lenght bit 5 position. */
+#define USART_RXPL_6_bm  (1<<6)  /* Receiver Pulse Lenght bit 6 mask. */
+#define USART_RXPL_6_bp  6  /* Receiver Pulse Lenght bit 6 position. */
+
+
+
+/* VPORT - Virtual Ports */
+/* VPORT.INTFLAGS  bit masks and bit positions */
+#define VPORT_INT_gm  0xFF  /* Pin Interrupt Flag group mask. */
+#define VPORT_INT_gp  0  /* Pin Interrupt Flag group position. */
+#define VPORT_INT_0_bm  (1<<0)  /* Pin Interrupt Flag bit 0 mask. */
+#define VPORT_INT_0_bp  0  /* Pin Interrupt Flag bit 0 position. */
+#define VPORT_INT_1_bm  (1<<1)  /* Pin Interrupt Flag bit 1 mask. */
+#define VPORT_INT_1_bp  1  /* Pin Interrupt Flag bit 1 position. */
+#define VPORT_INT_2_bm  (1<<2)  /* Pin Interrupt Flag bit 2 mask. */
+#define VPORT_INT_2_bp  2  /* Pin Interrupt Flag bit 2 position. */
+#define VPORT_INT_3_bm  (1<<3)  /* Pin Interrupt Flag bit 3 mask. */
+#define VPORT_INT_3_bp  3  /* Pin Interrupt Flag bit 3 position. */
+#define VPORT_INT_4_bm  (1<<4)  /* Pin Interrupt Flag bit 4 mask. */
+#define VPORT_INT_4_bp  4  /* Pin Interrupt Flag bit 4 position. */
+#define VPORT_INT_5_bm  (1<<5)  /* Pin Interrupt Flag bit 5 mask. */
+#define VPORT_INT_5_bp  5  /* Pin Interrupt Flag bit 5 position. */
+#define VPORT_INT_6_bm  (1<<6)  /* Pin Interrupt Flag bit 6 mask. */
+#define VPORT_INT_6_bp  6  /* Pin Interrupt Flag bit 6 position. */
+#define VPORT_INT_7_bm  (1<<7)  /* Pin Interrupt Flag bit 7 mask. */
+#define VPORT_INT_7_bp  7  /* Pin Interrupt Flag bit 7 position. */
+
+
+/* VREF - Voltage reference */
+/* VREF.DAC0REF  bit masks and bit positions */
+#define VREF_REFSEL_gm  0x07  /* Reference select group mask. */
+#define VREF_REFSEL_gp  0  /* Reference select group position. */
+#define VREF_REFSEL_0_bm  (1<<0)  /* Reference select bit 0 mask. */
+#define VREF_REFSEL_0_bp  0  /* Reference select bit 0 position. */
+#define VREF_REFSEL_1_bm  (1<<1)  /* Reference select bit 1 mask. */
+#define VREF_REFSEL_1_bp  1  /* Reference select bit 1 position. */
+#define VREF_REFSEL_2_bm  (1<<2)  /* Reference select bit 2 mask. */
+#define VREF_REFSEL_2_bp  2  /* Reference select bit 2 position. */
+#define VREF_ALWAYSON_bm  0x80  /* Always on bit mask. */
+#define VREF_ALWAYSON_bp  7  /* Always on bit position. */
+
+/* VREF.ACREF  bit masks and bit positions */
+/* VREF_REFSEL  is already defined. */
+/* VREF_ALWAYSON  is already defined. */
+
+
+/* WDT - Watch-Dog Timer */
+/* WDT.CTRLA  bit masks and bit positions */
+#define WDT_PERIOD_gm  0x0F  /* Period group mask. */
+#define WDT_PERIOD_gp  0  /* Period group position. */
+#define WDT_PERIOD_0_bm  (1<<0)  /* Period bit 0 mask. */
+#define WDT_PERIOD_0_bp  0  /* Period bit 0 position. */
+#define WDT_PERIOD_1_bm  (1<<1)  /* Period bit 1 mask. */
+#define WDT_PERIOD_1_bp  1  /* Period bit 1 position. */
+#define WDT_PERIOD_2_bm  (1<<2)  /* Period bit 2 mask. */
+#define WDT_PERIOD_2_bp  2  /* Period bit 2 position. */
+#define WDT_PERIOD_3_bm  (1<<3)  /* Period bit 3 mask. */
+#define WDT_PERIOD_3_bp  3  /* Period bit 3 position. */
+#define WDT_WINDOW_gm  0xF0  /* Window group mask. */
+#define WDT_WINDOW_gp  4  /* Window group position. */
+#define WDT_WINDOW_0_bm  (1<<4)  /* Window bit 0 mask. */
+#define WDT_WINDOW_0_bp  4  /* Window bit 0 position. */
+#define WDT_WINDOW_1_bm  (1<<5)  /* Window bit 1 mask. */
+#define WDT_WINDOW_1_bp  5  /* Window bit 1 position. */
+#define WDT_WINDOW_2_bm  (1<<6)  /* Window bit 2 mask. */
+#define WDT_WINDOW_2_bp  6  /* Window bit 2 position. */
+#define WDT_WINDOW_3_bm  (1<<7)  /* Window bit 3 mask. */
+#define WDT_WINDOW_3_bp  7  /* Window bit 3 position. */
+
+/* WDT.STATUS  bit masks and bit positions */
+#define WDT_SYNCBUSY_bm  0x01  /* Syncronization busy bit mask. */
+#define WDT_SYNCBUSY_bp  0  /* Syncronization busy bit position. */
+#define WDT_LOCK_bm  0x80  /* Lock enable bit mask. */
+#define WDT_LOCK_bp  7  /* Lock enable bit position. */
+
+
+/* ========== Generic Port Pins ========== */
+#define PIN0_bm 0x01
+#define PIN0_bp 0
+#define PIN1_bm 0x02
+#define PIN1_bp 1
+#define PIN2_bm 0x04
+#define PIN2_bp 2
+#define PIN3_bm 0x08
+#define PIN3_bp 3
+#define PIN4_bm 0x10
+#define PIN4_bp 4
+#define PIN5_bm 0x20
+#define PIN5_bp 5
+#define PIN6_bm 0x40
+#define PIN6_bp 6
+#define PIN7_bm 0x80
+#define PIN7_bp 7
+
+/* ========== Interrupt Vector Definitions ========== */
+/* Vector 0 is the reset vector */
+
+/* NMI interrupt vectors */
+#define NMI_vect_num  1
+#define NMI_vect      _VECTOR(1)  /*  */
+
+/* BOD interrupt vectors */
+#define BOD_VLM_vect_num  2
+#define BOD_VLM_vect      _VECTOR(2)  /*  */
+
+/* CLKCTRL interrupt vectors */
+#define CLKCTRL_CFD_vect_num  3
+#define CLKCTRL_CFD_vect      _VECTOR(3)  /*  */
+
+/* RTC interrupt vectors */
+#define RTC_CNT_vect_num  4
+#define RTC_CNT_vect      _VECTOR(4)  /*  */
+#define RTC_PIT_vect_num  5
+#define RTC_PIT_vect      _VECTOR(5)  /*  */
+
+/* CCL interrupt vectors */
+#define CCL_CCL_vect_num  6
+#define CCL_CCL_vect      _VECTOR(6)  /*  */
+
+/* PORTA interrupt vectors */
+#define PORTA_PORT_vect_num  7
+#define PORTA_PORT_vect      _VECTOR(7)  /*  */
+
+/* TCA0 interrupt vectors */
+#define TCA0_LUNF_vect_num  8
+#define TCA0_LUNF_vect      _VECTOR(8)  /*  */
+#define TCA0_OVF_vect_num  8
+#define TCA0_OVF_vect      _VECTOR(8)  /*  */
+#define TCA0_HUNF_vect_num  9
+#define TCA0_HUNF_vect      _VECTOR(9)  /*  */
+#define TCA0_CMP0_vect_num  10
+#define TCA0_CMP0_vect      _VECTOR(10)  /*  */
+#define TCA0_LCMP0_vect_num  10
+#define TCA0_LCMP0_vect      _VECTOR(10)  /*  */
+#define TCA0_CMP1_vect_num  11
+#define TCA0_CMP1_vect      _VECTOR(11)  /*  */
+#define TCA0_LCMP1_vect_num  11
+#define TCA0_LCMP1_vect      _VECTOR(11)  /*  */
+#define TCA0_CMP2_vect_num  12
+#define TCA0_CMP2_vect      _VECTOR(12)  /*  */
+#define TCA0_LCMP2_vect_num  12
+#define TCA0_LCMP2_vect      _VECTOR(12)  /*  */
+
+/* TCB0 interrupt vectors */
+#define TCB0_INT_vect_num  13
+#define TCB0_INT_vect      _VECTOR(13)  /*  */
+
+/* TCB1 interrupt vectors */
+#define TCB1_INT_vect_num  14
+#define TCB1_INT_vect      _VECTOR(14)  /*  */
+
+/* TWI0 interrupt vectors */
+#define TWI0_TWIS_vect_num  15
+#define TWI0_TWIS_vect      _VECTOR(15)  /*  */
+#define TWI0_TWIM_vect_num  16
+#define TWI0_TWIM_vect      _VECTOR(16)  /*  */
+
+/* SPI0 interrupt vectors */
+#define SPI0_INT_vect_num  17
+#define SPI0_INT_vect      _VECTOR(17)  /*  */
+
+/* USART0 interrupt vectors */
+#define USART0_RXC_vect_num  18
+#define USART0_RXC_vect      _VECTOR(18)  /*  */
+#define USART0_DRE_vect_num  19
+#define USART0_DRE_vect      _VECTOR(19)  /*  */
+#define USART0_TXC_vect_num  20
+#define USART0_TXC_vect      _VECTOR(20)  /*  */
+
+/* PORTD interrupt vectors */
+#define PORTD_PORT_vect_num  21
+#define PORTD_PORT_vect      _VECTOR(21)  /*  */
+
+/* AC0 interrupt vectors */
+#define AC0_AC_vect_num  22
+#define AC0_AC_vect      _VECTOR(22)  /*  */
+
+/* ADC0 interrupt vectors */
+#define ADC0_ERROR_vect_num  23
+#define ADC0_ERROR_vect      _VECTOR(23)  /*  */
+#define ADC0_RESRDY_vect_num  24
+#define ADC0_RESRDY_vect      _VECTOR(24)  /*  */
+#define ADC0_SAMPRDY_vect_num  25
+#define ADC0_SAMPRDY_vect      _VECTOR(25)  /*  */
+
+/* AC1 interrupt vectors */
+#define AC1_AC_vect_num  26
+#define AC1_AC_vect      _VECTOR(26)  /*  */
+
+/* PORTC interrupt vectors */
+#define PORTC_PORT_vect_num  27
+#define PORTC_PORT_vect      _VECTOR(27)  /*  */
+
+/* TCB2 interrupt vectors */
+#define TCB2_INT_vect_num  28
+#define TCB2_INT_vect      _VECTOR(28)  /*  */
+
+/* USART1 interrupt vectors */
+#define USART1_RXC_vect_num  29
+#define USART1_RXC_vect      _VECTOR(29)  /*  */
+#define USART1_DRE_vect_num  30
+#define USART1_DRE_vect      _VECTOR(30)  /*  */
+#define USART1_TXC_vect_num  31
+#define USART1_TXC_vect      _VECTOR(31)  /*  */
+
+/* PORTF interrupt vectors */
+#define PORTF_PORT_vect_num  32
+#define PORTF_PORT_vect      _VECTOR(32)  /*  */
+
+/* NVMCTRL interrupt vectors */
+#define NVMCTRL_EEREADY_vect_num  33
+#define NVMCTRL_EEREADY_vect      _VECTOR(33)  /*  */
+#define NVMCTRL_FLREADY_vect_num  33
+#define NVMCTRL_FLREADY_vect      _VECTOR(33)  /*  */
+#define NVMCTRL_NVMREADY_vect_num  33
+#define NVMCTRL_NVMREADY_vect      _VECTOR(33)  /*  */
+
+/* USART2 interrupt vectors */
+#define USART2_RXC_vect_num  34
+#define USART2_RXC_vect      _VECTOR(34)  /*  */
+#define USART2_DRE_vect_num  35
+#define USART2_DRE_vect      _VECTOR(35)  /*  */
+#define USART2_TXC_vect_num  36
+#define USART2_TXC_vect      _VECTOR(36)  /*  */
+
+#define _VECTOR_SIZE 4 /* Size of individual vector. */
+#define _VECTORS_SIZE (37 * _VECTOR_SIZE)
+
+
+/* ========== Constants ========== */
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define DATAMEM_START     (0x0000)
+#  define DATAMEM_SIZE      (65536)
+#else
+#  define DATAMEM_START     (0x0000U)
+#  define DATAMEM_SIZE      (65536U)
+#endif
+#define DATAMEM_END       (DATAMEM_START + DATAMEM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define IO_START     (0x0000)
+#  define IO_SIZE      (4159)
+#  define IO_PAGE_SIZE (0)
+#else
+#  define IO_START     (0x0000U)
+#  define IO_SIZE      (4159U)
+#  define IO_PAGE_SIZE (0U)
+#endif
+#define IO_END       (IO_START + IO_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define LOCKBITS_START     (0x1040)
+#  define LOCKBITS_SIZE      (4)
+#  define LOCKBITS_PAGE_SIZE (4)
+#else
+#  define LOCKBITS_START     (0x1040U)
+#  define LOCKBITS_SIZE      (4U)
+#  define LOCKBITS_PAGE_SIZE (4U)
+#endif
+#define LOCKBITS_END       (LOCKBITS_START + LOCKBITS_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define FUSES_START     (0x1050)
+#  define FUSES_SIZE      (16)
+#  define FUSES_PAGE_SIZE (8)
+#else
+#  define FUSES_START     (0x1050U)
+#  define FUSES_SIZE      (16U)
+#  define FUSES_PAGE_SIZE (8U)
+#endif
+#define FUSES_END       (FUSES_START + FUSES_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define USER_SIGNATURES_START     (0x1080)
+#  define USER_SIGNATURES_SIZE      (64)
+#  define USER_SIGNATURES_PAGE_SIZE (64)
+#else
+#  define USER_SIGNATURES_START     (0x1080U)
+#  define USER_SIGNATURES_SIZE      (64U)
+#  define USER_SIGNATURES_PAGE_SIZE (64U)
+#endif
+#define USER_SIGNATURES_END       (USER_SIGNATURES_START + USER_SIGNATURES_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define SIGNATURES_START     (0x1100)
+#  define SIGNATURES_SIZE      (3)
+#  define SIGNATURES_PAGE_SIZE (128)
+#else
+#  define SIGNATURES_START     (0x1100U)
+#  define SIGNATURES_SIZE      (3U)
+#  define SIGNATURES_PAGE_SIZE (128U)
+#endif
+#define SIGNATURES_END       (SIGNATURES_START + SIGNATURES_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define PROD_SIGNATURES_START     (0x1103)
+#  define PROD_SIGNATURES_SIZE      (125)
+#  define PROD_SIGNATURES_PAGE_SIZE (128)
+#else
+#  define PROD_SIGNATURES_START     (0x1103U)
+#  define PROD_SIGNATURES_SIZE      (125U)
+#  define PROD_SIGNATURES_PAGE_SIZE (128U)
+#endif
+#define PROD_SIGNATURES_END       (PROD_SIGNATURES_START + PROD_SIGNATURES_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define EEPROM_START     (0x1400)
+#  define EEPROM_SIZE      (512)
+#  define EEPROM_PAGE_SIZE (8)
+#else
+#  define EEPROM_START     (0x1400U)
+#  define EEPROM_SIZE      (512U)
+#  define EEPROM_PAGE_SIZE (8U)
+#endif
+#define EEPROM_END       (EEPROM_START + EEPROM_SIZE - 1)
+
+/* Added MAPPED_EEPROM segment names for avr-libc */
+#define MAPPED_EEPROM_START     (EEPROM_START)
+#define MAPPED_EEPROM_SIZE      (EEPROM_SIZE)
+#define MAPPED_EEPROM_PAGE_SIZE (EEPROM_PAGE_SIZE)
+#define MAPPED_EEPROM_END       (MAPPED_EEPROM_START + MAPPED_EEPROM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define INTERNAL_SRAM_START     (0x7800)
+#  define INTERNAL_SRAM_SIZE      (2048)
+#  define INTERNAL_SRAM_PAGE_SIZE (0)
+#else
+#  define INTERNAL_SRAM_START     (0x7800U)
+#  define INTERNAL_SRAM_SIZE      (2048U)
+#  define INTERNAL_SRAM_PAGE_SIZE (0U)
+#endif
+#define INTERNAL_SRAM_END       (INTERNAL_SRAM_START + INTERNAL_SRAM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define MAPPED_PROGMEM_START     (0x8000)
+#  define MAPPED_PROGMEM_SIZE      (16384)
+#  define MAPPED_PROGMEM_PAGE_SIZE (64)
+#else
+#  define MAPPED_PROGMEM_START     (0x8000U)
+#  define MAPPED_PROGMEM_SIZE      (16384U)
+#  define MAPPED_PROGMEM_PAGE_SIZE (64U)
+#endif
+#define MAPPED_PROGMEM_END       (MAPPED_PROGMEM_START + MAPPED_PROGMEM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define PROGMEM_START     (0x0000)
+#  define PROGMEM_SIZE      (16384)
+#  define PROGMEM_PAGE_SIZE (64)
+#else
+#  define PROGMEM_START     (0x0000U)
+#  define PROGMEM_SIZE      (16384U)
+#  define PROGMEM_PAGE_SIZE (64U)
+#endif
+#define PROGMEM_END       (PROGMEM_START + PROGMEM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define PROGMEM_NRWW_START     (0x0000)
+#  define PROGMEM_NRWW_SIZE      (4096)
+#  define PROGMEM_NRWW_PAGE_SIZE (64)
+#else
+#  define PROGMEM_NRWW_START     (0x0000U)
+#  define PROGMEM_NRWW_SIZE      (4096U)
+#  define PROGMEM_NRWW_PAGE_SIZE (64U)
+#endif
+#define PROGMEM_NRWW_END       (PROGMEM_NRWW_START + PROGMEM_NRWW_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define PROGMEM_RWW_START     (0x1000)
+#  define PROGMEM_RWW_SIZE      (12288)
+#  define PROGMEM_RWW_PAGE_SIZE (64)
+#else
+#  define PROGMEM_RWW_START     (0x1000U)
+#  define PROGMEM_RWW_SIZE      (12288U)
+#  define PROGMEM_RWW_PAGE_SIZE (64U)
+#endif
+#define PROGMEM_RWW_END       (PROGMEM_RWW_START + PROGMEM_RWW_SIZE - 1)
+
+#define FLASHSTART   PROGMEM_START
+#define FLASHEND     PROGMEM_END
+#define RAMSTART     INTERNAL_SRAM_START
+#define RAMSIZE      INTERNAL_SRAM_SIZE
+#define RAMEND       INTERNAL_SRAM_END
+#define E2END        EEPROM_END
+#define E2PAGESIZE   EEPROM_PAGE_SIZE
+
+/* ========== Fuses ========== */
+#define FUSE_MEMORY_SIZE 16
+
+/* Fuse Byte 0 (WDTCFG) */
+#define FUSE_PERIOD0  (unsigned char)_BV(0)  /* Watchdog Timeout Period Bit 0 */
+#define FUSE_PERIOD1  (unsigned char)_BV(1)  /* Watchdog Timeout Period Bit 1 */
+#define FUSE_PERIOD2  (unsigned char)_BV(2)  /* Watchdog Timeout Period Bit 2 */
+#define FUSE_PERIOD3  (unsigned char)_BV(3)  /* Watchdog Timeout Period Bit 3 */
+#define FUSE_WINDOW0  (unsigned char)_BV(4)  /* Watchdog Window Timeout Period Bit 0 */
+#define FUSE_WINDOW1  (unsigned char)_BV(5)  /* Watchdog Window Timeout Period Bit 1 */
+#define FUSE_WINDOW2  (unsigned char)_BV(6)  /* Watchdog Window Timeout Period Bit 2 */
+#define FUSE_WINDOW3  (unsigned char)_BV(7)  /* Watchdog Window Timeout Period Bit 3 */
+#define FUSE0_DEFAULT  (0x0)
+#define FUSE_WDTCFG_DEFAULT  (0x0)
+
+/* Fuse Byte 1 (BODCFG) */
+#define FUSE_SLEEP0  (unsigned char)_BV(0)  /* BOD Operation in Sleep Mode Bit 0 */
+#define FUSE_SLEEP1  (unsigned char)_BV(1)  /* BOD Operation in Sleep Mode Bit 1 */
+#define FUSE_ACTIVE0  (unsigned char)_BV(2)  /* BOD Operation in Active Mode Bit 0 */
+#define FUSE_ACTIVE1  (unsigned char)_BV(3)  /* BOD Operation in Active Mode Bit 1 */
+#define FUSE_SAMPFREQ  (unsigned char)_BV(4)  /* BOD Sample Frequency */
+#define FUSE_LVL0  (unsigned char)_BV(5)  /* BOD Level Bit 0 */
+#define FUSE_LVL1  (unsigned char)_BV(6)  /* BOD Level Bit 1 */
+#define FUSE_LVL2  (unsigned char)_BV(7)  /* BOD Level Bit 2 */
+#define FUSE1_DEFAULT  (0x0)
+#define FUSE_BODCFG_DEFAULT  (0x0)
+
+/* Fuse Byte 2 (OSCCFG) */
+#define FUSE_OSCHFFRQ  (unsigned char)_BV(3)  /* High-frequency Oscillator Frequency */
+#define FUSE2_DEFAULT  (0x0)
+#define FUSE_OSCCFG_DEFAULT  (0x0)
+
+/* Fuse Byte 3 Reserved */
+
+/* Fuse Byte 4 Reserved */
+
+/* Fuse Byte 5 (SYSCFG0) */
+#define FUSE_EESAVE  (unsigned char)_BV(0)  /* EEPROM Save */
+#define FUSE_RSTPINCFG  (unsigned char)_BV(3)  /* Reset Pin Configuration */
+#define FUSE_UPDIPINCFG  (unsigned char)_BV(4)  /* UPDI Pin Configuration */
+#define FUSE_CRCSEL  (unsigned char)_BV(5)  /* CRC Select */
+#define FUSE_CRCSRC0  (unsigned char)_BV(6)  /* CRC Source Bit 0 */
+#define FUSE_CRCSRC1  (unsigned char)_BV(7)  /* CRC Source Bit 1 */
+#define FUSE5_DEFAULT  (0xD0)
+#define FUSE_SYSCFG0_DEFAULT  (0xD0)
+
+/* Fuse Byte 6 (SYSCFG1) */
+#define FUSE_SUT0  (unsigned char)_BV(0)  /* Startup Time Bit 0 */
+#define FUSE_SUT1  (unsigned char)_BV(1)  /* Startup Time Bit 1 */
+#define FUSE_SUT2  (unsigned char)_BV(2)  /* Startup Time Bit 2 */
+#define FUSE6_DEFAULT  (0x7)
+#define FUSE_SYSCFG1_DEFAULT  (0x7)
+
+/* Fuse Byte 7 (CODESIZE) */
+#define FUSE7_DEFAULT  (0x0)
+#define FUSE_CODESIZE_DEFAULT  (0x0)
+
+/* Fuse Byte 8 (BOOTSIZE) */
+#define FUSE8_DEFAULT  (0x0)
+#define FUSE_BOOTSIZE_DEFAULT  (0x0)
+
+/* ========== Lock Bits ========== */
+#define __LOCK_KEY_EXIST
+#ifdef LOCKBITS_DEFAULT
+#undef LOCKBITS_DEFAULT
+#endif //LOCKBITS_DEFAULT
+#define LOCKBITS_DEFAULT  (0x5CC5C55C)
+
+/* ========== Signature ========== */
+#define SIGNATURE_0 0x1E
+#define SIGNATURE_1 0x94
+#define SIGNATURE_2 0x37
+
+#endif /* #ifdef _AVR_AVR16EA28_H_INCLUDED */
+

--- a/include/avr/ioavr16ea32.h
+++ b/include/avr/ioavr16ea32.h
@@ -1,0 +1,5811 @@
+/*
+ * Copyright (C) 2023, Microchip Technology Inc. and its subsidiaries ("Microchip")
+ * All rights reserved.
+ *
+ * This software is developed by Microchip Technology Inc. and its subsidiaries ("Microchip").
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other
+ *        materials provided with the distribution. Publication is not required when
+ *        this file is used in an embedded application.
+ *
+ *     3. Microchip's name may not be used to endorse or promote products derived from this
+ *        software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY MICROCHIP "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL MICROCHIP BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING BUT NOT LIMITED TO
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWSOEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _AVR_IO_H_
+#  error "Include <avr/io.h> instead of this file."
+#endif
+
+#ifndef _AVR_IOXXX_H_
+#  define _AVR_IOXXX_H_ "ioavr16ea32.h"
+#else
+#  error "Attempt to include more than one <avr/ioXXX.h> file."
+#endif
+
+#ifndef _AVR_AVR16EA32_H_INCLUDED
+#define _AVR_AVR16EA32_H_INCLUDED
+
+/* Ungrouped common registers */
+#define CCP  _SFR_MEM8(0x0034)  /* Configuration Change Protection */
+#define SP  _SFR_MEM16(0x003D)  /* Stack Pointer */
+#define SPL  _SFR_MEM8(0x003D)  /* Stack Pointer Low */
+#define SPH  _SFR_MEM8(0x003E)  /* Stack Pointer High */
+#define SREG  _SFR_MEM8(0x003F)  /* Status Register */
+
+/* C Language Only */
+#if !defined (__ASSEMBLER__)
+
+#include <stdint.h>
+
+typedef volatile uint8_t register8_t;
+typedef volatile uint16_t register16_t;
+typedef volatile uint32_t register32_t;
+
+
+#ifdef _WORDREGISTER
+#undef _WORDREGISTER
+#endif
+#define _WORDREGISTER(regname)   \
+    __extension__ union \
+    { \
+        register16_t regname; \
+        struct \
+        { \
+            register8_t regname ## L; \
+            register8_t regname ## H; \
+        }; \
+    }
+
+#ifdef _DWORDREGISTER
+#undef _DWORDREGISTER
+#endif
+#define _DWORDREGISTER(regname)  \
+    __extension__ union \
+    { \
+        register32_t regname; \
+        struct \
+        { \
+            register8_t regname ## 0; \
+            register8_t regname ## 1; \
+            register8_t regname ## 2; \
+            register8_t regname ## 3; \
+        }; \
+    }
+
+
+/*
+==========================================================================
+IO Module Structures
+==========================================================================
+*/
+
+
+/*
+--------------------------------------------------------------------------
+AC - Analog Comparator
+--------------------------------------------------------------------------
+*/
+
+/* Analog Comparator */
+typedef struct AC_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t MUXCTRL;  /* Mux Control A */
+    register8_t reserved_1[2];
+    register8_t DACREF;  /* DAC Voltage Reference */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t STATUS;  /* Status */
+} AC_t;
+
+/* Hysteresis Mode select */
+typedef enum AC_HYSMODE_enum
+{
+    AC_HYSMODE_NONE_gc = (0x00<<1),  /* No hysteresis */
+    AC_HYSMODE_SMALL_gc = (0x01<<1),  /* Small hysteresis */
+    AC_HYSMODE_MEDIUM_gc = (0x02<<1),  /* Medium hysteresis */
+    AC_HYSMODE_LARGE_gc = (0x03<<1)  /* Large hysteresis */
+} AC_HYSMODE_t;
+
+/* AC Output Initial Value select */
+typedef enum AC_INITVAL_enum
+{
+    AC_INITVAL_LOW_gc = (0x00<<6),  /* Output initialized to 0 */
+    AC_INITVAL_HIGH_gc = (0x01<<6)  /* Output initialized to 1 */
+} AC_INITVAL_t;
+
+/* Interrupt Mode select */
+typedef enum AC_INTMODE_NORMAL_enum
+{
+    AC_INTMODE_NORMAL_BOTHEDGE_gc = (0x00<<4),  /* Positive and negative inputs crosses */
+    AC_INTMODE_NORMAL_NEGEDGE_gc = (0x02<<4),  /* Positive input goes below negative input */
+    AC_INTMODE_NORMAL_POSEDGE_gc = (0x03<<4)  /* Positive input goes above negative input */
+} AC_INTMODE_NORMAL_t;
+
+/* Interrupt Mode select */
+typedef enum AC_INTMODE_WINDOW_enum
+{
+    AC_INTMODE_WINDOW_ABOVE_gc = (0x00<<4),  /* Window interrupt when input above both references */
+    AC_INTMODE_WINDOW_INSIDE_gc = (0x01<<4),  /* Window interrupt when input betweeen references */
+    AC_INTMODE_WINDOW_BELOW_gc = (0x02<<4),  /* Window interrupt when input below both references */
+    AC_INTMODE_WINDOW_OUTSIDE_gc = (0x03<<4)  /* Window interrupt when input outside reference */
+} AC_INTMODE_WINDOW_t;
+
+/* Negative Input MUX Selection */
+typedef enum AC_MUXNEG_enum
+{
+    AC_MUXNEG_AINN0_gc = (0x00<<0),  /* Negative Pin 0 */
+    AC_MUXNEG_AINN1_gc = (0x01<<0),  /* Negative Pin 1 */
+    AC_MUXNEG_AINN2_gc = (0x02<<0),  /* Negative Pin 2 */
+    AC_MUXNEG_AINN3_gc = (0x03<<0),  /* Negative Pin 3 */
+    AC_MUXNEG_DACREF_gc = (0x04<<0)  /* DAC Reference */
+} AC_MUXNEG_t;
+
+/* Positive Input MUX Selection */
+typedef enum AC_MUXPOS_enum
+{
+    AC_MUXPOS_AINP0_gc = (0x00<<3),  /* Positive Pin 0 */
+    AC_MUXPOS_AINP1_gc = (0x01<<3),  /* Positive Pin 1 */
+    AC_MUXPOS_AINP2_gc = (0x02<<3),  /* Positive Pin 2 */
+    AC_MUXPOS_AINP3_gc = (0x03<<3),  /* Positive Pin 3 */
+    AC_MUXPOS_AINP4_gc = (0x04<<3)  /* Positive Pin 4 */
+} AC_MUXPOS_t;
+
+/* Power profile select */
+typedef enum AC_POWER_enum
+{
+    AC_POWER_PROFILE0_gc = (0x00<<3),  /* Power profile 0, Fastest response time, highest consumption */
+    AC_POWER_PROFILE1_gc = (0x01<<3)  /* Power profile 1 */
+} AC_POWER_t;
+
+/* Window selection mode */
+typedef enum AC_WINSEL_enum
+{
+    AC_WINSEL_DISABLED_gc = (0x00<<0),  /* Window function disabled */
+    AC_WINSEL_UPSEL1_gc = (0x01<<0)  /* Select ACn+1 as upper limit in window compare */
+} AC_WINSEL_t;
+
+/* Analog Comparator Window State select */
+typedef enum AC_WINSTATE_enum
+{
+    AC_WINSTATE_ABOVE_gc = (0x00<<6),  /* Above window */
+    AC_WINSTATE_INSIDE_gc = (0x01<<6),  /* Inside window */
+    AC_WINSTATE_BELOW_gc = (0x02<<6)  /* Below window */
+} AC_WINSTATE_t;
+
+/*
+--------------------------------------------------------------------------
+ADC - Analog to Digital Converter
+--------------------------------------------------------------------------
+*/
+
+/* Analog to Digital Converter */
+typedef struct ADC_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    register8_t CTRLD;  /* Control D */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t STATUS;  /* Status register */
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t CTRLE;  /* Control E */
+    register8_t CTRLF;  /* Control F */
+    register8_t COMMAND;  /* Command register */
+    register8_t PGACTRL;  /* PGA Control */
+    register8_t MUXPOS;  /* Positive Input Multiplexer */
+    register8_t MUXNEG;  /* Negative Input Multiplexer */
+    register8_t reserved_1[2];
+    _DWORDREGISTER(RESULT);  /* Result */
+    _WORDREGISTER(SAMPLE);  /* Sample */
+    register8_t reserved_2[2];
+    register8_t TEMP0;  /* Temporary Data 0 */
+    register8_t TEMP1;  /* Temporary Data 1 */
+    register8_t TEMP2;  /* Temporary Data 2 */
+    register8_t reserved_3[1];
+    _WORDREGISTER(WINLT);  /* Window Low Threshold */
+    _WORDREGISTER(WINHT);  /* Window High Threshold */
+    register8_t reserved_4[32];
+} ADC_t;
+
+/* Sign Chopping select */
+typedef enum ADC_CHOPPING_enum
+{
+    ADC_CHOPPING_DISABLE_gc = (0x00<<6),  /* Sign Chopping Disabled */
+    ADC_CHOPPING_ENABLE_gc = (0x01<<6)  /* Sign Chopping Enabled */
+} ADC_CHOPPING_t;
+
+/* Gain select */
+typedef enum ADC_GAIN_enum
+{
+    ADC_GAIN_1X_gc = (0x00<<5),  /* 1x gain */
+    ADC_GAIN_2X_gc = (0x01<<5),  /* 2x gain */
+    ADC_GAIN_4X_gc = (0x02<<5),  /* 4x gain */
+    ADC_GAIN_8X_gc = (0x03<<5),  /* 8x gain */
+    ADC_GAIN_16X_gc = (0x04<<5)  /* 16x gain */
+} ADC_GAIN_t;
+
+/* Mode select */
+typedef enum ADC_MODE_enum
+{
+    ADC_MODE_SINGLE_8BIT_gc = (0x00<<4),  /* Single Conversion with 8-bit resolution */
+    ADC_MODE_SINGLE_12BIT_gc = (0x01<<4),  /* Single Conversion with 12-bit resolution */
+    ADC_MODE_SERIES_gc = (0x02<<4),  /* Series with accumulation, separate trigger for every 12-bit conversion */
+    ADC_MODE_SERIES_SCALING_gc = (0x03<<4),  /* Series with accumulation and scaling, separate trigger for every 12-bit conversion */
+    ADC_MODE_BURST_gc = (0x04<<4),  /* Burst with accumulation, one trigger will run SAMPNUM 12-bit conversions */
+    ADC_MODE_BURST_SCALING_gc = (0x05<<4)  /* Burst with accumulation and scaling, one trigger will run SAMPNUM 12-bit conversions */
+} ADC_MODE_t;
+
+/* Analog Channel Selection Bits */
+typedef enum ADC_MUXNEG_enum
+{
+    ADC_MUXNEG_AIN0_gc = (0x00<<0),  /* ADC input pin 0 */
+    ADC_MUXNEG_AIN1_gc = (0x01<<0),  /* ADC input pin 1 */
+    ADC_MUXNEG_AIN2_gc = (0x02<<0),  /* ADC input pin 2 */
+    ADC_MUXNEG_AIN3_gc = (0x03<<0),  /* ADC input pin 3 */
+    ADC_MUXNEG_AIN4_gc = (0x04<<0),  /* ADC input pin 4 */
+    ADC_MUXNEG_AIN5_gc = (0x05<<0),  /* ADC input pin 5 */
+    ADC_MUXNEG_AIN6_gc = (0x06<<0),  /* ADC input pin 6 */
+    ADC_MUXNEG_AIN7_gc = (0x07<<0),  /* ADC input pin 7 */
+    ADC_MUXNEG_AIN16_gc = (0x10<<0),  /* ADC input pin 16 */
+    ADC_MUXNEG_AIN17_gc = (0x11<<0),  /* ADC input pin 17 */
+    ADC_MUXNEG_AIN18_gc = (0x12<<0),  /* ADC input pin 18 */
+    ADC_MUXNEG_AIN19_gc = (0x13<<0),  /* ADC input pin 19 */
+    ADC_MUXNEG_AIN20_gc = (0x14<<0),  /* ADC input pin 20 */
+    ADC_MUXNEG_AIN21_gc = (0x15<<0),  /* ADC input pin 21 */
+    ADC_MUXNEG_AIN22_gc = (0x16<<0),  /* ADC input pin 22 */
+    ADC_MUXNEG_AIN23_gc = (0x17<<0),  /* ADC input pin 23 */
+    ADC_MUXNEG_AIN24_gc = (0x18<<0),  /* ADC input pin 24 */
+    ADC_MUXNEG_AIN25_gc = (0x19<<0),  /* ADC input pin 25 */
+    ADC_MUXNEG_AIN26_gc = (0x1A<<0),  /* ADC input pin 26 */
+    ADC_MUXNEG_AIN27_gc = (0x1B<<0),  /* ADC input pin 27 */
+    ADC_MUXNEG_AIN28_gc = (0x1C<<0),  /* ADC input pin 28 */
+    ADC_MUXNEG_AIN29_gc = (0x1D<<0),  /* ADC input pin 29 */
+    ADC_MUXNEG_AIN30_gc = (0x1E<<0),  /* ADC input pin 30 */
+    ADC_MUXNEG_AIN31_gc = (0x1F<<0),  /* ADC input pin 31 */
+    ADC_MUXNEG_GND_gc = (0x30<<0),  /* Ground */
+    ADC_MUXNEG_DAC0_gc = (0x38<<0),  /* Digital to Analog Converter 0 */
+    ADC_MUXNEG_DACREF0_gc = (0x39<<0),  /* AC0 DAC reference */
+    ADC_MUXNEG_DACREF1_gc = (0x3A<<0)  /* AC1 DAC reference */
+} ADC_MUXNEG_t;
+
+/* Analog Channel Selection Bits */
+typedef enum ADC_MUXPOS_enum
+{
+    ADC_MUXPOS_AIN0_gc = (0x00<<0),  /* ADC input pin 0 */
+    ADC_MUXPOS_AIN1_gc = (0x01<<0),  /* ADC input pin 1 */
+    ADC_MUXPOS_AIN2_gc = (0x02<<0),  /* ADC input pin 2 */
+    ADC_MUXPOS_AIN3_gc = (0x03<<0),  /* ADC input pin 3 */
+    ADC_MUXPOS_AIN4_gc = (0x04<<0),  /* ADC input pin 4 */
+    ADC_MUXPOS_AIN5_gc = (0x05<<0),  /* ADC input pin 5 */
+    ADC_MUXPOS_AIN6_gc = (0x06<<0),  /* ADC input pin 6 */
+    ADC_MUXPOS_AIN7_gc = (0x07<<0),  /* ADC input pin 7 */
+    ADC_MUXPOS_AIN16_gc = (0x10<<0),  /* ADC input pin 16 */
+    ADC_MUXPOS_AIN17_gc = (0x11<<0),  /* ADC input pin 17 */
+    ADC_MUXPOS_AIN18_gc = (0x12<<0),  /* ADC input pin 18 */
+    ADC_MUXPOS_AIN19_gc = (0x13<<0),  /* ADC input pin 19 */
+    ADC_MUXPOS_AIN20_gc = (0x14<<0),  /* ADC input pin 20 */
+    ADC_MUXPOS_AIN21_gc = (0x15<<0),  /* ADC input pin 21 */
+    ADC_MUXPOS_AIN22_gc = (0x16<<0),  /* ADC input pin 22 */
+    ADC_MUXPOS_AIN23_gc = (0x17<<0),  /* ADC input pin 23 */
+    ADC_MUXPOS_AIN24_gc = (0x18<<0),  /* ADC input pin 24 */
+    ADC_MUXPOS_AIN25_gc = (0x19<<0),  /* ADC input pin 25 */
+    ADC_MUXPOS_AIN26_gc = (0x1A<<0),  /* ADC input pin 26 */
+    ADC_MUXPOS_AIN27_gc = (0x1B<<0),  /* ADC input pin 27 */
+    ADC_MUXPOS_AIN28_gc = (0x1C<<0),  /* ADC input pin 28 */
+    ADC_MUXPOS_AIN29_gc = (0x1D<<0),  /* ADC input pin 29 */
+    ADC_MUXPOS_AIN30_gc = (0x1E<<0),  /* ADC input pin 30 */
+    ADC_MUXPOS_AIN31_gc = (0x1F<<0),  /* ADC input pin 31 */
+    ADC_MUXPOS_GND_gc = (0x30<<0),  /* Ground */
+    ADC_MUXPOS_VDD10_gc = (0x31<<0),  /* VDD Divided by 10 */
+    ADC_MUXPOS_TEMPSENSE_gc = (0x32<<0),  /* Temperature Sensor */
+    ADC_MUXPOS_DAC0_gc = (0x38<<0)  /* Digital to Analog Converter 0 */
+} ADC_MUXPOS_t;
+
+/* PGA BIAS Select */
+typedef enum ADC_PGABIASSEL_enum
+{
+    ADC_PGABIASSEL_100PCT_gc = (0x00<<3),  /* 100% BIAS current. */
+    ADC_PGABIASSEL_75PCT_gc = (0x01<<3),  /* 75% BIAS current. Usable for CLK_ADC<4.5MHz */
+    ADC_PGABIASSEL_50PCT_gc = (0x02<<3),  /* 50% BIAS current. Usable for CLK_ADC<3MHz */
+    ADC_PGABIASSEL_25PCT_gc = (0x03<<3)  /* 25% BIAS current. Usable for CLK_ADC<1.5MHz */
+} ADC_PGABIASSEL_t;
+
+/* Prescaler Value select */
+typedef enum ADC_PRESC_enum
+{
+    ADC_PRESC_DIV2_gc = (0x00<<0),  /* System clock divided by 2 */
+    ADC_PRESC_DIV4_gc = (0x01<<0),  /* System clock divided by 4 */
+    ADC_PRESC_DIV6_gc = (0x02<<0),  /* System clock divided by 6 */
+    ADC_PRESC_DIV8_gc = (0x03<<0),  /* System clock divided by 8 */
+    ADC_PRESC_DIV10_gc = (0x04<<0),  /* System clock divided by 10 */
+    ADC_PRESC_DIV12_gc = (0x05<<0),  /* System clock divided by 12 */
+    ADC_PRESC_DIV14_gc = (0x06<<0),  /* System clock divided by 14 */
+    ADC_PRESC_DIV16_gc = (0x07<<0),  /* System clock divided by 16 */
+    ADC_PRESC_DIV20_gc = (0x08<<0),  /* System clock divided by 20 */
+    ADC_PRESC_DIV24_gc = (0x09<<0),  /* System clock divided by 24 */
+    ADC_PRESC_DIV28_gc = (0x0A<<0),  /* System clock divided by 28 */
+    ADC_PRESC_DIV32_gc = (0x0B<<0),  /* System clock divided by 32 */
+    ADC_PRESC_DIV40_gc = (0x0C<<0),  /* System clock divided by 40 */
+    ADC_PRESC_DIV48_gc = (0x0D<<0),  /* System clock divided by 48 */
+    ADC_PRESC_DIV56_gc = (0x0E<<0),  /* System clock divided by 56 */
+    ADC_PRESC_DIV64_gc = (0x0F<<0)  /* System clock divided by 64 */
+} ADC_PRESC_t;
+
+/* Reference select */
+typedef enum ADC_REFSEL_enum
+{
+    ADC_REFSEL_VDD_gc = (0x00<<0),  /* VDD */
+    ADC_REFSEL_VREFA_gc = (0x02<<0),  /* External Reference */
+    ADC_REFSEL_1V024_gc = (0x04<<0),  /* Internal 1.024V Reference */
+    ADC_REFSEL_2V048_gc = (0x05<<0),  /* Internal 2.048V Reference */
+    ADC_REFSEL_4V096_gc = (0x06<<0),  /* Internal 4.096V Reference */
+    ADC_REFSEL_2V500_gc = (0x07<<0)  /* Internal 2.500V Reference */
+} ADC_REFSEL_t;
+
+/* Sample numbers select */
+typedef enum ADC_SAMPNUM_enum
+{
+    ADC_SAMPNUM_NONE_gc = (0x00<<0),  /* No accumulation */
+    ADC_SAMPNUM_ACC2_gc = (0x01<<0),  /* 2 samples accumulated */
+    ADC_SAMPNUM_ACC4_gc = (0x02<<0),  /* 4 samples accumulated */
+    ADC_SAMPNUM_ACC8_gc = (0x03<<0),  /* 8 samples accumulated */
+    ADC_SAMPNUM_ACC16_gc = (0x04<<0),  /* 16 samples accumulated */
+    ADC_SAMPNUM_ACC32_gc = (0x05<<0),  /* 32 samples accumulated */
+    ADC_SAMPNUM_ACC64_gc = (0x06<<0),  /* 64 samples accumulated */
+    ADC_SAMPNUM_ACC128_gc = (0x07<<0),  /* 128 samples accumulated */
+    ADC_SAMPNUM_ACC256_gc = (0x08<<0),  /* 256 samples accumulated */
+    ADC_SAMPNUM_ACC512_gc = (0x09<<0),  /* 512 samples accumulated */
+    ADC_SAMPNUM_ACC1024_gc = (0x0A<<0)  /* 1024 samples accumulated */
+} ADC_SAMPNUM_t;
+
+/* Start command select */
+typedef enum ADC_START_enum
+{
+    ADC_START_STOP_gc = (0x00<<0),  /* Stop an ongoing conversion */
+    ADC_START_IMMEDIATE_gc = (0x01<<0),  /* Start a conversion immediately. This will be set back to STOP when the first conversion is done, unless Free-Running mode is enabled */
+    ADC_START_MUXPOS_WRITE_gc = (0x02<<0),  /* Start when MUXPOS register is written */
+    ADC_START_MUXNEG_WRITE_gc = (0x03<<0),  /* Start when MUXNEG register is written */
+    ADC_START_EVENT_TRIGGER_gc = (0x04<<0)  /* Start when an event is received */
+} ADC_START_t;
+
+/* VIA select */
+typedef enum ADC_VIA_enum
+{
+    ADC_VIA_DIRECT_gc = (0x00<<6),  /* Inputs connected directly to ADC */
+    ADC_VIA_PGA_gc = (0x01<<6)  /* Inputs connected via PGA */
+} ADC_VIA_t;
+
+/* Window Comparator Mode select */
+typedef enum ADC_WINCM_enum
+{
+    ADC_WINCM_NONE_gc = (0x00<<0),  /* No Window Comparison */
+    ADC_WINCM_BELOW_gc = (0x01<<0),  /* Below Window */
+    ADC_WINCM_ABOVE_gc = (0x02<<0),  /* Above Window */
+    ADC_WINCM_INSIDE_gc = (0x03<<0),  /* Inside Window */
+    ADC_WINCM_OUTSIDE_gc = (0x04<<0)  /* Outside Window */
+} ADC_WINCM_t;
+
+/* Window Mode Source select */
+typedef enum ADC_WINSRC_enum
+{
+    ADC_WINSRC_RESULT_gc = (0x00<<3),  /* Result register used as Window Comparator Source */
+    ADC_WINSRC_SAMPLE_gc = (0x01<<3)  /* Sample register used as Window Comparator Source */
+} ADC_WINSRC_t;
+
+/*
+--------------------------------------------------------------------------
+BOD - Bod interface
+--------------------------------------------------------------------------
+*/
+
+/* Bod interface */
+typedef struct BOD_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t reserved_1[6];
+    register8_t VLMCTRLA;  /* Voltage level monitor Control */
+    register8_t INTCTRL;  /* Voltage level monitor interrupt Control */
+    register8_t INTFLAGS;  /* Voltage level monitor interrupt Flags */
+    register8_t STATUS;  /* Voltage level monitor status */
+    register8_t reserved_2[4];
+} BOD_t;
+
+/* Operation in active mode select */
+typedef enum BOD_ACTIVE_enum
+{
+    BOD_ACTIVE_DISABLE_gc = (0x00<<2),  /* Disabled */
+    BOD_ACTIVE_ENABLED_gc = (0x01<<2),  /* Enabled in continuous mode */
+    BOD_ACTIVE_SAMPLED_gc = (0x02<<2),  /* Enabled in sampled mode */
+    BOD_ACTIVE_ENABLEWAIT_gc = (0x03<<2)  /* Enabled in continuous mode. Execution halted at wake-up until BOD is running */
+} BOD_ACTIVE_t;
+
+/* Bod level select */
+typedef enum BOD_LVL_enum
+{
+    BOD_LVL_BODLEVEL0_gc = (0x00<<0),  /* BOD Disabled during normal operation */
+    BOD_LVL_BODLEVEL1_gc = (0x01<<0),  /* 1.9 V */
+    BOD_LVL_BODLEVEL2_gc = (0x02<<0),  /* 2.7 V */
+    BOD_LVL_BODLEVEL3_gc = (0x03<<0)  /* 4.5 V */
+} BOD_LVL_t;
+
+/* Sample frequency select */
+typedef enum BOD_SAMPFREQ_enum
+{
+    BOD_SAMPFREQ_128HZ_gc = (0x00<<4),  /* Sampling frequency is 128 Hz */
+    BOD_SAMPFREQ_32HZ_gc = (0x01<<4)  /* Sample frequency is 32 Hz */
+} BOD_SAMPFREQ_t;
+
+/* Operation in sleep mode select */
+typedef enum BOD_SLEEP_enum
+{
+    BOD_SLEEP_DISABLE_gc = (0x00<<0),  /* Disabled */
+    BOD_SLEEP_ENABLE_gc = (0x01<<0),  /* Enabled in continuous mode */
+    BOD_SLEEP_SAMPLE_gc = (0x02<<0)  /* Enabled in sampled mode */
+} BOD_SLEEP_t;
+
+/* Configuration select */
+typedef enum BOD_VLMCFG_enum
+{
+    BOD_VLMCFG_FALLING_gc = (0x00<<1),  /* VDD falls below VLM threshold */
+    BOD_VLMCFG_RISING_gc = (0x01<<1),  /* VDD rises above VLM threshold */
+    BOD_VLMCFG_BOTH_gc = (0x02<<1)  /* VDD crosses VLM threshold */
+} BOD_VLMCFG_t;
+
+/* voltage level monitor level select */
+typedef enum BOD_VLMLVL_enum
+{
+    BOD_VLMLVL_OFF_gc = (0x00<<0),  /* VLM Disabled */
+    BOD_VLMLVL_5ABOVE_gc = (0x01<<0),  /* VLM threshold 5% above BOD level */
+    BOD_VLMLVL_15ABOVE_gc = (0x02<<0),  /* VLM threshold 15% above BOD level */
+    BOD_VLMLVL_25ABOVE_gc = (0x03<<0)  /* VLM threshold 25% above BOD level */
+} BOD_VLMLVL_t;
+
+/* Voltage level monitor status select */
+typedef enum BOD_VLMS_enum
+{
+    BOD_VLMS_ABOVE_gc = (0x00<<0),  /* The voltage is above the VLM threshold level */
+    BOD_VLMS_BELOW_gc = (0x01<<0)  /* The voltage is below the VLM threshold level */
+} BOD_VLMS_t;
+
+/*
+--------------------------------------------------------------------------
+CCL - Configurable Custom Logic
+--------------------------------------------------------------------------
+*/
+
+/* Configurable Custom Logic */
+typedef struct CCL_struct
+{
+    register8_t CTRLA;  /* Control Register A */
+    register8_t SEQCTRL0;  /* Sequential Control 0 */
+    register8_t SEQCTRL1;  /* Sequential Control 1 */
+    register8_t reserved_1[2];
+    register8_t INTCTRL0;  /* Interrupt Control 0 */
+    register8_t reserved_2[1];
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t LUT0CTRLA;  /* LUT 0 Control A */
+    register8_t LUT0CTRLB;  /* LUT 0 Control B */
+    register8_t LUT0CTRLC;  /* LUT 0 Control C */
+    register8_t TRUTH0;  /* Truth 0 */
+    register8_t LUT1CTRLA;  /* LUT 1 Control A */
+    register8_t LUT1CTRLB;  /* LUT 1 Control B */
+    register8_t LUT1CTRLC;  /* LUT 1 Control C */
+    register8_t TRUTH1;  /* Truth 1 */
+    register8_t LUT2CTRLA;  /* LUT 2 Control A */
+    register8_t LUT2CTRLB;  /* LUT 2 Control B */
+    register8_t LUT2CTRLC;  /* LUT 2 Control C */
+    register8_t TRUTH2;  /* Truth 2 */
+    register8_t LUT3CTRLA;  /* LUT 3 Control A */
+    register8_t LUT3CTRLB;  /* LUT 3 Control B */
+    register8_t LUT3CTRLC;  /* LUT 3 Control C */
+    register8_t TRUTH3;  /* Truth 3 */
+    register8_t reserved_3[40];
+} CCL_t;
+
+/* Clock Source Selection */
+typedef enum CCL_CLKSRC_enum
+{
+    CCL_CLKSRC_CLKPER_gc = (0x00<<1),  /* Peripheral Clock */
+    CCL_CLKSRC_IN2_gc = (0x01<<1),  /* INSEL2 selection */
+    CCL_CLKSRC_OSCHF_gc = (0x04<<1),  /* Internal High Frequency oscillator */
+    CCL_CLKSRC_OSC32K_gc = (0x05<<1),  /* Internal 32.768 kHz oscillator */
+    CCL_CLKSRC_OSC1K_gc = (0x06<<1)  /* Internal 32.768 kHz oscillator divided by 32 */
+} CCL_CLKSRC_t;
+
+/* Edge Detection Enable select */
+typedef enum CCL_EDGEDET_enum
+{
+    CCL_EDGEDET_DIS_gc = (0x00<<7),  /* Edge detector is disabled */
+    CCL_EDGEDET_EN_gc = (0x01<<7)  /* Edge detector is enabled */
+} CCL_EDGEDET_t;
+
+/* Filter Selection */
+typedef enum CCL_FILTSEL_enum
+{
+    CCL_FILTSEL_DISABLE_gc = (0x00<<4),  /* Filter disabled */
+    CCL_FILTSEL_SYNCH_gc = (0x01<<4),  /* Synchronizer enabled */
+    CCL_FILTSEL_FILTER_gc = (0x02<<4)  /* Filter enabled */
+} CCL_FILTSEL_t;
+
+/* LUT Input 0 Source Selection */
+typedef enum CCL_INSEL0_enum
+{
+    CCL_INSEL0_MASK_gc = (0x00<<0),  /* Masked input */
+    CCL_INSEL0_FEEDBACK_gc = (0x01<<0),  /* Feedback input */
+    CCL_INSEL0_LINK_gc = (0x02<<0),  /* Output from LUT[n+1] as input source */
+    CCL_INSEL0_EVENTA_gc = (0x03<<0),  /* Event A as input source */
+    CCL_INSEL0_EVENTB_gc = (0x04<<0),  /* Event B as input source */
+    CCL_INSEL0_IO_gc = (0x05<<0),  /* IN0 input source */
+    CCL_INSEL0_AC0_gc = (0x06<<0),  /* AC0 output input source */
+    CCL_INSEL0_USART0_gc = (0x07<<0),  /* USART0 TxD input source */
+    CCL_INSEL0_SPI0_gc = (0x08<<0),  /* SPI0 MISO input source */
+    CCL_INSEL0_TCA0_gc = (0x09<<0),  /* TCA0 WO0 input source */
+    CCL_INSEL0_TCA1_gc = (0x0A<<0),  /* TCA1 WO0 input source */
+    CCL_INSEL0_TCB0_gc = (0x0B<<0)  /* TCB0 WO input source */
+} CCL_INSEL0_t;
+
+/* LUT Input 1 Source Selection */
+typedef enum CCL_INSEL1_enum
+{
+    CCL_INSEL1_MASK_gc = (0x00<<4),  /* Masked input */
+    CCL_INSEL1_FEEDBACK_gc = (0x01<<4),  /* Feedback input */
+    CCL_INSEL1_LINK_gc = (0x02<<4),  /* Output from LUT[n+1] as input source */
+    CCL_INSEL1_EVENTA_gc = (0x03<<4),  /* Event A as input source */
+    CCL_INSEL1_EVENTB_gc = (0x04<<4),  /* Event B as input source */
+    CCL_INSEL1_IO_gc = (0x05<<4),  /* IN0 input source */
+    CCL_INSEL1_AC1_gc = (0x06<<4),  /* AC1 output input source */
+    CCL_INSEL1_USART1_gc = (0x07<<4),  /* USART1 TxD input source */
+    CCL_INSEL1_SPI0_gc = (0x08<<4),  /* SPI0 MISO input source */
+    CCL_INSEL1_TCA0_gc = (0x09<<4),  /* TCA0 WO1 input source */
+    CCL_INSEL1_TCA1_gc = (0x0A<<4),  /* TCA1 WO1 input source */
+    CCL_INSEL1_TCB1_gc = (0x0B<<4)  /* TCB1 WO input source */
+} CCL_INSEL1_t;
+
+/* LUT Input 2 Source Selection */
+typedef enum CCL_INSEL2_enum
+{
+    CCL_INSEL2_MASK_gc = (0x00<<0),  /* Masked input */
+    CCL_INSEL2_FEEDBACK_gc = (0x01<<0),  /* Feedback input */
+    CCL_INSEL2_LINK_gc = (0x02<<0),  /* Output from LUT[n+1] as input source */
+    CCL_INSEL2_EVENTA_gc = (0x03<<0),  /* Event A as input source */
+    CCL_INSEL2_EVENTB_gc = (0x04<<0),  /* Event B as input source */
+    CCL_INSEL2_IO_gc = (0x05<<0),  /* IN0 input source */
+    CCL_INSEL2_AC1_gc = (0x06<<0),  /* AC1 output input source */
+    CCL_INSEL2_USART2_gc = (0x07<<0),  /* USART2 TxD input source */
+    CCL_INSEL2_SPI0_gc = (0x08<<0),  /* SPI0 MISO input source */
+    CCL_INSEL2_TCA0_gc = (0x09<<0),  /* TCA0 WO2 input source */
+    CCL_INSEL2_TCA1_gc = (0x0A<<0),  /* TCA1 WO2 input source */
+    CCL_INSEL2_TCB2_gc = (0x0B<<0)  /* TCB2 WO input source */
+} CCL_INSEL2_t;
+
+/* Interrupt Mode for LUT0 select */
+typedef enum CCL_INTMODE0_enum
+{
+    CCL_INTMODE0_INTDISABLE_gc = (0x00<<0),  /* Interrupt disabled */
+    CCL_INTMODE0_RISING_gc = (0x01<<0),  /* Sense rising edge */
+    CCL_INTMODE0_FALLING_gc = (0x02<<0),  /* Sense falling edge */
+    CCL_INTMODE0_BOTH_gc = (0x03<<0)  /* Sense both edges */
+} CCL_INTMODE0_t;
+
+/* Interrupt Mode for LUT1 select */
+typedef enum CCL_INTMODE1_enum
+{
+    CCL_INTMODE1_INTDISABLE_gc = (0x00<<2),  /* Interrupt disabled */
+    CCL_INTMODE1_RISING_gc = (0x01<<2),  /* Sense rising edge */
+    CCL_INTMODE1_FALLING_gc = (0x02<<2),  /* Sense falling edge */
+    CCL_INTMODE1_BOTH_gc = (0x03<<2)  /* Sense both edges */
+} CCL_INTMODE1_t;
+
+/* Interrupt Mode for LUT2 select */
+typedef enum CCL_INTMODE2_enum
+{
+    CCL_INTMODE2_INTDISABLE_gc = (0x00<<4),  /* Interrupt disabled */
+    CCL_INTMODE2_RISING_gc = (0x01<<4),  /* Sense rising edge */
+    CCL_INTMODE2_FALLING_gc = (0x02<<4),  /* Sense falling edge */
+    CCL_INTMODE2_BOTH_gc = (0x03<<4)  /* Sense both edges */
+} CCL_INTMODE2_t;
+
+/* Interrupt Mode for LUT3 select */
+typedef enum CCL_INTMODE3_enum
+{
+    CCL_INTMODE3_INTDISABLE_gc = (0x00<<6),  /* Interrupt disabled */
+    CCL_INTMODE3_RISING_gc = (0x01<<6),  /* Sense rising edge */
+    CCL_INTMODE3_FALLING_gc = (0x02<<6),  /* Sense falling edge */
+    CCL_INTMODE3_BOTH_gc = (0x03<<6)  /* Sense both edges */
+} CCL_INTMODE3_t;
+
+/* Sequential Selection */
+typedef enum CCL_SEQSEL_enum
+{
+    CCL_SEQSEL_DISABLE_gc = (0x00<<0),  /* Sequential logic disabled */
+    CCL_SEQSEL_DFF_gc = (0x01<<0),  /* D FlipFlop */
+    CCL_SEQSEL_JK_gc = (0x02<<0),  /* JK FlipFlop */
+    CCL_SEQSEL_LATCH_gc = (0x03<<0),  /* D Latch */
+    CCL_SEQSEL_RS_gc = (0x04<<0)  /* RS Latch */
+} CCL_SEQSEL_t;
+
+/*
+--------------------------------------------------------------------------
+CLKCTRL - Clock controller
+--------------------------------------------------------------------------
+*/
+
+/* Clock controller */
+typedef struct CLKCTRL_struct
+{
+    register8_t MCLKCTRLA;  /* MCLK Control A */
+    register8_t MCLKCTRLB;  /* MCLK Control B */
+    register8_t MCLKCTRLC;  /* MCLK Control C */
+    register8_t MCLKINTCTRL;  /* MCLK Interrupt Control */
+    register8_t MCLKINTFLAGS;  /* MCLK Interrupt Flags */
+    register8_t MCLKSTATUS;  /* MCLK Status */
+    register8_t MCLKTIMEBASE;  /* MCLK Timebase */
+    register8_t reserved_1[1];
+    register8_t OSCHFCTRLA;  /* OSCHF Control A */
+    register8_t OSCHFTUNE;  /* OSCHF Tune */
+    register8_t reserved_2[14];
+    register8_t OSC32KCTRLA;  /* OSC32K Control A */
+    register8_t reserved_3[3];
+    register8_t XOSC32KCTRLA;  /* XOSC32K Control A */
+    register8_t reserved_4[3];
+    register8_t XOSCHFCTRLA;  /* XOSCHF Control A */
+} CLKCTRL_t;
+
+/* Automatic Oscillator Tune select */
+typedef enum CLKCTRL_AUTOTUNE_enum
+{
+    CLKCTRL_AUTOTUNE_OFF_gc = (0x00<<0),  /* Disabled */
+    CLKCTRL_AUTOTUNE_XOSC32K_gc = (0x01<<0)  /* Tune against 32.768 kHz Crystal Oscillator */
+} CLKCTRL_AUTOTUNE_t;
+
+/* CFD Source select */
+typedef enum CLKCTRL_CFDSRC_enum
+{
+    CLKCTRL_CFDSRC_CLKMAIN_gc = (0x00<<2),  /* Main Clock */
+    CLKCTRL_CFDSRC_XOSCHF_gc = (0x01<<2),  /* High Frequency Crystal Oscillator */
+    CLKCTRL_CFDSRC_XOSC32K_gc = (0x02<<2)  /* 32.768 kHz Crystal Oscillator */
+} CLKCTRL_CFDSRC_t;
+
+/* Clock select */
+typedef enum CLKCTRL_CLKSEL_enum
+{
+    CLKCTRL_CLKSEL_OSCHF_gc = (0x00<<0),  /* Internal high-frequency oscillator */
+    CLKCTRL_CLKSEL_OSC32K_gc = (0x01<<0),  /* Internal 32.768 kHz oscillator */
+    CLKCTRL_CLKSEL_XOSC32K_gc = (0x02<<0),  /* 32.768 kHz crystal oscillator */
+    CLKCTRL_CLKSEL_EXTCLK_gc = (0x03<<0)  /* External clock */
+} CLKCTRL_CLKSEL_t;
+
+/* Crystal startup time select */
+typedef enum CLKCTRL_CSUT_enum
+{
+    CLKCTRL_CSUT_1K_gc = (0x00<<4),  /* 1k cycles */
+    CLKCTRL_CSUT_16K_gc = (0x01<<4),  /* 16k cycles */
+    CLKCTRL_CSUT_32K_gc = (0x02<<4),  /* 32k cycles */
+    CLKCTRL_CSUT_64K_gc = (0x03<<4)  /* 64k cycles */
+} CLKCTRL_CSUT_t;
+
+/* Start-Up Time select */
+typedef enum CLKCTRL_CSUTHF_enum
+{
+    CLKCTRL_CSUTHF_256CYC_gc = (0x00<<4),  /* 256 XOSCHF Cycles */
+    CLKCTRL_CSUTHF_1KCYC_gc = (0x01<<4),  /* 1K XOSCHF Cycles */
+    CLKCTRL_CSUTHF_4KCYC_gc = (0x02<<4)  /* 4K XOSCHF Cycles */
+} CLKCTRL_CSUTHF_t;
+
+/* Interrupt Type select */
+typedef enum CLKCTRL_INTTYPE_enum
+{
+    CLKCTRL_INTTYPE_INT_gc = (0x00<<7),  /* Regular interrupt */
+    CLKCTRL_INTTYPE_NMI_gc = (0x01<<7)  /* Non-maskable interrupt */
+} CLKCTRL_INTTYPE_t;
+
+/* Prescaler division select */
+typedef enum CLKCTRL_PDIV_enum
+{
+    CLKCTRL_PDIV_DIV2_gc = (0x00<<1),  /* Divide by 2 */
+    CLKCTRL_PDIV_DIV4_gc = (0x01<<1),  /* Divide by 4 */
+    CLKCTRL_PDIV_DIV8_gc = (0x02<<1),  /* Divide by 8 */
+    CLKCTRL_PDIV_DIV16_gc = (0x03<<1),  /* Divide by 16 */
+    CLKCTRL_PDIV_DIV32_gc = (0x04<<1),  /* Divide by 32 */
+    CLKCTRL_PDIV_DIV64_gc = (0x05<<1),  /* Divide by 64 */
+    CLKCTRL_PDIV_DIV6_gc = (0x08<<1),  /* Divide by 6 */
+    CLKCTRL_PDIV_DIV10_gc = (0x09<<1),  /* Divide by 10 */
+    CLKCTRL_PDIV_DIV12_gc = (0x0A<<1),  /* Divide by 12 */
+    CLKCTRL_PDIV_DIV24_gc = (0x0B<<1),  /* Divide by 24 */
+    CLKCTRL_PDIV_DIV48_gc = (0x0C<<1)  /* Divide by 48 */
+} CLKCTRL_PDIV_t;
+
+/* Source Select */
+typedef enum CLKCTRL_SELHF_enum
+{
+    CLKCTRL_SELHF_CRYSTAL_gc = (0x00<<1),  /* External Crystal */
+    CLKCTRL_SELHF_EXTCLK_gc = (0x01<<1)  /* Extenal Clock on XTALHF1 pin */
+} CLKCTRL_SELHF_t;
+
+/*
+--------------------------------------------------------------------------
+CPU - CPU
+--------------------------------------------------------------------------
+*/
+
+#define CORE_VERSION  V4S
+
+/* CCP signature select */
+typedef enum CCP_enum
+{
+    CCP_SPM_gc = (0x9D<<0),  /* SPM Instruction Protection */
+    CCP_IOREG_gc = (0xD8<<0)  /* IO Register Protection */
+} CCP_t;
+
+/*
+--------------------------------------------------------------------------
+CPUINT - Interrupt Controller
+--------------------------------------------------------------------------
+*/
+
+/* Interrupt Controller */
+typedef struct CPUINT_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t STATUS;  /* Status */
+    register8_t LVL0PRI;  /* Interrupt Level 0 Priority */
+    register8_t LVL1VEC;  /* Interrupt Level 1 Priority Vector */
+} CPUINT_t;
+
+
+/*
+--------------------------------------------------------------------------
+CRCSCAN - CRCSCAN
+--------------------------------------------------------------------------
+*/
+
+/* CRCSCAN */
+typedef struct CRCSCAN_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t STATUS;  /* Status */
+    register8_t reserved_1[13];
+} CRCSCAN_t;
+
+/* CRC Source select */
+typedef enum CRCSCAN_SRC_enum
+{
+    CRCSCAN_SRC_FLASH_gc = (0x00<<0),  /* CRC on entire flash */
+    CRCSCAN_SRC_APPLICATION_gc = (0x01<<0),  /* CRC on boot and appl section of flash */
+    CRCSCAN_SRC_BOOT_gc = (0x02<<0)  /* CRC on boot section of flash */
+} CRCSCAN_SRC_t;
+
+/*
+--------------------------------------------------------------------------
+DAC - Digital to Analog Converter
+--------------------------------------------------------------------------
+*/
+
+/* Digital to Analog Converter */
+typedef struct DAC_struct
+{
+    register8_t CTRLA;  /* Control Register A */
+    register8_t reserved_1[1];
+    _WORDREGISTER(DATA);  /* DATA Register */
+    register8_t reserved_2[12];
+} DAC_t;
+
+/* Output Buffer Range select */
+typedef enum DAC_OUTRANGE_enum
+{
+    DAC_OUTRANGE_AUTO_gc = (0x00<<4),  /* Output buffer automatically choose best range */
+    DAC_OUTRANGE_LOW_gc = (0x02<<4),  /* Output buffer configured to low range */
+    DAC_OUTRANGE_HIGH_gc = (0x03<<4)  /* Output buffer configured to high range */
+} DAC_OUTRANGE_t;
+
+/*
+--------------------------------------------------------------------------
+EVSYS - Event System
+--------------------------------------------------------------------------
+*/
+
+/* Event System */
+typedef struct EVSYS_struct
+{
+    register8_t SWEVENTA;  /* Software Event A */
+    register8_t reserved_1[15];
+    register8_t CHANNEL0;  /* Multiplexer Channel 0 */
+    register8_t CHANNEL1;  /* Multiplexer Channel 1 */
+    register8_t CHANNEL2;  /* Multiplexer Channel 2 */
+    register8_t CHANNEL3;  /* Multiplexer Channel 3 */
+    register8_t CHANNEL4;  /* Multiplexer Channel 4 */
+    register8_t CHANNEL5;  /* Multiplexer Channel 5 */
+    register8_t reserved_2[10];
+    register8_t USERCCLLUT0A;  /* CCL0 Event A */
+    register8_t USERCCLLUT0B;  /* CCL0 Event B */
+    register8_t USERCCLLUT1A;  /* CCL1 Event A */
+    register8_t USERCCLLUT1B;  /* CCL1 Event B */
+    register8_t USERCCLLUT2A;  /* CCL2 Event A */
+    register8_t USERCCLLUT2B;  /* CCL2 Event B */
+    register8_t USERCCLLUT3A;  /* CCL3 Event A */
+    register8_t USERCCLLUT3B;  /* CCL3 Event B */
+    register8_t USERADC0START;  /* ADC0 */
+    register8_t USEREVSYSEVOUTA;  /* EVOUTA */
+    register8_t reserved_3[1];
+    register8_t USEREVSYSEVOUTC;  /* EVOUTC */
+    register8_t USEREVSYSEVOUTD;  /* EVOUTD */
+    register8_t reserved_4[1];
+    register8_t USEREVSYSEVOUTF;  /* EVOUTF */
+    register8_t USERUSART0IRDA;  /* USART0 */
+    register8_t USERUSART1IRDA;  /* USART1 */
+    register8_t USERUSART2IRDA;  /* USART2 */
+    register8_t USERTCA0CNTA;  /* TCA0 Event A */
+    register8_t USERTCA0CNTB;  /* TCA0 Event B */
+    register8_t USERTCA1CNTA;  /* TCA1 Event A */
+    register8_t USERTCA1CNTB;  /* TCA1 Event B */
+    register8_t USERTCB0CAPT;  /* TCB0 Event A */
+    register8_t USERTCB0COUNT;  /* TCB0 Event B */
+    register8_t USERTCB1CAPT;  /* TCB1 Event A */
+    register8_t USERTCB1COUNT;  /* TCB1 Event B */
+    register8_t USERTCB2CAPT;  /* TCB2 Event A */
+    register8_t USERTCB2COUNT;  /* TCB2 Event B */
+    register8_t USERTCB3CAPT;  /* TCB3 Event A */
+    register8_t USERTCB3COUNT;  /* TCB3 Event B */
+    register8_t reserved_5[2];
+} EVSYS_t;
+
+/* Channel generator select */
+typedef enum EVSYS_CHANNEL_enum
+{
+    EVSYS_CHANNEL_OFF_gc = (0x00<<0),  /* Off */
+    EVSYS_CHANNEL_UPDI_SYNCH_gc = (0x01<<0),  /* UPDI SYNCH character */
+    EVSYS_CHANNEL_RTC_OVF_gc = (0x06<<0),  /* Real Time Counter overflow */
+    EVSYS_CHANNEL_RTC_CMP_gc = (0x07<<0),  /* Real Time Counter compare */
+    EVSYS_CHANNEL_RTC_PITEV0_gc = (0x08<<0),  /* Periodic Interrupt Timer Event 0 */
+    EVSYS_CHANNEL_RTC_PITEV1_gc = (0x09<<0),  /* Periodic Interrupt Timer Event 1 */
+    EVSYS_CHANNEL_CCL_LUT0_gc = (0x10<<0),  /* Configurable Custom Logic LUT0 */
+    EVSYS_CHANNEL_CCL_LUT1_gc = (0x11<<0),  /* Configurable Custom Logic LUT1 */
+    EVSYS_CHANNEL_CCL_LUT2_gc = (0x12<<0),  /* Configurable Custom Logic LUT2 */
+    EVSYS_CHANNEL_CCL_LUT3_gc = (0x13<<0),  /* Configurable Custom Logic LUT3 */
+    EVSYS_CHANNEL_AC0_OUT_gc = (0x20<<0),  /* Analog Comparator 0 out */
+    EVSYS_CHANNEL_AC1_OUT_gc = (0x21<<0),  /* Analog Comparator 1 out */
+    EVSYS_CHANNEL_ADC0_RES_gc = (0x24<<0),  /* ADC 0 Result Ready */
+    EVSYS_CHANNEL_ADC0_SAMP_gc = (0x25<<0),  /* ADC 0 Sample Ready */
+    EVSYS_CHANNEL_ADC0_WCMP_gc = (0x26<<0),  /* ADC 0 Window Compare */
+    EVSYS_CHANNEL_PORTA_EV0_gc = (0x40<<0),  /* Port A Event 0 */
+    EVSYS_CHANNEL_PORTA_EV1_gc = (0x41<<0),  /* Port A Event 1 */
+    EVSYS_CHANNEL_PORTC_EV0_gc = (0x44<<0),  /* Port C Event 0 */
+    EVSYS_CHANNEL_PORTC_EV1_gc = (0x45<<0),  /* Port C Event 1 */
+    EVSYS_CHANNEL_PORTD_EV0_gc = (0x46<<0),  /* Port D Event 0 */
+    EVSYS_CHANNEL_PORTD_EV1_gc = (0x47<<0),  /* Port D Event 1 */
+    EVSYS_CHANNEL_PORTF_EV0_gc = (0x4A<<0),  /* Port F Event 0 */
+    EVSYS_CHANNEL_PORTF_EV1_gc = (0x4B<<0),  /* Port F Event 1 */
+    EVSYS_CHANNEL_USART0_XCK_gc = (0x60<<0),  /* USART 0 XCK */
+    EVSYS_CHANNEL_USART1_XCK_gc = (0x61<<0),  /* USART 1 XCK */
+    EVSYS_CHANNEL_USART2_XCK_gc = (0x62<<0),  /* USART 2 XCK */
+    EVSYS_CHANNEL_SPI0_SCK_gc = (0x68<<0),  /* SPI 0 SCK */
+    EVSYS_CHANNEL_TCA0_OVF_LUNF_gc = (0x80<<0),  /* Timer/Counter A0 overflow / low byte timer underflow */
+    EVSYS_CHANNEL_TCA0_HUNF_gc = (0x81<<0),  /* Timer/Counter A0 high byte timer underflow */
+    EVSYS_CHANNEL_TCA0_CMP0_LCMP0_gc = (0x84<<0),  /* Timer/Counter A0 compare 0 / low byte timer compare 0 */
+    EVSYS_CHANNEL_TCA0_CMP1_LCMP1_gc = (0x85<<0),  /* Timer/Counter A0 compare 1 / low byte timer compare 1 */
+    EVSYS_CHANNEL_TCA0_CMP2_LCMP2_gc = (0x86<<0),  /* Timer/Counter A0 compare 2 / low byte timer compare 2 */
+    EVSYS_CHANNEL_TCA1_OVF_LUNF_gc = (0x88<<0),  /* Timer/Counter A1 overflow / low byte timer underflow */
+    EVSYS_CHANNEL_TCA1_HUNF_gc = (0x89<<0),  /* Timer/Counter A1 high byte timer underflow */
+    EVSYS_CHANNEL_TCA1_CMP0_LCMP0_gc = (0x8C<<0),  /* Timer/Counter A1 compare 0 / low byte timer compare 0 */
+    EVSYS_CHANNEL_TCA1_CMP1_LCMP1_gc = (0x8D<<0),  /* Timer/Counter A1 compare 1 / low byte timer compare 1 */
+    EVSYS_CHANNEL_TCA1_CMP2_LCMP2_gc = (0x8E<<0),  /* Timer/Counter A1 compare 2 / low byte timer compare 2 */
+    EVSYS_CHANNEL_TCB0_CAPT_gc = (0xA0<<0),  /* Timer/Counter B0 capture */
+    EVSYS_CHANNEL_TCB0_OVF_gc = (0xA1<<0),  /* Timer/Counter B0 overflow */
+    EVSYS_CHANNEL_TCB1_CAPT_gc = (0xA2<<0),  /* Timer/Counter B1 capture */
+    EVSYS_CHANNEL_TCB1_OVF_gc = (0xA3<<0),  /* Timer/Counter B1 overflow */
+    EVSYS_CHANNEL_TCB2_CAPT_gc = (0xA4<<0),  /* Timer/Counter B2 capture */
+    EVSYS_CHANNEL_TCB2_OVF_gc = (0xA5<<0),  /* Timer/Counter B2 overflow */
+    EVSYS_CHANNEL_TCB3_CAPT_gc = (0xA6<<0),  /* Timer/Counter B3 capture */
+    EVSYS_CHANNEL_TCB3_OVF_gc = (0xA7<<0)  /* Timer/Counter B3 overflow */
+} EVSYS_CHANNEL_t;
+
+/* Software event on channel select */
+typedef enum EVSYS_SWEVENTA_enum
+{
+    EVSYS_SWEVENTA_CH0_gc = (0x01<<0),  /* Software event on channel 0 */
+    EVSYS_SWEVENTA_CH1_gc = (0x02<<0),  /* Software event on channel 1 */
+    EVSYS_SWEVENTA_CH2_gc = (0x04<<0),  /* Software event on channel 2 */
+    EVSYS_SWEVENTA_CH3_gc = (0x08<<0),  /* Software event on channel 3 */
+    EVSYS_SWEVENTA_CH4_gc = (0x10<<0),  /* Software event on channel 4 */
+    EVSYS_SWEVENTA_CH5_gc = (0x20<<0),  /* Software event on channel 5 */
+    EVSYS_SWEVENTA_CH6_gc = (0x40<<0),  /* Software event on channel 6 */
+    EVSYS_SWEVENTA_CH7_gc = (0x80<<0)  /* Software event on channel 7 */
+} EVSYS_SWEVENTA_t;
+
+/* User channel select */
+typedef enum EVSYS_USER_enum
+{
+    EVSYS_USER_OFF_gc = (0x00<<0),  /* Off, No Eventsys Channel connected */
+    EVSYS_USER_CHANNEL0_gc = (0x01<<0),  /* Connect user to event channel 0 */
+    EVSYS_USER_CHANNEL1_gc = (0x02<<0),  /* Connect user to event channel 1 */
+    EVSYS_USER_CHANNEL2_gc = (0x03<<0),  /* Connect user to event channel 2 */
+    EVSYS_USER_CHANNEL3_gc = (0x04<<0),  /* Connect user to event channel 3 */
+    EVSYS_USER_CHANNEL4_gc = (0x05<<0),  /* Connect user to event channel 4 */
+    EVSYS_USER_CHANNEL5_gc = (0x06<<0)  /* Connect user to event channel 5 */
+} EVSYS_USER_t;
+
+/*
+--------------------------------------------------------------------------
+FUSE - Fuses
+--------------------------------------------------------------------------
+*/
+
+/* Fuses */
+typedef struct FUSE_struct
+{
+    register8_t WDTCFG;  /* Watchdog Configuration */
+    register8_t BODCFG;  /* BOD Configuration */
+    register8_t OSCCFG;  /* Oscillator Configuration */
+    register8_t reserved_1[2];
+    register8_t SYSCFG0;  /* System Configuration 0 */
+    register8_t SYSCFG1;  /* System Configuration 1 */
+    register8_t CODESIZE;  /* Code Section Size */
+    register8_t BOOTSIZE;  /* Boot Section Size */
+} FUSE_t;
+
+/* avr-libc typedef for avr/fuse.h */
+typedef FUSE_t NVM_FUSES_t;
+
+/* BOD Operation in Active Mode select */
+typedef enum ACTIVE_enum
+{
+    ACTIVE_DISABLE_gc = (0x00<<2),  /* Disabled */
+    ACTIVE_ENABLED_gc = (0x01<<2),  /* Enabled in continuous mode */
+    ACTIVE_SAMPLED_gc = (0x02<<2),  /* Enabled in sampled mode */
+    ACTIVE_ENABLEWAIT_gc = (0x03<<2)  /* Enabled in continuous mode. Execution halted at wake-up until BOD is running */
+} ACTIVE_t;
+
+/* CRC Select */
+typedef enum CRCSEL_enum
+{
+    CRCSEL_CRC16_gc = (0x00<<5),  /* Enable CRC16 */
+    CRCSEL_CRC32_gc = (0x01<<5)  /* Enable CRC32 */
+} CRCSEL_t;
+
+/* CRC Source select */
+typedef enum CRCSRC_enum
+{
+    CRCSRC_FLASH_gc = (0x00<<6),  /* CRC of full Flash (boot, application code and application data) */
+    CRCSRC_BOOT_gc = (0x01<<6),  /* CRC of boot section */
+    CRCSRC_BOOTAPP_gc = (0x02<<6),  /* CRC of application code and boot sections */
+    CRCSRC_NOCRC_gc = (0x03<<6)  /* No CRC */
+} CRCSRC_t;
+
+/* EEPROM Save select */
+typedef enum EESAVE_enum
+{
+    EESAVE_DISABLE_gc = (0x00<<0),  /* EEPROM content is erased during chip erase */
+    EESAVE_ENABLE_gc = (0x01<<0)  /* EEPROM content is preserved during chip erase */
+} EESAVE_t;
+
+/* BOD Level select */
+typedef enum LVL_enum
+{
+    LVL_BODLEVEL0_gc = (0x00<<5),  /* BOD Disabled during normal operation */
+    LVL_BODLEVEL1_gc = (0x01<<5),  /* 1.9 V */
+    LVL_BODLEVEL2_gc = (0x02<<5),  /* 2.7 V */
+    LVL_BODLEVEL3_gc = (0x03<<5)  /* 4.5 V */
+} LVL_t;
+
+/* High-frequency Oscillator Frequency select */
+typedef enum OSCHFFRQ_enum
+{
+    OSCHFFRQ_20M_gc = (0x00<<3),  /* OSCHF running at 20 MHz */
+    OSCHFFRQ_16M_gc = (0x01<<3)  /* OSCHF running at 16 MHz */
+} OSCHFFRQ_t;
+
+/* Watchdog Timeout Period select */
+typedef enum PERIOD_enum
+{
+    PERIOD_OFF_gc = (0x00<<0),  /* Watch-Dog timer Off */
+    PERIOD_8CLK_gc = (0x01<<0),  /* 8 cycles (8ms) */
+    PERIOD_16CLK_gc = (0x02<<0),  /* 16 cycles (16ms) */
+    PERIOD_32CLK_gc = (0x03<<0),  /* 32 cycles (32ms) */
+    PERIOD_64CLK_gc = (0x04<<0),  /* 64 cycles (64ms) */
+    PERIOD_128CLK_gc = (0x05<<0),  /* 128 cycles (0.128s) */
+    PERIOD_256CLK_gc = (0x06<<0),  /* 256 cycles (0.256s) */
+    PERIOD_512CLK_gc = (0x07<<0),  /* 512 cycles (0.512s) */
+    PERIOD_1KCLK_gc = (0x08<<0),  /* 1K cycles (1.0s) */
+    PERIOD_2KCLK_gc = (0x09<<0),  /* 2K cycles (2.0s) */
+    PERIOD_4KCLK_gc = (0x0A<<0),  /* 4K cycles (4.0s) */
+    PERIOD_8KCLK_gc = (0x0B<<0)  /* 8K cycles (8.0s) */
+} PERIOD_t;
+
+/* Reset Pin Configuration select */
+typedef enum RSTPINCFG_enum
+{
+    RSTPINCFG_NONE_gc = (0x00<<3),  /* No External Reset */
+    RSTPINCFG_RESET_gc = (0x01<<3)  /* PF6 configured as RESET pin */
+} RSTPINCFG_t;
+
+/* BOD Sample Frequency select */
+typedef enum SAMPFREQ_enum
+{
+    SAMPFREQ_128HZ_gc = (0x00<<4),  /* Sampling frequency is 128 Hz */
+    SAMPFREQ_32HZ_gc = (0x01<<4)  /* Sample frequency is 32 Hz */
+} SAMPFREQ_t;
+
+/* BOD Operation in Sleep Mode select */
+typedef enum SLEEP_enum
+{
+    SLEEP_DISABLE_gc = (0x00<<0),  /* Disabled */
+    SLEEP_ENABLE_gc = (0x01<<0),  /* Enabled in continuous mode */
+    SLEEP_SAMPLE_gc = (0x02<<0)  /* Enabled in sampled mode */
+} SLEEP_t;
+
+/* Startup Time select */
+typedef enum SUT_enum
+{
+    SUT_0MS_gc = (0x00<<0),  /* 0 ms */
+    SUT_1MS_gc = (0x01<<0),  /* 1 ms */
+    SUT_2MS_gc = (0x02<<0),  /* 2 ms */
+    SUT_4MS_gc = (0x03<<0),  /* 4 ms */
+    SUT_8MS_gc = (0x04<<0),  /* 8 ms */
+    SUT_16MS_gc = (0x05<<0),  /* 16 ms */
+    SUT_32MS_gc = (0x06<<0),  /* 32 ms */
+    SUT_64MS_gc = (0x07<<0)  /* 64 ms */
+} SUT_t;
+
+/* UPDI Pin Configuration select */
+typedef enum UPDIPINCFG_enum
+{
+    UPDIPINCFG_GPIO_gc = (0x00<<4),  /* PF7 Configured as GPIO pin */
+    UPDIPINCFG_UPDI_gc = (0x01<<4)  /* PF7 Configured as UPDI pin */
+} UPDIPINCFG_t;
+
+/* Watchdog Window Timeout Period select */
+typedef enum WINDOW_enum
+{
+    WINDOW_OFF_gc = (0x00<<4),  /* Window mode off */
+    WINDOW_8CLK_gc = (0x01<<4),  /* 8 cycles (8ms) */
+    WINDOW_16CLK_gc = (0x02<<4),  /* 16 cycles (16ms) */
+    WINDOW_32CLK_gc = (0x03<<4),  /* 32 cycles (32ms) */
+    WINDOW_64CLK_gc = (0x04<<4),  /* 64 cycles (64ms) */
+    WINDOW_128CLK_gc = (0x05<<4),  /* 128 cycles (0.128s) */
+    WINDOW_256CLK_gc = (0x06<<4),  /* 256 cycles (0.256s) */
+    WINDOW_512CLK_gc = (0x07<<4),  /* 512 cycles (0.512s) */
+    WINDOW_1KCLK_gc = (0x08<<4),  /* 1K cycles (1.0s) */
+    WINDOW_2KCLK_gc = (0x09<<4),  /* 2K cycles (2.0s) */
+    WINDOW_4KCLK_gc = (0x0A<<4),  /* 4K cycles (4.0s) */
+    WINDOW_8KCLK_gc = (0x0B<<4)  /* 8K cycles (8.0s) */
+} WINDOW_t;
+
+/*
+--------------------------------------------------------------------------
+GPR - General Purpose Registers
+--------------------------------------------------------------------------
+*/
+
+/* General Purpose Registers */
+typedef struct GPR_struct
+{
+    register8_t GPR0;  /* General Purpose Register 0 */
+    register8_t GPR1;  /* General Purpose Register 1 */
+    register8_t GPR2;  /* General Purpose Register 2 */
+    register8_t GPR3;  /* General Purpose Register 3 */
+} GPR_t;
+
+
+/*
+--------------------------------------------------------------------------
+LOCK - Lockbits
+--------------------------------------------------------------------------
+*/
+
+/* Lockbits */
+typedef struct LOCK_struct
+{
+    _DWORDREGISTER(KEY);  /* Lock Key Bits */
+} LOCK_t;
+
+/* Lock Key select */
+typedef enum LOCK_KEY_enum
+{
+    LOCK_KEY_NOLOCK_gc = (0x5CC5C55C<<0),  /* No locks */
+    LOCK_KEY_RWLOCK_gc = (0xA33A3AA3<<0)  /* Read and write lock */
+} LOCK_KEY_t;
+
+/*
+--------------------------------------------------------------------------
+NVMCTRL - Non-volatile Memory Controller
+--------------------------------------------------------------------------
+*/
+
+/* Non-volatile Memory Controller */
+typedef struct NVMCTRL_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t reserved_1[2];
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t STATUS;  /* Status */
+    register8_t reserved_2[1];
+    _WORDREGISTER(DATA);  /* Data */
+    register8_t reserved_3[2];
+    _DWORDREGISTER(ADDR);  /* Address */
+    register8_t reserved_4[48];
+} NVMCTRL_t;
+
+/* Command select */
+typedef enum NVMCTRL_CMD_enum
+{
+    NVMCTRL_CMD_NOCMD_gc = (0x00<<0),  /* No Command */
+    NVMCTRL_CMD_NOOP_gc = (0x01<<0),  /* No Operation */
+    NVMCTRL_CMD_FLPW_gc = (0x04<<0),  /* Flash Page Write */
+    NVMCTRL_CMD_FLPERW_gc = (0x05<<0),  /* Flash Page Erase and Write */
+    NVMCTRL_CMD_FLPER_gc = (0x08<<0),  /* Flash Page Erase */
+    NVMCTRL_CMD_FLMPER2_gc = (0x09<<0),  /* Flash 2-page erase enable */
+    NVMCTRL_CMD_FLMPER4_gc = (0x0A<<0),  /* Flash 4-page erase enable */
+    NVMCTRL_CMD_FLMPER8_gc = (0x0B<<0),  /* Flash 8-page erase enable */
+    NVMCTRL_CMD_FLMPER16_gc = (0x0C<<0),  /* Flash 16-page erase enable */
+    NVMCTRL_CMD_FLMPER32_gc = (0x0D<<0),  /* Flash 32-page erase enable */
+    NVMCTRL_CMD_FLPBCLR_gc = (0x0F<<0),  /* Flash Page Buffer Clear */
+    NVMCTRL_CMD_EEPW_gc = (0x14<<0),  /* EEPROM Page Write */
+    NVMCTRL_CMD_EEPERW_gc = (0x15<<0),  /* EEPROM Page Erase and Write */
+    NVMCTRL_CMD_EEPER_gc = (0x17<<0),  /* EEPROM Page Erase */
+    NVMCTRL_CMD_EEPBCLR_gc = (0x1F<<0),  /* EEPROM Page Buffer Clear */
+    NVMCTRL_CMD_CHER_gc = (0x20<<0),  /* Chip Erase Command (UPDI only) */
+    NVMCTRL_CMD_EECHER_gc = (0x30<<0)  /* EEPROM Erase Command (UPDI only) */
+} NVMCTRL_CMD_t;
+
+/* Write error select */
+typedef enum NVMCTRL_ERROR_enum
+{
+    NVMCTRL_ERROR_NOERROR_gc = (0x00<<4),  /* No Error */
+    NVMCTRL_ERROR_WRITEPROTECT_gc = (0x02<<4),  /* Attempt to program write protected area */
+    NVMCTRL_ERROR_CMDCOLLISION_gc = (0x03<<4),  /* Selecting new write command while write command already seleted */
+    NVMCTRL_ERROR_WRONGSECTION_gc = (0x04<<4)  /* Address cannot be written with selected command */
+} NVMCTRL_ERROR_t;
+
+/* Flash Mapping in Data space select */
+typedef enum NVMCTRL_FLMAP_enum
+{
+    NVMCTRL_FLMAP_SECTION0_gc = (0x00<<4),  /* Flash section 0, 0 - 32KB */
+    NVMCTRL_FLMAP_SECTION1_gc = (0x01<<4),  /* Flash section 1, 32 - 64KB */
+    NVMCTRL_FLMAP_SECTION2_gc = (0x02<<4),  /* Flash section 2, 64 - 96KB */
+    NVMCTRL_FLMAP_SECTION3_gc = (0x03<<4)  /* Flash section 3, 96 - 128KB */
+} NVMCTRL_FLMAP_t;
+
+/*
+--------------------------------------------------------------------------
+PORT - I/O Ports
+--------------------------------------------------------------------------
+*/
+
+/* I/O Ports */
+typedef struct PORT_struct
+{
+    register8_t DIR;  /* Data Direction */
+    register8_t DIRSET;  /* Data Direction Set */
+    register8_t DIRCLR;  /* Data Direction Clear */
+    register8_t DIRTGL;  /* Data Direction Toggle */
+    register8_t OUT;  /* Output Value */
+    register8_t OUTSET;  /* Output Value Set */
+    register8_t OUTCLR;  /* Output Value Clear */
+    register8_t OUTTGL;  /* Output Value Toggle */
+    register8_t IN;  /* Input Value */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t PORTCTRL;  /* Port Control */
+    register8_t PINCONFIG;  /* Pin Control Config */
+    register8_t PINCTRLUPD;  /* Pin Control Update */
+    register8_t PINCTRLSET;  /* Pin Control Set */
+    register8_t PINCTRLCLR;  /* Pin Control Clear */
+    register8_t reserved_1[1];
+    register8_t PIN0CTRL;  /* Pin 0 Control */
+    register8_t PIN1CTRL;  /* Pin 1 Control */
+    register8_t PIN2CTRL;  /* Pin 2 Control */
+    register8_t PIN3CTRL;  /* Pin 3 Control */
+    register8_t PIN4CTRL;  /* Pin 4 Control */
+    register8_t PIN5CTRL;  /* Pin 5 Control */
+    register8_t PIN6CTRL;  /* Pin 6 Control */
+    register8_t PIN7CTRL;  /* Pin 7 Control */
+    register8_t EVGENCTRL;  /* Event Generation Control */
+    register8_t reserved_2[7];
+} PORT_t;
+
+/* Event Generator 0 Select */
+typedef enum PORT_EVGEN0SEL_enum
+{
+    PORT_EVGEN0SEL_PIN0_gc = (0x00<<0),  /* Pin 0 used as event generator */
+    PORT_EVGEN0SEL_PIN1_gc = (0x01<<0),  /* Pin 1 used as event generator */
+    PORT_EVGEN0SEL_PIN2_gc = (0x02<<0),  /* Pin 2 used as event generator */
+    PORT_EVGEN0SEL_PIN3_gc = (0x03<<0),  /* Pin 3 used as event generator */
+    PORT_EVGEN0SEL_PIN4_gc = (0x04<<0),  /* Pin 4 used as event generator */
+    PORT_EVGEN0SEL_PIN5_gc = (0x05<<0),  /* Pin 5 used as event generator */
+    PORT_EVGEN0SEL_PIN6_gc = (0x06<<0),  /* Pin 6 used as event generator */
+    PORT_EVGEN0SEL_PIN7_gc = (0x07<<0)  /* Pin 7 used as event generator */
+} PORT_EVGEN0SEL_t;
+
+/* Event Generator 1 Select */
+typedef enum PORT_EVGEN1SEL_enum
+{
+    PORT_EVGEN1SEL_PIN0_gc = (0x00<<4),  /* Pin 0 used as event generator */
+    PORT_EVGEN1SEL_PIN1_gc = (0x01<<4),  /* Pin 1 used as event generator */
+    PORT_EVGEN1SEL_PIN2_gc = (0x02<<4),  /* Pin 2 used as event generator */
+    PORT_EVGEN1SEL_PIN3_gc = (0x03<<4),  /* Pin 3 used as event generator */
+    PORT_EVGEN1SEL_PIN4_gc = (0x04<<4),  /* Pin 4 used as event generator */
+    PORT_EVGEN1SEL_PIN5_gc = (0x05<<4),  /* Pin 5 used as event generator */
+    PORT_EVGEN1SEL_PIN6_gc = (0x06<<4),  /* Pin 6 used as event generator */
+    PORT_EVGEN1SEL_PIN7_gc = (0x07<<4)  /* Pin 7 used as event generator */
+} PORT_EVGEN1SEL_t;
+
+/* Input Level Select */
+typedef enum PORT_INLVL_enum
+{
+    PORT_INLVL_ST_gc = (0x00<<6),  /* Schmitt-Trigger input level */
+    PORT_INLVL_TTL_gc = (0x01<<6)  /* TTL Input level */
+} PORT_INLVL_t;
+
+/* Input/Sense Configuration select */
+typedef enum PORT_ISC_enum
+{
+    PORT_ISC_INTDISABLE_gc = (0x00<<0),  /* Interrupt disabled but input buffer enabled */
+    PORT_ISC_BOTHEDGES_gc = (0x01<<0),  /* Sense Both Edges */
+    PORT_ISC_RISING_gc = (0x02<<0),  /* Sense Rising Edge */
+    PORT_ISC_FALLING_gc = (0x03<<0),  /* Sense Falling Edge */
+    PORT_ISC_INPUT_DISABLE_gc = (0x04<<0),  /* Digital Input Buffer disabled */
+    PORT_ISC_LEVEL_gc = (0x05<<0)  /* Sense low Level */
+} PORT_ISC_t;
+
+/*
+--------------------------------------------------------------------------
+PORTMUX - Port Multiplexer
+--------------------------------------------------------------------------
+*/
+
+/* Port Multiplexer */
+typedef struct PORTMUX_struct
+{
+    register8_t EVSYSROUTEA;  /* EVSYS route A */
+    register8_t CCLROUTEA;  /* CCL route A */
+    register8_t USARTROUTEA;  /* USART route A */
+    register8_t USARTROUTEB;  /* USART route B */
+    register8_t reserved_1[1];
+    register8_t SPIROUTEA;  /* SPI route A */
+    register8_t TWIROUTEA;  /* TWI route A */
+    register8_t TCAROUTEA;  /* TCA route A */
+    register8_t TCBROUTEA;  /* TCB route A */
+    register8_t reserved_2[1];
+    register8_t ACROUTEA;  /* AC route A */
+    register8_t reserved_3[21];
+} PORTMUX_t;
+
+/* Analog Comparator 0 Output select */
+typedef enum PORTMUX_AC0_enum
+{
+    PORTMUX_AC0_DEFAULT_gc = (0x00<<0)  /* OUT: PA7 */
+} PORTMUX_AC0_t;
+
+/* Analog Comparator 1 Output select */
+typedef enum PORTMUX_AC1_enum
+{
+    PORTMUX_AC1_DEFAULT_gc = (0x00<<1)  /* OUT: PA7 */
+} PORTMUX_AC1_t;
+
+/* Event Output A select */
+typedef enum PORTMUX_EVOUTA_enum
+{
+    PORTMUX_EVOUTA_DEFAULT_gc = (0x00<<0),  /* EVOUTA: PA2 */
+    PORTMUX_EVOUTA_ALT1_gc = (0x01<<0)  /* EVOUTA: PA7 */
+} PORTMUX_EVOUTA_t;
+
+/* Event Output C select */
+typedef enum PORTMUX_EVOUTC_enum
+{
+    PORTMUX_EVOUTC_DEFAULT_gc = (0x00<<2)  /* EVOUTC: PC2 */
+} PORTMUX_EVOUTC_t;
+
+/* Event Output D select */
+typedef enum PORTMUX_EVOUTD_enum
+{
+    PORTMUX_EVOUTD_DEFAULT_gc = (0x00<<3),  /* EVOUTD: PD2 */
+    PORTMUX_EVOUTD_ALT1_gc = (0x01<<3)  /* EVOUTD: PD7 */
+} PORTMUX_EVOUTD_t;
+
+/* Event Output F select */
+typedef enum PORTMUX_EVOUTF_enum
+{
+    PORTMUX_EVOUTF_DEFAULT_gc = (0x00<<5),  /* EVOUTF: PF2 */
+    PORTMUX_EVOUTF_ALT1_gc = (0x01<<5)  /* EVOUTF: PF7 */
+} PORTMUX_EVOUTF_t;
+
+/* CCL Look-Up Table 0 Signals select */
+typedef enum PORTMUX_LUT0_enum
+{
+    PORTMUX_LUT0_DEFAULT_gc = (0x00<<0),  /* In: PA0, PA1, PA2, Out: PA3 */
+    PORTMUX_LUT0_ALT1_gc = (0x01<<0)  /* In: PA0, PA1, PA2, Out: PA6 */
+} PORTMUX_LUT0_t;
+
+/* CCL Look-Up Table 1 Signals select */
+typedef enum PORTMUX_LUT1_enum
+{
+    PORTMUX_LUT1_DEFAULT_gc = (0x00<<1),  /* In: PC0, PC1, PC2, Out: PC3 */
+    PORTMUX_LUT1_ALT1_gc = (0x01<<1)  /* In: PC0, PC1, PC2, Out: - */
+} PORTMUX_LUT1_t;
+
+/* CCL Look-Up Table 2 Signals select */
+typedef enum PORTMUX_LUT2_enum
+{
+    PORTMUX_LUT2_DEFAULT_gc = (0x00<<2),  /* In: PD0, PD1, PD2, Out: PD3 */
+    PORTMUX_LUT2_ALT1_gc = (0x01<<2)  /* In: PD0, PD1, PD2, Out: PD6 */
+} PORTMUX_LUT2_t;
+
+/* SPI0 Signals select */
+typedef enum PORTMUX_SPI0_enum
+{
+    PORTMUX_SPI0_DEFAULT_gc = (0x00<<0),  /* MOSI: PA4, MISO: PA5, SCK: PA6, SS: PA7 */
+    PORTMUX_SPI0_ALT3_gc = (0x03<<0),  /* MOSI: PA0, MISO: PA1, SCK: PC0, SS: PC1 */
+    PORTMUX_SPI0_ALT4_gc = (0x04<<0),  /* MOSI: PD4, MISO: PD5, SCK: PD6, SS: PD7 */
+    PORTMUX_SPI0_ALT5_gc = (0x05<<0),  /* MOSI: PC0, MISO: PC1, SCK: PC2, SS: PC3 */
+    PORTMUX_SPI0_ALT6_gc = (0x06<<0),  /* MOSI: PC1, MISO: PC2, SCK: PC3, SS: PF7 */
+    PORTMUX_SPI0_NONE_gc = (0x07<<0)  /* Not connected to any pins, SS set to 1 */
+} PORTMUX_SPI0_t;
+
+/* TCA0 Signals select */
+typedef enum PORTMUX_TCA0_enum
+{
+    PORTMUX_TCA0_PORTA_gc = (0x00<<0),  /* WOn: PA0, PA1, PA2, PA3, PA4, PA5 */
+    PORTMUX_TCA0_PORTC_gc = (0x02<<0),  /* WOn: PC0, PC1, PC2, PC3, -, - */
+    PORTMUX_TCA0_PORTD_gc = (0x03<<0),  /* WOn: PD0, PD1, PD2, PD3, PD4, PD5 */
+    PORTMUX_TCA0_PORTF_gc = (0x05<<0)  /* WOn: PF0, PF1, PF2, PF3, PF4, PF5 */
+} PORTMUX_TCA0_t;
+
+/* TCA1 Signals select */
+typedef enum PORTMUX_TCA1_enum
+{
+    PORTMUX_TCA1_PORTB_gc = (0x00<<3),  /* Not connected to any pins */
+    PORTMUX_TCA1_PORTA_gc = (0x04<<3),  /* WOn: PA4, PA5, PA6, -, -, - */
+    PORTMUX_TCA1_PORTD_gc = (0x05<<3)  /* WOn: PD4, PD5, PD6, -, -, - */
+} PORTMUX_TCA1_t;
+
+/* TCB0 Output select */
+typedef enum PORTMUX_TCB0_enum
+{
+    PORTMUX_TCB0_DEFAULT_gc = (0x00<<0),  /* WO: PA2 */
+    PORTMUX_TCB0_ALT1_gc = (0x01<<0)  /* WO: PF4 */
+} PORTMUX_TCB0_t;
+
+/* TCB1 Output select */
+typedef enum PORTMUX_TCB1_enum
+{
+    PORTMUX_TCB1_DEFAULT_gc = (0x00<<1),  /* WO: PA3 */
+    PORTMUX_TCB1_ALT1_gc = (0x01<<1)  /* WO: PF5 */
+} PORTMUX_TCB1_t;
+
+/* TCB2 Output select */
+typedef enum PORTMUX_TCB2_enum
+{
+    PORTMUX_TCB2_DEFAULT_gc = (0x00<<2)  /* WO: PC0 */
+} PORTMUX_TCB2_t;
+
+/* TCB3 Output select */
+typedef enum PORTMUX_TCB3_enum
+{
+    PORTMUX_TCB3_DEFAULT_gc = (0x00<<3),  /* Not connected to any pins */
+    PORTMUX_TCB3_ALT1_gc = (0x01<<3)  /* WO: PC1 */
+} PORTMUX_TCB3_t;
+
+/* TWI0 Signals select */
+typedef enum PORTMUX_TWI0_enum
+{
+    PORTMUX_TWI0_DEFAULT_gc = (0x00<<0),  /* SDA: PA2, SCL: PA3. Dual mode: SDA: PC2, SCL: PC3 */
+    PORTMUX_TWI0_ALT1_gc = (0x01<<0),  /* SDA: PA2, SCL: PA3. Dual mode: SDA: -, SCL: - */
+    PORTMUX_TWI0_ALT2_gc = (0x02<<0),  /* SDA: PC2, SCL: PC3. Dual mode: SDA: -, SCL: - */
+    PORTMUX_TWI0_ALT3_gc = (0x03<<0)  /* SDA: PA0, SCL: PA1. Dual mode: SDA: PC2, SCL: PC3 */
+} PORTMUX_TWI0_t;
+
+/* USART0 Routing select */
+typedef enum PORTMUX_USART0_enum
+{
+    PORTMUX_USART0_DEFAULT_gc = (0x00<<0),  /* TxD: PA0, RxD: PA1, XCK: PA2, XDIR: PA3 */
+    PORTMUX_USART0_ALT1_gc = (0x01<<0),  /* TxD: PA4, RxD: PA5, XCK: PA6, XDIR: PA7 */
+    PORTMUX_USART0_ALT2_gc = (0x02<<0),  /* TxD: PA2, RxD: PA3, XCK: -, XDIR: - */
+    PORTMUX_USART0_ALT3_gc = (0x03<<0),  /* TxD: PD4, RxD: PD5, XCK: PD6, XDIR: PD7 */
+    PORTMUX_USART0_ALT4_gc = (0x04<<0),  /* TxD: PC1, RxD: PC2, XCK: PC3, XDIR: - */
+    PORTMUX_USART0_NONE_gc = (0x05<<0)  /* Not connected to any pins */
+} PORTMUX_USART0_t;
+
+/* USART1 Routing select */
+typedef enum PORTMUX_USART1_enum
+{
+    PORTMUX_USART1_DEFAULT_gc = (0x00<<3),  /* TxD: PC0, RxD: PC1, XCK: PC2, XDIR: PC3 */
+    PORTMUX_USART1_ALT2_gc = (0x02<<3),  /* TxD: PD6, RxD: PD7, XCK: -, XDIR: - */
+    PORTMUX_USART1_NONE_gc = (0x03<<3)  /* Not connected to any pins */
+} PORTMUX_USART1_t;
+
+/* USART2 Routing select */
+typedef enum PORTMUX_USART2_enum
+{
+    PORTMUX_USART2_DEFAULT_gc = (0x00<<0),  /* TxD: PF0, RxD: PF1, XCK: PF2, XDIR: PF3 */
+    PORTMUX_USART2_ALT1_gc = (0x01<<0),  /* TxD: PF4, RxD: PF5, XCK: - , XDIR: - */
+    PORTMUX_USART2_NONE_gc = (0x03<<0)  /* Not connected to any pins */
+} PORTMUX_USART2_t;
+
+/*
+--------------------------------------------------------------------------
+RSTCTRL - Reset controller
+--------------------------------------------------------------------------
+*/
+
+/* Reset controller */
+typedef struct RSTCTRL_struct
+{
+    register8_t RSTFR;  /* Reset Flags */
+    register8_t SWRR;  /* Software Reset */
+    register8_t reserved_1[14];
+} RSTCTRL_t;
+
+
+/*
+--------------------------------------------------------------------------
+RTC - Real-Time Counter
+--------------------------------------------------------------------------
+*/
+
+/* Real-Time Counter */
+typedef struct RTC_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t STATUS;  /* Status */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t TEMP;  /* Temporary */
+    register8_t DBGCTRL;  /* Debug control */
+    register8_t CALIB;  /* Calibration */
+    register8_t CLKSEL;  /* Clock Select */
+    _WORDREGISTER(CNT);  /* Counter */
+    _WORDREGISTER(PER);  /* Period */
+    _WORDREGISTER(CMP);  /* Compare */
+    register8_t reserved_1[2];
+    register8_t PITCTRLA;  /* PIT Control A */
+    register8_t PITSTATUS;  /* PIT Status */
+    register8_t PITINTCTRL;  /* PIT Interrupt Control */
+    register8_t PITINTFLAGS;  /* PIT Interrupt Flags */
+    register8_t reserved_2[1];
+    register8_t PITDBGCTRL;  /* PIT Debug control */
+    register8_t PITEVGENCTRLA;  /* PIT Event Generation Control A */
+    register8_t reserved_3[9];
+} RTC_t;
+
+/* Clock Select */
+typedef enum RTC_CLKSEL_enum
+{
+    RTC_CLKSEL_OSC32K_gc = (0x00<<0),  /* Internal 32.768 kHz Oscillator */
+    RTC_CLKSEL_OSC1K_gc = (0x01<<0),  /* Internal 32.768 kHz Oscillator Divided by 32 */
+    RTC_CLKSEL_XOSC32K_gc = (0x02<<0),  /* 32.768 kHz Crystal Oscillator */
+    RTC_CLKSEL_EXTCLK_gc = (0x03<<0)  /* External Clock */
+} RTC_CLKSEL_t;
+
+/* Event Generation 0 Select */
+typedef enum RTC_EVGEN0SEL_enum
+{
+    RTC_EVGEN0SEL_OFF_gc = (0x00<<0),  /* No Event Generated */
+    RTC_EVGEN0SEL_DIV4_gc = (0x01<<0),  /* CLK_RTC divided by 4 */
+    RTC_EVGEN0SEL_DIV8_gc = (0x02<<0),  /* CLK_RTC divided by 8 */
+    RTC_EVGEN0SEL_DIV16_gc = (0x03<<0),  /* CLK_RTC divided by 16 */
+    RTC_EVGEN0SEL_DIV32_gc = (0x04<<0),  /* CLK_RTC divided by 32 */
+    RTC_EVGEN0SEL_DIV64_gc = (0x05<<0),  /* CLK_RTC divided by 64 */
+    RTC_EVGEN0SEL_DIV128_gc = (0x06<<0),  /* CLK_RTC divided by 128 */
+    RTC_EVGEN0SEL_DIV256_gc = (0x07<<0),  /* CLK_RTC divided by 256 */
+    RTC_EVGEN0SEL_DIV512_gc = (0x08<<0),  /* CLK_RTC divided by 512 */
+    RTC_EVGEN0SEL_DIV1024_gc = (0x09<<0),  /* CLK_RTC divided by 1024 */
+    RTC_EVGEN0SEL_DIV2048_gc = (0x0A<<0),  /* CLK_RTC divided by 2048 */
+    RTC_EVGEN0SEL_DIV4096_gc = (0x0B<<0),  /* CLK_RTC divided by 4096 */
+    RTC_EVGEN0SEL_DIV8192_gc = (0x0C<<0),  /* CLK_RTC divided by 8192 */
+    RTC_EVGEN0SEL_DIV16384_gc = (0x0D<<0),  /* CLK_RTC divided by 16384 */
+    RTC_EVGEN0SEL_DIV32768_gc = (0x0E<<0)  /* CLK_RTC divided by 32768 */
+} RTC_EVGEN0SEL_t;
+
+/* Event Generation 1 Select */
+typedef enum RTC_EVGEN1SEL_enum
+{
+    RTC_EVGEN1SEL_OFF_gc = (0x00<<4),  /* No Event Generated */
+    RTC_EVGEN1SEL_DIV4_gc = (0x01<<4),  /* CLK_RTC divided by 4 */
+    RTC_EVGEN1SEL_DIV8_gc = (0x02<<4),  /* CLK_RTC divided by 8 */
+    RTC_EVGEN1SEL_DIV16_gc = (0x03<<4),  /* CLK_RTC divided by 16 */
+    RTC_EVGEN1SEL_DIV32_gc = (0x04<<4),  /* CLK_RTC divided by 32 */
+    RTC_EVGEN1SEL_DIV64_gc = (0x05<<4),  /* CLK_RTC divided by 64 */
+    RTC_EVGEN1SEL_DIV128_gc = (0x06<<4),  /* CLK_RTC divided by 128 */
+    RTC_EVGEN1SEL_DIV256_gc = (0x07<<4),  /* CLK_RTC divided by 256 */
+    RTC_EVGEN1SEL_DIV512_gc = (0x08<<4),  /* CLK_RTC divided by 512 */
+    RTC_EVGEN1SEL_DIV1024_gc = (0x09<<4),  /* CLK_RTC divided by 1024 */
+    RTC_EVGEN1SEL_DIV2048_gc = (0x0A<<4),  /* CLK_RTC divided by 2048 */
+    RTC_EVGEN1SEL_DIV4096_gc = (0x0B<<4),  /* CLK_RTC divided by 4096 */
+    RTC_EVGEN1SEL_DIV8192_gc = (0x0C<<4),  /* CLK_RTC divided by 8192 */
+    RTC_EVGEN1SEL_DIV16384_gc = (0x0D<<4),  /* CLK_RTC divided by 16384 */
+    RTC_EVGEN1SEL_DIV32768_gc = (0x0E<<4)  /* CLK_RTC divided by 32768 */
+} RTC_EVGEN1SEL_t;
+
+/* Period select */
+typedef enum RTC_PERIOD_enum
+{
+    RTC_PERIOD_OFF_gc = (0x00<<3),  /* Off */
+    RTC_PERIOD_CYC4_gc = (0x01<<3),  /* RTC Clock Cycles 4 */
+    RTC_PERIOD_CYC8_gc = (0x02<<3),  /* RTC Clock Cycles 8 */
+    RTC_PERIOD_CYC16_gc = (0x03<<3),  /* RTC Clock Cycles 16 */
+    RTC_PERIOD_CYC32_gc = (0x04<<3),  /* RTC Clock Cycles 32 */
+    RTC_PERIOD_CYC64_gc = (0x05<<3),  /* RTC Clock Cycles 64 */
+    RTC_PERIOD_CYC128_gc = (0x06<<3),  /* RTC Clock Cycles 128 */
+    RTC_PERIOD_CYC256_gc = (0x07<<3),  /* RTC Clock Cycles 256 */
+    RTC_PERIOD_CYC512_gc = (0x08<<3),  /* RTC Clock Cycles 512 */
+    RTC_PERIOD_CYC1024_gc = (0x09<<3),  /* RTC Clock Cycles 1024 */
+    RTC_PERIOD_CYC2048_gc = (0x0A<<3),  /* RTC Clock Cycles 2048 */
+    RTC_PERIOD_CYC4096_gc = (0x0B<<3),  /* RTC Clock Cycles 4096 */
+    RTC_PERIOD_CYC8192_gc = (0x0C<<3),  /* RTC Clock Cycles 8192 */
+    RTC_PERIOD_CYC16384_gc = (0x0D<<3),  /* RTC Clock Cycles 16384 */
+    RTC_PERIOD_CYC32768_gc = (0x0E<<3)  /* RTC Clock Cycles 32768 */
+} RTC_PERIOD_t;
+
+/* Prescaling Factor select */
+typedef enum RTC_PRESCALER_enum
+{
+    RTC_PRESCALER_DIV1_gc = (0x00<<3),  /* RTC Clock / 1 */
+    RTC_PRESCALER_DIV2_gc = (0x01<<3),  /* RTC Clock / 2 */
+    RTC_PRESCALER_DIV4_gc = (0x02<<3),  /* RTC Clock / 4 */
+    RTC_PRESCALER_DIV8_gc = (0x03<<3),  /* RTC Clock / 8 */
+    RTC_PRESCALER_DIV16_gc = (0x04<<3),  /* RTC Clock / 16 */
+    RTC_PRESCALER_DIV32_gc = (0x05<<3),  /* RTC Clock / 32 */
+    RTC_PRESCALER_DIV64_gc = (0x06<<3),  /* RTC Clock / 64 */
+    RTC_PRESCALER_DIV128_gc = (0x07<<3),  /* RTC Clock / 128 */
+    RTC_PRESCALER_DIV256_gc = (0x08<<3),  /* RTC Clock / 256 */
+    RTC_PRESCALER_DIV512_gc = (0x09<<3),  /* RTC Clock / 512 */
+    RTC_PRESCALER_DIV1024_gc = (0x0A<<3),  /* RTC Clock / 1024 */
+    RTC_PRESCALER_DIV2048_gc = (0x0B<<3),  /* RTC Clock / 2048 */
+    RTC_PRESCALER_DIV4096_gc = (0x0C<<3),  /* RTC Clock / 4096 */
+    RTC_PRESCALER_DIV8192_gc = (0x0D<<3),  /* RTC Clock / 8192 */
+    RTC_PRESCALER_DIV16384_gc = (0x0E<<3),  /* RTC Clock / 16384 */
+    RTC_PRESCALER_DIV32768_gc = (0x0F<<3)  /* RTC Clock / 32768 */
+} RTC_PRESCALER_t;
+
+/*
+--------------------------------------------------------------------------
+SIGROW - Signature row
+--------------------------------------------------------------------------
+*/
+
+/* Signature row */
+typedef struct SIGROW_struct
+{
+    register8_t DEVICEID0;  /* Device ID Byte 0 */
+    register8_t DEVICEID1;  /* Device ID Byte 1 */
+    register8_t DEVICEID2;  /* Device ID Byte 2 */
+    register8_t reserved_1[1];
+    _WORDREGISTER(TEMPSENSE0);  /* Temperature Calibration 0 */
+    _WORDREGISTER(TEMPSENSE1);  /* Temperature Calibration 1 */
+    register8_t reserved_2[8];
+    register8_t SERNUM0;  /* Serial Number Byte 0 */
+    register8_t SERNUM1;  /* Serial Number Byte 1 */
+    register8_t SERNUM2;  /* Serial Number Byte 2 */
+    register8_t SERNUM3;  /* Serial Number Byte 3 */
+    register8_t SERNUM4;  /* Serial Number Byte 4 */
+    register8_t SERNUM5;  /* Serial Number Byte 5 */
+    register8_t SERNUM6;  /* Serial Number Byte 6 */
+    register8_t SERNUM7;  /* Serial Number Byte 7 */
+    register8_t SERNUM8;  /* Serial Number Byte 8 */
+    register8_t SERNUM9;  /* Serial Number Byte 9 */
+    register8_t SERNUM10;  /* Serial Number Byte 10 */
+    register8_t SERNUM11;  /* Serial Number Byte 11 */
+    register8_t SERNUM12;  /* Serial Number Byte 12 */
+    register8_t SERNUM13;  /* Serial Number Byte 13 */
+    register8_t SERNUM14;  /* Serial Number Byte 14 */
+    register8_t SERNUM15;  /* Serial Number Byte 15 */
+    register8_t reserved_3[32];
+} SIGROW_t;
+
+
+/*
+--------------------------------------------------------------------------
+SLPCTRL - Sleep Controller
+--------------------------------------------------------------------------
+*/
+
+/* Sleep Controller */
+typedef struct SLPCTRL_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t reserved_1[1];
+} SLPCTRL_t;
+
+/* Sleep mode select */
+typedef enum SLPCTRL_SMODE_enum
+{
+    SLPCTRL_SMODE_IDLE_gc = (0x00<<1),  /* Idle mode */
+    SLPCTRL_SMODE_STDBY_gc = (0x01<<1),  /* Standby Mode */
+    SLPCTRL_SMODE_PDOWN_gc = (0x02<<1)  /* Power-down Mode */
+} SLPCTRL_SMODE_t;
+
+#define SLEEP_MODE_IDLE (0x00<<1)
+#define SLEEP_MODE_STANDBY (0x01<<1)
+#define SLEEP_MODE_PWR_DOWN (0x02<<1)
+/*
+--------------------------------------------------------------------------
+SPI - Serial Peripheral Interface
+--------------------------------------------------------------------------
+*/
+
+/* Serial Peripheral Interface */
+typedef struct SPI_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t DATA;  /* Data */
+    register8_t reserved_1[3];
+} SPI_t;
+
+/* SPI Mode select */
+typedef enum SPI_MODE_enum
+{
+    SPI_MODE_0_gc = (0x00<<0),  /* SPI Mode 0 */
+    SPI_MODE_1_gc = (0x01<<0),  /* SPI Mode 1 */
+    SPI_MODE_2_gc = (0x02<<0),  /* SPI Mode 2 */
+    SPI_MODE_3_gc = (0x03<<0)  /* SPI Mode 3 */
+} SPI_MODE_t;
+
+/* Prescaler select */
+typedef enum SPI_PRESC_enum
+{
+    SPI_PRESC_DIV4_gc = (0x00<<1),  /* CLK_PER / 4 */
+    SPI_PRESC_DIV16_gc = (0x01<<1),  /* CLK_PER / 16 */
+    SPI_PRESC_DIV64_gc = (0x02<<1),  /* CLK_PER / 64 */
+    SPI_PRESC_DIV128_gc = (0x03<<1)  /* CLK_PER / 128 */
+} SPI_PRESC_t;
+
+/*
+--------------------------------------------------------------------------
+SYSCFG - System Configuration Registers
+--------------------------------------------------------------------------
+*/
+
+/* System Configuration Registers */
+typedef struct SYSCFG_struct
+{
+    register8_t reserved_1[1];
+    register8_t REVID;  /* Revision ID */
+    register8_t reserved_2[2];
+    register8_t OCDMCTRL;  /* OCD Message Control */
+    register8_t OCDMSTATUS;  /* OCD Message Status */
+    register8_t reserved_3[26];
+} SYSCFG_t;
+
+
+/*
+--------------------------------------------------------------------------
+TCA - 16-bit Timer/Counter Type A
+--------------------------------------------------------------------------
+*/
+
+/* 16-bit Timer/Counter Type A - Single Mode */
+typedef struct TCA_SINGLE_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    register8_t CTRLD;  /* Control D */
+    register8_t CTRLECLR;  /* Control E Clear */
+    register8_t CTRLESET;  /* Control E Set */
+    register8_t CTRLFCLR;  /* Control F Clear */
+    register8_t CTRLFSET;  /* Control F Set */
+    register8_t reserved_1[1];
+    register8_t EVCTRL;  /* Event Control */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t reserved_2[2];
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t TEMP;  /* Temporary data for 16-bit Access */
+    register8_t reserved_3[16];
+    _WORDREGISTER(CNT);  /* Count */
+    register8_t reserved_4[4];
+    _WORDREGISTER(PER);  /* Period */
+    _WORDREGISTER(CMP0);  /* Compare 0 */
+    _WORDREGISTER(CMP1);  /* Compare 1 */
+    _WORDREGISTER(CMP2);  /* Compare 2 */
+    register8_t reserved_5[8];
+    _WORDREGISTER(PERBUF);  /* Period Buffer */
+    _WORDREGISTER(CMP0BUF);  /* Compare 0 Buffer */
+    _WORDREGISTER(CMP1BUF);  /* Compare 1 Buffer */
+    _WORDREGISTER(CMP2BUF);  /* Compare 2 Buffer */
+    register8_t reserved_6[2];
+} TCA_SINGLE_t;
+
+/* 16-bit Timer/Counter Type A - Split Mode */
+typedef struct TCA_SPLIT_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    register8_t CTRLD;  /* Control D */
+    register8_t CTRLECLR;  /* Control E Clear */
+    register8_t CTRLESET;  /* Control E Set */
+    register8_t reserved_1[4];
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t reserved_2[2];
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t reserved_3[17];
+    register8_t LCNT;  /* Low Count */
+    register8_t HCNT;  /* High Count */
+    register8_t reserved_4[4];
+    register8_t LPER;  /* Low Period */
+    register8_t HPER;  /* High Period */
+    register8_t LCMP0;  /* Low Compare */
+    register8_t HCMP0;  /* High Compare */
+    register8_t LCMP1;  /* Low Compare */
+    register8_t HCMP1;  /* High Compare */
+    register8_t LCMP2;  /* Low Compare */
+    register8_t HCMP2;  /* High Compare */
+    register8_t reserved_5[18];
+} TCA_SPLIT_t;
+
+/* 16-bit Timer/Counter Type A */
+typedef union TCA_union
+{
+    TCA_SINGLE_t SINGLE;  /* Single Mode */
+    TCA_SPLIT_t SPLIT;  /* Split Mode */
+} TCA_t;
+
+/* Clock Selection */
+typedef enum TCA_SINGLE_CLKSEL_enum
+{
+    TCA_SINGLE_CLKSEL_DIV1_gc = (0x00<<1),  /* CLK_PER */
+    TCA_SINGLE_CLKSEL_DIV2_gc = (0x01<<1),  /* CLK_PER / 2 */
+    TCA_SINGLE_CLKSEL_DIV4_gc = (0x02<<1),  /* CLK_PER / 4 */
+    TCA_SINGLE_CLKSEL_DIV8_gc = (0x03<<1),  /* CLK_PER / 8 */
+    TCA_SINGLE_CLKSEL_DIV16_gc = (0x04<<1),  /* CLK_PER / 16 */
+    TCA_SINGLE_CLKSEL_DIV64_gc = (0x05<<1),  /* CLK_PER / 64 */
+    TCA_SINGLE_CLKSEL_DIV256_gc = (0x06<<1),  /* CLK_PER / 256 */
+    TCA_SINGLE_CLKSEL_DIV1024_gc = (0x07<<1)  /* CLK_PER / 1024 */
+} TCA_SINGLE_CLKSEL_t;
+
+/* Command select */
+typedef enum TCA_SINGLE_CMD_enum
+{
+    TCA_SINGLE_CMD_NONE_gc = (0x00<<2),  /* No Command */
+    TCA_SINGLE_CMD_UPDATE_gc = (0x01<<2),  /* Force Update */
+    TCA_SINGLE_CMD_RESTART_gc = (0x02<<2),  /* Force Restart */
+    TCA_SINGLE_CMD_RESET_gc = (0x03<<2)  /* Force Hard Reset */
+} TCA_SINGLE_CMD_t;
+
+/* Direction select */
+typedef enum TCA_SINGLE_DIR_enum
+{
+    TCA_SINGLE_DIR_UP_gc = (0x00<<0),  /* Count up */
+    TCA_SINGLE_DIR_DOWN_gc = (0x01<<0)  /* Count down */
+} TCA_SINGLE_DIR_t;
+
+/* Event Action A select */
+typedef enum TCA_SINGLE_EVACTA_enum
+{
+    TCA_SINGLE_EVACTA_CNT_POSEDGE_gc = (0x00<<1),  /* Count on positive edge event */
+    TCA_SINGLE_EVACTA_CNT_ANYEDGE_gc = (0x01<<1),  /* Count on any edge event */
+    TCA_SINGLE_EVACTA_CNT_HIGHLVL_gc = (0x02<<1),  /* Count on prescaled clock while event line is 1. */
+    TCA_SINGLE_EVACTA_UPDOWN_gc = (0x03<<1)  /* Count on prescaled clock. Event controls count direction. Up-count when event line is 0, down-count when event line is 1. */
+} TCA_SINGLE_EVACTA_t;
+
+/* Event Action B select */
+typedef enum TCA_SINGLE_EVACTB_enum
+{
+    TCA_SINGLE_EVACTB_NONE_gc = (0x00<<5),  /* No Action */
+    TCA_SINGLE_EVACTB_UPDOWN_gc = (0x03<<5),  /* Count on prescaled clock. Event controls count direction. Up-count when event line is 0, down-count when event line is 1. */
+    TCA_SINGLE_EVACTB_RESTART_POSEDGE_gc = (0x04<<5),  /* Restart counter at positive edge event */
+    TCA_SINGLE_EVACTB_RESTART_ANYEDGE_gc = (0x05<<5),  /* Restart counter on any edge event */
+    TCA_SINGLE_EVACTB_RESTART_HIGHLVL_gc = (0x06<<5)  /* Restart counter while event line is 1. */
+} TCA_SINGLE_EVACTB_t;
+
+/* Waveform generation mode select */
+typedef enum TCA_SINGLE_WGMODE_enum
+{
+    TCA_SINGLE_WGMODE_NORMAL_gc = (0x00<<0),  /* Normal Mode */
+    TCA_SINGLE_WGMODE_FRQ_gc = (0x01<<0),  /* Frequency Generation Mode */
+    TCA_SINGLE_WGMODE_SINGLESLOPE_gc = (0x03<<0),  /* Single Slope PWM */
+    TCA_SINGLE_WGMODE_DSTOP_gc = (0x05<<0),  /* Dual Slope PWM, overflow on TOP */
+    TCA_SINGLE_WGMODE_DSBOTH_gc = (0x06<<0),  /* Dual Slope PWM, overflow on TOP and BOTTOM */
+    TCA_SINGLE_WGMODE_DSBOTTOM_gc = (0x07<<0)  /* Dual Slope PWM, overflow on BOTTOM */
+} TCA_SINGLE_WGMODE_t;
+
+/* Clock Selection */
+typedef enum TCA_SPLIT_CLKSEL_enum
+{
+    TCA_SPLIT_CLKSEL_DIV1_gc = (0x00<<1),  /* CLK_PER */
+    TCA_SPLIT_CLKSEL_DIV2_gc = (0x01<<1),  /* CLK_PER / 2 */
+    TCA_SPLIT_CLKSEL_DIV4_gc = (0x02<<1),  /* CLK_PER / 4 */
+    TCA_SPLIT_CLKSEL_DIV8_gc = (0x03<<1),  /* CLK_PER / 8 */
+    TCA_SPLIT_CLKSEL_DIV16_gc = (0x04<<1),  /* CLK_PER / 16 */
+    TCA_SPLIT_CLKSEL_DIV64_gc = (0x05<<1),  /* CLK_PER / 64 */
+    TCA_SPLIT_CLKSEL_DIV256_gc = (0x06<<1),  /* CLK_PER / 256 */
+    TCA_SPLIT_CLKSEL_DIV1024_gc = (0x07<<1)  /* CLK_PER / 1024 */
+} TCA_SPLIT_CLKSEL_t;
+
+/* Command select */
+typedef enum TCA_SPLIT_CMD_enum
+{
+    TCA_SPLIT_CMD_NONE_gc = (0x00<<2),  /* No Command */
+    TCA_SPLIT_CMD_UPDATE_gc = (0x01<<2),  /* Force Update */
+    TCA_SPLIT_CMD_RESTART_gc = (0x02<<2),  /* Force Restart */
+    TCA_SPLIT_CMD_RESET_gc = (0x03<<2)  /* Force Hard Reset */
+} TCA_SPLIT_CMD_t;
+
+/* Command Enable select */
+typedef enum TCA_SPLIT_CMDEN_enum
+{
+    TCA_SPLIT_CMDEN_NONE_gc = (0x00<<0),  /* None */
+    TCA_SPLIT_CMDEN_BOTH_gc = (0x03<<0)  /* Both low byte and high byte counter */
+} TCA_SPLIT_CMDEN_t;
+
+/*
+--------------------------------------------------------------------------
+TCB - 16-bit Timer Type B
+--------------------------------------------------------------------------
+*/
+
+/* 16-bit Timer Type B */
+typedef struct TCB_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control Register B */
+    register8_t reserved_1[2];
+    register8_t EVCTRL;  /* Event Control */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t STATUS;  /* Status */
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t TEMP;  /* Temporary Value */
+    _WORDREGISTER(CNT);  /* Count */
+    _WORDREGISTER(CCMP);  /* Compare or Capture */
+    register8_t reserved_2[2];
+} TCB_t;
+
+/* Clock Select */
+typedef enum TCB_CLKSEL_enum
+{
+    TCB_CLKSEL_DIV1_gc = (0x00<<1),  /* CLK_PER */
+    TCB_CLKSEL_DIV2_gc = (0x01<<1),  /* CLK_PER/2 */
+    TCB_CLKSEL_TCA0_gc = (0x02<<1),  /* Use CLK_TCA from TCA0 */
+    TCB_CLKSEL_TCA1_gc = (0x03<<1),  /* Use CLK_TCA from TCA1 */
+    TCB_CLKSEL_EVENT_gc = (0x07<<1)  /* Count on event edge */
+} TCB_CLKSEL_t;
+
+/* Timer Mode select */
+typedef enum TCB_CNTMODE_enum
+{
+    TCB_CNTMODE_INT_gc = (0x00<<0),  /* Periodic Interrupt */
+    TCB_CNTMODE_TIMEOUT_gc = (0x01<<0),  /* Periodic Timeout */
+    TCB_CNTMODE_CAPT_gc = (0x02<<0),  /* Input Capture Event */
+    TCB_CNTMODE_FRQ_gc = (0x03<<0),  /* Input Capture Frequency measurement */
+    TCB_CNTMODE_PW_gc = (0x04<<0),  /* Input Capture Pulse-Width measurement */
+    TCB_CNTMODE_FRQPW_gc = (0x05<<0),  /* Input Capture Frequency and Pulse-Width measurement */
+    TCB_CNTMODE_SINGLE_gc = (0x06<<0),  /* Single Shot */
+    TCB_CNTMODE_PWM8_gc = (0x07<<0)  /* 8-bit PWM */
+} TCB_CNTMODE_t;
+
+/*
+--------------------------------------------------------------------------
+TWI - Two-Wire Interface
+--------------------------------------------------------------------------
+*/
+
+/* Two-Wire Interface */
+typedef struct TWI_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t DUALCTRL;  /* Dual Mode Control */
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t MCTRLA;  /* Host Control A */
+    register8_t MCTRLB;  /* Host Control B */
+    register8_t MSTATUS;  /* Host STATUS */
+    register8_t MBAUD;  /* Host Baud Rate */
+    register8_t MADDR;  /* Host Address */
+    register8_t MDATA;  /* Host Data */
+    register8_t SCTRLA;  /* Client Control A */
+    register8_t SCTRLB;  /* Client Control B */
+    register8_t SSTATUS;  /* Client Status */
+    register8_t SADDR;  /* Client Address */
+    register8_t SDATA;  /* Client Data */
+    register8_t SADDRMASK;  /* Client Address Mask */
+    register8_t reserved_1[1];
+} TWI_t;
+
+/* Acknowledge Action select */
+typedef enum TWI_ACKACT_enum
+{
+    TWI_ACKACT_ACK_gc = (0x00<<2),  /* Send ACK */
+    TWI_ACKACT_NACK_gc = (0x01<<2)  /* Send NACK */
+} TWI_ACKACT_t;
+
+/* Address or Stop select */
+typedef enum TWI_AP_enum
+{
+    TWI_AP_STOP_gc = (0x00<<0),  /* A Stop condition generated the interrupt on APIF flag */
+    TWI_AP_ADR_gc = (0x01<<0)  /* Address detection generated the interrupt on APIF flag */
+} TWI_AP_t;
+
+/* Bus State select */
+typedef enum TWI_BUSSTATE_enum
+{
+    TWI_BUSSTATE_UNKNOWN_gc = (0x00<<0),  /* Unknown bus state */
+    TWI_BUSSTATE_IDLE_gc = (0x01<<0),  /* Bus is idle */
+    TWI_BUSSTATE_OWNER_gc = (0x02<<0),  /* This TWI controls the bus */
+    TWI_BUSSTATE_BUSY_gc = (0x03<<0)  /* The bus is busy */
+} TWI_BUSSTATE_t;
+
+/* Debug Run select */
+typedef enum TWI_DBGRUN_enum
+{
+    TWI_DBGRUN_HALT_gc = (0x00<<0),  /* The peripheral is halted in Break Debug mode and ignores events */
+    TWI_DBGRUN_RUN_gc = (0x01<<0)  /* The peripheral will continue to run in Break Debug mode when the CPU is halted */
+} TWI_DBGRUN_t;
+
+/* Fast-mode Enable select */
+typedef enum TWI_FMEN_enum
+{
+    TWI_FMEN_OFF_gc = (0x00<<0),  /* SCL duty cycle operating according to Sm specification */
+    TWI_FMEN_ON_gc = (0x01<<0)  /* SCL duty cycle operating according to Fm specification */
+} TWI_FMEN_t;
+
+/* Fast-mode Plus Enable select */
+typedef enum TWI_FMPEN_enum
+{
+    TWI_FMPEN_OFF_gc = (0x00<<1),  /* Operating in Standard-mode or Fast-mode */
+    TWI_FMPEN_ON_gc = (0x01<<1)  /* Operating in Fast-mode Plus */
+} TWI_FMPEN_t;
+
+/* Input voltage transition level select */
+typedef enum TWI_INPUTLVL_enum
+{
+    TWI_INPUTLVL_I2C_gc = (0x00<<6),  /* I2C input voltage transition level */
+    TWI_INPUTLVL_SMBUS_gc = (0x01<<6)  /* SMBus 3.0 input voltage transition level */
+} TWI_INPUTLVL_t;
+
+/* Command select */
+typedef enum TWI_MCMD_enum
+{
+    TWI_MCMD_NOACT_gc = (0x00<<0),  /* No action */
+    TWI_MCMD_REPSTART_gc = (0x01<<0),  /* Execute Acknowledge Action followed by repeated Start. */
+    TWI_MCMD_RECVTRANS_gc = (0x02<<0),  /* Execute Acknowledge Action followed by a byte read/write operation. Read/write is defined by DIR. */
+    TWI_MCMD_STOP_gc = (0x03<<0)  /* Execute Acknowledge Action followed by issuing a Stop condition. */
+} TWI_MCMD_t;
+
+/* Command select */
+typedef enum TWI_SCMD_enum
+{
+    TWI_SCMD_NOACT_gc = (0x00<<0),  /* No Action */
+    TWI_SCMD_COMPTRANS_gc = (0x02<<0),  /* Complete transaction */
+    TWI_SCMD_RESPONSE_gc = (0x03<<0)  /* Used in response to an interrupt */
+} TWI_SCMD_t;
+
+/* SDA Hold Time select */
+typedef enum TWI_SDAHOLD_enum
+{
+    TWI_SDAHOLD_OFF_gc = (0x00<<2),  /* No SDA Hold Delay */
+    TWI_SDAHOLD_50NS_gc = (0x01<<2),  /* Short SDA hold time */
+    TWI_SDAHOLD_300NS_gc = (0x02<<2),  /* Meets SMBUS 2.0 specification under typical conditions */
+    TWI_SDAHOLD_500NS_gc = (0x03<<2)  /* Meets SMBUS 2.0 specificaiton across all corners */
+} TWI_SDAHOLD_t;
+
+/* SDA Setup Time select */
+typedef enum TWI_SDASETUP_enum
+{
+    TWI_SDASETUP_4CYC_gc = (0x00<<4),  /* SDA setup time is four clock cycles */
+    TWI_SDASETUP_8CYC_gc = (0x01<<4)  /* SDA setup time is eight clock cycle */
+} TWI_SDASETUP_t;
+
+/* Inactive Bus Time-Out select */
+typedef enum TWI_TIMEOUT_enum
+{
+    TWI_TIMEOUT_DISABLED_gc = (0x00<<2),  /* Bus time-out disabled. I2C. */
+    TWI_TIMEOUT_50US_gc = (0x01<<2),  /* 50us - SMBus */
+    TWI_TIMEOUT_100US_gc = (0x02<<2),  /* 100us */
+    TWI_TIMEOUT_200US_gc = (0x03<<2)  /* 200us */
+} TWI_TIMEOUT_t;
+
+/*
+--------------------------------------------------------------------------
+USART - Universal Synchronous and Asynchronous Receiver and Transmitter
+--------------------------------------------------------------------------
+*/
+
+/* Universal Synchronous and Asynchronous Receiver and Transmitter */
+typedef struct USART_struct
+{
+    register8_t RXDATAL;  /* Receive Data Low Byte */
+    register8_t RXDATAH;  /* Receive Data High Byte */
+    register8_t TXDATAL;  /* Transmit Data Low Byte */
+    register8_t TXDATAH;  /* Transmit Data High Byte */
+    register8_t STATUS;  /* Status */
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    _WORDREGISTER(BAUD);  /* Baud Rate */
+    register8_t CTRLD;  /* Control D */
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t EVCTRL;  /* Event Control */
+    register8_t TXPLCTRL;  /* IRCOM Transmitter Pulse Length Control */
+    register8_t RXPLCTRL;  /* IRCOM Receiver Pulse Length Control */
+    register8_t reserved_1[1];
+} USART_t;
+
+/* Auto Baud Window select */
+typedef enum USART_ABW_enum
+{
+    USART_ABW_WDW0_gc = (0x00<<6),  /* 18% tolerance */
+    USART_ABW_WDW1_gc = (0x01<<6),  /* 15% tolerance */
+    USART_ABW_WDW2_gc = (0x02<<6),  /* 21% tolerance */
+    USART_ABW_WDW3_gc = (0x03<<6)  /* 25% tolerance */
+} USART_ABW_t;
+
+/* Character Size select */
+typedef enum USART_CHSIZE_enum
+{
+    USART_CHSIZE_5BIT_gc = (0x00<<0),  /* Character size: 5 bit */
+    USART_CHSIZE_6BIT_gc = (0x01<<0),  /* Character size: 6 bit */
+    USART_CHSIZE_7BIT_gc = (0x02<<0),  /* Character size: 7 bit */
+    USART_CHSIZE_8BIT_gc = (0x03<<0),  /* Character size: 8 bit */
+    USART_CHSIZE_9BITL_gc = (0x06<<0),  /* Character size: 9 bit read low byte first */
+    USART_CHSIZE_9BITH_gc = (0x07<<0)  /* Character size: 9 bit read high byte first */
+} USART_CHSIZE_t;
+
+/* Communication Mode select */
+typedef enum USART_CMODE_enum
+{
+    USART_CMODE_ASYNCHRONOUS_gc = (0x00<<6),  /* Asynchronous Mode */
+    USART_CMODE_SYNCHRONOUS_gc = (0x01<<6),  /* Synchronous Mode */
+    USART_CMODE_IRCOM_gc = (0x02<<6),  /* Infrared Communication */
+    USART_CMODE_MSPI_gc = (0x03<<6)  /* SPI Host Mode */
+} USART_CMODE_t;
+
+/* Parity Mode select */
+typedef enum USART_PMODE_enum
+{
+    USART_PMODE_DISABLED_gc = (0x00<<4),  /* No Parity */
+    USART_PMODE_EVEN_gc = (0x02<<4),  /* Even Parity */
+    USART_PMODE_ODD_gc = (0x03<<4)  /* Odd Parity */
+} USART_PMODE_t;
+
+/* RS485 Mode internal transmitter select */
+typedef enum USART_RS485_enum
+{
+    USART_RS485_DISABLE_gc = (0x00<<0),  /* RS485 Mode disabled */
+    USART_RS485_ENABLE_gc = (0x01<<0)  /* RS485 Mode enabled */
+} USART_RS485_t;
+
+/* Receiver Mode select */
+typedef enum USART_RXMODE_enum
+{
+    USART_RXMODE_NORMAL_gc = (0x00<<1),  /* Normal mode */
+    USART_RXMODE_CLK2X_gc = (0x01<<1),  /* CLK2x mode */
+    USART_RXMODE_GENAUTO_gc = (0x02<<1),  /* Generic autobaud mode */
+    USART_RXMODE_LINAUTO_gc = (0x03<<1)  /* LIN constrained autobaud mode */
+} USART_RXMODE_t;
+
+/* Stop Bit Mode select */
+typedef enum USART_SBMODE_enum
+{
+    USART_SBMODE_1BIT_gc = (0x00<<3),  /* 1 stop bit */
+    USART_SBMODE_2BIT_gc = (0x01<<3)  /* 2 stop bits */
+} USART_SBMODE_t;
+
+/*
+--------------------------------------------------------------------------
+USERROW - User Row
+--------------------------------------------------------------------------
+*/
+
+/* User Row */
+typedef struct USERROW_struct
+{
+    register8_t USERROW0;  /* User Row Byte 0 */
+    register8_t USERROW1;  /* User Row Byte 1 */
+    register8_t USERROW2;  /* User Row Byte 2 */
+    register8_t USERROW3;  /* User Row Byte 3 */
+    register8_t USERROW4;  /* User Row Byte 4 */
+    register8_t USERROW5;  /* User Row Byte 5 */
+    register8_t USERROW6;  /* User Row Byte 6 */
+    register8_t USERROW7;  /* User Row Byte 7 */
+    register8_t USERROW8;  /* User Row Byte 8 */
+    register8_t USERROW9;  /* User Row Byte 9 */
+    register8_t USERROW10;  /* User Row Byte 10 */
+    register8_t USERROW11;  /* User Row Byte 11 */
+    register8_t USERROW12;  /* User Row Byte 12 */
+    register8_t USERROW13;  /* User Row Byte 13 */
+    register8_t USERROW14;  /* User Row Byte 14 */
+    register8_t USERROW15;  /* User Row Byte 15 */
+    register8_t USERROW16;  /* User Row Byte 16 */
+    register8_t USERROW17;  /* User Row Byte 17 */
+    register8_t USERROW18;  /* User Row Byte 18 */
+    register8_t USERROW19;  /* User Row Byte 19 */
+    register8_t USERROW20;  /* User Row Byte 20 */
+    register8_t USERROW21;  /* User Row Byte 21 */
+    register8_t USERROW22;  /* User Row Byte 22 */
+    register8_t USERROW23;  /* User Row Byte 23 */
+    register8_t USERROW24;  /* User Row Byte 24 */
+    register8_t USERROW25;  /* User Row Byte 25 */
+    register8_t USERROW26;  /* User Row Byte 26 */
+    register8_t USERROW27;  /* User Row Byte 27 */
+    register8_t USERROW28;  /* User Row Byte 28 */
+    register8_t USERROW29;  /* User Row Byte 29 */
+    register8_t USERROW30;  /* User Row Byte 30 */
+    register8_t USERROW31;  /* User Row Byte 31 */
+    register8_t USERROW32;  /* User Row Byte 32 */
+    register8_t USERROW33;  /* User Row Byte 33 */
+    register8_t USERROW34;  /* User Row Byte 34 */
+    register8_t USERROW35;  /* User Row Byte 35 */
+    register8_t USERROW36;  /* User Row Byte 36 */
+    register8_t USERROW37;  /* User Row Byte 37 */
+    register8_t USERROW38;  /* User Row Byte 38 */
+    register8_t USERROW39;  /* User Row Byte 39 */
+    register8_t USERROW40;  /* User Row Byte 40 */
+    register8_t USERROW41;  /* User Row Byte 41 */
+    register8_t USERROW42;  /* User Row Byte 42 */
+    register8_t USERROW43;  /* User Row Byte 43 */
+    register8_t USERROW44;  /* User Row Byte 44 */
+    register8_t USERROW45;  /* User Row Byte 45 */
+    register8_t USERROW46;  /* User Row Byte 46 */
+    register8_t USERROW47;  /* User Row Byte 47 */
+    register8_t USERROW48;  /* User Row Byte 48 */
+    register8_t USERROW49;  /* User Row Byte 49 */
+    register8_t USERROW50;  /* User Row Byte 50 */
+    register8_t USERROW51;  /* User Row Byte 51 */
+    register8_t USERROW52;  /* User Row Byte 52 */
+    register8_t USERROW53;  /* User Row Byte 53 */
+    register8_t USERROW54;  /* User Row Byte 54 */
+    register8_t USERROW55;  /* User Row Byte 55 */
+    register8_t USERROW56;  /* User Row Byte 56 */
+    register8_t USERROW57;  /* User Row Byte 57 */
+    register8_t USERROW58;  /* User Row Byte 58 */
+    register8_t USERROW59;  /* User Row Byte 59 */
+    register8_t USERROW60;  /* User Row Byte 60 */
+    register8_t USERROW61;  /* User Row Byte 61 */
+    register8_t USERROW62;  /* User Row Byte 62 */
+    register8_t USERROW63;  /* User Row Byte 63 */
+} USERROW_t;
+
+
+/*
+--------------------------------------------------------------------------
+VPORT - Virtual Ports
+--------------------------------------------------------------------------
+*/
+
+/* Virtual Ports */
+typedef struct VPORT_struct
+{
+    register8_t DIR;  /* Data Direction */
+    register8_t OUT;  /* Output Value */
+    register8_t IN;  /* Input Value */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+} VPORT_t;
+
+
+/*
+--------------------------------------------------------------------------
+VREF - Voltage reference
+--------------------------------------------------------------------------
+*/
+
+/* Voltage reference */
+typedef struct VREF_struct
+{
+    register8_t reserved_1[2];
+    register8_t DAC0REF;  /* DAC0 Reference */
+    register8_t reserved_2[1];
+    register8_t ACREF;  /* AC Reference */
+} VREF_t;
+
+/* Reference select */
+typedef enum VREF_REFSEL_enum
+{
+    VREF_REFSEL_1V024_gc = (0x00<<0),  /* Internal 1.024V reference */
+    VREF_REFSEL_2V048_gc = (0x01<<0),  /* Internal 2.048V reference */
+    VREF_REFSEL_4V096_gc = (0x02<<0),  /* Internal 4.096V reference */
+    VREF_REFSEL_2V500_gc = (0x03<<0),  /* Internal 2.500V reference */
+    VREF_REFSEL_VDD_gc = (0x05<<0),  /* VDD as reference */
+    VREF_REFSEL_VREFA_gc = (0x06<<0)  /* External reference on VREFA pin */
+} VREF_REFSEL_t;
+
+/*
+--------------------------------------------------------------------------
+WDT - Watch-Dog Timer
+--------------------------------------------------------------------------
+*/
+
+/* Watch-Dog Timer */
+typedef struct WDT_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t STATUS;  /* Status */
+    register8_t reserved_1[14];
+} WDT_t;
+
+/* Period select */
+typedef enum WDT_PERIOD_enum
+{
+    WDT_PERIOD_OFF_gc = (0x00<<0),  /* Off */
+    WDT_PERIOD_8CLK_gc = (0x01<<0),  /* 8 cycles (8ms) */
+    WDT_PERIOD_16CLK_gc = (0x02<<0),  /* 16 cycles (16ms) */
+    WDT_PERIOD_32CLK_gc = (0x03<<0),  /* 32 cycles (32ms) */
+    WDT_PERIOD_64CLK_gc = (0x04<<0),  /* 64 cycles (64ms) */
+    WDT_PERIOD_128CLK_gc = (0x05<<0),  /* 128 cycles (0.128s) */
+    WDT_PERIOD_256CLK_gc = (0x06<<0),  /* 256 cycles (0.256s) */
+    WDT_PERIOD_512CLK_gc = (0x07<<0),  /* 512 cycles (0.512s) */
+    WDT_PERIOD_1KCLK_gc = (0x08<<0),  /* 1K cycles (1.0s) */
+    WDT_PERIOD_2KCLK_gc = (0x09<<0),  /* 2K cycles (2.0s) */
+    WDT_PERIOD_4KCLK_gc = (0x0A<<0),  /* 4K cycles (4.1s) */
+    WDT_PERIOD_8KCLK_gc = (0x0B<<0)  /* 8K cycles (8.2s) */
+} WDT_PERIOD_t;
+
+/* Window select */
+typedef enum WDT_WINDOW_enum
+{
+    WDT_WINDOW_OFF_gc = (0x00<<4),  /* Off */
+    WDT_WINDOW_8CLK_gc = (0x01<<4),  /* 8 cycles (8ms) */
+    WDT_WINDOW_16CLK_gc = (0x02<<4),  /* 16 cycles (16ms) */
+    WDT_WINDOW_32CLK_gc = (0x03<<4),  /* 32 cycles (32ms) */
+    WDT_WINDOW_64CLK_gc = (0x04<<4),  /* 64 cycles (64ms) */
+    WDT_WINDOW_128CLK_gc = (0x05<<4),  /* 128 cycles (0.128s) */
+    WDT_WINDOW_256CLK_gc = (0x06<<4),  /* 256 cycles (0.256s) */
+    WDT_WINDOW_512CLK_gc = (0x07<<4),  /* 512 cycles (0.512s) */
+    WDT_WINDOW_1KCLK_gc = (0x08<<4),  /* 1K cycles (1.0s) */
+    WDT_WINDOW_2KCLK_gc = (0x09<<4),  /* 2K cycles (2.0s) */
+    WDT_WINDOW_4KCLK_gc = (0x0A<<4),  /* 4K cycles (4.1s) */
+    WDT_WINDOW_8KCLK_gc = (0x0B<<4)  /* 8K cycles (8.2s) */
+} WDT_WINDOW_t;
+/*
+==========================================================================
+IO Module Instances. Mapped to memory.
+==========================================================================
+*/
+
+#define VPORTA              (*(VPORT_t *) 0x0000) /* Virtual Ports */
+#define VPORTC              (*(VPORT_t *) 0x0008) /* Virtual Ports */
+#define VPORTD              (*(VPORT_t *) 0x000C) /* Virtual Ports */
+#define VPORTF              (*(VPORT_t *) 0x0014) /* Virtual Ports */
+#define GPR                   (*(GPR_t *) 0x001C) /* General Purpose Registers */
+#define RSTCTRL           (*(RSTCTRL_t *) 0x0040) /* Reset controller */
+#define SLPCTRL           (*(SLPCTRL_t *) 0x0050) /* Sleep Controller */
+#define CLKCTRL           (*(CLKCTRL_t *) 0x0060) /* Clock controller */
+#define BOD                   (*(BOD_t *) 0x00A0) /* Bod interface */
+#define VREF                 (*(VREF_t *) 0x00B0) /* Voltage reference */
+#define WDT                   (*(WDT_t *) 0x0100) /* Watch-Dog Timer */
+#define CPUINT             (*(CPUINT_t *) 0x0110) /* Interrupt Controller */
+#define CRCSCAN           (*(CRCSCAN_t *) 0x0120) /* CRCSCAN */
+#define RTC                   (*(RTC_t *) 0x0140) /* Real-Time Counter */
+#define CCL                   (*(CCL_t *) 0x01C0) /* Configurable Custom Logic */
+#define EVSYS               (*(EVSYS_t *) 0x0200) /* Event System */
+#define PORTA                (*(PORT_t *) 0x0400) /* I/O Ports */
+#define PORTC                (*(PORT_t *) 0x0440) /* I/O Ports */
+#define PORTD                (*(PORT_t *) 0x0460) /* I/O Ports */
+#define PORTF                (*(PORT_t *) 0x04A0) /* I/O Ports */
+#define PORTMUX           (*(PORTMUX_t *) 0x05E0) /* Port Multiplexer */
+#define ADC0                  (*(ADC_t *) 0x0600) /* Analog to Digital Converter */
+#define AC0                    (*(AC_t *) 0x0680) /* Analog Comparator */
+#define AC1                    (*(AC_t *) 0x0688) /* Analog Comparator */
+#define DAC0                  (*(DAC_t *) 0x06A0) /* Digital to Analog Converter */
+#define USART0              (*(USART_t *) 0x0800) /* Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define USART1              (*(USART_t *) 0x0820) /* Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define USART2              (*(USART_t *) 0x0840) /* Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define TWI0                  (*(TWI_t *) 0x0900) /* Two-Wire Interface */
+#define SPI0                  (*(SPI_t *) 0x0940) /* Serial Peripheral Interface */
+#define TCA0                  (*(TCA_t *) 0x0A00) /* 16-bit Timer/Counter Type A */
+#define TCB0                  (*(TCB_t *) 0x0B00) /* 16-bit Timer Type B */
+#define TCB1                  (*(TCB_t *) 0x0B10) /* 16-bit Timer Type B */
+#define TCB2                  (*(TCB_t *) 0x0B20) /* 16-bit Timer Type B */
+#define SYSCFG             (*(SYSCFG_t *) 0x0F00) /* System Configuration Registers */
+#define NVMCTRL           (*(NVMCTRL_t *) 0x1000) /* Non-volatile Memory Controller */
+#define LOCK                 (*(LOCK_t *) 0x1040) /* Lockbits */
+#define FUSE                 (*(FUSE_t *) 0x1050) /* Fuses */
+#define USERROW           (*(USERROW_t *) 0x1080) /* User Row */
+#define SIGROW             (*(SIGROW_t *) 0x1100) /* Signature row */
+
+#endif /* !defined (__ASSEMBLER__) */
+
+
+/* ========== Flattened fully qualified IO register names ========== */
+
+
+/* VPORT (VPORTA) - Virtual Ports */
+#define VPORTA_DIR  _SFR_MEM8(0x0000)
+#define VPORTA_OUT  _SFR_MEM8(0x0001)
+#define VPORTA_IN  _SFR_MEM8(0x0002)
+#define VPORTA_INTFLAGS  _SFR_MEM8(0x0003)
+
+
+/* VPORT (VPORTC) - Virtual Ports */
+#define VPORTC_DIR  _SFR_MEM8(0x0008)
+#define VPORTC_OUT  _SFR_MEM8(0x0009)
+#define VPORTC_IN  _SFR_MEM8(0x000A)
+#define VPORTC_INTFLAGS  _SFR_MEM8(0x000B)
+
+
+/* VPORT (VPORTD) - Virtual Ports */
+#define VPORTD_DIR  _SFR_MEM8(0x000C)
+#define VPORTD_OUT  _SFR_MEM8(0x000D)
+#define VPORTD_IN  _SFR_MEM8(0x000E)
+#define VPORTD_INTFLAGS  _SFR_MEM8(0x000F)
+
+
+/* VPORT (VPORTF) - Virtual Ports */
+#define VPORTF_DIR  _SFR_MEM8(0x0014)
+#define VPORTF_OUT  _SFR_MEM8(0x0015)
+#define VPORTF_IN  _SFR_MEM8(0x0016)
+#define VPORTF_INTFLAGS  _SFR_MEM8(0x0017)
+
+
+/* GPR - General Purpose Registers */
+#define GPR_GPR0  _SFR_MEM8(0x001C)
+#define GPR_GPR1  _SFR_MEM8(0x001D)
+#define GPR_GPR2  _SFR_MEM8(0x001E)
+#define GPR_GPR3  _SFR_MEM8(0x001F)
+
+
+/* CPU - CPU */
+#define CPU_CCP  _SFR_MEM8(0x0034)
+#define CPU_SP  _SFR_MEM16(0x003D)
+#define CPU_SPL  _SFR_MEM8(0x003D)
+#define CPU_SPH  _SFR_MEM8(0x003E)
+#define CPU_SREG  _SFR_MEM8(0x003F)
+
+
+/* RSTCTRL - Reset controller */
+#define RSTCTRL_RSTFR  _SFR_MEM8(0x0040)
+#define RSTCTRL_SWRR  _SFR_MEM8(0x0041)
+
+
+/* SLPCTRL - Sleep Controller */
+#define SLPCTRL_CTRLA  _SFR_MEM8(0x0050)
+
+
+/* CLKCTRL - Clock controller */
+#define CLKCTRL_MCLKCTRLA  _SFR_MEM8(0x0060)
+#define CLKCTRL_MCLKCTRLB  _SFR_MEM8(0x0061)
+#define CLKCTRL_MCLKCTRLC  _SFR_MEM8(0x0062)
+#define CLKCTRL_MCLKINTCTRL  _SFR_MEM8(0x0063)
+#define CLKCTRL_MCLKINTFLAGS  _SFR_MEM8(0x0064)
+#define CLKCTRL_MCLKSTATUS  _SFR_MEM8(0x0065)
+#define CLKCTRL_MCLKTIMEBASE  _SFR_MEM8(0x0066)
+#define CLKCTRL_OSCHFCTRLA  _SFR_MEM8(0x0068)
+#define CLKCTRL_OSCHFTUNE  _SFR_MEM8(0x0069)
+#define CLKCTRL_OSC32KCTRLA  _SFR_MEM8(0x0078)
+#define CLKCTRL_XOSC32KCTRLA  _SFR_MEM8(0x007C)
+#define CLKCTRL_XOSCHFCTRLA  _SFR_MEM8(0x0080)
+
+
+/* BOD - Bod interface */
+#define BOD_CTRLA  _SFR_MEM8(0x00A0)
+#define BOD_CTRLB  _SFR_MEM8(0x00A1)
+#define BOD_VLMCTRLA  _SFR_MEM8(0x00A8)
+#define BOD_INTCTRL  _SFR_MEM8(0x00A9)
+#define BOD_INTFLAGS  _SFR_MEM8(0x00AA)
+#define BOD_STATUS  _SFR_MEM8(0x00AB)
+
+
+/* VREF - Voltage reference */
+#define VREF_DAC0REF  _SFR_MEM8(0x00B2)
+#define VREF_ACREF  _SFR_MEM8(0x00B4)
+
+
+/* WDT - Watch-Dog Timer */
+#define WDT_CTRLA  _SFR_MEM8(0x0100)
+#define WDT_STATUS  _SFR_MEM8(0x0101)
+
+
+/* CPUINT - Interrupt Controller */
+#define CPUINT_CTRLA  _SFR_MEM8(0x0110)
+#define CPUINT_STATUS  _SFR_MEM8(0x0111)
+#define CPUINT_LVL0PRI  _SFR_MEM8(0x0112)
+#define CPUINT_LVL1VEC  _SFR_MEM8(0x0113)
+
+
+/* CRCSCAN - CRCSCAN */
+#define CRCSCAN_CTRLA  _SFR_MEM8(0x0120)
+#define CRCSCAN_CTRLB  _SFR_MEM8(0x0121)
+#define CRCSCAN_STATUS  _SFR_MEM8(0x0122)
+
+
+/* RTC - Real-Time Counter */
+#define RTC_CTRLA  _SFR_MEM8(0x0140)
+#define RTC_STATUS  _SFR_MEM8(0x0141)
+#define RTC_INTCTRL  _SFR_MEM8(0x0142)
+#define RTC_INTFLAGS  _SFR_MEM8(0x0143)
+#define RTC_TEMP  _SFR_MEM8(0x0144)
+#define RTC_DBGCTRL  _SFR_MEM8(0x0145)
+#define RTC_CALIB  _SFR_MEM8(0x0146)
+#define RTC_CLKSEL  _SFR_MEM8(0x0147)
+#define RTC_CNT  _SFR_MEM16(0x0148)
+#define RTC_CNTL  _SFR_MEM8(0x0148)
+#define RTC_CNTH  _SFR_MEM8(0x0149)
+#define RTC_PER  _SFR_MEM16(0x014A)
+#define RTC_PERL  _SFR_MEM8(0x014A)
+#define RTC_PERH  _SFR_MEM8(0x014B)
+#define RTC_CMP  _SFR_MEM16(0x014C)
+#define RTC_CMPL  _SFR_MEM8(0x014C)
+#define RTC_CMPH  _SFR_MEM8(0x014D)
+#define RTC_PITCTRLA  _SFR_MEM8(0x0150)
+#define RTC_PITSTATUS  _SFR_MEM8(0x0151)
+#define RTC_PITINTCTRL  _SFR_MEM8(0x0152)
+#define RTC_PITINTFLAGS  _SFR_MEM8(0x0153)
+#define RTC_PITDBGCTRL  _SFR_MEM8(0x0155)
+#define RTC_PITEVGENCTRLA  _SFR_MEM8(0x0156)
+
+
+/* CCL - Configurable Custom Logic */
+#define CCL_CTRLA  _SFR_MEM8(0x01C0)
+#define CCL_SEQCTRL0  _SFR_MEM8(0x01C1)
+#define CCL_SEQCTRL1  _SFR_MEM8(0x01C2)
+#define CCL_INTCTRL0  _SFR_MEM8(0x01C5)
+#define CCL_INTFLAGS  _SFR_MEM8(0x01C7)
+#define CCL_LUT0CTRLA  _SFR_MEM8(0x01C8)
+#define CCL_LUT0CTRLB  _SFR_MEM8(0x01C9)
+#define CCL_LUT0CTRLC  _SFR_MEM8(0x01CA)
+#define CCL_TRUTH0  _SFR_MEM8(0x01CB)
+#define CCL_LUT1CTRLA  _SFR_MEM8(0x01CC)
+#define CCL_LUT1CTRLB  _SFR_MEM8(0x01CD)
+#define CCL_LUT1CTRLC  _SFR_MEM8(0x01CE)
+#define CCL_TRUTH1  _SFR_MEM8(0x01CF)
+#define CCL_LUT2CTRLA  _SFR_MEM8(0x01D0)
+#define CCL_LUT2CTRLB  _SFR_MEM8(0x01D1)
+#define CCL_LUT2CTRLC  _SFR_MEM8(0x01D2)
+#define CCL_TRUTH2  _SFR_MEM8(0x01D3)
+#define CCL_LUT3CTRLA  _SFR_MEM8(0x01D4)
+#define CCL_LUT3CTRLB  _SFR_MEM8(0x01D5)
+#define CCL_LUT3CTRLC  _SFR_MEM8(0x01D6)
+#define CCL_TRUTH3  _SFR_MEM8(0x01D7)
+
+
+/* EVSYS - Event System */
+#define EVSYS_SWEVENTA  _SFR_MEM8(0x0200)
+#define EVSYS_CHANNEL0  _SFR_MEM8(0x0210)
+#define EVSYS_CHANNEL1  _SFR_MEM8(0x0211)
+#define EVSYS_CHANNEL2  _SFR_MEM8(0x0212)
+#define EVSYS_CHANNEL3  _SFR_MEM8(0x0213)
+#define EVSYS_CHANNEL4  _SFR_MEM8(0x0214)
+#define EVSYS_CHANNEL5  _SFR_MEM8(0x0215)
+#define EVSYS_USERCCLLUT0A  _SFR_MEM8(0x0220)
+#define EVSYS_USERCCLLUT0B  _SFR_MEM8(0x0221)
+#define EVSYS_USERCCLLUT1A  _SFR_MEM8(0x0222)
+#define EVSYS_USERCCLLUT1B  _SFR_MEM8(0x0223)
+#define EVSYS_USERCCLLUT2A  _SFR_MEM8(0x0224)
+#define EVSYS_USERCCLLUT2B  _SFR_MEM8(0x0225)
+#define EVSYS_USERCCLLUT3A  _SFR_MEM8(0x0226)
+#define EVSYS_USERCCLLUT3B  _SFR_MEM8(0x0227)
+#define EVSYS_USERADC0START  _SFR_MEM8(0x0228)
+#define EVSYS_USEREVSYSEVOUTA  _SFR_MEM8(0x0229)
+#define EVSYS_USEREVSYSEVOUTC  _SFR_MEM8(0x022B)
+#define EVSYS_USEREVSYSEVOUTD  _SFR_MEM8(0x022C)
+#define EVSYS_USEREVSYSEVOUTF  _SFR_MEM8(0x022E)
+#define EVSYS_USERUSART0IRDA  _SFR_MEM8(0x022F)
+#define EVSYS_USERUSART1IRDA  _SFR_MEM8(0x0230)
+#define EVSYS_USERUSART2IRDA  _SFR_MEM8(0x0231)
+#define EVSYS_USERTCA0CNTA  _SFR_MEM8(0x0232)
+#define EVSYS_USERTCA0CNTB  _SFR_MEM8(0x0233)
+#define EVSYS_USERTCA1CNTA  _SFR_MEM8(0x0234)
+#define EVSYS_USERTCA1CNTB  _SFR_MEM8(0x0235)
+#define EVSYS_USERTCB0CAPT  _SFR_MEM8(0x0236)
+#define EVSYS_USERTCB0COUNT  _SFR_MEM8(0x0237)
+#define EVSYS_USERTCB1CAPT  _SFR_MEM8(0x0238)
+#define EVSYS_USERTCB1COUNT  _SFR_MEM8(0x0239)
+#define EVSYS_USERTCB2CAPT  _SFR_MEM8(0x023A)
+#define EVSYS_USERTCB2COUNT  _SFR_MEM8(0x023B)
+#define EVSYS_USERTCB3CAPT  _SFR_MEM8(0x023C)
+#define EVSYS_USERTCB3COUNT  _SFR_MEM8(0x023D)
+
+
+/* PORT (PORTA) - I/O Ports */
+#define PORTA_DIR  _SFR_MEM8(0x0400)
+#define PORTA_DIRSET  _SFR_MEM8(0x0401)
+#define PORTA_DIRCLR  _SFR_MEM8(0x0402)
+#define PORTA_DIRTGL  _SFR_MEM8(0x0403)
+#define PORTA_OUT  _SFR_MEM8(0x0404)
+#define PORTA_OUTSET  _SFR_MEM8(0x0405)
+#define PORTA_OUTCLR  _SFR_MEM8(0x0406)
+#define PORTA_OUTTGL  _SFR_MEM8(0x0407)
+#define PORTA_IN  _SFR_MEM8(0x0408)
+#define PORTA_INTFLAGS  _SFR_MEM8(0x0409)
+#define PORTA_PORTCTRL  _SFR_MEM8(0x040A)
+#define PORTA_PINCONFIG  _SFR_MEM8(0x040B)
+#define PORTA_PINCTRLUPD  _SFR_MEM8(0x040C)
+#define PORTA_PINCTRLSET  _SFR_MEM8(0x040D)
+#define PORTA_PINCTRLCLR  _SFR_MEM8(0x040E)
+#define PORTA_PIN0CTRL  _SFR_MEM8(0x0410)
+#define PORTA_PIN1CTRL  _SFR_MEM8(0x0411)
+#define PORTA_PIN2CTRL  _SFR_MEM8(0x0412)
+#define PORTA_PIN3CTRL  _SFR_MEM8(0x0413)
+#define PORTA_PIN4CTRL  _SFR_MEM8(0x0414)
+#define PORTA_PIN5CTRL  _SFR_MEM8(0x0415)
+#define PORTA_PIN6CTRL  _SFR_MEM8(0x0416)
+#define PORTA_PIN7CTRL  _SFR_MEM8(0x0417)
+#define PORTA_EVGENCTRL  _SFR_MEM8(0x0418)
+
+
+/* PORT (PORTC) - I/O Ports */
+#define PORTC_DIR  _SFR_MEM8(0x0440)
+#define PORTC_DIRSET  _SFR_MEM8(0x0441)
+#define PORTC_DIRCLR  _SFR_MEM8(0x0442)
+#define PORTC_DIRTGL  _SFR_MEM8(0x0443)
+#define PORTC_OUT  _SFR_MEM8(0x0444)
+#define PORTC_OUTSET  _SFR_MEM8(0x0445)
+#define PORTC_OUTCLR  _SFR_MEM8(0x0446)
+#define PORTC_OUTTGL  _SFR_MEM8(0x0447)
+#define PORTC_IN  _SFR_MEM8(0x0448)
+#define PORTC_INTFLAGS  _SFR_MEM8(0x0449)
+#define PORTC_PORTCTRL  _SFR_MEM8(0x044A)
+#define PORTC_PINCONFIG  _SFR_MEM8(0x044B)
+#define PORTC_PINCTRLUPD  _SFR_MEM8(0x044C)
+#define PORTC_PINCTRLSET  _SFR_MEM8(0x044D)
+#define PORTC_PINCTRLCLR  _SFR_MEM8(0x044E)
+#define PORTC_PIN0CTRL  _SFR_MEM8(0x0450)
+#define PORTC_PIN1CTRL  _SFR_MEM8(0x0451)
+#define PORTC_PIN2CTRL  _SFR_MEM8(0x0452)
+#define PORTC_PIN3CTRL  _SFR_MEM8(0x0453)
+#define PORTC_PIN4CTRL  _SFR_MEM8(0x0454)
+#define PORTC_PIN5CTRL  _SFR_MEM8(0x0455)
+#define PORTC_PIN6CTRL  _SFR_MEM8(0x0456)
+#define PORTC_PIN7CTRL  _SFR_MEM8(0x0457)
+#define PORTC_EVGENCTRL  _SFR_MEM8(0x0458)
+
+
+/* PORT (PORTD) - I/O Ports */
+#define PORTD_DIR  _SFR_MEM8(0x0460)
+#define PORTD_DIRSET  _SFR_MEM8(0x0461)
+#define PORTD_DIRCLR  _SFR_MEM8(0x0462)
+#define PORTD_DIRTGL  _SFR_MEM8(0x0463)
+#define PORTD_OUT  _SFR_MEM8(0x0464)
+#define PORTD_OUTSET  _SFR_MEM8(0x0465)
+#define PORTD_OUTCLR  _SFR_MEM8(0x0466)
+#define PORTD_OUTTGL  _SFR_MEM8(0x0467)
+#define PORTD_IN  _SFR_MEM8(0x0468)
+#define PORTD_INTFLAGS  _SFR_MEM8(0x0469)
+#define PORTD_PORTCTRL  _SFR_MEM8(0x046A)
+#define PORTD_PINCONFIG  _SFR_MEM8(0x046B)
+#define PORTD_PINCTRLUPD  _SFR_MEM8(0x046C)
+#define PORTD_PINCTRLSET  _SFR_MEM8(0x046D)
+#define PORTD_PINCTRLCLR  _SFR_MEM8(0x046E)
+#define PORTD_PIN0CTRL  _SFR_MEM8(0x0470)
+#define PORTD_PIN1CTRL  _SFR_MEM8(0x0471)
+#define PORTD_PIN2CTRL  _SFR_MEM8(0x0472)
+#define PORTD_PIN3CTRL  _SFR_MEM8(0x0473)
+#define PORTD_PIN4CTRL  _SFR_MEM8(0x0474)
+#define PORTD_PIN5CTRL  _SFR_MEM8(0x0475)
+#define PORTD_PIN6CTRL  _SFR_MEM8(0x0476)
+#define PORTD_PIN7CTRL  _SFR_MEM8(0x0477)
+#define PORTD_EVGENCTRL  _SFR_MEM8(0x0478)
+
+
+/* PORT (PORTF) - I/O Ports */
+#define PORTF_DIR  _SFR_MEM8(0x04A0)
+#define PORTF_DIRSET  _SFR_MEM8(0x04A1)
+#define PORTF_DIRCLR  _SFR_MEM8(0x04A2)
+#define PORTF_DIRTGL  _SFR_MEM8(0x04A3)
+#define PORTF_OUT  _SFR_MEM8(0x04A4)
+#define PORTF_OUTSET  _SFR_MEM8(0x04A5)
+#define PORTF_OUTCLR  _SFR_MEM8(0x04A6)
+#define PORTF_OUTTGL  _SFR_MEM8(0x04A7)
+#define PORTF_IN  _SFR_MEM8(0x04A8)
+#define PORTF_INTFLAGS  _SFR_MEM8(0x04A9)
+#define PORTF_PORTCTRL  _SFR_MEM8(0x04AA)
+#define PORTF_PINCONFIG  _SFR_MEM8(0x04AB)
+#define PORTF_PINCTRLUPD  _SFR_MEM8(0x04AC)
+#define PORTF_PINCTRLSET  _SFR_MEM8(0x04AD)
+#define PORTF_PINCTRLCLR  _SFR_MEM8(0x04AE)
+#define PORTF_PIN0CTRL  _SFR_MEM8(0x04B0)
+#define PORTF_PIN1CTRL  _SFR_MEM8(0x04B1)
+#define PORTF_PIN2CTRL  _SFR_MEM8(0x04B2)
+#define PORTF_PIN3CTRL  _SFR_MEM8(0x04B3)
+#define PORTF_PIN4CTRL  _SFR_MEM8(0x04B4)
+#define PORTF_PIN5CTRL  _SFR_MEM8(0x04B5)
+#define PORTF_PIN6CTRL  _SFR_MEM8(0x04B6)
+#define PORTF_PIN7CTRL  _SFR_MEM8(0x04B7)
+#define PORTF_EVGENCTRL  _SFR_MEM8(0x04B8)
+
+
+/* PORTMUX - Port Multiplexer */
+#define PORTMUX_EVSYSROUTEA  _SFR_MEM8(0x05E0)
+#define PORTMUX_CCLROUTEA  _SFR_MEM8(0x05E1)
+#define PORTMUX_USARTROUTEA  _SFR_MEM8(0x05E2)
+#define PORTMUX_USARTROUTEB  _SFR_MEM8(0x05E3)
+#define PORTMUX_SPIROUTEA  _SFR_MEM8(0x05E5)
+#define PORTMUX_TWIROUTEA  _SFR_MEM8(0x05E6)
+#define PORTMUX_TCAROUTEA  _SFR_MEM8(0x05E7)
+#define PORTMUX_TCBROUTEA  _SFR_MEM8(0x05E8)
+#define PORTMUX_ACROUTEA  _SFR_MEM8(0x05EA)
+
+
+/* ADC (ADC0) - Analog to Digital Converter */
+#define ADC0_CTRLA  _SFR_MEM8(0x0600)
+#define ADC0_CTRLB  _SFR_MEM8(0x0601)
+#define ADC0_CTRLC  _SFR_MEM8(0x0602)
+#define ADC0_CTRLD  _SFR_MEM8(0x0603)
+#define ADC0_INTCTRL  _SFR_MEM8(0x0604)
+#define ADC0_INTFLAGS  _SFR_MEM8(0x0605)
+#define ADC0_STATUS  _SFR_MEM8(0x0606)
+#define ADC0_DBGCTRL  _SFR_MEM8(0x0607)
+#define ADC0_CTRLE  _SFR_MEM8(0x0608)
+#define ADC0_CTRLF  _SFR_MEM8(0x0609)
+#define ADC0_COMMAND  _SFR_MEM8(0x060A)
+#define ADC0_PGACTRL  _SFR_MEM8(0x060B)
+#define ADC0_MUXPOS  _SFR_MEM8(0x060C)
+#define ADC0_MUXNEG  _SFR_MEM8(0x060D)
+#define ADC0_RESULT  _SFR_MEM32(0x0610)
+#define ADC0_RESULT0  _SFR_MEM8(0x0610)
+#define ADC0_RESULT1  _SFR_MEM8(0x0611)
+#define ADC0_RESULT2  _SFR_MEM8(0x0612)
+#define ADC0_RESULT3  _SFR_MEM8(0x0613)
+#define ADC0_SAMPLE  _SFR_MEM16(0x0614)
+#define ADC0_SAMPLEL  _SFR_MEM8(0x0614)
+#define ADC0_SAMPLEH  _SFR_MEM8(0x0615)
+#define ADC0_TEMP0  _SFR_MEM8(0x0618)
+#define ADC0_TEMP1  _SFR_MEM8(0x0619)
+#define ADC0_TEMP2  _SFR_MEM8(0x061A)
+#define ADC0_WINLT  _SFR_MEM16(0x061C)
+#define ADC0_WINLTL  _SFR_MEM8(0x061C)
+#define ADC0_WINLTH  _SFR_MEM8(0x061D)
+#define ADC0_WINHT  _SFR_MEM16(0x061E)
+#define ADC0_WINHTL  _SFR_MEM8(0x061E)
+#define ADC0_WINHTH  _SFR_MEM8(0x061F)
+
+
+/* AC (AC0) - Analog Comparator */
+#define AC0_CTRLA  _SFR_MEM8(0x0680)
+#define AC0_CTRLB  _SFR_MEM8(0x0681)
+#define AC0_MUXCTRL  _SFR_MEM8(0x0682)
+#define AC0_DACREF  _SFR_MEM8(0x0685)
+#define AC0_INTCTRL  _SFR_MEM8(0x0686)
+#define AC0_STATUS  _SFR_MEM8(0x0687)
+
+
+/* AC (AC1) - Analog Comparator */
+#define AC1_CTRLA  _SFR_MEM8(0x0688)
+#define AC1_CTRLB  _SFR_MEM8(0x0689)
+#define AC1_MUXCTRL  _SFR_MEM8(0x068A)
+#define AC1_DACREF  _SFR_MEM8(0x068D)
+#define AC1_INTCTRL  _SFR_MEM8(0x068E)
+#define AC1_STATUS  _SFR_MEM8(0x068F)
+
+
+/* DAC (DAC0) - Digital to Analog Converter */
+#define DAC0_CTRLA  _SFR_MEM8(0x06A0)
+#define DAC0_DATA  _SFR_MEM16(0x06A2)
+#define DAC0_DATAL  _SFR_MEM8(0x06A2)
+#define DAC0_DATAH  _SFR_MEM8(0x06A3)
+
+
+/* USART (USART0) - Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define USART0_RXDATAL  _SFR_MEM8(0x0800)
+#define USART0_RXDATAH  _SFR_MEM8(0x0801)
+#define USART0_TXDATAL  _SFR_MEM8(0x0802)
+#define USART0_TXDATAH  _SFR_MEM8(0x0803)
+#define USART0_STATUS  _SFR_MEM8(0x0804)
+#define USART0_CTRLA  _SFR_MEM8(0x0805)
+#define USART0_CTRLB  _SFR_MEM8(0x0806)
+#define USART0_CTRLC  _SFR_MEM8(0x0807)
+#define USART0_BAUD  _SFR_MEM16(0x0808)
+#define USART0_BAUDL  _SFR_MEM8(0x0808)
+#define USART0_BAUDH  _SFR_MEM8(0x0809)
+#define USART0_CTRLD  _SFR_MEM8(0x080A)
+#define USART0_DBGCTRL  _SFR_MEM8(0x080B)
+#define USART0_EVCTRL  _SFR_MEM8(0x080C)
+#define USART0_TXPLCTRL  _SFR_MEM8(0x080D)
+#define USART0_RXPLCTRL  _SFR_MEM8(0x080E)
+
+
+/* USART (USART1) - Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define USART1_RXDATAL  _SFR_MEM8(0x0820)
+#define USART1_RXDATAH  _SFR_MEM8(0x0821)
+#define USART1_TXDATAL  _SFR_MEM8(0x0822)
+#define USART1_TXDATAH  _SFR_MEM8(0x0823)
+#define USART1_STATUS  _SFR_MEM8(0x0824)
+#define USART1_CTRLA  _SFR_MEM8(0x0825)
+#define USART1_CTRLB  _SFR_MEM8(0x0826)
+#define USART1_CTRLC  _SFR_MEM8(0x0827)
+#define USART1_BAUD  _SFR_MEM16(0x0828)
+#define USART1_BAUDL  _SFR_MEM8(0x0828)
+#define USART1_BAUDH  _SFR_MEM8(0x0829)
+#define USART1_CTRLD  _SFR_MEM8(0x082A)
+#define USART1_DBGCTRL  _SFR_MEM8(0x082B)
+#define USART1_EVCTRL  _SFR_MEM8(0x082C)
+#define USART1_TXPLCTRL  _SFR_MEM8(0x082D)
+#define USART1_RXPLCTRL  _SFR_MEM8(0x082E)
+
+
+/* USART (USART2) - Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define USART2_RXDATAL  _SFR_MEM8(0x0840)
+#define USART2_RXDATAH  _SFR_MEM8(0x0841)
+#define USART2_TXDATAL  _SFR_MEM8(0x0842)
+#define USART2_TXDATAH  _SFR_MEM8(0x0843)
+#define USART2_STATUS  _SFR_MEM8(0x0844)
+#define USART2_CTRLA  _SFR_MEM8(0x0845)
+#define USART2_CTRLB  _SFR_MEM8(0x0846)
+#define USART2_CTRLC  _SFR_MEM8(0x0847)
+#define USART2_BAUD  _SFR_MEM16(0x0848)
+#define USART2_BAUDL  _SFR_MEM8(0x0848)
+#define USART2_BAUDH  _SFR_MEM8(0x0849)
+#define USART2_CTRLD  _SFR_MEM8(0x084A)
+#define USART2_DBGCTRL  _SFR_MEM8(0x084B)
+#define USART2_EVCTRL  _SFR_MEM8(0x084C)
+#define USART2_TXPLCTRL  _SFR_MEM8(0x084D)
+#define USART2_RXPLCTRL  _SFR_MEM8(0x084E)
+
+
+/* TWI (TWI0) - Two-Wire Interface */
+#define TWI0_CTRLA  _SFR_MEM8(0x0900)
+#define TWI0_DUALCTRL  _SFR_MEM8(0x0901)
+#define TWI0_DBGCTRL  _SFR_MEM8(0x0902)
+#define TWI0_MCTRLA  _SFR_MEM8(0x0903)
+#define TWI0_MCTRLB  _SFR_MEM8(0x0904)
+#define TWI0_MSTATUS  _SFR_MEM8(0x0905)
+#define TWI0_MBAUD  _SFR_MEM8(0x0906)
+#define TWI0_MADDR  _SFR_MEM8(0x0907)
+#define TWI0_MDATA  _SFR_MEM8(0x0908)
+#define TWI0_SCTRLA  _SFR_MEM8(0x0909)
+#define TWI0_SCTRLB  _SFR_MEM8(0x090A)
+#define TWI0_SSTATUS  _SFR_MEM8(0x090B)
+#define TWI0_SADDR  _SFR_MEM8(0x090C)
+#define TWI0_SDATA  _SFR_MEM8(0x090D)
+#define TWI0_SADDRMASK  _SFR_MEM8(0x090E)
+
+
+/* SPI (SPI0) - Serial Peripheral Interface */
+#define SPI0_CTRLA  _SFR_MEM8(0x0940)
+#define SPI0_CTRLB  _SFR_MEM8(0x0941)
+#define SPI0_INTCTRL  _SFR_MEM8(0x0942)
+#define SPI0_INTFLAGS  _SFR_MEM8(0x0943)
+#define SPI0_DATA  _SFR_MEM8(0x0944)
+
+
+/* TCA (TCA0) - 16-bit Timer/Counter Type A - Single Mode */
+#define TCA0_SINGLE_CTRLA  _SFR_MEM8(0x0A00)
+#define TCA0_SINGLE_CTRLB  _SFR_MEM8(0x0A01)
+#define TCA0_SINGLE_CTRLC  _SFR_MEM8(0x0A02)
+#define TCA0_SINGLE_CTRLD  _SFR_MEM8(0x0A03)
+#define TCA0_SINGLE_CTRLECLR  _SFR_MEM8(0x0A04)
+#define TCA0_SINGLE_CTRLESET  _SFR_MEM8(0x0A05)
+#define TCA0_SINGLE_CTRLFCLR  _SFR_MEM8(0x0A06)
+#define TCA0_SINGLE_CTRLFSET  _SFR_MEM8(0x0A07)
+#define TCA0_SINGLE_EVCTRL  _SFR_MEM8(0x0A09)
+#define TCA0_SINGLE_INTCTRL  _SFR_MEM8(0x0A0A)
+#define TCA0_SINGLE_INTFLAGS  _SFR_MEM8(0x0A0B)
+#define TCA0_SINGLE_DBGCTRL  _SFR_MEM8(0x0A0E)
+#define TCA0_SINGLE_TEMP  _SFR_MEM8(0x0A0F)
+#define TCA0_SINGLE_CNT  _SFR_MEM16(0x0A20)
+#define TCA0_SINGLE_CNTL  _SFR_MEM8(0x0A20)
+#define TCA0_SINGLE_CNTH  _SFR_MEM8(0x0A21)
+#define TCA0_SINGLE_PER  _SFR_MEM16(0x0A26)
+#define TCA0_SINGLE_PERL  _SFR_MEM8(0x0A26)
+#define TCA0_SINGLE_PERH  _SFR_MEM8(0x0A27)
+#define TCA0_SINGLE_CMP0  _SFR_MEM16(0x0A28)
+#define TCA0_SINGLE_CMP0L  _SFR_MEM8(0x0A28)
+#define TCA0_SINGLE_CMP0H  _SFR_MEM8(0x0A29)
+#define TCA0_SINGLE_CMP1  _SFR_MEM16(0x0A2A)
+#define TCA0_SINGLE_CMP1L  _SFR_MEM8(0x0A2A)
+#define TCA0_SINGLE_CMP1H  _SFR_MEM8(0x0A2B)
+#define TCA0_SINGLE_CMP2  _SFR_MEM16(0x0A2C)
+#define TCA0_SINGLE_CMP2L  _SFR_MEM8(0x0A2C)
+#define TCA0_SINGLE_CMP2H  _SFR_MEM8(0x0A2D)
+#define TCA0_SINGLE_PERBUF  _SFR_MEM16(0x0A36)
+#define TCA0_SINGLE_PERBUFL  _SFR_MEM8(0x0A36)
+#define TCA0_SINGLE_PERBUFH  _SFR_MEM8(0x0A37)
+#define TCA0_SINGLE_CMP0BUF  _SFR_MEM16(0x0A38)
+#define TCA0_SINGLE_CMP0BUFL  _SFR_MEM8(0x0A38)
+#define TCA0_SINGLE_CMP0BUFH  _SFR_MEM8(0x0A39)
+#define TCA0_SINGLE_CMP1BUF  _SFR_MEM16(0x0A3A)
+#define TCA0_SINGLE_CMP1BUFL  _SFR_MEM8(0x0A3A)
+#define TCA0_SINGLE_CMP1BUFH  _SFR_MEM8(0x0A3B)
+#define TCA0_SINGLE_CMP2BUF  _SFR_MEM16(0x0A3C)
+#define TCA0_SINGLE_CMP2BUFL  _SFR_MEM8(0x0A3C)
+#define TCA0_SINGLE_CMP2BUFH  _SFR_MEM8(0x0A3D)
+
+
+/* TCA (TCA0) - 16-bit Timer/Counter Type A - Split Mode */
+#define TCA0_SPLIT_CTRLA  _SFR_MEM8(0x0A00)
+#define TCA0_SPLIT_CTRLB  _SFR_MEM8(0x0A01)
+#define TCA0_SPLIT_CTRLC  _SFR_MEM8(0x0A02)
+#define TCA0_SPLIT_CTRLD  _SFR_MEM8(0x0A03)
+#define TCA0_SPLIT_CTRLECLR  _SFR_MEM8(0x0A04)
+#define TCA0_SPLIT_CTRLESET  _SFR_MEM8(0x0A05)
+#define TCA0_SPLIT_INTCTRL  _SFR_MEM8(0x0A0A)
+#define TCA0_SPLIT_INTFLAGS  _SFR_MEM8(0x0A0B)
+#define TCA0_SPLIT_DBGCTRL  _SFR_MEM8(0x0A0E)
+#define TCA0_SPLIT_LCNT  _SFR_MEM8(0x0A20)
+#define TCA0_SPLIT_HCNT  _SFR_MEM8(0x0A21)
+#define TCA0_SPLIT_LPER  _SFR_MEM8(0x0A26)
+#define TCA0_SPLIT_HPER  _SFR_MEM8(0x0A27)
+#define TCA0_SPLIT_LCMP0  _SFR_MEM8(0x0A28)
+#define TCA0_SPLIT_HCMP0  _SFR_MEM8(0x0A29)
+#define TCA0_SPLIT_LCMP1  _SFR_MEM8(0x0A2A)
+#define TCA0_SPLIT_HCMP1  _SFR_MEM8(0x0A2B)
+#define TCA0_SPLIT_LCMP2  _SFR_MEM8(0x0A2C)
+#define TCA0_SPLIT_HCMP2  _SFR_MEM8(0x0A2D)
+
+
+/* TCB (TCB0) - 16-bit Timer Type B */
+#define TCB0_CTRLA  _SFR_MEM8(0x0B00)
+#define TCB0_CTRLB  _SFR_MEM8(0x0B01)
+#define TCB0_EVCTRL  _SFR_MEM8(0x0B04)
+#define TCB0_INTCTRL  _SFR_MEM8(0x0B05)
+#define TCB0_INTFLAGS  _SFR_MEM8(0x0B06)
+#define TCB0_STATUS  _SFR_MEM8(0x0B07)
+#define TCB0_DBGCTRL  _SFR_MEM8(0x0B08)
+#define TCB0_TEMP  _SFR_MEM8(0x0B09)
+#define TCB0_CNT  _SFR_MEM16(0x0B0A)
+#define TCB0_CNTL  _SFR_MEM8(0x0B0A)
+#define TCB0_CNTH  _SFR_MEM8(0x0B0B)
+#define TCB0_CCMP  _SFR_MEM16(0x0B0C)
+#define TCB0_CCMPL  _SFR_MEM8(0x0B0C)
+#define TCB0_CCMPH  _SFR_MEM8(0x0B0D)
+
+
+/* TCB (TCB1) - 16-bit Timer Type B */
+#define TCB1_CTRLA  _SFR_MEM8(0x0B10)
+#define TCB1_CTRLB  _SFR_MEM8(0x0B11)
+#define TCB1_EVCTRL  _SFR_MEM8(0x0B14)
+#define TCB1_INTCTRL  _SFR_MEM8(0x0B15)
+#define TCB1_INTFLAGS  _SFR_MEM8(0x0B16)
+#define TCB1_STATUS  _SFR_MEM8(0x0B17)
+#define TCB1_DBGCTRL  _SFR_MEM8(0x0B18)
+#define TCB1_TEMP  _SFR_MEM8(0x0B19)
+#define TCB1_CNT  _SFR_MEM16(0x0B1A)
+#define TCB1_CNTL  _SFR_MEM8(0x0B1A)
+#define TCB1_CNTH  _SFR_MEM8(0x0B1B)
+#define TCB1_CCMP  _SFR_MEM16(0x0B1C)
+#define TCB1_CCMPL  _SFR_MEM8(0x0B1C)
+#define TCB1_CCMPH  _SFR_MEM8(0x0B1D)
+
+
+/* TCB (TCB2) - 16-bit Timer Type B */
+#define TCB2_CTRLA  _SFR_MEM8(0x0B20)
+#define TCB2_CTRLB  _SFR_MEM8(0x0B21)
+#define TCB2_EVCTRL  _SFR_MEM8(0x0B24)
+#define TCB2_INTCTRL  _SFR_MEM8(0x0B25)
+#define TCB2_INTFLAGS  _SFR_MEM8(0x0B26)
+#define TCB2_STATUS  _SFR_MEM8(0x0B27)
+#define TCB2_DBGCTRL  _SFR_MEM8(0x0B28)
+#define TCB2_TEMP  _SFR_MEM8(0x0B29)
+#define TCB2_CNT  _SFR_MEM16(0x0B2A)
+#define TCB2_CNTL  _SFR_MEM8(0x0B2A)
+#define TCB2_CNTH  _SFR_MEM8(0x0B2B)
+#define TCB2_CCMP  _SFR_MEM16(0x0B2C)
+#define TCB2_CCMPL  _SFR_MEM8(0x0B2C)
+#define TCB2_CCMPH  _SFR_MEM8(0x0B2D)
+
+
+/* SYSCFG - System Configuration Registers */
+#define SYSCFG_REVID  _SFR_MEM8(0x0F01)
+#define SYSCFG_OCDMCTRL  _SFR_MEM8(0x0F04)
+#define SYSCFG_OCDMSTATUS  _SFR_MEM8(0x0F05)
+
+
+/* NVMCTRL - Non-volatile Memory Controller */
+#define NVMCTRL_CTRLA  _SFR_MEM8(0x1000)
+#define NVMCTRL_CTRLB  _SFR_MEM8(0x1001)
+#define NVMCTRL_INTCTRL  _SFR_MEM8(0x1004)
+#define NVMCTRL_INTFLAGS  _SFR_MEM8(0x1005)
+#define NVMCTRL_STATUS  _SFR_MEM8(0x1006)
+#define NVMCTRL_DATA  _SFR_MEM16(0x1008)
+#define NVMCTRL_DATAL  _SFR_MEM8(0x1008)
+#define NVMCTRL_DATAH  _SFR_MEM8(0x1009)
+#define NVMCTRL_ADDR  _SFR_MEM32(0x100C)
+#define NVMCTRL_ADDR0  _SFR_MEM8(0x100C)
+#define NVMCTRL_ADDR1  _SFR_MEM8(0x100D)
+#define NVMCTRL_ADDR2  _SFR_MEM8(0x100E)
+#define NVMCTRL_ADDR3  _SFR_MEM8(0x100F)
+
+
+/* LOCK - Lockbits */
+#define LOCK_KEY  _SFR_MEM32(0x1040)
+#define LOCK_KEY0  _SFR_MEM8(0x1040)
+#define LOCK_KEY1  _SFR_MEM8(0x1041)
+#define LOCK_KEY2  _SFR_MEM8(0x1042)
+#define LOCK_KEY3  _SFR_MEM8(0x1043)
+
+
+/* FUSE - Fuses */
+#define FUSE_WDTCFG  _SFR_MEM8(0x1050)
+#define FUSE_BODCFG  _SFR_MEM8(0x1051)
+#define FUSE_OSCCFG  _SFR_MEM8(0x1052)
+#define FUSE_SYSCFG0  _SFR_MEM8(0x1055)
+#define FUSE_SYSCFG1  _SFR_MEM8(0x1056)
+#define FUSE_CODESIZE  _SFR_MEM8(0x1057)
+#define FUSE_BOOTSIZE  _SFR_MEM8(0x1058)
+
+
+/* USERROW - User Row */
+#define USERROW_USERROW0  _SFR_MEM8(0x1080)
+#define USERROW_USERROW1  _SFR_MEM8(0x1081)
+#define USERROW_USERROW2  _SFR_MEM8(0x1082)
+#define USERROW_USERROW3  _SFR_MEM8(0x1083)
+#define USERROW_USERROW4  _SFR_MEM8(0x1084)
+#define USERROW_USERROW5  _SFR_MEM8(0x1085)
+#define USERROW_USERROW6  _SFR_MEM8(0x1086)
+#define USERROW_USERROW7  _SFR_MEM8(0x1087)
+#define USERROW_USERROW8  _SFR_MEM8(0x1088)
+#define USERROW_USERROW9  _SFR_MEM8(0x1089)
+#define USERROW_USERROW10  _SFR_MEM8(0x108A)
+#define USERROW_USERROW11  _SFR_MEM8(0x108B)
+#define USERROW_USERROW12  _SFR_MEM8(0x108C)
+#define USERROW_USERROW13  _SFR_MEM8(0x108D)
+#define USERROW_USERROW14  _SFR_MEM8(0x108E)
+#define USERROW_USERROW15  _SFR_MEM8(0x108F)
+#define USERROW_USERROW16  _SFR_MEM8(0x1090)
+#define USERROW_USERROW17  _SFR_MEM8(0x1091)
+#define USERROW_USERROW18  _SFR_MEM8(0x1092)
+#define USERROW_USERROW19  _SFR_MEM8(0x1093)
+#define USERROW_USERROW20  _SFR_MEM8(0x1094)
+#define USERROW_USERROW21  _SFR_MEM8(0x1095)
+#define USERROW_USERROW22  _SFR_MEM8(0x1096)
+#define USERROW_USERROW23  _SFR_MEM8(0x1097)
+#define USERROW_USERROW24  _SFR_MEM8(0x1098)
+#define USERROW_USERROW25  _SFR_MEM8(0x1099)
+#define USERROW_USERROW26  _SFR_MEM8(0x109A)
+#define USERROW_USERROW27  _SFR_MEM8(0x109B)
+#define USERROW_USERROW28  _SFR_MEM8(0x109C)
+#define USERROW_USERROW29  _SFR_MEM8(0x109D)
+#define USERROW_USERROW30  _SFR_MEM8(0x109E)
+#define USERROW_USERROW31  _SFR_MEM8(0x109F)
+#define USERROW_USERROW32  _SFR_MEM8(0x10A0)
+#define USERROW_USERROW33  _SFR_MEM8(0x10A1)
+#define USERROW_USERROW34  _SFR_MEM8(0x10A2)
+#define USERROW_USERROW35  _SFR_MEM8(0x10A3)
+#define USERROW_USERROW36  _SFR_MEM8(0x10A4)
+#define USERROW_USERROW37  _SFR_MEM8(0x10A5)
+#define USERROW_USERROW38  _SFR_MEM8(0x10A6)
+#define USERROW_USERROW39  _SFR_MEM8(0x10A7)
+#define USERROW_USERROW40  _SFR_MEM8(0x10A8)
+#define USERROW_USERROW41  _SFR_MEM8(0x10A9)
+#define USERROW_USERROW42  _SFR_MEM8(0x10AA)
+#define USERROW_USERROW43  _SFR_MEM8(0x10AB)
+#define USERROW_USERROW44  _SFR_MEM8(0x10AC)
+#define USERROW_USERROW45  _SFR_MEM8(0x10AD)
+#define USERROW_USERROW46  _SFR_MEM8(0x10AE)
+#define USERROW_USERROW47  _SFR_MEM8(0x10AF)
+#define USERROW_USERROW48  _SFR_MEM8(0x10B0)
+#define USERROW_USERROW49  _SFR_MEM8(0x10B1)
+#define USERROW_USERROW50  _SFR_MEM8(0x10B2)
+#define USERROW_USERROW51  _SFR_MEM8(0x10B3)
+#define USERROW_USERROW52  _SFR_MEM8(0x10B4)
+#define USERROW_USERROW53  _SFR_MEM8(0x10B5)
+#define USERROW_USERROW54  _SFR_MEM8(0x10B6)
+#define USERROW_USERROW55  _SFR_MEM8(0x10B7)
+#define USERROW_USERROW56  _SFR_MEM8(0x10B8)
+#define USERROW_USERROW57  _SFR_MEM8(0x10B9)
+#define USERROW_USERROW58  _SFR_MEM8(0x10BA)
+#define USERROW_USERROW59  _SFR_MEM8(0x10BB)
+#define USERROW_USERROW60  _SFR_MEM8(0x10BC)
+#define USERROW_USERROW61  _SFR_MEM8(0x10BD)
+#define USERROW_USERROW62  _SFR_MEM8(0x10BE)
+#define USERROW_USERROW63  _SFR_MEM8(0x10BF)
+
+
+/* SIGROW - Signature row */
+#define SIGROW_DEVICEID0  _SFR_MEM8(0x1100)
+#define SIGROW_DEVICEID1  _SFR_MEM8(0x1101)
+#define SIGROW_DEVICEID2  _SFR_MEM8(0x1102)
+#define SIGROW_TEMPSENSE0  _SFR_MEM16(0x1104)
+#define SIGROW_TEMPSENSE0L  _SFR_MEM8(0x1104)
+#define SIGROW_TEMPSENSE0H  _SFR_MEM8(0x1105)
+#define SIGROW_TEMPSENSE1  _SFR_MEM16(0x1106)
+#define SIGROW_TEMPSENSE1L  _SFR_MEM8(0x1106)
+#define SIGROW_TEMPSENSE1H  _SFR_MEM8(0x1107)
+#define SIGROW_SERNUM0  _SFR_MEM8(0x1110)
+#define SIGROW_SERNUM1  _SFR_MEM8(0x1111)
+#define SIGROW_SERNUM2  _SFR_MEM8(0x1112)
+#define SIGROW_SERNUM3  _SFR_MEM8(0x1113)
+#define SIGROW_SERNUM4  _SFR_MEM8(0x1114)
+#define SIGROW_SERNUM5  _SFR_MEM8(0x1115)
+#define SIGROW_SERNUM6  _SFR_MEM8(0x1116)
+#define SIGROW_SERNUM7  _SFR_MEM8(0x1117)
+#define SIGROW_SERNUM8  _SFR_MEM8(0x1118)
+#define SIGROW_SERNUM9  _SFR_MEM8(0x1119)
+#define SIGROW_SERNUM10  _SFR_MEM8(0x111A)
+#define SIGROW_SERNUM11  _SFR_MEM8(0x111B)
+#define SIGROW_SERNUM12  _SFR_MEM8(0x111C)
+#define SIGROW_SERNUM13  _SFR_MEM8(0x111D)
+#define SIGROW_SERNUM14  _SFR_MEM8(0x111E)
+#define SIGROW_SERNUM15  _SFR_MEM8(0x111F)
+
+
+
+/*================== Bitfield Definitions ================== */
+
+/* AC - Analog Comparator */
+/* AC.CTRLA  bit masks and bit positions */
+#define AC_ENABLE_bm  0x01  /* Enable bit mask. */
+#define AC_ENABLE_bp  0  /* Enable bit position. */
+#define AC_HYSMODE_gm  0x06  /* Hysteresis Mode group mask. */
+#define AC_HYSMODE_gp  1  /* Hysteresis Mode group position. */
+#define AC_HYSMODE_0_bm  (1<<1)  /* Hysteresis Mode bit 0 mask. */
+#define AC_HYSMODE_0_bp  1  /* Hysteresis Mode bit 0 position. */
+#define AC_HYSMODE_1_bm  (1<<2)  /* Hysteresis Mode bit 1 mask. */
+#define AC_HYSMODE_1_bp  2  /* Hysteresis Mode bit 1 position. */
+#define AC_POWER_gm  0x18  /* Power profile group mask. */
+#define AC_POWER_gp  3  /* Power profile group position. */
+#define AC_POWER_0_bm  (1<<3)  /* Power profile bit 0 mask. */
+#define AC_POWER_0_bp  3  /* Power profile bit 0 position. */
+#define AC_POWER_1_bm  (1<<4)  /* Power profile bit 1 mask. */
+#define AC_POWER_1_bp  4  /* Power profile bit 1 position. */
+#define AC_OUTEN_bm  0x40  /* Output Pad Enable bit mask. */
+#define AC_OUTEN_bp  6  /* Output Pad Enable bit position. */
+#define AC_RUNSTDBY_bm  0x80  /* Run in Standby Mode bit mask. */
+#define AC_RUNSTDBY_bp  7  /* Run in Standby Mode bit position. */
+
+/* AC.CTRLB  bit masks and bit positions */
+#define AC_WINSEL_gm  0x03  /* Window selection mode group mask. */
+#define AC_WINSEL_gp  0  /* Window selection mode group position. */
+#define AC_WINSEL_0_bm  (1<<0)  /* Window selection mode bit 0 mask. */
+#define AC_WINSEL_0_bp  0  /* Window selection mode bit 0 position. */
+#define AC_WINSEL_1_bm  (1<<1)  /* Window selection mode bit 1 mask. */
+#define AC_WINSEL_1_bp  1  /* Window selection mode bit 1 position. */
+
+/* AC.MUXCTRL  bit masks and bit positions */
+#define AC_MUXNEG_gm  0x07  /* Negative Input MUX Selection group mask. */
+#define AC_MUXNEG_gp  0  /* Negative Input MUX Selection group position. */
+#define AC_MUXNEG_0_bm  (1<<0)  /* Negative Input MUX Selection bit 0 mask. */
+#define AC_MUXNEG_0_bp  0  /* Negative Input MUX Selection bit 0 position. */
+#define AC_MUXNEG_1_bm  (1<<1)  /* Negative Input MUX Selection bit 1 mask. */
+#define AC_MUXNEG_1_bp  1  /* Negative Input MUX Selection bit 1 position. */
+#define AC_MUXNEG_2_bm  (1<<2)  /* Negative Input MUX Selection bit 2 mask. */
+#define AC_MUXNEG_2_bp  2  /* Negative Input MUX Selection bit 2 position. */
+#define AC_MUXPOS_gm  0x38  /* Positive Input MUX Selection group mask. */
+#define AC_MUXPOS_gp  3  /* Positive Input MUX Selection group position. */
+#define AC_MUXPOS_0_bm  (1<<3)  /* Positive Input MUX Selection bit 0 mask. */
+#define AC_MUXPOS_0_bp  3  /* Positive Input MUX Selection bit 0 position. */
+#define AC_MUXPOS_1_bm  (1<<4)  /* Positive Input MUX Selection bit 1 mask. */
+#define AC_MUXPOS_1_bp  4  /* Positive Input MUX Selection bit 1 position. */
+#define AC_MUXPOS_2_bm  (1<<5)  /* Positive Input MUX Selection bit 2 mask. */
+#define AC_MUXPOS_2_bp  5  /* Positive Input MUX Selection bit 2 position. */
+#define AC_INITVAL_bm  0x40  /* AC Output Initial Value bit mask. */
+#define AC_INITVAL_bp  6  /* AC Output Initial Value bit position. */
+#define AC_INVERT_bm  0x80  /* Invert AC Output bit mask. */
+#define AC_INVERT_bp  7  /* Invert AC Output bit position. */
+
+/* AC.DACREF  bit masks and bit positions */
+#define AC_DACREF_gm  0xFF  /* DACREF group mask. */
+#define AC_DACREF_gp  0  /* DACREF group position. */
+#define AC_DACREF_0_bm  (1<<0)  /* DACREF bit 0 mask. */
+#define AC_DACREF_0_bp  0  /* DACREF bit 0 position. */
+#define AC_DACREF_1_bm  (1<<1)  /* DACREF bit 1 mask. */
+#define AC_DACREF_1_bp  1  /* DACREF bit 1 position. */
+#define AC_DACREF_2_bm  (1<<2)  /* DACREF bit 2 mask. */
+#define AC_DACREF_2_bp  2  /* DACREF bit 2 position. */
+#define AC_DACREF_3_bm  (1<<3)  /* DACREF bit 3 mask. */
+#define AC_DACREF_3_bp  3  /* DACREF bit 3 position. */
+#define AC_DACREF_4_bm  (1<<4)  /* DACREF bit 4 mask. */
+#define AC_DACREF_4_bp  4  /* DACREF bit 4 position. */
+#define AC_DACREF_5_bm  (1<<5)  /* DACREF bit 5 mask. */
+#define AC_DACREF_5_bp  5  /* DACREF bit 5 position. */
+#define AC_DACREF_6_bm  (1<<6)  /* DACREF bit 6 mask. */
+#define AC_DACREF_6_bp  6  /* DACREF bit 6 position. */
+#define AC_DACREF_7_bm  (1<<7)  /* DACREF bit 7 mask. */
+#define AC_DACREF_7_bp  7  /* DACREF bit 7 position. */
+
+/* AC.INTCTRL  bit masks and bit positions */
+#define AC_CMP_bm  0x01  /* Interrupt Enable bit mask. */
+#define AC_CMP_bp  0  /* Interrupt Enable bit position. */
+#define AC_INTMODE_NORMAL_gm  0x30  /* Interrupt Mode group mask. */
+#define AC_INTMODE_NORMAL_gp  4  /* Interrupt Mode group position. */
+#define AC_INTMODE_NORMAL_0_bm  (1<<4)  /* Interrupt Mode bit 0 mask. */
+#define AC_INTMODE_NORMAL_0_bp  4  /* Interrupt Mode bit 0 position. */
+#define AC_INTMODE_NORMAL_1_bm  (1<<5)  /* Interrupt Mode bit 1 mask. */
+#define AC_INTMODE_NORMAL_1_bp  5  /* Interrupt Mode bit 1 position. */
+#define AC_INTMODE_WINDOW_gm  0x30  /* Interrupt Mode group mask. */
+#define AC_INTMODE_WINDOW_gp  4  /* Interrupt Mode group position. */
+#define AC_INTMODE_WINDOW_0_bm  (1<<4)  /* Interrupt Mode bit 0 mask. */
+#define AC_INTMODE_WINDOW_0_bp  4  /* Interrupt Mode bit 0 position. */
+#define AC_INTMODE_WINDOW_1_bm  (1<<5)  /* Interrupt Mode bit 1 mask. */
+#define AC_INTMODE_WINDOW_1_bp  5  /* Interrupt Mode bit 1 position. */
+
+/* AC.STATUS  bit masks and bit positions */
+#define AC_CMPIF_bm  0x01  /* Analog Comparator Interrupt Flag bit mask. */
+#define AC_CMPIF_bp  0  /* Analog Comparator Interrupt Flag bit position. */
+#define AC_CMPSTATE_bm  0x10  /* Analog Comparator State bit mask. */
+#define AC_CMPSTATE_bp  4  /* Analog Comparator State bit position. */
+#define AC_WINSTATE_gm  0xC0  /* Analog Comparator Window State group mask. */
+#define AC_WINSTATE_gp  6  /* Analog Comparator Window State group position. */
+#define AC_WINSTATE_0_bm  (1<<6)  /* Analog Comparator Window State bit 0 mask. */
+#define AC_WINSTATE_0_bp  6  /* Analog Comparator Window State bit 0 position. */
+#define AC_WINSTATE_1_bm  (1<<7)  /* Analog Comparator Window State bit 1 mask. */
+#define AC_WINSTATE_1_bp  7  /* Analog Comparator Window State bit 1 position. */
+
+
+/* ADC - Analog to Digital Converter */
+/* ADC.CTRLA  bit masks and bit positions */
+#define ADC_ENABLE_bm  0x01  /* ADC Enable bit mask. */
+#define ADC_ENABLE_bp  0  /* ADC Enable bit position. */
+#define ADC_LOWLAT_bm  0x20  /* Low Latency bit mask. */
+#define ADC_LOWLAT_bp  5  /* Low Latency bit position. */
+#define ADC_RUNSTDBY_bm  0x80  /* Run in Standby bit mask. */
+#define ADC_RUNSTDBY_bp  7  /* Run in Standby bit position. */
+
+/* ADC.CTRLB  bit masks and bit positions */
+#define ADC_PRESC_gm  0x0F  /* Prescaler Value group mask. */
+#define ADC_PRESC_gp  0  /* Prescaler Value group position. */
+#define ADC_PRESC_0_bm  (1<<0)  /* Prescaler Value bit 0 mask. */
+#define ADC_PRESC_0_bp  0  /* Prescaler Value bit 0 position. */
+#define ADC_PRESC_1_bm  (1<<1)  /* Prescaler Value bit 1 mask. */
+#define ADC_PRESC_1_bp  1  /* Prescaler Value bit 1 position. */
+#define ADC_PRESC_2_bm  (1<<2)  /* Prescaler Value bit 2 mask. */
+#define ADC_PRESC_2_bp  2  /* Prescaler Value bit 2 position. */
+#define ADC_PRESC_3_bm  (1<<3)  /* Prescaler Value bit 3 mask. */
+#define ADC_PRESC_3_bp  3  /* Prescaler Value bit 3 position. */
+
+/* ADC.CTRLC  bit masks and bit positions */
+#define ADC_REFSEL_gm  0x07  /* Reference select group mask. */
+#define ADC_REFSEL_gp  0  /* Reference select group position. */
+#define ADC_REFSEL_0_bm  (1<<0)  /* Reference select bit 0 mask. */
+#define ADC_REFSEL_0_bp  0  /* Reference select bit 0 position. */
+#define ADC_REFSEL_1_bm  (1<<1)  /* Reference select bit 1 mask. */
+#define ADC_REFSEL_1_bp  1  /* Reference select bit 1 position. */
+#define ADC_REFSEL_2_bm  (1<<2)  /* Reference select bit 2 mask. */
+#define ADC_REFSEL_2_bp  2  /* Reference select bit 2 position. */
+
+/* ADC.CTRLD  bit masks and bit positions */
+#define ADC_WINCM_gm  0x07  /* Window Comparator Mode group mask. */
+#define ADC_WINCM_gp  0  /* Window Comparator Mode group position. */
+#define ADC_WINCM_0_bm  (1<<0)  /* Window Comparator Mode bit 0 mask. */
+#define ADC_WINCM_0_bp  0  /* Window Comparator Mode bit 0 position. */
+#define ADC_WINCM_1_bm  (1<<1)  /* Window Comparator Mode bit 1 mask. */
+#define ADC_WINCM_1_bp  1  /* Window Comparator Mode bit 1 position. */
+#define ADC_WINCM_2_bm  (1<<2)  /* Window Comparator Mode bit 2 mask. */
+#define ADC_WINCM_2_bp  2  /* Window Comparator Mode bit 2 position. */
+#define ADC_WINSRC_bm  0x08  /* Window Mode Source bit mask. */
+#define ADC_WINSRC_bp  3  /* Window Mode Source bit position. */
+
+/* ADC.INTCTRL  bit masks and bit positions */
+#define ADC_RESRDY_bm  0x01  /* Result Ready Interrupt Enable bit mask. */
+#define ADC_RESRDY_bp  0  /* Result Ready Interrupt Enable bit position. */
+#define ADC_SAMPRDY_bm  0x02  /* Sample Ready Interrupt Enable bit mask. */
+#define ADC_SAMPRDY_bp  1  /* Sample Ready Interrupt Enable bit position. */
+#define ADC_WCMP_bm  0x04  /* Window Comparator Interrupt Enable bit mask. */
+#define ADC_WCMP_bp  2  /* Window Comparator Interrupt Enable bit position. */
+#define ADC_RESOVR_bm  0x08  /* Result Overwrite Interrupt Enable bit mask. */
+#define ADC_RESOVR_bp  3  /* Result Overwrite Interrupt Enable bit position. */
+#define ADC_SAMPOVR_bm  0x10  /* Sample Overwrite Interrupt Enable bit mask. */
+#define ADC_SAMPOVR_bp  4  /* Sample Overwrite Interrupt Enable bit position. */
+#define ADC_TRIGOVR_bm  0x20  /* Trigger Overrun Interrupt Enable bit mask. */
+#define ADC_TRIGOVR_bp  5  /* Trigger Overrun Interrupt Enable bit position. */
+
+/* ADC.INTFLAGS  bit masks and bit positions */
+/* ADC_RESRDY  is already defined. */
+/* ADC_SAMPRDY  is already defined. */
+/* ADC_WCMP  is already defined. */
+/* ADC_RESOVR  is already defined. */
+/* ADC_SAMPOVR  is already defined. */
+/* ADC_TRIGOVR  is already defined. */
+
+/* ADC.STATUS  bit masks and bit positions */
+#define ADC_ADCBUSY_bm  0x01  /* ADC Busy bit mask. */
+#define ADC_ADCBUSY_bp  0  /* ADC Busy bit position. */
+
+/* ADC.DBGCTRL  bit masks and bit positions */
+#define ADC_DBGRUN_bm  0x01  /* Run in Debug Mode bit mask. */
+#define ADC_DBGRUN_bp  0  /* Run in Debug Mode bit position. */
+
+/* ADC.CTRLE  bit masks and bit positions */
+#define ADC_SAMPDUR_gm  0xFF  /* Sample Duration group mask. */
+#define ADC_SAMPDUR_gp  0  /* Sample Duration group position. */
+#define ADC_SAMPDUR_0_bm  (1<<0)  /* Sample Duration bit 0 mask. */
+#define ADC_SAMPDUR_0_bp  0  /* Sample Duration bit 0 position. */
+#define ADC_SAMPDUR_1_bm  (1<<1)  /* Sample Duration bit 1 mask. */
+#define ADC_SAMPDUR_1_bp  1  /* Sample Duration bit 1 position. */
+#define ADC_SAMPDUR_2_bm  (1<<2)  /* Sample Duration bit 2 mask. */
+#define ADC_SAMPDUR_2_bp  2  /* Sample Duration bit 2 position. */
+#define ADC_SAMPDUR_3_bm  (1<<3)  /* Sample Duration bit 3 mask. */
+#define ADC_SAMPDUR_3_bp  3  /* Sample Duration bit 3 position. */
+#define ADC_SAMPDUR_4_bm  (1<<4)  /* Sample Duration bit 4 mask. */
+#define ADC_SAMPDUR_4_bp  4  /* Sample Duration bit 4 position. */
+#define ADC_SAMPDUR_5_bm  (1<<5)  /* Sample Duration bit 5 mask. */
+#define ADC_SAMPDUR_5_bp  5  /* Sample Duration bit 5 position. */
+#define ADC_SAMPDUR_6_bm  (1<<6)  /* Sample Duration bit 6 mask. */
+#define ADC_SAMPDUR_6_bp  6  /* Sample Duration bit 6 position. */
+#define ADC_SAMPDUR_7_bm  (1<<7)  /* Sample Duration bit 7 mask. */
+#define ADC_SAMPDUR_7_bp  7  /* Sample Duration bit 7 position. */
+
+/* ADC.CTRLF  bit masks and bit positions */
+#define ADC_SAMPNUM_gm  0x0F  /* Sample numbers group mask. */
+#define ADC_SAMPNUM_gp  0  /* Sample numbers group position. */
+#define ADC_SAMPNUM_0_bm  (1<<0)  /* Sample numbers bit 0 mask. */
+#define ADC_SAMPNUM_0_bp  0  /* Sample numbers bit 0 position. */
+#define ADC_SAMPNUM_1_bm  (1<<1)  /* Sample numbers bit 1 mask. */
+#define ADC_SAMPNUM_1_bp  1  /* Sample numbers bit 1 position. */
+#define ADC_SAMPNUM_2_bm  (1<<2)  /* Sample numbers bit 2 mask. */
+#define ADC_SAMPNUM_2_bp  2  /* Sample numbers bit 2 position. */
+#define ADC_SAMPNUM_3_bm  (1<<3)  /* Sample numbers bit 3 mask. */
+#define ADC_SAMPNUM_3_bp  3  /* Sample numbers bit 3 position. */
+#define ADC_LEFTADJ_bm  0x10  /* Left Adjust bit mask. */
+#define ADC_LEFTADJ_bp  4  /* Left Adjust bit position. */
+#define ADC_FREERUN_bm  0x20  /* Free-Running mode bit mask. */
+#define ADC_FREERUN_bp  5  /* Free-Running mode bit position. */
+#define ADC_CHOPPING_bm  0x40  /* Sign Chopping bit mask. */
+#define ADC_CHOPPING_bp  6  /* Sign Chopping bit position. */
+
+/* ADC.COMMAND  bit masks and bit positions */
+#define ADC_START_gm  0x07  /* Start command group mask. */
+#define ADC_START_gp  0  /* Start command group position. */
+#define ADC_START_0_bm  (1<<0)  /* Start command bit 0 mask. */
+#define ADC_START_0_bp  0  /* Start command bit 0 position. */
+#define ADC_START_1_bm  (1<<1)  /* Start command bit 1 mask. */
+#define ADC_START_1_bp  1  /* Start command bit 1 position. */
+#define ADC_START_2_bm  (1<<2)  /* Start command bit 2 mask. */
+#define ADC_START_2_bp  2  /* Start command bit 2 position. */
+#define ADC_MODE_gm  0x70  /* Mode group mask. */
+#define ADC_MODE_gp  4  /* Mode group position. */
+#define ADC_MODE_0_bm  (1<<4)  /* Mode bit 0 mask. */
+#define ADC_MODE_0_bp  4  /* Mode bit 0 position. */
+#define ADC_MODE_1_bm  (1<<5)  /* Mode bit 1 mask. */
+#define ADC_MODE_1_bp  5  /* Mode bit 1 position. */
+#define ADC_MODE_2_bm  (1<<6)  /* Mode bit 2 mask. */
+#define ADC_MODE_2_bp  6  /* Mode bit 2 position. */
+#define ADC_DIFF_bm  0x80  /* Differential mode bit mask. */
+#define ADC_DIFF_bp  7  /* Differential mode bit position. */
+
+/* ADC.PGACTRL  bit masks and bit positions */
+#define ADC_PGAEN_bm  0x01  /* PGA Enable bit mask. */
+#define ADC_PGAEN_bp  0  /* PGA Enable bit position. */
+#define ADC_PGABIASSEL_gm  0x18  /* PGA BIAS Select group mask. */
+#define ADC_PGABIASSEL_gp  3  /* PGA BIAS Select group position. */
+#define ADC_PGABIASSEL_0_bm  (1<<3)  /* PGA BIAS Select bit 0 mask. */
+#define ADC_PGABIASSEL_0_bp  3  /* PGA BIAS Select bit 0 position. */
+#define ADC_PGABIASSEL_1_bm  (1<<4)  /* PGA BIAS Select bit 1 mask. */
+#define ADC_PGABIASSEL_1_bp  4  /* PGA BIAS Select bit 1 position. */
+#define ADC_GAIN_gm  0xE0  /* Gain group mask. */
+#define ADC_GAIN_gp  5  /* Gain group position. */
+#define ADC_GAIN_0_bm  (1<<5)  /* Gain bit 0 mask. */
+#define ADC_GAIN_0_bp  5  /* Gain bit 0 position. */
+#define ADC_GAIN_1_bm  (1<<6)  /* Gain bit 1 mask. */
+#define ADC_GAIN_1_bp  6  /* Gain bit 1 position. */
+#define ADC_GAIN_2_bm  (1<<7)  /* Gain bit 2 mask. */
+#define ADC_GAIN_2_bp  7  /* Gain bit 2 position. */
+
+/* ADC.MUXPOS  bit masks and bit positions */
+#define ADC_MUXPOS_gm  0x3F  /* Analog Channel Selection Bits group mask. */
+#define ADC_MUXPOS_gp  0  /* Analog Channel Selection Bits group position. */
+#define ADC_MUXPOS_0_bm  (1<<0)  /* Analog Channel Selection Bits bit 0 mask. */
+#define ADC_MUXPOS_0_bp  0  /* Analog Channel Selection Bits bit 0 position. */
+#define ADC_MUXPOS_1_bm  (1<<1)  /* Analog Channel Selection Bits bit 1 mask. */
+#define ADC_MUXPOS_1_bp  1  /* Analog Channel Selection Bits bit 1 position. */
+#define ADC_MUXPOS_2_bm  (1<<2)  /* Analog Channel Selection Bits bit 2 mask. */
+#define ADC_MUXPOS_2_bp  2  /* Analog Channel Selection Bits bit 2 position. */
+#define ADC_MUXPOS_3_bm  (1<<3)  /* Analog Channel Selection Bits bit 3 mask. */
+#define ADC_MUXPOS_3_bp  3  /* Analog Channel Selection Bits bit 3 position. */
+#define ADC_MUXPOS_4_bm  (1<<4)  /* Analog Channel Selection Bits bit 4 mask. */
+#define ADC_MUXPOS_4_bp  4  /* Analog Channel Selection Bits bit 4 position. */
+#define ADC_MUXPOS_5_bm  (1<<5)  /* Analog Channel Selection Bits bit 5 mask. */
+#define ADC_MUXPOS_5_bp  5  /* Analog Channel Selection Bits bit 5 position. */
+#define ADC_VIA_gm  0xC0  /* VIA group mask. */
+#define ADC_VIA_gp  6  /* VIA group position. */
+#define ADC_VIA_0_bm  (1<<6)  /* VIA bit 0 mask. */
+#define ADC_VIA_0_bp  6  /* VIA bit 0 position. */
+#define ADC_VIA_1_bm  (1<<7)  /* VIA bit 1 mask. */
+#define ADC_VIA_1_bp  7  /* VIA bit 1 position. */
+
+/* ADC.MUXNEG  bit masks and bit positions */
+#define ADC_MUXNEG_gm  0x3F  /* Analog Channel Selection Bits group mask. */
+#define ADC_MUXNEG_gp  0  /* Analog Channel Selection Bits group position. */
+#define ADC_MUXNEG_0_bm  (1<<0)  /* Analog Channel Selection Bits bit 0 mask. */
+#define ADC_MUXNEG_0_bp  0  /* Analog Channel Selection Bits bit 0 position. */
+#define ADC_MUXNEG_1_bm  (1<<1)  /* Analog Channel Selection Bits bit 1 mask. */
+#define ADC_MUXNEG_1_bp  1  /* Analog Channel Selection Bits bit 1 position. */
+#define ADC_MUXNEG_2_bm  (1<<2)  /* Analog Channel Selection Bits bit 2 mask. */
+#define ADC_MUXNEG_2_bp  2  /* Analog Channel Selection Bits bit 2 position. */
+#define ADC_MUXNEG_3_bm  (1<<3)  /* Analog Channel Selection Bits bit 3 mask. */
+#define ADC_MUXNEG_3_bp  3  /* Analog Channel Selection Bits bit 3 position. */
+#define ADC_MUXNEG_4_bm  (1<<4)  /* Analog Channel Selection Bits bit 4 mask. */
+#define ADC_MUXNEG_4_bp  4  /* Analog Channel Selection Bits bit 4 position. */
+#define ADC_MUXNEG_5_bm  (1<<5)  /* Analog Channel Selection Bits bit 5 mask. */
+#define ADC_MUXNEG_5_bp  5  /* Analog Channel Selection Bits bit 5 position. */
+/* ADC_VIA  is already defined. */
+
+
+/* BOD - Bod interface */
+/* BOD.CTRLA  bit masks and bit positions */
+#define BOD_SLEEP_gm  0x03  /* Operation in sleep mode group mask. */
+#define BOD_SLEEP_gp  0  /* Operation in sleep mode group position. */
+#define BOD_SLEEP_0_bm  (1<<0)  /* Operation in sleep mode bit 0 mask. */
+#define BOD_SLEEP_0_bp  0  /* Operation in sleep mode bit 0 position. */
+#define BOD_SLEEP_1_bm  (1<<1)  /* Operation in sleep mode bit 1 mask. */
+#define BOD_SLEEP_1_bp  1  /* Operation in sleep mode bit 1 position. */
+#define BOD_ACTIVE_gm  0x0C  /* Operation in active mode group mask. */
+#define BOD_ACTIVE_gp  2  /* Operation in active mode group position. */
+#define BOD_ACTIVE_0_bm  (1<<2)  /* Operation in active mode bit 0 mask. */
+#define BOD_ACTIVE_0_bp  2  /* Operation in active mode bit 0 position. */
+#define BOD_ACTIVE_1_bm  (1<<3)  /* Operation in active mode bit 1 mask. */
+#define BOD_ACTIVE_1_bp  3  /* Operation in active mode bit 1 position. */
+#define BOD_SAMPFREQ_bm  0x10  /* Sample frequency bit mask. */
+#define BOD_SAMPFREQ_bp  4  /* Sample frequency bit position. */
+
+/* BOD.CTRLB  bit masks and bit positions */
+#define BOD_LVL_gm  0x07  /* Bod level group mask. */
+#define BOD_LVL_gp  0  /* Bod level group position. */
+#define BOD_LVL_0_bm  (1<<0)  /* Bod level bit 0 mask. */
+#define BOD_LVL_0_bp  0  /* Bod level bit 0 position. */
+#define BOD_LVL_1_bm  (1<<1)  /* Bod level bit 1 mask. */
+#define BOD_LVL_1_bp  1  /* Bod level bit 1 position. */
+#define BOD_LVL_2_bm  (1<<2)  /* Bod level bit 2 mask. */
+#define BOD_LVL_2_bp  2  /* Bod level bit 2 position. */
+
+/* BOD.VLMCTRLA  bit masks and bit positions */
+#define BOD_VLMLVL_gm  0x03  /* voltage level monitor level group mask. */
+#define BOD_VLMLVL_gp  0  /* voltage level monitor level group position. */
+#define BOD_VLMLVL_0_bm  (1<<0)  /* voltage level monitor level bit 0 mask. */
+#define BOD_VLMLVL_0_bp  0  /* voltage level monitor level bit 0 position. */
+#define BOD_VLMLVL_1_bm  (1<<1)  /* voltage level monitor level bit 1 mask. */
+#define BOD_VLMLVL_1_bp  1  /* voltage level monitor level bit 1 position. */
+
+/* BOD.INTCTRL  bit masks and bit positions */
+#define BOD_VLMIE_bm  0x01  /* voltage level monitor interrrupt enable bit mask. */
+#define BOD_VLMIE_bp  0  /* voltage level monitor interrrupt enable bit position. */
+#define BOD_VLMCFG_gm  0x06  /* Configuration group mask. */
+#define BOD_VLMCFG_gp  1  /* Configuration group position. */
+#define BOD_VLMCFG_0_bm  (1<<1)  /* Configuration bit 0 mask. */
+#define BOD_VLMCFG_0_bp  1  /* Configuration bit 0 position. */
+#define BOD_VLMCFG_1_bm  (1<<2)  /* Configuration bit 1 mask. */
+#define BOD_VLMCFG_1_bp  2  /* Configuration bit 1 position. */
+
+/* BOD.INTFLAGS  bit masks and bit positions */
+#define BOD_VLMIF_bm  0x01  /* Voltage level monitor interrupt flag bit mask. */
+#define BOD_VLMIF_bp  0  /* Voltage level monitor interrupt flag bit position. */
+
+/* BOD.STATUS  bit masks and bit positions */
+#define BOD_VLMS_bm  0x01  /* Voltage level monitor status bit mask. */
+#define BOD_VLMS_bp  0  /* Voltage level monitor status bit position. */
+
+
+/* CCL - Configurable Custom Logic */
+/* CCL.CTRLA  bit masks and bit positions */
+#define CCL_ENABLE_bm  0x01  /* Enable bit mask. */
+#define CCL_ENABLE_bp  0  /* Enable bit position. */
+#define CCL_RUNSTDBY_bm  0x40  /* Run in Standby bit mask. */
+#define CCL_RUNSTDBY_bp  6  /* Run in Standby bit position. */
+
+/* CCL.SEQCTRL0  bit masks and bit positions */
+#define CCL_SEQSEL_gm  0x07  /* Sequential Selection group mask. */
+#define CCL_SEQSEL_gp  0  /* Sequential Selection group position. */
+#define CCL_SEQSEL_0_bm  (1<<0)  /* Sequential Selection bit 0 mask. */
+#define CCL_SEQSEL_0_bp  0  /* Sequential Selection bit 0 position. */
+#define CCL_SEQSEL_1_bm  (1<<1)  /* Sequential Selection bit 1 mask. */
+#define CCL_SEQSEL_1_bp  1  /* Sequential Selection bit 1 position. */
+#define CCL_SEQSEL_2_bm  (1<<2)  /* Sequential Selection bit 2 mask. */
+#define CCL_SEQSEL_2_bp  2  /* Sequential Selection bit 2 position. */
+
+/* CCL.SEQCTRL1  bit masks and bit positions */
+/* CCL_SEQSEL  is already defined. */
+
+/* CCL.INTCTRL0  bit masks and bit positions */
+#define CCL_INTMODE0_gm  0x03  /* Interrupt Mode for LUT0 group mask. */
+#define CCL_INTMODE0_gp  0  /* Interrupt Mode for LUT0 group position. */
+#define CCL_INTMODE0_0_bm  (1<<0)  /* Interrupt Mode for LUT0 bit 0 mask. */
+#define CCL_INTMODE0_0_bp  0  /* Interrupt Mode for LUT0 bit 0 position. */
+#define CCL_INTMODE0_1_bm  (1<<1)  /* Interrupt Mode for LUT0 bit 1 mask. */
+#define CCL_INTMODE0_1_bp  1  /* Interrupt Mode for LUT0 bit 1 position. */
+#define CCL_INTMODE1_gm  0x0C  /* Interrupt Mode for LUT1 group mask. */
+#define CCL_INTMODE1_gp  2  /* Interrupt Mode for LUT1 group position. */
+#define CCL_INTMODE1_0_bm  (1<<2)  /* Interrupt Mode for LUT1 bit 0 mask. */
+#define CCL_INTMODE1_0_bp  2  /* Interrupt Mode for LUT1 bit 0 position. */
+#define CCL_INTMODE1_1_bm  (1<<3)  /* Interrupt Mode for LUT1 bit 1 mask. */
+#define CCL_INTMODE1_1_bp  3  /* Interrupt Mode for LUT1 bit 1 position. */
+#define CCL_INTMODE2_gm  0x30  /* Interrupt Mode for LUT2 group mask. */
+#define CCL_INTMODE2_gp  4  /* Interrupt Mode for LUT2 group position. */
+#define CCL_INTMODE2_0_bm  (1<<4)  /* Interrupt Mode for LUT2 bit 0 mask. */
+#define CCL_INTMODE2_0_bp  4  /* Interrupt Mode for LUT2 bit 0 position. */
+#define CCL_INTMODE2_1_bm  (1<<5)  /* Interrupt Mode for LUT2 bit 1 mask. */
+#define CCL_INTMODE2_1_bp  5  /* Interrupt Mode for LUT2 bit 1 position. */
+#define CCL_INTMODE3_gm  0xC0  /* Interrupt Mode for LUT3 group mask. */
+#define CCL_INTMODE3_gp  6  /* Interrupt Mode for LUT3 group position. */
+#define CCL_INTMODE3_0_bm  (1<<6)  /* Interrupt Mode for LUT3 bit 0 mask. */
+#define CCL_INTMODE3_0_bp  6  /* Interrupt Mode for LUT3 bit 0 position. */
+#define CCL_INTMODE3_1_bm  (1<<7)  /* Interrupt Mode for LUT3 bit 1 mask. */
+#define CCL_INTMODE3_1_bp  7  /* Interrupt Mode for LUT3 bit 1 position. */
+
+/* CCL.INTFLAGS  bit masks and bit positions */
+#define CCL_INT_gm  0x0F  /* Interrupt Flag group mask. */
+#define CCL_INT_gp  0  /* Interrupt Flag group position. */
+#define CCL_INT_0_bm  (1<<0)  /* Interrupt Flag bit 0 mask. */
+#define CCL_INT_0_bp  0  /* Interrupt Flag bit 0 position. */
+#define CCL_INT0_bm  CCL_INT_0_bm  /* This define is deprecated and should not be used */
+#define CCL_INT0_bp  CCL_INT_0_bp  /* This define is deprecated and should not be used */
+#define CCL_INT_1_bm  (1<<1)  /* Interrupt Flag bit 1 mask. */
+#define CCL_INT_1_bp  1  /* Interrupt Flag bit 1 position. */
+#define CCL_INT1_bm  CCL_INT_1_bm  /* This define is deprecated and should not be used */
+#define CCL_INT1_bp  CCL_INT_1_bp  /* This define is deprecated and should not be used */
+#define CCL_INT_2_bm  (1<<2)  /* Interrupt Flag bit 2 mask. */
+#define CCL_INT_2_bp  2  /* Interrupt Flag bit 2 position. */
+#define CCL_INT2_bm  CCL_INT_2_bm  /* This define is deprecated and should not be used */
+#define CCL_INT2_bp  CCL_INT_2_bp  /* This define is deprecated and should not be used */
+#define CCL_INT_3_bm  (1<<3)  /* Interrupt Flag bit 3 mask. */
+#define CCL_INT_3_bp  3  /* Interrupt Flag bit 3 position. */
+#define CCL_INT3_bm  CCL_INT_3_bm  /* This define is deprecated and should not be used */
+#define CCL_INT3_bp  CCL_INT_3_bp  /* This define is deprecated and should not be used */
+
+/* CCL.LUT0CTRLA  bit masks and bit positions */
+/* CCL_ENABLE  is already defined. */
+#define CCL_CLKSRC_gm  0x0E  /* Clock Source Selection group mask. */
+#define CCL_CLKSRC_gp  1  /* Clock Source Selection group position. */
+#define CCL_CLKSRC_0_bm  (1<<1)  /* Clock Source Selection bit 0 mask. */
+#define CCL_CLKSRC_0_bp  1  /* Clock Source Selection bit 0 position. */
+#define CCL_CLKSRC_1_bm  (1<<2)  /* Clock Source Selection bit 1 mask. */
+#define CCL_CLKSRC_1_bp  2  /* Clock Source Selection bit 1 position. */
+#define CCL_CLKSRC_2_bm  (1<<3)  /* Clock Source Selection bit 2 mask. */
+#define CCL_CLKSRC_2_bp  3  /* Clock Source Selection bit 2 position. */
+#define CCL_FILTSEL_gm  0x30  /* Filter Selection group mask. */
+#define CCL_FILTSEL_gp  4  /* Filter Selection group position. */
+#define CCL_FILTSEL_0_bm  (1<<4)  /* Filter Selection bit 0 mask. */
+#define CCL_FILTSEL_0_bp  4  /* Filter Selection bit 0 position. */
+#define CCL_FILTSEL_1_bm  (1<<5)  /* Filter Selection bit 1 mask. */
+#define CCL_FILTSEL_1_bp  5  /* Filter Selection bit 1 position. */
+#define CCL_OUTEN_bm  0x40  /* Output Enable bit mask. */
+#define CCL_OUTEN_bp  6  /* Output Enable bit position. */
+#define CCL_EDGEDET_bm  0x80  /* Edge Detection Enable bit mask. */
+#define CCL_EDGEDET_bp  7  /* Edge Detection Enable bit position. */
+
+/* CCL.LUT0CTRLB  bit masks and bit positions */
+#define CCL_INSEL0_gm  0x0F  /* LUT Input 0 Source Selection group mask. */
+#define CCL_INSEL0_gp  0  /* LUT Input 0 Source Selection group position. */
+#define CCL_INSEL0_0_bm  (1<<0)  /* LUT Input 0 Source Selection bit 0 mask. */
+#define CCL_INSEL0_0_bp  0  /* LUT Input 0 Source Selection bit 0 position. */
+#define CCL_INSEL0_1_bm  (1<<1)  /* LUT Input 0 Source Selection bit 1 mask. */
+#define CCL_INSEL0_1_bp  1  /* LUT Input 0 Source Selection bit 1 position. */
+#define CCL_INSEL0_2_bm  (1<<2)  /* LUT Input 0 Source Selection bit 2 mask. */
+#define CCL_INSEL0_2_bp  2  /* LUT Input 0 Source Selection bit 2 position. */
+#define CCL_INSEL0_3_bm  (1<<3)  /* LUT Input 0 Source Selection bit 3 mask. */
+#define CCL_INSEL0_3_bp  3  /* LUT Input 0 Source Selection bit 3 position. */
+#define CCL_INSEL1_gm  0xF0  /* LUT Input 1 Source Selection group mask. */
+#define CCL_INSEL1_gp  4  /* LUT Input 1 Source Selection group position. */
+#define CCL_INSEL1_0_bm  (1<<4)  /* LUT Input 1 Source Selection bit 0 mask. */
+#define CCL_INSEL1_0_bp  4  /* LUT Input 1 Source Selection bit 0 position. */
+#define CCL_INSEL1_1_bm  (1<<5)  /* LUT Input 1 Source Selection bit 1 mask. */
+#define CCL_INSEL1_1_bp  5  /* LUT Input 1 Source Selection bit 1 position. */
+#define CCL_INSEL1_2_bm  (1<<6)  /* LUT Input 1 Source Selection bit 2 mask. */
+#define CCL_INSEL1_2_bp  6  /* LUT Input 1 Source Selection bit 2 position. */
+#define CCL_INSEL1_3_bm  (1<<7)  /* LUT Input 1 Source Selection bit 3 mask. */
+#define CCL_INSEL1_3_bp  7  /* LUT Input 1 Source Selection bit 3 position. */
+
+/* CCL.LUT0CTRLC  bit masks and bit positions */
+#define CCL_INSEL2_gm  0x0F  /* LUT Input 2 Source Selection group mask. */
+#define CCL_INSEL2_gp  0  /* LUT Input 2 Source Selection group position. */
+#define CCL_INSEL2_0_bm  (1<<0)  /* LUT Input 2 Source Selection bit 0 mask. */
+#define CCL_INSEL2_0_bp  0  /* LUT Input 2 Source Selection bit 0 position. */
+#define CCL_INSEL2_1_bm  (1<<1)  /* LUT Input 2 Source Selection bit 1 mask. */
+#define CCL_INSEL2_1_bp  1  /* LUT Input 2 Source Selection bit 1 position. */
+#define CCL_INSEL2_2_bm  (1<<2)  /* LUT Input 2 Source Selection bit 2 mask. */
+#define CCL_INSEL2_2_bp  2  /* LUT Input 2 Source Selection bit 2 position. */
+#define CCL_INSEL2_3_bm  (1<<3)  /* LUT Input 2 Source Selection bit 3 mask. */
+#define CCL_INSEL2_3_bp  3  /* LUT Input 2 Source Selection bit 3 position. */
+
+/* CCL.TRUTH0  bit masks and bit positions */
+#define CCL_TRUTH_gm  0xFF  /* Truth Table group mask. */
+#define CCL_TRUTH_gp  0  /* Truth Table group position. */
+#define CCL_TRUTH_0_bm  (1<<0)  /* Truth Table bit 0 mask. */
+#define CCL_TRUTH_0_bp  0  /* Truth Table bit 0 position. */
+#define CCL_TRUTH_1_bm  (1<<1)  /* Truth Table bit 1 mask. */
+#define CCL_TRUTH_1_bp  1  /* Truth Table bit 1 position. */
+#define CCL_TRUTH_2_bm  (1<<2)  /* Truth Table bit 2 mask. */
+#define CCL_TRUTH_2_bp  2  /* Truth Table bit 2 position. */
+#define CCL_TRUTH_3_bm  (1<<3)  /* Truth Table bit 3 mask. */
+#define CCL_TRUTH_3_bp  3  /* Truth Table bit 3 position. */
+#define CCL_TRUTH_4_bm  (1<<4)  /* Truth Table bit 4 mask. */
+#define CCL_TRUTH_4_bp  4  /* Truth Table bit 4 position. */
+#define CCL_TRUTH_5_bm  (1<<5)  /* Truth Table bit 5 mask. */
+#define CCL_TRUTH_5_bp  5  /* Truth Table bit 5 position. */
+#define CCL_TRUTH_6_bm  (1<<6)  /* Truth Table bit 6 mask. */
+#define CCL_TRUTH_6_bp  6  /* Truth Table bit 6 position. */
+#define CCL_TRUTH_7_bm  (1<<7)  /* Truth Table bit 7 mask. */
+#define CCL_TRUTH_7_bp  7  /* Truth Table bit 7 position. */
+
+/* CCL.LUT1CTRLA  bit masks and bit positions */
+/* CCL_ENABLE  is already defined. */
+/* CCL_CLKSRC  is already defined. */
+/* CCL_FILTSEL  is already defined. */
+/* CCL_OUTEN  is already defined. */
+/* CCL_EDGEDET  is already defined. */
+
+/* CCL.LUT1CTRLB  bit masks and bit positions */
+/* CCL_INSEL0  is already defined. */
+/* CCL_INSEL1  is already defined. */
+
+/* CCL.LUT1CTRLC  bit masks and bit positions */
+/* CCL_INSEL2  is already defined. */
+
+/* CCL.TRUTH1  bit masks and bit positions */
+/* CCL_TRUTH  is already defined. */
+
+/* CCL.LUT2CTRLA  bit masks and bit positions */
+/* CCL_ENABLE  is already defined. */
+/* CCL_CLKSRC  is already defined. */
+/* CCL_FILTSEL  is already defined. */
+/* CCL_OUTEN  is already defined. */
+/* CCL_EDGEDET  is already defined. */
+
+/* CCL.LUT2CTRLB  bit masks and bit positions */
+/* CCL_INSEL0  is already defined. */
+/* CCL_INSEL1  is already defined. */
+
+/* CCL.LUT2CTRLC  bit masks and bit positions */
+/* CCL_INSEL2  is already defined. */
+
+/* CCL.TRUTH2  bit masks and bit positions */
+/* CCL_TRUTH  is already defined. */
+
+/* CCL.LUT3CTRLA  bit masks and bit positions */
+/* CCL_ENABLE  is already defined. */
+/* CCL_CLKSRC  is already defined. */
+/* CCL_FILTSEL  is already defined. */
+/* CCL_OUTEN  is already defined. */
+/* CCL_EDGEDET  is already defined. */
+
+/* CCL.LUT3CTRLB  bit masks and bit positions */
+/* CCL_INSEL0  is already defined. */
+/* CCL_INSEL1  is already defined. */
+
+/* CCL.LUT3CTRLC  bit masks and bit positions */
+/* CCL_INSEL2  is already defined. */
+
+/* CCL.TRUTH3  bit masks and bit positions */
+/* CCL_TRUTH  is already defined. */
+
+
+/* CLKCTRL - Clock controller */
+/* CLKCTRL.MCLKCTRLA  bit masks and bit positions */
+#define CLKCTRL_CLKSEL_gm  0x07  /* Clock select group mask. */
+#define CLKCTRL_CLKSEL_gp  0  /* Clock select group position. */
+#define CLKCTRL_CLKSEL_0_bm  (1<<0)  /* Clock select bit 0 mask. */
+#define CLKCTRL_CLKSEL_0_bp  0  /* Clock select bit 0 position. */
+#define CLKCTRL_CLKSEL_1_bm  (1<<1)  /* Clock select bit 1 mask. */
+#define CLKCTRL_CLKSEL_1_bp  1  /* Clock select bit 1 position. */
+#define CLKCTRL_CLKSEL_2_bm  (1<<2)  /* Clock select bit 2 mask. */
+#define CLKCTRL_CLKSEL_2_bp  2  /* Clock select bit 2 position. */
+#define CLKCTRL_CLKOUT_bm  0x80  /* System clock out bit mask. */
+#define CLKCTRL_CLKOUT_bp  7  /* System clock out bit position. */
+
+/* CLKCTRL.MCLKCTRLB  bit masks and bit positions */
+#define CLKCTRL_PEN_bm  0x01  /* Prescaler enable bit mask. */
+#define CLKCTRL_PEN_bp  0  /* Prescaler enable bit position. */
+#define CLKCTRL_PDIV_gm  0x1E  /* Prescaler division group mask. */
+#define CLKCTRL_PDIV_gp  1  /* Prescaler division group position. */
+#define CLKCTRL_PDIV_0_bm  (1<<1)  /* Prescaler division bit 0 mask. */
+#define CLKCTRL_PDIV_0_bp  1  /* Prescaler division bit 0 position. */
+#define CLKCTRL_PDIV_1_bm  (1<<2)  /* Prescaler division bit 1 mask. */
+#define CLKCTRL_PDIV_1_bp  2  /* Prescaler division bit 1 position. */
+#define CLKCTRL_PDIV_2_bm  (1<<3)  /* Prescaler division bit 2 mask. */
+#define CLKCTRL_PDIV_2_bp  3  /* Prescaler division bit 2 position. */
+#define CLKCTRL_PDIV_3_bm  (1<<4)  /* Prescaler division bit 3 mask. */
+#define CLKCTRL_PDIV_3_bp  4  /* Prescaler division bit 3 position. */
+
+/* CLKCTRL.MCLKCTRLC  bit masks and bit positions */
+#define CLKCTRL_CFDEN_bm  0x01  /* Clock Failure Detect Enable bit mask. */
+#define CLKCTRL_CFDEN_bp  0  /* Clock Failure Detect Enable bit position. */
+#define CLKCTRL_CFDTST_bm  0x02  /* CFD Test bit mask. */
+#define CLKCTRL_CFDTST_bp  1  /* CFD Test bit position. */
+#define CLKCTRL_CFDSRC_gm  0x0C  /* CFD Source group mask. */
+#define CLKCTRL_CFDSRC_gp  2  /* CFD Source group position. */
+#define CLKCTRL_CFDSRC_0_bm  (1<<2)  /* CFD Source bit 0 mask. */
+#define CLKCTRL_CFDSRC_0_bp  2  /* CFD Source bit 0 position. */
+#define CLKCTRL_CFDSRC_1_bm  (1<<3)  /* CFD Source bit 1 mask. */
+#define CLKCTRL_CFDSRC_1_bp  3  /* CFD Source bit 1 position. */
+
+/* CLKCTRL.MCLKINTCTRL  bit masks and bit positions */
+#define CLKCTRL_CFD_bm  0x01  /* Interrupt Enable bit mask. */
+#define CLKCTRL_CFD_bp  0  /* Interrupt Enable bit position. */
+#define CLKCTRL_INTTYPE_bm  0x80  /* Interrupt Type bit mask. */
+#define CLKCTRL_INTTYPE_bp  7  /* Interrupt Type bit position. */
+
+/* CLKCTRL.MCLKINTFLAGS  bit masks and bit positions */
+/* CLKCTRL_CFD  is already defined. */
+
+/* CLKCTRL.MCLKSTATUS  bit masks and bit positions */
+#define CLKCTRL_SOSC_bm  0x01  /* System Oscillator changing bit mask. */
+#define CLKCTRL_SOSC_bp  0  /* System Oscillator changing bit position. */
+#define CLKCTRL_OSCHFS_bm  0x02  /* High frequency oscillator status bit mask. */
+#define CLKCTRL_OSCHFS_bp  1  /* High frequency oscillator status bit position. */
+#define CLKCTRL_OSC32KS_bm  0x04  /* 32KHz oscillator status bit mask. */
+#define CLKCTRL_OSC32KS_bp  2  /* 32KHz oscillator status bit position. */
+#define CLKCTRL_XOSC32KS_bm  0x08  /* 32.768 kHz Crystal Oscillator status bit mask. */
+#define CLKCTRL_XOSC32KS_bp  3  /* 32.768 kHz Crystal Oscillator status bit position. */
+#define CLKCTRL_EXTS_bm  0x10  /* External Clock status / XOSCHF status bit mask. */
+#define CLKCTRL_EXTS_bp  4  /* External Clock status / XOSCHF status bit position. */
+
+/* CLKCTRL.MCLKTIMEBASE  bit masks and bit positions */
+#define CLKCTRL_TIMEBASE_gm  0x1F  /* Timebase group mask. */
+#define CLKCTRL_TIMEBASE_gp  0  /* Timebase group position. */
+#define CLKCTRL_TIMEBASE_0_bm  (1<<0)  /* Timebase bit 0 mask. */
+#define CLKCTRL_TIMEBASE_0_bp  0  /* Timebase bit 0 position. */
+#define CLKCTRL_TIMEBASE_1_bm  (1<<1)  /* Timebase bit 1 mask. */
+#define CLKCTRL_TIMEBASE_1_bp  1  /* Timebase bit 1 position. */
+#define CLKCTRL_TIMEBASE_2_bm  (1<<2)  /* Timebase bit 2 mask. */
+#define CLKCTRL_TIMEBASE_2_bp  2  /* Timebase bit 2 position. */
+#define CLKCTRL_TIMEBASE_3_bm  (1<<3)  /* Timebase bit 3 mask. */
+#define CLKCTRL_TIMEBASE_3_bp  3  /* Timebase bit 3 position. */
+#define CLKCTRL_TIMEBASE_4_bm  (1<<4)  /* Timebase bit 4 mask. */
+#define CLKCTRL_TIMEBASE_4_bp  4  /* Timebase bit 4 position. */
+
+/* CLKCTRL.OSCHFCTRLA  bit masks and bit positions */
+#define CLKCTRL_AUTOTUNE_gm  0x03  /* Automatic Oscillator Tune group mask. */
+#define CLKCTRL_AUTOTUNE_gp  0  /* Automatic Oscillator Tune group position. */
+#define CLKCTRL_AUTOTUNE_0_bm  (1<<0)  /* Automatic Oscillator Tune bit 0 mask. */
+#define CLKCTRL_AUTOTUNE_0_bp  0  /* Automatic Oscillator Tune bit 0 position. */
+#define CLKCTRL_AUTOTUNE_1_bm  (1<<1)  /* Automatic Oscillator Tune bit 1 mask. */
+#define CLKCTRL_AUTOTUNE_1_bp  1  /* Automatic Oscillator Tune bit 1 position. */
+#define CLKCTRL_RUNSTDBY_bm  0x80  /* Run in standby bit mask. */
+#define CLKCTRL_RUNSTDBY_bp  7  /* Run in standby bit position. */
+
+/* CLKCTRL.OSCHFTUNE  bit masks and bit positions */
+#define CLKCTRL_TUNE_gm  0xFF  /* Oscillator Tune group mask. */
+#define CLKCTRL_TUNE_gp  0  /* Oscillator Tune group position. */
+#define CLKCTRL_TUNE_0_bm  (1<<0)  /* Oscillator Tune bit 0 mask. */
+#define CLKCTRL_TUNE_0_bp  0  /* Oscillator Tune bit 0 position. */
+#define CLKCTRL_TUNE_1_bm  (1<<1)  /* Oscillator Tune bit 1 mask. */
+#define CLKCTRL_TUNE_1_bp  1  /* Oscillator Tune bit 1 position. */
+#define CLKCTRL_TUNE_2_bm  (1<<2)  /* Oscillator Tune bit 2 mask. */
+#define CLKCTRL_TUNE_2_bp  2  /* Oscillator Tune bit 2 position. */
+#define CLKCTRL_TUNE_3_bm  (1<<3)  /* Oscillator Tune bit 3 mask. */
+#define CLKCTRL_TUNE_3_bp  3  /* Oscillator Tune bit 3 position. */
+#define CLKCTRL_TUNE_4_bm  (1<<4)  /* Oscillator Tune bit 4 mask. */
+#define CLKCTRL_TUNE_4_bp  4  /* Oscillator Tune bit 4 position. */
+#define CLKCTRL_TUNE_5_bm  (1<<5)  /* Oscillator Tune bit 5 mask. */
+#define CLKCTRL_TUNE_5_bp  5  /* Oscillator Tune bit 5 position. */
+#define CLKCTRL_TUNE_6_bm  (1<<6)  /* Oscillator Tune bit 6 mask. */
+#define CLKCTRL_TUNE_6_bp  6  /* Oscillator Tune bit 6 position. */
+#define CLKCTRL_TUNE_7_bm  (1<<7)  /* Oscillator Tune bit 7 mask. */
+#define CLKCTRL_TUNE_7_bp  7  /* Oscillator Tune bit 7 position. */
+
+/* CLKCTRL.OSC32KCTRLA  bit masks and bit positions */
+/* CLKCTRL_RUNSTDBY  is already defined. */
+
+/* CLKCTRL.XOSC32KCTRLA  bit masks and bit positions */
+#define CLKCTRL_ENABLE_bm  0x01  /* Enable bit mask. */
+#define CLKCTRL_ENABLE_bp  0  /* Enable bit position. */
+#define CLKCTRL_LPMODE_bm  0x02  /* Low power mode bit mask. */
+#define CLKCTRL_LPMODE_bp  1  /* Low power mode bit position. */
+#define CLKCTRL_SEL_bm  0x04  /* Select bit mask. */
+#define CLKCTRL_SEL_bp  2  /* Select bit position. */
+#define CLKCTRL_CSUT_gm  0x30  /* Crystal startup time group mask. */
+#define CLKCTRL_CSUT_gp  4  /* Crystal startup time group position. */
+#define CLKCTRL_CSUT_0_bm  (1<<4)  /* Crystal startup time bit 0 mask. */
+#define CLKCTRL_CSUT_0_bp  4  /* Crystal startup time bit 0 position. */
+#define CLKCTRL_CSUT_1_bm  (1<<5)  /* Crystal startup time bit 1 mask. */
+#define CLKCTRL_CSUT_1_bp  5  /* Crystal startup time bit 1 position. */
+/* CLKCTRL_RUNSTDBY  is already defined. */
+
+/* CLKCTRL.XOSCHFCTRLA  bit masks and bit positions */
+/* CLKCTRL_ENABLE  is already defined. */
+#define CLKCTRL_SELHF_bm  0x02  /* Source Select bit mask. */
+#define CLKCTRL_SELHF_bp  1  /* Source Select bit position. */
+#define CLKCTRL_CSUTHF_gm  0x30  /* Start-Up Time group mask. */
+#define CLKCTRL_CSUTHF_gp  4  /* Start-Up Time group position. */
+#define CLKCTRL_CSUTHF_0_bm  (1<<4)  /* Start-Up Time bit 0 mask. */
+#define CLKCTRL_CSUTHF_0_bp  4  /* Start-Up Time bit 0 position. */
+#define CLKCTRL_CSUTHF_1_bm  (1<<5)  /* Start-Up Time bit 1 mask. */
+#define CLKCTRL_CSUTHF_1_bp  5  /* Start-Up Time bit 1 position. */
+/* CLKCTRL_RUNSTDBY  is already defined. */
+
+
+/* CPU - CPU */
+/* CPU.CCP  bit masks and bit positions */
+#define CPU_CCP_gm  0xFF  /* CCP signature group mask. */
+#define CPU_CCP_gp  0  /* CCP signature group position. */
+#define CPU_CCP_0_bm  (1<<0)  /* CCP signature bit 0 mask. */
+#define CPU_CCP_0_bp  0  /* CCP signature bit 0 position. */
+#define CPU_CCP_1_bm  (1<<1)  /* CCP signature bit 1 mask. */
+#define CPU_CCP_1_bp  1  /* CCP signature bit 1 position. */
+#define CPU_CCP_2_bm  (1<<2)  /* CCP signature bit 2 mask. */
+#define CPU_CCP_2_bp  2  /* CCP signature bit 2 position. */
+#define CPU_CCP_3_bm  (1<<3)  /* CCP signature bit 3 mask. */
+#define CPU_CCP_3_bp  3  /* CCP signature bit 3 position. */
+#define CPU_CCP_4_bm  (1<<4)  /* CCP signature bit 4 mask. */
+#define CPU_CCP_4_bp  4  /* CCP signature bit 4 position. */
+#define CPU_CCP_5_bm  (1<<5)  /* CCP signature bit 5 mask. */
+#define CPU_CCP_5_bp  5  /* CCP signature bit 5 position. */
+#define CPU_CCP_6_bm  (1<<6)  /* CCP signature bit 6 mask. */
+#define CPU_CCP_6_bp  6  /* CCP signature bit 6 position. */
+#define CPU_CCP_7_bm  (1<<7)  /* CCP signature bit 7 mask. */
+#define CPU_CCP_7_bp  7  /* CCP signature bit 7 position. */
+
+/* CPU.SREG  bit masks and bit positions */
+#define CPU_C_bm  0x01  /* Carry Flag bit mask. */
+#define CPU_C_bp  0  /* Carry Flag bit position. */
+#define CPU_Z_bm  0x02  /* Zero Flag bit mask. */
+#define CPU_Z_bp  1  /* Zero Flag bit position. */
+#define CPU_N_bm  0x04  /* Negative Flag bit mask. */
+#define CPU_N_bp  2  /* Negative Flag bit position. */
+#define CPU_V_bm  0x08  /* Two's Complement Overflow Flag bit mask. */
+#define CPU_V_bp  3  /* Two's Complement Overflow Flag bit position. */
+#define CPU_S_bm  0x10  /* N Exclusive Or V Flag bit mask. */
+#define CPU_S_bp  4  /* N Exclusive Or V Flag bit position. */
+#define CPU_H_bm  0x20  /* Half Carry Flag bit mask. */
+#define CPU_H_bp  5  /* Half Carry Flag bit position. */
+#define CPU_T_bm  0x40  /* Transfer Bit bit mask. */
+#define CPU_T_bp  6  /* Transfer Bit bit position. */
+#define CPU_I_bm  0x80  /* Global Interrupt Enable Flag bit mask. */
+#define CPU_I_bp  7  /* Global Interrupt Enable Flag bit position. */
+
+
+/* CPUINT - Interrupt Controller */
+/* CPUINT.CTRLA  bit masks and bit positions */
+#define CPUINT_LVL0RR_bm  0x01  /* Round-robin Scheduling Enable bit mask. */
+#define CPUINT_LVL0RR_bp  0  /* Round-robin Scheduling Enable bit position. */
+#define CPUINT_CVT_bm  0x20  /* Compact Vector Table bit mask. */
+#define CPUINT_CVT_bp  5  /* Compact Vector Table bit position. */
+#define CPUINT_IVSEL_bm  0x40  /* Interrupt Vector Select bit mask. */
+#define CPUINT_IVSEL_bp  6  /* Interrupt Vector Select bit position. */
+
+/* CPUINT.STATUS  bit masks and bit positions */
+#define CPUINT_LVL0EX_bm  0x01  /* Level 0 Interrupt Executing bit mask. */
+#define CPUINT_LVL0EX_bp  0  /* Level 0 Interrupt Executing bit position. */
+#define CPUINT_LVL1EX_bm  0x02  /* Level 1 Interrupt Executing bit mask. */
+#define CPUINT_LVL1EX_bp  1  /* Level 1 Interrupt Executing bit position. */
+#define CPUINT_NMIEX_bm  0x80  /* Non-maskable Interrupt Executing bit mask. */
+#define CPUINT_NMIEX_bp  7  /* Non-maskable Interrupt Executing bit position. */
+
+/* CPUINT.LVL0PRI  bit masks and bit positions */
+#define CPUINT_LVL0PRI_gm  0xFF  /* Interrupt Level Priority group mask. */
+#define CPUINT_LVL0PRI_gp  0  /* Interrupt Level Priority group position. */
+#define CPUINT_LVL0PRI_0_bm  (1<<0)  /* Interrupt Level Priority bit 0 mask. */
+#define CPUINT_LVL0PRI_0_bp  0  /* Interrupt Level Priority bit 0 position. */
+#define CPUINT_LVL0PRI_1_bm  (1<<1)  /* Interrupt Level Priority bit 1 mask. */
+#define CPUINT_LVL0PRI_1_bp  1  /* Interrupt Level Priority bit 1 position. */
+#define CPUINT_LVL0PRI_2_bm  (1<<2)  /* Interrupt Level Priority bit 2 mask. */
+#define CPUINT_LVL0PRI_2_bp  2  /* Interrupt Level Priority bit 2 position. */
+#define CPUINT_LVL0PRI_3_bm  (1<<3)  /* Interrupt Level Priority bit 3 mask. */
+#define CPUINT_LVL0PRI_3_bp  3  /* Interrupt Level Priority bit 3 position. */
+#define CPUINT_LVL0PRI_4_bm  (1<<4)  /* Interrupt Level Priority bit 4 mask. */
+#define CPUINT_LVL0PRI_4_bp  4  /* Interrupt Level Priority bit 4 position. */
+#define CPUINT_LVL0PRI_5_bm  (1<<5)  /* Interrupt Level Priority bit 5 mask. */
+#define CPUINT_LVL0PRI_5_bp  5  /* Interrupt Level Priority bit 5 position. */
+#define CPUINT_LVL0PRI_6_bm  (1<<6)  /* Interrupt Level Priority bit 6 mask. */
+#define CPUINT_LVL0PRI_6_bp  6  /* Interrupt Level Priority bit 6 position. */
+#define CPUINT_LVL0PRI_7_bm  (1<<7)  /* Interrupt Level Priority bit 7 mask. */
+#define CPUINT_LVL0PRI_7_bp  7  /* Interrupt Level Priority bit 7 position. */
+
+/* CPUINT.LVL1VEC  bit masks and bit positions */
+#define CPUINT_LVL1VEC_gm  0xFF  /* Interrupt Vector with High Priority group mask. */
+#define CPUINT_LVL1VEC_gp  0  /* Interrupt Vector with High Priority group position. */
+#define CPUINT_LVL1VEC_0_bm  (1<<0)  /* Interrupt Vector with High Priority bit 0 mask. */
+#define CPUINT_LVL1VEC_0_bp  0  /* Interrupt Vector with High Priority bit 0 position. */
+#define CPUINT_LVL1VEC_1_bm  (1<<1)  /* Interrupt Vector with High Priority bit 1 mask. */
+#define CPUINT_LVL1VEC_1_bp  1  /* Interrupt Vector with High Priority bit 1 position. */
+#define CPUINT_LVL1VEC_2_bm  (1<<2)  /* Interrupt Vector with High Priority bit 2 mask. */
+#define CPUINT_LVL1VEC_2_bp  2  /* Interrupt Vector with High Priority bit 2 position. */
+#define CPUINT_LVL1VEC_3_bm  (1<<3)  /* Interrupt Vector with High Priority bit 3 mask. */
+#define CPUINT_LVL1VEC_3_bp  3  /* Interrupt Vector with High Priority bit 3 position. */
+#define CPUINT_LVL1VEC_4_bm  (1<<4)  /* Interrupt Vector with High Priority bit 4 mask. */
+#define CPUINT_LVL1VEC_4_bp  4  /* Interrupt Vector with High Priority bit 4 position. */
+#define CPUINT_LVL1VEC_5_bm  (1<<5)  /* Interrupt Vector with High Priority bit 5 mask. */
+#define CPUINT_LVL1VEC_5_bp  5  /* Interrupt Vector with High Priority bit 5 position. */
+#define CPUINT_LVL1VEC_6_bm  (1<<6)  /* Interrupt Vector with High Priority bit 6 mask. */
+#define CPUINT_LVL1VEC_6_bp  6  /* Interrupt Vector with High Priority bit 6 position. */
+#define CPUINT_LVL1VEC_7_bm  (1<<7)  /* Interrupt Vector with High Priority bit 7 mask. */
+#define CPUINT_LVL1VEC_7_bp  7  /* Interrupt Vector with High Priority bit 7 position. */
+
+
+/* CRCSCAN - CRCSCAN */
+/* CRCSCAN.CTRLA  bit masks and bit positions */
+#define CRCSCAN_ENABLE_bm  0x01  /* Enable CRC scan bit mask. */
+#define CRCSCAN_ENABLE_bp  0  /* Enable CRC scan bit position. */
+#define CRCSCAN_NMIEN_bm  0x02  /* Enable NMI Trigger bit mask. */
+#define CRCSCAN_NMIEN_bp  1  /* Enable NMI Trigger bit position. */
+#define CRCSCAN_RESET_bm  0x80  /* Reset CRC scan bit mask. */
+#define CRCSCAN_RESET_bp  7  /* Reset CRC scan bit position. */
+
+/* CRCSCAN.CTRLB  bit masks and bit positions */
+#define CRCSCAN_SRC_gm  0x03  /* CRC Source group mask. */
+#define CRCSCAN_SRC_gp  0  /* CRC Source group position. */
+#define CRCSCAN_SRC_0_bm  (1<<0)  /* CRC Source bit 0 mask. */
+#define CRCSCAN_SRC_0_bp  0  /* CRC Source bit 0 position. */
+#define CRCSCAN_SRC_1_bm  (1<<1)  /* CRC Source bit 1 mask. */
+#define CRCSCAN_SRC_1_bp  1  /* CRC Source bit 1 position. */
+
+/* CRCSCAN.STATUS  bit masks and bit positions */
+#define CRCSCAN_BUSY_bm  0x01  /* CRC Busy bit mask. */
+#define CRCSCAN_BUSY_bp  0  /* CRC Busy bit position. */
+#define CRCSCAN_OK_bm  0x02  /* CRC Ok bit mask. */
+#define CRCSCAN_OK_bp  1  /* CRC Ok bit position. */
+
+
+/* DAC - Digital to Analog Converter */
+/* DAC.CTRLA  bit masks and bit positions */
+#define DAC_ENABLE_bm  0x01  /* DAC Enable bit mask. */
+#define DAC_ENABLE_bp  0  /* DAC Enable bit position. */
+#define DAC_OUTRANGE_gm  0x30  /* Output Buffer Range group mask. */
+#define DAC_OUTRANGE_gp  4  /* Output Buffer Range group position. */
+#define DAC_OUTRANGE_0_bm  (1<<4)  /* Output Buffer Range bit 0 mask. */
+#define DAC_OUTRANGE_0_bp  4  /* Output Buffer Range bit 0 position. */
+#define DAC_OUTRANGE_1_bm  (1<<5)  /* Output Buffer Range bit 1 mask. */
+#define DAC_OUTRANGE_1_bp  5  /* Output Buffer Range bit 1 position. */
+#define DAC_OUTEN_bm  0x40  /* Output Buffer Enable bit mask. */
+#define DAC_OUTEN_bp  6  /* Output Buffer Enable bit position. */
+#define DAC_RUNSTDBY_bm  0x80  /* Run in Standby Mode bit mask. */
+#define DAC_RUNSTDBY_bp  7  /* Run in Standby Mode bit position. */
+
+/* DAC.DATA  bit masks and bit positions */
+#define DAC_DATA_gm  0xFFC0  /* Data group mask. */
+#define DAC_DATA_gp  6  /* Data group position. */
+#define DAC_DATA_0_bm  (1<<6)  /* Data bit 0 mask. */
+#define DAC_DATA_0_bp  6  /* Data bit 0 position. */
+#define DAC_DATA_1_bm  (1<<7)  /* Data bit 1 mask. */
+#define DAC_DATA_1_bp  7  /* Data bit 1 position. */
+#define DAC_DATA_2_bm  (1<<8)  /* Data bit 2 mask. */
+#define DAC_DATA_2_bp  8  /* Data bit 2 position. */
+#define DAC_DATA_3_bm  (1<<9)  /* Data bit 3 mask. */
+#define DAC_DATA_3_bp  9  /* Data bit 3 position. */
+#define DAC_DATA_4_bm  (1<<10)  /* Data bit 4 mask. */
+#define DAC_DATA_4_bp  10  /* Data bit 4 position. */
+#define DAC_DATA_5_bm  (1<<11)  /* Data bit 5 mask. */
+#define DAC_DATA_5_bp  11  /* Data bit 5 position. */
+#define DAC_DATA_6_bm  (1<<12)  /* Data bit 6 mask. */
+#define DAC_DATA_6_bp  12  /* Data bit 6 position. */
+#define DAC_DATA_7_bm  (1<<13)  /* Data bit 7 mask. */
+#define DAC_DATA_7_bp  13  /* Data bit 7 position. */
+#define DAC_DATA_8_bm  (1<<14)  /* Data bit 8 mask. */
+#define DAC_DATA_8_bp  14  /* Data bit 8 position. */
+#define DAC_DATA_9_bm  (1<<15)  /* Data bit 9 mask. */
+#define DAC_DATA_9_bp  15  /* Data bit 9 position. */
+
+
+/* EVSYS - Event System */
+/* EVSYS.SWEVENTA  bit masks and bit positions */
+#define EVSYS_SWEVENTA_gm  0xFF  /* Software event on channel select group mask. */
+#define EVSYS_SWEVENTA_gp  0  /* Software event on channel select group position. */
+#define EVSYS_SWEVENTA_0_bm  (1<<0)  /* Software event on channel select bit 0 mask. */
+#define EVSYS_SWEVENTA_0_bp  0  /* Software event on channel select bit 0 position. */
+#define EVSYS_SWEVENTA_1_bm  (1<<1)  /* Software event on channel select bit 1 mask. */
+#define EVSYS_SWEVENTA_1_bp  1  /* Software event on channel select bit 1 position. */
+#define EVSYS_SWEVENTA_2_bm  (1<<2)  /* Software event on channel select bit 2 mask. */
+#define EVSYS_SWEVENTA_2_bp  2  /* Software event on channel select bit 2 position. */
+#define EVSYS_SWEVENTA_3_bm  (1<<3)  /* Software event on channel select bit 3 mask. */
+#define EVSYS_SWEVENTA_3_bp  3  /* Software event on channel select bit 3 position. */
+#define EVSYS_SWEVENTA_4_bm  (1<<4)  /* Software event on channel select bit 4 mask. */
+#define EVSYS_SWEVENTA_4_bp  4  /* Software event on channel select bit 4 position. */
+#define EVSYS_SWEVENTA_5_bm  (1<<5)  /* Software event on channel select bit 5 mask. */
+#define EVSYS_SWEVENTA_5_bp  5  /* Software event on channel select bit 5 position. */
+#define EVSYS_SWEVENTA_6_bm  (1<<6)  /* Software event on channel select bit 6 mask. */
+#define EVSYS_SWEVENTA_6_bp  6  /* Software event on channel select bit 6 position. */
+#define EVSYS_SWEVENTA_7_bm  (1<<7)  /* Software event on channel select bit 7 mask. */
+#define EVSYS_SWEVENTA_7_bp  7  /* Software event on channel select bit 7 position. */
+
+/* EVSYS.CHANNEL0  bit masks and bit positions */
+#define EVSYS_CHANNEL_gm  0xFF  /* Channel generator select group mask. */
+#define EVSYS_CHANNEL_gp  0  /* Channel generator select group position. */
+#define EVSYS_CHANNEL_0_bm  (1<<0)  /* Channel generator select bit 0 mask. */
+#define EVSYS_CHANNEL_0_bp  0  /* Channel generator select bit 0 position. */
+#define EVSYS_CHANNEL_1_bm  (1<<1)  /* Channel generator select bit 1 mask. */
+#define EVSYS_CHANNEL_1_bp  1  /* Channel generator select bit 1 position. */
+#define EVSYS_CHANNEL_2_bm  (1<<2)  /* Channel generator select bit 2 mask. */
+#define EVSYS_CHANNEL_2_bp  2  /* Channel generator select bit 2 position. */
+#define EVSYS_CHANNEL_3_bm  (1<<3)  /* Channel generator select bit 3 mask. */
+#define EVSYS_CHANNEL_3_bp  3  /* Channel generator select bit 3 position. */
+#define EVSYS_CHANNEL_4_bm  (1<<4)  /* Channel generator select bit 4 mask. */
+#define EVSYS_CHANNEL_4_bp  4  /* Channel generator select bit 4 position. */
+#define EVSYS_CHANNEL_5_bm  (1<<5)  /* Channel generator select bit 5 mask. */
+#define EVSYS_CHANNEL_5_bp  5  /* Channel generator select bit 5 position. */
+#define EVSYS_CHANNEL_6_bm  (1<<6)  /* Channel generator select bit 6 mask. */
+#define EVSYS_CHANNEL_6_bp  6  /* Channel generator select bit 6 position. */
+#define EVSYS_CHANNEL_7_bm  (1<<7)  /* Channel generator select bit 7 mask. */
+#define EVSYS_CHANNEL_7_bp  7  /* Channel generator select bit 7 position. */
+
+/* EVSYS.CHANNEL1  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.CHANNEL2  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.CHANNEL3  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.CHANNEL4  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.CHANNEL5  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.USERCCLLUT0A  bit masks and bit positions */
+#define EVSYS_USER_gm  0xFF  /* User channel select group mask. */
+#define EVSYS_USER_gp  0  /* User channel select group position. */
+#define EVSYS_USER_0_bm  (1<<0)  /* User channel select bit 0 mask. */
+#define EVSYS_USER_0_bp  0  /* User channel select bit 0 position. */
+#define EVSYS_USER_1_bm  (1<<1)  /* User channel select bit 1 mask. */
+#define EVSYS_USER_1_bp  1  /* User channel select bit 1 position. */
+#define EVSYS_USER_2_bm  (1<<2)  /* User channel select bit 2 mask. */
+#define EVSYS_USER_2_bp  2  /* User channel select bit 2 position. */
+#define EVSYS_USER_3_bm  (1<<3)  /* User channel select bit 3 mask. */
+#define EVSYS_USER_3_bp  3  /* User channel select bit 3 position. */
+#define EVSYS_USER_4_bm  (1<<4)  /* User channel select bit 4 mask. */
+#define EVSYS_USER_4_bp  4  /* User channel select bit 4 position. */
+#define EVSYS_USER_5_bm  (1<<5)  /* User channel select bit 5 mask. */
+#define EVSYS_USER_5_bp  5  /* User channel select bit 5 position. */
+#define EVSYS_USER_6_bm  (1<<6)  /* User channel select bit 6 mask. */
+#define EVSYS_USER_6_bp  6  /* User channel select bit 6 position. */
+#define EVSYS_USER_7_bm  (1<<7)  /* User channel select bit 7 mask. */
+#define EVSYS_USER_7_bp  7  /* User channel select bit 7 position. */
+
+/* EVSYS.USERCCLLUT0B  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT1A  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT1B  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT2A  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT2B  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT3A  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT3B  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERADC0START  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTC  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTD  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTF  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERUSART0IRDA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERUSART1IRDA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERUSART2IRDA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCA0CNTA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCA0CNTB  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCA1CNTA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCA1CNTB  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB0CAPT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB0COUNT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB1CAPT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB1COUNT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB2CAPT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB2COUNT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB3CAPT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB3COUNT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+
+/* FUSE - Fuses */
+/* FUSE.WDTCFG  bit masks and bit positions */
+#define FUSE_PERIOD_gm  0x0F  /* Watchdog Timeout Period group mask. */
+#define FUSE_PERIOD_gp  0  /* Watchdog Timeout Period group position. */
+#define FUSE_PERIOD_0_bm  (1<<0)  /* Watchdog Timeout Period bit 0 mask. */
+#define FUSE_PERIOD_0_bp  0  /* Watchdog Timeout Period bit 0 position. */
+#define FUSE_PERIOD_1_bm  (1<<1)  /* Watchdog Timeout Period bit 1 mask. */
+#define FUSE_PERIOD_1_bp  1  /* Watchdog Timeout Period bit 1 position. */
+#define FUSE_PERIOD_2_bm  (1<<2)  /* Watchdog Timeout Period bit 2 mask. */
+#define FUSE_PERIOD_2_bp  2  /* Watchdog Timeout Period bit 2 position. */
+#define FUSE_PERIOD_3_bm  (1<<3)  /* Watchdog Timeout Period bit 3 mask. */
+#define FUSE_PERIOD_3_bp  3  /* Watchdog Timeout Period bit 3 position. */
+#define FUSE_WINDOW_gm  0xF0  /* Watchdog Window Timeout Period group mask. */
+#define FUSE_WINDOW_gp  4  /* Watchdog Window Timeout Period group position. */
+#define FUSE_WINDOW_0_bm  (1<<4)  /* Watchdog Window Timeout Period bit 0 mask. */
+#define FUSE_WINDOW_0_bp  4  /* Watchdog Window Timeout Period bit 0 position. */
+#define FUSE_WINDOW_1_bm  (1<<5)  /* Watchdog Window Timeout Period bit 1 mask. */
+#define FUSE_WINDOW_1_bp  5  /* Watchdog Window Timeout Period bit 1 position. */
+#define FUSE_WINDOW_2_bm  (1<<6)  /* Watchdog Window Timeout Period bit 2 mask. */
+#define FUSE_WINDOW_2_bp  6  /* Watchdog Window Timeout Period bit 2 position. */
+#define FUSE_WINDOW_3_bm  (1<<7)  /* Watchdog Window Timeout Period bit 3 mask. */
+#define FUSE_WINDOW_3_bp  7  /* Watchdog Window Timeout Period bit 3 position. */
+
+/* FUSE.BODCFG  bit masks and bit positions */
+#define FUSE_SLEEP_gm  0x03  /* BOD Operation in Sleep Mode group mask. */
+#define FUSE_SLEEP_gp  0  /* BOD Operation in Sleep Mode group position. */
+#define FUSE_SLEEP_0_bm  (1<<0)  /* BOD Operation in Sleep Mode bit 0 mask. */
+#define FUSE_SLEEP_0_bp  0  /* BOD Operation in Sleep Mode bit 0 position. */
+#define FUSE_SLEEP_1_bm  (1<<1)  /* BOD Operation in Sleep Mode bit 1 mask. */
+#define FUSE_SLEEP_1_bp  1  /* BOD Operation in Sleep Mode bit 1 position. */
+#define FUSE_ACTIVE_gm  0x0C  /* BOD Operation in Active Mode group mask. */
+#define FUSE_ACTIVE_gp  2  /* BOD Operation in Active Mode group position. */
+#define FUSE_ACTIVE_0_bm  (1<<2)  /* BOD Operation in Active Mode bit 0 mask. */
+#define FUSE_ACTIVE_0_bp  2  /* BOD Operation in Active Mode bit 0 position. */
+#define FUSE_ACTIVE_1_bm  (1<<3)  /* BOD Operation in Active Mode bit 1 mask. */
+#define FUSE_ACTIVE_1_bp  3  /* BOD Operation in Active Mode bit 1 position. */
+#define FUSE_SAMPFREQ_bm  0x10  /* BOD Sample Frequency bit mask. */
+#define FUSE_SAMPFREQ_bp  4  /* BOD Sample Frequency bit position. */
+#define FUSE_LVL_gm  0xE0  /* BOD Level group mask. */
+#define FUSE_LVL_gp  5  /* BOD Level group position. */
+#define FUSE_LVL_0_bm  (1<<5)  /* BOD Level bit 0 mask. */
+#define FUSE_LVL_0_bp  5  /* BOD Level bit 0 position. */
+#define FUSE_LVL_1_bm  (1<<6)  /* BOD Level bit 1 mask. */
+#define FUSE_LVL_1_bp  6  /* BOD Level bit 1 position. */
+#define FUSE_LVL_2_bm  (1<<7)  /* BOD Level bit 2 mask. */
+#define FUSE_LVL_2_bp  7  /* BOD Level bit 2 position. */
+
+/* FUSE.OSCCFG  bit masks and bit positions */
+#define FUSE_OSCHFFRQ_bm  0x08  /* High-frequency Oscillator Frequency bit mask. */
+#define FUSE_OSCHFFRQ_bp  3  /* High-frequency Oscillator Frequency bit position. */
+
+/* FUSE.SYSCFG0  bit masks and bit positions */
+#define FUSE_EESAVE_bm  0x01  /* EEPROM Save bit mask. */
+#define FUSE_EESAVE_bp  0  /* EEPROM Save bit position. */
+#define FUSE_RSTPINCFG_bm  0x08  /* Reset Pin Configuration bit mask. */
+#define FUSE_RSTPINCFG_bp  3  /* Reset Pin Configuration bit position. */
+#define FUSE_UPDIPINCFG_bm  0x10  /* UPDI Pin Configuration bit mask. */
+#define FUSE_UPDIPINCFG_bp  4  /* UPDI Pin Configuration bit position. */
+#define FUSE_CRCSEL_bm  0x20  /* CRC Select bit mask. */
+#define FUSE_CRCSEL_bp  5  /* CRC Select bit position. */
+#define FUSE_CRCSRC_gm  0xC0  /* CRC Source group mask. */
+#define FUSE_CRCSRC_gp  6  /* CRC Source group position. */
+#define FUSE_CRCSRC_0_bm  (1<<6)  /* CRC Source bit 0 mask. */
+#define FUSE_CRCSRC_0_bp  6  /* CRC Source bit 0 position. */
+#define FUSE_CRCSRC_1_bm  (1<<7)  /* CRC Source bit 1 mask. */
+#define FUSE_CRCSRC_1_bp  7  /* CRC Source bit 1 position. */
+
+/* FUSE.SYSCFG1  bit masks and bit positions */
+#define FUSE_SUT_gm  0x07  /* Startup Time group mask. */
+#define FUSE_SUT_gp  0  /* Startup Time group position. */
+#define FUSE_SUT_0_bm  (1<<0)  /* Startup Time bit 0 mask. */
+#define FUSE_SUT_0_bp  0  /* Startup Time bit 0 position. */
+#define FUSE_SUT_1_bm  (1<<1)  /* Startup Time bit 1 mask. */
+#define FUSE_SUT_1_bp  1  /* Startup Time bit 1 position. */
+#define FUSE_SUT_2_bm  (1<<2)  /* Startup Time bit 2 mask. */
+#define FUSE_SUT_2_bp  2  /* Startup Time bit 2 position. */
+
+
+
+/* LOCK - Lockbits */
+/* LOCK.KEY  bit masks and bit positions */
+#define LOCK_KEY_gm  0xFFFFFFFF  /* Lock Key group mask. */
+#define LOCK_KEY_gp  0  /* Lock Key group position. */
+#define LOCK_KEY_0_bm  (1<<0)  /* Lock Key bit 0 mask. */
+#define LOCK_KEY_0_bp  0  /* Lock Key bit 0 position. */
+#define LOCK_KEY_1_bm  (1<<1)  /* Lock Key bit 1 mask. */
+#define LOCK_KEY_1_bp  1  /* Lock Key bit 1 position. */
+#define LOCK_KEY_2_bm  (1<<2)  /* Lock Key bit 2 mask. */
+#define LOCK_KEY_2_bp  2  /* Lock Key bit 2 position. */
+#define LOCK_KEY_3_bm  (1<<3)  /* Lock Key bit 3 mask. */
+#define LOCK_KEY_3_bp  3  /* Lock Key bit 3 position. */
+#define LOCK_KEY_4_bm  (1<<4)  /* Lock Key bit 4 mask. */
+#define LOCK_KEY_4_bp  4  /* Lock Key bit 4 position. */
+#define LOCK_KEY_5_bm  (1<<5)  /* Lock Key bit 5 mask. */
+#define LOCK_KEY_5_bp  5  /* Lock Key bit 5 position. */
+#define LOCK_KEY_6_bm  (1<<6)  /* Lock Key bit 6 mask. */
+#define LOCK_KEY_6_bp  6  /* Lock Key bit 6 position. */
+#define LOCK_KEY_7_bm  (1<<7)  /* Lock Key bit 7 mask. */
+#define LOCK_KEY_7_bp  7  /* Lock Key bit 7 position. */
+#define LOCK_KEY_8_bm  (1<<8)  /* Lock Key bit 8 mask. */
+#define LOCK_KEY_8_bp  8  /* Lock Key bit 8 position. */
+#define LOCK_KEY_9_bm  (1<<9)  /* Lock Key bit 9 mask. */
+#define LOCK_KEY_9_bp  9  /* Lock Key bit 9 position. */
+#define LOCK_KEY_10_bm  (1<<10)  /* Lock Key bit 10 mask. */
+#define LOCK_KEY_10_bp  10  /* Lock Key bit 10 position. */
+#define LOCK_KEY_11_bm  (1<<11)  /* Lock Key bit 11 mask. */
+#define LOCK_KEY_11_bp  11  /* Lock Key bit 11 position. */
+#define LOCK_KEY_12_bm  (1<<12)  /* Lock Key bit 12 mask. */
+#define LOCK_KEY_12_bp  12  /* Lock Key bit 12 position. */
+#define LOCK_KEY_13_bm  (1<<13)  /* Lock Key bit 13 mask. */
+#define LOCK_KEY_13_bp  13  /* Lock Key bit 13 position. */
+#define LOCK_KEY_14_bm  (1<<14)  /* Lock Key bit 14 mask. */
+#define LOCK_KEY_14_bp  14  /* Lock Key bit 14 position. */
+#define LOCK_KEY_15_bm  (1<<15)  /* Lock Key bit 15 mask. */
+#define LOCK_KEY_15_bp  15  /* Lock Key bit 15 position. */
+#define LOCK_KEY_16_bm  (1<<16)  /* Lock Key bit 16 mask. */
+#define LOCK_KEY_16_bp  16  /* Lock Key bit 16 position. */
+#define LOCK_KEY_17_bm  (1<<17)  /* Lock Key bit 17 mask. */
+#define LOCK_KEY_17_bp  17  /* Lock Key bit 17 position. */
+#define LOCK_KEY_18_bm  (1<<18)  /* Lock Key bit 18 mask. */
+#define LOCK_KEY_18_bp  18  /* Lock Key bit 18 position. */
+#define LOCK_KEY_19_bm  (1<<19)  /* Lock Key bit 19 mask. */
+#define LOCK_KEY_19_bp  19  /* Lock Key bit 19 position. */
+#define LOCK_KEY_20_bm  (1<<20)  /* Lock Key bit 20 mask. */
+#define LOCK_KEY_20_bp  20  /* Lock Key bit 20 position. */
+#define LOCK_KEY_21_bm  (1<<21)  /* Lock Key bit 21 mask. */
+#define LOCK_KEY_21_bp  21  /* Lock Key bit 21 position. */
+#define LOCK_KEY_22_bm  (1<<22)  /* Lock Key bit 22 mask. */
+#define LOCK_KEY_22_bp  22  /* Lock Key bit 22 position. */
+#define LOCK_KEY_23_bm  (1<<23)  /* Lock Key bit 23 mask. */
+#define LOCK_KEY_23_bp  23  /* Lock Key bit 23 position. */
+#define LOCK_KEY_24_bm  (1<<24)  /* Lock Key bit 24 mask. */
+#define LOCK_KEY_24_bp  24  /* Lock Key bit 24 position. */
+#define LOCK_KEY_25_bm  (1<<25)  /* Lock Key bit 25 mask. */
+#define LOCK_KEY_25_bp  25  /* Lock Key bit 25 position. */
+#define LOCK_KEY_26_bm  (1<<26)  /* Lock Key bit 26 mask. */
+#define LOCK_KEY_26_bp  26  /* Lock Key bit 26 position. */
+#define LOCK_KEY_27_bm  (1<<27)  /* Lock Key bit 27 mask. */
+#define LOCK_KEY_27_bp  27  /* Lock Key bit 27 position. */
+#define LOCK_KEY_28_bm  (1<<28)  /* Lock Key bit 28 mask. */
+#define LOCK_KEY_28_bp  28  /* Lock Key bit 28 position. */
+#define LOCK_KEY_29_bm  (1<<29)  /* Lock Key bit 29 mask. */
+#define LOCK_KEY_29_bp  29  /* Lock Key bit 29 position. */
+#define LOCK_KEY_30_bm  (1<<30)  /* Lock Key bit 30 mask. */
+#define LOCK_KEY_30_bp  30  /* Lock Key bit 30 position. */
+#define LOCK_KEY_31_bm  (1<<31)  /* Lock Key bit 31 mask. */
+#define LOCK_KEY_31_bp  31  /* Lock Key bit 31 position. */
+
+
+/* NVMCTRL - Non-volatile Memory Controller */
+/* NVMCTRL.CTRLA  bit masks and bit positions */
+#define NVMCTRL_CMD_gm  0x7F  /* Command group mask. */
+#define NVMCTRL_CMD_gp  0  /* Command group position. */
+#define NVMCTRL_CMD_0_bm  (1<<0)  /* Command bit 0 mask. */
+#define NVMCTRL_CMD_0_bp  0  /* Command bit 0 position. */
+#define NVMCTRL_CMD_1_bm  (1<<1)  /* Command bit 1 mask. */
+#define NVMCTRL_CMD_1_bp  1  /* Command bit 1 position. */
+#define NVMCTRL_CMD_2_bm  (1<<2)  /* Command bit 2 mask. */
+#define NVMCTRL_CMD_2_bp  2  /* Command bit 2 position. */
+#define NVMCTRL_CMD_3_bm  (1<<3)  /* Command bit 3 mask. */
+#define NVMCTRL_CMD_3_bp  3  /* Command bit 3 position. */
+#define NVMCTRL_CMD_4_bm  (1<<4)  /* Command bit 4 mask. */
+#define NVMCTRL_CMD_4_bp  4  /* Command bit 4 position. */
+#define NVMCTRL_CMD_5_bm  (1<<5)  /* Command bit 5 mask. */
+#define NVMCTRL_CMD_5_bp  5  /* Command bit 5 position. */
+#define NVMCTRL_CMD_6_bm  (1<<6)  /* Command bit 6 mask. */
+#define NVMCTRL_CMD_6_bp  6  /* Command bit 6 position. */
+
+/* NVMCTRL.CTRLB  bit masks and bit positions */
+#define NVMCTRL_APPCODEWP_bm  0x01  /* Application Code Write Protect bit mask. */
+#define NVMCTRL_APPCODEWP_bp  0  /* Application Code Write Protect bit position. */
+#define NVMCTRL_BOOTRP_bm  0x02  /* Boot Read Protect bit mask. */
+#define NVMCTRL_BOOTRP_bp  1  /* Boot Read Protect bit position. */
+#define NVMCTRL_APPDATAWP_bm  0x04  /* Application Data Write Protect bit mask. */
+#define NVMCTRL_APPDATAWP_bp  2  /* Application Data Write Protect bit position. */
+#define NVMCTRL_EEWP_bm  0x08  /* EEPROM Write Protect bit mask. */
+#define NVMCTRL_EEWP_bp  3  /* EEPROM Write Protect bit position. */
+#define NVMCTRL_FLMAP_gm  0x30  /* Flash Mapping in Data space group mask. */
+#define NVMCTRL_FLMAP_gp  4  /* Flash Mapping in Data space group position. */
+#define NVMCTRL_FLMAP_0_bm  (1<<4)  /* Flash Mapping in Data space bit 0 mask. */
+#define NVMCTRL_FLMAP_0_bp  4  /* Flash Mapping in Data space bit 0 position. */
+#define NVMCTRL_FLMAP_1_bm  (1<<5)  /* Flash Mapping in Data space bit 1 mask. */
+#define NVMCTRL_FLMAP_1_bp  5  /* Flash Mapping in Data space bit 1 position. */
+#define NVMCTRL_FLMAPLOCK_bm  0x80  /* Flash Mapping Lock bit mask. */
+#define NVMCTRL_FLMAPLOCK_bp  7  /* Flash Mapping Lock bit position. */
+
+/* NVMCTRL.INTCTRL  bit masks and bit positions */
+#define NVMCTRL_EEREADY_bm  0x01  /* EEPROM Ready bit mask. */
+#define NVMCTRL_EEREADY_bp  0  /* EEPROM Ready bit position. */
+#define NVMCTRL_FLREADY_bm  0x02  /* Flash Ready bit mask. */
+#define NVMCTRL_FLREADY_bp  1  /* Flash Ready bit position. */
+
+/* NVMCTRL.INTFLAGS  bit masks and bit positions */
+/* NVMCTRL_EEREADY  is already defined. */
+/* NVMCTRL_FLREADY  is already defined. */
+
+/* NVMCTRL.STATUS  bit masks and bit positions */
+#define NVMCTRL_EEBUSY_bm  0x01  /* EEPROM busy bit mask. */
+#define NVMCTRL_EEBUSY_bp  0  /* EEPROM busy bit position. */
+#define NVMCTRL_FLBUSY_bm  0x02  /* Flash busy bit mask. */
+#define NVMCTRL_FLBUSY_bp  1  /* Flash busy bit position. */
+#define NVMCTRL_ERROR_gm  0x70  /* Write error group mask. */
+#define NVMCTRL_ERROR_gp  4  /* Write error group position. */
+#define NVMCTRL_ERROR_0_bm  (1<<4)  /* Write error bit 0 mask. */
+#define NVMCTRL_ERROR_0_bp  4  /* Write error bit 0 position. */
+#define NVMCTRL_ERROR_1_bm  (1<<5)  /* Write error bit 1 mask. */
+#define NVMCTRL_ERROR_1_bp  5  /* Write error bit 1 position. */
+#define NVMCTRL_ERROR_2_bm  (1<<6)  /* Write error bit 2 mask. */
+#define NVMCTRL_ERROR_2_bp  6  /* Write error bit 2 position. */
+
+
+/* PORT - I/O Ports */
+/* PORT.INTFLAGS  bit masks and bit positions */
+#define PORT_INT_gm  0xFF  /* Pin Interrupt Flag group mask. */
+#define PORT_INT_gp  0  /* Pin Interrupt Flag group position. */
+#define PORT_INT_0_bm  (1<<0)  /* Pin Interrupt Flag bit 0 mask. */
+#define PORT_INT_0_bp  0  /* Pin Interrupt Flag bit 0 position. */
+#define PORT_INT0_bm  PORT_INT_0_bm  /* This define is deprecated and should not be used */
+#define PORT_INT0_bp  PORT_INT_0_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_1_bm  (1<<1)  /* Pin Interrupt Flag bit 1 mask. */
+#define PORT_INT_1_bp  1  /* Pin Interrupt Flag bit 1 position. */
+#define PORT_INT1_bm  PORT_INT_1_bm  /* This define is deprecated and should not be used */
+#define PORT_INT1_bp  PORT_INT_1_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_2_bm  (1<<2)  /* Pin Interrupt Flag bit 2 mask. */
+#define PORT_INT_2_bp  2  /* Pin Interrupt Flag bit 2 position. */
+#define PORT_INT2_bm  PORT_INT_2_bm  /* This define is deprecated and should not be used */
+#define PORT_INT2_bp  PORT_INT_2_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_3_bm  (1<<3)  /* Pin Interrupt Flag bit 3 mask. */
+#define PORT_INT_3_bp  3  /* Pin Interrupt Flag bit 3 position. */
+#define PORT_INT3_bm  PORT_INT_3_bm  /* This define is deprecated and should not be used */
+#define PORT_INT3_bp  PORT_INT_3_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_4_bm  (1<<4)  /* Pin Interrupt Flag bit 4 mask. */
+#define PORT_INT_4_bp  4  /* Pin Interrupt Flag bit 4 position. */
+#define PORT_INT4_bm  PORT_INT_4_bm  /* This define is deprecated and should not be used */
+#define PORT_INT4_bp  PORT_INT_4_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_5_bm  (1<<5)  /* Pin Interrupt Flag bit 5 mask. */
+#define PORT_INT_5_bp  5  /* Pin Interrupt Flag bit 5 position. */
+#define PORT_INT5_bm  PORT_INT_5_bm  /* This define is deprecated and should not be used */
+#define PORT_INT5_bp  PORT_INT_5_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_6_bm  (1<<6)  /* Pin Interrupt Flag bit 6 mask. */
+#define PORT_INT_6_bp  6  /* Pin Interrupt Flag bit 6 position. */
+#define PORT_INT6_bm  PORT_INT_6_bm  /* This define is deprecated and should not be used */
+#define PORT_INT6_bp  PORT_INT_6_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_7_bm  (1<<7)  /* Pin Interrupt Flag bit 7 mask. */
+#define PORT_INT_7_bp  7  /* Pin Interrupt Flag bit 7 position. */
+#define PORT_INT7_bm  PORT_INT_7_bm  /* This define is deprecated and should not be used */
+#define PORT_INT7_bp  PORT_INT_7_bp  /* This define is deprecated and should not be used */
+
+/* PORT.PORTCTRL  bit masks and bit positions */
+#define PORT_SRL_bm  0x01  /* Slew Rate Limit Enable bit mask. */
+#define PORT_SRL_bp  0  /* Slew Rate Limit Enable bit position. */
+
+/* PORT.PINCONFIG  bit masks and bit positions */
+#define PORT_ISC_gm  0x07  /* Input/Sense Configuration group mask. */
+#define PORT_ISC_gp  0  /* Input/Sense Configuration group position. */
+#define PORT_ISC_0_bm  (1<<0)  /* Input/Sense Configuration bit 0 mask. */
+#define PORT_ISC_0_bp  0  /* Input/Sense Configuration bit 0 position. */
+#define PORT_ISC_1_bm  (1<<1)  /* Input/Sense Configuration bit 1 mask. */
+#define PORT_ISC_1_bp  1  /* Input/Sense Configuration bit 1 position. */
+#define PORT_ISC_2_bm  (1<<2)  /* Input/Sense Configuration bit 2 mask. */
+#define PORT_ISC_2_bp  2  /* Input/Sense Configuration bit 2 position. */
+#define PORT_PULLUPEN_bm  0x08  /* Pullup enable bit mask. */
+#define PORT_PULLUPEN_bp  3  /* Pullup enable bit position. */
+#define PORT_INLVL_bm  0x40  /* Input Level Select bit mask. */
+#define PORT_INLVL_bp  6  /* Input Level Select bit position. */
+#define PORT_INVEN_bm  0x80  /* Inverted I/O Enable bit mask. */
+#define PORT_INVEN_bp  7  /* Inverted I/O Enable bit position. */
+
+/* PORT.PIN0CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN1CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN2CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN3CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN4CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN5CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN6CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN7CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.EVGENCTRL  bit masks and bit positions */
+#define PORT_EVGEN0SEL_gm  0x07  /* Event Generator 0 Select group mask. */
+#define PORT_EVGEN0SEL_gp  0  /* Event Generator 0 Select group position. */
+#define PORT_EVGEN0SEL_0_bm  (1<<0)  /* Event Generator 0 Select bit 0 mask. */
+#define PORT_EVGEN0SEL_0_bp  0  /* Event Generator 0 Select bit 0 position. */
+#define PORT_EVGEN0SEL_1_bm  (1<<1)  /* Event Generator 0 Select bit 1 mask. */
+#define PORT_EVGEN0SEL_1_bp  1  /* Event Generator 0 Select bit 1 position. */
+#define PORT_EVGEN0SEL_2_bm  (1<<2)  /* Event Generator 0 Select bit 2 mask. */
+#define PORT_EVGEN0SEL_2_bp  2  /* Event Generator 0 Select bit 2 position. */
+#define PORT_EVGEN1SEL_gm  0x70  /* Event Generator 1 Select group mask. */
+#define PORT_EVGEN1SEL_gp  4  /* Event Generator 1 Select group position. */
+#define PORT_EVGEN1SEL_0_bm  (1<<4)  /* Event Generator 1 Select bit 0 mask. */
+#define PORT_EVGEN1SEL_0_bp  4  /* Event Generator 1 Select bit 0 position. */
+#define PORT_EVGEN1SEL_1_bm  (1<<5)  /* Event Generator 1 Select bit 1 mask. */
+#define PORT_EVGEN1SEL_1_bp  5  /* Event Generator 1 Select bit 1 position. */
+#define PORT_EVGEN1SEL_2_bm  (1<<6)  /* Event Generator 1 Select bit 2 mask. */
+#define PORT_EVGEN1SEL_2_bp  6  /* Event Generator 1 Select bit 2 position. */
+
+
+/* PORTMUX - Port Multiplexer */
+/* PORTMUX.EVSYSROUTEA  bit masks and bit positions */
+#define PORTMUX_EVOUTA_bm  0x01  /* Event Output A bit mask. */
+#define PORTMUX_EVOUTA_bp  0  /* Event Output A bit position. */
+#define PORTMUX_EVOUTC_bm  0x04  /* Event Output C bit mask. */
+#define PORTMUX_EVOUTC_bp  2  /* Event Output C bit position. */
+#define PORTMUX_EVOUTD_bm  0x08  /* Event Output D bit mask. */
+#define PORTMUX_EVOUTD_bp  3  /* Event Output D bit position. */
+#define PORTMUX_EVOUTF_bm  0x20  /* Event Output F bit mask. */
+#define PORTMUX_EVOUTF_bp  5  /* Event Output F bit position. */
+
+/* PORTMUX.CCLROUTEA  bit masks and bit positions */
+#define PORTMUX_LUT0_bm  0x01  /* CCL Look-Up Table 0 Signals bit mask. */
+#define PORTMUX_LUT0_bp  0  /* CCL Look-Up Table 0 Signals bit position. */
+#define PORTMUX_LUT1_bm  0x02  /* CCL Look-Up Table 1 Signals bit mask. */
+#define PORTMUX_LUT1_bp  1  /* CCL Look-Up Table 1 Signals bit position. */
+#define PORTMUX_LUT2_bm  0x04  /* CCL Look-Up Table 2 Signals bit mask. */
+#define PORTMUX_LUT2_bp  2  /* CCL Look-Up Table 2 Signals bit position. */
+
+/* PORTMUX.USARTROUTEA  bit masks and bit positions */
+#define PORTMUX_USART0_gm  0x07  /* USART0 Routing group mask. */
+#define PORTMUX_USART0_gp  0  /* USART0 Routing group position. */
+#define PORTMUX_USART0_0_bm  (1<<0)  /* USART0 Routing bit 0 mask. */
+#define PORTMUX_USART0_0_bp  0  /* USART0 Routing bit 0 position. */
+#define PORTMUX_USART0_1_bm  (1<<1)  /* USART0 Routing bit 1 mask. */
+#define PORTMUX_USART0_1_bp  1  /* USART0 Routing bit 1 position. */
+#define PORTMUX_USART0_2_bm  (1<<2)  /* USART0 Routing bit 2 mask. */
+#define PORTMUX_USART0_2_bp  2  /* USART0 Routing bit 2 position. */
+#define PORTMUX_USART1_gm  0x18  /* USART1 Routing group mask. */
+#define PORTMUX_USART1_gp  3  /* USART1 Routing group position. */
+#define PORTMUX_USART1_0_bm  (1<<3)  /* USART1 Routing bit 0 mask. */
+#define PORTMUX_USART1_0_bp  3  /* USART1 Routing bit 0 position. */
+#define PORTMUX_USART1_1_bm  (1<<4)  /* USART1 Routing bit 1 mask. */
+#define PORTMUX_USART1_1_bp  4  /* USART1 Routing bit 1 position. */
+
+/* PORTMUX.USARTROUTEB  bit masks and bit positions */
+#define PORTMUX_USART2_gm  0x03  /* USART2 Routing group mask. */
+#define PORTMUX_USART2_gp  0  /* USART2 Routing group position. */
+#define PORTMUX_USART2_0_bm  (1<<0)  /* USART2 Routing bit 0 mask. */
+#define PORTMUX_USART2_0_bp  0  /* USART2 Routing bit 0 position. */
+#define PORTMUX_USART2_1_bm  (1<<1)  /* USART2 Routing bit 1 mask. */
+#define PORTMUX_USART2_1_bp  1  /* USART2 Routing bit 1 position. */
+
+/* PORTMUX.SPIROUTEA  bit masks and bit positions */
+#define PORTMUX_SPI0_gm  0x07  /* SPI0 Signals group mask. */
+#define PORTMUX_SPI0_gp  0  /* SPI0 Signals group position. */
+#define PORTMUX_SPI0_0_bm  (1<<0)  /* SPI0 Signals bit 0 mask. */
+#define PORTMUX_SPI0_0_bp  0  /* SPI0 Signals bit 0 position. */
+#define PORTMUX_SPI0_1_bm  (1<<1)  /* SPI0 Signals bit 1 mask. */
+#define PORTMUX_SPI0_1_bp  1  /* SPI0 Signals bit 1 position. */
+#define PORTMUX_SPI0_2_bm  (1<<2)  /* SPI0 Signals bit 2 mask. */
+#define PORTMUX_SPI0_2_bp  2  /* SPI0 Signals bit 2 position. */
+
+/* PORTMUX.TWIROUTEA  bit masks and bit positions */
+#define PORTMUX_TWI0_gm  0x03  /* TWI0 Signals group mask. */
+#define PORTMUX_TWI0_gp  0  /* TWI0 Signals group position. */
+#define PORTMUX_TWI0_0_bm  (1<<0)  /* TWI0 Signals bit 0 mask. */
+#define PORTMUX_TWI0_0_bp  0  /* TWI0 Signals bit 0 position. */
+#define PORTMUX_TWI0_1_bm  (1<<1)  /* TWI0 Signals bit 1 mask. */
+#define PORTMUX_TWI0_1_bp  1  /* TWI0 Signals bit 1 position. */
+
+/* PORTMUX.TCAROUTEA  bit masks and bit positions */
+#define PORTMUX_TCA0_gm  0x07  /* TCA0 Signals group mask. */
+#define PORTMUX_TCA0_gp  0  /* TCA0 Signals group position. */
+#define PORTMUX_TCA0_0_bm  (1<<0)  /* TCA0 Signals bit 0 mask. */
+#define PORTMUX_TCA0_0_bp  0  /* TCA0 Signals bit 0 position. */
+#define PORTMUX_TCA0_1_bm  (1<<1)  /* TCA0 Signals bit 1 mask. */
+#define PORTMUX_TCA0_1_bp  1  /* TCA0 Signals bit 1 position. */
+#define PORTMUX_TCA0_2_bm  (1<<2)  /* TCA0 Signals bit 2 mask. */
+#define PORTMUX_TCA0_2_bp  2  /* TCA0 Signals bit 2 position. */
+#define PORTMUX_TCA1_gm  0x38  /* TCA1 Signals group mask. */
+#define PORTMUX_TCA1_gp  3  /* TCA1 Signals group position. */
+#define PORTMUX_TCA1_0_bm  (1<<3)  /* TCA1 Signals bit 0 mask. */
+#define PORTMUX_TCA1_0_bp  3  /* TCA1 Signals bit 0 position. */
+#define PORTMUX_TCA1_1_bm  (1<<4)  /* TCA1 Signals bit 1 mask. */
+#define PORTMUX_TCA1_1_bp  4  /* TCA1 Signals bit 1 position. */
+#define PORTMUX_TCA1_2_bm  (1<<5)  /* TCA1 Signals bit 2 mask. */
+#define PORTMUX_TCA1_2_bp  5  /* TCA1 Signals bit 2 position. */
+
+/* PORTMUX.TCBROUTEA  bit masks and bit positions */
+#define PORTMUX_TCB0_bm  0x01  /* TCB0 Output bit mask. */
+#define PORTMUX_TCB0_bp  0  /* TCB0 Output bit position. */
+#define PORTMUX_TCB1_bm  0x02  /* TCB1 Output bit mask. */
+#define PORTMUX_TCB1_bp  1  /* TCB1 Output bit position. */
+#define PORTMUX_TCB2_bm  0x04  /* TCB2 Output bit mask. */
+#define PORTMUX_TCB2_bp  2  /* TCB2 Output bit position. */
+#define PORTMUX_TCB3_bm  0x08  /* TCB3 Output bit mask. */
+#define PORTMUX_TCB3_bp  3  /* TCB3 Output bit position. */
+
+/* PORTMUX.ACROUTEA  bit masks and bit positions */
+#define PORTMUX_AC0_bm  0x01  /* Analog Comparator 0 Output bit mask. */
+#define PORTMUX_AC0_bp  0  /* Analog Comparator 0 Output bit position. */
+#define PORTMUX_AC1_bm  0x02  /* Analog Comparator 1 Output bit mask. */
+#define PORTMUX_AC1_bp  1  /* Analog Comparator 1 Output bit position. */
+
+
+/* RSTCTRL - Reset controller */
+/* RSTCTRL.RSTFR  bit masks and bit positions */
+#define RSTCTRL_PORF_bm  0x01  /* Power on Reset flag bit mask. */
+#define RSTCTRL_PORF_bp  0  /* Power on Reset flag bit position. */
+#define RSTCTRL_BORF_bm  0x02  /* Brown out detector Reset flag bit mask. */
+#define RSTCTRL_BORF_bp  1  /* Brown out detector Reset flag bit position. */
+#define RSTCTRL_EXTRF_bm  0x04  /* External Reset flag bit mask. */
+#define RSTCTRL_EXTRF_bp  2  /* External Reset flag bit position. */
+#define RSTCTRL_WDRF_bm  0x08  /* Watch dog Reset flag bit mask. */
+#define RSTCTRL_WDRF_bp  3  /* Watch dog Reset flag bit position. */
+#define RSTCTRL_SWRF_bm  0x10  /* Software Reset flag bit mask. */
+#define RSTCTRL_SWRF_bp  4  /* Software Reset flag bit position. */
+#define RSTCTRL_UPDIRF_bm  0x20  /* UPDI Reset flag bit mask. */
+#define RSTCTRL_UPDIRF_bp  5  /* UPDI Reset flag bit position. */
+
+/* RSTCTRL.SWRR  bit masks and bit positions */
+#define RSTCTRL_SWRE_bm  0x01  /* Software Reset Enable bit mask. */
+#define RSTCTRL_SWRE_bp  0  /* Software Reset Enable bit position. */
+
+
+/* RTC - Real-Time Counter */
+/* RTC.CTRLA  bit masks and bit positions */
+#define RTC_RTCEN_bm  0x01  /* Enable bit mask. */
+#define RTC_RTCEN_bp  0  /* Enable bit position. */
+#define RTC_CORREN_bm  0x04  /* Correction enable bit mask. */
+#define RTC_CORREN_bp  2  /* Correction enable bit position. */
+#define RTC_PRESCALER_gm  0x78  /* Prescaling Factor group mask. */
+#define RTC_PRESCALER_gp  3  /* Prescaling Factor group position. */
+#define RTC_PRESCALER_0_bm  (1<<3)  /* Prescaling Factor bit 0 mask. */
+#define RTC_PRESCALER_0_bp  3  /* Prescaling Factor bit 0 position. */
+#define RTC_PRESCALER_1_bm  (1<<4)  /* Prescaling Factor bit 1 mask. */
+#define RTC_PRESCALER_1_bp  4  /* Prescaling Factor bit 1 position. */
+#define RTC_PRESCALER_2_bm  (1<<5)  /* Prescaling Factor bit 2 mask. */
+#define RTC_PRESCALER_2_bp  5  /* Prescaling Factor bit 2 position. */
+#define RTC_PRESCALER_3_bm  (1<<6)  /* Prescaling Factor bit 3 mask. */
+#define RTC_PRESCALER_3_bp  6  /* Prescaling Factor bit 3 position. */
+#define RTC_RUNSTDBY_bm  0x80  /* Run In Standby bit mask. */
+#define RTC_RUNSTDBY_bp  7  /* Run In Standby bit position. */
+
+/* RTC.STATUS  bit masks and bit positions */
+#define RTC_CTRLABUSY_bm  0x01  /* CTRLA Synchronization Busy Flag bit mask. */
+#define RTC_CTRLABUSY_bp  0  /* CTRLA Synchronization Busy Flag bit position. */
+#define RTC_CNTBUSY_bm  0x02  /* Count Synchronization Busy Flag bit mask. */
+#define RTC_CNTBUSY_bp  1  /* Count Synchronization Busy Flag bit position. */
+#define RTC_PERBUSY_bm  0x04  /* Period Synchronization Busy Flag bit mask. */
+#define RTC_PERBUSY_bp  2  /* Period Synchronization Busy Flag bit position. */
+#define RTC_CMPBUSY_bm  0x08  /* Comparator Synchronization Busy Flag bit mask. */
+#define RTC_CMPBUSY_bp  3  /* Comparator Synchronization Busy Flag bit position. */
+
+/* RTC.INTCTRL  bit masks and bit positions */
+#define RTC_OVF_bm  0x01  /* Overflow Interrupt enable bit mask. */
+#define RTC_OVF_bp  0  /* Overflow Interrupt enable bit position. */
+#define RTC_CMP_bm  0x02  /* Compare Match Interrupt enable bit mask. */
+#define RTC_CMP_bp  1  /* Compare Match Interrupt enable bit position. */
+
+/* RTC.INTFLAGS  bit masks and bit positions */
+/* RTC_OVF  is already defined. */
+/* RTC_CMP  is already defined. */
+
+/* RTC.DBGCTRL  bit masks and bit positions */
+#define RTC_DBGRUN_bm  0x01  /* Run in debug bit mask. */
+#define RTC_DBGRUN_bp  0  /* Run in debug bit position. */
+
+/* RTC.CALIB  bit masks and bit positions */
+#define RTC_ERROR_gm  0x7F  /* Error Correction Value group mask. */
+#define RTC_ERROR_gp  0  /* Error Correction Value group position. */
+#define RTC_ERROR_0_bm  (1<<0)  /* Error Correction Value bit 0 mask. */
+#define RTC_ERROR_0_bp  0  /* Error Correction Value bit 0 position. */
+#define RTC_ERROR_1_bm  (1<<1)  /* Error Correction Value bit 1 mask. */
+#define RTC_ERROR_1_bp  1  /* Error Correction Value bit 1 position. */
+#define RTC_ERROR_2_bm  (1<<2)  /* Error Correction Value bit 2 mask. */
+#define RTC_ERROR_2_bp  2  /* Error Correction Value bit 2 position. */
+#define RTC_ERROR_3_bm  (1<<3)  /* Error Correction Value bit 3 mask. */
+#define RTC_ERROR_3_bp  3  /* Error Correction Value bit 3 position. */
+#define RTC_ERROR_4_bm  (1<<4)  /* Error Correction Value bit 4 mask. */
+#define RTC_ERROR_4_bp  4  /* Error Correction Value bit 4 position. */
+#define RTC_ERROR_5_bm  (1<<5)  /* Error Correction Value bit 5 mask. */
+#define RTC_ERROR_5_bp  5  /* Error Correction Value bit 5 position. */
+#define RTC_ERROR_6_bm  (1<<6)  /* Error Correction Value bit 6 mask. */
+#define RTC_ERROR_6_bp  6  /* Error Correction Value bit 6 position. */
+#define RTC_SIGN_bm  0x80  /* Error Correction Sign Bit bit mask. */
+#define RTC_SIGN_bp  7  /* Error Correction Sign Bit bit position. */
+
+/* RTC.CLKSEL  bit masks and bit positions */
+#define RTC_CLKSEL_gm  0x03  /* Clock Select group mask. */
+#define RTC_CLKSEL_gp  0  /* Clock Select group position. */
+#define RTC_CLKSEL_0_bm  (1<<0)  /* Clock Select bit 0 mask. */
+#define RTC_CLKSEL_0_bp  0  /* Clock Select bit 0 position. */
+#define RTC_CLKSEL_1_bm  (1<<1)  /* Clock Select bit 1 mask. */
+#define RTC_CLKSEL_1_bp  1  /* Clock Select bit 1 position. */
+
+/* RTC.PITCTRLA  bit masks and bit positions */
+#define RTC_PITEN_bm  0x01  /* Enable bit mask. */
+#define RTC_PITEN_bp  0  /* Enable bit position. */
+#define RTC_PERIOD_gm  0x78  /* Period group mask. */
+#define RTC_PERIOD_gp  3  /* Period group position. */
+#define RTC_PERIOD_0_bm  (1<<3)  /* Period bit 0 mask. */
+#define RTC_PERIOD_0_bp  3  /* Period bit 0 position. */
+#define RTC_PERIOD_1_bm  (1<<4)  /* Period bit 1 mask. */
+#define RTC_PERIOD_1_bp  4  /* Period bit 1 position. */
+#define RTC_PERIOD_2_bm  (1<<5)  /* Period bit 2 mask. */
+#define RTC_PERIOD_2_bp  5  /* Period bit 2 position. */
+#define RTC_PERIOD_3_bm  (1<<6)  /* Period bit 3 mask. */
+#define RTC_PERIOD_3_bp  6  /* Period bit 3 position. */
+
+/* RTC.PITSTATUS  bit masks and bit positions */
+#define RTC_CTRLBUSY_bm  0x01  /* CTRLA Synchronization Busy Flag bit mask. */
+#define RTC_CTRLBUSY_bp  0  /* CTRLA Synchronization Busy Flag bit position. */
+
+/* RTC.PITINTCTRL  bit masks and bit positions */
+#define RTC_PI_bm  0x01  /* Periodic Interrupt bit mask. */
+#define RTC_PI_bp  0  /* Periodic Interrupt bit position. */
+
+/* RTC.PITINTFLAGS  bit masks and bit positions */
+/* RTC_PI  is already defined. */
+
+/* RTC.PITDBGCTRL  bit masks and bit positions */
+/* RTC_DBGRUN  is already defined. */
+
+/* RTC.PITEVGENCTRLA  bit masks and bit positions */
+#define RTC_EVGEN0SEL_gm  0x0F  /* Event Generation 0 Select group mask. */
+#define RTC_EVGEN0SEL_gp  0  /* Event Generation 0 Select group position. */
+#define RTC_EVGEN0SEL_0_bm  (1<<0)  /* Event Generation 0 Select bit 0 mask. */
+#define RTC_EVGEN0SEL_0_bp  0  /* Event Generation 0 Select bit 0 position. */
+#define RTC_EVGEN0SEL_1_bm  (1<<1)  /* Event Generation 0 Select bit 1 mask. */
+#define RTC_EVGEN0SEL_1_bp  1  /* Event Generation 0 Select bit 1 position. */
+#define RTC_EVGEN0SEL_2_bm  (1<<2)  /* Event Generation 0 Select bit 2 mask. */
+#define RTC_EVGEN0SEL_2_bp  2  /* Event Generation 0 Select bit 2 position. */
+#define RTC_EVGEN0SEL_3_bm  (1<<3)  /* Event Generation 0 Select bit 3 mask. */
+#define RTC_EVGEN0SEL_3_bp  3  /* Event Generation 0 Select bit 3 position. */
+#define RTC_EVGEN1SEL_gm  0xF0  /* Event Generation 1 Select group mask. */
+#define RTC_EVGEN1SEL_gp  4  /* Event Generation 1 Select group position. */
+#define RTC_EVGEN1SEL_0_bm  (1<<4)  /* Event Generation 1 Select bit 0 mask. */
+#define RTC_EVGEN1SEL_0_bp  4  /* Event Generation 1 Select bit 0 position. */
+#define RTC_EVGEN1SEL_1_bm  (1<<5)  /* Event Generation 1 Select bit 1 mask. */
+#define RTC_EVGEN1SEL_1_bp  5  /* Event Generation 1 Select bit 1 position. */
+#define RTC_EVGEN1SEL_2_bm  (1<<6)  /* Event Generation 1 Select bit 2 mask. */
+#define RTC_EVGEN1SEL_2_bp  6  /* Event Generation 1 Select bit 2 position. */
+#define RTC_EVGEN1SEL_3_bm  (1<<7)  /* Event Generation 1 Select bit 3 mask. */
+#define RTC_EVGEN1SEL_3_bp  7  /* Event Generation 1 Select bit 3 position. */
+
+
+
+/* SLPCTRL - Sleep Controller */
+/* SLPCTRL.CTRLA  bit masks and bit positions */
+#define SLPCTRL_SEN_bm  0x01  /* Sleep enable bit mask. */
+#define SLPCTRL_SEN_bp  0  /* Sleep enable bit position. */
+#define SLPCTRL_SMODE_gm  0x06  /* Sleep mode group mask. */
+#define SLPCTRL_SMODE_gp  1  /* Sleep mode group position. */
+#define SLPCTRL_SMODE_0_bm  (1<<1)  /* Sleep mode bit 0 mask. */
+#define SLPCTRL_SMODE_0_bp  1  /* Sleep mode bit 0 position. */
+#define SLPCTRL_SMODE_1_bm  (1<<2)  /* Sleep mode bit 1 mask. */
+#define SLPCTRL_SMODE_1_bp  2  /* Sleep mode bit 1 position. */
+
+
+/* SPI - Serial Peripheral Interface */
+/* SPI.CTRLA  bit masks and bit positions */
+#define SPI_ENABLE_bm  0x01  /* Enable Module bit mask. */
+#define SPI_ENABLE_bp  0  /* Enable Module bit position. */
+#define SPI_PRESC_gm  0x06  /* Prescaler group mask. */
+#define SPI_PRESC_gp  1  /* Prescaler group position. */
+#define SPI_PRESC_0_bm  (1<<1)  /* Prescaler bit 0 mask. */
+#define SPI_PRESC_0_bp  1  /* Prescaler bit 0 position. */
+#define SPI_PRESC_1_bm  (1<<2)  /* Prescaler bit 1 mask. */
+#define SPI_PRESC_1_bp  2  /* Prescaler bit 1 position. */
+#define SPI_CLK2X_bm  0x10  /* Enable Double Speed bit mask. */
+#define SPI_CLK2X_bp  4  /* Enable Double Speed bit position. */
+#define SPI_MASTER_bm  0x20  /* Host Operation Enable bit mask. */
+#define SPI_MASTER_bp  5  /* Host Operation Enable bit position. */
+#define SPI_DORD_bm  0x40  /* Data Order Setting bit mask. */
+#define SPI_DORD_bp  6  /* Data Order Setting bit position. */
+
+/* SPI.CTRLB  bit masks and bit positions */
+#define SPI_MODE_gm  0x03  /* SPI Mode group mask. */
+#define SPI_MODE_gp  0  /* SPI Mode group position. */
+#define SPI_MODE_0_bm  (1<<0)  /* SPI Mode bit 0 mask. */
+#define SPI_MODE_0_bp  0  /* SPI Mode bit 0 position. */
+#define SPI_MODE_1_bm  (1<<1)  /* SPI Mode bit 1 mask. */
+#define SPI_MODE_1_bp  1  /* SPI Mode bit 1 position. */
+#define SPI_SSD_bm  0x04  /* SPI Select Disable bit mask. */
+#define SPI_SSD_bp  2  /* SPI Select Disable bit position. */
+#define SPI_BUFWR_bm  0x40  /* Buffer Mode Wait for Receive bit mask. */
+#define SPI_BUFWR_bp  6  /* Buffer Mode Wait for Receive bit position. */
+#define SPI_BUFEN_bm  0x80  /* Buffer Mode Enable bit mask. */
+#define SPI_BUFEN_bp  7  /* Buffer Mode Enable bit position. */
+
+/* SPI.INTCTRL  bit masks and bit positions */
+#define SPI_IE_bm  0x01  /* Interrupt Enable bit mask. */
+#define SPI_IE_bp  0  /* Interrupt Enable bit position. */
+#define SPI_SSIE_bm  0x10  /* SPI Select Trigger Interrupt Enable bit mask. */
+#define SPI_SSIE_bp  4  /* SPI Select Trigger Interrupt Enable bit position. */
+#define SPI_DREIE_bm  0x20  /* Data Register Empty Interrupt Enable bit mask. */
+#define SPI_DREIE_bp  5  /* Data Register Empty Interrupt Enable bit position. */
+#define SPI_TXCIE_bm  0x40  /* Transfer Complete Interrupt Enable bit mask. */
+#define SPI_TXCIE_bp  6  /* Transfer Complete Interrupt Enable bit position. */
+#define SPI_RXCIE_bm  0x80  /* Receive Complete Interrupt Enable bit mask. */
+#define SPI_RXCIE_bp  7  /* Receive Complete Interrupt Enable bit position. */
+
+/* SPI.INTFLAGS  bit masks and bit positions */
+#define SPI_BUFOVF_bm  0x01  /* Buffer Overflow bit mask. */
+#define SPI_BUFOVF_bp  0  /* Buffer Overflow bit position. */
+#define SPI_SSIF_bm  0x10  /* SPI Select Trigger Interrupt Flag bit mask. */
+#define SPI_SSIF_bp  4  /* SPI Select Trigger Interrupt Flag bit position. */
+#define SPI_DREIF_bm  0x20  /* Data Register Empty Interrupt Flag bit mask. */
+#define SPI_DREIF_bp  5  /* Data Register Empty Interrupt Flag bit position. */
+#define SPI_TXCIF_bm  0x40  /* Transfer Complete Interrupt Flag bit mask. */
+#define SPI_TXCIF_bp  6  /* Transfer Complete Interrupt Flag bit position. */
+#define SPI_WRCOL_bm  0x40  /* Write Collision bit mask. */
+#define SPI_WRCOL_bp  6  /* Write Collision bit position. */
+#define SPI_RXCIF_bm  0x80  /* Receive Complete Interrupt Flag bit mask. */
+#define SPI_RXCIF_bp  7  /* Receive Complete Interrupt Flag bit position. */
+#define SPI_IF_bm  0x80  /* Interrupt Flag bit mask. */
+#define SPI_IF_bp  7  /* Interrupt Flag bit position. */
+
+
+/* SYSCFG - System Configuration Registers */
+/* SYSCFG.REVID  bit masks and bit positions */
+#define SYSCFG_MINOR_gm  0x0F  /* Minor Revision group mask. */
+#define SYSCFG_MINOR_gp  0  /* Minor Revision group position. */
+#define SYSCFG_MINOR_0_bm  (1<<0)  /* Minor Revision bit 0 mask. */
+#define SYSCFG_MINOR_0_bp  0  /* Minor Revision bit 0 position. */
+#define SYSCFG_MINOR_1_bm  (1<<1)  /* Minor Revision bit 1 mask. */
+#define SYSCFG_MINOR_1_bp  1  /* Minor Revision bit 1 position. */
+#define SYSCFG_MINOR_2_bm  (1<<2)  /* Minor Revision bit 2 mask. */
+#define SYSCFG_MINOR_2_bp  2  /* Minor Revision bit 2 position. */
+#define SYSCFG_MINOR_3_bm  (1<<3)  /* Minor Revision bit 3 mask. */
+#define SYSCFG_MINOR_3_bp  3  /* Minor Revision bit 3 position. */
+#define SYSCFG_MAJOR_gm  0xF0  /* Major Revision group mask. */
+#define SYSCFG_MAJOR_gp  4  /* Major Revision group position. */
+#define SYSCFG_MAJOR_0_bm  (1<<4)  /* Major Revision bit 0 mask. */
+#define SYSCFG_MAJOR_0_bp  4  /* Major Revision bit 0 position. */
+#define SYSCFG_MAJOR_1_bm  (1<<5)  /* Major Revision bit 1 mask. */
+#define SYSCFG_MAJOR_1_bp  5  /* Major Revision bit 1 position. */
+#define SYSCFG_MAJOR_2_bm  (1<<6)  /* Major Revision bit 2 mask. */
+#define SYSCFG_MAJOR_2_bp  6  /* Major Revision bit 2 position. */
+#define SYSCFG_MAJOR_3_bm  (1<<7)  /* Major Revision bit 3 mask. */
+#define SYSCFG_MAJOR_3_bp  7  /* Major Revision bit 3 position. */
+
+/* SYSCFG.OCDMCTRL  bit masks and bit positions */
+#define SYSCFG_OCDM_gm  0xFF  /* OCD Message group mask. */
+#define SYSCFG_OCDM_gp  0  /* OCD Message group position. */
+#define SYSCFG_OCDM_0_bm  (1<<0)  /* OCD Message bit 0 mask. */
+#define SYSCFG_OCDM_0_bp  0  /* OCD Message bit 0 position. */
+#define SYSCFG_OCDM_1_bm  (1<<1)  /* OCD Message bit 1 mask. */
+#define SYSCFG_OCDM_1_bp  1  /* OCD Message bit 1 position. */
+#define SYSCFG_OCDM_2_bm  (1<<2)  /* OCD Message bit 2 mask. */
+#define SYSCFG_OCDM_2_bp  2  /* OCD Message bit 2 position. */
+#define SYSCFG_OCDM_3_bm  (1<<3)  /* OCD Message bit 3 mask. */
+#define SYSCFG_OCDM_3_bp  3  /* OCD Message bit 3 position. */
+#define SYSCFG_OCDM_4_bm  (1<<4)  /* OCD Message bit 4 mask. */
+#define SYSCFG_OCDM_4_bp  4  /* OCD Message bit 4 position. */
+#define SYSCFG_OCDM_5_bm  (1<<5)  /* OCD Message bit 5 mask. */
+#define SYSCFG_OCDM_5_bp  5  /* OCD Message bit 5 position. */
+#define SYSCFG_OCDM_6_bm  (1<<6)  /* OCD Message bit 6 mask. */
+#define SYSCFG_OCDM_6_bp  6  /* OCD Message bit 6 position. */
+#define SYSCFG_OCDM_7_bm  (1<<7)  /* OCD Message bit 7 mask. */
+#define SYSCFG_OCDM_7_bp  7  /* OCD Message bit 7 position. */
+
+/* SYSCFG.OCDMSTATUS  bit masks and bit positions */
+#define SYSCFG_VALID_bm  0x01  /* OCD Message Valid bit mask. */
+#define SYSCFG_VALID_bp  0  /* OCD Message Valid bit position. */
+
+
+/* TCA - 16-bit Timer/Counter Type A */
+/* TCA_SINGLE.CTRLA  bit masks and bit positions */
+#define TCA_SINGLE_ENABLE_bm  0x01  /* Module Enable bit mask. */
+#define TCA_SINGLE_ENABLE_bp  0  /* Module Enable bit position. */
+#define TCA_SINGLE_CLKSEL_gm  0x0E  /* Clock Selection group mask. */
+#define TCA_SINGLE_CLKSEL_gp  1  /* Clock Selection group position. */
+#define TCA_SINGLE_CLKSEL_0_bm  (1<<1)  /* Clock Selection bit 0 mask. */
+#define TCA_SINGLE_CLKSEL_0_bp  1  /* Clock Selection bit 0 position. */
+#define TCA_SINGLE_CLKSEL_1_bm  (1<<2)  /* Clock Selection bit 1 mask. */
+#define TCA_SINGLE_CLKSEL_1_bp  2  /* Clock Selection bit 1 position. */
+#define TCA_SINGLE_CLKSEL_2_bm  (1<<3)  /* Clock Selection bit 2 mask. */
+#define TCA_SINGLE_CLKSEL_2_bp  3  /* Clock Selection bit 2 position. */
+#define TCA_SINGLE_RUNSTDBY_bm  0x80  /* Run in Standby bit mask. */
+#define TCA_SINGLE_RUNSTDBY_bp  7  /* Run in Standby bit position. */
+
+/* TCA_SINGLE.CTRLB  bit masks and bit positions */
+#define TCA_SINGLE_WGMODE_gm  0x07  /* Waveform generation mode group mask. */
+#define TCA_SINGLE_WGMODE_gp  0  /* Waveform generation mode group position. */
+#define TCA_SINGLE_WGMODE_0_bm  (1<<0)  /* Waveform generation mode bit 0 mask. */
+#define TCA_SINGLE_WGMODE_0_bp  0  /* Waveform generation mode bit 0 position. */
+#define TCA_SINGLE_WGMODE_1_bm  (1<<1)  /* Waveform generation mode bit 1 mask. */
+#define TCA_SINGLE_WGMODE_1_bp  1  /* Waveform generation mode bit 1 position. */
+#define TCA_SINGLE_WGMODE_2_bm  (1<<2)  /* Waveform generation mode bit 2 mask. */
+#define TCA_SINGLE_WGMODE_2_bp  2  /* Waveform generation mode bit 2 position. */
+#define TCA_SINGLE_ALUPD_bm  0x08  /* Auto Lock Update bit mask. */
+#define TCA_SINGLE_ALUPD_bp  3  /* Auto Lock Update bit position. */
+#define TCA_SINGLE_CMP0EN_bm  0x10  /* Compare 0 Enable bit mask. */
+#define TCA_SINGLE_CMP0EN_bp  4  /* Compare 0 Enable bit position. */
+#define TCA_SINGLE_CMP1EN_bm  0x20  /* Compare 1 Enable bit mask. */
+#define TCA_SINGLE_CMP1EN_bp  5  /* Compare 1 Enable bit position. */
+#define TCA_SINGLE_CMP2EN_bm  0x40  /* Compare 2 Enable bit mask. */
+#define TCA_SINGLE_CMP2EN_bp  6  /* Compare 2 Enable bit position. */
+
+/* TCA_SINGLE.CTRLC  bit masks and bit positions */
+#define TCA_SINGLE_CMP0OV_bm  0x01  /* Compare 0 Waveform Output Value bit mask. */
+#define TCA_SINGLE_CMP0OV_bp  0  /* Compare 0 Waveform Output Value bit position. */
+#define TCA_SINGLE_CMP1OV_bm  0x02  /* Compare 1 Waveform Output Value bit mask. */
+#define TCA_SINGLE_CMP1OV_bp  1  /* Compare 1 Waveform Output Value bit position. */
+#define TCA_SINGLE_CMP2OV_bm  0x04  /* Compare 2 Waveform Output Value bit mask. */
+#define TCA_SINGLE_CMP2OV_bp  2  /* Compare 2 Waveform Output Value bit position. */
+
+/* TCA_SINGLE.CTRLD  bit masks and bit positions */
+#define TCA_SINGLE_SPLITM_bm  0x01  /* Split Mode Enable bit mask. */
+#define TCA_SINGLE_SPLITM_bp  0  /* Split Mode Enable bit position. */
+
+/* TCA_SINGLE.CTRLECLR  bit masks and bit positions */
+#define TCA_SINGLE_DIR_bm  0x01  /* Direction bit mask. */
+#define TCA_SINGLE_DIR_bp  0  /* Direction bit position. */
+#define TCA_SINGLE_LUPD_bm  0x02  /* Lock Update bit mask. */
+#define TCA_SINGLE_LUPD_bp  1  /* Lock Update bit position. */
+#define TCA_SINGLE_CMD_gm  0x0C  /* Command group mask. */
+#define TCA_SINGLE_CMD_gp  2  /* Command group position. */
+#define TCA_SINGLE_CMD_0_bm  (1<<2)  /* Command bit 0 mask. */
+#define TCA_SINGLE_CMD_0_bp  2  /* Command bit 0 position. */
+#define TCA_SINGLE_CMD_1_bm  (1<<3)  /* Command bit 1 mask. */
+#define TCA_SINGLE_CMD_1_bp  3  /* Command bit 1 position. */
+
+/* TCA_SINGLE.CTRLESET  bit masks and bit positions */
+/* TCA_SINGLE_DIR  is already defined. */
+/* TCA_SINGLE_LUPD  is already defined. */
+/* TCA_SINGLE_CMD  is already defined. */
+
+/* TCA_SINGLE.CTRLFCLR  bit masks and bit positions */
+#define TCA_SINGLE_PERBV_bm  0x01  /* Period Buffer Valid bit mask. */
+#define TCA_SINGLE_PERBV_bp  0  /* Period Buffer Valid bit position. */
+#define TCA_SINGLE_CMP0BV_bm  0x02  /* Compare 0 Buffer Valid bit mask. */
+#define TCA_SINGLE_CMP0BV_bp  1  /* Compare 0 Buffer Valid bit position. */
+#define TCA_SINGLE_CMP1BV_bm  0x04  /* Compare 1 Buffer Valid bit mask. */
+#define TCA_SINGLE_CMP1BV_bp  2  /* Compare 1 Buffer Valid bit position. */
+#define TCA_SINGLE_CMP2BV_bm  0x08  /* Compare 2 Buffer Valid bit mask. */
+#define TCA_SINGLE_CMP2BV_bp  3  /* Compare 2 Buffer Valid bit position. */
+
+/* TCA_SINGLE.CTRLFSET  bit masks and bit positions */
+/* TCA_SINGLE_PERBV  is already defined. */
+/* TCA_SINGLE_CMP0BV  is already defined. */
+/* TCA_SINGLE_CMP1BV  is already defined. */
+/* TCA_SINGLE_CMP2BV  is already defined. */
+
+/* TCA_SINGLE.EVCTRL  bit masks and bit positions */
+#define TCA_SINGLE_CNTAEI_bm  0x01  /* Count on Event Input A bit mask. */
+#define TCA_SINGLE_CNTAEI_bp  0  /* Count on Event Input A bit position. */
+#define TCA_SINGLE_EVACTA_gm  0x0E  /* Event Action A group mask. */
+#define TCA_SINGLE_EVACTA_gp  1  /* Event Action A group position. */
+#define TCA_SINGLE_EVACTA_0_bm  (1<<1)  /* Event Action A bit 0 mask. */
+#define TCA_SINGLE_EVACTA_0_bp  1  /* Event Action A bit 0 position. */
+#define TCA_SINGLE_EVACTA_1_bm  (1<<2)  /* Event Action A bit 1 mask. */
+#define TCA_SINGLE_EVACTA_1_bp  2  /* Event Action A bit 1 position. */
+#define TCA_SINGLE_EVACTA_2_bm  (1<<3)  /* Event Action A bit 2 mask. */
+#define TCA_SINGLE_EVACTA_2_bp  3  /* Event Action A bit 2 position. */
+#define TCA_SINGLE_CNTBEI_bm  0x10  /* Count on Event Input B bit mask. */
+#define TCA_SINGLE_CNTBEI_bp  4  /* Count on Event Input B bit position. */
+#define TCA_SINGLE_EVACTB_gm  0xE0  /* Event Action B group mask. */
+#define TCA_SINGLE_EVACTB_gp  5  /* Event Action B group position. */
+#define TCA_SINGLE_EVACTB_0_bm  (1<<5)  /* Event Action B bit 0 mask. */
+#define TCA_SINGLE_EVACTB_0_bp  5  /* Event Action B bit 0 position. */
+#define TCA_SINGLE_EVACTB_1_bm  (1<<6)  /* Event Action B bit 1 mask. */
+#define TCA_SINGLE_EVACTB_1_bp  6  /* Event Action B bit 1 position. */
+#define TCA_SINGLE_EVACTB_2_bm  (1<<7)  /* Event Action B bit 2 mask. */
+#define TCA_SINGLE_EVACTB_2_bp  7  /* Event Action B bit 2 position. */
+
+/* TCA_SINGLE.INTCTRL  bit masks and bit positions */
+#define TCA_SINGLE_OVF_bm  0x01  /* Overflow Interrupt bit mask. */
+#define TCA_SINGLE_OVF_bp  0  /* Overflow Interrupt bit position. */
+#define TCA_SINGLE_CMP0_bm  0x10  /* Compare 0 Interrupt bit mask. */
+#define TCA_SINGLE_CMP0_bp  4  /* Compare 0 Interrupt bit position. */
+#define TCA_SINGLE_CMP1_bm  0x20  /* Compare 1 Interrupt bit mask. */
+#define TCA_SINGLE_CMP1_bp  5  /* Compare 1 Interrupt bit position. */
+#define TCA_SINGLE_CMP2_bm  0x40  /* Compare 2 Interrupt bit mask. */
+#define TCA_SINGLE_CMP2_bp  6  /* Compare 2 Interrupt bit position. */
+
+/* TCA_SINGLE.INTFLAGS  bit masks and bit positions */
+/* TCA_SINGLE_OVF  is already defined. */
+/* TCA_SINGLE_CMP0  is already defined. */
+/* TCA_SINGLE_CMP1  is already defined. */
+/* TCA_SINGLE_CMP2  is already defined. */
+
+/* TCA_SINGLE.DBGCTRL  bit masks and bit positions */
+#define TCA_SINGLE_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define TCA_SINGLE_DBGRUN_bp  0  /* Debug Run bit position. */
+
+/* TCA_SPLIT.CTRLA  bit masks and bit positions */
+#define TCA_SPLIT_ENABLE_bm  0x01  /* Module Enable bit mask. */
+#define TCA_SPLIT_ENABLE_bp  0  /* Module Enable bit position. */
+#define TCA_SPLIT_CLKSEL_gm  0x0E  /* Clock Selection group mask. */
+#define TCA_SPLIT_CLKSEL_gp  1  /* Clock Selection group position. */
+#define TCA_SPLIT_CLKSEL_0_bm  (1<<1)  /* Clock Selection bit 0 mask. */
+#define TCA_SPLIT_CLKSEL_0_bp  1  /* Clock Selection bit 0 position. */
+#define TCA_SPLIT_CLKSEL_1_bm  (1<<2)  /* Clock Selection bit 1 mask. */
+#define TCA_SPLIT_CLKSEL_1_bp  2  /* Clock Selection bit 1 position. */
+#define TCA_SPLIT_CLKSEL_2_bm  (1<<3)  /* Clock Selection bit 2 mask. */
+#define TCA_SPLIT_CLKSEL_2_bp  3  /* Clock Selection bit 2 position. */
+#define TCA_SPLIT_RUNSTDBY_bm  0x80  /* Run in Standby bit mask. */
+#define TCA_SPLIT_RUNSTDBY_bp  7  /* Run in Standby bit position. */
+
+/* TCA_SPLIT.CTRLB  bit masks and bit positions */
+#define TCA_SPLIT_LCMP0EN_bm  0x01  /* Low Compare 0 Enable bit mask. */
+#define TCA_SPLIT_LCMP0EN_bp  0  /* Low Compare 0 Enable bit position. */
+#define TCA_SPLIT_LCMP1EN_bm  0x02  /* Low Compare 1 Enable bit mask. */
+#define TCA_SPLIT_LCMP1EN_bp  1  /* Low Compare 1 Enable bit position. */
+#define TCA_SPLIT_LCMP2EN_bm  0x04  /* Low Compare 2 Enable bit mask. */
+#define TCA_SPLIT_LCMP2EN_bp  2  /* Low Compare 2 Enable bit position. */
+#define TCA_SPLIT_HCMP0EN_bm  0x10  /* High Compare 0 Enable bit mask. */
+#define TCA_SPLIT_HCMP0EN_bp  4  /* High Compare 0 Enable bit position. */
+#define TCA_SPLIT_HCMP1EN_bm  0x20  /* High Compare 1 Enable bit mask. */
+#define TCA_SPLIT_HCMP1EN_bp  5  /* High Compare 1 Enable bit position. */
+#define TCA_SPLIT_HCMP2EN_bm  0x40  /* High Compare 2 Enable bit mask. */
+#define TCA_SPLIT_HCMP2EN_bp  6  /* High Compare 2 Enable bit position. */
+
+/* TCA_SPLIT.CTRLC  bit masks and bit positions */
+#define TCA_SPLIT_LCMP0OV_bm  0x01  /* Low Compare 0 Output Value bit mask. */
+#define TCA_SPLIT_LCMP0OV_bp  0  /* Low Compare 0 Output Value bit position. */
+#define TCA_SPLIT_LCMP1OV_bm  0x02  /* Low Compare 1 Output Value bit mask. */
+#define TCA_SPLIT_LCMP1OV_bp  1  /* Low Compare 1 Output Value bit position. */
+#define TCA_SPLIT_LCMP2OV_bm  0x04  /* Low Compare 2 Output Value bit mask. */
+#define TCA_SPLIT_LCMP2OV_bp  2  /* Low Compare 2 Output Value bit position. */
+#define TCA_SPLIT_HCMP0OV_bm  0x10  /* High Compare 0 Output Value bit mask. */
+#define TCA_SPLIT_HCMP0OV_bp  4  /* High Compare 0 Output Value bit position. */
+#define TCA_SPLIT_HCMP1OV_bm  0x20  /* High Compare 1 Output Value bit mask. */
+#define TCA_SPLIT_HCMP1OV_bp  5  /* High Compare 1 Output Value bit position. */
+#define TCA_SPLIT_HCMP2OV_bm  0x40  /* High Compare 2 Output Value bit mask. */
+#define TCA_SPLIT_HCMP2OV_bp  6  /* High Compare 2 Output Value bit position. */
+
+/* TCA_SPLIT.CTRLD  bit masks and bit positions */
+#define TCA_SPLIT_SPLITM_bm  0x01  /* Split Mode Enable bit mask. */
+#define TCA_SPLIT_SPLITM_bp  0  /* Split Mode Enable bit position. */
+
+/* TCA_SPLIT.CTRLECLR  bit masks and bit positions */
+#define TCA_SPLIT_CMDEN_gm  0x03  /* Command Enable group mask. */
+#define TCA_SPLIT_CMDEN_gp  0  /* Command Enable group position. */
+#define TCA_SPLIT_CMDEN_0_bm  (1<<0)  /* Command Enable bit 0 mask. */
+#define TCA_SPLIT_CMDEN_0_bp  0  /* Command Enable bit 0 position. */
+#define TCA_SPLIT_CMDEN_1_bm  (1<<1)  /* Command Enable bit 1 mask. */
+#define TCA_SPLIT_CMDEN_1_bp  1  /* Command Enable bit 1 position. */
+#define TCA_SPLIT_CMD_gm  0x0C  /* Command group mask. */
+#define TCA_SPLIT_CMD_gp  2  /* Command group position. */
+#define TCA_SPLIT_CMD_0_bm  (1<<2)  /* Command bit 0 mask. */
+#define TCA_SPLIT_CMD_0_bp  2  /* Command bit 0 position. */
+#define TCA_SPLIT_CMD_1_bm  (1<<3)  /* Command bit 1 mask. */
+#define TCA_SPLIT_CMD_1_bp  3  /* Command bit 1 position. */
+
+/* TCA_SPLIT.CTRLESET  bit masks and bit positions */
+/* TCA_SPLIT_CMDEN  is already defined. */
+/* TCA_SPLIT_CMD  is already defined. */
+
+/* TCA_SPLIT.INTCTRL  bit masks and bit positions */
+#define TCA_SPLIT_LUNF_bm  0x01  /* Low Underflow Interrupt Enable bit mask. */
+#define TCA_SPLIT_LUNF_bp  0  /* Low Underflow Interrupt Enable bit position. */
+#define TCA_SPLIT_HUNF_bm  0x02  /* High Underflow Interrupt Enable bit mask. */
+#define TCA_SPLIT_HUNF_bp  1  /* High Underflow Interrupt Enable bit position. */
+#define TCA_SPLIT_LCMP0_bm  0x10  /* Low Compare 0 Interrupt Enable bit mask. */
+#define TCA_SPLIT_LCMP0_bp  4  /* Low Compare 0 Interrupt Enable bit position. */
+#define TCA_SPLIT_LCMP1_bm  0x20  /* Low Compare 1 Interrupt Enable bit mask. */
+#define TCA_SPLIT_LCMP1_bp  5  /* Low Compare 1 Interrupt Enable bit position. */
+#define TCA_SPLIT_LCMP2_bm  0x40  /* Low Compare 2 Interrupt Enable bit mask. */
+#define TCA_SPLIT_LCMP2_bp  6  /* Low Compare 2 Interrupt Enable bit position. */
+
+/* TCA_SPLIT.INTFLAGS  bit masks and bit positions */
+/* TCA_SPLIT_LUNF  is already defined. */
+/* TCA_SPLIT_HUNF  is already defined. */
+/* TCA_SPLIT_LCMP0  is already defined. */
+/* TCA_SPLIT_LCMP1  is already defined. */
+/* TCA_SPLIT_LCMP2  is already defined. */
+
+/* TCA_SPLIT.DBGCTRL  bit masks and bit positions */
+#define TCA_SPLIT_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define TCA_SPLIT_DBGRUN_bp  0  /* Debug Run bit position. */
+
+
+/* TCB - 16-bit Timer Type B */
+/* TCB.CTRLA  bit masks and bit positions */
+#define TCB_ENABLE_bm  0x01  /* Enable bit mask. */
+#define TCB_ENABLE_bp  0  /* Enable bit position. */
+#define TCB_CLKSEL_gm  0x0E  /* Clock Select group mask. */
+#define TCB_CLKSEL_gp  1  /* Clock Select group position. */
+#define TCB_CLKSEL_0_bm  (1<<1)  /* Clock Select bit 0 mask. */
+#define TCB_CLKSEL_0_bp  1  /* Clock Select bit 0 position. */
+#define TCB_CLKSEL_1_bm  (1<<2)  /* Clock Select bit 1 mask. */
+#define TCB_CLKSEL_1_bp  2  /* Clock Select bit 1 position. */
+#define TCB_CLKSEL_2_bm  (1<<3)  /* Clock Select bit 2 mask. */
+#define TCB_CLKSEL_2_bp  3  /* Clock Select bit 2 position. */
+#define TCB_SYNCUPD_bm  0x10  /* Synchronize Update bit mask. */
+#define TCB_SYNCUPD_bp  4  /* Synchronize Update bit position. */
+#define TCB_CASCADE_bm  0x20  /* Cascade two timers bit mask. */
+#define TCB_CASCADE_bp  5  /* Cascade two timers bit position. */
+#define TCB_RUNSTDBY_bm  0x40  /* Run Standby bit mask. */
+#define TCB_RUNSTDBY_bp  6  /* Run Standby bit position. */
+
+/* TCB.CTRLB  bit masks and bit positions */
+#define TCB_CNTMODE_gm  0x07  /* Timer Mode group mask. */
+#define TCB_CNTMODE_gp  0  /* Timer Mode group position. */
+#define TCB_CNTMODE_0_bm  (1<<0)  /* Timer Mode bit 0 mask. */
+#define TCB_CNTMODE_0_bp  0  /* Timer Mode bit 0 position. */
+#define TCB_CNTMODE_1_bm  (1<<1)  /* Timer Mode bit 1 mask. */
+#define TCB_CNTMODE_1_bp  1  /* Timer Mode bit 1 position. */
+#define TCB_CNTMODE_2_bm  (1<<2)  /* Timer Mode bit 2 mask. */
+#define TCB_CNTMODE_2_bp  2  /* Timer Mode bit 2 position. */
+#define TCB_CCMPEN_bm  0x10  /* Pin Output Enable bit mask. */
+#define TCB_CCMPEN_bp  4  /* Pin Output Enable bit position. */
+#define TCB_CCMPINIT_bm  0x20  /* Pin Initial State bit mask. */
+#define TCB_CCMPINIT_bp  5  /* Pin Initial State bit position. */
+#define TCB_ASYNC_bm  0x40  /* Asynchronous Enable bit mask. */
+#define TCB_ASYNC_bp  6  /* Asynchronous Enable bit position. */
+
+/* TCB.EVCTRL  bit masks and bit positions */
+#define TCB_CAPTEI_bm  0x01  /* Event Input Enable bit mask. */
+#define TCB_CAPTEI_bp  0  /* Event Input Enable bit position. */
+#define TCB_EDGE_bm  0x10  /* Event Edge bit mask. */
+#define TCB_EDGE_bp  4  /* Event Edge bit position. */
+#define TCB_FILTER_bm  0x40  /* Input Capture Noise Cancellation Filter bit mask. */
+#define TCB_FILTER_bp  6  /* Input Capture Noise Cancellation Filter bit position. */
+
+/* TCB.INTCTRL  bit masks and bit positions */
+#define TCB_CAPT_bm  0x01  /* Capture or Timeout bit mask. */
+#define TCB_CAPT_bp  0  /* Capture or Timeout bit position. */
+#define TCB_OVF_bm  0x02  /* Overflow bit mask. */
+#define TCB_OVF_bp  1  /* Overflow bit position. */
+
+/* TCB.INTFLAGS  bit masks and bit positions */
+/* TCB_CAPT  is already defined. */
+/* TCB_OVF  is already defined. */
+
+/* TCB.STATUS  bit masks and bit positions */
+#define TCB_RUN_bm  0x01  /* Run bit mask. */
+#define TCB_RUN_bp  0  /* Run bit position. */
+
+/* TCB.DBGCTRL  bit masks and bit positions */
+#define TCB_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define TCB_DBGRUN_bp  0  /* Debug Run bit position. */
+
+
+/* TWI - Two-Wire Interface */
+/* TWI.CTRLA  bit masks and bit positions */
+#define TWI_FMEN_bm  0x01  /* Fast-mode Enable bit mask. */
+#define TWI_FMEN_bp  0  /* Fast-mode Enable bit position. */
+#define TWI_FMPEN_bm  0x02  /* Fast-mode Plus Enable bit mask. */
+#define TWI_FMPEN_bp  1  /* Fast-mode Plus Enable bit position. */
+#define TWI_SDAHOLD_gm  0x0C  /* SDA Hold Time group mask. */
+#define TWI_SDAHOLD_gp  2  /* SDA Hold Time group position. */
+#define TWI_SDAHOLD_0_bm  (1<<2)  /* SDA Hold Time bit 0 mask. */
+#define TWI_SDAHOLD_0_bp  2  /* SDA Hold Time bit 0 position. */
+#define TWI_SDAHOLD_1_bm  (1<<3)  /* SDA Hold Time bit 1 mask. */
+#define TWI_SDAHOLD_1_bp  3  /* SDA Hold Time bit 1 position. */
+#define TWI_SDASETUP_bm  0x10  /* SDA Setup Time bit mask. */
+#define TWI_SDASETUP_bp  4  /* SDA Setup Time bit position. */
+#define TWI_INPUTLVL_bm  0x40  /* Input voltage transition level bit mask. */
+#define TWI_INPUTLVL_bp  6  /* Input voltage transition level bit position. */
+
+/* TWI.DUALCTRL  bit masks and bit positions */
+#define TWI_ENABLE_bm  0x01  /* Enable bit mask. */
+#define TWI_ENABLE_bp  0  /* Enable bit position. */
+/* TWI_FMPEN  is already defined. */
+/* TWI_SDAHOLD  is already defined. */
+/* TWI_INPUTLVL  is already defined. */
+
+/* TWI.DBGCTRL  bit masks and bit positions */
+#define TWI_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define TWI_DBGRUN_bp  0  /* Debug Run bit position. */
+
+/* TWI.MCTRLA  bit masks and bit positions */
+/* TWI_ENABLE  is already defined. */
+#define TWI_SMEN_bm  0x02  /* Smart Mode Enable bit mask. */
+#define TWI_SMEN_bp  1  /* Smart Mode Enable bit position. */
+#define TWI_TIMEOUT_gm  0x0C  /* Inactive Bus Time-Out group mask. */
+#define TWI_TIMEOUT_gp  2  /* Inactive Bus Time-Out group position. */
+#define TWI_TIMEOUT_0_bm  (1<<2)  /* Inactive Bus Time-Out bit 0 mask. */
+#define TWI_TIMEOUT_0_bp  2  /* Inactive Bus Time-Out bit 0 position. */
+#define TWI_TIMEOUT_1_bm  (1<<3)  /* Inactive Bus Time-Out bit 1 mask. */
+#define TWI_TIMEOUT_1_bp  3  /* Inactive Bus Time-Out bit 1 position. */
+#define TWI_QCEN_bm  0x10  /* Quick Command Enable bit mask. */
+#define TWI_QCEN_bp  4  /* Quick Command Enable bit position. */
+#define TWI_WIEN_bm  0x40  /* Write Interrupt Enable bit mask. */
+#define TWI_WIEN_bp  6  /* Write Interrupt Enable bit position. */
+#define TWI_RIEN_bm  0x80  /* Read Interrupt Enable bit mask. */
+#define TWI_RIEN_bp  7  /* Read Interrupt Enable bit position. */
+
+/* TWI.MCTRLB  bit masks and bit positions */
+#define TWI_MCMD_gm  0x03  /* Command group mask. */
+#define TWI_MCMD_gp  0  /* Command group position. */
+#define TWI_MCMD_0_bm  (1<<0)  /* Command bit 0 mask. */
+#define TWI_MCMD_0_bp  0  /* Command bit 0 position. */
+#define TWI_MCMD_1_bm  (1<<1)  /* Command bit 1 mask. */
+#define TWI_MCMD_1_bp  1  /* Command bit 1 position. */
+#define TWI_ACKACT_bm  0x04  /* Acknowledge Action bit mask. */
+#define TWI_ACKACT_bp  2  /* Acknowledge Action bit position. */
+#define TWI_FLUSH_bm  0x08  /* Flush bit mask. */
+#define TWI_FLUSH_bp  3  /* Flush bit position. */
+
+/* TWI.MSTATUS  bit masks and bit positions */
+#define TWI_BUSSTATE_gm  0x03  /* Bus State group mask. */
+#define TWI_BUSSTATE_gp  0  /* Bus State group position. */
+#define TWI_BUSSTATE_0_bm  (1<<0)  /* Bus State bit 0 mask. */
+#define TWI_BUSSTATE_0_bp  0  /* Bus State bit 0 position. */
+#define TWI_BUSSTATE_1_bm  (1<<1)  /* Bus State bit 1 mask. */
+#define TWI_BUSSTATE_1_bp  1  /* Bus State bit 1 position. */
+#define TWI_BUSERR_bm  0x04  /* Bus Error bit mask. */
+#define TWI_BUSERR_bp  2  /* Bus Error bit position. */
+#define TWI_ARBLOST_bm  0x08  /* Arbitration Lost bit mask. */
+#define TWI_ARBLOST_bp  3  /* Arbitration Lost bit position. */
+#define TWI_RXACK_bm  0x10  /* Received Acknowledge bit mask. */
+#define TWI_RXACK_bp  4  /* Received Acknowledge bit position. */
+#define TWI_CLKHOLD_bm  0x20  /* Clock Hold bit mask. */
+#define TWI_CLKHOLD_bp  5  /* Clock Hold bit position. */
+#define TWI_WIF_bm  0x40  /* Write Interrupt Flag bit mask. */
+#define TWI_WIF_bp  6  /* Write Interrupt Flag bit position. */
+#define TWI_RIF_bm  0x80  /* Read Interrupt Flag bit mask. */
+#define TWI_RIF_bp  7  /* Read Interrupt Flag bit position. */
+
+/* TWI.MBAUD  bit masks and bit positions */
+#define TWI_BAUD_gm  0xFF  /* Baud Rate group mask. */
+#define TWI_BAUD_gp  0  /* Baud Rate group position. */
+#define TWI_BAUD_0_bm  (1<<0)  /* Baud Rate bit 0 mask. */
+#define TWI_BAUD_0_bp  0  /* Baud Rate bit 0 position. */
+#define TWI_BAUD_1_bm  (1<<1)  /* Baud Rate bit 1 mask. */
+#define TWI_BAUD_1_bp  1  /* Baud Rate bit 1 position. */
+#define TWI_BAUD_2_bm  (1<<2)  /* Baud Rate bit 2 mask. */
+#define TWI_BAUD_2_bp  2  /* Baud Rate bit 2 position. */
+#define TWI_BAUD_3_bm  (1<<3)  /* Baud Rate bit 3 mask. */
+#define TWI_BAUD_3_bp  3  /* Baud Rate bit 3 position. */
+#define TWI_BAUD_4_bm  (1<<4)  /* Baud Rate bit 4 mask. */
+#define TWI_BAUD_4_bp  4  /* Baud Rate bit 4 position. */
+#define TWI_BAUD_5_bm  (1<<5)  /* Baud Rate bit 5 mask. */
+#define TWI_BAUD_5_bp  5  /* Baud Rate bit 5 position. */
+#define TWI_BAUD_6_bm  (1<<6)  /* Baud Rate bit 6 mask. */
+#define TWI_BAUD_6_bp  6  /* Baud Rate bit 6 position. */
+#define TWI_BAUD_7_bm  (1<<7)  /* Baud Rate bit 7 mask. */
+#define TWI_BAUD_7_bp  7  /* Baud Rate bit 7 position. */
+
+/* TWI.MADDR  bit masks and bit positions */
+#define TWI_ADDR_gm  0xFF  /* Address group mask. */
+#define TWI_ADDR_gp  0  /* Address group position. */
+#define TWI_ADDR_0_bm  (1<<0)  /* Address bit 0 mask. */
+#define TWI_ADDR_0_bp  0  /* Address bit 0 position. */
+#define TWI_ADDR_1_bm  (1<<1)  /* Address bit 1 mask. */
+#define TWI_ADDR_1_bp  1  /* Address bit 1 position. */
+#define TWI_ADDR_2_bm  (1<<2)  /* Address bit 2 mask. */
+#define TWI_ADDR_2_bp  2  /* Address bit 2 position. */
+#define TWI_ADDR_3_bm  (1<<3)  /* Address bit 3 mask. */
+#define TWI_ADDR_3_bp  3  /* Address bit 3 position. */
+#define TWI_ADDR_4_bm  (1<<4)  /* Address bit 4 mask. */
+#define TWI_ADDR_4_bp  4  /* Address bit 4 position. */
+#define TWI_ADDR_5_bm  (1<<5)  /* Address bit 5 mask. */
+#define TWI_ADDR_5_bp  5  /* Address bit 5 position. */
+#define TWI_ADDR_6_bm  (1<<6)  /* Address bit 6 mask. */
+#define TWI_ADDR_6_bp  6  /* Address bit 6 position. */
+#define TWI_ADDR_7_bm  (1<<7)  /* Address bit 7 mask. */
+#define TWI_ADDR_7_bp  7  /* Address bit 7 position. */
+
+/* TWI.MDATA  bit masks and bit positions */
+#define TWI_DATA_gm  0xFF  /* Data group mask. */
+#define TWI_DATA_gp  0  /* Data group position. */
+#define TWI_DATA_0_bm  (1<<0)  /* Data bit 0 mask. */
+#define TWI_DATA_0_bp  0  /* Data bit 0 position. */
+#define TWI_DATA_1_bm  (1<<1)  /* Data bit 1 mask. */
+#define TWI_DATA_1_bp  1  /* Data bit 1 position. */
+#define TWI_DATA_2_bm  (1<<2)  /* Data bit 2 mask. */
+#define TWI_DATA_2_bp  2  /* Data bit 2 position. */
+#define TWI_DATA_3_bm  (1<<3)  /* Data bit 3 mask. */
+#define TWI_DATA_3_bp  3  /* Data bit 3 position. */
+#define TWI_DATA_4_bm  (1<<4)  /* Data bit 4 mask. */
+#define TWI_DATA_4_bp  4  /* Data bit 4 position. */
+#define TWI_DATA_5_bm  (1<<5)  /* Data bit 5 mask. */
+#define TWI_DATA_5_bp  5  /* Data bit 5 position. */
+#define TWI_DATA_6_bm  (1<<6)  /* Data bit 6 mask. */
+#define TWI_DATA_6_bp  6  /* Data bit 6 position. */
+#define TWI_DATA_7_bm  (1<<7)  /* Data bit 7 mask. */
+#define TWI_DATA_7_bp  7  /* Data bit 7 position. */
+
+/* TWI.SCTRLA  bit masks and bit positions */
+/* TWI_ENABLE  is already defined. */
+/* TWI_SMEN  is already defined. */
+#define TWI_PMEN_bm  0x04  /* Address Recognition Mode bit mask. */
+#define TWI_PMEN_bp  2  /* Address Recognition Mode bit position. */
+#define TWI_PIEN_bm  0x20  /* Stop Interrupt Enable bit mask. */
+#define TWI_PIEN_bp  5  /* Stop Interrupt Enable bit position. */
+#define TWI_APIEN_bm  0x40  /* Address or Stop Interrupt Enable bit mask. */
+#define TWI_APIEN_bp  6  /* Address or Stop Interrupt Enable bit position. */
+#define TWI_DIEN_bm  0x80  /* Data Interrupt Enable bit mask. */
+#define TWI_DIEN_bp  7  /* Data Interrupt Enable bit position. */
+
+/* TWI.SCTRLB  bit masks and bit positions */
+#define TWI_SCMD_gm  0x03  /* Command group mask. */
+#define TWI_SCMD_gp  0  /* Command group position. */
+#define TWI_SCMD_0_bm  (1<<0)  /* Command bit 0 mask. */
+#define TWI_SCMD_0_bp  0  /* Command bit 0 position. */
+#define TWI_SCMD_1_bm  (1<<1)  /* Command bit 1 mask. */
+#define TWI_SCMD_1_bp  1  /* Command bit 1 position. */
+/* TWI_ACKACT  is already defined. */
+
+/* TWI.SSTATUS  bit masks and bit positions */
+#define TWI_AP_bm  0x01  /* Address or Stop bit mask. */
+#define TWI_AP_bp  0  /* Address or Stop bit position. */
+#define TWI_DIR_bm  0x02  /* Read/Write Direction bit mask. */
+#define TWI_DIR_bp  1  /* Read/Write Direction bit position. */
+/* TWI_BUSERR  is already defined. */
+#define TWI_COLL_bm  0x08  /* Collision bit mask. */
+#define TWI_COLL_bp  3  /* Collision bit position. */
+/* TWI_RXACK  is already defined. */
+/* TWI_CLKHOLD  is already defined. */
+#define TWI_APIF_bm  0x40  /* Address or Stop Interrupt Flag bit mask. */
+#define TWI_APIF_bp  6  /* Address or Stop Interrupt Flag bit position. */
+#define TWI_DIF_bm  0x80  /* Data Interrupt Flag bit mask. */
+#define TWI_DIF_bp  7  /* Data Interrupt Flag bit position. */
+
+/* TWI.SADDR  bit masks and bit positions */
+/* TWI_ADDR  is already defined. */
+
+/* TWI.SDATA  bit masks and bit positions */
+/* TWI_DATA  is already defined. */
+
+/* TWI.SADDRMASK  bit masks and bit positions */
+#define TWI_ADDREN_bm  0x01  /* Address Mask Enable bit mask. */
+#define TWI_ADDREN_bp  0  /* Address Mask Enable bit position. */
+#define TWI_ADDRMASK_gm  0xFE  /* Address Mask group mask. */
+#define TWI_ADDRMASK_gp  1  /* Address Mask group position. */
+#define TWI_ADDRMASK_0_bm  (1<<1)  /* Address Mask bit 0 mask. */
+#define TWI_ADDRMASK_0_bp  1  /* Address Mask bit 0 position. */
+#define TWI_ADDRMASK_1_bm  (1<<2)  /* Address Mask bit 1 mask. */
+#define TWI_ADDRMASK_1_bp  2  /* Address Mask bit 1 position. */
+#define TWI_ADDRMASK_2_bm  (1<<3)  /* Address Mask bit 2 mask. */
+#define TWI_ADDRMASK_2_bp  3  /* Address Mask bit 2 position. */
+#define TWI_ADDRMASK_3_bm  (1<<4)  /* Address Mask bit 3 mask. */
+#define TWI_ADDRMASK_3_bp  4  /* Address Mask bit 3 position. */
+#define TWI_ADDRMASK_4_bm  (1<<5)  /* Address Mask bit 4 mask. */
+#define TWI_ADDRMASK_4_bp  5  /* Address Mask bit 4 position. */
+#define TWI_ADDRMASK_5_bm  (1<<6)  /* Address Mask bit 5 mask. */
+#define TWI_ADDRMASK_5_bp  6  /* Address Mask bit 5 position. */
+#define TWI_ADDRMASK_6_bm  (1<<7)  /* Address Mask bit 6 mask. */
+#define TWI_ADDRMASK_6_bp  7  /* Address Mask bit 6 position. */
+
+
+/* USART - Universal Synchronous and Asynchronous Receiver and Transmitter */
+/* USART.RXDATAL  bit masks and bit positions */
+#define USART_DATA_gm  0xFF  /* RX Data group mask. */
+#define USART_DATA_gp  0  /* RX Data group position. */
+#define USART_DATA_0_bm  (1<<0)  /* RX Data bit 0 mask. */
+#define USART_DATA_0_bp  0  /* RX Data bit 0 position. */
+#define USART_DATA_1_bm  (1<<1)  /* RX Data bit 1 mask. */
+#define USART_DATA_1_bp  1  /* RX Data bit 1 position. */
+#define USART_DATA_2_bm  (1<<2)  /* RX Data bit 2 mask. */
+#define USART_DATA_2_bp  2  /* RX Data bit 2 position. */
+#define USART_DATA_3_bm  (1<<3)  /* RX Data bit 3 mask. */
+#define USART_DATA_3_bp  3  /* RX Data bit 3 position. */
+#define USART_DATA_4_bm  (1<<4)  /* RX Data bit 4 mask. */
+#define USART_DATA_4_bp  4  /* RX Data bit 4 position. */
+#define USART_DATA_5_bm  (1<<5)  /* RX Data bit 5 mask. */
+#define USART_DATA_5_bp  5  /* RX Data bit 5 position. */
+#define USART_DATA_6_bm  (1<<6)  /* RX Data bit 6 mask. */
+#define USART_DATA_6_bp  6  /* RX Data bit 6 position. */
+#define USART_DATA_7_bm  (1<<7)  /* RX Data bit 7 mask. */
+#define USART_DATA_7_bp  7  /* RX Data bit 7 position. */
+
+/* USART.RXDATAH  bit masks and bit positions */
+#define USART_DATA8_bm  0x01  /* Receiver Data Register bit mask. */
+#define USART_DATA8_bp  0  /* Receiver Data Register bit position. */
+#define USART_PERR_bm  0x02  /* Parity Error bit mask. */
+#define USART_PERR_bp  1  /* Parity Error bit position. */
+#define USART_FERR_bm  0x04  /* Frame Error bit mask. */
+#define USART_FERR_bp  2  /* Frame Error bit position. */
+#define USART_BUFOVF_bm  0x40  /* Buffer Overflow bit mask. */
+#define USART_BUFOVF_bp  6  /* Buffer Overflow bit position. */
+#define USART_RXCIF_bm  0x80  /* Receive Complete Interrupt Flag bit mask. */
+#define USART_RXCIF_bp  7  /* Receive Complete Interrupt Flag bit position. */
+
+/* USART.TXDATAL  bit masks and bit positions */
+/* USART_DATA  is already defined. */
+
+/* USART.TXDATAH  bit masks and bit positions */
+/* USART_DATA8  is already defined. */
+
+/* USART.STATUS  bit masks and bit positions */
+#define USART_WFB_bm  0x01  /* Wait For Break bit mask. */
+#define USART_WFB_bp  0  /* Wait For Break bit position. */
+#define USART_BDF_bm  0x02  /* Break Detected Flag bit mask. */
+#define USART_BDF_bp  1  /* Break Detected Flag bit position. */
+#define USART_ISFIF_bm  0x08  /* Inconsistent Sync Field Interrupt Flag bit mask. */
+#define USART_ISFIF_bp  3  /* Inconsistent Sync Field Interrupt Flag bit position. */
+#define USART_RXSIF_bm  0x10  /* Receive Start Interrupt bit mask. */
+#define USART_RXSIF_bp  4  /* Receive Start Interrupt bit position. */
+#define USART_DREIF_bm  0x20  /* Data Register Empty Flag bit mask. */
+#define USART_DREIF_bp  5  /* Data Register Empty Flag bit position. */
+#define USART_TXCIF_bm  0x40  /* Transmit Interrupt Flag bit mask. */
+#define USART_TXCIF_bp  6  /* Transmit Interrupt Flag bit position. */
+/* USART_RXCIF  is already defined. */
+
+/* USART.CTRLA  bit masks and bit positions */
+#define USART_RS485_bm  0x01  /* RS485 Mode internal transmitter bit mask. */
+#define USART_RS485_bp  0  /* RS485 Mode internal transmitter bit position. */
+#define USART_ABEIE_bm  0x04  /* Auto-baud Error Interrupt Enable bit mask. */
+#define USART_ABEIE_bp  2  /* Auto-baud Error Interrupt Enable bit position. */
+#define USART_LBME_bm  0x08  /* Loop-back Mode Enable bit mask. */
+#define USART_LBME_bp  3  /* Loop-back Mode Enable bit position. */
+#define USART_RXSIE_bm  0x10  /* Receiver Start Frame Interrupt Enable bit mask. */
+#define USART_RXSIE_bp  4  /* Receiver Start Frame Interrupt Enable bit position. */
+#define USART_DREIE_bm  0x20  /* Data Register Empty Interrupt Enable bit mask. */
+#define USART_DREIE_bp  5  /* Data Register Empty Interrupt Enable bit position. */
+#define USART_TXCIE_bm  0x40  /* Transmit Complete Interrupt Enable bit mask. */
+#define USART_TXCIE_bp  6  /* Transmit Complete Interrupt Enable bit position. */
+#define USART_RXCIE_bm  0x80  /* Receive Complete Interrupt Enable bit mask. */
+#define USART_RXCIE_bp  7  /* Receive Complete Interrupt Enable bit position. */
+
+/* USART.CTRLB  bit masks and bit positions */
+#define USART_MPCM_bm  0x01  /* Multi-processor Communication Mode bit mask. */
+#define USART_MPCM_bp  0  /* Multi-processor Communication Mode bit position. */
+#define USART_RXMODE_gm  0x06  /* Receiver Mode group mask. */
+#define USART_RXMODE_gp  1  /* Receiver Mode group position. */
+#define USART_RXMODE_0_bm  (1<<1)  /* Receiver Mode bit 0 mask. */
+#define USART_RXMODE_0_bp  1  /* Receiver Mode bit 0 position. */
+#define USART_RXMODE_1_bm  (1<<2)  /* Receiver Mode bit 1 mask. */
+#define USART_RXMODE_1_bp  2  /* Receiver Mode bit 1 position. */
+#define USART_ODME_bm  0x08  /* Open Drain Mode Enable bit mask. */
+#define USART_ODME_bp  3  /* Open Drain Mode Enable bit position. */
+#define USART_SFDEN_bm  0x10  /* Start Frame Detection Enable bit mask. */
+#define USART_SFDEN_bp  4  /* Start Frame Detection Enable bit position. */
+#define USART_TXEN_bm  0x40  /* Transmitter Enable bit mask. */
+#define USART_TXEN_bp  6  /* Transmitter Enable bit position. */
+#define USART_RXEN_bm  0x80  /* Reciever enable bit mask. */
+#define USART_RXEN_bp  7  /* Reciever enable bit position. */
+
+/* USART.CTRLC  bit masks and bit positions */
+#define USART_UCPHA_bm  0x02  /* SPI Host Mode, Clock Phase bit mask. */
+#define USART_UCPHA_bp  1  /* SPI Host Mode, Clock Phase bit position. */
+#define USART_UDORD_bm  0x04  /* SPI Host Mode, Data Order bit mask. */
+#define USART_UDORD_bp  2  /* SPI Host Mode, Data Order bit position. */
+#define USART_CHSIZE_gm  0x07  /* Character Size group mask. */
+#define USART_CHSIZE_gp  0  /* Character Size group position. */
+#define USART_CHSIZE_0_bm  (1<<0)  /* Character Size bit 0 mask. */
+#define USART_CHSIZE_0_bp  0  /* Character Size bit 0 position. */
+#define USART_CHSIZE_1_bm  (1<<1)  /* Character Size bit 1 mask. */
+#define USART_CHSIZE_1_bp  1  /* Character Size bit 1 position. */
+#define USART_CHSIZE_2_bm  (1<<2)  /* Character Size bit 2 mask. */
+#define USART_CHSIZE_2_bp  2  /* Character Size bit 2 position. */
+#define USART_SBMODE_bm  0x08  /* Stop Bit Mode bit mask. */
+#define USART_SBMODE_bp  3  /* Stop Bit Mode bit position. */
+#define USART_PMODE_gm  0x30  /* Parity Mode group mask. */
+#define USART_PMODE_gp  4  /* Parity Mode group position. */
+#define USART_PMODE_0_bm  (1<<4)  /* Parity Mode bit 0 mask. */
+#define USART_PMODE_0_bp  4  /* Parity Mode bit 0 position. */
+#define USART_PMODE_1_bm  (1<<5)  /* Parity Mode bit 1 mask. */
+#define USART_PMODE_1_bp  5  /* Parity Mode bit 1 position. */
+#define USART_CMODE_gm  0xC0  /* Communication Mode group mask. */
+#define USART_CMODE_gp  6  /* Communication Mode group position. */
+#define USART_CMODE_0_bm  (1<<6)  /* Communication Mode bit 0 mask. */
+#define USART_CMODE_0_bp  6  /* Communication Mode bit 0 position. */
+#define USART_CMODE_1_bm  (1<<7)  /* Communication Mode bit 1 mask. */
+#define USART_CMODE_1_bp  7  /* Communication Mode bit 1 position. */
+
+/* USART.CTRLD  bit masks and bit positions */
+#define USART_ABW_gm  0xC0  /* Auto Baud Window group mask. */
+#define USART_ABW_gp  6  /* Auto Baud Window group position. */
+#define USART_ABW_0_bm  (1<<6)  /* Auto Baud Window bit 0 mask. */
+#define USART_ABW_0_bp  6  /* Auto Baud Window bit 0 position. */
+#define USART_ABW_1_bm  (1<<7)  /* Auto Baud Window bit 1 mask. */
+#define USART_ABW_1_bp  7  /* Auto Baud Window bit 1 position. */
+
+/* USART.DBGCTRL  bit masks and bit positions */
+#define USART_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define USART_DBGRUN_bp  0  /* Debug Run bit position. */
+
+/* USART.EVCTRL  bit masks and bit positions */
+#define USART_IREI_bm  0x01  /* IrDA Event Input Enable bit mask. */
+#define USART_IREI_bp  0  /* IrDA Event Input Enable bit position. */
+
+/* USART.TXPLCTRL  bit masks and bit positions */
+#define USART_TXPL_gm  0xFF  /* Transmit pulse length group mask. */
+#define USART_TXPL_gp  0  /* Transmit pulse length group position. */
+#define USART_TXPL_0_bm  (1<<0)  /* Transmit pulse length bit 0 mask. */
+#define USART_TXPL_0_bp  0  /* Transmit pulse length bit 0 position. */
+#define USART_TXPL_1_bm  (1<<1)  /* Transmit pulse length bit 1 mask. */
+#define USART_TXPL_1_bp  1  /* Transmit pulse length bit 1 position. */
+#define USART_TXPL_2_bm  (1<<2)  /* Transmit pulse length bit 2 mask. */
+#define USART_TXPL_2_bp  2  /* Transmit pulse length bit 2 position. */
+#define USART_TXPL_3_bm  (1<<3)  /* Transmit pulse length bit 3 mask. */
+#define USART_TXPL_3_bp  3  /* Transmit pulse length bit 3 position. */
+#define USART_TXPL_4_bm  (1<<4)  /* Transmit pulse length bit 4 mask. */
+#define USART_TXPL_4_bp  4  /* Transmit pulse length bit 4 position. */
+#define USART_TXPL_5_bm  (1<<5)  /* Transmit pulse length bit 5 mask. */
+#define USART_TXPL_5_bp  5  /* Transmit pulse length bit 5 position. */
+#define USART_TXPL_6_bm  (1<<6)  /* Transmit pulse length bit 6 mask. */
+#define USART_TXPL_6_bp  6  /* Transmit pulse length bit 6 position. */
+#define USART_TXPL_7_bm  (1<<7)  /* Transmit pulse length bit 7 mask. */
+#define USART_TXPL_7_bp  7  /* Transmit pulse length bit 7 position. */
+
+/* USART.RXPLCTRL  bit masks and bit positions */
+#define USART_RXPL_gm  0x7F  /* Receiver Pulse Lenght group mask. */
+#define USART_RXPL_gp  0  /* Receiver Pulse Lenght group position. */
+#define USART_RXPL_0_bm  (1<<0)  /* Receiver Pulse Lenght bit 0 mask. */
+#define USART_RXPL_0_bp  0  /* Receiver Pulse Lenght bit 0 position. */
+#define USART_RXPL_1_bm  (1<<1)  /* Receiver Pulse Lenght bit 1 mask. */
+#define USART_RXPL_1_bp  1  /* Receiver Pulse Lenght bit 1 position. */
+#define USART_RXPL_2_bm  (1<<2)  /* Receiver Pulse Lenght bit 2 mask. */
+#define USART_RXPL_2_bp  2  /* Receiver Pulse Lenght bit 2 position. */
+#define USART_RXPL_3_bm  (1<<3)  /* Receiver Pulse Lenght bit 3 mask. */
+#define USART_RXPL_3_bp  3  /* Receiver Pulse Lenght bit 3 position. */
+#define USART_RXPL_4_bm  (1<<4)  /* Receiver Pulse Lenght bit 4 mask. */
+#define USART_RXPL_4_bp  4  /* Receiver Pulse Lenght bit 4 position. */
+#define USART_RXPL_5_bm  (1<<5)  /* Receiver Pulse Lenght bit 5 mask. */
+#define USART_RXPL_5_bp  5  /* Receiver Pulse Lenght bit 5 position. */
+#define USART_RXPL_6_bm  (1<<6)  /* Receiver Pulse Lenght bit 6 mask. */
+#define USART_RXPL_6_bp  6  /* Receiver Pulse Lenght bit 6 position. */
+
+
+
+/* VPORT - Virtual Ports */
+/* VPORT.INTFLAGS  bit masks and bit positions */
+#define VPORT_INT_gm  0xFF  /* Pin Interrupt Flag group mask. */
+#define VPORT_INT_gp  0  /* Pin Interrupt Flag group position. */
+#define VPORT_INT_0_bm  (1<<0)  /* Pin Interrupt Flag bit 0 mask. */
+#define VPORT_INT_0_bp  0  /* Pin Interrupt Flag bit 0 position. */
+#define VPORT_INT_1_bm  (1<<1)  /* Pin Interrupt Flag bit 1 mask. */
+#define VPORT_INT_1_bp  1  /* Pin Interrupt Flag bit 1 position. */
+#define VPORT_INT_2_bm  (1<<2)  /* Pin Interrupt Flag bit 2 mask. */
+#define VPORT_INT_2_bp  2  /* Pin Interrupt Flag bit 2 position. */
+#define VPORT_INT_3_bm  (1<<3)  /* Pin Interrupt Flag bit 3 mask. */
+#define VPORT_INT_3_bp  3  /* Pin Interrupt Flag bit 3 position. */
+#define VPORT_INT_4_bm  (1<<4)  /* Pin Interrupt Flag bit 4 mask. */
+#define VPORT_INT_4_bp  4  /* Pin Interrupt Flag bit 4 position. */
+#define VPORT_INT_5_bm  (1<<5)  /* Pin Interrupt Flag bit 5 mask. */
+#define VPORT_INT_5_bp  5  /* Pin Interrupt Flag bit 5 position. */
+#define VPORT_INT_6_bm  (1<<6)  /* Pin Interrupt Flag bit 6 mask. */
+#define VPORT_INT_6_bp  6  /* Pin Interrupt Flag bit 6 position. */
+#define VPORT_INT_7_bm  (1<<7)  /* Pin Interrupt Flag bit 7 mask. */
+#define VPORT_INT_7_bp  7  /* Pin Interrupt Flag bit 7 position. */
+
+
+/* VREF - Voltage reference */
+/* VREF.DAC0REF  bit masks and bit positions */
+#define VREF_REFSEL_gm  0x07  /* Reference select group mask. */
+#define VREF_REFSEL_gp  0  /* Reference select group position. */
+#define VREF_REFSEL_0_bm  (1<<0)  /* Reference select bit 0 mask. */
+#define VREF_REFSEL_0_bp  0  /* Reference select bit 0 position. */
+#define VREF_REFSEL_1_bm  (1<<1)  /* Reference select bit 1 mask. */
+#define VREF_REFSEL_1_bp  1  /* Reference select bit 1 position. */
+#define VREF_REFSEL_2_bm  (1<<2)  /* Reference select bit 2 mask. */
+#define VREF_REFSEL_2_bp  2  /* Reference select bit 2 position. */
+#define VREF_ALWAYSON_bm  0x80  /* Always on bit mask. */
+#define VREF_ALWAYSON_bp  7  /* Always on bit position. */
+
+/* VREF.ACREF  bit masks and bit positions */
+/* VREF_REFSEL  is already defined. */
+/* VREF_ALWAYSON  is already defined. */
+
+
+/* WDT - Watch-Dog Timer */
+/* WDT.CTRLA  bit masks and bit positions */
+#define WDT_PERIOD_gm  0x0F  /* Period group mask. */
+#define WDT_PERIOD_gp  0  /* Period group position. */
+#define WDT_PERIOD_0_bm  (1<<0)  /* Period bit 0 mask. */
+#define WDT_PERIOD_0_bp  0  /* Period bit 0 position. */
+#define WDT_PERIOD_1_bm  (1<<1)  /* Period bit 1 mask. */
+#define WDT_PERIOD_1_bp  1  /* Period bit 1 position. */
+#define WDT_PERIOD_2_bm  (1<<2)  /* Period bit 2 mask. */
+#define WDT_PERIOD_2_bp  2  /* Period bit 2 position. */
+#define WDT_PERIOD_3_bm  (1<<3)  /* Period bit 3 mask. */
+#define WDT_PERIOD_3_bp  3  /* Period bit 3 position. */
+#define WDT_WINDOW_gm  0xF0  /* Window group mask. */
+#define WDT_WINDOW_gp  4  /* Window group position. */
+#define WDT_WINDOW_0_bm  (1<<4)  /* Window bit 0 mask. */
+#define WDT_WINDOW_0_bp  4  /* Window bit 0 position. */
+#define WDT_WINDOW_1_bm  (1<<5)  /* Window bit 1 mask. */
+#define WDT_WINDOW_1_bp  5  /* Window bit 1 position. */
+#define WDT_WINDOW_2_bm  (1<<6)  /* Window bit 2 mask. */
+#define WDT_WINDOW_2_bp  6  /* Window bit 2 position. */
+#define WDT_WINDOW_3_bm  (1<<7)  /* Window bit 3 mask. */
+#define WDT_WINDOW_3_bp  7  /* Window bit 3 position. */
+
+/* WDT.STATUS  bit masks and bit positions */
+#define WDT_SYNCBUSY_bm  0x01  /* Syncronization busy bit mask. */
+#define WDT_SYNCBUSY_bp  0  /* Syncronization busy bit position. */
+#define WDT_LOCK_bm  0x80  /* Lock enable bit mask. */
+#define WDT_LOCK_bp  7  /* Lock enable bit position. */
+
+
+/* ========== Generic Port Pins ========== */
+#define PIN0_bm 0x01
+#define PIN0_bp 0
+#define PIN1_bm 0x02
+#define PIN1_bp 1
+#define PIN2_bm 0x04
+#define PIN2_bp 2
+#define PIN3_bm 0x08
+#define PIN3_bp 3
+#define PIN4_bm 0x10
+#define PIN4_bp 4
+#define PIN5_bm 0x20
+#define PIN5_bp 5
+#define PIN6_bm 0x40
+#define PIN6_bp 6
+#define PIN7_bm 0x80
+#define PIN7_bp 7
+
+/* ========== Interrupt Vector Definitions ========== */
+/* Vector 0 is the reset vector */
+
+/* NMI interrupt vectors */
+#define NMI_vect_num  1
+#define NMI_vect      _VECTOR(1)  /*  */
+
+/* BOD interrupt vectors */
+#define BOD_VLM_vect_num  2
+#define BOD_VLM_vect      _VECTOR(2)  /*  */
+
+/* CLKCTRL interrupt vectors */
+#define CLKCTRL_CFD_vect_num  3
+#define CLKCTRL_CFD_vect      _VECTOR(3)  /*  */
+
+/* RTC interrupt vectors */
+#define RTC_CNT_vect_num  4
+#define RTC_CNT_vect      _VECTOR(4)  /*  */
+#define RTC_PIT_vect_num  5
+#define RTC_PIT_vect      _VECTOR(5)  /*  */
+
+/* CCL interrupt vectors */
+#define CCL_CCL_vect_num  6
+#define CCL_CCL_vect      _VECTOR(6)  /*  */
+
+/* PORTA interrupt vectors */
+#define PORTA_PORT_vect_num  7
+#define PORTA_PORT_vect      _VECTOR(7)  /*  */
+
+/* TCA0 interrupt vectors */
+#define TCA0_LUNF_vect_num  8
+#define TCA0_LUNF_vect      _VECTOR(8)  /*  */
+#define TCA0_OVF_vect_num  8
+#define TCA0_OVF_vect      _VECTOR(8)  /*  */
+#define TCA0_HUNF_vect_num  9
+#define TCA0_HUNF_vect      _VECTOR(9)  /*  */
+#define TCA0_CMP0_vect_num  10
+#define TCA0_CMP0_vect      _VECTOR(10)  /*  */
+#define TCA0_LCMP0_vect_num  10
+#define TCA0_LCMP0_vect      _VECTOR(10)  /*  */
+#define TCA0_CMP1_vect_num  11
+#define TCA0_CMP1_vect      _VECTOR(11)  /*  */
+#define TCA0_LCMP1_vect_num  11
+#define TCA0_LCMP1_vect      _VECTOR(11)  /*  */
+#define TCA0_CMP2_vect_num  12
+#define TCA0_CMP2_vect      _VECTOR(12)  /*  */
+#define TCA0_LCMP2_vect_num  12
+#define TCA0_LCMP2_vect      _VECTOR(12)  /*  */
+
+/* TCB0 interrupt vectors */
+#define TCB0_INT_vect_num  13
+#define TCB0_INT_vect      _VECTOR(13)  /*  */
+
+/* TCB1 interrupt vectors */
+#define TCB1_INT_vect_num  14
+#define TCB1_INT_vect      _VECTOR(14)  /*  */
+
+/* TWI0 interrupt vectors */
+#define TWI0_TWIS_vect_num  15
+#define TWI0_TWIS_vect      _VECTOR(15)  /*  */
+#define TWI0_TWIM_vect_num  16
+#define TWI0_TWIM_vect      _VECTOR(16)  /*  */
+
+/* SPI0 interrupt vectors */
+#define SPI0_INT_vect_num  17
+#define SPI0_INT_vect      _VECTOR(17)  /*  */
+
+/* USART0 interrupt vectors */
+#define USART0_RXC_vect_num  18
+#define USART0_RXC_vect      _VECTOR(18)  /*  */
+#define USART0_DRE_vect_num  19
+#define USART0_DRE_vect      _VECTOR(19)  /*  */
+#define USART0_TXC_vect_num  20
+#define USART0_TXC_vect      _VECTOR(20)  /*  */
+
+/* PORTD interrupt vectors */
+#define PORTD_PORT_vect_num  21
+#define PORTD_PORT_vect      _VECTOR(21)  /*  */
+
+/* AC0 interrupt vectors */
+#define AC0_AC_vect_num  22
+#define AC0_AC_vect      _VECTOR(22)  /*  */
+
+/* ADC0 interrupt vectors */
+#define ADC0_ERROR_vect_num  23
+#define ADC0_ERROR_vect      _VECTOR(23)  /*  */
+#define ADC0_RESRDY_vect_num  24
+#define ADC0_RESRDY_vect      _VECTOR(24)  /*  */
+#define ADC0_SAMPRDY_vect_num  25
+#define ADC0_SAMPRDY_vect      _VECTOR(25)  /*  */
+
+/* AC1 interrupt vectors */
+#define AC1_AC_vect_num  26
+#define AC1_AC_vect      _VECTOR(26)  /*  */
+
+/* PORTC interrupt vectors */
+#define PORTC_PORT_vect_num  27
+#define PORTC_PORT_vect      _VECTOR(27)  /*  */
+
+/* TCB2 interrupt vectors */
+#define TCB2_INT_vect_num  28
+#define TCB2_INT_vect      _VECTOR(28)  /*  */
+
+/* USART1 interrupt vectors */
+#define USART1_RXC_vect_num  29
+#define USART1_RXC_vect      _VECTOR(29)  /*  */
+#define USART1_DRE_vect_num  30
+#define USART1_DRE_vect      _VECTOR(30)  /*  */
+#define USART1_TXC_vect_num  31
+#define USART1_TXC_vect      _VECTOR(31)  /*  */
+
+/* PORTF interrupt vectors */
+#define PORTF_PORT_vect_num  32
+#define PORTF_PORT_vect      _VECTOR(32)  /*  */
+
+/* NVMCTRL interrupt vectors */
+#define NVMCTRL_EEREADY_vect_num  33
+#define NVMCTRL_EEREADY_vect      _VECTOR(33)  /*  */
+#define NVMCTRL_FLREADY_vect_num  33
+#define NVMCTRL_FLREADY_vect      _VECTOR(33)  /*  */
+#define NVMCTRL_NVMREADY_vect_num  33
+#define NVMCTRL_NVMREADY_vect      _VECTOR(33)  /*  */
+
+/* USART2 interrupt vectors */
+#define USART2_RXC_vect_num  34
+#define USART2_RXC_vect      _VECTOR(34)  /*  */
+#define USART2_DRE_vect_num  35
+#define USART2_DRE_vect      _VECTOR(35)  /*  */
+#define USART2_TXC_vect_num  36
+#define USART2_TXC_vect      _VECTOR(36)  /*  */
+
+#define _VECTOR_SIZE 4 /* Size of individual vector. */
+#define _VECTORS_SIZE (37 * _VECTOR_SIZE)
+
+
+/* ========== Constants ========== */
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define DATAMEM_START     (0x0000)
+#  define DATAMEM_SIZE      (65536)
+#else
+#  define DATAMEM_START     (0x0000U)
+#  define DATAMEM_SIZE      (65536U)
+#endif
+#define DATAMEM_END       (DATAMEM_START + DATAMEM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define IO_START     (0x0000)
+#  define IO_SIZE      (4159)
+#  define IO_PAGE_SIZE (0)
+#else
+#  define IO_START     (0x0000U)
+#  define IO_SIZE      (4159U)
+#  define IO_PAGE_SIZE (0U)
+#endif
+#define IO_END       (IO_START + IO_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define LOCKBITS_START     (0x1040)
+#  define LOCKBITS_SIZE      (4)
+#  define LOCKBITS_PAGE_SIZE (4)
+#else
+#  define LOCKBITS_START     (0x1040U)
+#  define LOCKBITS_SIZE      (4U)
+#  define LOCKBITS_PAGE_SIZE (4U)
+#endif
+#define LOCKBITS_END       (LOCKBITS_START + LOCKBITS_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define FUSES_START     (0x1050)
+#  define FUSES_SIZE      (16)
+#  define FUSES_PAGE_SIZE (8)
+#else
+#  define FUSES_START     (0x1050U)
+#  define FUSES_SIZE      (16U)
+#  define FUSES_PAGE_SIZE (8U)
+#endif
+#define FUSES_END       (FUSES_START + FUSES_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define USER_SIGNATURES_START     (0x1080)
+#  define USER_SIGNATURES_SIZE      (64)
+#  define USER_SIGNATURES_PAGE_SIZE (64)
+#else
+#  define USER_SIGNATURES_START     (0x1080U)
+#  define USER_SIGNATURES_SIZE      (64U)
+#  define USER_SIGNATURES_PAGE_SIZE (64U)
+#endif
+#define USER_SIGNATURES_END       (USER_SIGNATURES_START + USER_SIGNATURES_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define SIGNATURES_START     (0x1100)
+#  define SIGNATURES_SIZE      (3)
+#  define SIGNATURES_PAGE_SIZE (128)
+#else
+#  define SIGNATURES_START     (0x1100U)
+#  define SIGNATURES_SIZE      (3U)
+#  define SIGNATURES_PAGE_SIZE (128U)
+#endif
+#define SIGNATURES_END       (SIGNATURES_START + SIGNATURES_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define PROD_SIGNATURES_START     (0x1103)
+#  define PROD_SIGNATURES_SIZE      (125)
+#  define PROD_SIGNATURES_PAGE_SIZE (128)
+#else
+#  define PROD_SIGNATURES_START     (0x1103U)
+#  define PROD_SIGNATURES_SIZE      (125U)
+#  define PROD_SIGNATURES_PAGE_SIZE (128U)
+#endif
+#define PROD_SIGNATURES_END       (PROD_SIGNATURES_START + PROD_SIGNATURES_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define EEPROM_START     (0x1400)
+#  define EEPROM_SIZE      (512)
+#  define EEPROM_PAGE_SIZE (8)
+#else
+#  define EEPROM_START     (0x1400U)
+#  define EEPROM_SIZE      (512U)
+#  define EEPROM_PAGE_SIZE (8U)
+#endif
+#define EEPROM_END       (EEPROM_START + EEPROM_SIZE - 1)
+
+/* Added MAPPED_EEPROM segment names for avr-libc */
+#define MAPPED_EEPROM_START     (EEPROM_START)
+#define MAPPED_EEPROM_SIZE      (EEPROM_SIZE)
+#define MAPPED_EEPROM_PAGE_SIZE (EEPROM_PAGE_SIZE)
+#define MAPPED_EEPROM_END       (MAPPED_EEPROM_START + MAPPED_EEPROM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define INTERNAL_SRAM_START     (0x7800)
+#  define INTERNAL_SRAM_SIZE      (2048)
+#  define INTERNAL_SRAM_PAGE_SIZE (0)
+#else
+#  define INTERNAL_SRAM_START     (0x7800U)
+#  define INTERNAL_SRAM_SIZE      (2048U)
+#  define INTERNAL_SRAM_PAGE_SIZE (0U)
+#endif
+#define INTERNAL_SRAM_END       (INTERNAL_SRAM_START + INTERNAL_SRAM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define MAPPED_PROGMEM_START     (0x8000)
+#  define MAPPED_PROGMEM_SIZE      (16384)
+#  define MAPPED_PROGMEM_PAGE_SIZE (64)
+#else
+#  define MAPPED_PROGMEM_START     (0x8000U)
+#  define MAPPED_PROGMEM_SIZE      (16384U)
+#  define MAPPED_PROGMEM_PAGE_SIZE (64U)
+#endif
+#define MAPPED_PROGMEM_END       (MAPPED_PROGMEM_START + MAPPED_PROGMEM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define PROGMEM_START     (0x0000)
+#  define PROGMEM_SIZE      (16384)
+#  define PROGMEM_PAGE_SIZE (64)
+#else
+#  define PROGMEM_START     (0x0000U)
+#  define PROGMEM_SIZE      (16384U)
+#  define PROGMEM_PAGE_SIZE (64U)
+#endif
+#define PROGMEM_END       (PROGMEM_START + PROGMEM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define PROGMEM_NRWW_START     (0x0000)
+#  define PROGMEM_NRWW_SIZE      (4096)
+#  define PROGMEM_NRWW_PAGE_SIZE (64)
+#else
+#  define PROGMEM_NRWW_START     (0x0000U)
+#  define PROGMEM_NRWW_SIZE      (4096U)
+#  define PROGMEM_NRWW_PAGE_SIZE (64U)
+#endif
+#define PROGMEM_NRWW_END       (PROGMEM_NRWW_START + PROGMEM_NRWW_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define PROGMEM_RWW_START     (0x1000)
+#  define PROGMEM_RWW_SIZE      (12288)
+#  define PROGMEM_RWW_PAGE_SIZE (64)
+#else
+#  define PROGMEM_RWW_START     (0x1000U)
+#  define PROGMEM_RWW_SIZE      (12288U)
+#  define PROGMEM_RWW_PAGE_SIZE (64U)
+#endif
+#define PROGMEM_RWW_END       (PROGMEM_RWW_START + PROGMEM_RWW_SIZE - 1)
+
+#define FLASHSTART   PROGMEM_START
+#define FLASHEND     PROGMEM_END
+#define RAMSTART     INTERNAL_SRAM_START
+#define RAMSIZE      INTERNAL_SRAM_SIZE
+#define RAMEND       INTERNAL_SRAM_END
+#define E2END        EEPROM_END
+#define E2PAGESIZE   EEPROM_PAGE_SIZE
+
+/* ========== Fuses ========== */
+#define FUSE_MEMORY_SIZE 16
+
+/* Fuse Byte 0 (WDTCFG) */
+#define FUSE_PERIOD0  (unsigned char)_BV(0)  /* Watchdog Timeout Period Bit 0 */
+#define FUSE_PERIOD1  (unsigned char)_BV(1)  /* Watchdog Timeout Period Bit 1 */
+#define FUSE_PERIOD2  (unsigned char)_BV(2)  /* Watchdog Timeout Period Bit 2 */
+#define FUSE_PERIOD3  (unsigned char)_BV(3)  /* Watchdog Timeout Period Bit 3 */
+#define FUSE_WINDOW0  (unsigned char)_BV(4)  /* Watchdog Window Timeout Period Bit 0 */
+#define FUSE_WINDOW1  (unsigned char)_BV(5)  /* Watchdog Window Timeout Period Bit 1 */
+#define FUSE_WINDOW2  (unsigned char)_BV(6)  /* Watchdog Window Timeout Period Bit 2 */
+#define FUSE_WINDOW3  (unsigned char)_BV(7)  /* Watchdog Window Timeout Period Bit 3 */
+#define FUSE0_DEFAULT  (0x0)
+#define FUSE_WDTCFG_DEFAULT  (0x0)
+
+/* Fuse Byte 1 (BODCFG) */
+#define FUSE_SLEEP0  (unsigned char)_BV(0)  /* BOD Operation in Sleep Mode Bit 0 */
+#define FUSE_SLEEP1  (unsigned char)_BV(1)  /* BOD Operation in Sleep Mode Bit 1 */
+#define FUSE_ACTIVE0  (unsigned char)_BV(2)  /* BOD Operation in Active Mode Bit 0 */
+#define FUSE_ACTIVE1  (unsigned char)_BV(3)  /* BOD Operation in Active Mode Bit 1 */
+#define FUSE_SAMPFREQ  (unsigned char)_BV(4)  /* BOD Sample Frequency */
+#define FUSE_LVL0  (unsigned char)_BV(5)  /* BOD Level Bit 0 */
+#define FUSE_LVL1  (unsigned char)_BV(6)  /* BOD Level Bit 1 */
+#define FUSE_LVL2  (unsigned char)_BV(7)  /* BOD Level Bit 2 */
+#define FUSE1_DEFAULT  (0x0)
+#define FUSE_BODCFG_DEFAULT  (0x0)
+
+/* Fuse Byte 2 (OSCCFG) */
+#define FUSE_OSCHFFRQ  (unsigned char)_BV(3)  /* High-frequency Oscillator Frequency */
+#define FUSE2_DEFAULT  (0x0)
+#define FUSE_OSCCFG_DEFAULT  (0x0)
+
+/* Fuse Byte 3 Reserved */
+
+/* Fuse Byte 4 Reserved */
+
+/* Fuse Byte 5 (SYSCFG0) */
+#define FUSE_EESAVE  (unsigned char)_BV(0)  /* EEPROM Save */
+#define FUSE_RSTPINCFG  (unsigned char)_BV(3)  /* Reset Pin Configuration */
+#define FUSE_UPDIPINCFG  (unsigned char)_BV(4)  /* UPDI Pin Configuration */
+#define FUSE_CRCSEL  (unsigned char)_BV(5)  /* CRC Select */
+#define FUSE_CRCSRC0  (unsigned char)_BV(6)  /* CRC Source Bit 0 */
+#define FUSE_CRCSRC1  (unsigned char)_BV(7)  /* CRC Source Bit 1 */
+#define FUSE5_DEFAULT  (0xD0)
+#define FUSE_SYSCFG0_DEFAULT  (0xD0)
+
+/* Fuse Byte 6 (SYSCFG1) */
+#define FUSE_SUT0  (unsigned char)_BV(0)  /* Startup Time Bit 0 */
+#define FUSE_SUT1  (unsigned char)_BV(1)  /* Startup Time Bit 1 */
+#define FUSE_SUT2  (unsigned char)_BV(2)  /* Startup Time Bit 2 */
+#define FUSE6_DEFAULT  (0x7)
+#define FUSE_SYSCFG1_DEFAULT  (0x7)
+
+/* Fuse Byte 7 (CODESIZE) */
+#define FUSE7_DEFAULT  (0x0)
+#define FUSE_CODESIZE_DEFAULT  (0x0)
+
+/* Fuse Byte 8 (BOOTSIZE) */
+#define FUSE8_DEFAULT  (0x0)
+#define FUSE_BOOTSIZE_DEFAULT  (0x0)
+
+/* ========== Lock Bits ========== */
+#define __LOCK_KEY_EXIST
+#ifdef LOCKBITS_DEFAULT
+#undef LOCKBITS_DEFAULT
+#endif //LOCKBITS_DEFAULT
+#define LOCKBITS_DEFAULT  (0x5CC5C55C)
+
+/* ========== Signature ========== */
+#define SIGNATURE_0 0x1E
+#define SIGNATURE_1 0x94
+#define SIGNATURE_2 0x36
+
+#endif /* #ifdef _AVR_AVR16EA32_H_INCLUDED */
+

--- a/include/avr/ioavr16ea48.h
+++ b/include/avr/ioavr16ea48.h
@@ -1,0 +1,6044 @@
+/*
+ * Copyright (C) 2023, Microchip Technology Inc. and its subsidiaries ("Microchip")
+ * All rights reserved.
+ *
+ * This software is developed by Microchip Technology Inc. and its subsidiaries ("Microchip").
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other
+ *        materials provided with the distribution. Publication is not required when
+ *        this file is used in an embedded application.
+ *
+ *     3. Microchip's name may not be used to endorse or promote products derived from this
+ *        software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY MICROCHIP "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL MICROCHIP BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING BUT NOT LIMITED TO
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWSOEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _AVR_IO_H_
+#  error "Include <avr/io.h> instead of this file."
+#endif
+
+#ifndef _AVR_IOXXX_H_
+#  define _AVR_IOXXX_H_ "ioavr16ea48.h"
+#else
+#  error "Attempt to include more than one <avr/ioXXX.h> file."
+#endif
+
+#ifndef _AVR_AVR16EA48_H_INCLUDED
+#define _AVR_AVR16EA48_H_INCLUDED
+
+/* Ungrouped common registers */
+#define CCP  _SFR_MEM8(0x0034)  /* Configuration Change Protection */
+#define SP  _SFR_MEM16(0x003D)  /* Stack Pointer */
+#define SPL  _SFR_MEM8(0x003D)  /* Stack Pointer Low */
+#define SPH  _SFR_MEM8(0x003E)  /* Stack Pointer High */
+#define SREG  _SFR_MEM8(0x003F)  /* Status Register */
+
+/* C Language Only */
+#if !defined (__ASSEMBLER__)
+
+#include <stdint.h>
+
+typedef volatile uint8_t register8_t;
+typedef volatile uint16_t register16_t;
+typedef volatile uint32_t register32_t;
+
+
+#ifdef _WORDREGISTER
+#undef _WORDREGISTER
+#endif
+#define _WORDREGISTER(regname)   \
+    __extension__ union \
+    { \
+        register16_t regname; \
+        struct \
+        { \
+            register8_t regname ## L; \
+            register8_t regname ## H; \
+        }; \
+    }
+
+#ifdef _DWORDREGISTER
+#undef _DWORDREGISTER
+#endif
+#define _DWORDREGISTER(regname)  \
+    __extension__ union \
+    { \
+        register32_t regname; \
+        struct \
+        { \
+            register8_t regname ## 0; \
+            register8_t regname ## 1; \
+            register8_t regname ## 2; \
+            register8_t regname ## 3; \
+        }; \
+    }
+
+
+/*
+==========================================================================
+IO Module Structures
+==========================================================================
+*/
+
+
+/*
+--------------------------------------------------------------------------
+AC - Analog Comparator
+--------------------------------------------------------------------------
+*/
+
+/* Analog Comparator */
+typedef struct AC_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t MUXCTRL;  /* Mux Control A */
+    register8_t reserved_1[2];
+    register8_t DACREF;  /* DAC Voltage Reference */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t STATUS;  /* Status */
+} AC_t;
+
+/* Hysteresis Mode select */
+typedef enum AC_HYSMODE_enum
+{
+    AC_HYSMODE_NONE_gc = (0x00<<1),  /* No hysteresis */
+    AC_HYSMODE_SMALL_gc = (0x01<<1),  /* Small hysteresis */
+    AC_HYSMODE_MEDIUM_gc = (0x02<<1),  /* Medium hysteresis */
+    AC_HYSMODE_LARGE_gc = (0x03<<1)  /* Large hysteresis */
+} AC_HYSMODE_t;
+
+/* AC Output Initial Value select */
+typedef enum AC_INITVAL_enum
+{
+    AC_INITVAL_LOW_gc = (0x00<<6),  /* Output initialized to 0 */
+    AC_INITVAL_HIGH_gc = (0x01<<6)  /* Output initialized to 1 */
+} AC_INITVAL_t;
+
+/* Interrupt Mode select */
+typedef enum AC_INTMODE_NORMAL_enum
+{
+    AC_INTMODE_NORMAL_BOTHEDGE_gc = (0x00<<4),  /* Positive and negative inputs crosses */
+    AC_INTMODE_NORMAL_NEGEDGE_gc = (0x02<<4),  /* Positive input goes below negative input */
+    AC_INTMODE_NORMAL_POSEDGE_gc = (0x03<<4)  /* Positive input goes above negative input */
+} AC_INTMODE_NORMAL_t;
+
+/* Interrupt Mode select */
+typedef enum AC_INTMODE_WINDOW_enum
+{
+    AC_INTMODE_WINDOW_ABOVE_gc = (0x00<<4),  /* Window interrupt when input above both references */
+    AC_INTMODE_WINDOW_INSIDE_gc = (0x01<<4),  /* Window interrupt when input betweeen references */
+    AC_INTMODE_WINDOW_BELOW_gc = (0x02<<4),  /* Window interrupt when input below both references */
+    AC_INTMODE_WINDOW_OUTSIDE_gc = (0x03<<4)  /* Window interrupt when input outside reference */
+} AC_INTMODE_WINDOW_t;
+
+/* Negative Input MUX Selection */
+typedef enum AC_MUXNEG_enum
+{
+    AC_MUXNEG_AINN0_gc = (0x00<<0),  /* Negative Pin 0 */
+    AC_MUXNEG_AINN1_gc = (0x01<<0),  /* Negative Pin 1 */
+    AC_MUXNEG_AINN2_gc = (0x02<<0),  /* Negative Pin 2 */
+    AC_MUXNEG_AINN3_gc = (0x03<<0),  /* Negative Pin 3 */
+    AC_MUXNEG_DACREF_gc = (0x04<<0)  /* DAC Reference */
+} AC_MUXNEG_t;
+
+/* Positive Input MUX Selection */
+typedef enum AC_MUXPOS_enum
+{
+    AC_MUXPOS_AINP0_gc = (0x00<<3),  /* Positive Pin 0 */
+    AC_MUXPOS_AINP1_gc = (0x01<<3),  /* Positive Pin 1 */
+    AC_MUXPOS_AINP2_gc = (0x02<<3),  /* Positive Pin 2 */
+    AC_MUXPOS_AINP3_gc = (0x03<<3),  /* Positive Pin 3 */
+    AC_MUXPOS_AINP4_gc = (0x04<<3)  /* Positive Pin 4 */
+} AC_MUXPOS_t;
+
+/* Power profile select */
+typedef enum AC_POWER_enum
+{
+    AC_POWER_PROFILE0_gc = (0x00<<3),  /* Power profile 0, Fastest response time, highest consumption */
+    AC_POWER_PROFILE1_gc = (0x01<<3)  /* Power profile 1 */
+} AC_POWER_t;
+
+/* Window selection mode */
+typedef enum AC_WINSEL_enum
+{
+    AC_WINSEL_DISABLED_gc = (0x00<<0),  /* Window function disabled */
+    AC_WINSEL_UPSEL1_gc = (0x01<<0)  /* Select ACn+1 as upper limit in window compare */
+} AC_WINSEL_t;
+
+/* Analog Comparator Window State select */
+typedef enum AC_WINSTATE_enum
+{
+    AC_WINSTATE_ABOVE_gc = (0x00<<6),  /* Above window */
+    AC_WINSTATE_INSIDE_gc = (0x01<<6),  /* Inside window */
+    AC_WINSTATE_BELOW_gc = (0x02<<6)  /* Below window */
+} AC_WINSTATE_t;
+
+/*
+--------------------------------------------------------------------------
+ADC - Analog to Digital Converter
+--------------------------------------------------------------------------
+*/
+
+/* Analog to Digital Converter */
+typedef struct ADC_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    register8_t CTRLD;  /* Control D */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t STATUS;  /* Status register */
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t CTRLE;  /* Control E */
+    register8_t CTRLF;  /* Control F */
+    register8_t COMMAND;  /* Command register */
+    register8_t PGACTRL;  /* PGA Control */
+    register8_t MUXPOS;  /* Positive Input Multiplexer */
+    register8_t MUXNEG;  /* Negative Input Multiplexer */
+    register8_t reserved_1[2];
+    _DWORDREGISTER(RESULT);  /* Result */
+    _WORDREGISTER(SAMPLE);  /* Sample */
+    register8_t reserved_2[2];
+    register8_t TEMP0;  /* Temporary Data 0 */
+    register8_t TEMP1;  /* Temporary Data 1 */
+    register8_t TEMP2;  /* Temporary Data 2 */
+    register8_t reserved_3[1];
+    _WORDREGISTER(WINLT);  /* Window Low Threshold */
+    _WORDREGISTER(WINHT);  /* Window High Threshold */
+    register8_t reserved_4[32];
+} ADC_t;
+
+/* Sign Chopping select */
+typedef enum ADC_CHOPPING_enum
+{
+    ADC_CHOPPING_DISABLE_gc = (0x00<<6),  /* Sign Chopping Disabled */
+    ADC_CHOPPING_ENABLE_gc = (0x01<<6)  /* Sign Chopping Enabled */
+} ADC_CHOPPING_t;
+
+/* Gain select */
+typedef enum ADC_GAIN_enum
+{
+    ADC_GAIN_1X_gc = (0x00<<5),  /* 1x gain */
+    ADC_GAIN_2X_gc = (0x01<<5),  /* 2x gain */
+    ADC_GAIN_4X_gc = (0x02<<5),  /* 4x gain */
+    ADC_GAIN_8X_gc = (0x03<<5),  /* 8x gain */
+    ADC_GAIN_16X_gc = (0x04<<5)  /* 16x gain */
+} ADC_GAIN_t;
+
+/* Mode select */
+typedef enum ADC_MODE_enum
+{
+    ADC_MODE_SINGLE_8BIT_gc = (0x00<<4),  /* Single Conversion with 8-bit resolution */
+    ADC_MODE_SINGLE_12BIT_gc = (0x01<<4),  /* Single Conversion with 12-bit resolution */
+    ADC_MODE_SERIES_gc = (0x02<<4),  /* Series with accumulation, separate trigger for every 12-bit conversion */
+    ADC_MODE_SERIES_SCALING_gc = (0x03<<4),  /* Series with accumulation and scaling, separate trigger for every 12-bit conversion */
+    ADC_MODE_BURST_gc = (0x04<<4),  /* Burst with accumulation, one trigger will run SAMPNUM 12-bit conversions */
+    ADC_MODE_BURST_SCALING_gc = (0x05<<4)  /* Burst with accumulation and scaling, one trigger will run SAMPNUM 12-bit conversions */
+} ADC_MODE_t;
+
+/* Analog Channel Selection Bits */
+typedef enum ADC_MUXNEG_enum
+{
+    ADC_MUXNEG_AIN0_gc = (0x00<<0),  /* ADC input pin 0 */
+    ADC_MUXNEG_AIN1_gc = (0x01<<0),  /* ADC input pin 1 */
+    ADC_MUXNEG_AIN2_gc = (0x02<<0),  /* ADC input pin 2 */
+    ADC_MUXNEG_AIN3_gc = (0x03<<0),  /* ADC input pin 3 */
+    ADC_MUXNEG_AIN4_gc = (0x04<<0),  /* ADC input pin 4 */
+    ADC_MUXNEG_AIN5_gc = (0x05<<0),  /* ADC input pin 5 */
+    ADC_MUXNEG_AIN6_gc = (0x06<<0),  /* ADC input pin 6 */
+    ADC_MUXNEG_AIN7_gc = (0x07<<0),  /* ADC input pin 7 */
+    ADC_MUXNEG_AIN8_gc = (0x08<<0),  /* ADC input pin 8 */
+    ADC_MUXNEG_AIN9_gc = (0x09<<0),  /* ADC input pin 9 */
+    ADC_MUXNEG_AIN10_gc = (0x0A<<0),  /* ADC input pin 10 */
+    ADC_MUXNEG_AIN11_gc = (0x0B<<0),  /* ADC input pin 11 */
+    ADC_MUXNEG_AIN16_gc = (0x10<<0),  /* ADC input pin 16 */
+    ADC_MUXNEG_AIN17_gc = (0x11<<0),  /* ADC input pin 17 */
+    ADC_MUXNEG_AIN18_gc = (0x12<<0),  /* ADC input pin 18 */
+    ADC_MUXNEG_AIN19_gc = (0x13<<0),  /* ADC input pin 19 */
+    ADC_MUXNEG_AIN20_gc = (0x14<<0),  /* ADC input pin 20 */
+    ADC_MUXNEG_AIN21_gc = (0x15<<0),  /* ADC input pin 21 */
+    ADC_MUXNEG_AIN22_gc = (0x16<<0),  /* ADC input pin 22 */
+    ADC_MUXNEG_AIN23_gc = (0x17<<0),  /* ADC input pin 23 */
+    ADC_MUXNEG_AIN24_gc = (0x18<<0),  /* ADC input pin 24 */
+    ADC_MUXNEG_AIN25_gc = (0x19<<0),  /* ADC input pin 25 */
+    ADC_MUXNEG_AIN26_gc = (0x1A<<0),  /* ADC input pin 26 */
+    ADC_MUXNEG_AIN27_gc = (0x1B<<0),  /* ADC input pin 27 */
+    ADC_MUXNEG_AIN28_gc = (0x1C<<0),  /* ADC input pin 28 */
+    ADC_MUXNEG_AIN29_gc = (0x1D<<0),  /* ADC input pin 29 */
+    ADC_MUXNEG_AIN30_gc = (0x1E<<0),  /* ADC input pin 30 */
+    ADC_MUXNEG_AIN31_gc = (0x1F<<0),  /* ADC input pin 31 */
+    ADC_MUXNEG_GND_gc = (0x30<<0),  /* Ground */
+    ADC_MUXNEG_DAC0_gc = (0x38<<0),  /* Digital to Analog Converter 0 */
+    ADC_MUXNEG_DACREF0_gc = (0x39<<0),  /* AC0 DAC reference */
+    ADC_MUXNEG_DACREF1_gc = (0x3A<<0)  /* AC1 DAC reference */
+} ADC_MUXNEG_t;
+
+/* Analog Channel Selection Bits */
+typedef enum ADC_MUXPOS_enum
+{
+    ADC_MUXPOS_AIN0_gc = (0x00<<0),  /* ADC input pin 0 */
+    ADC_MUXPOS_AIN1_gc = (0x01<<0),  /* ADC input pin 1 */
+    ADC_MUXPOS_AIN2_gc = (0x02<<0),  /* ADC input pin 2 */
+    ADC_MUXPOS_AIN3_gc = (0x03<<0),  /* ADC input pin 3 */
+    ADC_MUXPOS_AIN4_gc = (0x04<<0),  /* ADC input pin 4 */
+    ADC_MUXPOS_AIN5_gc = (0x05<<0),  /* ADC input pin 5 */
+    ADC_MUXPOS_AIN6_gc = (0x06<<0),  /* ADC input pin 6 */
+    ADC_MUXPOS_AIN7_gc = (0x07<<0),  /* ADC input pin 7 */
+    ADC_MUXPOS_AIN8_gc = (0x08<<0),  /* ADC input pin 8 */
+    ADC_MUXPOS_AIN9_gc = (0x09<<0),  /* ADC input pin 9 */
+    ADC_MUXPOS_AIN10_gc = (0x0A<<0),  /* ADC input pin 10 */
+    ADC_MUXPOS_AIN11_gc = (0x0B<<0),  /* ADC input pin 11 */
+    ADC_MUXPOS_AIN16_gc = (0x10<<0),  /* ADC input pin 16 */
+    ADC_MUXPOS_AIN17_gc = (0x11<<0),  /* ADC input pin 17 */
+    ADC_MUXPOS_AIN18_gc = (0x12<<0),  /* ADC input pin 18 */
+    ADC_MUXPOS_AIN19_gc = (0x13<<0),  /* ADC input pin 19 */
+    ADC_MUXPOS_AIN20_gc = (0x14<<0),  /* ADC input pin 20 */
+    ADC_MUXPOS_AIN21_gc = (0x15<<0),  /* ADC input pin 21 */
+    ADC_MUXPOS_AIN22_gc = (0x16<<0),  /* ADC input pin 22 */
+    ADC_MUXPOS_AIN23_gc = (0x17<<0),  /* ADC input pin 23 */
+    ADC_MUXPOS_AIN24_gc = (0x18<<0),  /* ADC input pin 24 */
+    ADC_MUXPOS_AIN25_gc = (0x19<<0),  /* ADC input pin 25 */
+    ADC_MUXPOS_AIN26_gc = (0x1A<<0),  /* ADC input pin 26 */
+    ADC_MUXPOS_AIN27_gc = (0x1B<<0),  /* ADC input pin 27 */
+    ADC_MUXPOS_AIN28_gc = (0x1C<<0),  /* ADC input pin 28 */
+    ADC_MUXPOS_AIN29_gc = (0x1D<<0),  /* ADC input pin 29 */
+    ADC_MUXPOS_AIN30_gc = (0x1E<<0),  /* ADC input pin 30 */
+    ADC_MUXPOS_AIN31_gc = (0x1F<<0),  /* ADC input pin 31 */
+    ADC_MUXPOS_GND_gc = (0x30<<0),  /* Ground */
+    ADC_MUXPOS_VDD10_gc = (0x31<<0),  /* VDD Divided by 10 */
+    ADC_MUXPOS_TEMPSENSE_gc = (0x32<<0),  /* Temperature Sensor */
+    ADC_MUXPOS_DAC0_gc = (0x38<<0)  /* Digital to Analog Converter 0 */
+} ADC_MUXPOS_t;
+
+/* PGA BIAS Select */
+typedef enum ADC_PGABIASSEL_enum
+{
+    ADC_PGABIASSEL_100PCT_gc = (0x00<<3),  /* 100% BIAS current. */
+    ADC_PGABIASSEL_75PCT_gc = (0x01<<3),  /* 75% BIAS current. Usable for CLK_ADC<4.5MHz */
+    ADC_PGABIASSEL_50PCT_gc = (0x02<<3),  /* 50% BIAS current. Usable for CLK_ADC<3MHz */
+    ADC_PGABIASSEL_25PCT_gc = (0x03<<3)  /* 25% BIAS current. Usable for CLK_ADC<1.5MHz */
+} ADC_PGABIASSEL_t;
+
+/* Prescaler Value select */
+typedef enum ADC_PRESC_enum
+{
+    ADC_PRESC_DIV2_gc = (0x00<<0),  /* System clock divided by 2 */
+    ADC_PRESC_DIV4_gc = (0x01<<0),  /* System clock divided by 4 */
+    ADC_PRESC_DIV6_gc = (0x02<<0),  /* System clock divided by 6 */
+    ADC_PRESC_DIV8_gc = (0x03<<0),  /* System clock divided by 8 */
+    ADC_PRESC_DIV10_gc = (0x04<<0),  /* System clock divided by 10 */
+    ADC_PRESC_DIV12_gc = (0x05<<0),  /* System clock divided by 12 */
+    ADC_PRESC_DIV14_gc = (0x06<<0),  /* System clock divided by 14 */
+    ADC_PRESC_DIV16_gc = (0x07<<0),  /* System clock divided by 16 */
+    ADC_PRESC_DIV20_gc = (0x08<<0),  /* System clock divided by 20 */
+    ADC_PRESC_DIV24_gc = (0x09<<0),  /* System clock divided by 24 */
+    ADC_PRESC_DIV28_gc = (0x0A<<0),  /* System clock divided by 28 */
+    ADC_PRESC_DIV32_gc = (0x0B<<0),  /* System clock divided by 32 */
+    ADC_PRESC_DIV40_gc = (0x0C<<0),  /* System clock divided by 40 */
+    ADC_PRESC_DIV48_gc = (0x0D<<0),  /* System clock divided by 48 */
+    ADC_PRESC_DIV56_gc = (0x0E<<0),  /* System clock divided by 56 */
+    ADC_PRESC_DIV64_gc = (0x0F<<0)  /* System clock divided by 64 */
+} ADC_PRESC_t;
+
+/* Reference select */
+typedef enum ADC_REFSEL_enum
+{
+    ADC_REFSEL_VDD_gc = (0x00<<0),  /* VDD */
+    ADC_REFSEL_VREFA_gc = (0x02<<0),  /* External Reference */
+    ADC_REFSEL_1V024_gc = (0x04<<0),  /* Internal 1.024V Reference */
+    ADC_REFSEL_2V048_gc = (0x05<<0),  /* Internal 2.048V Reference */
+    ADC_REFSEL_4V096_gc = (0x06<<0),  /* Internal 4.096V Reference */
+    ADC_REFSEL_2V500_gc = (0x07<<0)  /* Internal 2.500V Reference */
+} ADC_REFSEL_t;
+
+/* Sample numbers select */
+typedef enum ADC_SAMPNUM_enum
+{
+    ADC_SAMPNUM_NONE_gc = (0x00<<0),  /* No accumulation */
+    ADC_SAMPNUM_ACC2_gc = (0x01<<0),  /* 2 samples accumulated */
+    ADC_SAMPNUM_ACC4_gc = (0x02<<0),  /* 4 samples accumulated */
+    ADC_SAMPNUM_ACC8_gc = (0x03<<0),  /* 8 samples accumulated */
+    ADC_SAMPNUM_ACC16_gc = (0x04<<0),  /* 16 samples accumulated */
+    ADC_SAMPNUM_ACC32_gc = (0x05<<0),  /* 32 samples accumulated */
+    ADC_SAMPNUM_ACC64_gc = (0x06<<0),  /* 64 samples accumulated */
+    ADC_SAMPNUM_ACC128_gc = (0x07<<0),  /* 128 samples accumulated */
+    ADC_SAMPNUM_ACC256_gc = (0x08<<0),  /* 256 samples accumulated */
+    ADC_SAMPNUM_ACC512_gc = (0x09<<0),  /* 512 samples accumulated */
+    ADC_SAMPNUM_ACC1024_gc = (0x0A<<0)  /* 1024 samples accumulated */
+} ADC_SAMPNUM_t;
+
+/* Start command select */
+typedef enum ADC_START_enum
+{
+    ADC_START_STOP_gc = (0x00<<0),  /* Stop an ongoing conversion */
+    ADC_START_IMMEDIATE_gc = (0x01<<0),  /* Start a conversion immediately. This will be set back to STOP when the first conversion is done, unless Free-Running mode is enabled */
+    ADC_START_MUXPOS_WRITE_gc = (0x02<<0),  /* Start when MUXPOS register is written */
+    ADC_START_MUXNEG_WRITE_gc = (0x03<<0),  /* Start when MUXNEG register is written */
+    ADC_START_EVENT_TRIGGER_gc = (0x04<<0)  /* Start when an event is received */
+} ADC_START_t;
+
+/* VIA select */
+typedef enum ADC_VIA_enum
+{
+    ADC_VIA_DIRECT_gc = (0x00<<6),  /* Inputs connected directly to ADC */
+    ADC_VIA_PGA_gc = (0x01<<6)  /* Inputs connected via PGA */
+} ADC_VIA_t;
+
+/* Window Comparator Mode select */
+typedef enum ADC_WINCM_enum
+{
+    ADC_WINCM_NONE_gc = (0x00<<0),  /* No Window Comparison */
+    ADC_WINCM_BELOW_gc = (0x01<<0),  /* Below Window */
+    ADC_WINCM_ABOVE_gc = (0x02<<0),  /* Above Window */
+    ADC_WINCM_INSIDE_gc = (0x03<<0),  /* Inside Window */
+    ADC_WINCM_OUTSIDE_gc = (0x04<<0)  /* Outside Window */
+} ADC_WINCM_t;
+
+/* Window Mode Source select */
+typedef enum ADC_WINSRC_enum
+{
+    ADC_WINSRC_RESULT_gc = (0x00<<3),  /* Result register used as Window Comparator Source */
+    ADC_WINSRC_SAMPLE_gc = (0x01<<3)  /* Sample register used as Window Comparator Source */
+} ADC_WINSRC_t;
+
+/*
+--------------------------------------------------------------------------
+BOD - Bod interface
+--------------------------------------------------------------------------
+*/
+
+/* Bod interface */
+typedef struct BOD_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t reserved_1[6];
+    register8_t VLMCTRLA;  /* Voltage level monitor Control */
+    register8_t INTCTRL;  /* Voltage level monitor interrupt Control */
+    register8_t INTFLAGS;  /* Voltage level monitor interrupt Flags */
+    register8_t STATUS;  /* Voltage level monitor status */
+    register8_t reserved_2[4];
+} BOD_t;
+
+/* Operation in active mode select */
+typedef enum BOD_ACTIVE_enum
+{
+    BOD_ACTIVE_DISABLE_gc = (0x00<<2),  /* Disabled */
+    BOD_ACTIVE_ENABLED_gc = (0x01<<2),  /* Enabled in continuous mode */
+    BOD_ACTIVE_SAMPLED_gc = (0x02<<2),  /* Enabled in sampled mode */
+    BOD_ACTIVE_ENABLEWAIT_gc = (0x03<<2)  /* Enabled in continuous mode. Execution halted at wake-up until BOD is running */
+} BOD_ACTIVE_t;
+
+/* Bod level select */
+typedef enum BOD_LVL_enum
+{
+    BOD_LVL_BODLEVEL0_gc = (0x00<<0),  /* BOD Disabled during normal operation */
+    BOD_LVL_BODLEVEL1_gc = (0x01<<0),  /* 1.9 V */
+    BOD_LVL_BODLEVEL2_gc = (0x02<<0),  /* 2.7 V */
+    BOD_LVL_BODLEVEL3_gc = (0x03<<0)  /* 4.5 V */
+} BOD_LVL_t;
+
+/* Sample frequency select */
+typedef enum BOD_SAMPFREQ_enum
+{
+    BOD_SAMPFREQ_128HZ_gc = (0x00<<4),  /* Sampling frequency is 128 Hz */
+    BOD_SAMPFREQ_32HZ_gc = (0x01<<4)  /* Sample frequency is 32 Hz */
+} BOD_SAMPFREQ_t;
+
+/* Operation in sleep mode select */
+typedef enum BOD_SLEEP_enum
+{
+    BOD_SLEEP_DISABLE_gc = (0x00<<0),  /* Disabled */
+    BOD_SLEEP_ENABLE_gc = (0x01<<0),  /* Enabled in continuous mode */
+    BOD_SLEEP_SAMPLE_gc = (0x02<<0)  /* Enabled in sampled mode */
+} BOD_SLEEP_t;
+
+/* Configuration select */
+typedef enum BOD_VLMCFG_enum
+{
+    BOD_VLMCFG_FALLING_gc = (0x00<<1),  /* VDD falls below VLM threshold */
+    BOD_VLMCFG_RISING_gc = (0x01<<1),  /* VDD rises above VLM threshold */
+    BOD_VLMCFG_BOTH_gc = (0x02<<1)  /* VDD crosses VLM threshold */
+} BOD_VLMCFG_t;
+
+/* voltage level monitor level select */
+typedef enum BOD_VLMLVL_enum
+{
+    BOD_VLMLVL_OFF_gc = (0x00<<0),  /* VLM Disabled */
+    BOD_VLMLVL_5ABOVE_gc = (0x01<<0),  /* VLM threshold 5% above BOD level */
+    BOD_VLMLVL_15ABOVE_gc = (0x02<<0),  /* VLM threshold 15% above BOD level */
+    BOD_VLMLVL_25ABOVE_gc = (0x03<<0)  /* VLM threshold 25% above BOD level */
+} BOD_VLMLVL_t;
+
+/* Voltage level monitor status select */
+typedef enum BOD_VLMS_enum
+{
+    BOD_VLMS_ABOVE_gc = (0x00<<0),  /* The voltage is above the VLM threshold level */
+    BOD_VLMS_BELOW_gc = (0x01<<0)  /* The voltage is below the VLM threshold level */
+} BOD_VLMS_t;
+
+/*
+--------------------------------------------------------------------------
+CCL - Configurable Custom Logic
+--------------------------------------------------------------------------
+*/
+
+/* Configurable Custom Logic */
+typedef struct CCL_struct
+{
+    register8_t CTRLA;  /* Control Register A */
+    register8_t SEQCTRL0;  /* Sequential Control 0 */
+    register8_t SEQCTRL1;  /* Sequential Control 1 */
+    register8_t reserved_1[2];
+    register8_t INTCTRL0;  /* Interrupt Control 0 */
+    register8_t reserved_2[1];
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t LUT0CTRLA;  /* LUT 0 Control A */
+    register8_t LUT0CTRLB;  /* LUT 0 Control B */
+    register8_t LUT0CTRLC;  /* LUT 0 Control C */
+    register8_t TRUTH0;  /* Truth 0 */
+    register8_t LUT1CTRLA;  /* LUT 1 Control A */
+    register8_t LUT1CTRLB;  /* LUT 1 Control B */
+    register8_t LUT1CTRLC;  /* LUT 1 Control C */
+    register8_t TRUTH1;  /* Truth 1 */
+    register8_t LUT2CTRLA;  /* LUT 2 Control A */
+    register8_t LUT2CTRLB;  /* LUT 2 Control B */
+    register8_t LUT2CTRLC;  /* LUT 2 Control C */
+    register8_t TRUTH2;  /* Truth 2 */
+    register8_t LUT3CTRLA;  /* LUT 3 Control A */
+    register8_t LUT3CTRLB;  /* LUT 3 Control B */
+    register8_t LUT3CTRLC;  /* LUT 3 Control C */
+    register8_t TRUTH3;  /* Truth 3 */
+    register8_t reserved_3[40];
+} CCL_t;
+
+/* Clock Source Selection */
+typedef enum CCL_CLKSRC_enum
+{
+    CCL_CLKSRC_CLKPER_gc = (0x00<<1),  /* Peripheral Clock */
+    CCL_CLKSRC_IN2_gc = (0x01<<1),  /* INSEL2 selection */
+    CCL_CLKSRC_OSCHF_gc = (0x04<<1),  /* Internal High Frequency oscillator */
+    CCL_CLKSRC_OSC32K_gc = (0x05<<1),  /* Internal 32.768 kHz oscillator */
+    CCL_CLKSRC_OSC1K_gc = (0x06<<1)  /* Internal 32.768 kHz oscillator divided by 32 */
+} CCL_CLKSRC_t;
+
+/* Edge Detection Enable select */
+typedef enum CCL_EDGEDET_enum
+{
+    CCL_EDGEDET_DIS_gc = (0x00<<7),  /* Edge detector is disabled */
+    CCL_EDGEDET_EN_gc = (0x01<<7)  /* Edge detector is enabled */
+} CCL_EDGEDET_t;
+
+/* Filter Selection */
+typedef enum CCL_FILTSEL_enum
+{
+    CCL_FILTSEL_DISABLE_gc = (0x00<<4),  /* Filter disabled */
+    CCL_FILTSEL_SYNCH_gc = (0x01<<4),  /* Synchronizer enabled */
+    CCL_FILTSEL_FILTER_gc = (0x02<<4)  /* Filter enabled */
+} CCL_FILTSEL_t;
+
+/* LUT Input 0 Source Selection */
+typedef enum CCL_INSEL0_enum
+{
+    CCL_INSEL0_MASK_gc = (0x00<<0),  /* Masked input */
+    CCL_INSEL0_FEEDBACK_gc = (0x01<<0),  /* Feedback input */
+    CCL_INSEL0_LINK_gc = (0x02<<0),  /* Output from LUT[n+1] as input source */
+    CCL_INSEL0_EVENTA_gc = (0x03<<0),  /* Event A as input source */
+    CCL_INSEL0_EVENTB_gc = (0x04<<0),  /* Event B as input source */
+    CCL_INSEL0_IO_gc = (0x05<<0),  /* IN0 input source */
+    CCL_INSEL0_AC0_gc = (0x06<<0),  /* AC0 output input source */
+    CCL_INSEL0_USART0_gc = (0x07<<0),  /* USART0 TxD input source */
+    CCL_INSEL0_SPI0_gc = (0x08<<0),  /* SPI0 MISO input source */
+    CCL_INSEL0_TCA0_gc = (0x09<<0),  /* TCA0 WO0 input source */
+    CCL_INSEL0_TCA1_gc = (0x0A<<0),  /* TCA1 WO0 input source */
+    CCL_INSEL0_TCB0_gc = (0x0B<<0)  /* TCB0 WO input source */
+} CCL_INSEL0_t;
+
+/* LUT Input 1 Source Selection */
+typedef enum CCL_INSEL1_enum
+{
+    CCL_INSEL1_MASK_gc = (0x00<<4),  /* Masked input */
+    CCL_INSEL1_FEEDBACK_gc = (0x01<<4),  /* Feedback input */
+    CCL_INSEL1_LINK_gc = (0x02<<4),  /* Output from LUT[n+1] as input source */
+    CCL_INSEL1_EVENTA_gc = (0x03<<4),  /* Event A as input source */
+    CCL_INSEL1_EVENTB_gc = (0x04<<4),  /* Event B as input source */
+    CCL_INSEL1_IO_gc = (0x05<<4),  /* IN0 input source */
+    CCL_INSEL1_AC1_gc = (0x06<<4),  /* AC1 output input source */
+    CCL_INSEL1_USART1_gc = (0x07<<4),  /* USART1 TxD input source */
+    CCL_INSEL1_SPI0_gc = (0x08<<4),  /* SPI0 MISO input source */
+    CCL_INSEL1_TCA0_gc = (0x09<<4),  /* TCA0 WO1 input source */
+    CCL_INSEL1_TCA1_gc = (0x0A<<4),  /* TCA1 WO1 input source */
+    CCL_INSEL1_TCB1_gc = (0x0B<<4)  /* TCB1 WO input source */
+} CCL_INSEL1_t;
+
+/* LUT Input 2 Source Selection */
+typedef enum CCL_INSEL2_enum
+{
+    CCL_INSEL2_MASK_gc = (0x00<<0),  /* Masked input */
+    CCL_INSEL2_FEEDBACK_gc = (0x01<<0),  /* Feedback input */
+    CCL_INSEL2_LINK_gc = (0x02<<0),  /* Output from LUT[n+1] as input source */
+    CCL_INSEL2_EVENTA_gc = (0x03<<0),  /* Event A as input source */
+    CCL_INSEL2_EVENTB_gc = (0x04<<0),  /* Event B as input source */
+    CCL_INSEL2_IO_gc = (0x05<<0),  /* IN0 input source */
+    CCL_INSEL2_AC1_gc = (0x06<<0),  /* AC1 output input source */
+    CCL_INSEL2_USART2_gc = (0x07<<0),  /* USART2 TxD input source */
+    CCL_INSEL2_SPI0_gc = (0x08<<0),  /* SPI0 MISO input source */
+    CCL_INSEL2_TCA0_gc = (0x09<<0),  /* TCA0 WO2 input source */
+    CCL_INSEL2_TCA1_gc = (0x0A<<0),  /* TCA1 WO2 input source */
+    CCL_INSEL2_TCB2_gc = (0x0B<<0)  /* TCB2 WO input source */
+} CCL_INSEL2_t;
+
+/* Interrupt Mode for LUT0 select */
+typedef enum CCL_INTMODE0_enum
+{
+    CCL_INTMODE0_INTDISABLE_gc = (0x00<<0),  /* Interrupt disabled */
+    CCL_INTMODE0_RISING_gc = (0x01<<0),  /* Sense rising edge */
+    CCL_INTMODE0_FALLING_gc = (0x02<<0),  /* Sense falling edge */
+    CCL_INTMODE0_BOTH_gc = (0x03<<0)  /* Sense both edges */
+} CCL_INTMODE0_t;
+
+/* Interrupt Mode for LUT1 select */
+typedef enum CCL_INTMODE1_enum
+{
+    CCL_INTMODE1_INTDISABLE_gc = (0x00<<2),  /* Interrupt disabled */
+    CCL_INTMODE1_RISING_gc = (0x01<<2),  /* Sense rising edge */
+    CCL_INTMODE1_FALLING_gc = (0x02<<2),  /* Sense falling edge */
+    CCL_INTMODE1_BOTH_gc = (0x03<<2)  /* Sense both edges */
+} CCL_INTMODE1_t;
+
+/* Interrupt Mode for LUT2 select */
+typedef enum CCL_INTMODE2_enum
+{
+    CCL_INTMODE2_INTDISABLE_gc = (0x00<<4),  /* Interrupt disabled */
+    CCL_INTMODE2_RISING_gc = (0x01<<4),  /* Sense rising edge */
+    CCL_INTMODE2_FALLING_gc = (0x02<<4),  /* Sense falling edge */
+    CCL_INTMODE2_BOTH_gc = (0x03<<4)  /* Sense both edges */
+} CCL_INTMODE2_t;
+
+/* Interrupt Mode for LUT3 select */
+typedef enum CCL_INTMODE3_enum
+{
+    CCL_INTMODE3_INTDISABLE_gc = (0x00<<6),  /* Interrupt disabled */
+    CCL_INTMODE3_RISING_gc = (0x01<<6),  /* Sense rising edge */
+    CCL_INTMODE3_FALLING_gc = (0x02<<6),  /* Sense falling edge */
+    CCL_INTMODE3_BOTH_gc = (0x03<<6)  /* Sense both edges */
+} CCL_INTMODE3_t;
+
+/* Sequential Selection */
+typedef enum CCL_SEQSEL_enum
+{
+    CCL_SEQSEL_DISABLE_gc = (0x00<<0),  /* Sequential logic disabled */
+    CCL_SEQSEL_DFF_gc = (0x01<<0),  /* D FlipFlop */
+    CCL_SEQSEL_JK_gc = (0x02<<0),  /* JK FlipFlop */
+    CCL_SEQSEL_LATCH_gc = (0x03<<0),  /* D Latch */
+    CCL_SEQSEL_RS_gc = (0x04<<0)  /* RS Latch */
+} CCL_SEQSEL_t;
+
+/*
+--------------------------------------------------------------------------
+CLKCTRL - Clock controller
+--------------------------------------------------------------------------
+*/
+
+/* Clock controller */
+typedef struct CLKCTRL_struct
+{
+    register8_t MCLKCTRLA;  /* MCLK Control A */
+    register8_t MCLKCTRLB;  /* MCLK Control B */
+    register8_t MCLKCTRLC;  /* MCLK Control C */
+    register8_t MCLKINTCTRL;  /* MCLK Interrupt Control */
+    register8_t MCLKINTFLAGS;  /* MCLK Interrupt Flags */
+    register8_t MCLKSTATUS;  /* MCLK Status */
+    register8_t MCLKTIMEBASE;  /* MCLK Timebase */
+    register8_t reserved_1[1];
+    register8_t OSCHFCTRLA;  /* OSCHF Control A */
+    register8_t OSCHFTUNE;  /* OSCHF Tune */
+    register8_t reserved_2[14];
+    register8_t OSC32KCTRLA;  /* OSC32K Control A */
+    register8_t reserved_3[3];
+    register8_t XOSC32KCTRLA;  /* XOSC32K Control A */
+    register8_t reserved_4[3];
+    register8_t XOSCHFCTRLA;  /* XOSCHF Control A */
+} CLKCTRL_t;
+
+/* Automatic Oscillator Tune select */
+typedef enum CLKCTRL_AUTOTUNE_enum
+{
+    CLKCTRL_AUTOTUNE_OFF_gc = (0x00<<0),  /* Disabled */
+    CLKCTRL_AUTOTUNE_XOSC32K_gc = (0x01<<0)  /* Tune against 32.768 kHz Crystal Oscillator */
+} CLKCTRL_AUTOTUNE_t;
+
+/* CFD Source select */
+typedef enum CLKCTRL_CFDSRC_enum
+{
+    CLKCTRL_CFDSRC_CLKMAIN_gc = (0x00<<2),  /* Main Clock */
+    CLKCTRL_CFDSRC_XOSCHF_gc = (0x01<<2),  /* High Frequency Crystal Oscillator */
+    CLKCTRL_CFDSRC_XOSC32K_gc = (0x02<<2)  /* 32.768 kHz Crystal Oscillator */
+} CLKCTRL_CFDSRC_t;
+
+/* Clock select */
+typedef enum CLKCTRL_CLKSEL_enum
+{
+    CLKCTRL_CLKSEL_OSCHF_gc = (0x00<<0),  /* Internal high-frequency oscillator */
+    CLKCTRL_CLKSEL_OSC32K_gc = (0x01<<0),  /* Internal 32.768 kHz oscillator */
+    CLKCTRL_CLKSEL_XOSC32K_gc = (0x02<<0),  /* 32.768 kHz crystal oscillator */
+    CLKCTRL_CLKSEL_EXTCLK_gc = (0x03<<0)  /* External clock */
+} CLKCTRL_CLKSEL_t;
+
+/* Crystal startup time select */
+typedef enum CLKCTRL_CSUT_enum
+{
+    CLKCTRL_CSUT_1K_gc = (0x00<<4),  /* 1k cycles */
+    CLKCTRL_CSUT_16K_gc = (0x01<<4),  /* 16k cycles */
+    CLKCTRL_CSUT_32K_gc = (0x02<<4),  /* 32k cycles */
+    CLKCTRL_CSUT_64K_gc = (0x03<<4)  /* 64k cycles */
+} CLKCTRL_CSUT_t;
+
+/* Start-Up Time select */
+typedef enum CLKCTRL_CSUTHF_enum
+{
+    CLKCTRL_CSUTHF_256CYC_gc = (0x00<<4),  /* 256 XOSCHF Cycles */
+    CLKCTRL_CSUTHF_1KCYC_gc = (0x01<<4),  /* 1K XOSCHF Cycles */
+    CLKCTRL_CSUTHF_4KCYC_gc = (0x02<<4)  /* 4K XOSCHF Cycles */
+} CLKCTRL_CSUTHF_t;
+
+/* Interrupt Type select */
+typedef enum CLKCTRL_INTTYPE_enum
+{
+    CLKCTRL_INTTYPE_INT_gc = (0x00<<7),  /* Regular interrupt */
+    CLKCTRL_INTTYPE_NMI_gc = (0x01<<7)  /* Non-maskable interrupt */
+} CLKCTRL_INTTYPE_t;
+
+/* Prescaler division select */
+typedef enum CLKCTRL_PDIV_enum
+{
+    CLKCTRL_PDIV_DIV2_gc = (0x00<<1),  /* Divide by 2 */
+    CLKCTRL_PDIV_DIV4_gc = (0x01<<1),  /* Divide by 4 */
+    CLKCTRL_PDIV_DIV8_gc = (0x02<<1),  /* Divide by 8 */
+    CLKCTRL_PDIV_DIV16_gc = (0x03<<1),  /* Divide by 16 */
+    CLKCTRL_PDIV_DIV32_gc = (0x04<<1),  /* Divide by 32 */
+    CLKCTRL_PDIV_DIV64_gc = (0x05<<1),  /* Divide by 64 */
+    CLKCTRL_PDIV_DIV6_gc = (0x08<<1),  /* Divide by 6 */
+    CLKCTRL_PDIV_DIV10_gc = (0x09<<1),  /* Divide by 10 */
+    CLKCTRL_PDIV_DIV12_gc = (0x0A<<1),  /* Divide by 12 */
+    CLKCTRL_PDIV_DIV24_gc = (0x0B<<1),  /* Divide by 24 */
+    CLKCTRL_PDIV_DIV48_gc = (0x0C<<1)  /* Divide by 48 */
+} CLKCTRL_PDIV_t;
+
+/* Source Select */
+typedef enum CLKCTRL_SELHF_enum
+{
+    CLKCTRL_SELHF_CRYSTAL_gc = (0x00<<1),  /* External Crystal */
+    CLKCTRL_SELHF_EXTCLK_gc = (0x01<<1)  /* Extenal Clock on XTALHF1 pin */
+} CLKCTRL_SELHF_t;
+
+/*
+--------------------------------------------------------------------------
+CPU - CPU
+--------------------------------------------------------------------------
+*/
+
+#define CORE_VERSION  V4S
+
+/* CCP signature select */
+typedef enum CCP_enum
+{
+    CCP_SPM_gc = (0x9D<<0),  /* SPM Instruction Protection */
+    CCP_IOREG_gc = (0xD8<<0)  /* IO Register Protection */
+} CCP_t;
+
+/*
+--------------------------------------------------------------------------
+CPUINT - Interrupt Controller
+--------------------------------------------------------------------------
+*/
+
+/* Interrupt Controller */
+typedef struct CPUINT_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t STATUS;  /* Status */
+    register8_t LVL0PRI;  /* Interrupt Level 0 Priority */
+    register8_t LVL1VEC;  /* Interrupt Level 1 Priority Vector */
+} CPUINT_t;
+
+
+/*
+--------------------------------------------------------------------------
+CRCSCAN - CRCSCAN
+--------------------------------------------------------------------------
+*/
+
+/* CRCSCAN */
+typedef struct CRCSCAN_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t STATUS;  /* Status */
+    register8_t reserved_1[13];
+} CRCSCAN_t;
+
+/* CRC Source select */
+typedef enum CRCSCAN_SRC_enum
+{
+    CRCSCAN_SRC_FLASH_gc = (0x00<<0),  /* CRC on entire flash */
+    CRCSCAN_SRC_APPLICATION_gc = (0x01<<0),  /* CRC on boot and appl section of flash */
+    CRCSCAN_SRC_BOOT_gc = (0x02<<0)  /* CRC on boot section of flash */
+} CRCSCAN_SRC_t;
+
+/*
+--------------------------------------------------------------------------
+DAC - Digital to Analog Converter
+--------------------------------------------------------------------------
+*/
+
+/* Digital to Analog Converter */
+typedef struct DAC_struct
+{
+    register8_t CTRLA;  /* Control Register A */
+    register8_t reserved_1[1];
+    _WORDREGISTER(DATA);  /* DATA Register */
+    register8_t reserved_2[12];
+} DAC_t;
+
+/* Output Buffer Range select */
+typedef enum DAC_OUTRANGE_enum
+{
+    DAC_OUTRANGE_AUTO_gc = (0x00<<4),  /* Output buffer automatically choose best range */
+    DAC_OUTRANGE_LOW_gc = (0x02<<4),  /* Output buffer configured to low range */
+    DAC_OUTRANGE_HIGH_gc = (0x03<<4)  /* Output buffer configured to high range */
+} DAC_OUTRANGE_t;
+
+/*
+--------------------------------------------------------------------------
+EVSYS - Event System
+--------------------------------------------------------------------------
+*/
+
+/* Event System */
+typedef struct EVSYS_struct
+{
+    register8_t SWEVENTA;  /* Software Event A */
+    register8_t reserved_1[15];
+    register8_t CHANNEL0;  /* Multiplexer Channel 0 */
+    register8_t CHANNEL1;  /* Multiplexer Channel 1 */
+    register8_t CHANNEL2;  /* Multiplexer Channel 2 */
+    register8_t CHANNEL3;  /* Multiplexer Channel 3 */
+    register8_t CHANNEL4;  /* Multiplexer Channel 4 */
+    register8_t CHANNEL5;  /* Multiplexer Channel 5 */
+    register8_t reserved_2[10];
+    register8_t USERCCLLUT0A;  /* CCL0 Event A */
+    register8_t USERCCLLUT0B;  /* CCL0 Event B */
+    register8_t USERCCLLUT1A;  /* CCL1 Event A */
+    register8_t USERCCLLUT1B;  /* CCL1 Event B */
+    register8_t USERCCLLUT2A;  /* CCL2 Event A */
+    register8_t USERCCLLUT2B;  /* CCL2 Event B */
+    register8_t USERCCLLUT3A;  /* CCL3 Event A */
+    register8_t USERCCLLUT3B;  /* CCL3 Event B */
+    register8_t USERADC0START;  /* ADC0 */
+    register8_t USEREVSYSEVOUTA;  /* EVOUTA */
+    register8_t USEREVSYSEVOUTB;  /* EVOUTB */
+    register8_t USEREVSYSEVOUTC;  /* EVOUTC */
+    register8_t USEREVSYSEVOUTD;  /* EVOUTD */
+    register8_t USEREVSYSEVOUTE;  /* EVOUTE */
+    register8_t USEREVSYSEVOUTF;  /* EVOUTF */
+    register8_t USERUSART0IRDA;  /* USART0 */
+    register8_t USERUSART1IRDA;  /* USART1 */
+    register8_t USERUSART2IRDA;  /* USART2 */
+    register8_t USERTCA0CNTA;  /* TCA0 Event A */
+    register8_t USERTCA0CNTB;  /* TCA0 Event B */
+    register8_t USERTCA1CNTA;  /* TCA1 Event A */
+    register8_t USERTCA1CNTB;  /* TCA1 Event B */
+    register8_t USERTCB0CAPT;  /* TCB0 Event A */
+    register8_t USERTCB0COUNT;  /* TCB0 Event B */
+    register8_t USERTCB1CAPT;  /* TCB1 Event A */
+    register8_t USERTCB1COUNT;  /* TCB1 Event B */
+    register8_t USERTCB2CAPT;  /* TCB2 Event A */
+    register8_t USERTCB2COUNT;  /* TCB2 Event B */
+    register8_t USERTCB3CAPT;  /* TCB3 Event A */
+    register8_t USERTCB3COUNT;  /* TCB3 Event B */
+    register8_t reserved_3[2];
+} EVSYS_t;
+
+/* Channel generator select */
+typedef enum EVSYS_CHANNEL_enum
+{
+    EVSYS_CHANNEL_OFF_gc = (0x00<<0),  /* Off */
+    EVSYS_CHANNEL_UPDI_SYNCH_gc = (0x01<<0),  /* UPDI SYNCH character */
+    EVSYS_CHANNEL_RTC_OVF_gc = (0x06<<0),  /* Real Time Counter overflow */
+    EVSYS_CHANNEL_RTC_CMP_gc = (0x07<<0),  /* Real Time Counter compare */
+    EVSYS_CHANNEL_RTC_PITEV0_gc = (0x08<<0),  /* Periodic Interrupt Timer Event 0 */
+    EVSYS_CHANNEL_RTC_PITEV1_gc = (0x09<<0),  /* Periodic Interrupt Timer Event 1 */
+    EVSYS_CHANNEL_CCL_LUT0_gc = (0x10<<0),  /* Configurable Custom Logic LUT0 */
+    EVSYS_CHANNEL_CCL_LUT1_gc = (0x11<<0),  /* Configurable Custom Logic LUT1 */
+    EVSYS_CHANNEL_CCL_LUT2_gc = (0x12<<0),  /* Configurable Custom Logic LUT2 */
+    EVSYS_CHANNEL_CCL_LUT3_gc = (0x13<<0),  /* Configurable Custom Logic LUT3 */
+    EVSYS_CHANNEL_AC0_OUT_gc = (0x20<<0),  /* Analog Comparator 0 out */
+    EVSYS_CHANNEL_AC1_OUT_gc = (0x21<<0),  /* Analog Comparator 1 out */
+    EVSYS_CHANNEL_ADC0_RES_gc = (0x24<<0),  /* ADC 0 Result Ready */
+    EVSYS_CHANNEL_ADC0_SAMP_gc = (0x25<<0),  /* ADC 0 Sample Ready */
+    EVSYS_CHANNEL_ADC0_WCMP_gc = (0x26<<0),  /* ADC 0 Window Compare */
+    EVSYS_CHANNEL_PORTA_EV0_gc = (0x40<<0),  /* Port A Event 0 */
+    EVSYS_CHANNEL_PORTA_EV1_gc = (0x41<<0),  /* Port A Event 1 */
+    EVSYS_CHANNEL_PORTB_EV0_gc = (0x42<<0),  /* Port B Event 0 */
+    EVSYS_CHANNEL_PORTB_EV1_gc = (0x43<<0),  /* Port B Event 1 */
+    EVSYS_CHANNEL_PORTC_EV0_gc = (0x44<<0),  /* Port C Event 0 */
+    EVSYS_CHANNEL_PORTC_EV1_gc = (0x45<<0),  /* Port C Event 1 */
+    EVSYS_CHANNEL_PORTD_EV0_gc = (0x46<<0),  /* Port D Event 0 */
+    EVSYS_CHANNEL_PORTD_EV1_gc = (0x47<<0),  /* Port D Event 1 */
+    EVSYS_CHANNEL_PORTE_EV0_gc = (0x48<<0),  /* Port E Event 0 */
+    EVSYS_CHANNEL_PORTE_EV1_gc = (0x49<<0),  /* Port E Event 1 */
+    EVSYS_CHANNEL_PORTF_EV0_gc = (0x4A<<0),  /* Port F Event 0 */
+    EVSYS_CHANNEL_PORTF_EV1_gc = (0x4B<<0),  /* Port F Event 1 */
+    EVSYS_CHANNEL_USART0_XCK_gc = (0x60<<0),  /* USART 0 XCK */
+    EVSYS_CHANNEL_USART1_XCK_gc = (0x61<<0),  /* USART 1 XCK */
+    EVSYS_CHANNEL_USART2_XCK_gc = (0x62<<0),  /* USART 2 XCK */
+    EVSYS_CHANNEL_SPI0_SCK_gc = (0x68<<0),  /* SPI 0 SCK */
+    EVSYS_CHANNEL_TCA0_OVF_LUNF_gc = (0x80<<0),  /* Timer/Counter A0 overflow / low byte timer underflow */
+    EVSYS_CHANNEL_TCA0_HUNF_gc = (0x81<<0),  /* Timer/Counter A0 high byte timer underflow */
+    EVSYS_CHANNEL_TCA0_CMP0_LCMP0_gc = (0x84<<0),  /* Timer/Counter A0 compare 0 / low byte timer compare 0 */
+    EVSYS_CHANNEL_TCA0_CMP1_LCMP1_gc = (0x85<<0),  /* Timer/Counter A0 compare 1 / low byte timer compare 1 */
+    EVSYS_CHANNEL_TCA0_CMP2_LCMP2_gc = (0x86<<0),  /* Timer/Counter A0 compare 2 / low byte timer compare 2 */
+    EVSYS_CHANNEL_TCA1_OVF_LUNF_gc = (0x88<<0),  /* Timer/Counter A1 overflow / low byte timer underflow */
+    EVSYS_CHANNEL_TCA1_HUNF_gc = (0x89<<0),  /* Timer/Counter A1 high byte timer underflow */
+    EVSYS_CHANNEL_TCA1_CMP0_LCMP0_gc = (0x8C<<0),  /* Timer/Counter A1 compare 0 / low byte timer compare 0 */
+    EVSYS_CHANNEL_TCA1_CMP1_LCMP1_gc = (0x8D<<0),  /* Timer/Counter A1 compare 1 / low byte timer compare 1 */
+    EVSYS_CHANNEL_TCA1_CMP2_LCMP2_gc = (0x8E<<0),  /* Timer/Counter A1 compare 2 / low byte timer compare 2 */
+    EVSYS_CHANNEL_TCB0_CAPT_gc = (0xA0<<0),  /* Timer/Counter B0 capture */
+    EVSYS_CHANNEL_TCB0_OVF_gc = (0xA1<<0),  /* Timer/Counter B0 overflow */
+    EVSYS_CHANNEL_TCB1_CAPT_gc = (0xA2<<0),  /* Timer/Counter B1 capture */
+    EVSYS_CHANNEL_TCB1_OVF_gc = (0xA3<<0),  /* Timer/Counter B1 overflow */
+    EVSYS_CHANNEL_TCB2_CAPT_gc = (0xA4<<0),  /* Timer/Counter B2 capture */
+    EVSYS_CHANNEL_TCB2_OVF_gc = (0xA5<<0),  /* Timer/Counter B2 overflow */
+    EVSYS_CHANNEL_TCB3_CAPT_gc = (0xA6<<0),  /* Timer/Counter B3 capture */
+    EVSYS_CHANNEL_TCB3_OVF_gc = (0xA7<<0)  /* Timer/Counter B3 overflow */
+} EVSYS_CHANNEL_t;
+
+/* Software event on channel select */
+typedef enum EVSYS_SWEVENTA_enum
+{
+    EVSYS_SWEVENTA_CH0_gc = (0x01<<0),  /* Software event on channel 0 */
+    EVSYS_SWEVENTA_CH1_gc = (0x02<<0),  /* Software event on channel 1 */
+    EVSYS_SWEVENTA_CH2_gc = (0x04<<0),  /* Software event on channel 2 */
+    EVSYS_SWEVENTA_CH3_gc = (0x08<<0),  /* Software event on channel 3 */
+    EVSYS_SWEVENTA_CH4_gc = (0x10<<0),  /* Software event on channel 4 */
+    EVSYS_SWEVENTA_CH5_gc = (0x20<<0),  /* Software event on channel 5 */
+    EVSYS_SWEVENTA_CH6_gc = (0x40<<0),  /* Software event on channel 6 */
+    EVSYS_SWEVENTA_CH7_gc = (0x80<<0)  /* Software event on channel 7 */
+} EVSYS_SWEVENTA_t;
+
+/* User channel select */
+typedef enum EVSYS_USER_enum
+{
+    EVSYS_USER_OFF_gc = (0x00<<0),  /* Off, No Eventsys Channel connected */
+    EVSYS_USER_CHANNEL0_gc = (0x01<<0),  /* Connect user to event channel 0 */
+    EVSYS_USER_CHANNEL1_gc = (0x02<<0),  /* Connect user to event channel 1 */
+    EVSYS_USER_CHANNEL2_gc = (0x03<<0),  /* Connect user to event channel 2 */
+    EVSYS_USER_CHANNEL3_gc = (0x04<<0),  /* Connect user to event channel 3 */
+    EVSYS_USER_CHANNEL4_gc = (0x05<<0),  /* Connect user to event channel 4 */
+    EVSYS_USER_CHANNEL5_gc = (0x06<<0)  /* Connect user to event channel 5 */
+} EVSYS_USER_t;
+
+/*
+--------------------------------------------------------------------------
+FUSE - Fuses
+--------------------------------------------------------------------------
+*/
+
+/* Fuses */
+typedef struct FUSE_struct
+{
+    register8_t WDTCFG;  /* Watchdog Configuration */
+    register8_t BODCFG;  /* BOD Configuration */
+    register8_t OSCCFG;  /* Oscillator Configuration */
+    register8_t reserved_1[2];
+    register8_t SYSCFG0;  /* System Configuration 0 */
+    register8_t SYSCFG1;  /* System Configuration 1 */
+    register8_t CODESIZE;  /* Code Section Size */
+    register8_t BOOTSIZE;  /* Boot Section Size */
+} FUSE_t;
+
+/* avr-libc typedef for avr/fuse.h */
+typedef FUSE_t NVM_FUSES_t;
+
+/* BOD Operation in Active Mode select */
+typedef enum ACTIVE_enum
+{
+    ACTIVE_DISABLE_gc = (0x00<<2),  /* Disabled */
+    ACTIVE_ENABLED_gc = (0x01<<2),  /* Enabled in continuous mode */
+    ACTIVE_SAMPLED_gc = (0x02<<2),  /* Enabled in sampled mode */
+    ACTIVE_ENABLEWAIT_gc = (0x03<<2)  /* Enabled in continuous mode. Execution halted at wake-up until BOD is running */
+} ACTIVE_t;
+
+/* CRC Select */
+typedef enum CRCSEL_enum
+{
+    CRCSEL_CRC16_gc = (0x00<<5),  /* Enable CRC16 */
+    CRCSEL_CRC32_gc = (0x01<<5)  /* Enable CRC32 */
+} CRCSEL_t;
+
+/* CRC Source select */
+typedef enum CRCSRC_enum
+{
+    CRCSRC_FLASH_gc = (0x00<<6),  /* CRC of full Flash (boot, application code and application data) */
+    CRCSRC_BOOT_gc = (0x01<<6),  /* CRC of boot section */
+    CRCSRC_BOOTAPP_gc = (0x02<<6),  /* CRC of application code and boot sections */
+    CRCSRC_NOCRC_gc = (0x03<<6)  /* No CRC */
+} CRCSRC_t;
+
+/* EEPROM Save select */
+typedef enum EESAVE_enum
+{
+    EESAVE_DISABLE_gc = (0x00<<0),  /* EEPROM content is erased during chip erase */
+    EESAVE_ENABLE_gc = (0x01<<0)  /* EEPROM content is preserved during chip erase */
+} EESAVE_t;
+
+/* BOD Level select */
+typedef enum LVL_enum
+{
+    LVL_BODLEVEL0_gc = (0x00<<5),  /* BOD Disabled during normal operation */
+    LVL_BODLEVEL1_gc = (0x01<<5),  /* 1.9 V */
+    LVL_BODLEVEL2_gc = (0x02<<5),  /* 2.7 V */
+    LVL_BODLEVEL3_gc = (0x03<<5)  /* 4.5 V */
+} LVL_t;
+
+/* High-frequency Oscillator Frequency select */
+typedef enum OSCHFFRQ_enum
+{
+    OSCHFFRQ_20M_gc = (0x00<<3),  /* OSCHF running at 20 MHz */
+    OSCHFFRQ_16M_gc = (0x01<<3)  /* OSCHF running at 16 MHz */
+} OSCHFFRQ_t;
+
+/* Watchdog Timeout Period select */
+typedef enum PERIOD_enum
+{
+    PERIOD_OFF_gc = (0x00<<0),  /* Watch-Dog timer Off */
+    PERIOD_8CLK_gc = (0x01<<0),  /* 8 cycles (8ms) */
+    PERIOD_16CLK_gc = (0x02<<0),  /* 16 cycles (16ms) */
+    PERIOD_32CLK_gc = (0x03<<0),  /* 32 cycles (32ms) */
+    PERIOD_64CLK_gc = (0x04<<0),  /* 64 cycles (64ms) */
+    PERIOD_128CLK_gc = (0x05<<0),  /* 128 cycles (0.128s) */
+    PERIOD_256CLK_gc = (0x06<<0),  /* 256 cycles (0.256s) */
+    PERIOD_512CLK_gc = (0x07<<0),  /* 512 cycles (0.512s) */
+    PERIOD_1KCLK_gc = (0x08<<0),  /* 1K cycles (1.0s) */
+    PERIOD_2KCLK_gc = (0x09<<0),  /* 2K cycles (2.0s) */
+    PERIOD_4KCLK_gc = (0x0A<<0),  /* 4K cycles (4.0s) */
+    PERIOD_8KCLK_gc = (0x0B<<0)  /* 8K cycles (8.0s) */
+} PERIOD_t;
+
+/* Reset Pin Configuration select */
+typedef enum RSTPINCFG_enum
+{
+    RSTPINCFG_NONE_gc = (0x00<<3),  /* No External Reset */
+    RSTPINCFG_RESET_gc = (0x01<<3)  /* PF6 configured as RESET pin */
+} RSTPINCFG_t;
+
+/* BOD Sample Frequency select */
+typedef enum SAMPFREQ_enum
+{
+    SAMPFREQ_128HZ_gc = (0x00<<4),  /* Sampling frequency is 128 Hz */
+    SAMPFREQ_32HZ_gc = (0x01<<4)  /* Sample frequency is 32 Hz */
+} SAMPFREQ_t;
+
+/* BOD Operation in Sleep Mode select */
+typedef enum SLEEP_enum
+{
+    SLEEP_DISABLE_gc = (0x00<<0),  /* Disabled */
+    SLEEP_ENABLE_gc = (0x01<<0),  /* Enabled in continuous mode */
+    SLEEP_SAMPLE_gc = (0x02<<0)  /* Enabled in sampled mode */
+} SLEEP_t;
+
+/* Startup Time select */
+typedef enum SUT_enum
+{
+    SUT_0MS_gc = (0x00<<0),  /* 0 ms */
+    SUT_1MS_gc = (0x01<<0),  /* 1 ms */
+    SUT_2MS_gc = (0x02<<0),  /* 2 ms */
+    SUT_4MS_gc = (0x03<<0),  /* 4 ms */
+    SUT_8MS_gc = (0x04<<0),  /* 8 ms */
+    SUT_16MS_gc = (0x05<<0),  /* 16 ms */
+    SUT_32MS_gc = (0x06<<0),  /* 32 ms */
+    SUT_64MS_gc = (0x07<<0)  /* 64 ms */
+} SUT_t;
+
+/* UPDI Pin Configuration select */
+typedef enum UPDIPINCFG_enum
+{
+    UPDIPINCFG_GPIO_gc = (0x00<<4),  /* PF7 Configured as GPIO pin */
+    UPDIPINCFG_UPDI_gc = (0x01<<4)  /* PF7 Configured as UPDI pin */
+} UPDIPINCFG_t;
+
+/* Watchdog Window Timeout Period select */
+typedef enum WINDOW_enum
+{
+    WINDOW_OFF_gc = (0x00<<4),  /* Window mode off */
+    WINDOW_8CLK_gc = (0x01<<4),  /* 8 cycles (8ms) */
+    WINDOW_16CLK_gc = (0x02<<4),  /* 16 cycles (16ms) */
+    WINDOW_32CLK_gc = (0x03<<4),  /* 32 cycles (32ms) */
+    WINDOW_64CLK_gc = (0x04<<4),  /* 64 cycles (64ms) */
+    WINDOW_128CLK_gc = (0x05<<4),  /* 128 cycles (0.128s) */
+    WINDOW_256CLK_gc = (0x06<<4),  /* 256 cycles (0.256s) */
+    WINDOW_512CLK_gc = (0x07<<4),  /* 512 cycles (0.512s) */
+    WINDOW_1KCLK_gc = (0x08<<4),  /* 1K cycles (1.0s) */
+    WINDOW_2KCLK_gc = (0x09<<4),  /* 2K cycles (2.0s) */
+    WINDOW_4KCLK_gc = (0x0A<<4),  /* 4K cycles (4.0s) */
+    WINDOW_8KCLK_gc = (0x0B<<4)  /* 8K cycles (8.0s) */
+} WINDOW_t;
+
+/*
+--------------------------------------------------------------------------
+GPR - General Purpose Registers
+--------------------------------------------------------------------------
+*/
+
+/* General Purpose Registers */
+typedef struct GPR_struct
+{
+    register8_t GPR0;  /* General Purpose Register 0 */
+    register8_t GPR1;  /* General Purpose Register 1 */
+    register8_t GPR2;  /* General Purpose Register 2 */
+    register8_t GPR3;  /* General Purpose Register 3 */
+} GPR_t;
+
+
+/*
+--------------------------------------------------------------------------
+LOCK - Lockbits
+--------------------------------------------------------------------------
+*/
+
+/* Lockbits */
+typedef struct LOCK_struct
+{
+    _DWORDREGISTER(KEY);  /* Lock Key Bits */
+} LOCK_t;
+
+/* Lock Key select */
+typedef enum LOCK_KEY_enum
+{
+    LOCK_KEY_NOLOCK_gc = (0x5CC5C55C<<0),  /* No locks */
+    LOCK_KEY_RWLOCK_gc = (0xA33A3AA3<<0)  /* Read and write lock */
+} LOCK_KEY_t;
+
+/*
+--------------------------------------------------------------------------
+NVMCTRL - Non-volatile Memory Controller
+--------------------------------------------------------------------------
+*/
+
+/* Non-volatile Memory Controller */
+typedef struct NVMCTRL_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t reserved_1[2];
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t STATUS;  /* Status */
+    register8_t reserved_2[1];
+    _WORDREGISTER(DATA);  /* Data */
+    register8_t reserved_3[2];
+    _DWORDREGISTER(ADDR);  /* Address */
+    register8_t reserved_4[48];
+} NVMCTRL_t;
+
+/* Command select */
+typedef enum NVMCTRL_CMD_enum
+{
+    NVMCTRL_CMD_NOCMD_gc = (0x00<<0),  /* No Command */
+    NVMCTRL_CMD_NOOP_gc = (0x01<<0),  /* No Operation */
+    NVMCTRL_CMD_FLPW_gc = (0x04<<0),  /* Flash Page Write */
+    NVMCTRL_CMD_FLPERW_gc = (0x05<<0),  /* Flash Page Erase and Write */
+    NVMCTRL_CMD_FLPER_gc = (0x08<<0),  /* Flash Page Erase */
+    NVMCTRL_CMD_FLMPER2_gc = (0x09<<0),  /* Flash 2-page erase enable */
+    NVMCTRL_CMD_FLMPER4_gc = (0x0A<<0),  /* Flash 4-page erase enable */
+    NVMCTRL_CMD_FLMPER8_gc = (0x0B<<0),  /* Flash 8-page erase enable */
+    NVMCTRL_CMD_FLMPER16_gc = (0x0C<<0),  /* Flash 16-page erase enable */
+    NVMCTRL_CMD_FLMPER32_gc = (0x0D<<0),  /* Flash 32-page erase enable */
+    NVMCTRL_CMD_FLPBCLR_gc = (0x0F<<0),  /* Flash Page Buffer Clear */
+    NVMCTRL_CMD_EEPW_gc = (0x14<<0),  /* EEPROM Page Write */
+    NVMCTRL_CMD_EEPERW_gc = (0x15<<0),  /* EEPROM Page Erase and Write */
+    NVMCTRL_CMD_EEPER_gc = (0x17<<0),  /* EEPROM Page Erase */
+    NVMCTRL_CMD_EEPBCLR_gc = (0x1F<<0),  /* EEPROM Page Buffer Clear */
+    NVMCTRL_CMD_CHER_gc = (0x20<<0),  /* Chip Erase Command (UPDI only) */
+    NVMCTRL_CMD_EECHER_gc = (0x30<<0)  /* EEPROM Erase Command (UPDI only) */
+} NVMCTRL_CMD_t;
+
+/* Write error select */
+typedef enum NVMCTRL_ERROR_enum
+{
+    NVMCTRL_ERROR_NOERROR_gc = (0x00<<4),  /* No Error */
+    NVMCTRL_ERROR_WRITEPROTECT_gc = (0x02<<4),  /* Attempt to program write protected area */
+    NVMCTRL_ERROR_CMDCOLLISION_gc = (0x03<<4),  /* Selecting new write command while write command already seleted */
+    NVMCTRL_ERROR_WRONGSECTION_gc = (0x04<<4)  /* Address cannot be written with selected command */
+} NVMCTRL_ERROR_t;
+
+/* Flash Mapping in Data space select */
+typedef enum NVMCTRL_FLMAP_enum
+{
+    NVMCTRL_FLMAP_SECTION0_gc = (0x00<<4),  /* Flash section 0, 0 - 32KB */
+    NVMCTRL_FLMAP_SECTION1_gc = (0x01<<4),  /* Flash section 1, 32 - 64KB */
+    NVMCTRL_FLMAP_SECTION2_gc = (0x02<<4),  /* Flash section 2, 64 - 96KB */
+    NVMCTRL_FLMAP_SECTION3_gc = (0x03<<4)  /* Flash section 3, 96 - 128KB */
+} NVMCTRL_FLMAP_t;
+
+/*
+--------------------------------------------------------------------------
+PORT - I/O Ports
+--------------------------------------------------------------------------
+*/
+
+/* I/O Ports */
+typedef struct PORT_struct
+{
+    register8_t DIR;  /* Data Direction */
+    register8_t DIRSET;  /* Data Direction Set */
+    register8_t DIRCLR;  /* Data Direction Clear */
+    register8_t DIRTGL;  /* Data Direction Toggle */
+    register8_t OUT;  /* Output Value */
+    register8_t OUTSET;  /* Output Value Set */
+    register8_t OUTCLR;  /* Output Value Clear */
+    register8_t OUTTGL;  /* Output Value Toggle */
+    register8_t IN;  /* Input Value */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t PORTCTRL;  /* Port Control */
+    register8_t PINCONFIG;  /* Pin Control Config */
+    register8_t PINCTRLUPD;  /* Pin Control Update */
+    register8_t PINCTRLSET;  /* Pin Control Set */
+    register8_t PINCTRLCLR;  /* Pin Control Clear */
+    register8_t reserved_1[1];
+    register8_t PIN0CTRL;  /* Pin 0 Control */
+    register8_t PIN1CTRL;  /* Pin 1 Control */
+    register8_t PIN2CTRL;  /* Pin 2 Control */
+    register8_t PIN3CTRL;  /* Pin 3 Control */
+    register8_t PIN4CTRL;  /* Pin 4 Control */
+    register8_t PIN5CTRL;  /* Pin 5 Control */
+    register8_t PIN6CTRL;  /* Pin 6 Control */
+    register8_t PIN7CTRL;  /* Pin 7 Control */
+    register8_t EVGENCTRL;  /* Event Generation Control */
+    register8_t reserved_2[7];
+} PORT_t;
+
+/* Event Generator 0 Select */
+typedef enum PORT_EVGEN0SEL_enum
+{
+    PORT_EVGEN0SEL_PIN0_gc = (0x00<<0),  /* Pin 0 used as event generator */
+    PORT_EVGEN0SEL_PIN1_gc = (0x01<<0),  /* Pin 1 used as event generator */
+    PORT_EVGEN0SEL_PIN2_gc = (0x02<<0),  /* Pin 2 used as event generator */
+    PORT_EVGEN0SEL_PIN3_gc = (0x03<<0),  /* Pin 3 used as event generator */
+    PORT_EVGEN0SEL_PIN4_gc = (0x04<<0),  /* Pin 4 used as event generator */
+    PORT_EVGEN0SEL_PIN5_gc = (0x05<<0),  /* Pin 5 used as event generator */
+    PORT_EVGEN0SEL_PIN6_gc = (0x06<<0),  /* Pin 6 used as event generator */
+    PORT_EVGEN0SEL_PIN7_gc = (0x07<<0)  /* Pin 7 used as event generator */
+} PORT_EVGEN0SEL_t;
+
+/* Event Generator 1 Select */
+typedef enum PORT_EVGEN1SEL_enum
+{
+    PORT_EVGEN1SEL_PIN0_gc = (0x00<<4),  /* Pin 0 used as event generator */
+    PORT_EVGEN1SEL_PIN1_gc = (0x01<<4),  /* Pin 1 used as event generator */
+    PORT_EVGEN1SEL_PIN2_gc = (0x02<<4),  /* Pin 2 used as event generator */
+    PORT_EVGEN1SEL_PIN3_gc = (0x03<<4),  /* Pin 3 used as event generator */
+    PORT_EVGEN1SEL_PIN4_gc = (0x04<<4),  /* Pin 4 used as event generator */
+    PORT_EVGEN1SEL_PIN5_gc = (0x05<<4),  /* Pin 5 used as event generator */
+    PORT_EVGEN1SEL_PIN6_gc = (0x06<<4),  /* Pin 6 used as event generator */
+    PORT_EVGEN1SEL_PIN7_gc = (0x07<<4)  /* Pin 7 used as event generator */
+} PORT_EVGEN1SEL_t;
+
+/* Input Level Select */
+typedef enum PORT_INLVL_enum
+{
+    PORT_INLVL_ST_gc = (0x00<<6),  /* Schmitt-Trigger input level */
+    PORT_INLVL_TTL_gc = (0x01<<6)  /* TTL Input level */
+} PORT_INLVL_t;
+
+/* Input/Sense Configuration select */
+typedef enum PORT_ISC_enum
+{
+    PORT_ISC_INTDISABLE_gc = (0x00<<0),  /* Interrupt disabled but input buffer enabled */
+    PORT_ISC_BOTHEDGES_gc = (0x01<<0),  /* Sense Both Edges */
+    PORT_ISC_RISING_gc = (0x02<<0),  /* Sense Rising Edge */
+    PORT_ISC_FALLING_gc = (0x03<<0),  /* Sense Falling Edge */
+    PORT_ISC_INPUT_DISABLE_gc = (0x04<<0),  /* Digital Input Buffer disabled */
+    PORT_ISC_LEVEL_gc = (0x05<<0)  /* Sense low Level */
+} PORT_ISC_t;
+
+/*
+--------------------------------------------------------------------------
+PORTMUX - Port Multiplexer
+--------------------------------------------------------------------------
+*/
+
+/* Port Multiplexer */
+typedef struct PORTMUX_struct
+{
+    register8_t EVSYSROUTEA;  /* EVSYS route A */
+    register8_t CCLROUTEA;  /* CCL route A */
+    register8_t USARTROUTEA;  /* USART route A */
+    register8_t USARTROUTEB;  /* USART route B */
+    register8_t reserved_1[1];
+    register8_t SPIROUTEA;  /* SPI route A */
+    register8_t TWIROUTEA;  /* TWI route A */
+    register8_t TCAROUTEA;  /* TCA route A */
+    register8_t TCBROUTEA;  /* TCB route A */
+    register8_t reserved_2[1];
+    register8_t ACROUTEA;  /* AC route A */
+    register8_t reserved_3[21];
+} PORTMUX_t;
+
+/* Analog Comparator 0 Output select */
+typedef enum PORTMUX_AC0_enum
+{
+    PORTMUX_AC0_DEFAULT_gc = (0x00<<0),  /* OUT: PA7 */
+    PORTMUX_AC0_ALT1_gc = (0x01<<0)  /* OUT: PC6 */
+} PORTMUX_AC0_t;
+
+/* Analog Comparator 1 Output select */
+typedef enum PORTMUX_AC1_enum
+{
+    PORTMUX_AC1_DEFAULT_gc = (0x00<<1),  /* OUT: PA7 */
+    PORTMUX_AC1_ALT1_gc = (0x01<<1)  /* OUT: PC6 */
+} PORTMUX_AC1_t;
+
+/* Event Output A select */
+typedef enum PORTMUX_EVOUTA_enum
+{
+    PORTMUX_EVOUTA_DEFAULT_gc = (0x00<<0),  /* EVOUTA: PA2 */
+    PORTMUX_EVOUTA_ALT1_gc = (0x01<<0)  /* EVOUTA: PA7 */
+} PORTMUX_EVOUTA_t;
+
+/* Event Output B select */
+typedef enum PORTMUX_EVOUTB_enum
+{
+    PORTMUX_EVOUTB_DEFAULT_gc = (0x00<<1)  /* EVOUTB: PB2 */
+} PORTMUX_EVOUTB_t;
+
+/* Event Output C select */
+typedef enum PORTMUX_EVOUTC_enum
+{
+    PORTMUX_EVOUTC_DEFAULT_gc = (0x00<<2),  /* EVOUTC: PC2 */
+    PORTMUX_EVOUTC_ALT1_gc = (0x01<<2)  /* EVOUTC: PC7 */
+} PORTMUX_EVOUTC_t;
+
+/* Event Output D select */
+typedef enum PORTMUX_EVOUTD_enum
+{
+    PORTMUX_EVOUTD_DEFAULT_gc = (0x00<<3),  /* EVOUTD: PD2 */
+    PORTMUX_EVOUTD_ALT1_gc = (0x01<<3)  /* EVOUTD: PD7 */
+} PORTMUX_EVOUTD_t;
+
+/* Event Output E select */
+typedef enum PORTMUX_EVOUTE_enum
+{
+    PORTMUX_EVOUTE_DEFAULT_gc = (0x00<<4)  /* EVOUTE: PE2 */
+} PORTMUX_EVOUTE_t;
+
+/* Event Output F select */
+typedef enum PORTMUX_EVOUTF_enum
+{
+    PORTMUX_EVOUTF_DEFAULT_gc = (0x00<<5),  /* EVOUTF: PF2 */
+    PORTMUX_EVOUTF_ALT1_gc = (0x01<<5)  /* EVOUTF: PF7 */
+} PORTMUX_EVOUTF_t;
+
+/* CCL Look-Up Table 0 Signals select */
+typedef enum PORTMUX_LUT0_enum
+{
+    PORTMUX_LUT0_DEFAULT_gc = (0x00<<0),  /* In: PA0, PA1, PA2, Out: PA3 */
+    PORTMUX_LUT0_ALT1_gc = (0x01<<0)  /* In: PA0, PA1, PA2, Out: PA6 */
+} PORTMUX_LUT0_t;
+
+/* CCL Look-Up Table 1 Signals select */
+typedef enum PORTMUX_LUT1_enum
+{
+    PORTMUX_LUT1_DEFAULT_gc = (0x00<<1),  /* In: PC0, PC1, PC2, Out: PC3 */
+    PORTMUX_LUT1_ALT1_gc = (0x01<<1)  /* In: PC0, PC1, PC2, Out: PC6 */
+} PORTMUX_LUT1_t;
+
+/* CCL Look-Up Table 2 Signals select */
+typedef enum PORTMUX_LUT2_enum
+{
+    PORTMUX_LUT2_DEFAULT_gc = (0x00<<2),  /* In: PD0, PD1, PD2, Out: PD3 */
+    PORTMUX_LUT2_ALT1_gc = (0x01<<2)  /* In: PD0, PD1, PD2, Out: PD6 */
+} PORTMUX_LUT2_t;
+
+/* SPI0 Signals select */
+typedef enum PORTMUX_SPI0_enum
+{
+    PORTMUX_SPI0_DEFAULT_gc = (0x00<<0),  /* MOSI: PA4, MISO: PA5, SCK: PA6, SS: PA7 */
+    PORTMUX_SPI0_ALT1_gc = (0x01<<0),  /* MOSI: PE0, MISO: PE1, SCK: PE2, SS: PE3 */
+    PORTMUX_SPI0_ALT3_gc = (0x03<<0),  /* MOSI: PA0, MISO: PA1, SCK: PC0, SS: PC1 */
+    PORTMUX_SPI0_ALT4_gc = (0x04<<0),  /* MOSI: PD4, MISO: PD5, SCK: PD6, SS: PD7 */
+    PORTMUX_SPI0_ALT5_gc = (0x05<<0),  /* MOSI: PC0, MISO: PC1, SCK: PC2, SS: PC3 */
+    PORTMUX_SPI0_ALT6_gc = (0x06<<0),  /* MOSI: PC1, MISO: PC2, SCK: PC3, SS: PF7 */
+    PORTMUX_SPI0_NONE_gc = (0x07<<0)  /* Not connected to any pins, SS set to 1 */
+} PORTMUX_SPI0_t;
+
+/* TCA0 Signals select */
+typedef enum PORTMUX_TCA0_enum
+{
+    PORTMUX_TCA0_PORTA_gc = (0x00<<0),  /* WOn: PA0, PA1, PA2, PA3, PA4, PA5 */
+    PORTMUX_TCA0_PORTB_gc = (0x01<<0),  /* WOn: PB0, PB1, PB2, PB3, PB4, PB5 */
+    PORTMUX_TCA0_PORTC_gc = (0x02<<0),  /* WOn: PC0, PC1, PC2, PC3, PC4, PC5 */
+    PORTMUX_TCA0_PORTD_gc = (0x03<<0),  /* WOn: PD0, PD1, PD2, PD3, PD4, PD5 */
+    PORTMUX_TCA0_PORTE_gc = (0x04<<0),  /* WOn: PE0, PE1, PE2, PE3, -, - */
+    PORTMUX_TCA0_PORTF_gc = (0x05<<0)  /* WOn: PF0, PF1, PF2, PF3, PF4, PF5 */
+} PORTMUX_TCA0_t;
+
+/* TCA1 Signals select */
+typedef enum PORTMUX_TCA1_enum
+{
+    PORTMUX_TCA1_PORTB_gc = (0x00<<3),  /* WOn: PB0, PB1, PB2, PB3, PB4, PB5 */
+    PORTMUX_TCA1_PORTC_gc = (0x01<<3),  /* WOn: PC4, PC5, PC6, -, -, - */
+    PORTMUX_TCA1_PORTA_gc = (0x04<<3),  /* WOn: PA4, PA5, PA6, -, -, - */
+    PORTMUX_TCA1_PORTD_gc = (0x05<<3)  /* WOn: PD4, PD5, PD6, -, -, - */
+} PORTMUX_TCA1_t;
+
+/* TCB0 Output select */
+typedef enum PORTMUX_TCB0_enum
+{
+    PORTMUX_TCB0_DEFAULT_gc = (0x00<<0),  /* WO: PA2 */
+    PORTMUX_TCB0_ALT1_gc = (0x01<<0)  /* WO: PF4 */
+} PORTMUX_TCB0_t;
+
+/* TCB1 Output select */
+typedef enum PORTMUX_TCB1_enum
+{
+    PORTMUX_TCB1_DEFAULT_gc = (0x00<<1),  /* WO: PA3 */
+    PORTMUX_TCB1_ALT1_gc = (0x01<<1)  /* WO: PF5 */
+} PORTMUX_TCB1_t;
+
+/* TCB2 Output select */
+typedef enum PORTMUX_TCB2_enum
+{
+    PORTMUX_TCB2_DEFAULT_gc = (0x00<<2),  /* WO: PC0 */
+    PORTMUX_TCB2_ALT1_gc = (0x01<<2)  /* WO: PB4 */
+} PORTMUX_TCB2_t;
+
+/* TCB3 Output select */
+typedef enum PORTMUX_TCB3_enum
+{
+    PORTMUX_TCB3_DEFAULT_gc = (0x00<<3),  /* WO: PB5 */
+    PORTMUX_TCB3_ALT1_gc = (0x01<<3)  /* WO: PC1 */
+} PORTMUX_TCB3_t;
+
+/* TWI0 Signals select */
+typedef enum PORTMUX_TWI0_enum
+{
+    PORTMUX_TWI0_DEFAULT_gc = (0x00<<0),  /* SDA: PA2, SCL: PA3. Dual mode: SDA: PC2, SCL: PC3 */
+    PORTMUX_TWI0_ALT1_gc = (0x01<<0),  /* SDA: PA2, SCL: PA3. Dual mode: SDA: PC6, SCL: PC7 */
+    PORTMUX_TWI0_ALT2_gc = (0x02<<0),  /* SDA: PC2, SCL: PC3. Dual mode: SDA: PC6, SCL: PC7 */
+    PORTMUX_TWI0_ALT3_gc = (0x03<<0)  /* SDA: PA0, SCL: PA1. Dual mode: SDA: PC2, SCL: PC3 */
+} PORTMUX_TWI0_t;
+
+/* USART0 Routing select */
+typedef enum PORTMUX_USART0_enum
+{
+    PORTMUX_USART0_DEFAULT_gc = (0x00<<0),  /* TxD: PA0, RxD: PA1, XCK: PA2, XDIR: PA3 */
+    PORTMUX_USART0_ALT1_gc = (0x01<<0),  /* TxD: PA4, RxD: PA5, XCK: PA6, XDIR: PA7 */
+    PORTMUX_USART0_ALT2_gc = (0x02<<0),  /* TxD: PA2, RxD: PA3, XCK: -, XDIR: - */
+    PORTMUX_USART0_ALT3_gc = (0x03<<0),  /* TxD: PD4, RxD: PD5, XCK: PD6, XDIR: PD7 */
+    PORTMUX_USART0_ALT4_gc = (0x04<<0),  /* TxD: PC1, RxD: PC2, XCK: PC3, XDIR: - */
+    PORTMUX_USART0_NONE_gc = (0x05<<0)  /* Not connected to any pins */
+} PORTMUX_USART0_t;
+
+/* USART1 Routing select */
+typedef enum PORTMUX_USART1_enum
+{
+    PORTMUX_USART1_DEFAULT_gc = (0x00<<3),  /* TxD: PC0, RxD: PC1, XCK: PC2, XDIR: PC3 */
+    PORTMUX_USART1_ALT1_gc = (0x01<<3),  /* TxD: PC4, RxD: PC5, XCK: PC6, XDIR: PC7 */
+    PORTMUX_USART1_ALT2_gc = (0x02<<3),  /* TxD: PD6, RxD: PD7, XCK: -, XDIR: - */
+    PORTMUX_USART1_NONE_gc = (0x03<<3)  /* Not connected to any pins */
+} PORTMUX_USART1_t;
+
+/* USART2 Routing select */
+typedef enum PORTMUX_USART2_enum
+{
+    PORTMUX_USART2_DEFAULT_gc = (0x00<<0),  /* TxD: PF0, RxD: PF1, XCK: PF2, XDIR: PF3 */
+    PORTMUX_USART2_ALT1_gc = (0x01<<0),  /* TxD: PF4, RxD: PF5, XCK: - , XDIR: - */
+    PORTMUX_USART2_NONE_gc = (0x03<<0)  /* Not connected to any pins */
+} PORTMUX_USART2_t;
+
+/*
+--------------------------------------------------------------------------
+RSTCTRL - Reset controller
+--------------------------------------------------------------------------
+*/
+
+/* Reset controller */
+typedef struct RSTCTRL_struct
+{
+    register8_t RSTFR;  /* Reset Flags */
+    register8_t SWRR;  /* Software Reset */
+    register8_t reserved_1[14];
+} RSTCTRL_t;
+
+
+/*
+--------------------------------------------------------------------------
+RTC - Real-Time Counter
+--------------------------------------------------------------------------
+*/
+
+/* Real-Time Counter */
+typedef struct RTC_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t STATUS;  /* Status */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t TEMP;  /* Temporary */
+    register8_t DBGCTRL;  /* Debug control */
+    register8_t CALIB;  /* Calibration */
+    register8_t CLKSEL;  /* Clock Select */
+    _WORDREGISTER(CNT);  /* Counter */
+    _WORDREGISTER(PER);  /* Period */
+    _WORDREGISTER(CMP);  /* Compare */
+    register8_t reserved_1[2];
+    register8_t PITCTRLA;  /* PIT Control A */
+    register8_t PITSTATUS;  /* PIT Status */
+    register8_t PITINTCTRL;  /* PIT Interrupt Control */
+    register8_t PITINTFLAGS;  /* PIT Interrupt Flags */
+    register8_t reserved_2[1];
+    register8_t PITDBGCTRL;  /* PIT Debug control */
+    register8_t PITEVGENCTRLA;  /* PIT Event Generation Control A */
+    register8_t reserved_3[9];
+} RTC_t;
+
+/* Clock Select */
+typedef enum RTC_CLKSEL_enum
+{
+    RTC_CLKSEL_OSC32K_gc = (0x00<<0),  /* Internal 32.768 kHz Oscillator */
+    RTC_CLKSEL_OSC1K_gc = (0x01<<0),  /* Internal 32.768 kHz Oscillator Divided by 32 */
+    RTC_CLKSEL_XOSC32K_gc = (0x02<<0),  /* 32.768 kHz Crystal Oscillator */
+    RTC_CLKSEL_EXTCLK_gc = (0x03<<0)  /* External Clock */
+} RTC_CLKSEL_t;
+
+/* Event Generation 0 Select */
+typedef enum RTC_EVGEN0SEL_enum
+{
+    RTC_EVGEN0SEL_OFF_gc = (0x00<<0),  /* No Event Generated */
+    RTC_EVGEN0SEL_DIV4_gc = (0x01<<0),  /* CLK_RTC divided by 4 */
+    RTC_EVGEN0SEL_DIV8_gc = (0x02<<0),  /* CLK_RTC divided by 8 */
+    RTC_EVGEN0SEL_DIV16_gc = (0x03<<0),  /* CLK_RTC divided by 16 */
+    RTC_EVGEN0SEL_DIV32_gc = (0x04<<0),  /* CLK_RTC divided by 32 */
+    RTC_EVGEN0SEL_DIV64_gc = (0x05<<0),  /* CLK_RTC divided by 64 */
+    RTC_EVGEN0SEL_DIV128_gc = (0x06<<0),  /* CLK_RTC divided by 128 */
+    RTC_EVGEN0SEL_DIV256_gc = (0x07<<0),  /* CLK_RTC divided by 256 */
+    RTC_EVGEN0SEL_DIV512_gc = (0x08<<0),  /* CLK_RTC divided by 512 */
+    RTC_EVGEN0SEL_DIV1024_gc = (0x09<<0),  /* CLK_RTC divided by 1024 */
+    RTC_EVGEN0SEL_DIV2048_gc = (0x0A<<0),  /* CLK_RTC divided by 2048 */
+    RTC_EVGEN0SEL_DIV4096_gc = (0x0B<<0),  /* CLK_RTC divided by 4096 */
+    RTC_EVGEN0SEL_DIV8192_gc = (0x0C<<0),  /* CLK_RTC divided by 8192 */
+    RTC_EVGEN0SEL_DIV16384_gc = (0x0D<<0),  /* CLK_RTC divided by 16384 */
+    RTC_EVGEN0SEL_DIV32768_gc = (0x0E<<0)  /* CLK_RTC divided by 32768 */
+} RTC_EVGEN0SEL_t;
+
+/* Event Generation 1 Select */
+typedef enum RTC_EVGEN1SEL_enum
+{
+    RTC_EVGEN1SEL_OFF_gc = (0x00<<4),  /* No Event Generated */
+    RTC_EVGEN1SEL_DIV4_gc = (0x01<<4),  /* CLK_RTC divided by 4 */
+    RTC_EVGEN1SEL_DIV8_gc = (0x02<<4),  /* CLK_RTC divided by 8 */
+    RTC_EVGEN1SEL_DIV16_gc = (0x03<<4),  /* CLK_RTC divided by 16 */
+    RTC_EVGEN1SEL_DIV32_gc = (0x04<<4),  /* CLK_RTC divided by 32 */
+    RTC_EVGEN1SEL_DIV64_gc = (0x05<<4),  /* CLK_RTC divided by 64 */
+    RTC_EVGEN1SEL_DIV128_gc = (0x06<<4),  /* CLK_RTC divided by 128 */
+    RTC_EVGEN1SEL_DIV256_gc = (0x07<<4),  /* CLK_RTC divided by 256 */
+    RTC_EVGEN1SEL_DIV512_gc = (0x08<<4),  /* CLK_RTC divided by 512 */
+    RTC_EVGEN1SEL_DIV1024_gc = (0x09<<4),  /* CLK_RTC divided by 1024 */
+    RTC_EVGEN1SEL_DIV2048_gc = (0x0A<<4),  /* CLK_RTC divided by 2048 */
+    RTC_EVGEN1SEL_DIV4096_gc = (0x0B<<4),  /* CLK_RTC divided by 4096 */
+    RTC_EVGEN1SEL_DIV8192_gc = (0x0C<<4),  /* CLK_RTC divided by 8192 */
+    RTC_EVGEN1SEL_DIV16384_gc = (0x0D<<4),  /* CLK_RTC divided by 16384 */
+    RTC_EVGEN1SEL_DIV32768_gc = (0x0E<<4)  /* CLK_RTC divided by 32768 */
+} RTC_EVGEN1SEL_t;
+
+/* Period select */
+typedef enum RTC_PERIOD_enum
+{
+    RTC_PERIOD_OFF_gc = (0x00<<3),  /* Off */
+    RTC_PERIOD_CYC4_gc = (0x01<<3),  /* RTC Clock Cycles 4 */
+    RTC_PERIOD_CYC8_gc = (0x02<<3),  /* RTC Clock Cycles 8 */
+    RTC_PERIOD_CYC16_gc = (0x03<<3),  /* RTC Clock Cycles 16 */
+    RTC_PERIOD_CYC32_gc = (0x04<<3),  /* RTC Clock Cycles 32 */
+    RTC_PERIOD_CYC64_gc = (0x05<<3),  /* RTC Clock Cycles 64 */
+    RTC_PERIOD_CYC128_gc = (0x06<<3),  /* RTC Clock Cycles 128 */
+    RTC_PERIOD_CYC256_gc = (0x07<<3),  /* RTC Clock Cycles 256 */
+    RTC_PERIOD_CYC512_gc = (0x08<<3),  /* RTC Clock Cycles 512 */
+    RTC_PERIOD_CYC1024_gc = (0x09<<3),  /* RTC Clock Cycles 1024 */
+    RTC_PERIOD_CYC2048_gc = (0x0A<<3),  /* RTC Clock Cycles 2048 */
+    RTC_PERIOD_CYC4096_gc = (0x0B<<3),  /* RTC Clock Cycles 4096 */
+    RTC_PERIOD_CYC8192_gc = (0x0C<<3),  /* RTC Clock Cycles 8192 */
+    RTC_PERIOD_CYC16384_gc = (0x0D<<3),  /* RTC Clock Cycles 16384 */
+    RTC_PERIOD_CYC32768_gc = (0x0E<<3)  /* RTC Clock Cycles 32768 */
+} RTC_PERIOD_t;
+
+/* Prescaling Factor select */
+typedef enum RTC_PRESCALER_enum
+{
+    RTC_PRESCALER_DIV1_gc = (0x00<<3),  /* RTC Clock / 1 */
+    RTC_PRESCALER_DIV2_gc = (0x01<<3),  /* RTC Clock / 2 */
+    RTC_PRESCALER_DIV4_gc = (0x02<<3),  /* RTC Clock / 4 */
+    RTC_PRESCALER_DIV8_gc = (0x03<<3),  /* RTC Clock / 8 */
+    RTC_PRESCALER_DIV16_gc = (0x04<<3),  /* RTC Clock / 16 */
+    RTC_PRESCALER_DIV32_gc = (0x05<<3),  /* RTC Clock / 32 */
+    RTC_PRESCALER_DIV64_gc = (0x06<<3),  /* RTC Clock / 64 */
+    RTC_PRESCALER_DIV128_gc = (0x07<<3),  /* RTC Clock / 128 */
+    RTC_PRESCALER_DIV256_gc = (0x08<<3),  /* RTC Clock / 256 */
+    RTC_PRESCALER_DIV512_gc = (0x09<<3),  /* RTC Clock / 512 */
+    RTC_PRESCALER_DIV1024_gc = (0x0A<<3),  /* RTC Clock / 1024 */
+    RTC_PRESCALER_DIV2048_gc = (0x0B<<3),  /* RTC Clock / 2048 */
+    RTC_PRESCALER_DIV4096_gc = (0x0C<<3),  /* RTC Clock / 4096 */
+    RTC_PRESCALER_DIV8192_gc = (0x0D<<3),  /* RTC Clock / 8192 */
+    RTC_PRESCALER_DIV16384_gc = (0x0E<<3),  /* RTC Clock / 16384 */
+    RTC_PRESCALER_DIV32768_gc = (0x0F<<3)  /* RTC Clock / 32768 */
+} RTC_PRESCALER_t;
+
+/*
+--------------------------------------------------------------------------
+SIGROW - Signature row
+--------------------------------------------------------------------------
+*/
+
+/* Signature row */
+typedef struct SIGROW_struct
+{
+    register8_t DEVICEID0;  /* Device ID Byte 0 */
+    register8_t DEVICEID1;  /* Device ID Byte 1 */
+    register8_t DEVICEID2;  /* Device ID Byte 2 */
+    register8_t reserved_1[1];
+    _WORDREGISTER(TEMPSENSE0);  /* Temperature Calibration 0 */
+    _WORDREGISTER(TEMPSENSE1);  /* Temperature Calibration 1 */
+    register8_t reserved_2[8];
+    register8_t SERNUM0;  /* Serial Number Byte 0 */
+    register8_t SERNUM1;  /* Serial Number Byte 1 */
+    register8_t SERNUM2;  /* Serial Number Byte 2 */
+    register8_t SERNUM3;  /* Serial Number Byte 3 */
+    register8_t SERNUM4;  /* Serial Number Byte 4 */
+    register8_t SERNUM5;  /* Serial Number Byte 5 */
+    register8_t SERNUM6;  /* Serial Number Byte 6 */
+    register8_t SERNUM7;  /* Serial Number Byte 7 */
+    register8_t SERNUM8;  /* Serial Number Byte 8 */
+    register8_t SERNUM9;  /* Serial Number Byte 9 */
+    register8_t SERNUM10;  /* Serial Number Byte 10 */
+    register8_t SERNUM11;  /* Serial Number Byte 11 */
+    register8_t SERNUM12;  /* Serial Number Byte 12 */
+    register8_t SERNUM13;  /* Serial Number Byte 13 */
+    register8_t SERNUM14;  /* Serial Number Byte 14 */
+    register8_t SERNUM15;  /* Serial Number Byte 15 */
+    register8_t reserved_3[32];
+} SIGROW_t;
+
+
+/*
+--------------------------------------------------------------------------
+SLPCTRL - Sleep Controller
+--------------------------------------------------------------------------
+*/
+
+/* Sleep Controller */
+typedef struct SLPCTRL_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t reserved_1[1];
+} SLPCTRL_t;
+
+/* Sleep mode select */
+typedef enum SLPCTRL_SMODE_enum
+{
+    SLPCTRL_SMODE_IDLE_gc = (0x00<<1),  /* Idle mode */
+    SLPCTRL_SMODE_STDBY_gc = (0x01<<1),  /* Standby Mode */
+    SLPCTRL_SMODE_PDOWN_gc = (0x02<<1)  /* Power-down Mode */
+} SLPCTRL_SMODE_t;
+
+#define SLEEP_MODE_IDLE (0x00<<1)
+#define SLEEP_MODE_STANDBY (0x01<<1)
+#define SLEEP_MODE_PWR_DOWN (0x02<<1)
+/*
+--------------------------------------------------------------------------
+SPI - Serial Peripheral Interface
+--------------------------------------------------------------------------
+*/
+
+/* Serial Peripheral Interface */
+typedef struct SPI_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t DATA;  /* Data */
+    register8_t reserved_1[3];
+} SPI_t;
+
+/* SPI Mode select */
+typedef enum SPI_MODE_enum
+{
+    SPI_MODE_0_gc = (0x00<<0),  /* SPI Mode 0 */
+    SPI_MODE_1_gc = (0x01<<0),  /* SPI Mode 1 */
+    SPI_MODE_2_gc = (0x02<<0),  /* SPI Mode 2 */
+    SPI_MODE_3_gc = (0x03<<0)  /* SPI Mode 3 */
+} SPI_MODE_t;
+
+/* Prescaler select */
+typedef enum SPI_PRESC_enum
+{
+    SPI_PRESC_DIV4_gc = (0x00<<1),  /* CLK_PER / 4 */
+    SPI_PRESC_DIV16_gc = (0x01<<1),  /* CLK_PER / 16 */
+    SPI_PRESC_DIV64_gc = (0x02<<1),  /* CLK_PER / 64 */
+    SPI_PRESC_DIV128_gc = (0x03<<1)  /* CLK_PER / 128 */
+} SPI_PRESC_t;
+
+/*
+--------------------------------------------------------------------------
+SYSCFG - System Configuration Registers
+--------------------------------------------------------------------------
+*/
+
+/* System Configuration Registers */
+typedef struct SYSCFG_struct
+{
+    register8_t reserved_1[1];
+    register8_t REVID;  /* Revision ID */
+    register8_t reserved_2[2];
+    register8_t OCDMCTRL;  /* OCD Message Control */
+    register8_t OCDMSTATUS;  /* OCD Message Status */
+    register8_t reserved_3[26];
+} SYSCFG_t;
+
+
+/*
+--------------------------------------------------------------------------
+TCA - 16-bit Timer/Counter Type A
+--------------------------------------------------------------------------
+*/
+
+/* 16-bit Timer/Counter Type A - Single Mode */
+typedef struct TCA_SINGLE_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    register8_t CTRLD;  /* Control D */
+    register8_t CTRLECLR;  /* Control E Clear */
+    register8_t CTRLESET;  /* Control E Set */
+    register8_t CTRLFCLR;  /* Control F Clear */
+    register8_t CTRLFSET;  /* Control F Set */
+    register8_t reserved_1[1];
+    register8_t EVCTRL;  /* Event Control */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t reserved_2[2];
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t TEMP;  /* Temporary data for 16-bit Access */
+    register8_t reserved_3[16];
+    _WORDREGISTER(CNT);  /* Count */
+    register8_t reserved_4[4];
+    _WORDREGISTER(PER);  /* Period */
+    _WORDREGISTER(CMP0);  /* Compare 0 */
+    _WORDREGISTER(CMP1);  /* Compare 1 */
+    _WORDREGISTER(CMP2);  /* Compare 2 */
+    register8_t reserved_5[8];
+    _WORDREGISTER(PERBUF);  /* Period Buffer */
+    _WORDREGISTER(CMP0BUF);  /* Compare 0 Buffer */
+    _WORDREGISTER(CMP1BUF);  /* Compare 1 Buffer */
+    _WORDREGISTER(CMP2BUF);  /* Compare 2 Buffer */
+    register8_t reserved_6[2];
+} TCA_SINGLE_t;
+
+/* 16-bit Timer/Counter Type A - Split Mode */
+typedef struct TCA_SPLIT_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    register8_t CTRLD;  /* Control D */
+    register8_t CTRLECLR;  /* Control E Clear */
+    register8_t CTRLESET;  /* Control E Set */
+    register8_t reserved_1[4];
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t reserved_2[2];
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t reserved_3[17];
+    register8_t LCNT;  /* Low Count */
+    register8_t HCNT;  /* High Count */
+    register8_t reserved_4[4];
+    register8_t LPER;  /* Low Period */
+    register8_t HPER;  /* High Period */
+    register8_t LCMP0;  /* Low Compare */
+    register8_t HCMP0;  /* High Compare */
+    register8_t LCMP1;  /* Low Compare */
+    register8_t HCMP1;  /* High Compare */
+    register8_t LCMP2;  /* Low Compare */
+    register8_t HCMP2;  /* High Compare */
+    register8_t reserved_5[18];
+} TCA_SPLIT_t;
+
+/* 16-bit Timer/Counter Type A */
+typedef union TCA_union
+{
+    TCA_SINGLE_t SINGLE;  /* Single Mode */
+    TCA_SPLIT_t SPLIT;  /* Split Mode */
+} TCA_t;
+
+/* Clock Selection */
+typedef enum TCA_SINGLE_CLKSEL_enum
+{
+    TCA_SINGLE_CLKSEL_DIV1_gc = (0x00<<1),  /* CLK_PER */
+    TCA_SINGLE_CLKSEL_DIV2_gc = (0x01<<1),  /* CLK_PER / 2 */
+    TCA_SINGLE_CLKSEL_DIV4_gc = (0x02<<1),  /* CLK_PER / 4 */
+    TCA_SINGLE_CLKSEL_DIV8_gc = (0x03<<1),  /* CLK_PER / 8 */
+    TCA_SINGLE_CLKSEL_DIV16_gc = (0x04<<1),  /* CLK_PER / 16 */
+    TCA_SINGLE_CLKSEL_DIV64_gc = (0x05<<1),  /* CLK_PER / 64 */
+    TCA_SINGLE_CLKSEL_DIV256_gc = (0x06<<1),  /* CLK_PER / 256 */
+    TCA_SINGLE_CLKSEL_DIV1024_gc = (0x07<<1)  /* CLK_PER / 1024 */
+} TCA_SINGLE_CLKSEL_t;
+
+/* Command select */
+typedef enum TCA_SINGLE_CMD_enum
+{
+    TCA_SINGLE_CMD_NONE_gc = (0x00<<2),  /* No Command */
+    TCA_SINGLE_CMD_UPDATE_gc = (0x01<<2),  /* Force Update */
+    TCA_SINGLE_CMD_RESTART_gc = (0x02<<2),  /* Force Restart */
+    TCA_SINGLE_CMD_RESET_gc = (0x03<<2)  /* Force Hard Reset */
+} TCA_SINGLE_CMD_t;
+
+/* Direction select */
+typedef enum TCA_SINGLE_DIR_enum
+{
+    TCA_SINGLE_DIR_UP_gc = (0x00<<0),  /* Count up */
+    TCA_SINGLE_DIR_DOWN_gc = (0x01<<0)  /* Count down */
+} TCA_SINGLE_DIR_t;
+
+/* Event Action A select */
+typedef enum TCA_SINGLE_EVACTA_enum
+{
+    TCA_SINGLE_EVACTA_CNT_POSEDGE_gc = (0x00<<1),  /* Count on positive edge event */
+    TCA_SINGLE_EVACTA_CNT_ANYEDGE_gc = (0x01<<1),  /* Count on any edge event */
+    TCA_SINGLE_EVACTA_CNT_HIGHLVL_gc = (0x02<<1),  /* Count on prescaled clock while event line is 1. */
+    TCA_SINGLE_EVACTA_UPDOWN_gc = (0x03<<1)  /* Count on prescaled clock. Event controls count direction. Up-count when event line is 0, down-count when event line is 1. */
+} TCA_SINGLE_EVACTA_t;
+
+/* Event Action B select */
+typedef enum TCA_SINGLE_EVACTB_enum
+{
+    TCA_SINGLE_EVACTB_NONE_gc = (0x00<<5),  /* No Action */
+    TCA_SINGLE_EVACTB_UPDOWN_gc = (0x03<<5),  /* Count on prescaled clock. Event controls count direction. Up-count when event line is 0, down-count when event line is 1. */
+    TCA_SINGLE_EVACTB_RESTART_POSEDGE_gc = (0x04<<5),  /* Restart counter at positive edge event */
+    TCA_SINGLE_EVACTB_RESTART_ANYEDGE_gc = (0x05<<5),  /* Restart counter on any edge event */
+    TCA_SINGLE_EVACTB_RESTART_HIGHLVL_gc = (0x06<<5)  /* Restart counter while event line is 1. */
+} TCA_SINGLE_EVACTB_t;
+
+/* Waveform generation mode select */
+typedef enum TCA_SINGLE_WGMODE_enum
+{
+    TCA_SINGLE_WGMODE_NORMAL_gc = (0x00<<0),  /* Normal Mode */
+    TCA_SINGLE_WGMODE_FRQ_gc = (0x01<<0),  /* Frequency Generation Mode */
+    TCA_SINGLE_WGMODE_SINGLESLOPE_gc = (0x03<<0),  /* Single Slope PWM */
+    TCA_SINGLE_WGMODE_DSTOP_gc = (0x05<<0),  /* Dual Slope PWM, overflow on TOP */
+    TCA_SINGLE_WGMODE_DSBOTH_gc = (0x06<<0),  /* Dual Slope PWM, overflow on TOP and BOTTOM */
+    TCA_SINGLE_WGMODE_DSBOTTOM_gc = (0x07<<0)  /* Dual Slope PWM, overflow on BOTTOM */
+} TCA_SINGLE_WGMODE_t;
+
+/* Clock Selection */
+typedef enum TCA_SPLIT_CLKSEL_enum
+{
+    TCA_SPLIT_CLKSEL_DIV1_gc = (0x00<<1),  /* CLK_PER */
+    TCA_SPLIT_CLKSEL_DIV2_gc = (0x01<<1),  /* CLK_PER / 2 */
+    TCA_SPLIT_CLKSEL_DIV4_gc = (0x02<<1),  /* CLK_PER / 4 */
+    TCA_SPLIT_CLKSEL_DIV8_gc = (0x03<<1),  /* CLK_PER / 8 */
+    TCA_SPLIT_CLKSEL_DIV16_gc = (0x04<<1),  /* CLK_PER / 16 */
+    TCA_SPLIT_CLKSEL_DIV64_gc = (0x05<<1),  /* CLK_PER / 64 */
+    TCA_SPLIT_CLKSEL_DIV256_gc = (0x06<<1),  /* CLK_PER / 256 */
+    TCA_SPLIT_CLKSEL_DIV1024_gc = (0x07<<1)  /* CLK_PER / 1024 */
+} TCA_SPLIT_CLKSEL_t;
+
+/* Command select */
+typedef enum TCA_SPLIT_CMD_enum
+{
+    TCA_SPLIT_CMD_NONE_gc = (0x00<<2),  /* No Command */
+    TCA_SPLIT_CMD_UPDATE_gc = (0x01<<2),  /* Force Update */
+    TCA_SPLIT_CMD_RESTART_gc = (0x02<<2),  /* Force Restart */
+    TCA_SPLIT_CMD_RESET_gc = (0x03<<2)  /* Force Hard Reset */
+} TCA_SPLIT_CMD_t;
+
+/* Command Enable select */
+typedef enum TCA_SPLIT_CMDEN_enum
+{
+    TCA_SPLIT_CMDEN_NONE_gc = (0x00<<0),  /* None */
+    TCA_SPLIT_CMDEN_BOTH_gc = (0x03<<0)  /* Both low byte and high byte counter */
+} TCA_SPLIT_CMDEN_t;
+
+/*
+--------------------------------------------------------------------------
+TCB - 16-bit Timer Type B
+--------------------------------------------------------------------------
+*/
+
+/* 16-bit Timer Type B */
+typedef struct TCB_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control Register B */
+    register8_t reserved_1[2];
+    register8_t EVCTRL;  /* Event Control */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t STATUS;  /* Status */
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t TEMP;  /* Temporary Value */
+    _WORDREGISTER(CNT);  /* Count */
+    _WORDREGISTER(CCMP);  /* Compare or Capture */
+    register8_t reserved_2[2];
+} TCB_t;
+
+/* Clock Select */
+typedef enum TCB_CLKSEL_enum
+{
+    TCB_CLKSEL_DIV1_gc = (0x00<<1),  /* CLK_PER */
+    TCB_CLKSEL_DIV2_gc = (0x01<<1),  /* CLK_PER/2 */
+    TCB_CLKSEL_TCA0_gc = (0x02<<1),  /* Use CLK_TCA from TCA0 */
+    TCB_CLKSEL_TCA1_gc = (0x03<<1),  /* Use CLK_TCA from TCA1 */
+    TCB_CLKSEL_EVENT_gc = (0x07<<1)  /* Count on event edge */
+} TCB_CLKSEL_t;
+
+/* Timer Mode select */
+typedef enum TCB_CNTMODE_enum
+{
+    TCB_CNTMODE_INT_gc = (0x00<<0),  /* Periodic Interrupt */
+    TCB_CNTMODE_TIMEOUT_gc = (0x01<<0),  /* Periodic Timeout */
+    TCB_CNTMODE_CAPT_gc = (0x02<<0),  /* Input Capture Event */
+    TCB_CNTMODE_FRQ_gc = (0x03<<0),  /* Input Capture Frequency measurement */
+    TCB_CNTMODE_PW_gc = (0x04<<0),  /* Input Capture Pulse-Width measurement */
+    TCB_CNTMODE_FRQPW_gc = (0x05<<0),  /* Input Capture Frequency and Pulse-Width measurement */
+    TCB_CNTMODE_SINGLE_gc = (0x06<<0),  /* Single Shot */
+    TCB_CNTMODE_PWM8_gc = (0x07<<0)  /* 8-bit PWM */
+} TCB_CNTMODE_t;
+
+/*
+--------------------------------------------------------------------------
+TWI - Two-Wire Interface
+--------------------------------------------------------------------------
+*/
+
+/* Two-Wire Interface */
+typedef struct TWI_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t DUALCTRL;  /* Dual Mode Control */
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t MCTRLA;  /* Host Control A */
+    register8_t MCTRLB;  /* Host Control B */
+    register8_t MSTATUS;  /* Host STATUS */
+    register8_t MBAUD;  /* Host Baud Rate */
+    register8_t MADDR;  /* Host Address */
+    register8_t MDATA;  /* Host Data */
+    register8_t SCTRLA;  /* Client Control A */
+    register8_t SCTRLB;  /* Client Control B */
+    register8_t SSTATUS;  /* Client Status */
+    register8_t SADDR;  /* Client Address */
+    register8_t SDATA;  /* Client Data */
+    register8_t SADDRMASK;  /* Client Address Mask */
+    register8_t reserved_1[1];
+} TWI_t;
+
+/* Acknowledge Action select */
+typedef enum TWI_ACKACT_enum
+{
+    TWI_ACKACT_ACK_gc = (0x00<<2),  /* Send ACK */
+    TWI_ACKACT_NACK_gc = (0x01<<2)  /* Send NACK */
+} TWI_ACKACT_t;
+
+/* Address or Stop select */
+typedef enum TWI_AP_enum
+{
+    TWI_AP_STOP_gc = (0x00<<0),  /* A Stop condition generated the interrupt on APIF flag */
+    TWI_AP_ADR_gc = (0x01<<0)  /* Address detection generated the interrupt on APIF flag */
+} TWI_AP_t;
+
+/* Bus State select */
+typedef enum TWI_BUSSTATE_enum
+{
+    TWI_BUSSTATE_UNKNOWN_gc = (0x00<<0),  /* Unknown bus state */
+    TWI_BUSSTATE_IDLE_gc = (0x01<<0),  /* Bus is idle */
+    TWI_BUSSTATE_OWNER_gc = (0x02<<0),  /* This TWI controls the bus */
+    TWI_BUSSTATE_BUSY_gc = (0x03<<0)  /* The bus is busy */
+} TWI_BUSSTATE_t;
+
+/* Debug Run select */
+typedef enum TWI_DBGRUN_enum
+{
+    TWI_DBGRUN_HALT_gc = (0x00<<0),  /* The peripheral is halted in Break Debug mode and ignores events */
+    TWI_DBGRUN_RUN_gc = (0x01<<0)  /* The peripheral will continue to run in Break Debug mode when the CPU is halted */
+} TWI_DBGRUN_t;
+
+/* Fast-mode Enable select */
+typedef enum TWI_FMEN_enum
+{
+    TWI_FMEN_OFF_gc = (0x00<<0),  /* SCL duty cycle operating according to Sm specification */
+    TWI_FMEN_ON_gc = (0x01<<0)  /* SCL duty cycle operating according to Fm specification */
+} TWI_FMEN_t;
+
+/* Fast-mode Plus Enable select */
+typedef enum TWI_FMPEN_enum
+{
+    TWI_FMPEN_OFF_gc = (0x00<<1),  /* Operating in Standard-mode or Fast-mode */
+    TWI_FMPEN_ON_gc = (0x01<<1)  /* Operating in Fast-mode Plus */
+} TWI_FMPEN_t;
+
+/* Input voltage transition level select */
+typedef enum TWI_INPUTLVL_enum
+{
+    TWI_INPUTLVL_I2C_gc = (0x00<<6),  /* I2C input voltage transition level */
+    TWI_INPUTLVL_SMBUS_gc = (0x01<<6)  /* SMBus 3.0 input voltage transition level */
+} TWI_INPUTLVL_t;
+
+/* Command select */
+typedef enum TWI_MCMD_enum
+{
+    TWI_MCMD_NOACT_gc = (0x00<<0),  /* No action */
+    TWI_MCMD_REPSTART_gc = (0x01<<0),  /* Execute Acknowledge Action followed by repeated Start. */
+    TWI_MCMD_RECVTRANS_gc = (0x02<<0),  /* Execute Acknowledge Action followed by a byte read/write operation. Read/write is defined by DIR. */
+    TWI_MCMD_STOP_gc = (0x03<<0)  /* Execute Acknowledge Action followed by issuing a Stop condition. */
+} TWI_MCMD_t;
+
+/* Command select */
+typedef enum TWI_SCMD_enum
+{
+    TWI_SCMD_NOACT_gc = (0x00<<0),  /* No Action */
+    TWI_SCMD_COMPTRANS_gc = (0x02<<0),  /* Complete transaction */
+    TWI_SCMD_RESPONSE_gc = (0x03<<0)  /* Used in response to an interrupt */
+} TWI_SCMD_t;
+
+/* SDA Hold Time select */
+typedef enum TWI_SDAHOLD_enum
+{
+    TWI_SDAHOLD_OFF_gc = (0x00<<2),  /* No SDA Hold Delay */
+    TWI_SDAHOLD_50NS_gc = (0x01<<2),  /* Short SDA hold time */
+    TWI_SDAHOLD_300NS_gc = (0x02<<2),  /* Meets SMBUS 2.0 specification under typical conditions */
+    TWI_SDAHOLD_500NS_gc = (0x03<<2)  /* Meets SMBUS 2.0 specificaiton across all corners */
+} TWI_SDAHOLD_t;
+
+/* SDA Setup Time select */
+typedef enum TWI_SDASETUP_enum
+{
+    TWI_SDASETUP_4CYC_gc = (0x00<<4),  /* SDA setup time is four clock cycles */
+    TWI_SDASETUP_8CYC_gc = (0x01<<4)  /* SDA setup time is eight clock cycle */
+} TWI_SDASETUP_t;
+
+/* Inactive Bus Time-Out select */
+typedef enum TWI_TIMEOUT_enum
+{
+    TWI_TIMEOUT_DISABLED_gc = (0x00<<2),  /* Bus time-out disabled. I2C. */
+    TWI_TIMEOUT_50US_gc = (0x01<<2),  /* 50us - SMBus */
+    TWI_TIMEOUT_100US_gc = (0x02<<2),  /* 100us */
+    TWI_TIMEOUT_200US_gc = (0x03<<2)  /* 200us */
+} TWI_TIMEOUT_t;
+
+/*
+--------------------------------------------------------------------------
+USART - Universal Synchronous and Asynchronous Receiver and Transmitter
+--------------------------------------------------------------------------
+*/
+
+/* Universal Synchronous and Asynchronous Receiver and Transmitter */
+typedef struct USART_struct
+{
+    register8_t RXDATAL;  /* Receive Data Low Byte */
+    register8_t RXDATAH;  /* Receive Data High Byte */
+    register8_t TXDATAL;  /* Transmit Data Low Byte */
+    register8_t TXDATAH;  /* Transmit Data High Byte */
+    register8_t STATUS;  /* Status */
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    _WORDREGISTER(BAUD);  /* Baud Rate */
+    register8_t CTRLD;  /* Control D */
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t EVCTRL;  /* Event Control */
+    register8_t TXPLCTRL;  /* IRCOM Transmitter Pulse Length Control */
+    register8_t RXPLCTRL;  /* IRCOM Receiver Pulse Length Control */
+    register8_t reserved_1[1];
+} USART_t;
+
+/* Auto Baud Window select */
+typedef enum USART_ABW_enum
+{
+    USART_ABW_WDW0_gc = (0x00<<6),  /* 18% tolerance */
+    USART_ABW_WDW1_gc = (0x01<<6),  /* 15% tolerance */
+    USART_ABW_WDW2_gc = (0x02<<6),  /* 21% tolerance */
+    USART_ABW_WDW3_gc = (0x03<<6)  /* 25% tolerance */
+} USART_ABW_t;
+
+/* Character Size select */
+typedef enum USART_CHSIZE_enum
+{
+    USART_CHSIZE_5BIT_gc = (0x00<<0),  /* Character size: 5 bit */
+    USART_CHSIZE_6BIT_gc = (0x01<<0),  /* Character size: 6 bit */
+    USART_CHSIZE_7BIT_gc = (0x02<<0),  /* Character size: 7 bit */
+    USART_CHSIZE_8BIT_gc = (0x03<<0),  /* Character size: 8 bit */
+    USART_CHSIZE_9BITL_gc = (0x06<<0),  /* Character size: 9 bit read low byte first */
+    USART_CHSIZE_9BITH_gc = (0x07<<0)  /* Character size: 9 bit read high byte first */
+} USART_CHSIZE_t;
+
+/* Communication Mode select */
+typedef enum USART_CMODE_enum
+{
+    USART_CMODE_ASYNCHRONOUS_gc = (0x00<<6),  /* Asynchronous Mode */
+    USART_CMODE_SYNCHRONOUS_gc = (0x01<<6),  /* Synchronous Mode */
+    USART_CMODE_IRCOM_gc = (0x02<<6),  /* Infrared Communication */
+    USART_CMODE_MSPI_gc = (0x03<<6)  /* SPI Host Mode */
+} USART_CMODE_t;
+
+/* Parity Mode select */
+typedef enum USART_PMODE_enum
+{
+    USART_PMODE_DISABLED_gc = (0x00<<4),  /* No Parity */
+    USART_PMODE_EVEN_gc = (0x02<<4),  /* Even Parity */
+    USART_PMODE_ODD_gc = (0x03<<4)  /* Odd Parity */
+} USART_PMODE_t;
+
+/* RS485 Mode internal transmitter select */
+typedef enum USART_RS485_enum
+{
+    USART_RS485_DISABLE_gc = (0x00<<0),  /* RS485 Mode disabled */
+    USART_RS485_ENABLE_gc = (0x01<<0)  /* RS485 Mode enabled */
+} USART_RS485_t;
+
+/* Receiver Mode select */
+typedef enum USART_RXMODE_enum
+{
+    USART_RXMODE_NORMAL_gc = (0x00<<1),  /* Normal mode */
+    USART_RXMODE_CLK2X_gc = (0x01<<1),  /* CLK2x mode */
+    USART_RXMODE_GENAUTO_gc = (0x02<<1),  /* Generic autobaud mode */
+    USART_RXMODE_LINAUTO_gc = (0x03<<1)  /* LIN constrained autobaud mode */
+} USART_RXMODE_t;
+
+/* Stop Bit Mode select */
+typedef enum USART_SBMODE_enum
+{
+    USART_SBMODE_1BIT_gc = (0x00<<3),  /* 1 stop bit */
+    USART_SBMODE_2BIT_gc = (0x01<<3)  /* 2 stop bits */
+} USART_SBMODE_t;
+
+/*
+--------------------------------------------------------------------------
+USERROW - User Row
+--------------------------------------------------------------------------
+*/
+
+/* User Row */
+typedef struct USERROW_struct
+{
+    register8_t USERROW0;  /* User Row Byte 0 */
+    register8_t USERROW1;  /* User Row Byte 1 */
+    register8_t USERROW2;  /* User Row Byte 2 */
+    register8_t USERROW3;  /* User Row Byte 3 */
+    register8_t USERROW4;  /* User Row Byte 4 */
+    register8_t USERROW5;  /* User Row Byte 5 */
+    register8_t USERROW6;  /* User Row Byte 6 */
+    register8_t USERROW7;  /* User Row Byte 7 */
+    register8_t USERROW8;  /* User Row Byte 8 */
+    register8_t USERROW9;  /* User Row Byte 9 */
+    register8_t USERROW10;  /* User Row Byte 10 */
+    register8_t USERROW11;  /* User Row Byte 11 */
+    register8_t USERROW12;  /* User Row Byte 12 */
+    register8_t USERROW13;  /* User Row Byte 13 */
+    register8_t USERROW14;  /* User Row Byte 14 */
+    register8_t USERROW15;  /* User Row Byte 15 */
+    register8_t USERROW16;  /* User Row Byte 16 */
+    register8_t USERROW17;  /* User Row Byte 17 */
+    register8_t USERROW18;  /* User Row Byte 18 */
+    register8_t USERROW19;  /* User Row Byte 19 */
+    register8_t USERROW20;  /* User Row Byte 20 */
+    register8_t USERROW21;  /* User Row Byte 21 */
+    register8_t USERROW22;  /* User Row Byte 22 */
+    register8_t USERROW23;  /* User Row Byte 23 */
+    register8_t USERROW24;  /* User Row Byte 24 */
+    register8_t USERROW25;  /* User Row Byte 25 */
+    register8_t USERROW26;  /* User Row Byte 26 */
+    register8_t USERROW27;  /* User Row Byte 27 */
+    register8_t USERROW28;  /* User Row Byte 28 */
+    register8_t USERROW29;  /* User Row Byte 29 */
+    register8_t USERROW30;  /* User Row Byte 30 */
+    register8_t USERROW31;  /* User Row Byte 31 */
+    register8_t USERROW32;  /* User Row Byte 32 */
+    register8_t USERROW33;  /* User Row Byte 33 */
+    register8_t USERROW34;  /* User Row Byte 34 */
+    register8_t USERROW35;  /* User Row Byte 35 */
+    register8_t USERROW36;  /* User Row Byte 36 */
+    register8_t USERROW37;  /* User Row Byte 37 */
+    register8_t USERROW38;  /* User Row Byte 38 */
+    register8_t USERROW39;  /* User Row Byte 39 */
+    register8_t USERROW40;  /* User Row Byte 40 */
+    register8_t USERROW41;  /* User Row Byte 41 */
+    register8_t USERROW42;  /* User Row Byte 42 */
+    register8_t USERROW43;  /* User Row Byte 43 */
+    register8_t USERROW44;  /* User Row Byte 44 */
+    register8_t USERROW45;  /* User Row Byte 45 */
+    register8_t USERROW46;  /* User Row Byte 46 */
+    register8_t USERROW47;  /* User Row Byte 47 */
+    register8_t USERROW48;  /* User Row Byte 48 */
+    register8_t USERROW49;  /* User Row Byte 49 */
+    register8_t USERROW50;  /* User Row Byte 50 */
+    register8_t USERROW51;  /* User Row Byte 51 */
+    register8_t USERROW52;  /* User Row Byte 52 */
+    register8_t USERROW53;  /* User Row Byte 53 */
+    register8_t USERROW54;  /* User Row Byte 54 */
+    register8_t USERROW55;  /* User Row Byte 55 */
+    register8_t USERROW56;  /* User Row Byte 56 */
+    register8_t USERROW57;  /* User Row Byte 57 */
+    register8_t USERROW58;  /* User Row Byte 58 */
+    register8_t USERROW59;  /* User Row Byte 59 */
+    register8_t USERROW60;  /* User Row Byte 60 */
+    register8_t USERROW61;  /* User Row Byte 61 */
+    register8_t USERROW62;  /* User Row Byte 62 */
+    register8_t USERROW63;  /* User Row Byte 63 */
+} USERROW_t;
+
+
+/*
+--------------------------------------------------------------------------
+VPORT - Virtual Ports
+--------------------------------------------------------------------------
+*/
+
+/* Virtual Ports */
+typedef struct VPORT_struct
+{
+    register8_t DIR;  /* Data Direction */
+    register8_t OUT;  /* Output Value */
+    register8_t IN;  /* Input Value */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+} VPORT_t;
+
+
+/*
+--------------------------------------------------------------------------
+VREF - Voltage reference
+--------------------------------------------------------------------------
+*/
+
+/* Voltage reference */
+typedef struct VREF_struct
+{
+    register8_t reserved_1[2];
+    register8_t DAC0REF;  /* DAC0 Reference */
+    register8_t reserved_2[1];
+    register8_t ACREF;  /* AC Reference */
+} VREF_t;
+
+/* Reference select */
+typedef enum VREF_REFSEL_enum
+{
+    VREF_REFSEL_1V024_gc = (0x00<<0),  /* Internal 1.024V reference */
+    VREF_REFSEL_2V048_gc = (0x01<<0),  /* Internal 2.048V reference */
+    VREF_REFSEL_4V096_gc = (0x02<<0),  /* Internal 4.096V reference */
+    VREF_REFSEL_2V500_gc = (0x03<<0),  /* Internal 2.500V reference */
+    VREF_REFSEL_VDD_gc = (0x05<<0),  /* VDD as reference */
+    VREF_REFSEL_VREFA_gc = (0x06<<0)  /* External reference on VREFA pin */
+} VREF_REFSEL_t;
+
+/*
+--------------------------------------------------------------------------
+WDT - Watch-Dog Timer
+--------------------------------------------------------------------------
+*/
+
+/* Watch-Dog Timer */
+typedef struct WDT_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t STATUS;  /* Status */
+    register8_t reserved_1[14];
+} WDT_t;
+
+/* Period select */
+typedef enum WDT_PERIOD_enum
+{
+    WDT_PERIOD_OFF_gc = (0x00<<0),  /* Off */
+    WDT_PERIOD_8CLK_gc = (0x01<<0),  /* 8 cycles (8ms) */
+    WDT_PERIOD_16CLK_gc = (0x02<<0),  /* 16 cycles (16ms) */
+    WDT_PERIOD_32CLK_gc = (0x03<<0),  /* 32 cycles (32ms) */
+    WDT_PERIOD_64CLK_gc = (0x04<<0),  /* 64 cycles (64ms) */
+    WDT_PERIOD_128CLK_gc = (0x05<<0),  /* 128 cycles (0.128s) */
+    WDT_PERIOD_256CLK_gc = (0x06<<0),  /* 256 cycles (0.256s) */
+    WDT_PERIOD_512CLK_gc = (0x07<<0),  /* 512 cycles (0.512s) */
+    WDT_PERIOD_1KCLK_gc = (0x08<<0),  /* 1K cycles (1.0s) */
+    WDT_PERIOD_2KCLK_gc = (0x09<<0),  /* 2K cycles (2.0s) */
+    WDT_PERIOD_4KCLK_gc = (0x0A<<0),  /* 4K cycles (4.1s) */
+    WDT_PERIOD_8KCLK_gc = (0x0B<<0)  /* 8K cycles (8.2s) */
+} WDT_PERIOD_t;
+
+/* Window select */
+typedef enum WDT_WINDOW_enum
+{
+    WDT_WINDOW_OFF_gc = (0x00<<4),  /* Off */
+    WDT_WINDOW_8CLK_gc = (0x01<<4),  /* 8 cycles (8ms) */
+    WDT_WINDOW_16CLK_gc = (0x02<<4),  /* 16 cycles (16ms) */
+    WDT_WINDOW_32CLK_gc = (0x03<<4),  /* 32 cycles (32ms) */
+    WDT_WINDOW_64CLK_gc = (0x04<<4),  /* 64 cycles (64ms) */
+    WDT_WINDOW_128CLK_gc = (0x05<<4),  /* 128 cycles (0.128s) */
+    WDT_WINDOW_256CLK_gc = (0x06<<4),  /* 256 cycles (0.256s) */
+    WDT_WINDOW_512CLK_gc = (0x07<<4),  /* 512 cycles (0.512s) */
+    WDT_WINDOW_1KCLK_gc = (0x08<<4),  /* 1K cycles (1.0s) */
+    WDT_WINDOW_2KCLK_gc = (0x09<<4),  /* 2K cycles (2.0s) */
+    WDT_WINDOW_4KCLK_gc = (0x0A<<4),  /* 4K cycles (4.1s) */
+    WDT_WINDOW_8KCLK_gc = (0x0B<<4)  /* 8K cycles (8.2s) */
+} WDT_WINDOW_t;
+/*
+==========================================================================
+IO Module Instances. Mapped to memory.
+==========================================================================
+*/
+
+#define VPORTA              (*(VPORT_t *) 0x0000) /* Virtual Ports */
+#define VPORTB              (*(VPORT_t *) 0x0004) /* Virtual Ports */
+#define VPORTC              (*(VPORT_t *) 0x0008) /* Virtual Ports */
+#define VPORTD              (*(VPORT_t *) 0x000C) /* Virtual Ports */
+#define VPORTE              (*(VPORT_t *) 0x0010) /* Virtual Ports */
+#define VPORTF              (*(VPORT_t *) 0x0014) /* Virtual Ports */
+#define GPR                   (*(GPR_t *) 0x001C) /* General Purpose Registers */
+#define RSTCTRL           (*(RSTCTRL_t *) 0x0040) /* Reset controller */
+#define SLPCTRL           (*(SLPCTRL_t *) 0x0050) /* Sleep Controller */
+#define CLKCTRL           (*(CLKCTRL_t *) 0x0060) /* Clock controller */
+#define BOD                   (*(BOD_t *) 0x00A0) /* Bod interface */
+#define VREF                 (*(VREF_t *) 0x00B0) /* Voltage reference */
+#define WDT                   (*(WDT_t *) 0x0100) /* Watch-Dog Timer */
+#define CPUINT             (*(CPUINT_t *) 0x0110) /* Interrupt Controller */
+#define CRCSCAN           (*(CRCSCAN_t *) 0x0120) /* CRCSCAN */
+#define RTC                   (*(RTC_t *) 0x0140) /* Real-Time Counter */
+#define CCL                   (*(CCL_t *) 0x01C0) /* Configurable Custom Logic */
+#define EVSYS               (*(EVSYS_t *) 0x0200) /* Event System */
+#define PORTA                (*(PORT_t *) 0x0400) /* I/O Ports */
+#define PORTB                (*(PORT_t *) 0x0420) /* I/O Ports */
+#define PORTC                (*(PORT_t *) 0x0440) /* I/O Ports */
+#define PORTD                (*(PORT_t *) 0x0460) /* I/O Ports */
+#define PORTE                (*(PORT_t *) 0x0480) /* I/O Ports */
+#define PORTF                (*(PORT_t *) 0x04A0) /* I/O Ports */
+#define PORTMUX           (*(PORTMUX_t *) 0x05E0) /* Port Multiplexer */
+#define ADC0                  (*(ADC_t *) 0x0600) /* Analog to Digital Converter */
+#define AC0                    (*(AC_t *) 0x0680) /* Analog Comparator */
+#define AC1                    (*(AC_t *) 0x0688) /* Analog Comparator */
+#define DAC0                  (*(DAC_t *) 0x06A0) /* Digital to Analog Converter */
+#define USART0              (*(USART_t *) 0x0800) /* Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define USART1              (*(USART_t *) 0x0820) /* Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define USART2              (*(USART_t *) 0x0840) /* Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define TWI0                  (*(TWI_t *) 0x0900) /* Two-Wire Interface */
+#define SPI0                  (*(SPI_t *) 0x0940) /* Serial Peripheral Interface */
+#define TCA0                  (*(TCA_t *) 0x0A00) /* 16-bit Timer/Counter Type A */
+#define TCA1                  (*(TCA_t *) 0x0A40) /* 16-bit Timer/Counter Type A */
+#define TCB0                  (*(TCB_t *) 0x0B00) /* 16-bit Timer Type B */
+#define TCB1                  (*(TCB_t *) 0x0B10) /* 16-bit Timer Type B */
+#define TCB2                  (*(TCB_t *) 0x0B20) /* 16-bit Timer Type B */
+#define TCB3                  (*(TCB_t *) 0x0B30) /* 16-bit Timer Type B */
+#define SYSCFG             (*(SYSCFG_t *) 0x0F00) /* System Configuration Registers */
+#define NVMCTRL           (*(NVMCTRL_t *) 0x1000) /* Non-volatile Memory Controller */
+#define LOCK                 (*(LOCK_t *) 0x1040) /* Lockbits */
+#define FUSE                 (*(FUSE_t *) 0x1050) /* Fuses */
+#define USERROW           (*(USERROW_t *) 0x1080) /* User Row */
+#define SIGROW             (*(SIGROW_t *) 0x1100) /* Signature row */
+
+#endif /* !defined (__ASSEMBLER__) */
+
+
+/* ========== Flattened fully qualified IO register names ========== */
+
+
+/* VPORT (VPORTA) - Virtual Ports */
+#define VPORTA_DIR  _SFR_MEM8(0x0000)
+#define VPORTA_OUT  _SFR_MEM8(0x0001)
+#define VPORTA_IN  _SFR_MEM8(0x0002)
+#define VPORTA_INTFLAGS  _SFR_MEM8(0x0003)
+
+
+/* VPORT (VPORTB) - Virtual Ports */
+#define VPORTB_DIR  _SFR_MEM8(0x0004)
+#define VPORTB_OUT  _SFR_MEM8(0x0005)
+#define VPORTB_IN  _SFR_MEM8(0x0006)
+#define VPORTB_INTFLAGS  _SFR_MEM8(0x0007)
+
+
+/* VPORT (VPORTC) - Virtual Ports */
+#define VPORTC_DIR  _SFR_MEM8(0x0008)
+#define VPORTC_OUT  _SFR_MEM8(0x0009)
+#define VPORTC_IN  _SFR_MEM8(0x000A)
+#define VPORTC_INTFLAGS  _SFR_MEM8(0x000B)
+
+
+/* VPORT (VPORTD) - Virtual Ports */
+#define VPORTD_DIR  _SFR_MEM8(0x000C)
+#define VPORTD_OUT  _SFR_MEM8(0x000D)
+#define VPORTD_IN  _SFR_MEM8(0x000E)
+#define VPORTD_INTFLAGS  _SFR_MEM8(0x000F)
+
+
+/* VPORT (VPORTE) - Virtual Ports */
+#define VPORTE_DIR  _SFR_MEM8(0x0010)
+#define VPORTE_OUT  _SFR_MEM8(0x0011)
+#define VPORTE_IN  _SFR_MEM8(0x0012)
+#define VPORTE_INTFLAGS  _SFR_MEM8(0x0013)
+
+
+/* VPORT (VPORTF) - Virtual Ports */
+#define VPORTF_DIR  _SFR_MEM8(0x0014)
+#define VPORTF_OUT  _SFR_MEM8(0x0015)
+#define VPORTF_IN  _SFR_MEM8(0x0016)
+#define VPORTF_INTFLAGS  _SFR_MEM8(0x0017)
+
+
+/* GPR - General Purpose Registers */
+#define GPR_GPR0  _SFR_MEM8(0x001C)
+#define GPR_GPR1  _SFR_MEM8(0x001D)
+#define GPR_GPR2  _SFR_MEM8(0x001E)
+#define GPR_GPR3  _SFR_MEM8(0x001F)
+
+
+/* CPU - CPU */
+#define CPU_CCP  _SFR_MEM8(0x0034)
+#define CPU_SP  _SFR_MEM16(0x003D)
+#define CPU_SPL  _SFR_MEM8(0x003D)
+#define CPU_SPH  _SFR_MEM8(0x003E)
+#define CPU_SREG  _SFR_MEM8(0x003F)
+
+
+/* RSTCTRL - Reset controller */
+#define RSTCTRL_RSTFR  _SFR_MEM8(0x0040)
+#define RSTCTRL_SWRR  _SFR_MEM8(0x0041)
+
+
+/* SLPCTRL - Sleep Controller */
+#define SLPCTRL_CTRLA  _SFR_MEM8(0x0050)
+
+
+/* CLKCTRL - Clock controller */
+#define CLKCTRL_MCLKCTRLA  _SFR_MEM8(0x0060)
+#define CLKCTRL_MCLKCTRLB  _SFR_MEM8(0x0061)
+#define CLKCTRL_MCLKCTRLC  _SFR_MEM8(0x0062)
+#define CLKCTRL_MCLKINTCTRL  _SFR_MEM8(0x0063)
+#define CLKCTRL_MCLKINTFLAGS  _SFR_MEM8(0x0064)
+#define CLKCTRL_MCLKSTATUS  _SFR_MEM8(0x0065)
+#define CLKCTRL_MCLKTIMEBASE  _SFR_MEM8(0x0066)
+#define CLKCTRL_OSCHFCTRLA  _SFR_MEM8(0x0068)
+#define CLKCTRL_OSCHFTUNE  _SFR_MEM8(0x0069)
+#define CLKCTRL_OSC32KCTRLA  _SFR_MEM8(0x0078)
+#define CLKCTRL_XOSC32KCTRLA  _SFR_MEM8(0x007C)
+#define CLKCTRL_XOSCHFCTRLA  _SFR_MEM8(0x0080)
+
+
+/* BOD - Bod interface */
+#define BOD_CTRLA  _SFR_MEM8(0x00A0)
+#define BOD_CTRLB  _SFR_MEM8(0x00A1)
+#define BOD_VLMCTRLA  _SFR_MEM8(0x00A8)
+#define BOD_INTCTRL  _SFR_MEM8(0x00A9)
+#define BOD_INTFLAGS  _SFR_MEM8(0x00AA)
+#define BOD_STATUS  _SFR_MEM8(0x00AB)
+
+
+/* VREF - Voltage reference */
+#define VREF_DAC0REF  _SFR_MEM8(0x00B2)
+#define VREF_ACREF  _SFR_MEM8(0x00B4)
+
+
+/* WDT - Watch-Dog Timer */
+#define WDT_CTRLA  _SFR_MEM8(0x0100)
+#define WDT_STATUS  _SFR_MEM8(0x0101)
+
+
+/* CPUINT - Interrupt Controller */
+#define CPUINT_CTRLA  _SFR_MEM8(0x0110)
+#define CPUINT_STATUS  _SFR_MEM8(0x0111)
+#define CPUINT_LVL0PRI  _SFR_MEM8(0x0112)
+#define CPUINT_LVL1VEC  _SFR_MEM8(0x0113)
+
+
+/* CRCSCAN - CRCSCAN */
+#define CRCSCAN_CTRLA  _SFR_MEM8(0x0120)
+#define CRCSCAN_CTRLB  _SFR_MEM8(0x0121)
+#define CRCSCAN_STATUS  _SFR_MEM8(0x0122)
+
+
+/* RTC - Real-Time Counter */
+#define RTC_CTRLA  _SFR_MEM8(0x0140)
+#define RTC_STATUS  _SFR_MEM8(0x0141)
+#define RTC_INTCTRL  _SFR_MEM8(0x0142)
+#define RTC_INTFLAGS  _SFR_MEM8(0x0143)
+#define RTC_TEMP  _SFR_MEM8(0x0144)
+#define RTC_DBGCTRL  _SFR_MEM8(0x0145)
+#define RTC_CALIB  _SFR_MEM8(0x0146)
+#define RTC_CLKSEL  _SFR_MEM8(0x0147)
+#define RTC_CNT  _SFR_MEM16(0x0148)
+#define RTC_CNTL  _SFR_MEM8(0x0148)
+#define RTC_CNTH  _SFR_MEM8(0x0149)
+#define RTC_PER  _SFR_MEM16(0x014A)
+#define RTC_PERL  _SFR_MEM8(0x014A)
+#define RTC_PERH  _SFR_MEM8(0x014B)
+#define RTC_CMP  _SFR_MEM16(0x014C)
+#define RTC_CMPL  _SFR_MEM8(0x014C)
+#define RTC_CMPH  _SFR_MEM8(0x014D)
+#define RTC_PITCTRLA  _SFR_MEM8(0x0150)
+#define RTC_PITSTATUS  _SFR_MEM8(0x0151)
+#define RTC_PITINTCTRL  _SFR_MEM8(0x0152)
+#define RTC_PITINTFLAGS  _SFR_MEM8(0x0153)
+#define RTC_PITDBGCTRL  _SFR_MEM8(0x0155)
+#define RTC_PITEVGENCTRLA  _SFR_MEM8(0x0156)
+
+
+/* CCL - Configurable Custom Logic */
+#define CCL_CTRLA  _SFR_MEM8(0x01C0)
+#define CCL_SEQCTRL0  _SFR_MEM8(0x01C1)
+#define CCL_SEQCTRL1  _SFR_MEM8(0x01C2)
+#define CCL_INTCTRL0  _SFR_MEM8(0x01C5)
+#define CCL_INTFLAGS  _SFR_MEM8(0x01C7)
+#define CCL_LUT0CTRLA  _SFR_MEM8(0x01C8)
+#define CCL_LUT0CTRLB  _SFR_MEM8(0x01C9)
+#define CCL_LUT0CTRLC  _SFR_MEM8(0x01CA)
+#define CCL_TRUTH0  _SFR_MEM8(0x01CB)
+#define CCL_LUT1CTRLA  _SFR_MEM8(0x01CC)
+#define CCL_LUT1CTRLB  _SFR_MEM8(0x01CD)
+#define CCL_LUT1CTRLC  _SFR_MEM8(0x01CE)
+#define CCL_TRUTH1  _SFR_MEM8(0x01CF)
+#define CCL_LUT2CTRLA  _SFR_MEM8(0x01D0)
+#define CCL_LUT2CTRLB  _SFR_MEM8(0x01D1)
+#define CCL_LUT2CTRLC  _SFR_MEM8(0x01D2)
+#define CCL_TRUTH2  _SFR_MEM8(0x01D3)
+#define CCL_LUT3CTRLA  _SFR_MEM8(0x01D4)
+#define CCL_LUT3CTRLB  _SFR_MEM8(0x01D5)
+#define CCL_LUT3CTRLC  _SFR_MEM8(0x01D6)
+#define CCL_TRUTH3  _SFR_MEM8(0x01D7)
+
+
+/* EVSYS - Event System */
+#define EVSYS_SWEVENTA  _SFR_MEM8(0x0200)
+#define EVSYS_CHANNEL0  _SFR_MEM8(0x0210)
+#define EVSYS_CHANNEL1  _SFR_MEM8(0x0211)
+#define EVSYS_CHANNEL2  _SFR_MEM8(0x0212)
+#define EVSYS_CHANNEL3  _SFR_MEM8(0x0213)
+#define EVSYS_CHANNEL4  _SFR_MEM8(0x0214)
+#define EVSYS_CHANNEL5  _SFR_MEM8(0x0215)
+#define EVSYS_USERCCLLUT0A  _SFR_MEM8(0x0220)
+#define EVSYS_USERCCLLUT0B  _SFR_MEM8(0x0221)
+#define EVSYS_USERCCLLUT1A  _SFR_MEM8(0x0222)
+#define EVSYS_USERCCLLUT1B  _SFR_MEM8(0x0223)
+#define EVSYS_USERCCLLUT2A  _SFR_MEM8(0x0224)
+#define EVSYS_USERCCLLUT2B  _SFR_MEM8(0x0225)
+#define EVSYS_USERCCLLUT3A  _SFR_MEM8(0x0226)
+#define EVSYS_USERCCLLUT3B  _SFR_MEM8(0x0227)
+#define EVSYS_USERADC0START  _SFR_MEM8(0x0228)
+#define EVSYS_USEREVSYSEVOUTA  _SFR_MEM8(0x0229)
+#define EVSYS_USEREVSYSEVOUTB  _SFR_MEM8(0x022A)
+#define EVSYS_USEREVSYSEVOUTC  _SFR_MEM8(0x022B)
+#define EVSYS_USEREVSYSEVOUTD  _SFR_MEM8(0x022C)
+#define EVSYS_USEREVSYSEVOUTE  _SFR_MEM8(0x022D)
+#define EVSYS_USEREVSYSEVOUTF  _SFR_MEM8(0x022E)
+#define EVSYS_USERUSART0IRDA  _SFR_MEM8(0x022F)
+#define EVSYS_USERUSART1IRDA  _SFR_MEM8(0x0230)
+#define EVSYS_USERUSART2IRDA  _SFR_MEM8(0x0231)
+#define EVSYS_USERTCA0CNTA  _SFR_MEM8(0x0232)
+#define EVSYS_USERTCA0CNTB  _SFR_MEM8(0x0233)
+#define EVSYS_USERTCA1CNTA  _SFR_MEM8(0x0234)
+#define EVSYS_USERTCA1CNTB  _SFR_MEM8(0x0235)
+#define EVSYS_USERTCB0CAPT  _SFR_MEM8(0x0236)
+#define EVSYS_USERTCB0COUNT  _SFR_MEM8(0x0237)
+#define EVSYS_USERTCB1CAPT  _SFR_MEM8(0x0238)
+#define EVSYS_USERTCB1COUNT  _SFR_MEM8(0x0239)
+#define EVSYS_USERTCB2CAPT  _SFR_MEM8(0x023A)
+#define EVSYS_USERTCB2COUNT  _SFR_MEM8(0x023B)
+#define EVSYS_USERTCB3CAPT  _SFR_MEM8(0x023C)
+#define EVSYS_USERTCB3COUNT  _SFR_MEM8(0x023D)
+
+
+/* PORT (PORTA) - I/O Ports */
+#define PORTA_DIR  _SFR_MEM8(0x0400)
+#define PORTA_DIRSET  _SFR_MEM8(0x0401)
+#define PORTA_DIRCLR  _SFR_MEM8(0x0402)
+#define PORTA_DIRTGL  _SFR_MEM8(0x0403)
+#define PORTA_OUT  _SFR_MEM8(0x0404)
+#define PORTA_OUTSET  _SFR_MEM8(0x0405)
+#define PORTA_OUTCLR  _SFR_MEM8(0x0406)
+#define PORTA_OUTTGL  _SFR_MEM8(0x0407)
+#define PORTA_IN  _SFR_MEM8(0x0408)
+#define PORTA_INTFLAGS  _SFR_MEM8(0x0409)
+#define PORTA_PORTCTRL  _SFR_MEM8(0x040A)
+#define PORTA_PINCONFIG  _SFR_MEM8(0x040B)
+#define PORTA_PINCTRLUPD  _SFR_MEM8(0x040C)
+#define PORTA_PINCTRLSET  _SFR_MEM8(0x040D)
+#define PORTA_PINCTRLCLR  _SFR_MEM8(0x040E)
+#define PORTA_PIN0CTRL  _SFR_MEM8(0x0410)
+#define PORTA_PIN1CTRL  _SFR_MEM8(0x0411)
+#define PORTA_PIN2CTRL  _SFR_MEM8(0x0412)
+#define PORTA_PIN3CTRL  _SFR_MEM8(0x0413)
+#define PORTA_PIN4CTRL  _SFR_MEM8(0x0414)
+#define PORTA_PIN5CTRL  _SFR_MEM8(0x0415)
+#define PORTA_PIN6CTRL  _SFR_MEM8(0x0416)
+#define PORTA_PIN7CTRL  _SFR_MEM8(0x0417)
+#define PORTA_EVGENCTRL  _SFR_MEM8(0x0418)
+
+
+/* PORT (PORTB) - I/O Ports */
+#define PORTB_DIR  _SFR_MEM8(0x0420)
+#define PORTB_DIRSET  _SFR_MEM8(0x0421)
+#define PORTB_DIRCLR  _SFR_MEM8(0x0422)
+#define PORTB_DIRTGL  _SFR_MEM8(0x0423)
+#define PORTB_OUT  _SFR_MEM8(0x0424)
+#define PORTB_OUTSET  _SFR_MEM8(0x0425)
+#define PORTB_OUTCLR  _SFR_MEM8(0x0426)
+#define PORTB_OUTTGL  _SFR_MEM8(0x0427)
+#define PORTB_IN  _SFR_MEM8(0x0428)
+#define PORTB_INTFLAGS  _SFR_MEM8(0x0429)
+#define PORTB_PORTCTRL  _SFR_MEM8(0x042A)
+#define PORTB_PINCONFIG  _SFR_MEM8(0x042B)
+#define PORTB_PINCTRLUPD  _SFR_MEM8(0x042C)
+#define PORTB_PINCTRLSET  _SFR_MEM8(0x042D)
+#define PORTB_PINCTRLCLR  _SFR_MEM8(0x042E)
+#define PORTB_PIN0CTRL  _SFR_MEM8(0x0430)
+#define PORTB_PIN1CTRL  _SFR_MEM8(0x0431)
+#define PORTB_PIN2CTRL  _SFR_MEM8(0x0432)
+#define PORTB_PIN3CTRL  _SFR_MEM8(0x0433)
+#define PORTB_PIN4CTRL  _SFR_MEM8(0x0434)
+#define PORTB_PIN5CTRL  _SFR_MEM8(0x0435)
+#define PORTB_PIN6CTRL  _SFR_MEM8(0x0436)
+#define PORTB_PIN7CTRL  _SFR_MEM8(0x0437)
+#define PORTB_EVGENCTRL  _SFR_MEM8(0x0438)
+
+
+/* PORT (PORTC) - I/O Ports */
+#define PORTC_DIR  _SFR_MEM8(0x0440)
+#define PORTC_DIRSET  _SFR_MEM8(0x0441)
+#define PORTC_DIRCLR  _SFR_MEM8(0x0442)
+#define PORTC_DIRTGL  _SFR_MEM8(0x0443)
+#define PORTC_OUT  _SFR_MEM8(0x0444)
+#define PORTC_OUTSET  _SFR_MEM8(0x0445)
+#define PORTC_OUTCLR  _SFR_MEM8(0x0446)
+#define PORTC_OUTTGL  _SFR_MEM8(0x0447)
+#define PORTC_IN  _SFR_MEM8(0x0448)
+#define PORTC_INTFLAGS  _SFR_MEM8(0x0449)
+#define PORTC_PORTCTRL  _SFR_MEM8(0x044A)
+#define PORTC_PINCONFIG  _SFR_MEM8(0x044B)
+#define PORTC_PINCTRLUPD  _SFR_MEM8(0x044C)
+#define PORTC_PINCTRLSET  _SFR_MEM8(0x044D)
+#define PORTC_PINCTRLCLR  _SFR_MEM8(0x044E)
+#define PORTC_PIN0CTRL  _SFR_MEM8(0x0450)
+#define PORTC_PIN1CTRL  _SFR_MEM8(0x0451)
+#define PORTC_PIN2CTRL  _SFR_MEM8(0x0452)
+#define PORTC_PIN3CTRL  _SFR_MEM8(0x0453)
+#define PORTC_PIN4CTRL  _SFR_MEM8(0x0454)
+#define PORTC_PIN5CTRL  _SFR_MEM8(0x0455)
+#define PORTC_PIN6CTRL  _SFR_MEM8(0x0456)
+#define PORTC_PIN7CTRL  _SFR_MEM8(0x0457)
+#define PORTC_EVGENCTRL  _SFR_MEM8(0x0458)
+
+
+/* PORT (PORTD) - I/O Ports */
+#define PORTD_DIR  _SFR_MEM8(0x0460)
+#define PORTD_DIRSET  _SFR_MEM8(0x0461)
+#define PORTD_DIRCLR  _SFR_MEM8(0x0462)
+#define PORTD_DIRTGL  _SFR_MEM8(0x0463)
+#define PORTD_OUT  _SFR_MEM8(0x0464)
+#define PORTD_OUTSET  _SFR_MEM8(0x0465)
+#define PORTD_OUTCLR  _SFR_MEM8(0x0466)
+#define PORTD_OUTTGL  _SFR_MEM8(0x0467)
+#define PORTD_IN  _SFR_MEM8(0x0468)
+#define PORTD_INTFLAGS  _SFR_MEM8(0x0469)
+#define PORTD_PORTCTRL  _SFR_MEM8(0x046A)
+#define PORTD_PINCONFIG  _SFR_MEM8(0x046B)
+#define PORTD_PINCTRLUPD  _SFR_MEM8(0x046C)
+#define PORTD_PINCTRLSET  _SFR_MEM8(0x046D)
+#define PORTD_PINCTRLCLR  _SFR_MEM8(0x046E)
+#define PORTD_PIN0CTRL  _SFR_MEM8(0x0470)
+#define PORTD_PIN1CTRL  _SFR_MEM8(0x0471)
+#define PORTD_PIN2CTRL  _SFR_MEM8(0x0472)
+#define PORTD_PIN3CTRL  _SFR_MEM8(0x0473)
+#define PORTD_PIN4CTRL  _SFR_MEM8(0x0474)
+#define PORTD_PIN5CTRL  _SFR_MEM8(0x0475)
+#define PORTD_PIN6CTRL  _SFR_MEM8(0x0476)
+#define PORTD_PIN7CTRL  _SFR_MEM8(0x0477)
+#define PORTD_EVGENCTRL  _SFR_MEM8(0x0478)
+
+
+/* PORT (PORTE) - I/O Ports */
+#define PORTE_DIR  _SFR_MEM8(0x0480)
+#define PORTE_DIRSET  _SFR_MEM8(0x0481)
+#define PORTE_DIRCLR  _SFR_MEM8(0x0482)
+#define PORTE_DIRTGL  _SFR_MEM8(0x0483)
+#define PORTE_OUT  _SFR_MEM8(0x0484)
+#define PORTE_OUTSET  _SFR_MEM8(0x0485)
+#define PORTE_OUTCLR  _SFR_MEM8(0x0486)
+#define PORTE_OUTTGL  _SFR_MEM8(0x0487)
+#define PORTE_IN  _SFR_MEM8(0x0488)
+#define PORTE_INTFLAGS  _SFR_MEM8(0x0489)
+#define PORTE_PORTCTRL  _SFR_MEM8(0x048A)
+#define PORTE_PINCONFIG  _SFR_MEM8(0x048B)
+#define PORTE_PINCTRLUPD  _SFR_MEM8(0x048C)
+#define PORTE_PINCTRLSET  _SFR_MEM8(0x048D)
+#define PORTE_PINCTRLCLR  _SFR_MEM8(0x048E)
+#define PORTE_PIN0CTRL  _SFR_MEM8(0x0490)
+#define PORTE_PIN1CTRL  _SFR_MEM8(0x0491)
+#define PORTE_PIN2CTRL  _SFR_MEM8(0x0492)
+#define PORTE_PIN3CTRL  _SFR_MEM8(0x0493)
+#define PORTE_PIN4CTRL  _SFR_MEM8(0x0494)
+#define PORTE_PIN5CTRL  _SFR_MEM8(0x0495)
+#define PORTE_PIN6CTRL  _SFR_MEM8(0x0496)
+#define PORTE_PIN7CTRL  _SFR_MEM8(0x0497)
+#define PORTE_EVGENCTRL  _SFR_MEM8(0x0498)
+
+
+/* PORT (PORTF) - I/O Ports */
+#define PORTF_DIR  _SFR_MEM8(0x04A0)
+#define PORTF_DIRSET  _SFR_MEM8(0x04A1)
+#define PORTF_DIRCLR  _SFR_MEM8(0x04A2)
+#define PORTF_DIRTGL  _SFR_MEM8(0x04A3)
+#define PORTF_OUT  _SFR_MEM8(0x04A4)
+#define PORTF_OUTSET  _SFR_MEM8(0x04A5)
+#define PORTF_OUTCLR  _SFR_MEM8(0x04A6)
+#define PORTF_OUTTGL  _SFR_MEM8(0x04A7)
+#define PORTF_IN  _SFR_MEM8(0x04A8)
+#define PORTF_INTFLAGS  _SFR_MEM8(0x04A9)
+#define PORTF_PORTCTRL  _SFR_MEM8(0x04AA)
+#define PORTF_PINCONFIG  _SFR_MEM8(0x04AB)
+#define PORTF_PINCTRLUPD  _SFR_MEM8(0x04AC)
+#define PORTF_PINCTRLSET  _SFR_MEM8(0x04AD)
+#define PORTF_PINCTRLCLR  _SFR_MEM8(0x04AE)
+#define PORTF_PIN0CTRL  _SFR_MEM8(0x04B0)
+#define PORTF_PIN1CTRL  _SFR_MEM8(0x04B1)
+#define PORTF_PIN2CTRL  _SFR_MEM8(0x04B2)
+#define PORTF_PIN3CTRL  _SFR_MEM8(0x04B3)
+#define PORTF_PIN4CTRL  _SFR_MEM8(0x04B4)
+#define PORTF_PIN5CTRL  _SFR_MEM8(0x04B5)
+#define PORTF_PIN6CTRL  _SFR_MEM8(0x04B6)
+#define PORTF_PIN7CTRL  _SFR_MEM8(0x04B7)
+#define PORTF_EVGENCTRL  _SFR_MEM8(0x04B8)
+
+
+/* PORTMUX - Port Multiplexer */
+#define PORTMUX_EVSYSROUTEA  _SFR_MEM8(0x05E0)
+#define PORTMUX_CCLROUTEA  _SFR_MEM8(0x05E1)
+#define PORTMUX_USARTROUTEA  _SFR_MEM8(0x05E2)
+#define PORTMUX_USARTROUTEB  _SFR_MEM8(0x05E3)
+#define PORTMUX_SPIROUTEA  _SFR_MEM8(0x05E5)
+#define PORTMUX_TWIROUTEA  _SFR_MEM8(0x05E6)
+#define PORTMUX_TCAROUTEA  _SFR_MEM8(0x05E7)
+#define PORTMUX_TCBROUTEA  _SFR_MEM8(0x05E8)
+#define PORTMUX_ACROUTEA  _SFR_MEM8(0x05EA)
+
+
+/* ADC (ADC0) - Analog to Digital Converter */
+#define ADC0_CTRLA  _SFR_MEM8(0x0600)
+#define ADC0_CTRLB  _SFR_MEM8(0x0601)
+#define ADC0_CTRLC  _SFR_MEM8(0x0602)
+#define ADC0_CTRLD  _SFR_MEM8(0x0603)
+#define ADC0_INTCTRL  _SFR_MEM8(0x0604)
+#define ADC0_INTFLAGS  _SFR_MEM8(0x0605)
+#define ADC0_STATUS  _SFR_MEM8(0x0606)
+#define ADC0_DBGCTRL  _SFR_MEM8(0x0607)
+#define ADC0_CTRLE  _SFR_MEM8(0x0608)
+#define ADC0_CTRLF  _SFR_MEM8(0x0609)
+#define ADC0_COMMAND  _SFR_MEM8(0x060A)
+#define ADC0_PGACTRL  _SFR_MEM8(0x060B)
+#define ADC0_MUXPOS  _SFR_MEM8(0x060C)
+#define ADC0_MUXNEG  _SFR_MEM8(0x060D)
+#define ADC0_RESULT  _SFR_MEM32(0x0610)
+#define ADC0_RESULT0  _SFR_MEM8(0x0610)
+#define ADC0_RESULT1  _SFR_MEM8(0x0611)
+#define ADC0_RESULT2  _SFR_MEM8(0x0612)
+#define ADC0_RESULT3  _SFR_MEM8(0x0613)
+#define ADC0_SAMPLE  _SFR_MEM16(0x0614)
+#define ADC0_SAMPLEL  _SFR_MEM8(0x0614)
+#define ADC0_SAMPLEH  _SFR_MEM8(0x0615)
+#define ADC0_TEMP0  _SFR_MEM8(0x0618)
+#define ADC0_TEMP1  _SFR_MEM8(0x0619)
+#define ADC0_TEMP2  _SFR_MEM8(0x061A)
+#define ADC0_WINLT  _SFR_MEM16(0x061C)
+#define ADC0_WINLTL  _SFR_MEM8(0x061C)
+#define ADC0_WINLTH  _SFR_MEM8(0x061D)
+#define ADC0_WINHT  _SFR_MEM16(0x061E)
+#define ADC0_WINHTL  _SFR_MEM8(0x061E)
+#define ADC0_WINHTH  _SFR_MEM8(0x061F)
+
+
+/* AC (AC0) - Analog Comparator */
+#define AC0_CTRLA  _SFR_MEM8(0x0680)
+#define AC0_CTRLB  _SFR_MEM8(0x0681)
+#define AC0_MUXCTRL  _SFR_MEM8(0x0682)
+#define AC0_DACREF  _SFR_MEM8(0x0685)
+#define AC0_INTCTRL  _SFR_MEM8(0x0686)
+#define AC0_STATUS  _SFR_MEM8(0x0687)
+
+
+/* AC (AC1) - Analog Comparator */
+#define AC1_CTRLA  _SFR_MEM8(0x0688)
+#define AC1_CTRLB  _SFR_MEM8(0x0689)
+#define AC1_MUXCTRL  _SFR_MEM8(0x068A)
+#define AC1_DACREF  _SFR_MEM8(0x068D)
+#define AC1_INTCTRL  _SFR_MEM8(0x068E)
+#define AC1_STATUS  _SFR_MEM8(0x068F)
+
+
+/* DAC (DAC0) - Digital to Analog Converter */
+#define DAC0_CTRLA  _SFR_MEM8(0x06A0)
+#define DAC0_DATA  _SFR_MEM16(0x06A2)
+#define DAC0_DATAL  _SFR_MEM8(0x06A2)
+#define DAC0_DATAH  _SFR_MEM8(0x06A3)
+
+
+/* USART (USART0) - Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define USART0_RXDATAL  _SFR_MEM8(0x0800)
+#define USART0_RXDATAH  _SFR_MEM8(0x0801)
+#define USART0_TXDATAL  _SFR_MEM8(0x0802)
+#define USART0_TXDATAH  _SFR_MEM8(0x0803)
+#define USART0_STATUS  _SFR_MEM8(0x0804)
+#define USART0_CTRLA  _SFR_MEM8(0x0805)
+#define USART0_CTRLB  _SFR_MEM8(0x0806)
+#define USART0_CTRLC  _SFR_MEM8(0x0807)
+#define USART0_BAUD  _SFR_MEM16(0x0808)
+#define USART0_BAUDL  _SFR_MEM8(0x0808)
+#define USART0_BAUDH  _SFR_MEM8(0x0809)
+#define USART0_CTRLD  _SFR_MEM8(0x080A)
+#define USART0_DBGCTRL  _SFR_MEM8(0x080B)
+#define USART0_EVCTRL  _SFR_MEM8(0x080C)
+#define USART0_TXPLCTRL  _SFR_MEM8(0x080D)
+#define USART0_RXPLCTRL  _SFR_MEM8(0x080E)
+
+
+/* USART (USART1) - Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define USART1_RXDATAL  _SFR_MEM8(0x0820)
+#define USART1_RXDATAH  _SFR_MEM8(0x0821)
+#define USART1_TXDATAL  _SFR_MEM8(0x0822)
+#define USART1_TXDATAH  _SFR_MEM8(0x0823)
+#define USART1_STATUS  _SFR_MEM8(0x0824)
+#define USART1_CTRLA  _SFR_MEM8(0x0825)
+#define USART1_CTRLB  _SFR_MEM8(0x0826)
+#define USART1_CTRLC  _SFR_MEM8(0x0827)
+#define USART1_BAUD  _SFR_MEM16(0x0828)
+#define USART1_BAUDL  _SFR_MEM8(0x0828)
+#define USART1_BAUDH  _SFR_MEM8(0x0829)
+#define USART1_CTRLD  _SFR_MEM8(0x082A)
+#define USART1_DBGCTRL  _SFR_MEM8(0x082B)
+#define USART1_EVCTRL  _SFR_MEM8(0x082C)
+#define USART1_TXPLCTRL  _SFR_MEM8(0x082D)
+#define USART1_RXPLCTRL  _SFR_MEM8(0x082E)
+
+
+/* USART (USART2) - Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define USART2_RXDATAL  _SFR_MEM8(0x0840)
+#define USART2_RXDATAH  _SFR_MEM8(0x0841)
+#define USART2_TXDATAL  _SFR_MEM8(0x0842)
+#define USART2_TXDATAH  _SFR_MEM8(0x0843)
+#define USART2_STATUS  _SFR_MEM8(0x0844)
+#define USART2_CTRLA  _SFR_MEM8(0x0845)
+#define USART2_CTRLB  _SFR_MEM8(0x0846)
+#define USART2_CTRLC  _SFR_MEM8(0x0847)
+#define USART2_BAUD  _SFR_MEM16(0x0848)
+#define USART2_BAUDL  _SFR_MEM8(0x0848)
+#define USART2_BAUDH  _SFR_MEM8(0x0849)
+#define USART2_CTRLD  _SFR_MEM8(0x084A)
+#define USART2_DBGCTRL  _SFR_MEM8(0x084B)
+#define USART2_EVCTRL  _SFR_MEM8(0x084C)
+#define USART2_TXPLCTRL  _SFR_MEM8(0x084D)
+#define USART2_RXPLCTRL  _SFR_MEM8(0x084E)
+
+
+/* TWI (TWI0) - Two-Wire Interface */
+#define TWI0_CTRLA  _SFR_MEM8(0x0900)
+#define TWI0_DUALCTRL  _SFR_MEM8(0x0901)
+#define TWI0_DBGCTRL  _SFR_MEM8(0x0902)
+#define TWI0_MCTRLA  _SFR_MEM8(0x0903)
+#define TWI0_MCTRLB  _SFR_MEM8(0x0904)
+#define TWI0_MSTATUS  _SFR_MEM8(0x0905)
+#define TWI0_MBAUD  _SFR_MEM8(0x0906)
+#define TWI0_MADDR  _SFR_MEM8(0x0907)
+#define TWI0_MDATA  _SFR_MEM8(0x0908)
+#define TWI0_SCTRLA  _SFR_MEM8(0x0909)
+#define TWI0_SCTRLB  _SFR_MEM8(0x090A)
+#define TWI0_SSTATUS  _SFR_MEM8(0x090B)
+#define TWI0_SADDR  _SFR_MEM8(0x090C)
+#define TWI0_SDATA  _SFR_MEM8(0x090D)
+#define TWI0_SADDRMASK  _SFR_MEM8(0x090E)
+
+
+/* SPI (SPI0) - Serial Peripheral Interface */
+#define SPI0_CTRLA  _SFR_MEM8(0x0940)
+#define SPI0_CTRLB  _SFR_MEM8(0x0941)
+#define SPI0_INTCTRL  _SFR_MEM8(0x0942)
+#define SPI0_INTFLAGS  _SFR_MEM8(0x0943)
+#define SPI0_DATA  _SFR_MEM8(0x0944)
+
+
+/* TCA (TCA0) - 16-bit Timer/Counter Type A - Single Mode */
+#define TCA0_SINGLE_CTRLA  _SFR_MEM8(0x0A00)
+#define TCA0_SINGLE_CTRLB  _SFR_MEM8(0x0A01)
+#define TCA0_SINGLE_CTRLC  _SFR_MEM8(0x0A02)
+#define TCA0_SINGLE_CTRLD  _SFR_MEM8(0x0A03)
+#define TCA0_SINGLE_CTRLECLR  _SFR_MEM8(0x0A04)
+#define TCA0_SINGLE_CTRLESET  _SFR_MEM8(0x0A05)
+#define TCA0_SINGLE_CTRLFCLR  _SFR_MEM8(0x0A06)
+#define TCA0_SINGLE_CTRLFSET  _SFR_MEM8(0x0A07)
+#define TCA0_SINGLE_EVCTRL  _SFR_MEM8(0x0A09)
+#define TCA0_SINGLE_INTCTRL  _SFR_MEM8(0x0A0A)
+#define TCA0_SINGLE_INTFLAGS  _SFR_MEM8(0x0A0B)
+#define TCA0_SINGLE_DBGCTRL  _SFR_MEM8(0x0A0E)
+#define TCA0_SINGLE_TEMP  _SFR_MEM8(0x0A0F)
+#define TCA0_SINGLE_CNT  _SFR_MEM16(0x0A20)
+#define TCA0_SINGLE_CNTL  _SFR_MEM8(0x0A20)
+#define TCA0_SINGLE_CNTH  _SFR_MEM8(0x0A21)
+#define TCA0_SINGLE_PER  _SFR_MEM16(0x0A26)
+#define TCA0_SINGLE_PERL  _SFR_MEM8(0x0A26)
+#define TCA0_SINGLE_PERH  _SFR_MEM8(0x0A27)
+#define TCA0_SINGLE_CMP0  _SFR_MEM16(0x0A28)
+#define TCA0_SINGLE_CMP0L  _SFR_MEM8(0x0A28)
+#define TCA0_SINGLE_CMP0H  _SFR_MEM8(0x0A29)
+#define TCA0_SINGLE_CMP1  _SFR_MEM16(0x0A2A)
+#define TCA0_SINGLE_CMP1L  _SFR_MEM8(0x0A2A)
+#define TCA0_SINGLE_CMP1H  _SFR_MEM8(0x0A2B)
+#define TCA0_SINGLE_CMP2  _SFR_MEM16(0x0A2C)
+#define TCA0_SINGLE_CMP2L  _SFR_MEM8(0x0A2C)
+#define TCA0_SINGLE_CMP2H  _SFR_MEM8(0x0A2D)
+#define TCA0_SINGLE_PERBUF  _SFR_MEM16(0x0A36)
+#define TCA0_SINGLE_PERBUFL  _SFR_MEM8(0x0A36)
+#define TCA0_SINGLE_PERBUFH  _SFR_MEM8(0x0A37)
+#define TCA0_SINGLE_CMP0BUF  _SFR_MEM16(0x0A38)
+#define TCA0_SINGLE_CMP0BUFL  _SFR_MEM8(0x0A38)
+#define TCA0_SINGLE_CMP0BUFH  _SFR_MEM8(0x0A39)
+#define TCA0_SINGLE_CMP1BUF  _SFR_MEM16(0x0A3A)
+#define TCA0_SINGLE_CMP1BUFL  _SFR_MEM8(0x0A3A)
+#define TCA0_SINGLE_CMP1BUFH  _SFR_MEM8(0x0A3B)
+#define TCA0_SINGLE_CMP2BUF  _SFR_MEM16(0x0A3C)
+#define TCA0_SINGLE_CMP2BUFL  _SFR_MEM8(0x0A3C)
+#define TCA0_SINGLE_CMP2BUFH  _SFR_MEM8(0x0A3D)
+
+
+/* TCA (TCA0) - 16-bit Timer/Counter Type A - Split Mode */
+#define TCA0_SPLIT_CTRLA  _SFR_MEM8(0x0A00)
+#define TCA0_SPLIT_CTRLB  _SFR_MEM8(0x0A01)
+#define TCA0_SPLIT_CTRLC  _SFR_MEM8(0x0A02)
+#define TCA0_SPLIT_CTRLD  _SFR_MEM8(0x0A03)
+#define TCA0_SPLIT_CTRLECLR  _SFR_MEM8(0x0A04)
+#define TCA0_SPLIT_CTRLESET  _SFR_MEM8(0x0A05)
+#define TCA0_SPLIT_INTCTRL  _SFR_MEM8(0x0A0A)
+#define TCA0_SPLIT_INTFLAGS  _SFR_MEM8(0x0A0B)
+#define TCA0_SPLIT_DBGCTRL  _SFR_MEM8(0x0A0E)
+#define TCA0_SPLIT_LCNT  _SFR_MEM8(0x0A20)
+#define TCA0_SPLIT_HCNT  _SFR_MEM8(0x0A21)
+#define TCA0_SPLIT_LPER  _SFR_MEM8(0x0A26)
+#define TCA0_SPLIT_HPER  _SFR_MEM8(0x0A27)
+#define TCA0_SPLIT_LCMP0  _SFR_MEM8(0x0A28)
+#define TCA0_SPLIT_HCMP0  _SFR_MEM8(0x0A29)
+#define TCA0_SPLIT_LCMP1  _SFR_MEM8(0x0A2A)
+#define TCA0_SPLIT_HCMP1  _SFR_MEM8(0x0A2B)
+#define TCA0_SPLIT_LCMP2  _SFR_MEM8(0x0A2C)
+#define TCA0_SPLIT_HCMP2  _SFR_MEM8(0x0A2D)
+
+
+/* TCA (TCA1) - 16-bit Timer/Counter Type A - Single Mode */
+#define TCA1_SINGLE_CTRLA  _SFR_MEM8(0x0A40)
+#define TCA1_SINGLE_CTRLB  _SFR_MEM8(0x0A41)
+#define TCA1_SINGLE_CTRLC  _SFR_MEM8(0x0A42)
+#define TCA1_SINGLE_CTRLD  _SFR_MEM8(0x0A43)
+#define TCA1_SINGLE_CTRLECLR  _SFR_MEM8(0x0A44)
+#define TCA1_SINGLE_CTRLESET  _SFR_MEM8(0x0A45)
+#define TCA1_SINGLE_CTRLFCLR  _SFR_MEM8(0x0A46)
+#define TCA1_SINGLE_CTRLFSET  _SFR_MEM8(0x0A47)
+#define TCA1_SINGLE_EVCTRL  _SFR_MEM8(0x0A49)
+#define TCA1_SINGLE_INTCTRL  _SFR_MEM8(0x0A4A)
+#define TCA1_SINGLE_INTFLAGS  _SFR_MEM8(0x0A4B)
+#define TCA1_SINGLE_DBGCTRL  _SFR_MEM8(0x0A4E)
+#define TCA1_SINGLE_TEMP  _SFR_MEM8(0x0A4F)
+#define TCA1_SINGLE_CNT  _SFR_MEM16(0x0A60)
+#define TCA1_SINGLE_CNTL  _SFR_MEM8(0x0A60)
+#define TCA1_SINGLE_CNTH  _SFR_MEM8(0x0A61)
+#define TCA1_SINGLE_PER  _SFR_MEM16(0x0A66)
+#define TCA1_SINGLE_PERL  _SFR_MEM8(0x0A66)
+#define TCA1_SINGLE_PERH  _SFR_MEM8(0x0A67)
+#define TCA1_SINGLE_CMP0  _SFR_MEM16(0x0A68)
+#define TCA1_SINGLE_CMP0L  _SFR_MEM8(0x0A68)
+#define TCA1_SINGLE_CMP0H  _SFR_MEM8(0x0A69)
+#define TCA1_SINGLE_CMP1  _SFR_MEM16(0x0A6A)
+#define TCA1_SINGLE_CMP1L  _SFR_MEM8(0x0A6A)
+#define TCA1_SINGLE_CMP1H  _SFR_MEM8(0x0A6B)
+#define TCA1_SINGLE_CMP2  _SFR_MEM16(0x0A6C)
+#define TCA1_SINGLE_CMP2L  _SFR_MEM8(0x0A6C)
+#define TCA1_SINGLE_CMP2H  _SFR_MEM8(0x0A6D)
+#define TCA1_SINGLE_PERBUF  _SFR_MEM16(0x0A76)
+#define TCA1_SINGLE_PERBUFL  _SFR_MEM8(0x0A76)
+#define TCA1_SINGLE_PERBUFH  _SFR_MEM8(0x0A77)
+#define TCA1_SINGLE_CMP0BUF  _SFR_MEM16(0x0A78)
+#define TCA1_SINGLE_CMP0BUFL  _SFR_MEM8(0x0A78)
+#define TCA1_SINGLE_CMP0BUFH  _SFR_MEM8(0x0A79)
+#define TCA1_SINGLE_CMP1BUF  _SFR_MEM16(0x0A7A)
+#define TCA1_SINGLE_CMP1BUFL  _SFR_MEM8(0x0A7A)
+#define TCA1_SINGLE_CMP1BUFH  _SFR_MEM8(0x0A7B)
+#define TCA1_SINGLE_CMP2BUF  _SFR_MEM16(0x0A7C)
+#define TCA1_SINGLE_CMP2BUFL  _SFR_MEM8(0x0A7C)
+#define TCA1_SINGLE_CMP2BUFH  _SFR_MEM8(0x0A7D)
+
+
+/* TCA (TCA1) - 16-bit Timer/Counter Type A - Split Mode */
+#define TCA1_SPLIT_CTRLA  _SFR_MEM8(0x0A40)
+#define TCA1_SPLIT_CTRLB  _SFR_MEM8(0x0A41)
+#define TCA1_SPLIT_CTRLC  _SFR_MEM8(0x0A42)
+#define TCA1_SPLIT_CTRLD  _SFR_MEM8(0x0A43)
+#define TCA1_SPLIT_CTRLECLR  _SFR_MEM8(0x0A44)
+#define TCA1_SPLIT_CTRLESET  _SFR_MEM8(0x0A45)
+#define TCA1_SPLIT_INTCTRL  _SFR_MEM8(0x0A4A)
+#define TCA1_SPLIT_INTFLAGS  _SFR_MEM8(0x0A4B)
+#define TCA1_SPLIT_DBGCTRL  _SFR_MEM8(0x0A4E)
+#define TCA1_SPLIT_LCNT  _SFR_MEM8(0x0A60)
+#define TCA1_SPLIT_HCNT  _SFR_MEM8(0x0A61)
+#define TCA1_SPLIT_LPER  _SFR_MEM8(0x0A66)
+#define TCA1_SPLIT_HPER  _SFR_MEM8(0x0A67)
+#define TCA1_SPLIT_LCMP0  _SFR_MEM8(0x0A68)
+#define TCA1_SPLIT_HCMP0  _SFR_MEM8(0x0A69)
+#define TCA1_SPLIT_LCMP1  _SFR_MEM8(0x0A6A)
+#define TCA1_SPLIT_HCMP1  _SFR_MEM8(0x0A6B)
+#define TCA1_SPLIT_LCMP2  _SFR_MEM8(0x0A6C)
+#define TCA1_SPLIT_HCMP2  _SFR_MEM8(0x0A6D)
+
+
+/* TCB (TCB0) - 16-bit Timer Type B */
+#define TCB0_CTRLA  _SFR_MEM8(0x0B00)
+#define TCB0_CTRLB  _SFR_MEM8(0x0B01)
+#define TCB0_EVCTRL  _SFR_MEM8(0x0B04)
+#define TCB0_INTCTRL  _SFR_MEM8(0x0B05)
+#define TCB0_INTFLAGS  _SFR_MEM8(0x0B06)
+#define TCB0_STATUS  _SFR_MEM8(0x0B07)
+#define TCB0_DBGCTRL  _SFR_MEM8(0x0B08)
+#define TCB0_TEMP  _SFR_MEM8(0x0B09)
+#define TCB0_CNT  _SFR_MEM16(0x0B0A)
+#define TCB0_CNTL  _SFR_MEM8(0x0B0A)
+#define TCB0_CNTH  _SFR_MEM8(0x0B0B)
+#define TCB0_CCMP  _SFR_MEM16(0x0B0C)
+#define TCB0_CCMPL  _SFR_MEM8(0x0B0C)
+#define TCB0_CCMPH  _SFR_MEM8(0x0B0D)
+
+
+/* TCB (TCB1) - 16-bit Timer Type B */
+#define TCB1_CTRLA  _SFR_MEM8(0x0B10)
+#define TCB1_CTRLB  _SFR_MEM8(0x0B11)
+#define TCB1_EVCTRL  _SFR_MEM8(0x0B14)
+#define TCB1_INTCTRL  _SFR_MEM8(0x0B15)
+#define TCB1_INTFLAGS  _SFR_MEM8(0x0B16)
+#define TCB1_STATUS  _SFR_MEM8(0x0B17)
+#define TCB1_DBGCTRL  _SFR_MEM8(0x0B18)
+#define TCB1_TEMP  _SFR_MEM8(0x0B19)
+#define TCB1_CNT  _SFR_MEM16(0x0B1A)
+#define TCB1_CNTL  _SFR_MEM8(0x0B1A)
+#define TCB1_CNTH  _SFR_MEM8(0x0B1B)
+#define TCB1_CCMP  _SFR_MEM16(0x0B1C)
+#define TCB1_CCMPL  _SFR_MEM8(0x0B1C)
+#define TCB1_CCMPH  _SFR_MEM8(0x0B1D)
+
+
+/* TCB (TCB2) - 16-bit Timer Type B */
+#define TCB2_CTRLA  _SFR_MEM8(0x0B20)
+#define TCB2_CTRLB  _SFR_MEM8(0x0B21)
+#define TCB2_EVCTRL  _SFR_MEM8(0x0B24)
+#define TCB2_INTCTRL  _SFR_MEM8(0x0B25)
+#define TCB2_INTFLAGS  _SFR_MEM8(0x0B26)
+#define TCB2_STATUS  _SFR_MEM8(0x0B27)
+#define TCB2_DBGCTRL  _SFR_MEM8(0x0B28)
+#define TCB2_TEMP  _SFR_MEM8(0x0B29)
+#define TCB2_CNT  _SFR_MEM16(0x0B2A)
+#define TCB2_CNTL  _SFR_MEM8(0x0B2A)
+#define TCB2_CNTH  _SFR_MEM8(0x0B2B)
+#define TCB2_CCMP  _SFR_MEM16(0x0B2C)
+#define TCB2_CCMPL  _SFR_MEM8(0x0B2C)
+#define TCB2_CCMPH  _SFR_MEM8(0x0B2D)
+
+
+/* TCB (TCB3) - 16-bit Timer Type B */
+#define TCB3_CTRLA  _SFR_MEM8(0x0B30)
+#define TCB3_CTRLB  _SFR_MEM8(0x0B31)
+#define TCB3_EVCTRL  _SFR_MEM8(0x0B34)
+#define TCB3_INTCTRL  _SFR_MEM8(0x0B35)
+#define TCB3_INTFLAGS  _SFR_MEM8(0x0B36)
+#define TCB3_STATUS  _SFR_MEM8(0x0B37)
+#define TCB3_DBGCTRL  _SFR_MEM8(0x0B38)
+#define TCB3_TEMP  _SFR_MEM8(0x0B39)
+#define TCB3_CNT  _SFR_MEM16(0x0B3A)
+#define TCB3_CNTL  _SFR_MEM8(0x0B3A)
+#define TCB3_CNTH  _SFR_MEM8(0x0B3B)
+#define TCB3_CCMP  _SFR_MEM16(0x0B3C)
+#define TCB3_CCMPL  _SFR_MEM8(0x0B3C)
+#define TCB3_CCMPH  _SFR_MEM8(0x0B3D)
+
+
+/* SYSCFG - System Configuration Registers */
+#define SYSCFG_REVID  _SFR_MEM8(0x0F01)
+#define SYSCFG_OCDMCTRL  _SFR_MEM8(0x0F04)
+#define SYSCFG_OCDMSTATUS  _SFR_MEM8(0x0F05)
+
+
+/* NVMCTRL - Non-volatile Memory Controller */
+#define NVMCTRL_CTRLA  _SFR_MEM8(0x1000)
+#define NVMCTRL_CTRLB  _SFR_MEM8(0x1001)
+#define NVMCTRL_INTCTRL  _SFR_MEM8(0x1004)
+#define NVMCTRL_INTFLAGS  _SFR_MEM8(0x1005)
+#define NVMCTRL_STATUS  _SFR_MEM8(0x1006)
+#define NVMCTRL_DATA  _SFR_MEM16(0x1008)
+#define NVMCTRL_DATAL  _SFR_MEM8(0x1008)
+#define NVMCTRL_DATAH  _SFR_MEM8(0x1009)
+#define NVMCTRL_ADDR  _SFR_MEM32(0x100C)
+#define NVMCTRL_ADDR0  _SFR_MEM8(0x100C)
+#define NVMCTRL_ADDR1  _SFR_MEM8(0x100D)
+#define NVMCTRL_ADDR2  _SFR_MEM8(0x100E)
+#define NVMCTRL_ADDR3  _SFR_MEM8(0x100F)
+
+
+/* LOCK - Lockbits */
+#define LOCK_KEY  _SFR_MEM32(0x1040)
+#define LOCK_KEY0  _SFR_MEM8(0x1040)
+#define LOCK_KEY1  _SFR_MEM8(0x1041)
+#define LOCK_KEY2  _SFR_MEM8(0x1042)
+#define LOCK_KEY3  _SFR_MEM8(0x1043)
+
+
+/* FUSE - Fuses */
+#define FUSE_WDTCFG  _SFR_MEM8(0x1050)
+#define FUSE_BODCFG  _SFR_MEM8(0x1051)
+#define FUSE_OSCCFG  _SFR_MEM8(0x1052)
+#define FUSE_SYSCFG0  _SFR_MEM8(0x1055)
+#define FUSE_SYSCFG1  _SFR_MEM8(0x1056)
+#define FUSE_CODESIZE  _SFR_MEM8(0x1057)
+#define FUSE_BOOTSIZE  _SFR_MEM8(0x1058)
+
+
+/* USERROW - User Row */
+#define USERROW_USERROW0  _SFR_MEM8(0x1080)
+#define USERROW_USERROW1  _SFR_MEM8(0x1081)
+#define USERROW_USERROW2  _SFR_MEM8(0x1082)
+#define USERROW_USERROW3  _SFR_MEM8(0x1083)
+#define USERROW_USERROW4  _SFR_MEM8(0x1084)
+#define USERROW_USERROW5  _SFR_MEM8(0x1085)
+#define USERROW_USERROW6  _SFR_MEM8(0x1086)
+#define USERROW_USERROW7  _SFR_MEM8(0x1087)
+#define USERROW_USERROW8  _SFR_MEM8(0x1088)
+#define USERROW_USERROW9  _SFR_MEM8(0x1089)
+#define USERROW_USERROW10  _SFR_MEM8(0x108A)
+#define USERROW_USERROW11  _SFR_MEM8(0x108B)
+#define USERROW_USERROW12  _SFR_MEM8(0x108C)
+#define USERROW_USERROW13  _SFR_MEM8(0x108D)
+#define USERROW_USERROW14  _SFR_MEM8(0x108E)
+#define USERROW_USERROW15  _SFR_MEM8(0x108F)
+#define USERROW_USERROW16  _SFR_MEM8(0x1090)
+#define USERROW_USERROW17  _SFR_MEM8(0x1091)
+#define USERROW_USERROW18  _SFR_MEM8(0x1092)
+#define USERROW_USERROW19  _SFR_MEM8(0x1093)
+#define USERROW_USERROW20  _SFR_MEM8(0x1094)
+#define USERROW_USERROW21  _SFR_MEM8(0x1095)
+#define USERROW_USERROW22  _SFR_MEM8(0x1096)
+#define USERROW_USERROW23  _SFR_MEM8(0x1097)
+#define USERROW_USERROW24  _SFR_MEM8(0x1098)
+#define USERROW_USERROW25  _SFR_MEM8(0x1099)
+#define USERROW_USERROW26  _SFR_MEM8(0x109A)
+#define USERROW_USERROW27  _SFR_MEM8(0x109B)
+#define USERROW_USERROW28  _SFR_MEM8(0x109C)
+#define USERROW_USERROW29  _SFR_MEM8(0x109D)
+#define USERROW_USERROW30  _SFR_MEM8(0x109E)
+#define USERROW_USERROW31  _SFR_MEM8(0x109F)
+#define USERROW_USERROW32  _SFR_MEM8(0x10A0)
+#define USERROW_USERROW33  _SFR_MEM8(0x10A1)
+#define USERROW_USERROW34  _SFR_MEM8(0x10A2)
+#define USERROW_USERROW35  _SFR_MEM8(0x10A3)
+#define USERROW_USERROW36  _SFR_MEM8(0x10A4)
+#define USERROW_USERROW37  _SFR_MEM8(0x10A5)
+#define USERROW_USERROW38  _SFR_MEM8(0x10A6)
+#define USERROW_USERROW39  _SFR_MEM8(0x10A7)
+#define USERROW_USERROW40  _SFR_MEM8(0x10A8)
+#define USERROW_USERROW41  _SFR_MEM8(0x10A9)
+#define USERROW_USERROW42  _SFR_MEM8(0x10AA)
+#define USERROW_USERROW43  _SFR_MEM8(0x10AB)
+#define USERROW_USERROW44  _SFR_MEM8(0x10AC)
+#define USERROW_USERROW45  _SFR_MEM8(0x10AD)
+#define USERROW_USERROW46  _SFR_MEM8(0x10AE)
+#define USERROW_USERROW47  _SFR_MEM8(0x10AF)
+#define USERROW_USERROW48  _SFR_MEM8(0x10B0)
+#define USERROW_USERROW49  _SFR_MEM8(0x10B1)
+#define USERROW_USERROW50  _SFR_MEM8(0x10B2)
+#define USERROW_USERROW51  _SFR_MEM8(0x10B3)
+#define USERROW_USERROW52  _SFR_MEM8(0x10B4)
+#define USERROW_USERROW53  _SFR_MEM8(0x10B5)
+#define USERROW_USERROW54  _SFR_MEM8(0x10B6)
+#define USERROW_USERROW55  _SFR_MEM8(0x10B7)
+#define USERROW_USERROW56  _SFR_MEM8(0x10B8)
+#define USERROW_USERROW57  _SFR_MEM8(0x10B9)
+#define USERROW_USERROW58  _SFR_MEM8(0x10BA)
+#define USERROW_USERROW59  _SFR_MEM8(0x10BB)
+#define USERROW_USERROW60  _SFR_MEM8(0x10BC)
+#define USERROW_USERROW61  _SFR_MEM8(0x10BD)
+#define USERROW_USERROW62  _SFR_MEM8(0x10BE)
+#define USERROW_USERROW63  _SFR_MEM8(0x10BF)
+
+
+/* SIGROW - Signature row */
+#define SIGROW_DEVICEID0  _SFR_MEM8(0x1100)
+#define SIGROW_DEVICEID1  _SFR_MEM8(0x1101)
+#define SIGROW_DEVICEID2  _SFR_MEM8(0x1102)
+#define SIGROW_TEMPSENSE0  _SFR_MEM16(0x1104)
+#define SIGROW_TEMPSENSE0L  _SFR_MEM8(0x1104)
+#define SIGROW_TEMPSENSE0H  _SFR_MEM8(0x1105)
+#define SIGROW_TEMPSENSE1  _SFR_MEM16(0x1106)
+#define SIGROW_TEMPSENSE1L  _SFR_MEM8(0x1106)
+#define SIGROW_TEMPSENSE1H  _SFR_MEM8(0x1107)
+#define SIGROW_SERNUM0  _SFR_MEM8(0x1110)
+#define SIGROW_SERNUM1  _SFR_MEM8(0x1111)
+#define SIGROW_SERNUM2  _SFR_MEM8(0x1112)
+#define SIGROW_SERNUM3  _SFR_MEM8(0x1113)
+#define SIGROW_SERNUM4  _SFR_MEM8(0x1114)
+#define SIGROW_SERNUM5  _SFR_MEM8(0x1115)
+#define SIGROW_SERNUM6  _SFR_MEM8(0x1116)
+#define SIGROW_SERNUM7  _SFR_MEM8(0x1117)
+#define SIGROW_SERNUM8  _SFR_MEM8(0x1118)
+#define SIGROW_SERNUM9  _SFR_MEM8(0x1119)
+#define SIGROW_SERNUM10  _SFR_MEM8(0x111A)
+#define SIGROW_SERNUM11  _SFR_MEM8(0x111B)
+#define SIGROW_SERNUM12  _SFR_MEM8(0x111C)
+#define SIGROW_SERNUM13  _SFR_MEM8(0x111D)
+#define SIGROW_SERNUM14  _SFR_MEM8(0x111E)
+#define SIGROW_SERNUM15  _SFR_MEM8(0x111F)
+
+
+
+/*================== Bitfield Definitions ================== */
+
+/* AC - Analog Comparator */
+/* AC.CTRLA  bit masks and bit positions */
+#define AC_ENABLE_bm  0x01  /* Enable bit mask. */
+#define AC_ENABLE_bp  0  /* Enable bit position. */
+#define AC_HYSMODE_gm  0x06  /* Hysteresis Mode group mask. */
+#define AC_HYSMODE_gp  1  /* Hysteresis Mode group position. */
+#define AC_HYSMODE_0_bm  (1<<1)  /* Hysteresis Mode bit 0 mask. */
+#define AC_HYSMODE_0_bp  1  /* Hysteresis Mode bit 0 position. */
+#define AC_HYSMODE_1_bm  (1<<2)  /* Hysteresis Mode bit 1 mask. */
+#define AC_HYSMODE_1_bp  2  /* Hysteresis Mode bit 1 position. */
+#define AC_POWER_gm  0x18  /* Power profile group mask. */
+#define AC_POWER_gp  3  /* Power profile group position. */
+#define AC_POWER_0_bm  (1<<3)  /* Power profile bit 0 mask. */
+#define AC_POWER_0_bp  3  /* Power profile bit 0 position. */
+#define AC_POWER_1_bm  (1<<4)  /* Power profile bit 1 mask. */
+#define AC_POWER_1_bp  4  /* Power profile bit 1 position. */
+#define AC_OUTEN_bm  0x40  /* Output Pad Enable bit mask. */
+#define AC_OUTEN_bp  6  /* Output Pad Enable bit position. */
+#define AC_RUNSTDBY_bm  0x80  /* Run in Standby Mode bit mask. */
+#define AC_RUNSTDBY_bp  7  /* Run in Standby Mode bit position. */
+
+/* AC.CTRLB  bit masks and bit positions */
+#define AC_WINSEL_gm  0x03  /* Window selection mode group mask. */
+#define AC_WINSEL_gp  0  /* Window selection mode group position. */
+#define AC_WINSEL_0_bm  (1<<0)  /* Window selection mode bit 0 mask. */
+#define AC_WINSEL_0_bp  0  /* Window selection mode bit 0 position. */
+#define AC_WINSEL_1_bm  (1<<1)  /* Window selection mode bit 1 mask. */
+#define AC_WINSEL_1_bp  1  /* Window selection mode bit 1 position. */
+
+/* AC.MUXCTRL  bit masks and bit positions */
+#define AC_MUXNEG_gm  0x07  /* Negative Input MUX Selection group mask. */
+#define AC_MUXNEG_gp  0  /* Negative Input MUX Selection group position. */
+#define AC_MUXNEG_0_bm  (1<<0)  /* Negative Input MUX Selection bit 0 mask. */
+#define AC_MUXNEG_0_bp  0  /* Negative Input MUX Selection bit 0 position. */
+#define AC_MUXNEG_1_bm  (1<<1)  /* Negative Input MUX Selection bit 1 mask. */
+#define AC_MUXNEG_1_bp  1  /* Negative Input MUX Selection bit 1 position. */
+#define AC_MUXNEG_2_bm  (1<<2)  /* Negative Input MUX Selection bit 2 mask. */
+#define AC_MUXNEG_2_bp  2  /* Negative Input MUX Selection bit 2 position. */
+#define AC_MUXPOS_gm  0x38  /* Positive Input MUX Selection group mask. */
+#define AC_MUXPOS_gp  3  /* Positive Input MUX Selection group position. */
+#define AC_MUXPOS_0_bm  (1<<3)  /* Positive Input MUX Selection bit 0 mask. */
+#define AC_MUXPOS_0_bp  3  /* Positive Input MUX Selection bit 0 position. */
+#define AC_MUXPOS_1_bm  (1<<4)  /* Positive Input MUX Selection bit 1 mask. */
+#define AC_MUXPOS_1_bp  4  /* Positive Input MUX Selection bit 1 position. */
+#define AC_MUXPOS_2_bm  (1<<5)  /* Positive Input MUX Selection bit 2 mask. */
+#define AC_MUXPOS_2_bp  5  /* Positive Input MUX Selection bit 2 position. */
+#define AC_INITVAL_bm  0x40  /* AC Output Initial Value bit mask. */
+#define AC_INITVAL_bp  6  /* AC Output Initial Value bit position. */
+#define AC_INVERT_bm  0x80  /* Invert AC Output bit mask. */
+#define AC_INVERT_bp  7  /* Invert AC Output bit position. */
+
+/* AC.DACREF  bit masks and bit positions */
+#define AC_DACREF_gm  0xFF  /* DACREF group mask. */
+#define AC_DACREF_gp  0  /* DACREF group position. */
+#define AC_DACREF_0_bm  (1<<0)  /* DACREF bit 0 mask. */
+#define AC_DACREF_0_bp  0  /* DACREF bit 0 position. */
+#define AC_DACREF_1_bm  (1<<1)  /* DACREF bit 1 mask. */
+#define AC_DACREF_1_bp  1  /* DACREF bit 1 position. */
+#define AC_DACREF_2_bm  (1<<2)  /* DACREF bit 2 mask. */
+#define AC_DACREF_2_bp  2  /* DACREF bit 2 position. */
+#define AC_DACREF_3_bm  (1<<3)  /* DACREF bit 3 mask. */
+#define AC_DACREF_3_bp  3  /* DACREF bit 3 position. */
+#define AC_DACREF_4_bm  (1<<4)  /* DACREF bit 4 mask. */
+#define AC_DACREF_4_bp  4  /* DACREF bit 4 position. */
+#define AC_DACREF_5_bm  (1<<5)  /* DACREF bit 5 mask. */
+#define AC_DACREF_5_bp  5  /* DACREF bit 5 position. */
+#define AC_DACREF_6_bm  (1<<6)  /* DACREF bit 6 mask. */
+#define AC_DACREF_6_bp  6  /* DACREF bit 6 position. */
+#define AC_DACREF_7_bm  (1<<7)  /* DACREF bit 7 mask. */
+#define AC_DACREF_7_bp  7  /* DACREF bit 7 position. */
+
+/* AC.INTCTRL  bit masks and bit positions */
+#define AC_CMP_bm  0x01  /* Interrupt Enable bit mask. */
+#define AC_CMP_bp  0  /* Interrupt Enable bit position. */
+#define AC_INTMODE_NORMAL_gm  0x30  /* Interrupt Mode group mask. */
+#define AC_INTMODE_NORMAL_gp  4  /* Interrupt Mode group position. */
+#define AC_INTMODE_NORMAL_0_bm  (1<<4)  /* Interrupt Mode bit 0 mask. */
+#define AC_INTMODE_NORMAL_0_bp  4  /* Interrupt Mode bit 0 position. */
+#define AC_INTMODE_NORMAL_1_bm  (1<<5)  /* Interrupt Mode bit 1 mask. */
+#define AC_INTMODE_NORMAL_1_bp  5  /* Interrupt Mode bit 1 position. */
+#define AC_INTMODE_WINDOW_gm  0x30  /* Interrupt Mode group mask. */
+#define AC_INTMODE_WINDOW_gp  4  /* Interrupt Mode group position. */
+#define AC_INTMODE_WINDOW_0_bm  (1<<4)  /* Interrupt Mode bit 0 mask. */
+#define AC_INTMODE_WINDOW_0_bp  4  /* Interrupt Mode bit 0 position. */
+#define AC_INTMODE_WINDOW_1_bm  (1<<5)  /* Interrupt Mode bit 1 mask. */
+#define AC_INTMODE_WINDOW_1_bp  5  /* Interrupt Mode bit 1 position. */
+
+/* AC.STATUS  bit masks and bit positions */
+#define AC_CMPIF_bm  0x01  /* Analog Comparator Interrupt Flag bit mask. */
+#define AC_CMPIF_bp  0  /* Analog Comparator Interrupt Flag bit position. */
+#define AC_CMPSTATE_bm  0x10  /* Analog Comparator State bit mask. */
+#define AC_CMPSTATE_bp  4  /* Analog Comparator State bit position. */
+#define AC_WINSTATE_gm  0xC0  /* Analog Comparator Window State group mask. */
+#define AC_WINSTATE_gp  6  /* Analog Comparator Window State group position. */
+#define AC_WINSTATE_0_bm  (1<<6)  /* Analog Comparator Window State bit 0 mask. */
+#define AC_WINSTATE_0_bp  6  /* Analog Comparator Window State bit 0 position. */
+#define AC_WINSTATE_1_bm  (1<<7)  /* Analog Comparator Window State bit 1 mask. */
+#define AC_WINSTATE_1_bp  7  /* Analog Comparator Window State bit 1 position. */
+
+
+/* ADC - Analog to Digital Converter */
+/* ADC.CTRLA  bit masks and bit positions */
+#define ADC_ENABLE_bm  0x01  /* ADC Enable bit mask. */
+#define ADC_ENABLE_bp  0  /* ADC Enable bit position. */
+#define ADC_LOWLAT_bm  0x20  /* Low Latency bit mask. */
+#define ADC_LOWLAT_bp  5  /* Low Latency bit position. */
+#define ADC_RUNSTDBY_bm  0x80  /* Run in Standby bit mask. */
+#define ADC_RUNSTDBY_bp  7  /* Run in Standby bit position. */
+
+/* ADC.CTRLB  bit masks and bit positions */
+#define ADC_PRESC_gm  0x0F  /* Prescaler Value group mask. */
+#define ADC_PRESC_gp  0  /* Prescaler Value group position. */
+#define ADC_PRESC_0_bm  (1<<0)  /* Prescaler Value bit 0 mask. */
+#define ADC_PRESC_0_bp  0  /* Prescaler Value bit 0 position. */
+#define ADC_PRESC_1_bm  (1<<1)  /* Prescaler Value bit 1 mask. */
+#define ADC_PRESC_1_bp  1  /* Prescaler Value bit 1 position. */
+#define ADC_PRESC_2_bm  (1<<2)  /* Prescaler Value bit 2 mask. */
+#define ADC_PRESC_2_bp  2  /* Prescaler Value bit 2 position. */
+#define ADC_PRESC_3_bm  (1<<3)  /* Prescaler Value bit 3 mask. */
+#define ADC_PRESC_3_bp  3  /* Prescaler Value bit 3 position. */
+
+/* ADC.CTRLC  bit masks and bit positions */
+#define ADC_REFSEL_gm  0x07  /* Reference select group mask. */
+#define ADC_REFSEL_gp  0  /* Reference select group position. */
+#define ADC_REFSEL_0_bm  (1<<0)  /* Reference select bit 0 mask. */
+#define ADC_REFSEL_0_bp  0  /* Reference select bit 0 position. */
+#define ADC_REFSEL_1_bm  (1<<1)  /* Reference select bit 1 mask. */
+#define ADC_REFSEL_1_bp  1  /* Reference select bit 1 position. */
+#define ADC_REFSEL_2_bm  (1<<2)  /* Reference select bit 2 mask. */
+#define ADC_REFSEL_2_bp  2  /* Reference select bit 2 position. */
+
+/* ADC.CTRLD  bit masks and bit positions */
+#define ADC_WINCM_gm  0x07  /* Window Comparator Mode group mask. */
+#define ADC_WINCM_gp  0  /* Window Comparator Mode group position. */
+#define ADC_WINCM_0_bm  (1<<0)  /* Window Comparator Mode bit 0 mask. */
+#define ADC_WINCM_0_bp  0  /* Window Comparator Mode bit 0 position. */
+#define ADC_WINCM_1_bm  (1<<1)  /* Window Comparator Mode bit 1 mask. */
+#define ADC_WINCM_1_bp  1  /* Window Comparator Mode bit 1 position. */
+#define ADC_WINCM_2_bm  (1<<2)  /* Window Comparator Mode bit 2 mask. */
+#define ADC_WINCM_2_bp  2  /* Window Comparator Mode bit 2 position. */
+#define ADC_WINSRC_bm  0x08  /* Window Mode Source bit mask. */
+#define ADC_WINSRC_bp  3  /* Window Mode Source bit position. */
+
+/* ADC.INTCTRL  bit masks and bit positions */
+#define ADC_RESRDY_bm  0x01  /* Result Ready Interrupt Enable bit mask. */
+#define ADC_RESRDY_bp  0  /* Result Ready Interrupt Enable bit position. */
+#define ADC_SAMPRDY_bm  0x02  /* Sample Ready Interrupt Enable bit mask. */
+#define ADC_SAMPRDY_bp  1  /* Sample Ready Interrupt Enable bit position. */
+#define ADC_WCMP_bm  0x04  /* Window Comparator Interrupt Enable bit mask. */
+#define ADC_WCMP_bp  2  /* Window Comparator Interrupt Enable bit position. */
+#define ADC_RESOVR_bm  0x08  /* Result Overwrite Interrupt Enable bit mask. */
+#define ADC_RESOVR_bp  3  /* Result Overwrite Interrupt Enable bit position. */
+#define ADC_SAMPOVR_bm  0x10  /* Sample Overwrite Interrupt Enable bit mask. */
+#define ADC_SAMPOVR_bp  4  /* Sample Overwrite Interrupt Enable bit position. */
+#define ADC_TRIGOVR_bm  0x20  /* Trigger Overrun Interrupt Enable bit mask. */
+#define ADC_TRIGOVR_bp  5  /* Trigger Overrun Interrupt Enable bit position. */
+
+/* ADC.INTFLAGS  bit masks and bit positions */
+/* ADC_RESRDY  is already defined. */
+/* ADC_SAMPRDY  is already defined. */
+/* ADC_WCMP  is already defined. */
+/* ADC_RESOVR  is already defined. */
+/* ADC_SAMPOVR  is already defined. */
+/* ADC_TRIGOVR  is already defined. */
+
+/* ADC.STATUS  bit masks and bit positions */
+#define ADC_ADCBUSY_bm  0x01  /* ADC Busy bit mask. */
+#define ADC_ADCBUSY_bp  0  /* ADC Busy bit position. */
+
+/* ADC.DBGCTRL  bit masks and bit positions */
+#define ADC_DBGRUN_bm  0x01  /* Run in Debug Mode bit mask. */
+#define ADC_DBGRUN_bp  0  /* Run in Debug Mode bit position. */
+
+/* ADC.CTRLE  bit masks and bit positions */
+#define ADC_SAMPDUR_gm  0xFF  /* Sample Duration group mask. */
+#define ADC_SAMPDUR_gp  0  /* Sample Duration group position. */
+#define ADC_SAMPDUR_0_bm  (1<<0)  /* Sample Duration bit 0 mask. */
+#define ADC_SAMPDUR_0_bp  0  /* Sample Duration bit 0 position. */
+#define ADC_SAMPDUR_1_bm  (1<<1)  /* Sample Duration bit 1 mask. */
+#define ADC_SAMPDUR_1_bp  1  /* Sample Duration bit 1 position. */
+#define ADC_SAMPDUR_2_bm  (1<<2)  /* Sample Duration bit 2 mask. */
+#define ADC_SAMPDUR_2_bp  2  /* Sample Duration bit 2 position. */
+#define ADC_SAMPDUR_3_bm  (1<<3)  /* Sample Duration bit 3 mask. */
+#define ADC_SAMPDUR_3_bp  3  /* Sample Duration bit 3 position. */
+#define ADC_SAMPDUR_4_bm  (1<<4)  /* Sample Duration bit 4 mask. */
+#define ADC_SAMPDUR_4_bp  4  /* Sample Duration bit 4 position. */
+#define ADC_SAMPDUR_5_bm  (1<<5)  /* Sample Duration bit 5 mask. */
+#define ADC_SAMPDUR_5_bp  5  /* Sample Duration bit 5 position. */
+#define ADC_SAMPDUR_6_bm  (1<<6)  /* Sample Duration bit 6 mask. */
+#define ADC_SAMPDUR_6_bp  6  /* Sample Duration bit 6 position. */
+#define ADC_SAMPDUR_7_bm  (1<<7)  /* Sample Duration bit 7 mask. */
+#define ADC_SAMPDUR_7_bp  7  /* Sample Duration bit 7 position. */
+
+/* ADC.CTRLF  bit masks and bit positions */
+#define ADC_SAMPNUM_gm  0x0F  /* Sample numbers group mask. */
+#define ADC_SAMPNUM_gp  0  /* Sample numbers group position. */
+#define ADC_SAMPNUM_0_bm  (1<<0)  /* Sample numbers bit 0 mask. */
+#define ADC_SAMPNUM_0_bp  0  /* Sample numbers bit 0 position. */
+#define ADC_SAMPNUM_1_bm  (1<<1)  /* Sample numbers bit 1 mask. */
+#define ADC_SAMPNUM_1_bp  1  /* Sample numbers bit 1 position. */
+#define ADC_SAMPNUM_2_bm  (1<<2)  /* Sample numbers bit 2 mask. */
+#define ADC_SAMPNUM_2_bp  2  /* Sample numbers bit 2 position. */
+#define ADC_SAMPNUM_3_bm  (1<<3)  /* Sample numbers bit 3 mask. */
+#define ADC_SAMPNUM_3_bp  3  /* Sample numbers bit 3 position. */
+#define ADC_LEFTADJ_bm  0x10  /* Left Adjust bit mask. */
+#define ADC_LEFTADJ_bp  4  /* Left Adjust bit position. */
+#define ADC_FREERUN_bm  0x20  /* Free-Running mode bit mask. */
+#define ADC_FREERUN_bp  5  /* Free-Running mode bit position. */
+#define ADC_CHOPPING_bm  0x40  /* Sign Chopping bit mask. */
+#define ADC_CHOPPING_bp  6  /* Sign Chopping bit position. */
+
+/* ADC.COMMAND  bit masks and bit positions */
+#define ADC_START_gm  0x07  /* Start command group mask. */
+#define ADC_START_gp  0  /* Start command group position. */
+#define ADC_START_0_bm  (1<<0)  /* Start command bit 0 mask. */
+#define ADC_START_0_bp  0  /* Start command bit 0 position. */
+#define ADC_START_1_bm  (1<<1)  /* Start command bit 1 mask. */
+#define ADC_START_1_bp  1  /* Start command bit 1 position. */
+#define ADC_START_2_bm  (1<<2)  /* Start command bit 2 mask. */
+#define ADC_START_2_bp  2  /* Start command bit 2 position. */
+#define ADC_MODE_gm  0x70  /* Mode group mask. */
+#define ADC_MODE_gp  4  /* Mode group position. */
+#define ADC_MODE_0_bm  (1<<4)  /* Mode bit 0 mask. */
+#define ADC_MODE_0_bp  4  /* Mode bit 0 position. */
+#define ADC_MODE_1_bm  (1<<5)  /* Mode bit 1 mask. */
+#define ADC_MODE_1_bp  5  /* Mode bit 1 position. */
+#define ADC_MODE_2_bm  (1<<6)  /* Mode bit 2 mask. */
+#define ADC_MODE_2_bp  6  /* Mode bit 2 position. */
+#define ADC_DIFF_bm  0x80  /* Differential mode bit mask. */
+#define ADC_DIFF_bp  7  /* Differential mode bit position. */
+
+/* ADC.PGACTRL  bit masks and bit positions */
+#define ADC_PGAEN_bm  0x01  /* PGA Enable bit mask. */
+#define ADC_PGAEN_bp  0  /* PGA Enable bit position. */
+#define ADC_PGABIASSEL_gm  0x18  /* PGA BIAS Select group mask. */
+#define ADC_PGABIASSEL_gp  3  /* PGA BIAS Select group position. */
+#define ADC_PGABIASSEL_0_bm  (1<<3)  /* PGA BIAS Select bit 0 mask. */
+#define ADC_PGABIASSEL_0_bp  3  /* PGA BIAS Select bit 0 position. */
+#define ADC_PGABIASSEL_1_bm  (1<<4)  /* PGA BIAS Select bit 1 mask. */
+#define ADC_PGABIASSEL_1_bp  4  /* PGA BIAS Select bit 1 position. */
+#define ADC_GAIN_gm  0xE0  /* Gain group mask. */
+#define ADC_GAIN_gp  5  /* Gain group position. */
+#define ADC_GAIN_0_bm  (1<<5)  /* Gain bit 0 mask. */
+#define ADC_GAIN_0_bp  5  /* Gain bit 0 position. */
+#define ADC_GAIN_1_bm  (1<<6)  /* Gain bit 1 mask. */
+#define ADC_GAIN_1_bp  6  /* Gain bit 1 position. */
+#define ADC_GAIN_2_bm  (1<<7)  /* Gain bit 2 mask. */
+#define ADC_GAIN_2_bp  7  /* Gain bit 2 position. */
+
+/* ADC.MUXPOS  bit masks and bit positions */
+#define ADC_MUXPOS_gm  0x3F  /* Analog Channel Selection Bits group mask. */
+#define ADC_MUXPOS_gp  0  /* Analog Channel Selection Bits group position. */
+#define ADC_MUXPOS_0_bm  (1<<0)  /* Analog Channel Selection Bits bit 0 mask. */
+#define ADC_MUXPOS_0_bp  0  /* Analog Channel Selection Bits bit 0 position. */
+#define ADC_MUXPOS_1_bm  (1<<1)  /* Analog Channel Selection Bits bit 1 mask. */
+#define ADC_MUXPOS_1_bp  1  /* Analog Channel Selection Bits bit 1 position. */
+#define ADC_MUXPOS_2_bm  (1<<2)  /* Analog Channel Selection Bits bit 2 mask. */
+#define ADC_MUXPOS_2_bp  2  /* Analog Channel Selection Bits bit 2 position. */
+#define ADC_MUXPOS_3_bm  (1<<3)  /* Analog Channel Selection Bits bit 3 mask. */
+#define ADC_MUXPOS_3_bp  3  /* Analog Channel Selection Bits bit 3 position. */
+#define ADC_MUXPOS_4_bm  (1<<4)  /* Analog Channel Selection Bits bit 4 mask. */
+#define ADC_MUXPOS_4_bp  4  /* Analog Channel Selection Bits bit 4 position. */
+#define ADC_MUXPOS_5_bm  (1<<5)  /* Analog Channel Selection Bits bit 5 mask. */
+#define ADC_MUXPOS_5_bp  5  /* Analog Channel Selection Bits bit 5 position. */
+#define ADC_VIA_gm  0xC0  /* VIA group mask. */
+#define ADC_VIA_gp  6  /* VIA group position. */
+#define ADC_VIA_0_bm  (1<<6)  /* VIA bit 0 mask. */
+#define ADC_VIA_0_bp  6  /* VIA bit 0 position. */
+#define ADC_VIA_1_bm  (1<<7)  /* VIA bit 1 mask. */
+#define ADC_VIA_1_bp  7  /* VIA bit 1 position. */
+
+/* ADC.MUXNEG  bit masks and bit positions */
+#define ADC_MUXNEG_gm  0x3F  /* Analog Channel Selection Bits group mask. */
+#define ADC_MUXNEG_gp  0  /* Analog Channel Selection Bits group position. */
+#define ADC_MUXNEG_0_bm  (1<<0)  /* Analog Channel Selection Bits bit 0 mask. */
+#define ADC_MUXNEG_0_bp  0  /* Analog Channel Selection Bits bit 0 position. */
+#define ADC_MUXNEG_1_bm  (1<<1)  /* Analog Channel Selection Bits bit 1 mask. */
+#define ADC_MUXNEG_1_bp  1  /* Analog Channel Selection Bits bit 1 position. */
+#define ADC_MUXNEG_2_bm  (1<<2)  /* Analog Channel Selection Bits bit 2 mask. */
+#define ADC_MUXNEG_2_bp  2  /* Analog Channel Selection Bits bit 2 position. */
+#define ADC_MUXNEG_3_bm  (1<<3)  /* Analog Channel Selection Bits bit 3 mask. */
+#define ADC_MUXNEG_3_bp  3  /* Analog Channel Selection Bits bit 3 position. */
+#define ADC_MUXNEG_4_bm  (1<<4)  /* Analog Channel Selection Bits bit 4 mask. */
+#define ADC_MUXNEG_4_bp  4  /* Analog Channel Selection Bits bit 4 position. */
+#define ADC_MUXNEG_5_bm  (1<<5)  /* Analog Channel Selection Bits bit 5 mask. */
+#define ADC_MUXNEG_5_bp  5  /* Analog Channel Selection Bits bit 5 position. */
+/* ADC_VIA  is already defined. */
+
+
+/* BOD - Bod interface */
+/* BOD.CTRLA  bit masks and bit positions */
+#define BOD_SLEEP_gm  0x03  /* Operation in sleep mode group mask. */
+#define BOD_SLEEP_gp  0  /* Operation in sleep mode group position. */
+#define BOD_SLEEP_0_bm  (1<<0)  /* Operation in sleep mode bit 0 mask. */
+#define BOD_SLEEP_0_bp  0  /* Operation in sleep mode bit 0 position. */
+#define BOD_SLEEP_1_bm  (1<<1)  /* Operation in sleep mode bit 1 mask. */
+#define BOD_SLEEP_1_bp  1  /* Operation in sleep mode bit 1 position. */
+#define BOD_ACTIVE_gm  0x0C  /* Operation in active mode group mask. */
+#define BOD_ACTIVE_gp  2  /* Operation in active mode group position. */
+#define BOD_ACTIVE_0_bm  (1<<2)  /* Operation in active mode bit 0 mask. */
+#define BOD_ACTIVE_0_bp  2  /* Operation in active mode bit 0 position. */
+#define BOD_ACTIVE_1_bm  (1<<3)  /* Operation in active mode bit 1 mask. */
+#define BOD_ACTIVE_1_bp  3  /* Operation in active mode bit 1 position. */
+#define BOD_SAMPFREQ_bm  0x10  /* Sample frequency bit mask. */
+#define BOD_SAMPFREQ_bp  4  /* Sample frequency bit position. */
+
+/* BOD.CTRLB  bit masks and bit positions */
+#define BOD_LVL_gm  0x07  /* Bod level group mask. */
+#define BOD_LVL_gp  0  /* Bod level group position. */
+#define BOD_LVL_0_bm  (1<<0)  /* Bod level bit 0 mask. */
+#define BOD_LVL_0_bp  0  /* Bod level bit 0 position. */
+#define BOD_LVL_1_bm  (1<<1)  /* Bod level bit 1 mask. */
+#define BOD_LVL_1_bp  1  /* Bod level bit 1 position. */
+#define BOD_LVL_2_bm  (1<<2)  /* Bod level bit 2 mask. */
+#define BOD_LVL_2_bp  2  /* Bod level bit 2 position. */
+
+/* BOD.VLMCTRLA  bit masks and bit positions */
+#define BOD_VLMLVL_gm  0x03  /* voltage level monitor level group mask. */
+#define BOD_VLMLVL_gp  0  /* voltage level monitor level group position. */
+#define BOD_VLMLVL_0_bm  (1<<0)  /* voltage level monitor level bit 0 mask. */
+#define BOD_VLMLVL_0_bp  0  /* voltage level monitor level bit 0 position. */
+#define BOD_VLMLVL_1_bm  (1<<1)  /* voltage level monitor level bit 1 mask. */
+#define BOD_VLMLVL_1_bp  1  /* voltage level monitor level bit 1 position. */
+
+/* BOD.INTCTRL  bit masks and bit positions */
+#define BOD_VLMIE_bm  0x01  /* voltage level monitor interrrupt enable bit mask. */
+#define BOD_VLMIE_bp  0  /* voltage level monitor interrrupt enable bit position. */
+#define BOD_VLMCFG_gm  0x06  /* Configuration group mask. */
+#define BOD_VLMCFG_gp  1  /* Configuration group position. */
+#define BOD_VLMCFG_0_bm  (1<<1)  /* Configuration bit 0 mask. */
+#define BOD_VLMCFG_0_bp  1  /* Configuration bit 0 position. */
+#define BOD_VLMCFG_1_bm  (1<<2)  /* Configuration bit 1 mask. */
+#define BOD_VLMCFG_1_bp  2  /* Configuration bit 1 position. */
+
+/* BOD.INTFLAGS  bit masks and bit positions */
+#define BOD_VLMIF_bm  0x01  /* Voltage level monitor interrupt flag bit mask. */
+#define BOD_VLMIF_bp  0  /* Voltage level monitor interrupt flag bit position. */
+
+/* BOD.STATUS  bit masks and bit positions */
+#define BOD_VLMS_bm  0x01  /* Voltage level monitor status bit mask. */
+#define BOD_VLMS_bp  0  /* Voltage level monitor status bit position. */
+
+
+/* CCL - Configurable Custom Logic */
+/* CCL.CTRLA  bit masks and bit positions */
+#define CCL_ENABLE_bm  0x01  /* Enable bit mask. */
+#define CCL_ENABLE_bp  0  /* Enable bit position. */
+#define CCL_RUNSTDBY_bm  0x40  /* Run in Standby bit mask. */
+#define CCL_RUNSTDBY_bp  6  /* Run in Standby bit position. */
+
+/* CCL.SEQCTRL0  bit masks and bit positions */
+#define CCL_SEQSEL_gm  0x07  /* Sequential Selection group mask. */
+#define CCL_SEQSEL_gp  0  /* Sequential Selection group position. */
+#define CCL_SEQSEL_0_bm  (1<<0)  /* Sequential Selection bit 0 mask. */
+#define CCL_SEQSEL_0_bp  0  /* Sequential Selection bit 0 position. */
+#define CCL_SEQSEL_1_bm  (1<<1)  /* Sequential Selection bit 1 mask. */
+#define CCL_SEQSEL_1_bp  1  /* Sequential Selection bit 1 position. */
+#define CCL_SEQSEL_2_bm  (1<<2)  /* Sequential Selection bit 2 mask. */
+#define CCL_SEQSEL_2_bp  2  /* Sequential Selection bit 2 position. */
+
+/* CCL.SEQCTRL1  bit masks and bit positions */
+/* CCL_SEQSEL  is already defined. */
+
+/* CCL.INTCTRL0  bit masks and bit positions */
+#define CCL_INTMODE0_gm  0x03  /* Interrupt Mode for LUT0 group mask. */
+#define CCL_INTMODE0_gp  0  /* Interrupt Mode for LUT0 group position. */
+#define CCL_INTMODE0_0_bm  (1<<0)  /* Interrupt Mode for LUT0 bit 0 mask. */
+#define CCL_INTMODE0_0_bp  0  /* Interrupt Mode for LUT0 bit 0 position. */
+#define CCL_INTMODE0_1_bm  (1<<1)  /* Interrupt Mode for LUT0 bit 1 mask. */
+#define CCL_INTMODE0_1_bp  1  /* Interrupt Mode for LUT0 bit 1 position. */
+#define CCL_INTMODE1_gm  0x0C  /* Interrupt Mode for LUT1 group mask. */
+#define CCL_INTMODE1_gp  2  /* Interrupt Mode for LUT1 group position. */
+#define CCL_INTMODE1_0_bm  (1<<2)  /* Interrupt Mode for LUT1 bit 0 mask. */
+#define CCL_INTMODE1_0_bp  2  /* Interrupt Mode for LUT1 bit 0 position. */
+#define CCL_INTMODE1_1_bm  (1<<3)  /* Interrupt Mode for LUT1 bit 1 mask. */
+#define CCL_INTMODE1_1_bp  3  /* Interrupt Mode for LUT1 bit 1 position. */
+#define CCL_INTMODE2_gm  0x30  /* Interrupt Mode for LUT2 group mask. */
+#define CCL_INTMODE2_gp  4  /* Interrupt Mode for LUT2 group position. */
+#define CCL_INTMODE2_0_bm  (1<<4)  /* Interrupt Mode for LUT2 bit 0 mask. */
+#define CCL_INTMODE2_0_bp  4  /* Interrupt Mode for LUT2 bit 0 position. */
+#define CCL_INTMODE2_1_bm  (1<<5)  /* Interrupt Mode for LUT2 bit 1 mask. */
+#define CCL_INTMODE2_1_bp  5  /* Interrupt Mode for LUT2 bit 1 position. */
+#define CCL_INTMODE3_gm  0xC0  /* Interrupt Mode for LUT3 group mask. */
+#define CCL_INTMODE3_gp  6  /* Interrupt Mode for LUT3 group position. */
+#define CCL_INTMODE3_0_bm  (1<<6)  /* Interrupt Mode for LUT3 bit 0 mask. */
+#define CCL_INTMODE3_0_bp  6  /* Interrupt Mode for LUT3 bit 0 position. */
+#define CCL_INTMODE3_1_bm  (1<<7)  /* Interrupt Mode for LUT3 bit 1 mask. */
+#define CCL_INTMODE3_1_bp  7  /* Interrupt Mode for LUT3 bit 1 position. */
+
+/* CCL.INTFLAGS  bit masks and bit positions */
+#define CCL_INT_gm  0x0F  /* Interrupt Flag group mask. */
+#define CCL_INT_gp  0  /* Interrupt Flag group position. */
+#define CCL_INT_0_bm  (1<<0)  /* Interrupt Flag bit 0 mask. */
+#define CCL_INT_0_bp  0  /* Interrupt Flag bit 0 position. */
+#define CCL_INT0_bm  CCL_INT_0_bm  /* This define is deprecated and should not be used */
+#define CCL_INT0_bp  CCL_INT_0_bp  /* This define is deprecated and should not be used */
+#define CCL_INT_1_bm  (1<<1)  /* Interrupt Flag bit 1 mask. */
+#define CCL_INT_1_bp  1  /* Interrupt Flag bit 1 position. */
+#define CCL_INT1_bm  CCL_INT_1_bm  /* This define is deprecated and should not be used */
+#define CCL_INT1_bp  CCL_INT_1_bp  /* This define is deprecated and should not be used */
+#define CCL_INT_2_bm  (1<<2)  /* Interrupt Flag bit 2 mask. */
+#define CCL_INT_2_bp  2  /* Interrupt Flag bit 2 position. */
+#define CCL_INT2_bm  CCL_INT_2_bm  /* This define is deprecated and should not be used */
+#define CCL_INT2_bp  CCL_INT_2_bp  /* This define is deprecated and should not be used */
+#define CCL_INT_3_bm  (1<<3)  /* Interrupt Flag bit 3 mask. */
+#define CCL_INT_3_bp  3  /* Interrupt Flag bit 3 position. */
+#define CCL_INT3_bm  CCL_INT_3_bm  /* This define is deprecated and should not be used */
+#define CCL_INT3_bp  CCL_INT_3_bp  /* This define is deprecated and should not be used */
+
+/* CCL.LUT0CTRLA  bit masks and bit positions */
+/* CCL_ENABLE  is already defined. */
+#define CCL_CLKSRC_gm  0x0E  /* Clock Source Selection group mask. */
+#define CCL_CLKSRC_gp  1  /* Clock Source Selection group position. */
+#define CCL_CLKSRC_0_bm  (1<<1)  /* Clock Source Selection bit 0 mask. */
+#define CCL_CLKSRC_0_bp  1  /* Clock Source Selection bit 0 position. */
+#define CCL_CLKSRC_1_bm  (1<<2)  /* Clock Source Selection bit 1 mask. */
+#define CCL_CLKSRC_1_bp  2  /* Clock Source Selection bit 1 position. */
+#define CCL_CLKSRC_2_bm  (1<<3)  /* Clock Source Selection bit 2 mask. */
+#define CCL_CLKSRC_2_bp  3  /* Clock Source Selection bit 2 position. */
+#define CCL_FILTSEL_gm  0x30  /* Filter Selection group mask. */
+#define CCL_FILTSEL_gp  4  /* Filter Selection group position. */
+#define CCL_FILTSEL_0_bm  (1<<4)  /* Filter Selection bit 0 mask. */
+#define CCL_FILTSEL_0_bp  4  /* Filter Selection bit 0 position. */
+#define CCL_FILTSEL_1_bm  (1<<5)  /* Filter Selection bit 1 mask. */
+#define CCL_FILTSEL_1_bp  5  /* Filter Selection bit 1 position. */
+#define CCL_OUTEN_bm  0x40  /* Output Enable bit mask. */
+#define CCL_OUTEN_bp  6  /* Output Enable bit position. */
+#define CCL_EDGEDET_bm  0x80  /* Edge Detection Enable bit mask. */
+#define CCL_EDGEDET_bp  7  /* Edge Detection Enable bit position. */
+
+/* CCL.LUT0CTRLB  bit masks and bit positions */
+#define CCL_INSEL0_gm  0x0F  /* LUT Input 0 Source Selection group mask. */
+#define CCL_INSEL0_gp  0  /* LUT Input 0 Source Selection group position. */
+#define CCL_INSEL0_0_bm  (1<<0)  /* LUT Input 0 Source Selection bit 0 mask. */
+#define CCL_INSEL0_0_bp  0  /* LUT Input 0 Source Selection bit 0 position. */
+#define CCL_INSEL0_1_bm  (1<<1)  /* LUT Input 0 Source Selection bit 1 mask. */
+#define CCL_INSEL0_1_bp  1  /* LUT Input 0 Source Selection bit 1 position. */
+#define CCL_INSEL0_2_bm  (1<<2)  /* LUT Input 0 Source Selection bit 2 mask. */
+#define CCL_INSEL0_2_bp  2  /* LUT Input 0 Source Selection bit 2 position. */
+#define CCL_INSEL0_3_bm  (1<<3)  /* LUT Input 0 Source Selection bit 3 mask. */
+#define CCL_INSEL0_3_bp  3  /* LUT Input 0 Source Selection bit 3 position. */
+#define CCL_INSEL1_gm  0xF0  /* LUT Input 1 Source Selection group mask. */
+#define CCL_INSEL1_gp  4  /* LUT Input 1 Source Selection group position. */
+#define CCL_INSEL1_0_bm  (1<<4)  /* LUT Input 1 Source Selection bit 0 mask. */
+#define CCL_INSEL1_0_bp  4  /* LUT Input 1 Source Selection bit 0 position. */
+#define CCL_INSEL1_1_bm  (1<<5)  /* LUT Input 1 Source Selection bit 1 mask. */
+#define CCL_INSEL1_1_bp  5  /* LUT Input 1 Source Selection bit 1 position. */
+#define CCL_INSEL1_2_bm  (1<<6)  /* LUT Input 1 Source Selection bit 2 mask. */
+#define CCL_INSEL1_2_bp  6  /* LUT Input 1 Source Selection bit 2 position. */
+#define CCL_INSEL1_3_bm  (1<<7)  /* LUT Input 1 Source Selection bit 3 mask. */
+#define CCL_INSEL1_3_bp  7  /* LUT Input 1 Source Selection bit 3 position. */
+
+/* CCL.LUT0CTRLC  bit masks and bit positions */
+#define CCL_INSEL2_gm  0x0F  /* LUT Input 2 Source Selection group mask. */
+#define CCL_INSEL2_gp  0  /* LUT Input 2 Source Selection group position. */
+#define CCL_INSEL2_0_bm  (1<<0)  /* LUT Input 2 Source Selection bit 0 mask. */
+#define CCL_INSEL2_0_bp  0  /* LUT Input 2 Source Selection bit 0 position. */
+#define CCL_INSEL2_1_bm  (1<<1)  /* LUT Input 2 Source Selection bit 1 mask. */
+#define CCL_INSEL2_1_bp  1  /* LUT Input 2 Source Selection bit 1 position. */
+#define CCL_INSEL2_2_bm  (1<<2)  /* LUT Input 2 Source Selection bit 2 mask. */
+#define CCL_INSEL2_2_bp  2  /* LUT Input 2 Source Selection bit 2 position. */
+#define CCL_INSEL2_3_bm  (1<<3)  /* LUT Input 2 Source Selection bit 3 mask. */
+#define CCL_INSEL2_3_bp  3  /* LUT Input 2 Source Selection bit 3 position. */
+
+/* CCL.TRUTH0  bit masks and bit positions */
+#define CCL_TRUTH_gm  0xFF  /* Truth Table group mask. */
+#define CCL_TRUTH_gp  0  /* Truth Table group position. */
+#define CCL_TRUTH_0_bm  (1<<0)  /* Truth Table bit 0 mask. */
+#define CCL_TRUTH_0_bp  0  /* Truth Table bit 0 position. */
+#define CCL_TRUTH_1_bm  (1<<1)  /* Truth Table bit 1 mask. */
+#define CCL_TRUTH_1_bp  1  /* Truth Table bit 1 position. */
+#define CCL_TRUTH_2_bm  (1<<2)  /* Truth Table bit 2 mask. */
+#define CCL_TRUTH_2_bp  2  /* Truth Table bit 2 position. */
+#define CCL_TRUTH_3_bm  (1<<3)  /* Truth Table bit 3 mask. */
+#define CCL_TRUTH_3_bp  3  /* Truth Table bit 3 position. */
+#define CCL_TRUTH_4_bm  (1<<4)  /* Truth Table bit 4 mask. */
+#define CCL_TRUTH_4_bp  4  /* Truth Table bit 4 position. */
+#define CCL_TRUTH_5_bm  (1<<5)  /* Truth Table bit 5 mask. */
+#define CCL_TRUTH_5_bp  5  /* Truth Table bit 5 position. */
+#define CCL_TRUTH_6_bm  (1<<6)  /* Truth Table bit 6 mask. */
+#define CCL_TRUTH_6_bp  6  /* Truth Table bit 6 position. */
+#define CCL_TRUTH_7_bm  (1<<7)  /* Truth Table bit 7 mask. */
+#define CCL_TRUTH_7_bp  7  /* Truth Table bit 7 position. */
+
+/* CCL.LUT1CTRLA  bit masks and bit positions */
+/* CCL_ENABLE  is already defined. */
+/* CCL_CLKSRC  is already defined. */
+/* CCL_FILTSEL  is already defined. */
+/* CCL_OUTEN  is already defined. */
+/* CCL_EDGEDET  is already defined. */
+
+/* CCL.LUT1CTRLB  bit masks and bit positions */
+/* CCL_INSEL0  is already defined. */
+/* CCL_INSEL1  is already defined. */
+
+/* CCL.LUT1CTRLC  bit masks and bit positions */
+/* CCL_INSEL2  is already defined. */
+
+/* CCL.TRUTH1  bit masks and bit positions */
+/* CCL_TRUTH  is already defined. */
+
+/* CCL.LUT2CTRLA  bit masks and bit positions */
+/* CCL_ENABLE  is already defined. */
+/* CCL_CLKSRC  is already defined. */
+/* CCL_FILTSEL  is already defined. */
+/* CCL_OUTEN  is already defined. */
+/* CCL_EDGEDET  is already defined. */
+
+/* CCL.LUT2CTRLB  bit masks and bit positions */
+/* CCL_INSEL0  is already defined. */
+/* CCL_INSEL1  is already defined. */
+
+/* CCL.LUT2CTRLC  bit masks and bit positions */
+/* CCL_INSEL2  is already defined. */
+
+/* CCL.TRUTH2  bit masks and bit positions */
+/* CCL_TRUTH  is already defined. */
+
+/* CCL.LUT3CTRLA  bit masks and bit positions */
+/* CCL_ENABLE  is already defined. */
+/* CCL_CLKSRC  is already defined. */
+/* CCL_FILTSEL  is already defined. */
+/* CCL_OUTEN  is already defined. */
+/* CCL_EDGEDET  is already defined. */
+
+/* CCL.LUT3CTRLB  bit masks and bit positions */
+/* CCL_INSEL0  is already defined. */
+/* CCL_INSEL1  is already defined. */
+
+/* CCL.LUT3CTRLC  bit masks and bit positions */
+/* CCL_INSEL2  is already defined. */
+
+/* CCL.TRUTH3  bit masks and bit positions */
+/* CCL_TRUTH  is already defined. */
+
+
+/* CLKCTRL - Clock controller */
+/* CLKCTRL.MCLKCTRLA  bit masks and bit positions */
+#define CLKCTRL_CLKSEL_gm  0x07  /* Clock select group mask. */
+#define CLKCTRL_CLKSEL_gp  0  /* Clock select group position. */
+#define CLKCTRL_CLKSEL_0_bm  (1<<0)  /* Clock select bit 0 mask. */
+#define CLKCTRL_CLKSEL_0_bp  0  /* Clock select bit 0 position. */
+#define CLKCTRL_CLKSEL_1_bm  (1<<1)  /* Clock select bit 1 mask. */
+#define CLKCTRL_CLKSEL_1_bp  1  /* Clock select bit 1 position. */
+#define CLKCTRL_CLKSEL_2_bm  (1<<2)  /* Clock select bit 2 mask. */
+#define CLKCTRL_CLKSEL_2_bp  2  /* Clock select bit 2 position. */
+#define CLKCTRL_CLKOUT_bm  0x80  /* System clock out bit mask. */
+#define CLKCTRL_CLKOUT_bp  7  /* System clock out bit position. */
+
+/* CLKCTRL.MCLKCTRLB  bit masks and bit positions */
+#define CLKCTRL_PEN_bm  0x01  /* Prescaler enable bit mask. */
+#define CLKCTRL_PEN_bp  0  /* Prescaler enable bit position. */
+#define CLKCTRL_PDIV_gm  0x1E  /* Prescaler division group mask. */
+#define CLKCTRL_PDIV_gp  1  /* Prescaler division group position. */
+#define CLKCTRL_PDIV_0_bm  (1<<1)  /* Prescaler division bit 0 mask. */
+#define CLKCTRL_PDIV_0_bp  1  /* Prescaler division bit 0 position. */
+#define CLKCTRL_PDIV_1_bm  (1<<2)  /* Prescaler division bit 1 mask. */
+#define CLKCTRL_PDIV_1_bp  2  /* Prescaler division bit 1 position. */
+#define CLKCTRL_PDIV_2_bm  (1<<3)  /* Prescaler division bit 2 mask. */
+#define CLKCTRL_PDIV_2_bp  3  /* Prescaler division bit 2 position. */
+#define CLKCTRL_PDIV_3_bm  (1<<4)  /* Prescaler division bit 3 mask. */
+#define CLKCTRL_PDIV_3_bp  4  /* Prescaler division bit 3 position. */
+
+/* CLKCTRL.MCLKCTRLC  bit masks and bit positions */
+#define CLKCTRL_CFDEN_bm  0x01  /* Clock Failure Detect Enable bit mask. */
+#define CLKCTRL_CFDEN_bp  0  /* Clock Failure Detect Enable bit position. */
+#define CLKCTRL_CFDTST_bm  0x02  /* CFD Test bit mask. */
+#define CLKCTRL_CFDTST_bp  1  /* CFD Test bit position. */
+#define CLKCTRL_CFDSRC_gm  0x0C  /* CFD Source group mask. */
+#define CLKCTRL_CFDSRC_gp  2  /* CFD Source group position. */
+#define CLKCTRL_CFDSRC_0_bm  (1<<2)  /* CFD Source bit 0 mask. */
+#define CLKCTRL_CFDSRC_0_bp  2  /* CFD Source bit 0 position. */
+#define CLKCTRL_CFDSRC_1_bm  (1<<3)  /* CFD Source bit 1 mask. */
+#define CLKCTRL_CFDSRC_1_bp  3  /* CFD Source bit 1 position. */
+
+/* CLKCTRL.MCLKINTCTRL  bit masks and bit positions */
+#define CLKCTRL_CFD_bm  0x01  /* Interrupt Enable bit mask. */
+#define CLKCTRL_CFD_bp  0  /* Interrupt Enable bit position. */
+#define CLKCTRL_INTTYPE_bm  0x80  /* Interrupt Type bit mask. */
+#define CLKCTRL_INTTYPE_bp  7  /* Interrupt Type bit position. */
+
+/* CLKCTRL.MCLKINTFLAGS  bit masks and bit positions */
+/* CLKCTRL_CFD  is already defined. */
+
+/* CLKCTRL.MCLKSTATUS  bit masks and bit positions */
+#define CLKCTRL_SOSC_bm  0x01  /* System Oscillator changing bit mask. */
+#define CLKCTRL_SOSC_bp  0  /* System Oscillator changing bit position. */
+#define CLKCTRL_OSCHFS_bm  0x02  /* High frequency oscillator status bit mask. */
+#define CLKCTRL_OSCHFS_bp  1  /* High frequency oscillator status bit position. */
+#define CLKCTRL_OSC32KS_bm  0x04  /* 32KHz oscillator status bit mask. */
+#define CLKCTRL_OSC32KS_bp  2  /* 32KHz oscillator status bit position. */
+#define CLKCTRL_XOSC32KS_bm  0x08  /* 32.768 kHz Crystal Oscillator status bit mask. */
+#define CLKCTRL_XOSC32KS_bp  3  /* 32.768 kHz Crystal Oscillator status bit position. */
+#define CLKCTRL_EXTS_bm  0x10  /* External Clock status / XOSCHF status bit mask. */
+#define CLKCTRL_EXTS_bp  4  /* External Clock status / XOSCHF status bit position. */
+
+/* CLKCTRL.MCLKTIMEBASE  bit masks and bit positions */
+#define CLKCTRL_TIMEBASE_gm  0x1F  /* Timebase group mask. */
+#define CLKCTRL_TIMEBASE_gp  0  /* Timebase group position. */
+#define CLKCTRL_TIMEBASE_0_bm  (1<<0)  /* Timebase bit 0 mask. */
+#define CLKCTRL_TIMEBASE_0_bp  0  /* Timebase bit 0 position. */
+#define CLKCTRL_TIMEBASE_1_bm  (1<<1)  /* Timebase bit 1 mask. */
+#define CLKCTRL_TIMEBASE_1_bp  1  /* Timebase bit 1 position. */
+#define CLKCTRL_TIMEBASE_2_bm  (1<<2)  /* Timebase bit 2 mask. */
+#define CLKCTRL_TIMEBASE_2_bp  2  /* Timebase bit 2 position. */
+#define CLKCTRL_TIMEBASE_3_bm  (1<<3)  /* Timebase bit 3 mask. */
+#define CLKCTRL_TIMEBASE_3_bp  3  /* Timebase bit 3 position. */
+#define CLKCTRL_TIMEBASE_4_bm  (1<<4)  /* Timebase bit 4 mask. */
+#define CLKCTRL_TIMEBASE_4_bp  4  /* Timebase bit 4 position. */
+
+/* CLKCTRL.OSCHFCTRLA  bit masks and bit positions */
+#define CLKCTRL_AUTOTUNE_gm  0x03  /* Automatic Oscillator Tune group mask. */
+#define CLKCTRL_AUTOTUNE_gp  0  /* Automatic Oscillator Tune group position. */
+#define CLKCTRL_AUTOTUNE_0_bm  (1<<0)  /* Automatic Oscillator Tune bit 0 mask. */
+#define CLKCTRL_AUTOTUNE_0_bp  0  /* Automatic Oscillator Tune bit 0 position. */
+#define CLKCTRL_AUTOTUNE_1_bm  (1<<1)  /* Automatic Oscillator Tune bit 1 mask. */
+#define CLKCTRL_AUTOTUNE_1_bp  1  /* Automatic Oscillator Tune bit 1 position. */
+#define CLKCTRL_RUNSTDBY_bm  0x80  /* Run in standby bit mask. */
+#define CLKCTRL_RUNSTDBY_bp  7  /* Run in standby bit position. */
+
+/* CLKCTRL.OSCHFTUNE  bit masks and bit positions */
+#define CLKCTRL_TUNE_gm  0xFF  /* Oscillator Tune group mask. */
+#define CLKCTRL_TUNE_gp  0  /* Oscillator Tune group position. */
+#define CLKCTRL_TUNE_0_bm  (1<<0)  /* Oscillator Tune bit 0 mask. */
+#define CLKCTRL_TUNE_0_bp  0  /* Oscillator Tune bit 0 position. */
+#define CLKCTRL_TUNE_1_bm  (1<<1)  /* Oscillator Tune bit 1 mask. */
+#define CLKCTRL_TUNE_1_bp  1  /* Oscillator Tune bit 1 position. */
+#define CLKCTRL_TUNE_2_bm  (1<<2)  /* Oscillator Tune bit 2 mask. */
+#define CLKCTRL_TUNE_2_bp  2  /* Oscillator Tune bit 2 position. */
+#define CLKCTRL_TUNE_3_bm  (1<<3)  /* Oscillator Tune bit 3 mask. */
+#define CLKCTRL_TUNE_3_bp  3  /* Oscillator Tune bit 3 position. */
+#define CLKCTRL_TUNE_4_bm  (1<<4)  /* Oscillator Tune bit 4 mask. */
+#define CLKCTRL_TUNE_4_bp  4  /* Oscillator Tune bit 4 position. */
+#define CLKCTRL_TUNE_5_bm  (1<<5)  /* Oscillator Tune bit 5 mask. */
+#define CLKCTRL_TUNE_5_bp  5  /* Oscillator Tune bit 5 position. */
+#define CLKCTRL_TUNE_6_bm  (1<<6)  /* Oscillator Tune bit 6 mask. */
+#define CLKCTRL_TUNE_6_bp  6  /* Oscillator Tune bit 6 position. */
+#define CLKCTRL_TUNE_7_bm  (1<<7)  /* Oscillator Tune bit 7 mask. */
+#define CLKCTRL_TUNE_7_bp  7  /* Oscillator Tune bit 7 position. */
+
+/* CLKCTRL.OSC32KCTRLA  bit masks and bit positions */
+/* CLKCTRL_RUNSTDBY  is already defined. */
+
+/* CLKCTRL.XOSC32KCTRLA  bit masks and bit positions */
+#define CLKCTRL_ENABLE_bm  0x01  /* Enable bit mask. */
+#define CLKCTRL_ENABLE_bp  0  /* Enable bit position. */
+#define CLKCTRL_LPMODE_bm  0x02  /* Low power mode bit mask. */
+#define CLKCTRL_LPMODE_bp  1  /* Low power mode bit position. */
+#define CLKCTRL_SEL_bm  0x04  /* Select bit mask. */
+#define CLKCTRL_SEL_bp  2  /* Select bit position. */
+#define CLKCTRL_CSUT_gm  0x30  /* Crystal startup time group mask. */
+#define CLKCTRL_CSUT_gp  4  /* Crystal startup time group position. */
+#define CLKCTRL_CSUT_0_bm  (1<<4)  /* Crystal startup time bit 0 mask. */
+#define CLKCTRL_CSUT_0_bp  4  /* Crystal startup time bit 0 position. */
+#define CLKCTRL_CSUT_1_bm  (1<<5)  /* Crystal startup time bit 1 mask. */
+#define CLKCTRL_CSUT_1_bp  5  /* Crystal startup time bit 1 position. */
+/* CLKCTRL_RUNSTDBY  is already defined. */
+
+/* CLKCTRL.XOSCHFCTRLA  bit masks and bit positions */
+/* CLKCTRL_ENABLE  is already defined. */
+#define CLKCTRL_SELHF_bm  0x02  /* Source Select bit mask. */
+#define CLKCTRL_SELHF_bp  1  /* Source Select bit position. */
+#define CLKCTRL_CSUTHF_gm  0x30  /* Start-Up Time group mask. */
+#define CLKCTRL_CSUTHF_gp  4  /* Start-Up Time group position. */
+#define CLKCTRL_CSUTHF_0_bm  (1<<4)  /* Start-Up Time bit 0 mask. */
+#define CLKCTRL_CSUTHF_0_bp  4  /* Start-Up Time bit 0 position. */
+#define CLKCTRL_CSUTHF_1_bm  (1<<5)  /* Start-Up Time bit 1 mask. */
+#define CLKCTRL_CSUTHF_1_bp  5  /* Start-Up Time bit 1 position. */
+/* CLKCTRL_RUNSTDBY  is already defined. */
+
+
+/* CPU - CPU */
+/* CPU.CCP  bit masks and bit positions */
+#define CPU_CCP_gm  0xFF  /* CCP signature group mask. */
+#define CPU_CCP_gp  0  /* CCP signature group position. */
+#define CPU_CCP_0_bm  (1<<0)  /* CCP signature bit 0 mask. */
+#define CPU_CCP_0_bp  0  /* CCP signature bit 0 position. */
+#define CPU_CCP_1_bm  (1<<1)  /* CCP signature bit 1 mask. */
+#define CPU_CCP_1_bp  1  /* CCP signature bit 1 position. */
+#define CPU_CCP_2_bm  (1<<2)  /* CCP signature bit 2 mask. */
+#define CPU_CCP_2_bp  2  /* CCP signature bit 2 position. */
+#define CPU_CCP_3_bm  (1<<3)  /* CCP signature bit 3 mask. */
+#define CPU_CCP_3_bp  3  /* CCP signature bit 3 position. */
+#define CPU_CCP_4_bm  (1<<4)  /* CCP signature bit 4 mask. */
+#define CPU_CCP_4_bp  4  /* CCP signature bit 4 position. */
+#define CPU_CCP_5_bm  (1<<5)  /* CCP signature bit 5 mask. */
+#define CPU_CCP_5_bp  5  /* CCP signature bit 5 position. */
+#define CPU_CCP_6_bm  (1<<6)  /* CCP signature bit 6 mask. */
+#define CPU_CCP_6_bp  6  /* CCP signature bit 6 position. */
+#define CPU_CCP_7_bm  (1<<7)  /* CCP signature bit 7 mask. */
+#define CPU_CCP_7_bp  7  /* CCP signature bit 7 position. */
+
+/* CPU.SREG  bit masks and bit positions */
+#define CPU_C_bm  0x01  /* Carry Flag bit mask. */
+#define CPU_C_bp  0  /* Carry Flag bit position. */
+#define CPU_Z_bm  0x02  /* Zero Flag bit mask. */
+#define CPU_Z_bp  1  /* Zero Flag bit position. */
+#define CPU_N_bm  0x04  /* Negative Flag bit mask. */
+#define CPU_N_bp  2  /* Negative Flag bit position. */
+#define CPU_V_bm  0x08  /* Two's Complement Overflow Flag bit mask. */
+#define CPU_V_bp  3  /* Two's Complement Overflow Flag bit position. */
+#define CPU_S_bm  0x10  /* N Exclusive Or V Flag bit mask. */
+#define CPU_S_bp  4  /* N Exclusive Or V Flag bit position. */
+#define CPU_H_bm  0x20  /* Half Carry Flag bit mask. */
+#define CPU_H_bp  5  /* Half Carry Flag bit position. */
+#define CPU_T_bm  0x40  /* Transfer Bit bit mask. */
+#define CPU_T_bp  6  /* Transfer Bit bit position. */
+#define CPU_I_bm  0x80  /* Global Interrupt Enable Flag bit mask. */
+#define CPU_I_bp  7  /* Global Interrupt Enable Flag bit position. */
+
+
+/* CPUINT - Interrupt Controller */
+/* CPUINT.CTRLA  bit masks and bit positions */
+#define CPUINT_LVL0RR_bm  0x01  /* Round-robin Scheduling Enable bit mask. */
+#define CPUINT_LVL0RR_bp  0  /* Round-robin Scheduling Enable bit position. */
+#define CPUINT_CVT_bm  0x20  /* Compact Vector Table bit mask. */
+#define CPUINT_CVT_bp  5  /* Compact Vector Table bit position. */
+#define CPUINT_IVSEL_bm  0x40  /* Interrupt Vector Select bit mask. */
+#define CPUINT_IVSEL_bp  6  /* Interrupt Vector Select bit position. */
+
+/* CPUINT.STATUS  bit masks and bit positions */
+#define CPUINT_LVL0EX_bm  0x01  /* Level 0 Interrupt Executing bit mask. */
+#define CPUINT_LVL0EX_bp  0  /* Level 0 Interrupt Executing bit position. */
+#define CPUINT_LVL1EX_bm  0x02  /* Level 1 Interrupt Executing bit mask. */
+#define CPUINT_LVL1EX_bp  1  /* Level 1 Interrupt Executing bit position. */
+#define CPUINT_NMIEX_bm  0x80  /* Non-maskable Interrupt Executing bit mask. */
+#define CPUINT_NMIEX_bp  7  /* Non-maskable Interrupt Executing bit position. */
+
+/* CPUINT.LVL0PRI  bit masks and bit positions */
+#define CPUINT_LVL0PRI_gm  0xFF  /* Interrupt Level Priority group mask. */
+#define CPUINT_LVL0PRI_gp  0  /* Interrupt Level Priority group position. */
+#define CPUINT_LVL0PRI_0_bm  (1<<0)  /* Interrupt Level Priority bit 0 mask. */
+#define CPUINT_LVL0PRI_0_bp  0  /* Interrupt Level Priority bit 0 position. */
+#define CPUINT_LVL0PRI_1_bm  (1<<1)  /* Interrupt Level Priority bit 1 mask. */
+#define CPUINT_LVL0PRI_1_bp  1  /* Interrupt Level Priority bit 1 position. */
+#define CPUINT_LVL0PRI_2_bm  (1<<2)  /* Interrupt Level Priority bit 2 mask. */
+#define CPUINT_LVL0PRI_2_bp  2  /* Interrupt Level Priority bit 2 position. */
+#define CPUINT_LVL0PRI_3_bm  (1<<3)  /* Interrupt Level Priority bit 3 mask. */
+#define CPUINT_LVL0PRI_3_bp  3  /* Interrupt Level Priority bit 3 position. */
+#define CPUINT_LVL0PRI_4_bm  (1<<4)  /* Interrupt Level Priority bit 4 mask. */
+#define CPUINT_LVL0PRI_4_bp  4  /* Interrupt Level Priority bit 4 position. */
+#define CPUINT_LVL0PRI_5_bm  (1<<5)  /* Interrupt Level Priority bit 5 mask. */
+#define CPUINT_LVL0PRI_5_bp  5  /* Interrupt Level Priority bit 5 position. */
+#define CPUINT_LVL0PRI_6_bm  (1<<6)  /* Interrupt Level Priority bit 6 mask. */
+#define CPUINT_LVL0PRI_6_bp  6  /* Interrupt Level Priority bit 6 position. */
+#define CPUINT_LVL0PRI_7_bm  (1<<7)  /* Interrupt Level Priority bit 7 mask. */
+#define CPUINT_LVL0PRI_7_bp  7  /* Interrupt Level Priority bit 7 position. */
+
+/* CPUINT.LVL1VEC  bit masks and bit positions */
+#define CPUINT_LVL1VEC_gm  0xFF  /* Interrupt Vector with High Priority group mask. */
+#define CPUINT_LVL1VEC_gp  0  /* Interrupt Vector with High Priority group position. */
+#define CPUINT_LVL1VEC_0_bm  (1<<0)  /* Interrupt Vector with High Priority bit 0 mask. */
+#define CPUINT_LVL1VEC_0_bp  0  /* Interrupt Vector with High Priority bit 0 position. */
+#define CPUINT_LVL1VEC_1_bm  (1<<1)  /* Interrupt Vector with High Priority bit 1 mask. */
+#define CPUINT_LVL1VEC_1_bp  1  /* Interrupt Vector with High Priority bit 1 position. */
+#define CPUINT_LVL1VEC_2_bm  (1<<2)  /* Interrupt Vector with High Priority bit 2 mask. */
+#define CPUINT_LVL1VEC_2_bp  2  /* Interrupt Vector with High Priority bit 2 position. */
+#define CPUINT_LVL1VEC_3_bm  (1<<3)  /* Interrupt Vector with High Priority bit 3 mask. */
+#define CPUINT_LVL1VEC_3_bp  3  /* Interrupt Vector with High Priority bit 3 position. */
+#define CPUINT_LVL1VEC_4_bm  (1<<4)  /* Interrupt Vector with High Priority bit 4 mask. */
+#define CPUINT_LVL1VEC_4_bp  4  /* Interrupt Vector with High Priority bit 4 position. */
+#define CPUINT_LVL1VEC_5_bm  (1<<5)  /* Interrupt Vector with High Priority bit 5 mask. */
+#define CPUINT_LVL1VEC_5_bp  5  /* Interrupt Vector with High Priority bit 5 position. */
+#define CPUINT_LVL1VEC_6_bm  (1<<6)  /* Interrupt Vector with High Priority bit 6 mask. */
+#define CPUINT_LVL1VEC_6_bp  6  /* Interrupt Vector with High Priority bit 6 position. */
+#define CPUINT_LVL1VEC_7_bm  (1<<7)  /* Interrupt Vector with High Priority bit 7 mask. */
+#define CPUINT_LVL1VEC_7_bp  7  /* Interrupt Vector with High Priority bit 7 position. */
+
+
+/* CRCSCAN - CRCSCAN */
+/* CRCSCAN.CTRLA  bit masks and bit positions */
+#define CRCSCAN_ENABLE_bm  0x01  /* Enable CRC scan bit mask. */
+#define CRCSCAN_ENABLE_bp  0  /* Enable CRC scan bit position. */
+#define CRCSCAN_NMIEN_bm  0x02  /* Enable NMI Trigger bit mask. */
+#define CRCSCAN_NMIEN_bp  1  /* Enable NMI Trigger bit position. */
+#define CRCSCAN_RESET_bm  0x80  /* Reset CRC scan bit mask. */
+#define CRCSCAN_RESET_bp  7  /* Reset CRC scan bit position. */
+
+/* CRCSCAN.CTRLB  bit masks and bit positions */
+#define CRCSCAN_SRC_gm  0x03  /* CRC Source group mask. */
+#define CRCSCAN_SRC_gp  0  /* CRC Source group position. */
+#define CRCSCAN_SRC_0_bm  (1<<0)  /* CRC Source bit 0 mask. */
+#define CRCSCAN_SRC_0_bp  0  /* CRC Source bit 0 position. */
+#define CRCSCAN_SRC_1_bm  (1<<1)  /* CRC Source bit 1 mask. */
+#define CRCSCAN_SRC_1_bp  1  /* CRC Source bit 1 position. */
+
+/* CRCSCAN.STATUS  bit masks and bit positions */
+#define CRCSCAN_BUSY_bm  0x01  /* CRC Busy bit mask. */
+#define CRCSCAN_BUSY_bp  0  /* CRC Busy bit position. */
+#define CRCSCAN_OK_bm  0x02  /* CRC Ok bit mask. */
+#define CRCSCAN_OK_bp  1  /* CRC Ok bit position. */
+
+
+/* DAC - Digital to Analog Converter */
+/* DAC.CTRLA  bit masks and bit positions */
+#define DAC_ENABLE_bm  0x01  /* DAC Enable bit mask. */
+#define DAC_ENABLE_bp  0  /* DAC Enable bit position. */
+#define DAC_OUTRANGE_gm  0x30  /* Output Buffer Range group mask. */
+#define DAC_OUTRANGE_gp  4  /* Output Buffer Range group position. */
+#define DAC_OUTRANGE_0_bm  (1<<4)  /* Output Buffer Range bit 0 mask. */
+#define DAC_OUTRANGE_0_bp  4  /* Output Buffer Range bit 0 position. */
+#define DAC_OUTRANGE_1_bm  (1<<5)  /* Output Buffer Range bit 1 mask. */
+#define DAC_OUTRANGE_1_bp  5  /* Output Buffer Range bit 1 position. */
+#define DAC_OUTEN_bm  0x40  /* Output Buffer Enable bit mask. */
+#define DAC_OUTEN_bp  6  /* Output Buffer Enable bit position. */
+#define DAC_RUNSTDBY_bm  0x80  /* Run in Standby Mode bit mask. */
+#define DAC_RUNSTDBY_bp  7  /* Run in Standby Mode bit position. */
+
+/* DAC.DATA  bit masks and bit positions */
+#define DAC_DATA_gm  0xFFC0  /* Data group mask. */
+#define DAC_DATA_gp  6  /* Data group position. */
+#define DAC_DATA_0_bm  (1<<6)  /* Data bit 0 mask. */
+#define DAC_DATA_0_bp  6  /* Data bit 0 position. */
+#define DAC_DATA_1_bm  (1<<7)  /* Data bit 1 mask. */
+#define DAC_DATA_1_bp  7  /* Data bit 1 position. */
+#define DAC_DATA_2_bm  (1<<8)  /* Data bit 2 mask. */
+#define DAC_DATA_2_bp  8  /* Data bit 2 position. */
+#define DAC_DATA_3_bm  (1<<9)  /* Data bit 3 mask. */
+#define DAC_DATA_3_bp  9  /* Data bit 3 position. */
+#define DAC_DATA_4_bm  (1<<10)  /* Data bit 4 mask. */
+#define DAC_DATA_4_bp  10  /* Data bit 4 position. */
+#define DAC_DATA_5_bm  (1<<11)  /* Data bit 5 mask. */
+#define DAC_DATA_5_bp  11  /* Data bit 5 position. */
+#define DAC_DATA_6_bm  (1<<12)  /* Data bit 6 mask. */
+#define DAC_DATA_6_bp  12  /* Data bit 6 position. */
+#define DAC_DATA_7_bm  (1<<13)  /* Data bit 7 mask. */
+#define DAC_DATA_7_bp  13  /* Data bit 7 position. */
+#define DAC_DATA_8_bm  (1<<14)  /* Data bit 8 mask. */
+#define DAC_DATA_8_bp  14  /* Data bit 8 position. */
+#define DAC_DATA_9_bm  (1<<15)  /* Data bit 9 mask. */
+#define DAC_DATA_9_bp  15  /* Data bit 9 position. */
+
+
+/* EVSYS - Event System */
+/* EVSYS.SWEVENTA  bit masks and bit positions */
+#define EVSYS_SWEVENTA_gm  0xFF  /* Software event on channel select group mask. */
+#define EVSYS_SWEVENTA_gp  0  /* Software event on channel select group position. */
+#define EVSYS_SWEVENTA_0_bm  (1<<0)  /* Software event on channel select bit 0 mask. */
+#define EVSYS_SWEVENTA_0_bp  0  /* Software event on channel select bit 0 position. */
+#define EVSYS_SWEVENTA_1_bm  (1<<1)  /* Software event on channel select bit 1 mask. */
+#define EVSYS_SWEVENTA_1_bp  1  /* Software event on channel select bit 1 position. */
+#define EVSYS_SWEVENTA_2_bm  (1<<2)  /* Software event on channel select bit 2 mask. */
+#define EVSYS_SWEVENTA_2_bp  2  /* Software event on channel select bit 2 position. */
+#define EVSYS_SWEVENTA_3_bm  (1<<3)  /* Software event on channel select bit 3 mask. */
+#define EVSYS_SWEVENTA_3_bp  3  /* Software event on channel select bit 3 position. */
+#define EVSYS_SWEVENTA_4_bm  (1<<4)  /* Software event on channel select bit 4 mask. */
+#define EVSYS_SWEVENTA_4_bp  4  /* Software event on channel select bit 4 position. */
+#define EVSYS_SWEVENTA_5_bm  (1<<5)  /* Software event on channel select bit 5 mask. */
+#define EVSYS_SWEVENTA_5_bp  5  /* Software event on channel select bit 5 position. */
+#define EVSYS_SWEVENTA_6_bm  (1<<6)  /* Software event on channel select bit 6 mask. */
+#define EVSYS_SWEVENTA_6_bp  6  /* Software event on channel select bit 6 position. */
+#define EVSYS_SWEVENTA_7_bm  (1<<7)  /* Software event on channel select bit 7 mask. */
+#define EVSYS_SWEVENTA_7_bp  7  /* Software event on channel select bit 7 position. */
+
+/* EVSYS.CHANNEL0  bit masks and bit positions */
+#define EVSYS_CHANNEL_gm  0xFF  /* Channel generator select group mask. */
+#define EVSYS_CHANNEL_gp  0  /* Channel generator select group position. */
+#define EVSYS_CHANNEL_0_bm  (1<<0)  /* Channel generator select bit 0 mask. */
+#define EVSYS_CHANNEL_0_bp  0  /* Channel generator select bit 0 position. */
+#define EVSYS_CHANNEL_1_bm  (1<<1)  /* Channel generator select bit 1 mask. */
+#define EVSYS_CHANNEL_1_bp  1  /* Channel generator select bit 1 position. */
+#define EVSYS_CHANNEL_2_bm  (1<<2)  /* Channel generator select bit 2 mask. */
+#define EVSYS_CHANNEL_2_bp  2  /* Channel generator select bit 2 position. */
+#define EVSYS_CHANNEL_3_bm  (1<<3)  /* Channel generator select bit 3 mask. */
+#define EVSYS_CHANNEL_3_bp  3  /* Channel generator select bit 3 position. */
+#define EVSYS_CHANNEL_4_bm  (1<<4)  /* Channel generator select bit 4 mask. */
+#define EVSYS_CHANNEL_4_bp  4  /* Channel generator select bit 4 position. */
+#define EVSYS_CHANNEL_5_bm  (1<<5)  /* Channel generator select bit 5 mask. */
+#define EVSYS_CHANNEL_5_bp  5  /* Channel generator select bit 5 position. */
+#define EVSYS_CHANNEL_6_bm  (1<<6)  /* Channel generator select bit 6 mask. */
+#define EVSYS_CHANNEL_6_bp  6  /* Channel generator select bit 6 position. */
+#define EVSYS_CHANNEL_7_bm  (1<<7)  /* Channel generator select bit 7 mask. */
+#define EVSYS_CHANNEL_7_bp  7  /* Channel generator select bit 7 position. */
+
+/* EVSYS.CHANNEL1  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.CHANNEL2  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.CHANNEL3  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.CHANNEL4  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.CHANNEL5  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.USERCCLLUT0A  bit masks and bit positions */
+#define EVSYS_USER_gm  0xFF  /* User channel select group mask. */
+#define EVSYS_USER_gp  0  /* User channel select group position. */
+#define EVSYS_USER_0_bm  (1<<0)  /* User channel select bit 0 mask. */
+#define EVSYS_USER_0_bp  0  /* User channel select bit 0 position. */
+#define EVSYS_USER_1_bm  (1<<1)  /* User channel select bit 1 mask. */
+#define EVSYS_USER_1_bp  1  /* User channel select bit 1 position. */
+#define EVSYS_USER_2_bm  (1<<2)  /* User channel select bit 2 mask. */
+#define EVSYS_USER_2_bp  2  /* User channel select bit 2 position. */
+#define EVSYS_USER_3_bm  (1<<3)  /* User channel select bit 3 mask. */
+#define EVSYS_USER_3_bp  3  /* User channel select bit 3 position. */
+#define EVSYS_USER_4_bm  (1<<4)  /* User channel select bit 4 mask. */
+#define EVSYS_USER_4_bp  4  /* User channel select bit 4 position. */
+#define EVSYS_USER_5_bm  (1<<5)  /* User channel select bit 5 mask. */
+#define EVSYS_USER_5_bp  5  /* User channel select bit 5 position. */
+#define EVSYS_USER_6_bm  (1<<6)  /* User channel select bit 6 mask. */
+#define EVSYS_USER_6_bp  6  /* User channel select bit 6 position. */
+#define EVSYS_USER_7_bm  (1<<7)  /* User channel select bit 7 mask. */
+#define EVSYS_USER_7_bp  7  /* User channel select bit 7 position. */
+
+/* EVSYS.USERCCLLUT0B  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT1A  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT1B  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT2A  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT2B  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT3A  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT3B  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERADC0START  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTB  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTC  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTD  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTE  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTF  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERUSART0IRDA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERUSART1IRDA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERUSART2IRDA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCA0CNTA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCA0CNTB  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCA1CNTA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCA1CNTB  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB0CAPT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB0COUNT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB1CAPT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB1COUNT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB2CAPT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB2COUNT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB3CAPT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB3COUNT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+
+/* FUSE - Fuses */
+/* FUSE.WDTCFG  bit masks and bit positions */
+#define FUSE_PERIOD_gm  0x0F  /* Watchdog Timeout Period group mask. */
+#define FUSE_PERIOD_gp  0  /* Watchdog Timeout Period group position. */
+#define FUSE_PERIOD_0_bm  (1<<0)  /* Watchdog Timeout Period bit 0 mask. */
+#define FUSE_PERIOD_0_bp  0  /* Watchdog Timeout Period bit 0 position. */
+#define FUSE_PERIOD_1_bm  (1<<1)  /* Watchdog Timeout Period bit 1 mask. */
+#define FUSE_PERIOD_1_bp  1  /* Watchdog Timeout Period bit 1 position. */
+#define FUSE_PERIOD_2_bm  (1<<2)  /* Watchdog Timeout Period bit 2 mask. */
+#define FUSE_PERIOD_2_bp  2  /* Watchdog Timeout Period bit 2 position. */
+#define FUSE_PERIOD_3_bm  (1<<3)  /* Watchdog Timeout Period bit 3 mask. */
+#define FUSE_PERIOD_3_bp  3  /* Watchdog Timeout Period bit 3 position. */
+#define FUSE_WINDOW_gm  0xF0  /* Watchdog Window Timeout Period group mask. */
+#define FUSE_WINDOW_gp  4  /* Watchdog Window Timeout Period group position. */
+#define FUSE_WINDOW_0_bm  (1<<4)  /* Watchdog Window Timeout Period bit 0 mask. */
+#define FUSE_WINDOW_0_bp  4  /* Watchdog Window Timeout Period bit 0 position. */
+#define FUSE_WINDOW_1_bm  (1<<5)  /* Watchdog Window Timeout Period bit 1 mask. */
+#define FUSE_WINDOW_1_bp  5  /* Watchdog Window Timeout Period bit 1 position. */
+#define FUSE_WINDOW_2_bm  (1<<6)  /* Watchdog Window Timeout Period bit 2 mask. */
+#define FUSE_WINDOW_2_bp  6  /* Watchdog Window Timeout Period bit 2 position. */
+#define FUSE_WINDOW_3_bm  (1<<7)  /* Watchdog Window Timeout Period bit 3 mask. */
+#define FUSE_WINDOW_3_bp  7  /* Watchdog Window Timeout Period bit 3 position. */
+
+/* FUSE.BODCFG  bit masks and bit positions */
+#define FUSE_SLEEP_gm  0x03  /* BOD Operation in Sleep Mode group mask. */
+#define FUSE_SLEEP_gp  0  /* BOD Operation in Sleep Mode group position. */
+#define FUSE_SLEEP_0_bm  (1<<0)  /* BOD Operation in Sleep Mode bit 0 mask. */
+#define FUSE_SLEEP_0_bp  0  /* BOD Operation in Sleep Mode bit 0 position. */
+#define FUSE_SLEEP_1_bm  (1<<1)  /* BOD Operation in Sleep Mode bit 1 mask. */
+#define FUSE_SLEEP_1_bp  1  /* BOD Operation in Sleep Mode bit 1 position. */
+#define FUSE_ACTIVE_gm  0x0C  /* BOD Operation in Active Mode group mask. */
+#define FUSE_ACTIVE_gp  2  /* BOD Operation in Active Mode group position. */
+#define FUSE_ACTIVE_0_bm  (1<<2)  /* BOD Operation in Active Mode bit 0 mask. */
+#define FUSE_ACTIVE_0_bp  2  /* BOD Operation in Active Mode bit 0 position. */
+#define FUSE_ACTIVE_1_bm  (1<<3)  /* BOD Operation in Active Mode bit 1 mask. */
+#define FUSE_ACTIVE_1_bp  3  /* BOD Operation in Active Mode bit 1 position. */
+#define FUSE_SAMPFREQ_bm  0x10  /* BOD Sample Frequency bit mask. */
+#define FUSE_SAMPFREQ_bp  4  /* BOD Sample Frequency bit position. */
+#define FUSE_LVL_gm  0xE0  /* BOD Level group mask. */
+#define FUSE_LVL_gp  5  /* BOD Level group position. */
+#define FUSE_LVL_0_bm  (1<<5)  /* BOD Level bit 0 mask. */
+#define FUSE_LVL_0_bp  5  /* BOD Level bit 0 position. */
+#define FUSE_LVL_1_bm  (1<<6)  /* BOD Level bit 1 mask. */
+#define FUSE_LVL_1_bp  6  /* BOD Level bit 1 position. */
+#define FUSE_LVL_2_bm  (1<<7)  /* BOD Level bit 2 mask. */
+#define FUSE_LVL_2_bp  7  /* BOD Level bit 2 position. */
+
+/* FUSE.OSCCFG  bit masks and bit positions */
+#define FUSE_OSCHFFRQ_bm  0x08  /* High-frequency Oscillator Frequency bit mask. */
+#define FUSE_OSCHFFRQ_bp  3  /* High-frequency Oscillator Frequency bit position. */
+
+/* FUSE.SYSCFG0  bit masks and bit positions */
+#define FUSE_EESAVE_bm  0x01  /* EEPROM Save bit mask. */
+#define FUSE_EESAVE_bp  0  /* EEPROM Save bit position. */
+#define FUSE_RSTPINCFG_bm  0x08  /* Reset Pin Configuration bit mask. */
+#define FUSE_RSTPINCFG_bp  3  /* Reset Pin Configuration bit position. */
+#define FUSE_UPDIPINCFG_bm  0x10  /* UPDI Pin Configuration bit mask. */
+#define FUSE_UPDIPINCFG_bp  4  /* UPDI Pin Configuration bit position. */
+#define FUSE_CRCSEL_bm  0x20  /* CRC Select bit mask. */
+#define FUSE_CRCSEL_bp  5  /* CRC Select bit position. */
+#define FUSE_CRCSRC_gm  0xC0  /* CRC Source group mask. */
+#define FUSE_CRCSRC_gp  6  /* CRC Source group position. */
+#define FUSE_CRCSRC_0_bm  (1<<6)  /* CRC Source bit 0 mask. */
+#define FUSE_CRCSRC_0_bp  6  /* CRC Source bit 0 position. */
+#define FUSE_CRCSRC_1_bm  (1<<7)  /* CRC Source bit 1 mask. */
+#define FUSE_CRCSRC_1_bp  7  /* CRC Source bit 1 position. */
+
+/* FUSE.SYSCFG1  bit masks and bit positions */
+#define FUSE_SUT_gm  0x07  /* Startup Time group mask. */
+#define FUSE_SUT_gp  0  /* Startup Time group position. */
+#define FUSE_SUT_0_bm  (1<<0)  /* Startup Time bit 0 mask. */
+#define FUSE_SUT_0_bp  0  /* Startup Time bit 0 position. */
+#define FUSE_SUT_1_bm  (1<<1)  /* Startup Time bit 1 mask. */
+#define FUSE_SUT_1_bp  1  /* Startup Time bit 1 position. */
+#define FUSE_SUT_2_bm  (1<<2)  /* Startup Time bit 2 mask. */
+#define FUSE_SUT_2_bp  2  /* Startup Time bit 2 position. */
+
+
+
+/* LOCK - Lockbits */
+/* LOCK.KEY  bit masks and bit positions */
+#define LOCK_KEY_gm  0xFFFFFFFF  /* Lock Key group mask. */
+#define LOCK_KEY_gp  0  /* Lock Key group position. */
+#define LOCK_KEY_0_bm  (1<<0)  /* Lock Key bit 0 mask. */
+#define LOCK_KEY_0_bp  0  /* Lock Key bit 0 position. */
+#define LOCK_KEY_1_bm  (1<<1)  /* Lock Key bit 1 mask. */
+#define LOCK_KEY_1_bp  1  /* Lock Key bit 1 position. */
+#define LOCK_KEY_2_bm  (1<<2)  /* Lock Key bit 2 mask. */
+#define LOCK_KEY_2_bp  2  /* Lock Key bit 2 position. */
+#define LOCK_KEY_3_bm  (1<<3)  /* Lock Key bit 3 mask. */
+#define LOCK_KEY_3_bp  3  /* Lock Key bit 3 position. */
+#define LOCK_KEY_4_bm  (1<<4)  /* Lock Key bit 4 mask. */
+#define LOCK_KEY_4_bp  4  /* Lock Key bit 4 position. */
+#define LOCK_KEY_5_bm  (1<<5)  /* Lock Key bit 5 mask. */
+#define LOCK_KEY_5_bp  5  /* Lock Key bit 5 position. */
+#define LOCK_KEY_6_bm  (1<<6)  /* Lock Key bit 6 mask. */
+#define LOCK_KEY_6_bp  6  /* Lock Key bit 6 position. */
+#define LOCK_KEY_7_bm  (1<<7)  /* Lock Key bit 7 mask. */
+#define LOCK_KEY_7_bp  7  /* Lock Key bit 7 position. */
+#define LOCK_KEY_8_bm  (1<<8)  /* Lock Key bit 8 mask. */
+#define LOCK_KEY_8_bp  8  /* Lock Key bit 8 position. */
+#define LOCK_KEY_9_bm  (1<<9)  /* Lock Key bit 9 mask. */
+#define LOCK_KEY_9_bp  9  /* Lock Key bit 9 position. */
+#define LOCK_KEY_10_bm  (1<<10)  /* Lock Key bit 10 mask. */
+#define LOCK_KEY_10_bp  10  /* Lock Key bit 10 position. */
+#define LOCK_KEY_11_bm  (1<<11)  /* Lock Key bit 11 mask. */
+#define LOCK_KEY_11_bp  11  /* Lock Key bit 11 position. */
+#define LOCK_KEY_12_bm  (1<<12)  /* Lock Key bit 12 mask. */
+#define LOCK_KEY_12_bp  12  /* Lock Key bit 12 position. */
+#define LOCK_KEY_13_bm  (1<<13)  /* Lock Key bit 13 mask. */
+#define LOCK_KEY_13_bp  13  /* Lock Key bit 13 position. */
+#define LOCK_KEY_14_bm  (1<<14)  /* Lock Key bit 14 mask. */
+#define LOCK_KEY_14_bp  14  /* Lock Key bit 14 position. */
+#define LOCK_KEY_15_bm  (1<<15)  /* Lock Key bit 15 mask. */
+#define LOCK_KEY_15_bp  15  /* Lock Key bit 15 position. */
+#define LOCK_KEY_16_bm  (1<<16)  /* Lock Key bit 16 mask. */
+#define LOCK_KEY_16_bp  16  /* Lock Key bit 16 position. */
+#define LOCK_KEY_17_bm  (1<<17)  /* Lock Key bit 17 mask. */
+#define LOCK_KEY_17_bp  17  /* Lock Key bit 17 position. */
+#define LOCK_KEY_18_bm  (1<<18)  /* Lock Key bit 18 mask. */
+#define LOCK_KEY_18_bp  18  /* Lock Key bit 18 position. */
+#define LOCK_KEY_19_bm  (1<<19)  /* Lock Key bit 19 mask. */
+#define LOCK_KEY_19_bp  19  /* Lock Key bit 19 position. */
+#define LOCK_KEY_20_bm  (1<<20)  /* Lock Key bit 20 mask. */
+#define LOCK_KEY_20_bp  20  /* Lock Key bit 20 position. */
+#define LOCK_KEY_21_bm  (1<<21)  /* Lock Key bit 21 mask. */
+#define LOCK_KEY_21_bp  21  /* Lock Key bit 21 position. */
+#define LOCK_KEY_22_bm  (1<<22)  /* Lock Key bit 22 mask. */
+#define LOCK_KEY_22_bp  22  /* Lock Key bit 22 position. */
+#define LOCK_KEY_23_bm  (1<<23)  /* Lock Key bit 23 mask. */
+#define LOCK_KEY_23_bp  23  /* Lock Key bit 23 position. */
+#define LOCK_KEY_24_bm  (1<<24)  /* Lock Key bit 24 mask. */
+#define LOCK_KEY_24_bp  24  /* Lock Key bit 24 position. */
+#define LOCK_KEY_25_bm  (1<<25)  /* Lock Key bit 25 mask. */
+#define LOCK_KEY_25_bp  25  /* Lock Key bit 25 position. */
+#define LOCK_KEY_26_bm  (1<<26)  /* Lock Key bit 26 mask. */
+#define LOCK_KEY_26_bp  26  /* Lock Key bit 26 position. */
+#define LOCK_KEY_27_bm  (1<<27)  /* Lock Key bit 27 mask. */
+#define LOCK_KEY_27_bp  27  /* Lock Key bit 27 position. */
+#define LOCK_KEY_28_bm  (1<<28)  /* Lock Key bit 28 mask. */
+#define LOCK_KEY_28_bp  28  /* Lock Key bit 28 position. */
+#define LOCK_KEY_29_bm  (1<<29)  /* Lock Key bit 29 mask. */
+#define LOCK_KEY_29_bp  29  /* Lock Key bit 29 position. */
+#define LOCK_KEY_30_bm  (1<<30)  /* Lock Key bit 30 mask. */
+#define LOCK_KEY_30_bp  30  /* Lock Key bit 30 position. */
+#define LOCK_KEY_31_bm  (1<<31)  /* Lock Key bit 31 mask. */
+#define LOCK_KEY_31_bp  31  /* Lock Key bit 31 position. */
+
+
+/* NVMCTRL - Non-volatile Memory Controller */
+/* NVMCTRL.CTRLA  bit masks and bit positions */
+#define NVMCTRL_CMD_gm  0x7F  /* Command group mask. */
+#define NVMCTRL_CMD_gp  0  /* Command group position. */
+#define NVMCTRL_CMD_0_bm  (1<<0)  /* Command bit 0 mask. */
+#define NVMCTRL_CMD_0_bp  0  /* Command bit 0 position. */
+#define NVMCTRL_CMD_1_bm  (1<<1)  /* Command bit 1 mask. */
+#define NVMCTRL_CMD_1_bp  1  /* Command bit 1 position. */
+#define NVMCTRL_CMD_2_bm  (1<<2)  /* Command bit 2 mask. */
+#define NVMCTRL_CMD_2_bp  2  /* Command bit 2 position. */
+#define NVMCTRL_CMD_3_bm  (1<<3)  /* Command bit 3 mask. */
+#define NVMCTRL_CMD_3_bp  3  /* Command bit 3 position. */
+#define NVMCTRL_CMD_4_bm  (1<<4)  /* Command bit 4 mask. */
+#define NVMCTRL_CMD_4_bp  4  /* Command bit 4 position. */
+#define NVMCTRL_CMD_5_bm  (1<<5)  /* Command bit 5 mask. */
+#define NVMCTRL_CMD_5_bp  5  /* Command bit 5 position. */
+#define NVMCTRL_CMD_6_bm  (1<<6)  /* Command bit 6 mask. */
+#define NVMCTRL_CMD_6_bp  6  /* Command bit 6 position. */
+
+/* NVMCTRL.CTRLB  bit masks and bit positions */
+#define NVMCTRL_APPCODEWP_bm  0x01  /* Application Code Write Protect bit mask. */
+#define NVMCTRL_APPCODEWP_bp  0  /* Application Code Write Protect bit position. */
+#define NVMCTRL_BOOTRP_bm  0x02  /* Boot Read Protect bit mask. */
+#define NVMCTRL_BOOTRP_bp  1  /* Boot Read Protect bit position. */
+#define NVMCTRL_APPDATAWP_bm  0x04  /* Application Data Write Protect bit mask. */
+#define NVMCTRL_APPDATAWP_bp  2  /* Application Data Write Protect bit position. */
+#define NVMCTRL_EEWP_bm  0x08  /* EEPROM Write Protect bit mask. */
+#define NVMCTRL_EEWP_bp  3  /* EEPROM Write Protect bit position. */
+#define NVMCTRL_FLMAP_gm  0x30  /* Flash Mapping in Data space group mask. */
+#define NVMCTRL_FLMAP_gp  4  /* Flash Mapping in Data space group position. */
+#define NVMCTRL_FLMAP_0_bm  (1<<4)  /* Flash Mapping in Data space bit 0 mask. */
+#define NVMCTRL_FLMAP_0_bp  4  /* Flash Mapping in Data space bit 0 position. */
+#define NVMCTRL_FLMAP_1_bm  (1<<5)  /* Flash Mapping in Data space bit 1 mask. */
+#define NVMCTRL_FLMAP_1_bp  5  /* Flash Mapping in Data space bit 1 position. */
+#define NVMCTRL_FLMAPLOCK_bm  0x80  /* Flash Mapping Lock bit mask. */
+#define NVMCTRL_FLMAPLOCK_bp  7  /* Flash Mapping Lock bit position. */
+
+/* NVMCTRL.INTCTRL  bit masks and bit positions */
+#define NVMCTRL_EEREADY_bm  0x01  /* EEPROM Ready bit mask. */
+#define NVMCTRL_EEREADY_bp  0  /* EEPROM Ready bit position. */
+#define NVMCTRL_FLREADY_bm  0x02  /* Flash Ready bit mask. */
+#define NVMCTRL_FLREADY_bp  1  /* Flash Ready bit position. */
+
+/* NVMCTRL.INTFLAGS  bit masks and bit positions */
+/* NVMCTRL_EEREADY  is already defined. */
+/* NVMCTRL_FLREADY  is already defined. */
+
+/* NVMCTRL.STATUS  bit masks and bit positions */
+#define NVMCTRL_EEBUSY_bm  0x01  /* EEPROM busy bit mask. */
+#define NVMCTRL_EEBUSY_bp  0  /* EEPROM busy bit position. */
+#define NVMCTRL_FLBUSY_bm  0x02  /* Flash busy bit mask. */
+#define NVMCTRL_FLBUSY_bp  1  /* Flash busy bit position. */
+#define NVMCTRL_ERROR_gm  0x70  /* Write error group mask. */
+#define NVMCTRL_ERROR_gp  4  /* Write error group position. */
+#define NVMCTRL_ERROR_0_bm  (1<<4)  /* Write error bit 0 mask. */
+#define NVMCTRL_ERROR_0_bp  4  /* Write error bit 0 position. */
+#define NVMCTRL_ERROR_1_bm  (1<<5)  /* Write error bit 1 mask. */
+#define NVMCTRL_ERROR_1_bp  5  /* Write error bit 1 position. */
+#define NVMCTRL_ERROR_2_bm  (1<<6)  /* Write error bit 2 mask. */
+#define NVMCTRL_ERROR_2_bp  6  /* Write error bit 2 position. */
+
+
+/* PORT - I/O Ports */
+/* PORT.INTFLAGS  bit masks and bit positions */
+#define PORT_INT_gm  0xFF  /* Pin Interrupt Flag group mask. */
+#define PORT_INT_gp  0  /* Pin Interrupt Flag group position. */
+#define PORT_INT_0_bm  (1<<0)  /* Pin Interrupt Flag bit 0 mask. */
+#define PORT_INT_0_bp  0  /* Pin Interrupt Flag bit 0 position. */
+#define PORT_INT0_bm  PORT_INT_0_bm  /* This define is deprecated and should not be used */
+#define PORT_INT0_bp  PORT_INT_0_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_1_bm  (1<<1)  /* Pin Interrupt Flag bit 1 mask. */
+#define PORT_INT_1_bp  1  /* Pin Interrupt Flag bit 1 position. */
+#define PORT_INT1_bm  PORT_INT_1_bm  /* This define is deprecated and should not be used */
+#define PORT_INT1_bp  PORT_INT_1_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_2_bm  (1<<2)  /* Pin Interrupt Flag bit 2 mask. */
+#define PORT_INT_2_bp  2  /* Pin Interrupt Flag bit 2 position. */
+#define PORT_INT2_bm  PORT_INT_2_bm  /* This define is deprecated and should not be used */
+#define PORT_INT2_bp  PORT_INT_2_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_3_bm  (1<<3)  /* Pin Interrupt Flag bit 3 mask. */
+#define PORT_INT_3_bp  3  /* Pin Interrupt Flag bit 3 position. */
+#define PORT_INT3_bm  PORT_INT_3_bm  /* This define is deprecated and should not be used */
+#define PORT_INT3_bp  PORT_INT_3_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_4_bm  (1<<4)  /* Pin Interrupt Flag bit 4 mask. */
+#define PORT_INT_4_bp  4  /* Pin Interrupt Flag bit 4 position. */
+#define PORT_INT4_bm  PORT_INT_4_bm  /* This define is deprecated and should not be used */
+#define PORT_INT4_bp  PORT_INT_4_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_5_bm  (1<<5)  /* Pin Interrupt Flag bit 5 mask. */
+#define PORT_INT_5_bp  5  /* Pin Interrupt Flag bit 5 position. */
+#define PORT_INT5_bm  PORT_INT_5_bm  /* This define is deprecated and should not be used */
+#define PORT_INT5_bp  PORT_INT_5_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_6_bm  (1<<6)  /* Pin Interrupt Flag bit 6 mask. */
+#define PORT_INT_6_bp  6  /* Pin Interrupt Flag bit 6 position. */
+#define PORT_INT6_bm  PORT_INT_6_bm  /* This define is deprecated and should not be used */
+#define PORT_INT6_bp  PORT_INT_6_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_7_bm  (1<<7)  /* Pin Interrupt Flag bit 7 mask. */
+#define PORT_INT_7_bp  7  /* Pin Interrupt Flag bit 7 position. */
+#define PORT_INT7_bm  PORT_INT_7_bm  /* This define is deprecated and should not be used */
+#define PORT_INT7_bp  PORT_INT_7_bp  /* This define is deprecated and should not be used */
+
+/* PORT.PORTCTRL  bit masks and bit positions */
+#define PORT_SRL_bm  0x01  /* Slew Rate Limit Enable bit mask. */
+#define PORT_SRL_bp  0  /* Slew Rate Limit Enable bit position. */
+
+/* PORT.PINCONFIG  bit masks and bit positions */
+#define PORT_ISC_gm  0x07  /* Input/Sense Configuration group mask. */
+#define PORT_ISC_gp  0  /* Input/Sense Configuration group position. */
+#define PORT_ISC_0_bm  (1<<0)  /* Input/Sense Configuration bit 0 mask. */
+#define PORT_ISC_0_bp  0  /* Input/Sense Configuration bit 0 position. */
+#define PORT_ISC_1_bm  (1<<1)  /* Input/Sense Configuration bit 1 mask. */
+#define PORT_ISC_1_bp  1  /* Input/Sense Configuration bit 1 position. */
+#define PORT_ISC_2_bm  (1<<2)  /* Input/Sense Configuration bit 2 mask. */
+#define PORT_ISC_2_bp  2  /* Input/Sense Configuration bit 2 position. */
+#define PORT_PULLUPEN_bm  0x08  /* Pullup enable bit mask. */
+#define PORT_PULLUPEN_bp  3  /* Pullup enable bit position. */
+#define PORT_INLVL_bm  0x40  /* Input Level Select bit mask. */
+#define PORT_INLVL_bp  6  /* Input Level Select bit position. */
+#define PORT_INVEN_bm  0x80  /* Inverted I/O Enable bit mask. */
+#define PORT_INVEN_bp  7  /* Inverted I/O Enable bit position. */
+
+/* PORT.PIN0CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN1CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN2CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN3CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN4CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN5CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN6CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN7CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.EVGENCTRL  bit masks and bit positions */
+#define PORT_EVGEN0SEL_gm  0x07  /* Event Generator 0 Select group mask. */
+#define PORT_EVGEN0SEL_gp  0  /* Event Generator 0 Select group position. */
+#define PORT_EVGEN0SEL_0_bm  (1<<0)  /* Event Generator 0 Select bit 0 mask. */
+#define PORT_EVGEN0SEL_0_bp  0  /* Event Generator 0 Select bit 0 position. */
+#define PORT_EVGEN0SEL_1_bm  (1<<1)  /* Event Generator 0 Select bit 1 mask. */
+#define PORT_EVGEN0SEL_1_bp  1  /* Event Generator 0 Select bit 1 position. */
+#define PORT_EVGEN0SEL_2_bm  (1<<2)  /* Event Generator 0 Select bit 2 mask. */
+#define PORT_EVGEN0SEL_2_bp  2  /* Event Generator 0 Select bit 2 position. */
+#define PORT_EVGEN1SEL_gm  0x70  /* Event Generator 1 Select group mask. */
+#define PORT_EVGEN1SEL_gp  4  /* Event Generator 1 Select group position. */
+#define PORT_EVGEN1SEL_0_bm  (1<<4)  /* Event Generator 1 Select bit 0 mask. */
+#define PORT_EVGEN1SEL_0_bp  4  /* Event Generator 1 Select bit 0 position. */
+#define PORT_EVGEN1SEL_1_bm  (1<<5)  /* Event Generator 1 Select bit 1 mask. */
+#define PORT_EVGEN1SEL_1_bp  5  /* Event Generator 1 Select bit 1 position. */
+#define PORT_EVGEN1SEL_2_bm  (1<<6)  /* Event Generator 1 Select bit 2 mask. */
+#define PORT_EVGEN1SEL_2_bp  6  /* Event Generator 1 Select bit 2 position. */
+
+
+/* PORTMUX - Port Multiplexer */
+/* PORTMUX.EVSYSROUTEA  bit masks and bit positions */
+#define PORTMUX_EVOUTA_bm  0x01  /* Event Output A bit mask. */
+#define PORTMUX_EVOUTA_bp  0  /* Event Output A bit position. */
+#define PORTMUX_EVOUTB_bm  0x02  /* Event Output B bit mask. */
+#define PORTMUX_EVOUTB_bp  1  /* Event Output B bit position. */
+#define PORTMUX_EVOUTC_bm  0x04  /* Event Output C bit mask. */
+#define PORTMUX_EVOUTC_bp  2  /* Event Output C bit position. */
+#define PORTMUX_EVOUTD_bm  0x08  /* Event Output D bit mask. */
+#define PORTMUX_EVOUTD_bp  3  /* Event Output D bit position. */
+#define PORTMUX_EVOUTE_bm  0x10  /* Event Output E bit mask. */
+#define PORTMUX_EVOUTE_bp  4  /* Event Output E bit position. */
+#define PORTMUX_EVOUTF_bm  0x20  /* Event Output F bit mask. */
+#define PORTMUX_EVOUTF_bp  5  /* Event Output F bit position. */
+
+/* PORTMUX.CCLROUTEA  bit masks and bit positions */
+#define PORTMUX_LUT0_bm  0x01  /* CCL Look-Up Table 0 Signals bit mask. */
+#define PORTMUX_LUT0_bp  0  /* CCL Look-Up Table 0 Signals bit position. */
+#define PORTMUX_LUT1_bm  0x02  /* CCL Look-Up Table 1 Signals bit mask. */
+#define PORTMUX_LUT1_bp  1  /* CCL Look-Up Table 1 Signals bit position. */
+#define PORTMUX_LUT2_bm  0x04  /* CCL Look-Up Table 2 Signals bit mask. */
+#define PORTMUX_LUT2_bp  2  /* CCL Look-Up Table 2 Signals bit position. */
+
+/* PORTMUX.USARTROUTEA  bit masks and bit positions */
+#define PORTMUX_USART0_gm  0x07  /* USART0 Routing group mask. */
+#define PORTMUX_USART0_gp  0  /* USART0 Routing group position. */
+#define PORTMUX_USART0_0_bm  (1<<0)  /* USART0 Routing bit 0 mask. */
+#define PORTMUX_USART0_0_bp  0  /* USART0 Routing bit 0 position. */
+#define PORTMUX_USART0_1_bm  (1<<1)  /* USART0 Routing bit 1 mask. */
+#define PORTMUX_USART0_1_bp  1  /* USART0 Routing bit 1 position. */
+#define PORTMUX_USART0_2_bm  (1<<2)  /* USART0 Routing bit 2 mask. */
+#define PORTMUX_USART0_2_bp  2  /* USART0 Routing bit 2 position. */
+#define PORTMUX_USART1_gm  0x18  /* USART1 Routing group mask. */
+#define PORTMUX_USART1_gp  3  /* USART1 Routing group position. */
+#define PORTMUX_USART1_0_bm  (1<<3)  /* USART1 Routing bit 0 mask. */
+#define PORTMUX_USART1_0_bp  3  /* USART1 Routing bit 0 position. */
+#define PORTMUX_USART1_1_bm  (1<<4)  /* USART1 Routing bit 1 mask. */
+#define PORTMUX_USART1_1_bp  4  /* USART1 Routing bit 1 position. */
+
+/* PORTMUX.USARTROUTEB  bit masks and bit positions */
+#define PORTMUX_USART2_gm  0x03  /* USART2 Routing group mask. */
+#define PORTMUX_USART2_gp  0  /* USART2 Routing group position. */
+#define PORTMUX_USART2_0_bm  (1<<0)  /* USART2 Routing bit 0 mask. */
+#define PORTMUX_USART2_0_bp  0  /* USART2 Routing bit 0 position. */
+#define PORTMUX_USART2_1_bm  (1<<1)  /* USART2 Routing bit 1 mask. */
+#define PORTMUX_USART2_1_bp  1  /* USART2 Routing bit 1 position. */
+
+/* PORTMUX.SPIROUTEA  bit masks and bit positions */
+#define PORTMUX_SPI0_gm  0x07  /* SPI0 Signals group mask. */
+#define PORTMUX_SPI0_gp  0  /* SPI0 Signals group position. */
+#define PORTMUX_SPI0_0_bm  (1<<0)  /* SPI0 Signals bit 0 mask. */
+#define PORTMUX_SPI0_0_bp  0  /* SPI0 Signals bit 0 position. */
+#define PORTMUX_SPI0_1_bm  (1<<1)  /* SPI0 Signals bit 1 mask. */
+#define PORTMUX_SPI0_1_bp  1  /* SPI0 Signals bit 1 position. */
+#define PORTMUX_SPI0_2_bm  (1<<2)  /* SPI0 Signals bit 2 mask. */
+#define PORTMUX_SPI0_2_bp  2  /* SPI0 Signals bit 2 position. */
+
+/* PORTMUX.TWIROUTEA  bit masks and bit positions */
+#define PORTMUX_TWI0_gm  0x03  /* TWI0 Signals group mask. */
+#define PORTMUX_TWI0_gp  0  /* TWI0 Signals group position. */
+#define PORTMUX_TWI0_0_bm  (1<<0)  /* TWI0 Signals bit 0 mask. */
+#define PORTMUX_TWI0_0_bp  0  /* TWI0 Signals bit 0 position. */
+#define PORTMUX_TWI0_1_bm  (1<<1)  /* TWI0 Signals bit 1 mask. */
+#define PORTMUX_TWI0_1_bp  1  /* TWI0 Signals bit 1 position. */
+
+/* PORTMUX.TCAROUTEA  bit masks and bit positions */
+#define PORTMUX_TCA0_gm  0x07  /* TCA0 Signals group mask. */
+#define PORTMUX_TCA0_gp  0  /* TCA0 Signals group position. */
+#define PORTMUX_TCA0_0_bm  (1<<0)  /* TCA0 Signals bit 0 mask. */
+#define PORTMUX_TCA0_0_bp  0  /* TCA0 Signals bit 0 position. */
+#define PORTMUX_TCA0_1_bm  (1<<1)  /* TCA0 Signals bit 1 mask. */
+#define PORTMUX_TCA0_1_bp  1  /* TCA0 Signals bit 1 position. */
+#define PORTMUX_TCA0_2_bm  (1<<2)  /* TCA0 Signals bit 2 mask. */
+#define PORTMUX_TCA0_2_bp  2  /* TCA0 Signals bit 2 position. */
+#define PORTMUX_TCA1_gm  0x38  /* TCA1 Signals group mask. */
+#define PORTMUX_TCA1_gp  3  /* TCA1 Signals group position. */
+#define PORTMUX_TCA1_0_bm  (1<<3)  /* TCA1 Signals bit 0 mask. */
+#define PORTMUX_TCA1_0_bp  3  /* TCA1 Signals bit 0 position. */
+#define PORTMUX_TCA1_1_bm  (1<<4)  /* TCA1 Signals bit 1 mask. */
+#define PORTMUX_TCA1_1_bp  4  /* TCA1 Signals bit 1 position. */
+#define PORTMUX_TCA1_2_bm  (1<<5)  /* TCA1 Signals bit 2 mask. */
+#define PORTMUX_TCA1_2_bp  5  /* TCA1 Signals bit 2 position. */
+
+/* PORTMUX.TCBROUTEA  bit masks and bit positions */
+#define PORTMUX_TCB0_bm  0x01  /* TCB0 Output bit mask. */
+#define PORTMUX_TCB0_bp  0  /* TCB0 Output bit position. */
+#define PORTMUX_TCB1_bm  0x02  /* TCB1 Output bit mask. */
+#define PORTMUX_TCB1_bp  1  /* TCB1 Output bit position. */
+#define PORTMUX_TCB2_bm  0x04  /* TCB2 Output bit mask. */
+#define PORTMUX_TCB2_bp  2  /* TCB2 Output bit position. */
+#define PORTMUX_TCB3_bm  0x08  /* TCB3 Output bit mask. */
+#define PORTMUX_TCB3_bp  3  /* TCB3 Output bit position. */
+
+/* PORTMUX.ACROUTEA  bit masks and bit positions */
+#define PORTMUX_AC0_bm  0x01  /* Analog Comparator 0 Output bit mask. */
+#define PORTMUX_AC0_bp  0  /* Analog Comparator 0 Output bit position. */
+#define PORTMUX_AC1_bm  0x02  /* Analog Comparator 1 Output bit mask. */
+#define PORTMUX_AC1_bp  1  /* Analog Comparator 1 Output bit position. */
+
+
+/* RSTCTRL - Reset controller */
+/* RSTCTRL.RSTFR  bit masks and bit positions */
+#define RSTCTRL_PORF_bm  0x01  /* Power on Reset flag bit mask. */
+#define RSTCTRL_PORF_bp  0  /* Power on Reset flag bit position. */
+#define RSTCTRL_BORF_bm  0x02  /* Brown out detector Reset flag bit mask. */
+#define RSTCTRL_BORF_bp  1  /* Brown out detector Reset flag bit position. */
+#define RSTCTRL_EXTRF_bm  0x04  /* External Reset flag bit mask. */
+#define RSTCTRL_EXTRF_bp  2  /* External Reset flag bit position. */
+#define RSTCTRL_WDRF_bm  0x08  /* Watch dog Reset flag bit mask. */
+#define RSTCTRL_WDRF_bp  3  /* Watch dog Reset flag bit position. */
+#define RSTCTRL_SWRF_bm  0x10  /* Software Reset flag bit mask. */
+#define RSTCTRL_SWRF_bp  4  /* Software Reset flag bit position. */
+#define RSTCTRL_UPDIRF_bm  0x20  /* UPDI Reset flag bit mask. */
+#define RSTCTRL_UPDIRF_bp  5  /* UPDI Reset flag bit position. */
+
+/* RSTCTRL.SWRR  bit masks and bit positions */
+#define RSTCTRL_SWRE_bm  0x01  /* Software Reset Enable bit mask. */
+#define RSTCTRL_SWRE_bp  0  /* Software Reset Enable bit position. */
+
+
+/* RTC - Real-Time Counter */
+/* RTC.CTRLA  bit masks and bit positions */
+#define RTC_RTCEN_bm  0x01  /* Enable bit mask. */
+#define RTC_RTCEN_bp  0  /* Enable bit position. */
+#define RTC_CORREN_bm  0x04  /* Correction enable bit mask. */
+#define RTC_CORREN_bp  2  /* Correction enable bit position. */
+#define RTC_PRESCALER_gm  0x78  /* Prescaling Factor group mask. */
+#define RTC_PRESCALER_gp  3  /* Prescaling Factor group position. */
+#define RTC_PRESCALER_0_bm  (1<<3)  /* Prescaling Factor bit 0 mask. */
+#define RTC_PRESCALER_0_bp  3  /* Prescaling Factor bit 0 position. */
+#define RTC_PRESCALER_1_bm  (1<<4)  /* Prescaling Factor bit 1 mask. */
+#define RTC_PRESCALER_1_bp  4  /* Prescaling Factor bit 1 position. */
+#define RTC_PRESCALER_2_bm  (1<<5)  /* Prescaling Factor bit 2 mask. */
+#define RTC_PRESCALER_2_bp  5  /* Prescaling Factor bit 2 position. */
+#define RTC_PRESCALER_3_bm  (1<<6)  /* Prescaling Factor bit 3 mask. */
+#define RTC_PRESCALER_3_bp  6  /* Prescaling Factor bit 3 position. */
+#define RTC_RUNSTDBY_bm  0x80  /* Run In Standby bit mask. */
+#define RTC_RUNSTDBY_bp  7  /* Run In Standby bit position. */
+
+/* RTC.STATUS  bit masks and bit positions */
+#define RTC_CTRLABUSY_bm  0x01  /* CTRLA Synchronization Busy Flag bit mask. */
+#define RTC_CTRLABUSY_bp  0  /* CTRLA Synchronization Busy Flag bit position. */
+#define RTC_CNTBUSY_bm  0x02  /* Count Synchronization Busy Flag bit mask. */
+#define RTC_CNTBUSY_bp  1  /* Count Synchronization Busy Flag bit position. */
+#define RTC_PERBUSY_bm  0x04  /* Period Synchronization Busy Flag bit mask. */
+#define RTC_PERBUSY_bp  2  /* Period Synchronization Busy Flag bit position. */
+#define RTC_CMPBUSY_bm  0x08  /* Comparator Synchronization Busy Flag bit mask. */
+#define RTC_CMPBUSY_bp  3  /* Comparator Synchronization Busy Flag bit position. */
+
+/* RTC.INTCTRL  bit masks and bit positions */
+#define RTC_OVF_bm  0x01  /* Overflow Interrupt enable bit mask. */
+#define RTC_OVF_bp  0  /* Overflow Interrupt enable bit position. */
+#define RTC_CMP_bm  0x02  /* Compare Match Interrupt enable bit mask. */
+#define RTC_CMP_bp  1  /* Compare Match Interrupt enable bit position. */
+
+/* RTC.INTFLAGS  bit masks and bit positions */
+/* RTC_OVF  is already defined. */
+/* RTC_CMP  is already defined. */
+
+/* RTC.DBGCTRL  bit masks and bit positions */
+#define RTC_DBGRUN_bm  0x01  /* Run in debug bit mask. */
+#define RTC_DBGRUN_bp  0  /* Run in debug bit position. */
+
+/* RTC.CALIB  bit masks and bit positions */
+#define RTC_ERROR_gm  0x7F  /* Error Correction Value group mask. */
+#define RTC_ERROR_gp  0  /* Error Correction Value group position. */
+#define RTC_ERROR_0_bm  (1<<0)  /* Error Correction Value bit 0 mask. */
+#define RTC_ERROR_0_bp  0  /* Error Correction Value bit 0 position. */
+#define RTC_ERROR_1_bm  (1<<1)  /* Error Correction Value bit 1 mask. */
+#define RTC_ERROR_1_bp  1  /* Error Correction Value bit 1 position. */
+#define RTC_ERROR_2_bm  (1<<2)  /* Error Correction Value bit 2 mask. */
+#define RTC_ERROR_2_bp  2  /* Error Correction Value bit 2 position. */
+#define RTC_ERROR_3_bm  (1<<3)  /* Error Correction Value bit 3 mask. */
+#define RTC_ERROR_3_bp  3  /* Error Correction Value bit 3 position. */
+#define RTC_ERROR_4_bm  (1<<4)  /* Error Correction Value bit 4 mask. */
+#define RTC_ERROR_4_bp  4  /* Error Correction Value bit 4 position. */
+#define RTC_ERROR_5_bm  (1<<5)  /* Error Correction Value bit 5 mask. */
+#define RTC_ERROR_5_bp  5  /* Error Correction Value bit 5 position. */
+#define RTC_ERROR_6_bm  (1<<6)  /* Error Correction Value bit 6 mask. */
+#define RTC_ERROR_6_bp  6  /* Error Correction Value bit 6 position. */
+#define RTC_SIGN_bm  0x80  /* Error Correction Sign Bit bit mask. */
+#define RTC_SIGN_bp  7  /* Error Correction Sign Bit bit position. */
+
+/* RTC.CLKSEL  bit masks and bit positions */
+#define RTC_CLKSEL_gm  0x03  /* Clock Select group mask. */
+#define RTC_CLKSEL_gp  0  /* Clock Select group position. */
+#define RTC_CLKSEL_0_bm  (1<<0)  /* Clock Select bit 0 mask. */
+#define RTC_CLKSEL_0_bp  0  /* Clock Select bit 0 position. */
+#define RTC_CLKSEL_1_bm  (1<<1)  /* Clock Select bit 1 mask. */
+#define RTC_CLKSEL_1_bp  1  /* Clock Select bit 1 position. */
+
+/* RTC.PITCTRLA  bit masks and bit positions */
+#define RTC_PITEN_bm  0x01  /* Enable bit mask. */
+#define RTC_PITEN_bp  0  /* Enable bit position. */
+#define RTC_PERIOD_gm  0x78  /* Period group mask. */
+#define RTC_PERIOD_gp  3  /* Period group position. */
+#define RTC_PERIOD_0_bm  (1<<3)  /* Period bit 0 mask. */
+#define RTC_PERIOD_0_bp  3  /* Period bit 0 position. */
+#define RTC_PERIOD_1_bm  (1<<4)  /* Period bit 1 mask. */
+#define RTC_PERIOD_1_bp  4  /* Period bit 1 position. */
+#define RTC_PERIOD_2_bm  (1<<5)  /* Period bit 2 mask. */
+#define RTC_PERIOD_2_bp  5  /* Period bit 2 position. */
+#define RTC_PERIOD_3_bm  (1<<6)  /* Period bit 3 mask. */
+#define RTC_PERIOD_3_bp  6  /* Period bit 3 position. */
+
+/* RTC.PITSTATUS  bit masks and bit positions */
+#define RTC_CTRLBUSY_bm  0x01  /* CTRLA Synchronization Busy Flag bit mask. */
+#define RTC_CTRLBUSY_bp  0  /* CTRLA Synchronization Busy Flag bit position. */
+
+/* RTC.PITINTCTRL  bit masks and bit positions */
+#define RTC_PI_bm  0x01  /* Periodic Interrupt bit mask. */
+#define RTC_PI_bp  0  /* Periodic Interrupt bit position. */
+
+/* RTC.PITINTFLAGS  bit masks and bit positions */
+/* RTC_PI  is already defined. */
+
+/* RTC.PITDBGCTRL  bit masks and bit positions */
+/* RTC_DBGRUN  is already defined. */
+
+/* RTC.PITEVGENCTRLA  bit masks and bit positions */
+#define RTC_EVGEN0SEL_gm  0x0F  /* Event Generation 0 Select group mask. */
+#define RTC_EVGEN0SEL_gp  0  /* Event Generation 0 Select group position. */
+#define RTC_EVGEN0SEL_0_bm  (1<<0)  /* Event Generation 0 Select bit 0 mask. */
+#define RTC_EVGEN0SEL_0_bp  0  /* Event Generation 0 Select bit 0 position. */
+#define RTC_EVGEN0SEL_1_bm  (1<<1)  /* Event Generation 0 Select bit 1 mask. */
+#define RTC_EVGEN0SEL_1_bp  1  /* Event Generation 0 Select bit 1 position. */
+#define RTC_EVGEN0SEL_2_bm  (1<<2)  /* Event Generation 0 Select bit 2 mask. */
+#define RTC_EVGEN0SEL_2_bp  2  /* Event Generation 0 Select bit 2 position. */
+#define RTC_EVGEN0SEL_3_bm  (1<<3)  /* Event Generation 0 Select bit 3 mask. */
+#define RTC_EVGEN0SEL_3_bp  3  /* Event Generation 0 Select bit 3 position. */
+#define RTC_EVGEN1SEL_gm  0xF0  /* Event Generation 1 Select group mask. */
+#define RTC_EVGEN1SEL_gp  4  /* Event Generation 1 Select group position. */
+#define RTC_EVGEN1SEL_0_bm  (1<<4)  /* Event Generation 1 Select bit 0 mask. */
+#define RTC_EVGEN1SEL_0_bp  4  /* Event Generation 1 Select bit 0 position. */
+#define RTC_EVGEN1SEL_1_bm  (1<<5)  /* Event Generation 1 Select bit 1 mask. */
+#define RTC_EVGEN1SEL_1_bp  5  /* Event Generation 1 Select bit 1 position. */
+#define RTC_EVGEN1SEL_2_bm  (1<<6)  /* Event Generation 1 Select bit 2 mask. */
+#define RTC_EVGEN1SEL_2_bp  6  /* Event Generation 1 Select bit 2 position. */
+#define RTC_EVGEN1SEL_3_bm  (1<<7)  /* Event Generation 1 Select bit 3 mask. */
+#define RTC_EVGEN1SEL_3_bp  7  /* Event Generation 1 Select bit 3 position. */
+
+
+
+/* SLPCTRL - Sleep Controller */
+/* SLPCTRL.CTRLA  bit masks and bit positions */
+#define SLPCTRL_SEN_bm  0x01  /* Sleep enable bit mask. */
+#define SLPCTRL_SEN_bp  0  /* Sleep enable bit position. */
+#define SLPCTRL_SMODE_gm  0x06  /* Sleep mode group mask. */
+#define SLPCTRL_SMODE_gp  1  /* Sleep mode group position. */
+#define SLPCTRL_SMODE_0_bm  (1<<1)  /* Sleep mode bit 0 mask. */
+#define SLPCTRL_SMODE_0_bp  1  /* Sleep mode bit 0 position. */
+#define SLPCTRL_SMODE_1_bm  (1<<2)  /* Sleep mode bit 1 mask. */
+#define SLPCTRL_SMODE_1_bp  2  /* Sleep mode bit 1 position. */
+
+
+/* SPI - Serial Peripheral Interface */
+/* SPI.CTRLA  bit masks and bit positions */
+#define SPI_ENABLE_bm  0x01  /* Enable Module bit mask. */
+#define SPI_ENABLE_bp  0  /* Enable Module bit position. */
+#define SPI_PRESC_gm  0x06  /* Prescaler group mask. */
+#define SPI_PRESC_gp  1  /* Prescaler group position. */
+#define SPI_PRESC_0_bm  (1<<1)  /* Prescaler bit 0 mask. */
+#define SPI_PRESC_0_bp  1  /* Prescaler bit 0 position. */
+#define SPI_PRESC_1_bm  (1<<2)  /* Prescaler bit 1 mask. */
+#define SPI_PRESC_1_bp  2  /* Prescaler bit 1 position. */
+#define SPI_CLK2X_bm  0x10  /* Enable Double Speed bit mask. */
+#define SPI_CLK2X_bp  4  /* Enable Double Speed bit position. */
+#define SPI_MASTER_bm  0x20  /* Host Operation Enable bit mask. */
+#define SPI_MASTER_bp  5  /* Host Operation Enable bit position. */
+#define SPI_DORD_bm  0x40  /* Data Order Setting bit mask. */
+#define SPI_DORD_bp  6  /* Data Order Setting bit position. */
+
+/* SPI.CTRLB  bit masks and bit positions */
+#define SPI_MODE_gm  0x03  /* SPI Mode group mask. */
+#define SPI_MODE_gp  0  /* SPI Mode group position. */
+#define SPI_MODE_0_bm  (1<<0)  /* SPI Mode bit 0 mask. */
+#define SPI_MODE_0_bp  0  /* SPI Mode bit 0 position. */
+#define SPI_MODE_1_bm  (1<<1)  /* SPI Mode bit 1 mask. */
+#define SPI_MODE_1_bp  1  /* SPI Mode bit 1 position. */
+#define SPI_SSD_bm  0x04  /* SPI Select Disable bit mask. */
+#define SPI_SSD_bp  2  /* SPI Select Disable bit position. */
+#define SPI_BUFWR_bm  0x40  /* Buffer Mode Wait for Receive bit mask. */
+#define SPI_BUFWR_bp  6  /* Buffer Mode Wait for Receive bit position. */
+#define SPI_BUFEN_bm  0x80  /* Buffer Mode Enable bit mask. */
+#define SPI_BUFEN_bp  7  /* Buffer Mode Enable bit position. */
+
+/* SPI.INTCTRL  bit masks and bit positions */
+#define SPI_IE_bm  0x01  /* Interrupt Enable bit mask. */
+#define SPI_IE_bp  0  /* Interrupt Enable bit position. */
+#define SPI_SSIE_bm  0x10  /* SPI Select Trigger Interrupt Enable bit mask. */
+#define SPI_SSIE_bp  4  /* SPI Select Trigger Interrupt Enable bit position. */
+#define SPI_DREIE_bm  0x20  /* Data Register Empty Interrupt Enable bit mask. */
+#define SPI_DREIE_bp  5  /* Data Register Empty Interrupt Enable bit position. */
+#define SPI_TXCIE_bm  0x40  /* Transfer Complete Interrupt Enable bit mask. */
+#define SPI_TXCIE_bp  6  /* Transfer Complete Interrupt Enable bit position. */
+#define SPI_RXCIE_bm  0x80  /* Receive Complete Interrupt Enable bit mask. */
+#define SPI_RXCIE_bp  7  /* Receive Complete Interrupt Enable bit position. */
+
+/* SPI.INTFLAGS  bit masks and bit positions */
+#define SPI_BUFOVF_bm  0x01  /* Buffer Overflow bit mask. */
+#define SPI_BUFOVF_bp  0  /* Buffer Overflow bit position. */
+#define SPI_SSIF_bm  0x10  /* SPI Select Trigger Interrupt Flag bit mask. */
+#define SPI_SSIF_bp  4  /* SPI Select Trigger Interrupt Flag bit position. */
+#define SPI_DREIF_bm  0x20  /* Data Register Empty Interrupt Flag bit mask. */
+#define SPI_DREIF_bp  5  /* Data Register Empty Interrupt Flag bit position. */
+#define SPI_TXCIF_bm  0x40  /* Transfer Complete Interrupt Flag bit mask. */
+#define SPI_TXCIF_bp  6  /* Transfer Complete Interrupt Flag bit position. */
+#define SPI_WRCOL_bm  0x40  /* Write Collision bit mask. */
+#define SPI_WRCOL_bp  6  /* Write Collision bit position. */
+#define SPI_RXCIF_bm  0x80  /* Receive Complete Interrupt Flag bit mask. */
+#define SPI_RXCIF_bp  7  /* Receive Complete Interrupt Flag bit position. */
+#define SPI_IF_bm  0x80  /* Interrupt Flag bit mask. */
+#define SPI_IF_bp  7  /* Interrupt Flag bit position. */
+
+
+/* SYSCFG - System Configuration Registers */
+/* SYSCFG.REVID  bit masks and bit positions */
+#define SYSCFG_MINOR_gm  0x0F  /* Minor Revision group mask. */
+#define SYSCFG_MINOR_gp  0  /* Minor Revision group position. */
+#define SYSCFG_MINOR_0_bm  (1<<0)  /* Minor Revision bit 0 mask. */
+#define SYSCFG_MINOR_0_bp  0  /* Minor Revision bit 0 position. */
+#define SYSCFG_MINOR_1_bm  (1<<1)  /* Minor Revision bit 1 mask. */
+#define SYSCFG_MINOR_1_bp  1  /* Minor Revision bit 1 position. */
+#define SYSCFG_MINOR_2_bm  (1<<2)  /* Minor Revision bit 2 mask. */
+#define SYSCFG_MINOR_2_bp  2  /* Minor Revision bit 2 position. */
+#define SYSCFG_MINOR_3_bm  (1<<3)  /* Minor Revision bit 3 mask. */
+#define SYSCFG_MINOR_3_bp  3  /* Minor Revision bit 3 position. */
+#define SYSCFG_MAJOR_gm  0xF0  /* Major Revision group mask. */
+#define SYSCFG_MAJOR_gp  4  /* Major Revision group position. */
+#define SYSCFG_MAJOR_0_bm  (1<<4)  /* Major Revision bit 0 mask. */
+#define SYSCFG_MAJOR_0_bp  4  /* Major Revision bit 0 position. */
+#define SYSCFG_MAJOR_1_bm  (1<<5)  /* Major Revision bit 1 mask. */
+#define SYSCFG_MAJOR_1_bp  5  /* Major Revision bit 1 position. */
+#define SYSCFG_MAJOR_2_bm  (1<<6)  /* Major Revision bit 2 mask. */
+#define SYSCFG_MAJOR_2_bp  6  /* Major Revision bit 2 position. */
+#define SYSCFG_MAJOR_3_bm  (1<<7)  /* Major Revision bit 3 mask. */
+#define SYSCFG_MAJOR_3_bp  7  /* Major Revision bit 3 position. */
+
+/* SYSCFG.OCDMCTRL  bit masks and bit positions */
+#define SYSCFG_OCDM_gm  0xFF  /* OCD Message group mask. */
+#define SYSCFG_OCDM_gp  0  /* OCD Message group position. */
+#define SYSCFG_OCDM_0_bm  (1<<0)  /* OCD Message bit 0 mask. */
+#define SYSCFG_OCDM_0_bp  0  /* OCD Message bit 0 position. */
+#define SYSCFG_OCDM_1_bm  (1<<1)  /* OCD Message bit 1 mask. */
+#define SYSCFG_OCDM_1_bp  1  /* OCD Message bit 1 position. */
+#define SYSCFG_OCDM_2_bm  (1<<2)  /* OCD Message bit 2 mask. */
+#define SYSCFG_OCDM_2_bp  2  /* OCD Message bit 2 position. */
+#define SYSCFG_OCDM_3_bm  (1<<3)  /* OCD Message bit 3 mask. */
+#define SYSCFG_OCDM_3_bp  3  /* OCD Message bit 3 position. */
+#define SYSCFG_OCDM_4_bm  (1<<4)  /* OCD Message bit 4 mask. */
+#define SYSCFG_OCDM_4_bp  4  /* OCD Message bit 4 position. */
+#define SYSCFG_OCDM_5_bm  (1<<5)  /* OCD Message bit 5 mask. */
+#define SYSCFG_OCDM_5_bp  5  /* OCD Message bit 5 position. */
+#define SYSCFG_OCDM_6_bm  (1<<6)  /* OCD Message bit 6 mask. */
+#define SYSCFG_OCDM_6_bp  6  /* OCD Message bit 6 position. */
+#define SYSCFG_OCDM_7_bm  (1<<7)  /* OCD Message bit 7 mask. */
+#define SYSCFG_OCDM_7_bp  7  /* OCD Message bit 7 position. */
+
+/* SYSCFG.OCDMSTATUS  bit masks and bit positions */
+#define SYSCFG_VALID_bm  0x01  /* OCD Message Valid bit mask. */
+#define SYSCFG_VALID_bp  0  /* OCD Message Valid bit position. */
+
+
+/* TCA - 16-bit Timer/Counter Type A */
+/* TCA_SINGLE.CTRLA  bit masks and bit positions */
+#define TCA_SINGLE_ENABLE_bm  0x01  /* Module Enable bit mask. */
+#define TCA_SINGLE_ENABLE_bp  0  /* Module Enable bit position. */
+#define TCA_SINGLE_CLKSEL_gm  0x0E  /* Clock Selection group mask. */
+#define TCA_SINGLE_CLKSEL_gp  1  /* Clock Selection group position. */
+#define TCA_SINGLE_CLKSEL_0_bm  (1<<1)  /* Clock Selection bit 0 mask. */
+#define TCA_SINGLE_CLKSEL_0_bp  1  /* Clock Selection bit 0 position. */
+#define TCA_SINGLE_CLKSEL_1_bm  (1<<2)  /* Clock Selection bit 1 mask. */
+#define TCA_SINGLE_CLKSEL_1_bp  2  /* Clock Selection bit 1 position. */
+#define TCA_SINGLE_CLKSEL_2_bm  (1<<3)  /* Clock Selection bit 2 mask. */
+#define TCA_SINGLE_CLKSEL_2_bp  3  /* Clock Selection bit 2 position. */
+#define TCA_SINGLE_RUNSTDBY_bm  0x80  /* Run in Standby bit mask. */
+#define TCA_SINGLE_RUNSTDBY_bp  7  /* Run in Standby bit position. */
+
+/* TCA_SINGLE.CTRLB  bit masks and bit positions */
+#define TCA_SINGLE_WGMODE_gm  0x07  /* Waveform generation mode group mask. */
+#define TCA_SINGLE_WGMODE_gp  0  /* Waveform generation mode group position. */
+#define TCA_SINGLE_WGMODE_0_bm  (1<<0)  /* Waveform generation mode bit 0 mask. */
+#define TCA_SINGLE_WGMODE_0_bp  0  /* Waveform generation mode bit 0 position. */
+#define TCA_SINGLE_WGMODE_1_bm  (1<<1)  /* Waveform generation mode bit 1 mask. */
+#define TCA_SINGLE_WGMODE_1_bp  1  /* Waveform generation mode bit 1 position. */
+#define TCA_SINGLE_WGMODE_2_bm  (1<<2)  /* Waveform generation mode bit 2 mask. */
+#define TCA_SINGLE_WGMODE_2_bp  2  /* Waveform generation mode bit 2 position. */
+#define TCA_SINGLE_ALUPD_bm  0x08  /* Auto Lock Update bit mask. */
+#define TCA_SINGLE_ALUPD_bp  3  /* Auto Lock Update bit position. */
+#define TCA_SINGLE_CMP0EN_bm  0x10  /* Compare 0 Enable bit mask. */
+#define TCA_SINGLE_CMP0EN_bp  4  /* Compare 0 Enable bit position. */
+#define TCA_SINGLE_CMP1EN_bm  0x20  /* Compare 1 Enable bit mask. */
+#define TCA_SINGLE_CMP1EN_bp  5  /* Compare 1 Enable bit position. */
+#define TCA_SINGLE_CMP2EN_bm  0x40  /* Compare 2 Enable bit mask. */
+#define TCA_SINGLE_CMP2EN_bp  6  /* Compare 2 Enable bit position. */
+
+/* TCA_SINGLE.CTRLC  bit masks and bit positions */
+#define TCA_SINGLE_CMP0OV_bm  0x01  /* Compare 0 Waveform Output Value bit mask. */
+#define TCA_SINGLE_CMP0OV_bp  0  /* Compare 0 Waveform Output Value bit position. */
+#define TCA_SINGLE_CMP1OV_bm  0x02  /* Compare 1 Waveform Output Value bit mask. */
+#define TCA_SINGLE_CMP1OV_bp  1  /* Compare 1 Waveform Output Value bit position. */
+#define TCA_SINGLE_CMP2OV_bm  0x04  /* Compare 2 Waveform Output Value bit mask. */
+#define TCA_SINGLE_CMP2OV_bp  2  /* Compare 2 Waveform Output Value bit position. */
+
+/* TCA_SINGLE.CTRLD  bit masks and bit positions */
+#define TCA_SINGLE_SPLITM_bm  0x01  /* Split Mode Enable bit mask. */
+#define TCA_SINGLE_SPLITM_bp  0  /* Split Mode Enable bit position. */
+
+/* TCA_SINGLE.CTRLECLR  bit masks and bit positions */
+#define TCA_SINGLE_DIR_bm  0x01  /* Direction bit mask. */
+#define TCA_SINGLE_DIR_bp  0  /* Direction bit position. */
+#define TCA_SINGLE_LUPD_bm  0x02  /* Lock Update bit mask. */
+#define TCA_SINGLE_LUPD_bp  1  /* Lock Update bit position. */
+#define TCA_SINGLE_CMD_gm  0x0C  /* Command group mask. */
+#define TCA_SINGLE_CMD_gp  2  /* Command group position. */
+#define TCA_SINGLE_CMD_0_bm  (1<<2)  /* Command bit 0 mask. */
+#define TCA_SINGLE_CMD_0_bp  2  /* Command bit 0 position. */
+#define TCA_SINGLE_CMD_1_bm  (1<<3)  /* Command bit 1 mask. */
+#define TCA_SINGLE_CMD_1_bp  3  /* Command bit 1 position. */
+
+/* TCA_SINGLE.CTRLESET  bit masks and bit positions */
+/* TCA_SINGLE_DIR  is already defined. */
+/* TCA_SINGLE_LUPD  is already defined. */
+/* TCA_SINGLE_CMD  is already defined. */
+
+/* TCA_SINGLE.CTRLFCLR  bit masks and bit positions */
+#define TCA_SINGLE_PERBV_bm  0x01  /* Period Buffer Valid bit mask. */
+#define TCA_SINGLE_PERBV_bp  0  /* Period Buffer Valid bit position. */
+#define TCA_SINGLE_CMP0BV_bm  0x02  /* Compare 0 Buffer Valid bit mask. */
+#define TCA_SINGLE_CMP0BV_bp  1  /* Compare 0 Buffer Valid bit position. */
+#define TCA_SINGLE_CMP1BV_bm  0x04  /* Compare 1 Buffer Valid bit mask. */
+#define TCA_SINGLE_CMP1BV_bp  2  /* Compare 1 Buffer Valid bit position. */
+#define TCA_SINGLE_CMP2BV_bm  0x08  /* Compare 2 Buffer Valid bit mask. */
+#define TCA_SINGLE_CMP2BV_bp  3  /* Compare 2 Buffer Valid bit position. */
+
+/* TCA_SINGLE.CTRLFSET  bit masks and bit positions */
+/* TCA_SINGLE_PERBV  is already defined. */
+/* TCA_SINGLE_CMP0BV  is already defined. */
+/* TCA_SINGLE_CMP1BV  is already defined. */
+/* TCA_SINGLE_CMP2BV  is already defined. */
+
+/* TCA_SINGLE.EVCTRL  bit masks and bit positions */
+#define TCA_SINGLE_CNTAEI_bm  0x01  /* Count on Event Input A bit mask. */
+#define TCA_SINGLE_CNTAEI_bp  0  /* Count on Event Input A bit position. */
+#define TCA_SINGLE_EVACTA_gm  0x0E  /* Event Action A group mask. */
+#define TCA_SINGLE_EVACTA_gp  1  /* Event Action A group position. */
+#define TCA_SINGLE_EVACTA_0_bm  (1<<1)  /* Event Action A bit 0 mask. */
+#define TCA_SINGLE_EVACTA_0_bp  1  /* Event Action A bit 0 position. */
+#define TCA_SINGLE_EVACTA_1_bm  (1<<2)  /* Event Action A bit 1 mask. */
+#define TCA_SINGLE_EVACTA_1_bp  2  /* Event Action A bit 1 position. */
+#define TCA_SINGLE_EVACTA_2_bm  (1<<3)  /* Event Action A bit 2 mask. */
+#define TCA_SINGLE_EVACTA_2_bp  3  /* Event Action A bit 2 position. */
+#define TCA_SINGLE_CNTBEI_bm  0x10  /* Count on Event Input B bit mask. */
+#define TCA_SINGLE_CNTBEI_bp  4  /* Count on Event Input B bit position. */
+#define TCA_SINGLE_EVACTB_gm  0xE0  /* Event Action B group mask. */
+#define TCA_SINGLE_EVACTB_gp  5  /* Event Action B group position. */
+#define TCA_SINGLE_EVACTB_0_bm  (1<<5)  /* Event Action B bit 0 mask. */
+#define TCA_SINGLE_EVACTB_0_bp  5  /* Event Action B bit 0 position. */
+#define TCA_SINGLE_EVACTB_1_bm  (1<<6)  /* Event Action B bit 1 mask. */
+#define TCA_SINGLE_EVACTB_1_bp  6  /* Event Action B bit 1 position. */
+#define TCA_SINGLE_EVACTB_2_bm  (1<<7)  /* Event Action B bit 2 mask. */
+#define TCA_SINGLE_EVACTB_2_bp  7  /* Event Action B bit 2 position. */
+
+/* TCA_SINGLE.INTCTRL  bit masks and bit positions */
+#define TCA_SINGLE_OVF_bm  0x01  /* Overflow Interrupt bit mask. */
+#define TCA_SINGLE_OVF_bp  0  /* Overflow Interrupt bit position. */
+#define TCA_SINGLE_CMP0_bm  0x10  /* Compare 0 Interrupt bit mask. */
+#define TCA_SINGLE_CMP0_bp  4  /* Compare 0 Interrupt bit position. */
+#define TCA_SINGLE_CMP1_bm  0x20  /* Compare 1 Interrupt bit mask. */
+#define TCA_SINGLE_CMP1_bp  5  /* Compare 1 Interrupt bit position. */
+#define TCA_SINGLE_CMP2_bm  0x40  /* Compare 2 Interrupt bit mask. */
+#define TCA_SINGLE_CMP2_bp  6  /* Compare 2 Interrupt bit position. */
+
+/* TCA_SINGLE.INTFLAGS  bit masks and bit positions */
+/* TCA_SINGLE_OVF  is already defined. */
+/* TCA_SINGLE_CMP0  is already defined. */
+/* TCA_SINGLE_CMP1  is already defined. */
+/* TCA_SINGLE_CMP2  is already defined. */
+
+/* TCA_SINGLE.DBGCTRL  bit masks and bit positions */
+#define TCA_SINGLE_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define TCA_SINGLE_DBGRUN_bp  0  /* Debug Run bit position. */
+
+/* TCA_SPLIT.CTRLA  bit masks and bit positions */
+#define TCA_SPLIT_ENABLE_bm  0x01  /* Module Enable bit mask. */
+#define TCA_SPLIT_ENABLE_bp  0  /* Module Enable bit position. */
+#define TCA_SPLIT_CLKSEL_gm  0x0E  /* Clock Selection group mask. */
+#define TCA_SPLIT_CLKSEL_gp  1  /* Clock Selection group position. */
+#define TCA_SPLIT_CLKSEL_0_bm  (1<<1)  /* Clock Selection bit 0 mask. */
+#define TCA_SPLIT_CLKSEL_0_bp  1  /* Clock Selection bit 0 position. */
+#define TCA_SPLIT_CLKSEL_1_bm  (1<<2)  /* Clock Selection bit 1 mask. */
+#define TCA_SPLIT_CLKSEL_1_bp  2  /* Clock Selection bit 1 position. */
+#define TCA_SPLIT_CLKSEL_2_bm  (1<<3)  /* Clock Selection bit 2 mask. */
+#define TCA_SPLIT_CLKSEL_2_bp  3  /* Clock Selection bit 2 position. */
+#define TCA_SPLIT_RUNSTDBY_bm  0x80  /* Run in Standby bit mask. */
+#define TCA_SPLIT_RUNSTDBY_bp  7  /* Run in Standby bit position. */
+
+/* TCA_SPLIT.CTRLB  bit masks and bit positions */
+#define TCA_SPLIT_LCMP0EN_bm  0x01  /* Low Compare 0 Enable bit mask. */
+#define TCA_SPLIT_LCMP0EN_bp  0  /* Low Compare 0 Enable bit position. */
+#define TCA_SPLIT_LCMP1EN_bm  0x02  /* Low Compare 1 Enable bit mask. */
+#define TCA_SPLIT_LCMP1EN_bp  1  /* Low Compare 1 Enable bit position. */
+#define TCA_SPLIT_LCMP2EN_bm  0x04  /* Low Compare 2 Enable bit mask. */
+#define TCA_SPLIT_LCMP2EN_bp  2  /* Low Compare 2 Enable bit position. */
+#define TCA_SPLIT_HCMP0EN_bm  0x10  /* High Compare 0 Enable bit mask. */
+#define TCA_SPLIT_HCMP0EN_bp  4  /* High Compare 0 Enable bit position. */
+#define TCA_SPLIT_HCMP1EN_bm  0x20  /* High Compare 1 Enable bit mask. */
+#define TCA_SPLIT_HCMP1EN_bp  5  /* High Compare 1 Enable bit position. */
+#define TCA_SPLIT_HCMP2EN_bm  0x40  /* High Compare 2 Enable bit mask. */
+#define TCA_SPLIT_HCMP2EN_bp  6  /* High Compare 2 Enable bit position. */
+
+/* TCA_SPLIT.CTRLC  bit masks and bit positions */
+#define TCA_SPLIT_LCMP0OV_bm  0x01  /* Low Compare 0 Output Value bit mask. */
+#define TCA_SPLIT_LCMP0OV_bp  0  /* Low Compare 0 Output Value bit position. */
+#define TCA_SPLIT_LCMP1OV_bm  0x02  /* Low Compare 1 Output Value bit mask. */
+#define TCA_SPLIT_LCMP1OV_bp  1  /* Low Compare 1 Output Value bit position. */
+#define TCA_SPLIT_LCMP2OV_bm  0x04  /* Low Compare 2 Output Value bit mask. */
+#define TCA_SPLIT_LCMP2OV_bp  2  /* Low Compare 2 Output Value bit position. */
+#define TCA_SPLIT_HCMP0OV_bm  0x10  /* High Compare 0 Output Value bit mask. */
+#define TCA_SPLIT_HCMP0OV_bp  4  /* High Compare 0 Output Value bit position. */
+#define TCA_SPLIT_HCMP1OV_bm  0x20  /* High Compare 1 Output Value bit mask. */
+#define TCA_SPLIT_HCMP1OV_bp  5  /* High Compare 1 Output Value bit position. */
+#define TCA_SPLIT_HCMP2OV_bm  0x40  /* High Compare 2 Output Value bit mask. */
+#define TCA_SPLIT_HCMP2OV_bp  6  /* High Compare 2 Output Value bit position. */
+
+/* TCA_SPLIT.CTRLD  bit masks and bit positions */
+#define TCA_SPLIT_SPLITM_bm  0x01  /* Split Mode Enable bit mask. */
+#define TCA_SPLIT_SPLITM_bp  0  /* Split Mode Enable bit position. */
+
+/* TCA_SPLIT.CTRLECLR  bit masks and bit positions */
+#define TCA_SPLIT_CMDEN_gm  0x03  /* Command Enable group mask. */
+#define TCA_SPLIT_CMDEN_gp  0  /* Command Enable group position. */
+#define TCA_SPLIT_CMDEN_0_bm  (1<<0)  /* Command Enable bit 0 mask. */
+#define TCA_SPLIT_CMDEN_0_bp  0  /* Command Enable bit 0 position. */
+#define TCA_SPLIT_CMDEN_1_bm  (1<<1)  /* Command Enable bit 1 mask. */
+#define TCA_SPLIT_CMDEN_1_bp  1  /* Command Enable bit 1 position. */
+#define TCA_SPLIT_CMD_gm  0x0C  /* Command group mask. */
+#define TCA_SPLIT_CMD_gp  2  /* Command group position. */
+#define TCA_SPLIT_CMD_0_bm  (1<<2)  /* Command bit 0 mask. */
+#define TCA_SPLIT_CMD_0_bp  2  /* Command bit 0 position. */
+#define TCA_SPLIT_CMD_1_bm  (1<<3)  /* Command bit 1 mask. */
+#define TCA_SPLIT_CMD_1_bp  3  /* Command bit 1 position. */
+
+/* TCA_SPLIT.CTRLESET  bit masks and bit positions */
+/* TCA_SPLIT_CMDEN  is already defined. */
+/* TCA_SPLIT_CMD  is already defined. */
+
+/* TCA_SPLIT.INTCTRL  bit masks and bit positions */
+#define TCA_SPLIT_LUNF_bm  0x01  /* Low Underflow Interrupt Enable bit mask. */
+#define TCA_SPLIT_LUNF_bp  0  /* Low Underflow Interrupt Enable bit position. */
+#define TCA_SPLIT_HUNF_bm  0x02  /* High Underflow Interrupt Enable bit mask. */
+#define TCA_SPLIT_HUNF_bp  1  /* High Underflow Interrupt Enable bit position. */
+#define TCA_SPLIT_LCMP0_bm  0x10  /* Low Compare 0 Interrupt Enable bit mask. */
+#define TCA_SPLIT_LCMP0_bp  4  /* Low Compare 0 Interrupt Enable bit position. */
+#define TCA_SPLIT_LCMP1_bm  0x20  /* Low Compare 1 Interrupt Enable bit mask. */
+#define TCA_SPLIT_LCMP1_bp  5  /* Low Compare 1 Interrupt Enable bit position. */
+#define TCA_SPLIT_LCMP2_bm  0x40  /* Low Compare 2 Interrupt Enable bit mask. */
+#define TCA_SPLIT_LCMP2_bp  6  /* Low Compare 2 Interrupt Enable bit position. */
+
+/* TCA_SPLIT.INTFLAGS  bit masks and bit positions */
+/* TCA_SPLIT_LUNF  is already defined. */
+/* TCA_SPLIT_HUNF  is already defined. */
+/* TCA_SPLIT_LCMP0  is already defined. */
+/* TCA_SPLIT_LCMP1  is already defined. */
+/* TCA_SPLIT_LCMP2  is already defined. */
+
+/* TCA_SPLIT.DBGCTRL  bit masks and bit positions */
+#define TCA_SPLIT_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define TCA_SPLIT_DBGRUN_bp  0  /* Debug Run bit position. */
+
+
+/* TCB - 16-bit Timer Type B */
+/* TCB.CTRLA  bit masks and bit positions */
+#define TCB_ENABLE_bm  0x01  /* Enable bit mask. */
+#define TCB_ENABLE_bp  0  /* Enable bit position. */
+#define TCB_CLKSEL_gm  0x0E  /* Clock Select group mask. */
+#define TCB_CLKSEL_gp  1  /* Clock Select group position. */
+#define TCB_CLKSEL_0_bm  (1<<1)  /* Clock Select bit 0 mask. */
+#define TCB_CLKSEL_0_bp  1  /* Clock Select bit 0 position. */
+#define TCB_CLKSEL_1_bm  (1<<2)  /* Clock Select bit 1 mask. */
+#define TCB_CLKSEL_1_bp  2  /* Clock Select bit 1 position. */
+#define TCB_CLKSEL_2_bm  (1<<3)  /* Clock Select bit 2 mask. */
+#define TCB_CLKSEL_2_bp  3  /* Clock Select bit 2 position. */
+#define TCB_SYNCUPD_bm  0x10  /* Synchronize Update bit mask. */
+#define TCB_SYNCUPD_bp  4  /* Synchronize Update bit position. */
+#define TCB_CASCADE_bm  0x20  /* Cascade two timers bit mask. */
+#define TCB_CASCADE_bp  5  /* Cascade two timers bit position. */
+#define TCB_RUNSTDBY_bm  0x40  /* Run Standby bit mask. */
+#define TCB_RUNSTDBY_bp  6  /* Run Standby bit position. */
+
+/* TCB.CTRLB  bit masks and bit positions */
+#define TCB_CNTMODE_gm  0x07  /* Timer Mode group mask. */
+#define TCB_CNTMODE_gp  0  /* Timer Mode group position. */
+#define TCB_CNTMODE_0_bm  (1<<0)  /* Timer Mode bit 0 mask. */
+#define TCB_CNTMODE_0_bp  0  /* Timer Mode bit 0 position. */
+#define TCB_CNTMODE_1_bm  (1<<1)  /* Timer Mode bit 1 mask. */
+#define TCB_CNTMODE_1_bp  1  /* Timer Mode bit 1 position. */
+#define TCB_CNTMODE_2_bm  (1<<2)  /* Timer Mode bit 2 mask. */
+#define TCB_CNTMODE_2_bp  2  /* Timer Mode bit 2 position. */
+#define TCB_CCMPEN_bm  0x10  /* Pin Output Enable bit mask. */
+#define TCB_CCMPEN_bp  4  /* Pin Output Enable bit position. */
+#define TCB_CCMPINIT_bm  0x20  /* Pin Initial State bit mask. */
+#define TCB_CCMPINIT_bp  5  /* Pin Initial State bit position. */
+#define TCB_ASYNC_bm  0x40  /* Asynchronous Enable bit mask. */
+#define TCB_ASYNC_bp  6  /* Asynchronous Enable bit position. */
+
+/* TCB.EVCTRL  bit masks and bit positions */
+#define TCB_CAPTEI_bm  0x01  /* Event Input Enable bit mask. */
+#define TCB_CAPTEI_bp  0  /* Event Input Enable bit position. */
+#define TCB_EDGE_bm  0x10  /* Event Edge bit mask. */
+#define TCB_EDGE_bp  4  /* Event Edge bit position. */
+#define TCB_FILTER_bm  0x40  /* Input Capture Noise Cancellation Filter bit mask. */
+#define TCB_FILTER_bp  6  /* Input Capture Noise Cancellation Filter bit position. */
+
+/* TCB.INTCTRL  bit masks and bit positions */
+#define TCB_CAPT_bm  0x01  /* Capture or Timeout bit mask. */
+#define TCB_CAPT_bp  0  /* Capture or Timeout bit position. */
+#define TCB_OVF_bm  0x02  /* Overflow bit mask. */
+#define TCB_OVF_bp  1  /* Overflow bit position. */
+
+/* TCB.INTFLAGS  bit masks and bit positions */
+/* TCB_CAPT  is already defined. */
+/* TCB_OVF  is already defined. */
+
+/* TCB.STATUS  bit masks and bit positions */
+#define TCB_RUN_bm  0x01  /* Run bit mask. */
+#define TCB_RUN_bp  0  /* Run bit position. */
+
+/* TCB.DBGCTRL  bit masks and bit positions */
+#define TCB_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define TCB_DBGRUN_bp  0  /* Debug Run bit position. */
+
+
+/* TWI - Two-Wire Interface */
+/* TWI.CTRLA  bit masks and bit positions */
+#define TWI_FMEN_bm  0x01  /* Fast-mode Enable bit mask. */
+#define TWI_FMEN_bp  0  /* Fast-mode Enable bit position. */
+#define TWI_FMPEN_bm  0x02  /* Fast-mode Plus Enable bit mask. */
+#define TWI_FMPEN_bp  1  /* Fast-mode Plus Enable bit position. */
+#define TWI_SDAHOLD_gm  0x0C  /* SDA Hold Time group mask. */
+#define TWI_SDAHOLD_gp  2  /* SDA Hold Time group position. */
+#define TWI_SDAHOLD_0_bm  (1<<2)  /* SDA Hold Time bit 0 mask. */
+#define TWI_SDAHOLD_0_bp  2  /* SDA Hold Time bit 0 position. */
+#define TWI_SDAHOLD_1_bm  (1<<3)  /* SDA Hold Time bit 1 mask. */
+#define TWI_SDAHOLD_1_bp  3  /* SDA Hold Time bit 1 position. */
+#define TWI_SDASETUP_bm  0x10  /* SDA Setup Time bit mask. */
+#define TWI_SDASETUP_bp  4  /* SDA Setup Time bit position. */
+#define TWI_INPUTLVL_bm  0x40  /* Input voltage transition level bit mask. */
+#define TWI_INPUTLVL_bp  6  /* Input voltage transition level bit position. */
+
+/* TWI.DUALCTRL  bit masks and bit positions */
+#define TWI_ENABLE_bm  0x01  /* Enable bit mask. */
+#define TWI_ENABLE_bp  0  /* Enable bit position. */
+/* TWI_FMPEN  is already defined. */
+/* TWI_SDAHOLD  is already defined. */
+/* TWI_INPUTLVL  is already defined. */
+
+/* TWI.DBGCTRL  bit masks and bit positions */
+#define TWI_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define TWI_DBGRUN_bp  0  /* Debug Run bit position. */
+
+/* TWI.MCTRLA  bit masks and bit positions */
+/* TWI_ENABLE  is already defined. */
+#define TWI_SMEN_bm  0x02  /* Smart Mode Enable bit mask. */
+#define TWI_SMEN_bp  1  /* Smart Mode Enable bit position. */
+#define TWI_TIMEOUT_gm  0x0C  /* Inactive Bus Time-Out group mask. */
+#define TWI_TIMEOUT_gp  2  /* Inactive Bus Time-Out group position. */
+#define TWI_TIMEOUT_0_bm  (1<<2)  /* Inactive Bus Time-Out bit 0 mask. */
+#define TWI_TIMEOUT_0_bp  2  /* Inactive Bus Time-Out bit 0 position. */
+#define TWI_TIMEOUT_1_bm  (1<<3)  /* Inactive Bus Time-Out bit 1 mask. */
+#define TWI_TIMEOUT_1_bp  3  /* Inactive Bus Time-Out bit 1 position. */
+#define TWI_QCEN_bm  0x10  /* Quick Command Enable bit mask. */
+#define TWI_QCEN_bp  4  /* Quick Command Enable bit position. */
+#define TWI_WIEN_bm  0x40  /* Write Interrupt Enable bit mask. */
+#define TWI_WIEN_bp  6  /* Write Interrupt Enable bit position. */
+#define TWI_RIEN_bm  0x80  /* Read Interrupt Enable bit mask. */
+#define TWI_RIEN_bp  7  /* Read Interrupt Enable bit position. */
+
+/* TWI.MCTRLB  bit masks and bit positions */
+#define TWI_MCMD_gm  0x03  /* Command group mask. */
+#define TWI_MCMD_gp  0  /* Command group position. */
+#define TWI_MCMD_0_bm  (1<<0)  /* Command bit 0 mask. */
+#define TWI_MCMD_0_bp  0  /* Command bit 0 position. */
+#define TWI_MCMD_1_bm  (1<<1)  /* Command bit 1 mask. */
+#define TWI_MCMD_1_bp  1  /* Command bit 1 position. */
+#define TWI_ACKACT_bm  0x04  /* Acknowledge Action bit mask. */
+#define TWI_ACKACT_bp  2  /* Acknowledge Action bit position. */
+#define TWI_FLUSH_bm  0x08  /* Flush bit mask. */
+#define TWI_FLUSH_bp  3  /* Flush bit position. */
+
+/* TWI.MSTATUS  bit masks and bit positions */
+#define TWI_BUSSTATE_gm  0x03  /* Bus State group mask. */
+#define TWI_BUSSTATE_gp  0  /* Bus State group position. */
+#define TWI_BUSSTATE_0_bm  (1<<0)  /* Bus State bit 0 mask. */
+#define TWI_BUSSTATE_0_bp  0  /* Bus State bit 0 position. */
+#define TWI_BUSSTATE_1_bm  (1<<1)  /* Bus State bit 1 mask. */
+#define TWI_BUSSTATE_1_bp  1  /* Bus State bit 1 position. */
+#define TWI_BUSERR_bm  0x04  /* Bus Error bit mask. */
+#define TWI_BUSERR_bp  2  /* Bus Error bit position. */
+#define TWI_ARBLOST_bm  0x08  /* Arbitration Lost bit mask. */
+#define TWI_ARBLOST_bp  3  /* Arbitration Lost bit position. */
+#define TWI_RXACK_bm  0x10  /* Received Acknowledge bit mask. */
+#define TWI_RXACK_bp  4  /* Received Acknowledge bit position. */
+#define TWI_CLKHOLD_bm  0x20  /* Clock Hold bit mask. */
+#define TWI_CLKHOLD_bp  5  /* Clock Hold bit position. */
+#define TWI_WIF_bm  0x40  /* Write Interrupt Flag bit mask. */
+#define TWI_WIF_bp  6  /* Write Interrupt Flag bit position. */
+#define TWI_RIF_bm  0x80  /* Read Interrupt Flag bit mask. */
+#define TWI_RIF_bp  7  /* Read Interrupt Flag bit position. */
+
+/* TWI.MBAUD  bit masks and bit positions */
+#define TWI_BAUD_gm  0xFF  /* Baud Rate group mask. */
+#define TWI_BAUD_gp  0  /* Baud Rate group position. */
+#define TWI_BAUD_0_bm  (1<<0)  /* Baud Rate bit 0 mask. */
+#define TWI_BAUD_0_bp  0  /* Baud Rate bit 0 position. */
+#define TWI_BAUD_1_bm  (1<<1)  /* Baud Rate bit 1 mask. */
+#define TWI_BAUD_1_bp  1  /* Baud Rate bit 1 position. */
+#define TWI_BAUD_2_bm  (1<<2)  /* Baud Rate bit 2 mask. */
+#define TWI_BAUD_2_bp  2  /* Baud Rate bit 2 position. */
+#define TWI_BAUD_3_bm  (1<<3)  /* Baud Rate bit 3 mask. */
+#define TWI_BAUD_3_bp  3  /* Baud Rate bit 3 position. */
+#define TWI_BAUD_4_bm  (1<<4)  /* Baud Rate bit 4 mask. */
+#define TWI_BAUD_4_bp  4  /* Baud Rate bit 4 position. */
+#define TWI_BAUD_5_bm  (1<<5)  /* Baud Rate bit 5 mask. */
+#define TWI_BAUD_5_bp  5  /* Baud Rate bit 5 position. */
+#define TWI_BAUD_6_bm  (1<<6)  /* Baud Rate bit 6 mask. */
+#define TWI_BAUD_6_bp  6  /* Baud Rate bit 6 position. */
+#define TWI_BAUD_7_bm  (1<<7)  /* Baud Rate bit 7 mask. */
+#define TWI_BAUD_7_bp  7  /* Baud Rate bit 7 position. */
+
+/* TWI.MADDR  bit masks and bit positions */
+#define TWI_ADDR_gm  0xFF  /* Address group mask. */
+#define TWI_ADDR_gp  0  /* Address group position. */
+#define TWI_ADDR_0_bm  (1<<0)  /* Address bit 0 mask. */
+#define TWI_ADDR_0_bp  0  /* Address bit 0 position. */
+#define TWI_ADDR_1_bm  (1<<1)  /* Address bit 1 mask. */
+#define TWI_ADDR_1_bp  1  /* Address bit 1 position. */
+#define TWI_ADDR_2_bm  (1<<2)  /* Address bit 2 mask. */
+#define TWI_ADDR_2_bp  2  /* Address bit 2 position. */
+#define TWI_ADDR_3_bm  (1<<3)  /* Address bit 3 mask. */
+#define TWI_ADDR_3_bp  3  /* Address bit 3 position. */
+#define TWI_ADDR_4_bm  (1<<4)  /* Address bit 4 mask. */
+#define TWI_ADDR_4_bp  4  /* Address bit 4 position. */
+#define TWI_ADDR_5_bm  (1<<5)  /* Address bit 5 mask. */
+#define TWI_ADDR_5_bp  5  /* Address bit 5 position. */
+#define TWI_ADDR_6_bm  (1<<6)  /* Address bit 6 mask. */
+#define TWI_ADDR_6_bp  6  /* Address bit 6 position. */
+#define TWI_ADDR_7_bm  (1<<7)  /* Address bit 7 mask. */
+#define TWI_ADDR_7_bp  7  /* Address bit 7 position. */
+
+/* TWI.MDATA  bit masks and bit positions */
+#define TWI_DATA_gm  0xFF  /* Data group mask. */
+#define TWI_DATA_gp  0  /* Data group position. */
+#define TWI_DATA_0_bm  (1<<0)  /* Data bit 0 mask. */
+#define TWI_DATA_0_bp  0  /* Data bit 0 position. */
+#define TWI_DATA_1_bm  (1<<1)  /* Data bit 1 mask. */
+#define TWI_DATA_1_bp  1  /* Data bit 1 position. */
+#define TWI_DATA_2_bm  (1<<2)  /* Data bit 2 mask. */
+#define TWI_DATA_2_bp  2  /* Data bit 2 position. */
+#define TWI_DATA_3_bm  (1<<3)  /* Data bit 3 mask. */
+#define TWI_DATA_3_bp  3  /* Data bit 3 position. */
+#define TWI_DATA_4_bm  (1<<4)  /* Data bit 4 mask. */
+#define TWI_DATA_4_bp  4  /* Data bit 4 position. */
+#define TWI_DATA_5_bm  (1<<5)  /* Data bit 5 mask. */
+#define TWI_DATA_5_bp  5  /* Data bit 5 position. */
+#define TWI_DATA_6_bm  (1<<6)  /* Data bit 6 mask. */
+#define TWI_DATA_6_bp  6  /* Data bit 6 position. */
+#define TWI_DATA_7_bm  (1<<7)  /* Data bit 7 mask. */
+#define TWI_DATA_7_bp  7  /* Data bit 7 position. */
+
+/* TWI.SCTRLA  bit masks and bit positions */
+/* TWI_ENABLE  is already defined. */
+/* TWI_SMEN  is already defined. */
+#define TWI_PMEN_bm  0x04  /* Address Recognition Mode bit mask. */
+#define TWI_PMEN_bp  2  /* Address Recognition Mode bit position. */
+#define TWI_PIEN_bm  0x20  /* Stop Interrupt Enable bit mask. */
+#define TWI_PIEN_bp  5  /* Stop Interrupt Enable bit position. */
+#define TWI_APIEN_bm  0x40  /* Address or Stop Interrupt Enable bit mask. */
+#define TWI_APIEN_bp  6  /* Address or Stop Interrupt Enable bit position. */
+#define TWI_DIEN_bm  0x80  /* Data Interrupt Enable bit mask. */
+#define TWI_DIEN_bp  7  /* Data Interrupt Enable bit position. */
+
+/* TWI.SCTRLB  bit masks and bit positions */
+#define TWI_SCMD_gm  0x03  /* Command group mask. */
+#define TWI_SCMD_gp  0  /* Command group position. */
+#define TWI_SCMD_0_bm  (1<<0)  /* Command bit 0 mask. */
+#define TWI_SCMD_0_bp  0  /* Command bit 0 position. */
+#define TWI_SCMD_1_bm  (1<<1)  /* Command bit 1 mask. */
+#define TWI_SCMD_1_bp  1  /* Command bit 1 position. */
+/* TWI_ACKACT  is already defined. */
+
+/* TWI.SSTATUS  bit masks and bit positions */
+#define TWI_AP_bm  0x01  /* Address or Stop bit mask. */
+#define TWI_AP_bp  0  /* Address or Stop bit position. */
+#define TWI_DIR_bm  0x02  /* Read/Write Direction bit mask. */
+#define TWI_DIR_bp  1  /* Read/Write Direction bit position. */
+/* TWI_BUSERR  is already defined. */
+#define TWI_COLL_bm  0x08  /* Collision bit mask. */
+#define TWI_COLL_bp  3  /* Collision bit position. */
+/* TWI_RXACK  is already defined. */
+/* TWI_CLKHOLD  is already defined. */
+#define TWI_APIF_bm  0x40  /* Address or Stop Interrupt Flag bit mask. */
+#define TWI_APIF_bp  6  /* Address or Stop Interrupt Flag bit position. */
+#define TWI_DIF_bm  0x80  /* Data Interrupt Flag bit mask. */
+#define TWI_DIF_bp  7  /* Data Interrupt Flag bit position. */
+
+/* TWI.SADDR  bit masks and bit positions */
+/* TWI_ADDR  is already defined. */
+
+/* TWI.SDATA  bit masks and bit positions */
+/* TWI_DATA  is already defined. */
+
+/* TWI.SADDRMASK  bit masks and bit positions */
+#define TWI_ADDREN_bm  0x01  /* Address Mask Enable bit mask. */
+#define TWI_ADDREN_bp  0  /* Address Mask Enable bit position. */
+#define TWI_ADDRMASK_gm  0xFE  /* Address Mask group mask. */
+#define TWI_ADDRMASK_gp  1  /* Address Mask group position. */
+#define TWI_ADDRMASK_0_bm  (1<<1)  /* Address Mask bit 0 mask. */
+#define TWI_ADDRMASK_0_bp  1  /* Address Mask bit 0 position. */
+#define TWI_ADDRMASK_1_bm  (1<<2)  /* Address Mask bit 1 mask. */
+#define TWI_ADDRMASK_1_bp  2  /* Address Mask bit 1 position. */
+#define TWI_ADDRMASK_2_bm  (1<<3)  /* Address Mask bit 2 mask. */
+#define TWI_ADDRMASK_2_bp  3  /* Address Mask bit 2 position. */
+#define TWI_ADDRMASK_3_bm  (1<<4)  /* Address Mask bit 3 mask. */
+#define TWI_ADDRMASK_3_bp  4  /* Address Mask bit 3 position. */
+#define TWI_ADDRMASK_4_bm  (1<<5)  /* Address Mask bit 4 mask. */
+#define TWI_ADDRMASK_4_bp  5  /* Address Mask bit 4 position. */
+#define TWI_ADDRMASK_5_bm  (1<<6)  /* Address Mask bit 5 mask. */
+#define TWI_ADDRMASK_5_bp  6  /* Address Mask bit 5 position. */
+#define TWI_ADDRMASK_6_bm  (1<<7)  /* Address Mask bit 6 mask. */
+#define TWI_ADDRMASK_6_bp  7  /* Address Mask bit 6 position. */
+
+
+/* USART - Universal Synchronous and Asynchronous Receiver and Transmitter */
+/* USART.RXDATAL  bit masks and bit positions */
+#define USART_DATA_gm  0xFF  /* RX Data group mask. */
+#define USART_DATA_gp  0  /* RX Data group position. */
+#define USART_DATA_0_bm  (1<<0)  /* RX Data bit 0 mask. */
+#define USART_DATA_0_bp  0  /* RX Data bit 0 position. */
+#define USART_DATA_1_bm  (1<<1)  /* RX Data bit 1 mask. */
+#define USART_DATA_1_bp  1  /* RX Data bit 1 position. */
+#define USART_DATA_2_bm  (1<<2)  /* RX Data bit 2 mask. */
+#define USART_DATA_2_bp  2  /* RX Data bit 2 position. */
+#define USART_DATA_3_bm  (1<<3)  /* RX Data bit 3 mask. */
+#define USART_DATA_3_bp  3  /* RX Data bit 3 position. */
+#define USART_DATA_4_bm  (1<<4)  /* RX Data bit 4 mask. */
+#define USART_DATA_4_bp  4  /* RX Data bit 4 position. */
+#define USART_DATA_5_bm  (1<<5)  /* RX Data bit 5 mask. */
+#define USART_DATA_5_bp  5  /* RX Data bit 5 position. */
+#define USART_DATA_6_bm  (1<<6)  /* RX Data bit 6 mask. */
+#define USART_DATA_6_bp  6  /* RX Data bit 6 position. */
+#define USART_DATA_7_bm  (1<<7)  /* RX Data bit 7 mask. */
+#define USART_DATA_7_bp  7  /* RX Data bit 7 position. */
+
+/* USART.RXDATAH  bit masks and bit positions */
+#define USART_DATA8_bm  0x01  /* Receiver Data Register bit mask. */
+#define USART_DATA8_bp  0  /* Receiver Data Register bit position. */
+#define USART_PERR_bm  0x02  /* Parity Error bit mask. */
+#define USART_PERR_bp  1  /* Parity Error bit position. */
+#define USART_FERR_bm  0x04  /* Frame Error bit mask. */
+#define USART_FERR_bp  2  /* Frame Error bit position. */
+#define USART_BUFOVF_bm  0x40  /* Buffer Overflow bit mask. */
+#define USART_BUFOVF_bp  6  /* Buffer Overflow bit position. */
+#define USART_RXCIF_bm  0x80  /* Receive Complete Interrupt Flag bit mask. */
+#define USART_RXCIF_bp  7  /* Receive Complete Interrupt Flag bit position. */
+
+/* USART.TXDATAL  bit masks and bit positions */
+/* USART_DATA  is already defined. */
+
+/* USART.TXDATAH  bit masks and bit positions */
+/* USART_DATA8  is already defined. */
+
+/* USART.STATUS  bit masks and bit positions */
+#define USART_WFB_bm  0x01  /* Wait For Break bit mask. */
+#define USART_WFB_bp  0  /* Wait For Break bit position. */
+#define USART_BDF_bm  0x02  /* Break Detected Flag bit mask. */
+#define USART_BDF_bp  1  /* Break Detected Flag bit position. */
+#define USART_ISFIF_bm  0x08  /* Inconsistent Sync Field Interrupt Flag bit mask. */
+#define USART_ISFIF_bp  3  /* Inconsistent Sync Field Interrupt Flag bit position. */
+#define USART_RXSIF_bm  0x10  /* Receive Start Interrupt bit mask. */
+#define USART_RXSIF_bp  4  /* Receive Start Interrupt bit position. */
+#define USART_DREIF_bm  0x20  /* Data Register Empty Flag bit mask. */
+#define USART_DREIF_bp  5  /* Data Register Empty Flag bit position. */
+#define USART_TXCIF_bm  0x40  /* Transmit Interrupt Flag bit mask. */
+#define USART_TXCIF_bp  6  /* Transmit Interrupt Flag bit position. */
+/* USART_RXCIF  is already defined. */
+
+/* USART.CTRLA  bit masks and bit positions */
+#define USART_RS485_bm  0x01  /* RS485 Mode internal transmitter bit mask. */
+#define USART_RS485_bp  0  /* RS485 Mode internal transmitter bit position. */
+#define USART_ABEIE_bm  0x04  /* Auto-baud Error Interrupt Enable bit mask. */
+#define USART_ABEIE_bp  2  /* Auto-baud Error Interrupt Enable bit position. */
+#define USART_LBME_bm  0x08  /* Loop-back Mode Enable bit mask. */
+#define USART_LBME_bp  3  /* Loop-back Mode Enable bit position. */
+#define USART_RXSIE_bm  0x10  /* Receiver Start Frame Interrupt Enable bit mask. */
+#define USART_RXSIE_bp  4  /* Receiver Start Frame Interrupt Enable bit position. */
+#define USART_DREIE_bm  0x20  /* Data Register Empty Interrupt Enable bit mask. */
+#define USART_DREIE_bp  5  /* Data Register Empty Interrupt Enable bit position. */
+#define USART_TXCIE_bm  0x40  /* Transmit Complete Interrupt Enable bit mask. */
+#define USART_TXCIE_bp  6  /* Transmit Complete Interrupt Enable bit position. */
+#define USART_RXCIE_bm  0x80  /* Receive Complete Interrupt Enable bit mask. */
+#define USART_RXCIE_bp  7  /* Receive Complete Interrupt Enable bit position. */
+
+/* USART.CTRLB  bit masks and bit positions */
+#define USART_MPCM_bm  0x01  /* Multi-processor Communication Mode bit mask. */
+#define USART_MPCM_bp  0  /* Multi-processor Communication Mode bit position. */
+#define USART_RXMODE_gm  0x06  /* Receiver Mode group mask. */
+#define USART_RXMODE_gp  1  /* Receiver Mode group position. */
+#define USART_RXMODE_0_bm  (1<<1)  /* Receiver Mode bit 0 mask. */
+#define USART_RXMODE_0_bp  1  /* Receiver Mode bit 0 position. */
+#define USART_RXMODE_1_bm  (1<<2)  /* Receiver Mode bit 1 mask. */
+#define USART_RXMODE_1_bp  2  /* Receiver Mode bit 1 position. */
+#define USART_ODME_bm  0x08  /* Open Drain Mode Enable bit mask. */
+#define USART_ODME_bp  3  /* Open Drain Mode Enable bit position. */
+#define USART_SFDEN_bm  0x10  /* Start Frame Detection Enable bit mask. */
+#define USART_SFDEN_bp  4  /* Start Frame Detection Enable bit position. */
+#define USART_TXEN_bm  0x40  /* Transmitter Enable bit mask. */
+#define USART_TXEN_bp  6  /* Transmitter Enable bit position. */
+#define USART_RXEN_bm  0x80  /* Reciever enable bit mask. */
+#define USART_RXEN_bp  7  /* Reciever enable bit position. */
+
+/* USART.CTRLC  bit masks and bit positions */
+#define USART_UCPHA_bm  0x02  /* SPI Host Mode, Clock Phase bit mask. */
+#define USART_UCPHA_bp  1  /* SPI Host Mode, Clock Phase bit position. */
+#define USART_UDORD_bm  0x04  /* SPI Host Mode, Data Order bit mask. */
+#define USART_UDORD_bp  2  /* SPI Host Mode, Data Order bit position. */
+#define USART_CHSIZE_gm  0x07  /* Character Size group mask. */
+#define USART_CHSIZE_gp  0  /* Character Size group position. */
+#define USART_CHSIZE_0_bm  (1<<0)  /* Character Size bit 0 mask. */
+#define USART_CHSIZE_0_bp  0  /* Character Size bit 0 position. */
+#define USART_CHSIZE_1_bm  (1<<1)  /* Character Size bit 1 mask. */
+#define USART_CHSIZE_1_bp  1  /* Character Size bit 1 position. */
+#define USART_CHSIZE_2_bm  (1<<2)  /* Character Size bit 2 mask. */
+#define USART_CHSIZE_2_bp  2  /* Character Size bit 2 position. */
+#define USART_SBMODE_bm  0x08  /* Stop Bit Mode bit mask. */
+#define USART_SBMODE_bp  3  /* Stop Bit Mode bit position. */
+#define USART_PMODE_gm  0x30  /* Parity Mode group mask. */
+#define USART_PMODE_gp  4  /* Parity Mode group position. */
+#define USART_PMODE_0_bm  (1<<4)  /* Parity Mode bit 0 mask. */
+#define USART_PMODE_0_bp  4  /* Parity Mode bit 0 position. */
+#define USART_PMODE_1_bm  (1<<5)  /* Parity Mode bit 1 mask. */
+#define USART_PMODE_1_bp  5  /* Parity Mode bit 1 position. */
+#define USART_CMODE_gm  0xC0  /* Communication Mode group mask. */
+#define USART_CMODE_gp  6  /* Communication Mode group position. */
+#define USART_CMODE_0_bm  (1<<6)  /* Communication Mode bit 0 mask. */
+#define USART_CMODE_0_bp  6  /* Communication Mode bit 0 position. */
+#define USART_CMODE_1_bm  (1<<7)  /* Communication Mode bit 1 mask. */
+#define USART_CMODE_1_bp  7  /* Communication Mode bit 1 position. */
+
+/* USART.CTRLD  bit masks and bit positions */
+#define USART_ABW_gm  0xC0  /* Auto Baud Window group mask. */
+#define USART_ABW_gp  6  /* Auto Baud Window group position. */
+#define USART_ABW_0_bm  (1<<6)  /* Auto Baud Window bit 0 mask. */
+#define USART_ABW_0_bp  6  /* Auto Baud Window bit 0 position. */
+#define USART_ABW_1_bm  (1<<7)  /* Auto Baud Window bit 1 mask. */
+#define USART_ABW_1_bp  7  /* Auto Baud Window bit 1 position. */
+
+/* USART.DBGCTRL  bit masks and bit positions */
+#define USART_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define USART_DBGRUN_bp  0  /* Debug Run bit position. */
+
+/* USART.EVCTRL  bit masks and bit positions */
+#define USART_IREI_bm  0x01  /* IrDA Event Input Enable bit mask. */
+#define USART_IREI_bp  0  /* IrDA Event Input Enable bit position. */
+
+/* USART.TXPLCTRL  bit masks and bit positions */
+#define USART_TXPL_gm  0xFF  /* Transmit pulse length group mask. */
+#define USART_TXPL_gp  0  /* Transmit pulse length group position. */
+#define USART_TXPL_0_bm  (1<<0)  /* Transmit pulse length bit 0 mask. */
+#define USART_TXPL_0_bp  0  /* Transmit pulse length bit 0 position. */
+#define USART_TXPL_1_bm  (1<<1)  /* Transmit pulse length bit 1 mask. */
+#define USART_TXPL_1_bp  1  /* Transmit pulse length bit 1 position. */
+#define USART_TXPL_2_bm  (1<<2)  /* Transmit pulse length bit 2 mask. */
+#define USART_TXPL_2_bp  2  /* Transmit pulse length bit 2 position. */
+#define USART_TXPL_3_bm  (1<<3)  /* Transmit pulse length bit 3 mask. */
+#define USART_TXPL_3_bp  3  /* Transmit pulse length bit 3 position. */
+#define USART_TXPL_4_bm  (1<<4)  /* Transmit pulse length bit 4 mask. */
+#define USART_TXPL_4_bp  4  /* Transmit pulse length bit 4 position. */
+#define USART_TXPL_5_bm  (1<<5)  /* Transmit pulse length bit 5 mask. */
+#define USART_TXPL_5_bp  5  /* Transmit pulse length bit 5 position. */
+#define USART_TXPL_6_bm  (1<<6)  /* Transmit pulse length bit 6 mask. */
+#define USART_TXPL_6_bp  6  /* Transmit pulse length bit 6 position. */
+#define USART_TXPL_7_bm  (1<<7)  /* Transmit pulse length bit 7 mask. */
+#define USART_TXPL_7_bp  7  /* Transmit pulse length bit 7 position. */
+
+/* USART.RXPLCTRL  bit masks and bit positions */
+#define USART_RXPL_gm  0x7F  /* Receiver Pulse Lenght group mask. */
+#define USART_RXPL_gp  0  /* Receiver Pulse Lenght group position. */
+#define USART_RXPL_0_bm  (1<<0)  /* Receiver Pulse Lenght bit 0 mask. */
+#define USART_RXPL_0_bp  0  /* Receiver Pulse Lenght bit 0 position. */
+#define USART_RXPL_1_bm  (1<<1)  /* Receiver Pulse Lenght bit 1 mask. */
+#define USART_RXPL_1_bp  1  /* Receiver Pulse Lenght bit 1 position. */
+#define USART_RXPL_2_bm  (1<<2)  /* Receiver Pulse Lenght bit 2 mask. */
+#define USART_RXPL_2_bp  2  /* Receiver Pulse Lenght bit 2 position. */
+#define USART_RXPL_3_bm  (1<<3)  /* Receiver Pulse Lenght bit 3 mask. */
+#define USART_RXPL_3_bp  3  /* Receiver Pulse Lenght bit 3 position. */
+#define USART_RXPL_4_bm  (1<<4)  /* Receiver Pulse Lenght bit 4 mask. */
+#define USART_RXPL_4_bp  4  /* Receiver Pulse Lenght bit 4 position. */
+#define USART_RXPL_5_bm  (1<<5)  /* Receiver Pulse Lenght bit 5 mask. */
+#define USART_RXPL_5_bp  5  /* Receiver Pulse Lenght bit 5 position. */
+#define USART_RXPL_6_bm  (1<<6)  /* Receiver Pulse Lenght bit 6 mask. */
+#define USART_RXPL_6_bp  6  /* Receiver Pulse Lenght bit 6 position. */
+
+
+
+/* VPORT - Virtual Ports */
+/* VPORT.INTFLAGS  bit masks and bit positions */
+#define VPORT_INT_gm  0xFF  /* Pin Interrupt Flag group mask. */
+#define VPORT_INT_gp  0  /* Pin Interrupt Flag group position. */
+#define VPORT_INT_0_bm  (1<<0)  /* Pin Interrupt Flag bit 0 mask. */
+#define VPORT_INT_0_bp  0  /* Pin Interrupt Flag bit 0 position. */
+#define VPORT_INT_1_bm  (1<<1)  /* Pin Interrupt Flag bit 1 mask. */
+#define VPORT_INT_1_bp  1  /* Pin Interrupt Flag bit 1 position. */
+#define VPORT_INT_2_bm  (1<<2)  /* Pin Interrupt Flag bit 2 mask. */
+#define VPORT_INT_2_bp  2  /* Pin Interrupt Flag bit 2 position. */
+#define VPORT_INT_3_bm  (1<<3)  /* Pin Interrupt Flag bit 3 mask. */
+#define VPORT_INT_3_bp  3  /* Pin Interrupt Flag bit 3 position. */
+#define VPORT_INT_4_bm  (1<<4)  /* Pin Interrupt Flag bit 4 mask. */
+#define VPORT_INT_4_bp  4  /* Pin Interrupt Flag bit 4 position. */
+#define VPORT_INT_5_bm  (1<<5)  /* Pin Interrupt Flag bit 5 mask. */
+#define VPORT_INT_5_bp  5  /* Pin Interrupt Flag bit 5 position. */
+#define VPORT_INT_6_bm  (1<<6)  /* Pin Interrupt Flag bit 6 mask. */
+#define VPORT_INT_6_bp  6  /* Pin Interrupt Flag bit 6 position. */
+#define VPORT_INT_7_bm  (1<<7)  /* Pin Interrupt Flag bit 7 mask. */
+#define VPORT_INT_7_bp  7  /* Pin Interrupt Flag bit 7 position. */
+
+
+/* VREF - Voltage reference */
+/* VREF.DAC0REF  bit masks and bit positions */
+#define VREF_REFSEL_gm  0x07  /* Reference select group mask. */
+#define VREF_REFSEL_gp  0  /* Reference select group position. */
+#define VREF_REFSEL_0_bm  (1<<0)  /* Reference select bit 0 mask. */
+#define VREF_REFSEL_0_bp  0  /* Reference select bit 0 position. */
+#define VREF_REFSEL_1_bm  (1<<1)  /* Reference select bit 1 mask. */
+#define VREF_REFSEL_1_bp  1  /* Reference select bit 1 position. */
+#define VREF_REFSEL_2_bm  (1<<2)  /* Reference select bit 2 mask. */
+#define VREF_REFSEL_2_bp  2  /* Reference select bit 2 position. */
+#define VREF_ALWAYSON_bm  0x80  /* Always on bit mask. */
+#define VREF_ALWAYSON_bp  7  /* Always on bit position. */
+
+/* VREF.ACREF  bit masks and bit positions */
+/* VREF_REFSEL  is already defined. */
+/* VREF_ALWAYSON  is already defined. */
+
+
+/* WDT - Watch-Dog Timer */
+/* WDT.CTRLA  bit masks and bit positions */
+#define WDT_PERIOD_gm  0x0F  /* Period group mask. */
+#define WDT_PERIOD_gp  0  /* Period group position. */
+#define WDT_PERIOD_0_bm  (1<<0)  /* Period bit 0 mask. */
+#define WDT_PERIOD_0_bp  0  /* Period bit 0 position. */
+#define WDT_PERIOD_1_bm  (1<<1)  /* Period bit 1 mask. */
+#define WDT_PERIOD_1_bp  1  /* Period bit 1 position. */
+#define WDT_PERIOD_2_bm  (1<<2)  /* Period bit 2 mask. */
+#define WDT_PERIOD_2_bp  2  /* Period bit 2 position. */
+#define WDT_PERIOD_3_bm  (1<<3)  /* Period bit 3 mask. */
+#define WDT_PERIOD_3_bp  3  /* Period bit 3 position. */
+#define WDT_WINDOW_gm  0xF0  /* Window group mask. */
+#define WDT_WINDOW_gp  4  /* Window group position. */
+#define WDT_WINDOW_0_bm  (1<<4)  /* Window bit 0 mask. */
+#define WDT_WINDOW_0_bp  4  /* Window bit 0 position. */
+#define WDT_WINDOW_1_bm  (1<<5)  /* Window bit 1 mask. */
+#define WDT_WINDOW_1_bp  5  /* Window bit 1 position. */
+#define WDT_WINDOW_2_bm  (1<<6)  /* Window bit 2 mask. */
+#define WDT_WINDOW_2_bp  6  /* Window bit 2 position. */
+#define WDT_WINDOW_3_bm  (1<<7)  /* Window bit 3 mask. */
+#define WDT_WINDOW_3_bp  7  /* Window bit 3 position. */
+
+/* WDT.STATUS  bit masks and bit positions */
+#define WDT_SYNCBUSY_bm  0x01  /* Syncronization busy bit mask. */
+#define WDT_SYNCBUSY_bp  0  /* Syncronization busy bit position. */
+#define WDT_LOCK_bm  0x80  /* Lock enable bit mask. */
+#define WDT_LOCK_bp  7  /* Lock enable bit position. */
+
+
+/* ========== Generic Port Pins ========== */
+#define PIN0_bm 0x01
+#define PIN0_bp 0
+#define PIN1_bm 0x02
+#define PIN1_bp 1
+#define PIN2_bm 0x04
+#define PIN2_bp 2
+#define PIN3_bm 0x08
+#define PIN3_bp 3
+#define PIN4_bm 0x10
+#define PIN4_bp 4
+#define PIN5_bm 0x20
+#define PIN5_bp 5
+#define PIN6_bm 0x40
+#define PIN6_bp 6
+#define PIN7_bm 0x80
+#define PIN7_bp 7
+
+/* ========== Interrupt Vector Definitions ========== */
+/* Vector 0 is the reset vector */
+
+/* NMI interrupt vectors */
+#define NMI_vect_num  1
+#define NMI_vect      _VECTOR(1)  /*  */
+
+/* BOD interrupt vectors */
+#define BOD_VLM_vect_num  2
+#define BOD_VLM_vect      _VECTOR(2)  /*  */
+
+/* CLKCTRL interrupt vectors */
+#define CLKCTRL_CFD_vect_num  3
+#define CLKCTRL_CFD_vect      _VECTOR(3)  /*  */
+
+/* RTC interrupt vectors */
+#define RTC_CNT_vect_num  4
+#define RTC_CNT_vect      _VECTOR(4)  /*  */
+#define RTC_PIT_vect_num  5
+#define RTC_PIT_vect      _VECTOR(5)  /*  */
+
+/* CCL interrupt vectors */
+#define CCL_CCL_vect_num  6
+#define CCL_CCL_vect      _VECTOR(6)  /*  */
+
+/* PORTA interrupt vectors */
+#define PORTA_PORT_vect_num  7
+#define PORTA_PORT_vect      _VECTOR(7)  /*  */
+
+/* TCA0 interrupt vectors */
+#define TCA0_LUNF_vect_num  8
+#define TCA0_LUNF_vect      _VECTOR(8)  /*  */
+#define TCA0_OVF_vect_num  8
+#define TCA0_OVF_vect      _VECTOR(8)  /*  */
+#define TCA0_HUNF_vect_num  9
+#define TCA0_HUNF_vect      _VECTOR(9)  /*  */
+#define TCA0_CMP0_vect_num  10
+#define TCA0_CMP0_vect      _VECTOR(10)  /*  */
+#define TCA0_LCMP0_vect_num  10
+#define TCA0_LCMP0_vect      _VECTOR(10)  /*  */
+#define TCA0_CMP1_vect_num  11
+#define TCA0_CMP1_vect      _VECTOR(11)  /*  */
+#define TCA0_LCMP1_vect_num  11
+#define TCA0_LCMP1_vect      _VECTOR(11)  /*  */
+#define TCA0_CMP2_vect_num  12
+#define TCA0_CMP2_vect      _VECTOR(12)  /*  */
+#define TCA0_LCMP2_vect_num  12
+#define TCA0_LCMP2_vect      _VECTOR(12)  /*  */
+
+/* TCB0 interrupt vectors */
+#define TCB0_INT_vect_num  13
+#define TCB0_INT_vect      _VECTOR(13)  /*  */
+
+/* TCB1 interrupt vectors */
+#define TCB1_INT_vect_num  14
+#define TCB1_INT_vect      _VECTOR(14)  /*  */
+
+/* TWI0 interrupt vectors */
+#define TWI0_TWIS_vect_num  15
+#define TWI0_TWIS_vect      _VECTOR(15)  /*  */
+#define TWI0_TWIM_vect_num  16
+#define TWI0_TWIM_vect      _VECTOR(16)  /*  */
+
+/* SPI0 interrupt vectors */
+#define SPI0_INT_vect_num  17
+#define SPI0_INT_vect      _VECTOR(17)  /*  */
+
+/* USART0 interrupt vectors */
+#define USART0_RXC_vect_num  18
+#define USART0_RXC_vect      _VECTOR(18)  /*  */
+#define USART0_DRE_vect_num  19
+#define USART0_DRE_vect      _VECTOR(19)  /*  */
+#define USART0_TXC_vect_num  20
+#define USART0_TXC_vect      _VECTOR(20)  /*  */
+
+/* PORTD interrupt vectors */
+#define PORTD_PORT_vect_num  21
+#define PORTD_PORT_vect      _VECTOR(21)  /*  */
+
+/* AC0 interrupt vectors */
+#define AC0_AC_vect_num  22
+#define AC0_AC_vect      _VECTOR(22)  /*  */
+
+/* ADC0 interrupt vectors */
+#define ADC0_ERROR_vect_num  23
+#define ADC0_ERROR_vect      _VECTOR(23)  /*  */
+#define ADC0_RESRDY_vect_num  24
+#define ADC0_RESRDY_vect      _VECTOR(24)  /*  */
+#define ADC0_SAMPRDY_vect_num  25
+#define ADC0_SAMPRDY_vect      _VECTOR(25)  /*  */
+
+/* AC1 interrupt vectors */
+#define AC1_AC_vect_num  26
+#define AC1_AC_vect      _VECTOR(26)  /*  */
+
+/* PORTC interrupt vectors */
+#define PORTC_PORT_vect_num  27
+#define PORTC_PORT_vect      _VECTOR(27)  /*  */
+
+/* TCB2 interrupt vectors */
+#define TCB2_INT_vect_num  28
+#define TCB2_INT_vect      _VECTOR(28)  /*  */
+
+/* USART1 interrupt vectors */
+#define USART1_RXC_vect_num  29
+#define USART1_RXC_vect      _VECTOR(29)  /*  */
+#define USART1_DRE_vect_num  30
+#define USART1_DRE_vect      _VECTOR(30)  /*  */
+#define USART1_TXC_vect_num  31
+#define USART1_TXC_vect      _VECTOR(31)  /*  */
+
+/* PORTF interrupt vectors */
+#define PORTF_PORT_vect_num  32
+#define PORTF_PORT_vect      _VECTOR(32)  /*  */
+
+/* NVMCTRL interrupt vectors */
+#define NVMCTRL_EEREADY_vect_num  33
+#define NVMCTRL_EEREADY_vect      _VECTOR(33)  /*  */
+#define NVMCTRL_FLREADY_vect_num  33
+#define NVMCTRL_FLREADY_vect      _VECTOR(33)  /*  */
+#define NVMCTRL_NVMREADY_vect_num  33
+#define NVMCTRL_NVMREADY_vect      _VECTOR(33)  /*  */
+
+/* USART2 interrupt vectors */
+#define USART2_RXC_vect_num  34
+#define USART2_RXC_vect      _VECTOR(34)  /*  */
+#define USART2_DRE_vect_num  35
+#define USART2_DRE_vect      _VECTOR(35)  /*  */
+#define USART2_TXC_vect_num  36
+#define USART2_TXC_vect      _VECTOR(36)  /*  */
+
+/* TCB3 interrupt vectors */
+#define TCB3_INT_vect_num  37
+#define TCB3_INT_vect      _VECTOR(37)  /*  */
+
+/* TCA1 interrupt vectors */
+#define TCA1_LUNF_vect_num  38
+#define TCA1_LUNF_vect      _VECTOR(38)  /*  */
+#define TCA1_OVF_vect_num  38
+#define TCA1_OVF_vect      _VECTOR(38)  /*  */
+#define TCA1_HUNF_vect_num  39
+#define TCA1_HUNF_vect      _VECTOR(39)  /*  */
+#define TCA1_CMP0_vect_num  40
+#define TCA1_CMP0_vect      _VECTOR(40)  /*  */
+#define TCA1_LCMP0_vect_num  40
+#define TCA1_LCMP0_vect      _VECTOR(40)  /*  */
+#define TCA1_CMP1_vect_num  41
+#define TCA1_CMP1_vect      _VECTOR(41)  /*  */
+#define TCA1_LCMP1_vect_num  41
+#define TCA1_LCMP1_vect      _VECTOR(41)  /*  */
+#define TCA1_CMP2_vect_num  42
+#define TCA1_CMP2_vect      _VECTOR(42)  /*  */
+#define TCA1_LCMP2_vect_num  42
+#define TCA1_LCMP2_vect      _VECTOR(42)  /*  */
+
+/* PORTE interrupt vectors */
+#define PORTE_PORT_vect_num  43
+#define PORTE_PORT_vect      _VECTOR(43)  /*  */
+
+/* PORTB interrupt vectors */
+#define PORTB_PORT_vect_num  44
+#define PORTB_PORT_vect      _VECTOR(44)  /*  */
+
+#define _VECTOR_SIZE 4 /* Size of individual vector. */
+#define _VECTORS_SIZE (45 * _VECTOR_SIZE)
+
+
+/* ========== Constants ========== */
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define DATAMEM_START     (0x0000)
+#  define DATAMEM_SIZE      (65536)
+#else
+#  define DATAMEM_START     (0x0000U)
+#  define DATAMEM_SIZE      (65536U)
+#endif
+#define DATAMEM_END       (DATAMEM_START + DATAMEM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define IO_START     (0x0000)
+#  define IO_SIZE      (4159)
+#  define IO_PAGE_SIZE (0)
+#else
+#  define IO_START     (0x0000U)
+#  define IO_SIZE      (4159U)
+#  define IO_PAGE_SIZE (0U)
+#endif
+#define IO_END       (IO_START + IO_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define LOCKBITS_START     (0x1040)
+#  define LOCKBITS_SIZE      (4)
+#  define LOCKBITS_PAGE_SIZE (4)
+#else
+#  define LOCKBITS_START     (0x1040U)
+#  define LOCKBITS_SIZE      (4U)
+#  define LOCKBITS_PAGE_SIZE (4U)
+#endif
+#define LOCKBITS_END       (LOCKBITS_START + LOCKBITS_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define FUSES_START     (0x1050)
+#  define FUSES_SIZE      (16)
+#  define FUSES_PAGE_SIZE (8)
+#else
+#  define FUSES_START     (0x1050U)
+#  define FUSES_SIZE      (16U)
+#  define FUSES_PAGE_SIZE (8U)
+#endif
+#define FUSES_END       (FUSES_START + FUSES_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define USER_SIGNATURES_START     (0x1080)
+#  define USER_SIGNATURES_SIZE      (64)
+#  define USER_SIGNATURES_PAGE_SIZE (64)
+#else
+#  define USER_SIGNATURES_START     (0x1080U)
+#  define USER_SIGNATURES_SIZE      (64U)
+#  define USER_SIGNATURES_PAGE_SIZE (64U)
+#endif
+#define USER_SIGNATURES_END       (USER_SIGNATURES_START + USER_SIGNATURES_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define SIGNATURES_START     (0x1100)
+#  define SIGNATURES_SIZE      (3)
+#  define SIGNATURES_PAGE_SIZE (128)
+#else
+#  define SIGNATURES_START     (0x1100U)
+#  define SIGNATURES_SIZE      (3U)
+#  define SIGNATURES_PAGE_SIZE (128U)
+#endif
+#define SIGNATURES_END       (SIGNATURES_START + SIGNATURES_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define PROD_SIGNATURES_START     (0x1103)
+#  define PROD_SIGNATURES_SIZE      (125)
+#  define PROD_SIGNATURES_PAGE_SIZE (128)
+#else
+#  define PROD_SIGNATURES_START     (0x1103U)
+#  define PROD_SIGNATURES_SIZE      (125U)
+#  define PROD_SIGNATURES_PAGE_SIZE (128U)
+#endif
+#define PROD_SIGNATURES_END       (PROD_SIGNATURES_START + PROD_SIGNATURES_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define EEPROM_START     (0x1400)
+#  define EEPROM_SIZE      (512)
+#  define EEPROM_PAGE_SIZE (8)
+#else
+#  define EEPROM_START     (0x1400U)
+#  define EEPROM_SIZE      (512U)
+#  define EEPROM_PAGE_SIZE (8U)
+#endif
+#define EEPROM_END       (EEPROM_START + EEPROM_SIZE - 1)
+
+/* Added MAPPED_EEPROM segment names for avr-libc */
+#define MAPPED_EEPROM_START     (EEPROM_START)
+#define MAPPED_EEPROM_SIZE      (EEPROM_SIZE)
+#define MAPPED_EEPROM_PAGE_SIZE (EEPROM_PAGE_SIZE)
+#define MAPPED_EEPROM_END       (MAPPED_EEPROM_START + MAPPED_EEPROM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define INTERNAL_SRAM_START     (0x7800)
+#  define INTERNAL_SRAM_SIZE      (2048)
+#  define INTERNAL_SRAM_PAGE_SIZE (0)
+#else
+#  define INTERNAL_SRAM_START     (0x7800U)
+#  define INTERNAL_SRAM_SIZE      (2048U)
+#  define INTERNAL_SRAM_PAGE_SIZE (0U)
+#endif
+#define INTERNAL_SRAM_END       (INTERNAL_SRAM_START + INTERNAL_SRAM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define MAPPED_PROGMEM_START     (0x8000)
+#  define MAPPED_PROGMEM_SIZE      (16384)
+#  define MAPPED_PROGMEM_PAGE_SIZE (64)
+#else
+#  define MAPPED_PROGMEM_START     (0x8000U)
+#  define MAPPED_PROGMEM_SIZE      (16384U)
+#  define MAPPED_PROGMEM_PAGE_SIZE (64U)
+#endif
+#define MAPPED_PROGMEM_END       (MAPPED_PROGMEM_START + MAPPED_PROGMEM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define PROGMEM_START     (0x0000)
+#  define PROGMEM_SIZE      (16384)
+#  define PROGMEM_PAGE_SIZE (64)
+#else
+#  define PROGMEM_START     (0x0000U)
+#  define PROGMEM_SIZE      (16384U)
+#  define PROGMEM_PAGE_SIZE (64U)
+#endif
+#define PROGMEM_END       (PROGMEM_START + PROGMEM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define PROGMEM_NRWW_START     (0x0000)
+#  define PROGMEM_NRWW_SIZE      (4096)
+#  define PROGMEM_NRWW_PAGE_SIZE (64)
+#else
+#  define PROGMEM_NRWW_START     (0x0000U)
+#  define PROGMEM_NRWW_SIZE      (4096U)
+#  define PROGMEM_NRWW_PAGE_SIZE (64U)
+#endif
+#define PROGMEM_NRWW_END       (PROGMEM_NRWW_START + PROGMEM_NRWW_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define PROGMEM_RWW_START     (0x1000)
+#  define PROGMEM_RWW_SIZE      (12288)
+#  define PROGMEM_RWW_PAGE_SIZE (64)
+#else
+#  define PROGMEM_RWW_START     (0x1000U)
+#  define PROGMEM_RWW_SIZE      (12288U)
+#  define PROGMEM_RWW_PAGE_SIZE (64U)
+#endif
+#define PROGMEM_RWW_END       (PROGMEM_RWW_START + PROGMEM_RWW_SIZE - 1)
+
+#define FLASHSTART   PROGMEM_START
+#define FLASHEND     PROGMEM_END
+#define RAMSTART     INTERNAL_SRAM_START
+#define RAMSIZE      INTERNAL_SRAM_SIZE
+#define RAMEND       INTERNAL_SRAM_END
+#define E2END        EEPROM_END
+#define E2PAGESIZE   EEPROM_PAGE_SIZE
+
+/* ========== Fuses ========== */
+#define FUSE_MEMORY_SIZE 16
+
+/* Fuse Byte 0 (WDTCFG) */
+#define FUSE_PERIOD0  (unsigned char)_BV(0)  /* Watchdog Timeout Period Bit 0 */
+#define FUSE_PERIOD1  (unsigned char)_BV(1)  /* Watchdog Timeout Period Bit 1 */
+#define FUSE_PERIOD2  (unsigned char)_BV(2)  /* Watchdog Timeout Period Bit 2 */
+#define FUSE_PERIOD3  (unsigned char)_BV(3)  /* Watchdog Timeout Period Bit 3 */
+#define FUSE_WINDOW0  (unsigned char)_BV(4)  /* Watchdog Window Timeout Period Bit 0 */
+#define FUSE_WINDOW1  (unsigned char)_BV(5)  /* Watchdog Window Timeout Period Bit 1 */
+#define FUSE_WINDOW2  (unsigned char)_BV(6)  /* Watchdog Window Timeout Period Bit 2 */
+#define FUSE_WINDOW3  (unsigned char)_BV(7)  /* Watchdog Window Timeout Period Bit 3 */
+#define FUSE0_DEFAULT  (0x0)
+#define FUSE_WDTCFG_DEFAULT  (0x0)
+
+/* Fuse Byte 1 (BODCFG) */
+#define FUSE_SLEEP0  (unsigned char)_BV(0)  /* BOD Operation in Sleep Mode Bit 0 */
+#define FUSE_SLEEP1  (unsigned char)_BV(1)  /* BOD Operation in Sleep Mode Bit 1 */
+#define FUSE_ACTIVE0  (unsigned char)_BV(2)  /* BOD Operation in Active Mode Bit 0 */
+#define FUSE_ACTIVE1  (unsigned char)_BV(3)  /* BOD Operation in Active Mode Bit 1 */
+#define FUSE_SAMPFREQ  (unsigned char)_BV(4)  /* BOD Sample Frequency */
+#define FUSE_LVL0  (unsigned char)_BV(5)  /* BOD Level Bit 0 */
+#define FUSE_LVL1  (unsigned char)_BV(6)  /* BOD Level Bit 1 */
+#define FUSE_LVL2  (unsigned char)_BV(7)  /* BOD Level Bit 2 */
+#define FUSE1_DEFAULT  (0x0)
+#define FUSE_BODCFG_DEFAULT  (0x0)
+
+/* Fuse Byte 2 (OSCCFG) */
+#define FUSE_OSCHFFRQ  (unsigned char)_BV(3)  /* High-frequency Oscillator Frequency */
+#define FUSE2_DEFAULT  (0x0)
+#define FUSE_OSCCFG_DEFAULT  (0x0)
+
+/* Fuse Byte 3 Reserved */
+
+/* Fuse Byte 4 Reserved */
+
+/* Fuse Byte 5 (SYSCFG0) */
+#define FUSE_EESAVE  (unsigned char)_BV(0)  /* EEPROM Save */
+#define FUSE_RSTPINCFG  (unsigned char)_BV(3)  /* Reset Pin Configuration */
+#define FUSE_UPDIPINCFG  (unsigned char)_BV(4)  /* UPDI Pin Configuration */
+#define FUSE_CRCSEL  (unsigned char)_BV(5)  /* CRC Select */
+#define FUSE_CRCSRC0  (unsigned char)_BV(6)  /* CRC Source Bit 0 */
+#define FUSE_CRCSRC1  (unsigned char)_BV(7)  /* CRC Source Bit 1 */
+#define FUSE5_DEFAULT  (0xD0)
+#define FUSE_SYSCFG0_DEFAULT  (0xD0)
+
+/* Fuse Byte 6 (SYSCFG1) */
+#define FUSE_SUT0  (unsigned char)_BV(0)  /* Startup Time Bit 0 */
+#define FUSE_SUT1  (unsigned char)_BV(1)  /* Startup Time Bit 1 */
+#define FUSE_SUT2  (unsigned char)_BV(2)  /* Startup Time Bit 2 */
+#define FUSE6_DEFAULT  (0x7)
+#define FUSE_SYSCFG1_DEFAULT  (0x7)
+
+/* Fuse Byte 7 (CODESIZE) */
+#define FUSE7_DEFAULT  (0x0)
+#define FUSE_CODESIZE_DEFAULT  (0x0)
+
+/* Fuse Byte 8 (BOOTSIZE) */
+#define FUSE8_DEFAULT  (0x0)
+#define FUSE_BOOTSIZE_DEFAULT  (0x0)
+
+/* ========== Lock Bits ========== */
+#define __LOCK_KEY_EXIST
+#ifdef LOCKBITS_DEFAULT
+#undef LOCKBITS_DEFAULT
+#endif //LOCKBITS_DEFAULT
+#define LOCKBITS_DEFAULT  (0x5CC5C55C)
+
+/* ========== Signature ========== */
+#define SIGNATURE_0 0x1E
+#define SIGNATURE_1 0x94
+#define SIGNATURE_2 0x35
+
+#endif /* #ifdef _AVR_AVR16EA48_H_INCLUDED */
+

--- a/include/avr/ioavr16eb14.h
+++ b/include/avr/ioavr16eb14.h
@@ -1,0 +1,6413 @@
+/*
+ * Copyright (C) 2023, Microchip Technology Inc. and its subsidiaries ("Microchip")
+ * All rights reserved.
+ *
+ * This software is developed by Microchip Technology Inc. and its subsidiaries ("Microchip").
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other
+ *        materials provided with the distribution. Publication is not required when
+ *        this file is used in an embedded application.
+ *
+ *     3. Microchip's name may not be used to endorse or promote products derived from this
+ *        software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY MICROCHIP "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL MICROCHIP BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING BUT NOT LIMITED TO
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWSOEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _AVR_IO_H_
+#  error "Include <avr/io.h> instead of this file."
+#endif
+
+#ifndef _AVR_IOXXX_H_
+#  define _AVR_IOXXX_H_ "ioavr16eb14.h"
+#else
+#  error "Attempt to include more than one <avr/ioXXX.h> file."
+#endif
+
+#ifndef _AVR_AVR16EB14_H_INCLUDED
+#define _AVR_AVR16EB14_H_INCLUDED
+
+/* Ungrouped common registers */
+#define CCP  _SFR_MEM8(0x0034)  /* Configuration Change Protection */
+#define RAMPZ  _SFR_MEM8(0x003B)  /* Extended Z-pointer Register */
+#define SP  _SFR_MEM16(0x003D)  /* Stack Pointer */
+#define SPL  _SFR_MEM8(0x003D)  /* Stack Pointer Low */
+#define SPH  _SFR_MEM8(0x003E)  /* Stack Pointer High */
+#define SREG  _SFR_MEM8(0x003F)  /* Status Register */
+
+/* C Language Only */
+#if !defined (__ASSEMBLER__)
+
+#include <stdint.h>
+
+typedef volatile uint8_t register8_t;
+typedef volatile uint16_t register16_t;
+typedef volatile uint32_t register32_t;
+
+
+#ifdef _WORDREGISTER
+#undef _WORDREGISTER
+#endif
+#define _WORDREGISTER(regname)   \
+    __extension__ union \
+    { \
+        register16_t regname; \
+        struct \
+        { \
+            register8_t regname ## L; \
+            register8_t regname ## H; \
+        }; \
+    }
+
+#ifdef _DWORDREGISTER
+#undef _DWORDREGISTER
+#endif
+#define _DWORDREGISTER(regname)  \
+    __extension__ union \
+    { \
+        register32_t regname; \
+        struct \
+        { \
+            register8_t regname ## 0; \
+            register8_t regname ## 1; \
+            register8_t regname ## 2; \
+            register8_t regname ## 3; \
+        }; \
+    }
+
+
+/*
+==========================================================================
+IO Module Structures
+==========================================================================
+*/
+
+
+/*
+--------------------------------------------------------------------------
+AC - Analog Comparator
+--------------------------------------------------------------------------
+*/
+
+/* Analog Comparator */
+typedef struct AC_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t MUXCTRL;  /* Mux Control A */
+    register8_t reserved_1[2];
+    register8_t DACREF;  /* DAC Voltage Reference */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t STATUS;  /* Status */
+} AC_t;
+
+/* Hysteresis Mode select */
+typedef enum AC_HYSMODE_enum
+{
+    AC_HYSMODE_NONE_gc = (0x00<<1),  /* No hysteresis */
+    AC_HYSMODE_SMALL_gc = (0x01<<1),  /* Small hysteresis */
+    AC_HYSMODE_MEDIUM_gc = (0x02<<1),  /* Medium hysteresis */
+    AC_HYSMODE_LARGE_gc = (0x03<<1)  /* Large hysteresis */
+} AC_HYSMODE_t;
+
+/* AC Output Initial Value select */
+typedef enum AC_INITVAL_enum
+{
+    AC_INITVAL_LOW_gc = (0x00<<6),  /* Output initialized to 0 */
+    AC_INITVAL_HIGH_gc = (0x01<<6)  /* Output initialized to 1 */
+} AC_INITVAL_t;
+
+/* Interrupt Mode select */
+typedef enum AC_INTMODE_NORMAL_enum
+{
+    AC_INTMODE_NORMAL_BOTHEDGE_gc = (0x00<<4),  /* Positive and negative inputs crosses */
+    AC_INTMODE_NORMAL_NEGEDGE_gc = (0x02<<4),  /* Positive input goes below negative input */
+    AC_INTMODE_NORMAL_POSEDGE_gc = (0x03<<4)  /* Positive input goes above negative input */
+} AC_INTMODE_NORMAL_t;
+
+/* Interrupt Mode select */
+typedef enum AC_INTMODE_WINDOW_enum
+{
+    AC_INTMODE_WINDOW_ABOVE_gc = (0x00<<4),  /* Window interrupt when input above both references */
+    AC_INTMODE_WINDOW_INSIDE_gc = (0x01<<4),  /* Window interrupt when input betweeen references */
+    AC_INTMODE_WINDOW_BELOW_gc = (0x02<<4),  /* Window interrupt when input below both references */
+    AC_INTMODE_WINDOW_OUTSIDE_gc = (0x03<<4)  /* Window interrupt when input outside reference */
+} AC_INTMODE_WINDOW_t;
+
+/* Negative Input MUX Selection */
+typedef enum AC_MUXNEG_enum
+{
+    AC_MUXNEG_AINN0_gc = (0x00<<0),  /* Negative Pin 0 */
+    AC_MUXNEG_AINN1_gc = (0x01<<0),  /* Negative Pin 1 */
+    AC_MUXNEG_AINN2_gc = (0x02<<0),  /* Negative Pin 2 */
+    AC_MUXNEG_AINN3_gc = (0x03<<0),  /* Negative Pin 3 */
+    AC_MUXNEG_DACREF_gc = (0x04<<0)  /* DAC Reference */
+} AC_MUXNEG_t;
+
+/* Positive Input MUX Selection */
+typedef enum AC_MUXPOS_enum
+{
+    AC_MUXPOS_AINP0_gc = (0x00<<3),  /* Positive Pin 0 */
+    AC_MUXPOS_AINP1_gc = (0x01<<3),  /* Positive Pin 1 */
+    AC_MUXPOS_AINP2_gc = (0x02<<3),  /* Positive Pin 2 */
+    AC_MUXPOS_AINP3_gc = (0x03<<3),  /* Positive Pin 3 */
+    AC_MUXPOS_AINP4_gc = (0x04<<3),  /* Positive Pin 4 */
+    AC_MUXPOS_AINP5_gc = (0x05<<3),  /* Positive Pin 5 */
+    AC_MUXPOS_AINP6_gc = (0x06<<3)  /* Positive Pin 6 */
+} AC_MUXPOS_t;
+
+/* Power profile select */
+typedef enum AC_POWER_enum
+{
+    AC_POWER_PROFILE0_gc = (0x00<<3),  /* Power profile 0, Fastest response time, highest consumption */
+    AC_POWER_PROFILE1_gc = (0x01<<3)  /* Power profile 1 */
+} AC_POWER_t;
+
+/* Window selection mode */
+typedef enum AC_WINSEL_enum
+{
+    AC_WINSEL_DISABLED_gc = (0x00<<0),  /* Window function disabled */
+    AC_WINSEL_UPSEL1_gc = (0x01<<0)  /* Select ACn+1 as upper limit in window compare */
+} AC_WINSEL_t;
+
+/* Analog Comparator Window State select */
+typedef enum AC_WINSTATE_enum
+{
+    AC_WINSTATE_ABOVE_gc = (0x00<<6),  /* Above window */
+    AC_WINSTATE_INSIDE_gc = (0x01<<6),  /* Inside window */
+    AC_WINSTATE_BELOW_gc = (0x02<<6)  /* Below window */
+} AC_WINSTATE_t;
+
+/*
+--------------------------------------------------------------------------
+ADC - Analog to Digital Converter
+--------------------------------------------------------------------------
+*/
+
+/* Analog to Digital Converter */
+typedef struct ADC_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    register8_t CTRLD;  /* Control D */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t STATUS;  /* Status register */
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t CTRLE;  /* Control E */
+    register8_t CTRLF;  /* Control F */
+    register8_t COMMAND;  /* Command register */
+    register8_t PGACTRL;  /* PGA Control */
+    register8_t MUXPOS;  /* Positive Input Multiplexer */
+    register8_t MUXNEG;  /* Negative Input Multiplexer */
+    register8_t reserved_1[2];
+    _DWORDREGISTER(RESULT);  /* Result */
+    _WORDREGISTER(SAMPLE);  /* Sample */
+    register8_t reserved_2[2];
+    register8_t TEMP0;  /* Temporary Data 0 */
+    register8_t TEMP1;  /* Temporary Data 1 */
+    register8_t TEMP2;  /* Temporary Data 2 */
+    register8_t reserved_3[1];
+    _WORDREGISTER(WINLT);  /* Window Low Threshold */
+    _WORDREGISTER(WINHT);  /* Window High Threshold */
+    register8_t reserved_4[32];
+} ADC_t;
+
+/* Sign Chopping select */
+typedef enum ADC_CHOPPING_enum
+{
+    ADC_CHOPPING_DISABLE_gc = (0x00<<6),  /* Sign Chopping Disabled */
+    ADC_CHOPPING_ENABLE_gc = (0x01<<6)  /* Sign Chopping Enabled */
+} ADC_CHOPPING_t;
+
+/* Gain select */
+typedef enum ADC_GAIN_enum
+{
+    ADC_GAIN_1X_gc = (0x00<<5),  /* 1x gain */
+    ADC_GAIN_2X_gc = (0x01<<5),  /* 2x gain */
+    ADC_GAIN_4X_gc = (0x02<<5),  /* 4x gain */
+    ADC_GAIN_8X_gc = (0x03<<5),  /* 8x gain */
+    ADC_GAIN_16X_gc = (0x04<<5)  /* 16x gain */
+} ADC_GAIN_t;
+
+/* Mode select */
+typedef enum ADC_MODE_enum
+{
+    ADC_MODE_SINGLE_8BIT_gc = (0x00<<4),  /* Single Conversion with 8-bit resolution */
+    ADC_MODE_SINGLE_12BIT_gc = (0x01<<4),  /* Single Conversion with 12-bit resolution */
+    ADC_MODE_SERIES_gc = (0x02<<4),  /* Series with accumulation, separate trigger for every 12-bit conversion */
+    ADC_MODE_SERIES_SCALING_gc = (0x03<<4),  /* Series with accumulation and scaling, separate trigger for every 12-bit conversion */
+    ADC_MODE_BURST_gc = (0x04<<4),  /* Burst with accumulation, one trigger will run SAMPNUM 12-bit conversions */
+    ADC_MODE_BURST_SCALING_gc = (0x05<<4)  /* Burst with accumulation and scaling, one trigger will run SAMPNUM 12-bit conversions */
+} ADC_MODE_t;
+
+/* Analog Channel Selection Bits */
+typedef enum ADC_MUXNEG_enum
+{
+    ADC_MUXNEG_AIN4_gc = (0x04<<0),  /* ADC input pin 4 */
+    ADC_MUXNEG_AIN5_gc = (0x05<<0),  /* ADC input pin 5 */
+    ADC_MUXNEG_AIN6_gc = (0x06<<0),  /* ADC input pin 6 */
+    ADC_MUXNEG_AIN7_gc = (0x07<<0),  /* ADC input pin 7 */
+    ADC_MUXNEG_AIN28_gc = (0x1C<<0),  /* ADC input pin 28 */
+    ADC_MUXNEG_AIN29_gc = (0x1D<<0),  /* ADC input pin 29 */
+    ADC_MUXNEG_AIN30_gc = (0x1E<<0),  /* ADC input pin 30 */
+    ADC_MUXNEG_AIN31_gc = (0x1F<<0),  /* ADC input pin 31 */
+    ADC_MUXNEG_GND_gc = (0x30<<0),  /* Ground */
+    ADC_MUXNEG_DAC0_gc = (0x38<<0),  /* Digital to Analog Converter 0 */
+    ADC_MUXNEG_DACREF0_gc = (0x39<<0),  /* AC0 DAC reference */
+    ADC_MUXNEG_DACREF1_gc = (0x3A<<0)  /* AC1 DAC reference */
+} ADC_MUXNEG_t;
+
+/* Analog Channel Selection Bits */
+typedef enum ADC_MUXPOS_enum
+{
+    ADC_MUXPOS_AIN4_gc = (0x04<<0),  /* ADC input pin 4 */
+    ADC_MUXPOS_AIN5_gc = (0x05<<0),  /* ADC input pin 5 */
+    ADC_MUXPOS_AIN6_gc = (0x06<<0),  /* ADC input pin 6 */
+    ADC_MUXPOS_AIN7_gc = (0x07<<0),  /* ADC input pin 7 */
+    ADC_MUXPOS_AIN28_gc = (0x1C<<0),  /* ADC input pin 28 */
+    ADC_MUXPOS_AIN29_gc = (0x1D<<0),  /* ADC input pin 29 */
+    ADC_MUXPOS_AIN30_gc = (0x1E<<0),  /* ADC input pin 30 */
+    ADC_MUXPOS_AIN31_gc = (0x1F<<0),  /* ADC input pin 31 */
+    ADC_MUXPOS_GND_gc = (0x30<<0),  /* Ground */
+    ADC_MUXPOS_VDD10_gc = (0x31<<0),  /* VDD Divided by 10 */
+    ADC_MUXPOS_TEMPSENSE_gc = (0x32<<0)  /* Temperature Sensor */
+} ADC_MUXPOS_t;
+
+/* PGA BIAS Select */
+typedef enum ADC_PGABIASSEL_enum
+{
+    ADC_PGABIASSEL_100PCT_gc = (0x00<<3),  /* 100% BIAS current. */
+    ADC_PGABIASSEL_75PCT_gc = (0x01<<3),  /* 75% BIAS current. Usable for CLK_ADC<4.5MHz */
+    ADC_PGABIASSEL_50PCT_gc = (0x02<<3),  /* 50% BIAS current. Usable for CLK_ADC<3MHz */
+    ADC_PGABIASSEL_25PCT_gc = (0x03<<3)  /* 25% BIAS current. Usable for CLK_ADC<1.5MHz */
+} ADC_PGABIASSEL_t;
+
+/* Prescaler Value select */
+typedef enum ADC_PRESC_enum
+{
+    ADC_PRESC_DIV2_gc = (0x00<<0),  /* System clock divided by 2 */
+    ADC_PRESC_DIV4_gc = (0x01<<0),  /* System clock divided by 4 */
+    ADC_PRESC_DIV6_gc = (0x02<<0),  /* System clock divided by 6 */
+    ADC_PRESC_DIV8_gc = (0x03<<0),  /* System clock divided by 8 */
+    ADC_PRESC_DIV10_gc = (0x04<<0),  /* System clock divided by 10 */
+    ADC_PRESC_DIV12_gc = (0x05<<0),  /* System clock divided by 12 */
+    ADC_PRESC_DIV14_gc = (0x06<<0),  /* System clock divided by 14 */
+    ADC_PRESC_DIV16_gc = (0x07<<0),  /* System clock divided by 16 */
+    ADC_PRESC_DIV20_gc = (0x08<<0),  /* System clock divided by 20 */
+    ADC_PRESC_DIV24_gc = (0x09<<0),  /* System clock divided by 24 */
+    ADC_PRESC_DIV28_gc = (0x0A<<0),  /* System clock divided by 28 */
+    ADC_PRESC_DIV32_gc = (0x0B<<0),  /* System clock divided by 32 */
+    ADC_PRESC_DIV40_gc = (0x0C<<0),  /* System clock divided by 40 */
+    ADC_PRESC_DIV48_gc = (0x0D<<0),  /* System clock divided by 48 */
+    ADC_PRESC_DIV56_gc = (0x0E<<0),  /* System clock divided by 56 */
+    ADC_PRESC_DIV64_gc = (0x0F<<0)  /* System clock divided by 64 */
+} ADC_PRESC_t;
+
+/* Reference select */
+typedef enum ADC_REFSEL_enum
+{
+    ADC_REFSEL_VDD_gc = (0x00<<0),  /* VDD */
+    ADC_REFSEL_VREFA_gc = (0x02<<0),  /* External Reference */
+    ADC_REFSEL_1V024_gc = (0x04<<0),  /* Internal 1.024V Reference */
+    ADC_REFSEL_2V048_gc = (0x05<<0),  /* Internal 2.048V Reference */
+    ADC_REFSEL_4V096_gc = (0x06<<0),  /* Internal 4.096V Reference */
+    ADC_REFSEL_2V500_gc = (0x07<<0)  /* Internal 2.500V Reference */
+} ADC_REFSEL_t;
+
+/* Sample numbers select */
+typedef enum ADC_SAMPNUM_enum
+{
+    ADC_SAMPNUM_NONE_gc = (0x00<<0),  /* No accumulation */
+    ADC_SAMPNUM_ACC2_gc = (0x01<<0),  /* 2 samples accumulated */
+    ADC_SAMPNUM_ACC4_gc = (0x02<<0),  /* 4 samples accumulated */
+    ADC_SAMPNUM_ACC8_gc = (0x03<<0),  /* 8 samples accumulated */
+    ADC_SAMPNUM_ACC16_gc = (0x04<<0),  /* 16 samples accumulated */
+    ADC_SAMPNUM_ACC32_gc = (0x05<<0),  /* 32 samples accumulated */
+    ADC_SAMPNUM_ACC64_gc = (0x06<<0),  /* 64 samples accumulated */
+    ADC_SAMPNUM_ACC128_gc = (0x07<<0),  /* 128 samples accumulated */
+    ADC_SAMPNUM_ACC256_gc = (0x08<<0),  /* 256 samples accumulated */
+    ADC_SAMPNUM_ACC512_gc = (0x09<<0),  /* 512 samples accumulated */
+    ADC_SAMPNUM_ACC1024_gc = (0x0A<<0)  /* 1024 samples accumulated */
+} ADC_SAMPNUM_t;
+
+/* Start command select */
+typedef enum ADC_START_enum
+{
+    ADC_START_STOP_gc = (0x00<<0),  /* Stop an ongoing conversion */
+    ADC_START_IMMEDIATE_gc = (0x01<<0),  /* Start a conversion immediately. This will be set back to STOP when the first conversion is done, unless Free-Running mode is enabled */
+    ADC_START_MUXPOS_WRITE_gc = (0x02<<0),  /* Start when MUXPOS register is written */
+    ADC_START_MUXNEG_WRITE_gc = (0x03<<0),  /* Start when MUXNEG register is written */
+    ADC_START_EVENT_TRIGGER_gc = (0x04<<0)  /* Start when an event is received */
+} ADC_START_t;
+
+/* VIA select */
+typedef enum ADC_VIA_enum
+{
+    ADC_VIA_DIRECT_gc = (0x00<<6),  /* Inputs connected directly to ADC */
+    ADC_VIA_PGA_gc = (0x01<<6)  /* Inputs connected via PGA */
+} ADC_VIA_t;
+
+/* Window Comparator Mode select */
+typedef enum ADC_WINCM_enum
+{
+    ADC_WINCM_NONE_gc = (0x00<<0),  /* No Window Comparison */
+    ADC_WINCM_BELOW_gc = (0x01<<0),  /* Below Window */
+    ADC_WINCM_ABOVE_gc = (0x02<<0),  /* Above Window */
+    ADC_WINCM_INSIDE_gc = (0x03<<0),  /* Inside Window */
+    ADC_WINCM_OUTSIDE_gc = (0x04<<0)  /* Outside Window */
+} ADC_WINCM_t;
+
+/* Window Mode Source select */
+typedef enum ADC_WINSRC_enum
+{
+    ADC_WINSRC_RESULT_gc = (0x00<<3),  /* Result register used as Window Comparator Source */
+    ADC_WINSRC_SAMPLE_gc = (0x01<<3)  /* Sample register used as Window Comparator Source */
+} ADC_WINSRC_t;
+
+/*
+--------------------------------------------------------------------------
+BOD - Bod interface
+--------------------------------------------------------------------------
+*/
+
+/* Bod interface */
+typedef struct BOD_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t reserved_1[6];
+    register8_t VLMCTRLA;  /* Voltage level monitor Control */
+    register8_t INTCTRL;  /* Voltage level monitor interrupt Control */
+    register8_t INTFLAGS;  /* Voltage level monitor interrupt Flags */
+    register8_t STATUS;  /* Voltage level monitor status */
+    register8_t reserved_2[4];
+} BOD_t;
+
+/* Operation in active mode select */
+typedef enum BOD_ACTIVE_enum
+{
+    BOD_ACTIVE_DISABLE_gc = (0x00<<2),  /* Disabled */
+    BOD_ACTIVE_ENABLED_gc = (0x01<<2),  /* Enabled in continuous mode */
+    BOD_ACTIVE_SAMPLED_gc = (0x02<<2),  /* Enabled in sampled mode */
+    BOD_ACTIVE_ENABLEWAIT_gc = (0x03<<2)  /* Enabled in continuous mode. Execution halted at wake-up until BOD is running */
+} BOD_ACTIVE_t;
+
+/* Bod level select */
+typedef enum BOD_LVL_enum
+{
+    BOD_LVL_BODLEVEL0_gc = (0x00<<0),  /* BOD Disabled during normal operation */
+    BOD_LVL_BODLEVEL1_gc = (0x01<<0),  /* 1.9 V */
+    BOD_LVL_BODLEVEL2_gc = (0x02<<0),  /* 2.7 V */
+    BOD_LVL_BODLEVEL3_gc = (0x03<<0)  /* 4.5 V */
+} BOD_LVL_t;
+
+/* Sample frequency select */
+typedef enum BOD_SAMPFREQ_enum
+{
+    BOD_SAMPFREQ_128HZ_gc = (0x00<<4),  /* Sampling frequency is 128 Hz */
+    BOD_SAMPFREQ_32HZ_gc = (0x01<<4)  /* Sample frequency is 32 Hz */
+} BOD_SAMPFREQ_t;
+
+/* Operation in sleep mode select */
+typedef enum BOD_SLEEP_enum
+{
+    BOD_SLEEP_DISABLE_gc = (0x00<<0),  /* Disabled */
+    BOD_SLEEP_ENABLE_gc = (0x01<<0),  /* Enabled in continuous mode */
+    BOD_SLEEP_SAMPLE_gc = (0x02<<0)  /* Enabled in sampled mode */
+} BOD_SLEEP_t;
+
+/* Configuration select */
+typedef enum BOD_VLMCFG_enum
+{
+    BOD_VLMCFG_FALLING_gc = (0x00<<1),  /* VDD falls below VLM threshold */
+    BOD_VLMCFG_RISING_gc = (0x01<<1),  /* VDD rises above VLM threshold */
+    BOD_VLMCFG_BOTH_gc = (0x02<<1)  /* VDD crosses VLM threshold */
+} BOD_VLMCFG_t;
+
+/* voltage level monitor level select */
+typedef enum BOD_VLMLVL_enum
+{
+    BOD_VLMLVL_OFF_gc = (0x00<<0),  /* VLM Disabled */
+    BOD_VLMLVL_5ABOVE_gc = (0x01<<0),  /* VLM threshold 5% above BOD level */
+    BOD_VLMLVL_15ABOVE_gc = (0x02<<0),  /* VLM threshold 15% above BOD level */
+    BOD_VLMLVL_25ABOVE_gc = (0x03<<0)  /* VLM threshold 25% above BOD level */
+} BOD_VLMLVL_t;
+
+/* Voltage level monitor status select */
+typedef enum BOD_VLMS_enum
+{
+    BOD_VLMS_ABOVE_gc = (0x00<<0),  /* The voltage is above the VLM threshold level */
+    BOD_VLMS_BELOW_gc = (0x01<<0)  /* The voltage is below the VLM threshold level */
+} BOD_VLMS_t;
+
+/*
+--------------------------------------------------------------------------
+BOOTROW - Boot Row
+--------------------------------------------------------------------------
+*/
+
+/* Boot Row */
+typedef struct BOOTROW_struct
+{
+    register8_t BOOTROW[64];  /* Boot Row */
+} BOOTROW_t;
+
+
+/*
+--------------------------------------------------------------------------
+CCL - Configurable Custom Logic
+--------------------------------------------------------------------------
+*/
+
+/* Configurable Custom Logic */
+typedef struct CCL_struct
+{
+    register8_t CTRLA;  /* Control Register A */
+    register8_t SEQCTRL0;  /* Sequential Control 0 */
+    register8_t SEQCTRL1;  /* Sequential Control 1 */
+    register8_t reserved_1[2];
+    register8_t INTCTRL0;  /* Interrupt Control 0 */
+    register8_t reserved_2[1];
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t LUT0CTRLA;  /* LUT 0 Control A */
+    register8_t LUT0CTRLB;  /* LUT 0 Control B */
+    register8_t LUT0CTRLC;  /* LUT 0 Control C */
+    register8_t TRUTH0;  /* Truth 0 */
+    register8_t LUT1CTRLA;  /* LUT 1 Control A */
+    register8_t LUT1CTRLB;  /* LUT 1 Control B */
+    register8_t LUT1CTRLC;  /* LUT 1 Control C */
+    register8_t TRUTH1;  /* Truth 1 */
+    register8_t LUT2CTRLA;  /* LUT 2 Control A */
+    register8_t LUT2CTRLB;  /* LUT 2 Control B */
+    register8_t LUT2CTRLC;  /* LUT 2 Control C */
+    register8_t TRUTH2;  /* Truth 2 */
+    register8_t LUT3CTRLA;  /* LUT 3 Control A */
+    register8_t LUT3CTRLB;  /* LUT 3 Control B */
+    register8_t LUT3CTRLC;  /* LUT 3 Control C */
+    register8_t TRUTH3;  /* Truth 3 */
+    register8_t reserved_3[40];
+} CCL_t;
+
+/* Clock Source Selection */
+typedef enum CCL_CLKSRC_enum
+{
+    CCL_CLKSRC_CLKPER_gc = (0x00<<1),  /* Peripheral Clock */
+    CCL_CLKSRC_IN2_gc = (0x01<<1),  /* INSEL2 selection */
+    CCL_CLKSRC_OSCHF_gc = (0x04<<1),  /* Internal High Frequency oscillator */
+    CCL_CLKSRC_OSC32K_gc = (0x05<<1),  /* Internal 32.768 kHz oscillator */
+    CCL_CLKSRC_OSC1K_gc = (0x06<<1),  /* Internal 32.768 kHz oscillator divided by 32 */
+    CCL_CLKSRC_PLL_gc = (0x07<<1)  /* PLL */
+} CCL_CLKSRC_t;
+
+/* Edge Detection Enable select */
+typedef enum CCL_EDGEDET_enum
+{
+    CCL_EDGEDET_DIS_gc = (0x00<<7),  /* Edge detector is disabled */
+    CCL_EDGEDET_EN_gc = (0x01<<7)  /* Edge detector is enabled */
+} CCL_EDGEDET_t;
+
+/* Filter Selection */
+typedef enum CCL_FILTSEL_enum
+{
+    CCL_FILTSEL_DISABLE_gc = (0x00<<4),  /* Filter disabled */
+    CCL_FILTSEL_SYNCH_gc = (0x01<<4),  /* Synchronizer enabled */
+    CCL_FILTSEL_FILTER_gc = (0x02<<4)  /* Filter enabled */
+} CCL_FILTSEL_t;
+
+/* LUT Input 0 Source Selection */
+typedef enum CCL_INSEL0_enum
+{
+    CCL_INSEL0_MASK_gc = (0x00<<0),  /* Masked input */
+    CCL_INSEL0_FEEDBACK_gc = (0x01<<0),  /* Feedback input */
+    CCL_INSEL0_LINK_gc = (0x02<<0),  /* Output from LUT[n+1] as input source */
+    CCL_INSEL0_EVENTA_gc = (0x03<<0),  /* Event A as input source */
+    CCL_INSEL0_EVENTB_gc = (0x04<<0),  /* Event B as input source */
+    CCL_INSEL0_IN0_gc = (0x05<<0),  /* IN0 input source */
+    CCL_INSEL0_AC0_gc = (0x06<<0),  /* AC0 output input source */
+    CCL_INSEL0_USART0_gc = (0x07<<0),  /* USART0 TxD input source */
+    CCL_INSEL0_SPI0_gc = (0x08<<0),  /* SPI0 MOSI input source */
+    CCL_INSEL0_TCE0_gc = (0x09<<0),  /* TCE0 WO0 input source */
+    CCL_INSEL0_TCB0_gc = (0x0A<<0),  /* TCB0 WO input source */
+    CCL_INSEL0_TCF0_gc = (0x0B<<0),  /* TCF0 WO0 input source */
+    CCL_INSEL0_WEX0_gc = (0x0C<<0)  /* Blanking input source */
+} CCL_INSEL0_t;
+
+/* LUT Input 1 Source Selection */
+typedef enum CCL_INSEL1_enum
+{
+    CCL_INSEL1_MASK_gc = (0x00<<4),  /* Masked input */
+    CCL_INSEL1_FEEDBACK_gc = (0x01<<4),  /* Feedback input */
+    CCL_INSEL1_LINK_gc = (0x02<<4),  /* Output from LUT[n+1] as input source */
+    CCL_INSEL1_EVENTA_gc = (0x03<<4),  /* Event A as input source */
+    CCL_INSEL1_EVENTB_gc = (0x04<<4),  /* Event B as input source */
+    CCL_INSEL1_IN1_gc = (0x05<<4),  /* IN1 input source */
+    CCL_INSEL1_AC1_gc = (0x06<<4),  /* AC1 output input source */
+    CCL_INSEL1_USART0_gc = (0x07<<4),  /* USART0 TxD input source */
+    CCL_INSEL1_SPI0_gc = (0x08<<4),  /* SPI0 MOSI input source */
+    CCL_INSEL1_TCE0_gc = (0x09<<4),  /* TCE0 WO1 input source */
+    CCL_INSEL1_TCB1_gc = (0x0A<<4),  /* TCB1 WO input source */
+    CCL_INSEL1_TCF0_gc = (0x0B<<4),  /* TCF0 WO1 input source */
+    CCL_INSEL1_WEX0_gc = (0x0C<<4)  /* Blanking input source */
+} CCL_INSEL1_t;
+
+/* LUT Input 2 Source Selection */
+typedef enum CCL_INSEL2_enum
+{
+    CCL_INSEL2_MASK_gc = (0x00<<0),  /* Masked input */
+    CCL_INSEL2_FEEDBACK_gc = (0x01<<0),  /* Feedback input */
+    CCL_INSEL2_LINK_gc = (0x02<<0),  /* Output from LUT[n+1] as input source */
+    CCL_INSEL2_EVENTA_gc = (0x03<<0),  /* Event A as input source */
+    CCL_INSEL2_EVENTB_gc = (0x04<<0),  /* Event B as input source */
+    CCL_INSEL2_IN2_gc = (0x05<<0),  /* IN2 input source */
+    CCL_INSEL2_AC1_gc = (0x06<<0),  /* AC1 output input source */
+    CCL_INSEL2_USART0_gc = (0x07<<0),  /* USART0 TxD input source */
+    CCL_INSEL2_SPI0_gc = (0x08<<0),  /* SPI0 SCK input source */
+    CCL_INSEL2_TCE0_gc = (0x09<<0),  /* TCE0 WO2 input source */
+    CCL_INSEL2_TCB1_gc = (0x0A<<0),  /* TCB1 WO input source */
+    CCL_INSEL2_TCF0_gc = (0x0B<<0),  /* TCF0 WO0 input source */
+    CCL_INSEL2_WEX0_gc = (0x0C<<0)  /* Blanking input source */
+} CCL_INSEL2_t;
+
+/* Interrupt Mode for LUT0 select */
+typedef enum CCL_INTMODE0_enum
+{
+    CCL_INTMODE0_INTDISABLE_gc = (0x00<<0),  /* Interrupt disabled */
+    CCL_INTMODE0_RISING_gc = (0x01<<0),  /* Sense rising edge */
+    CCL_INTMODE0_FALLING_gc = (0x02<<0),  /* Sense falling edge */
+    CCL_INTMODE0_BOTH_gc = (0x03<<0)  /* Sense both edges */
+} CCL_INTMODE0_t;
+
+/* Interrupt Mode for LUT1 select */
+typedef enum CCL_INTMODE1_enum
+{
+    CCL_INTMODE1_INTDISABLE_gc = (0x00<<2),  /* Interrupt disabled */
+    CCL_INTMODE1_RISING_gc = (0x01<<2),  /* Sense rising edge */
+    CCL_INTMODE1_FALLING_gc = (0x02<<2),  /* Sense falling edge */
+    CCL_INTMODE1_BOTH_gc = (0x03<<2)  /* Sense both edges */
+} CCL_INTMODE1_t;
+
+/* Interrupt Mode for LUT2 select */
+typedef enum CCL_INTMODE2_enum
+{
+    CCL_INTMODE2_INTDISABLE_gc = (0x00<<4),  /* Interrupt disabled */
+    CCL_INTMODE2_RISING_gc = (0x01<<4),  /* Sense rising edge */
+    CCL_INTMODE2_FALLING_gc = (0x02<<4),  /* Sense falling edge */
+    CCL_INTMODE2_BOTH_gc = (0x03<<4)  /* Sense both edges */
+} CCL_INTMODE2_t;
+
+/* Interrupt Mode for LUT3 select */
+typedef enum CCL_INTMODE3_enum
+{
+    CCL_INTMODE3_INTDISABLE_gc = (0x00<<6),  /* Interrupt disabled */
+    CCL_INTMODE3_RISING_gc = (0x01<<6),  /* Sense rising edge */
+    CCL_INTMODE3_FALLING_gc = (0x02<<6),  /* Sense falling edge */
+    CCL_INTMODE3_BOTH_gc = (0x03<<6)  /* Sense both edges */
+} CCL_INTMODE3_t;
+
+/* Sequential Selection */
+typedef enum CCL_SEQSEL_enum
+{
+    CCL_SEQSEL_DISABLE_gc = (0x00<<0),  /* Sequential logic disabled */
+    CCL_SEQSEL_DFF_gc = (0x01<<0),  /* D FlipFlop */
+    CCL_SEQSEL_JK_gc = (0x02<<0),  /* JK FlipFlop */
+    CCL_SEQSEL_LATCH_gc = (0x03<<0),  /* D Latch */
+    CCL_SEQSEL_RS_gc = (0x04<<0)  /* RS Latch */
+} CCL_SEQSEL_t;
+
+/*
+--------------------------------------------------------------------------
+CLKCTRL - Clock controller
+--------------------------------------------------------------------------
+*/
+
+/* Clock controller */
+typedef struct CLKCTRL_struct
+{
+    register8_t MCLKCTRLA;  /* MCLK Control A */
+    register8_t MCLKCTRLB;  /* MCLK Control B */
+    register8_t reserved_1[3];
+    register8_t MCLKSTATUS;  /* MCLK Status */
+    register8_t MCLKTIMEBASE;  /* MCLK Timebase */
+    register8_t reserved_2[1];
+    register8_t OSCHFCTRLA;  /* OSCHF Control A */
+    register8_t OSCHFTUNE;  /* OSCHF Tune */
+    register8_t reserved_3[6];
+    register8_t PLLCTRLA;  /* PLL Control A */
+    register8_t PLLCTRLB;  /* PLL Control B */
+    register8_t reserved_4[6];
+    register8_t OSC32KCTRLA;  /* OSC32K Control A */
+    register8_t reserved_5[3];
+    register8_t XOSC32KCTRLA;  /* XOSC32K Control A */
+    register8_t reserved_6[35];
+} CLKCTRL_t;
+
+/* Automatic Oscillator Tune select */
+typedef enum CLKCTRL_AUTOTUNE_enum
+{
+    CLKCTRL_AUTOTUNE_OFF_gc = (0x00<<0),  /* Disabled */
+    CLKCTRL_AUTOTUNE_XOSC32K_gc = (0x01<<0)  /* Tune against 32.768 kHz Crystal Oscillator */
+} CLKCTRL_AUTOTUNE_t;
+
+/* PLL Output Clock Division select */
+typedef enum CLKCTRL_CLKDIV_enum
+{
+    CLKCTRL_CLKDIV_NONE_gc = (0x00<<0),  /* PLL output clock undivided */
+    CLKCTRL_CLKDIV_DIV2_gc = (0x01<<0)  /* PLL output clock divided by 2 */
+} CLKCTRL_CLKDIV_t;
+
+/* Clock select */
+typedef enum CLKCTRL_CLKSEL_enum
+{
+    CLKCTRL_CLKSEL_OSCHF_gc = (0x00<<0),  /* Internal high-frequency oscillator */
+    CLKCTRL_CLKSEL_OSC32K_gc = (0x01<<0),  /* Internal 32.768 kHz oscillator */
+    CLKCTRL_CLKSEL_XOSC32K_gc = (0x02<<0),  /* 32.768 kHz crystal oscillator */
+    CLKCTRL_CLKSEL_EXTCLK_gc = (0x03<<0),  /* External clock */
+    CLKCTRL_CLKSEL_PLL_gc = (0x04<<0)  /* PLL Oscillator */
+} CLKCTRL_CLKSEL_t;
+
+/* Crystal startup time select */
+typedef enum CLKCTRL_CSUT_enum
+{
+    CLKCTRL_CSUT_1K_gc = (0x00<<4),  /* 1k cycles */
+    CLKCTRL_CSUT_16K_gc = (0x01<<4),  /* 16k cycles */
+    CLKCTRL_CSUT_32K_gc = (0x02<<4),  /* 32k cycles */
+    CLKCTRL_CSUT_64K_gc = (0x03<<4)  /* 64k cycles */
+} CLKCTRL_CSUT_t;
+
+/* PLL Multiplication Factor select */
+typedef enum CLKCTRL_MULFAC_enum
+{
+    CLKCTRL_MULFAC_OFF_gc = (0x00<<0),  /* PLL Disabled */
+    CLKCTRL_MULFAC_8X_gc = (0x02<<0),  /* Multiply by 8 */
+    CLKCTRL_MULFAC_16X_gc = (0x03<<0)  /* Multiply by 16 */
+} CLKCTRL_MULFAC_t;
+
+/* Prescaler B division select */
+typedef enum CLKCTRL_PBDIV_enum
+{
+    CLKCTRL_PBDIV_NONE_gc = (0x00<<5),  /* No division */
+    CLKCTRL_PBDIV_DIV4_gc = (0x01<<5)  /* Divide by 4 */
+} CLKCTRL_PBDIV_t;
+
+/* Prescaler division select */
+typedef enum CLKCTRL_PDIV_enum
+{
+    CLKCTRL_PDIV_DIV2_gc = (0x00<<1),  /* Divide by 2 */
+    CLKCTRL_PDIV_DIV4_gc = (0x01<<1),  /* Divide by 4 */
+    CLKCTRL_PDIV_DIV8_gc = (0x02<<1),  /* Divide by 8 */
+    CLKCTRL_PDIV_DIV16_gc = (0x03<<1),  /* Divide by 16 */
+    CLKCTRL_PDIV_DIV32_gc = (0x04<<1),  /* Divide by 32 */
+    CLKCTRL_PDIV_DIV64_gc = (0x05<<1),  /* Divide by 64 */
+    CLKCTRL_PDIV_DIV6_gc = (0x08<<1),  /* Divide by 6 */
+    CLKCTRL_PDIV_DIV10_gc = (0x09<<1),  /* Divide by 10 */
+    CLKCTRL_PDIV_DIV12_gc = (0x0A<<1),  /* Divide by 12 */
+    CLKCTRL_PDIV_DIV24_gc = (0x0B<<1),  /* Divide by 24 */
+    CLKCTRL_PDIV_DIV48_gc = (0x0C<<1)  /* Divide by 48 */
+} CLKCTRL_PDIV_t;
+
+/* PLL Source select */
+typedef enum CLKCTRL_SOURCE_enum
+{
+    CLKCTRL_SOURCE_OSCHF_gc = (0x00<<5),  /* Internal High Frequency Oscillator */
+    CLKCTRL_SOURCE_EXTCLK_gc = (0x01<<5)  /* External Clock */
+} CLKCTRL_SOURCE_t;
+
+/* PLL Source Division select */
+typedef enum CLKCTRL_SOURCEDIV_enum
+{
+    CLKCTRL_SOURCEDIV_DIV1_gc = (0x00<<3),  /* Source undivided */
+    CLKCTRL_SOURCEDIV_DIV2_gc = (0x01<<3),  /* Divide source by 2 */
+    CLKCTRL_SOURCEDIV_DIV4_gc = (0x02<<3),  /* Divide source by 4 */
+    CLKCTRL_SOURCEDIV_DIV6_gc = (0x03<<3)  /* Divide source by 6 */
+} CLKCTRL_SOURCEDIV_t;
+
+/*
+--------------------------------------------------------------------------
+CPU - CPU
+--------------------------------------------------------------------------
+*/
+
+#define CORE_VERSION  V4S
+
+/* CCP signature select */
+typedef enum CCP_enum
+{
+    CCP_SPM_gc = (0x9D<<0),  /* SPM Instruction Protection */
+    CCP_IOREG_gc = (0xD8<<0)  /* IO Register Protection */
+} CCP_t;
+
+/*
+--------------------------------------------------------------------------
+CPUINT - Interrupt Controller
+--------------------------------------------------------------------------
+*/
+
+/* Interrupt Controller */
+typedef struct CPUINT_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t STATUS;  /* Status */
+    register8_t LVL0PRI;  /* Interrupt Level 0 Priority */
+    register8_t LVL1VEC;  /* Interrupt Level 1 Priority Vector */
+} CPUINT_t;
+
+
+/*
+--------------------------------------------------------------------------
+CRCSCAN - CRCSCAN
+--------------------------------------------------------------------------
+*/
+
+/* CRCSCAN */
+typedef struct CRCSCAN_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t STATUS;  /* Status */
+    register8_t reserved_1[13];
+} CRCSCAN_t;
+
+/* CRC Source select */
+typedef enum CRCSCAN_SRC_enum
+{
+    CRCSCAN_SRC_FLASH_gc = (0x00<<0),  /* CRC on entire flash */
+    CRCSCAN_SRC_APPLICATION_gc = (0x01<<0),  /* CRC on boot and appl section of flash */
+    CRCSCAN_SRC_BOOT_gc = (0x02<<0)  /* CRC on boot section of flash */
+} CRCSCAN_SRC_t;
+
+/*
+--------------------------------------------------------------------------
+EVSYS - Event System
+--------------------------------------------------------------------------
+*/
+
+/* Event System */
+typedef struct EVSYS_struct
+{
+    register8_t SWEVENTA;  /* Software Event A */
+    register8_t reserved_1[15];
+    register8_t CHANNEL0;  /* Multiplexer Channel 0 */
+    register8_t CHANNEL1;  /* Multiplexer Channel 1 */
+    register8_t CHANNEL2;  /* Multiplexer Channel 2 */
+    register8_t CHANNEL3;  /* Multiplexer Channel 3 */
+    register8_t CHANNEL4;  /* Multiplexer Channel 4 */
+    register8_t CHANNEL5;  /* Multiplexer Channel 5 */
+    register8_t reserved_2[10];
+    register8_t USERCCLLUT0A;  /* CCL0 Event A */
+    register8_t USERCCLLUT0B;  /* CCL0 Event B */
+    register8_t USERCCLLUT1A;  /* CCL1 Event A */
+    register8_t USERCCLLUT1B;  /* CCL1 Event B */
+    register8_t USERCCLLUT2A;  /* CCL2 Event A */
+    register8_t USERCCLLUT2B;  /* CCL2 Event B */
+    register8_t USERCCLLUT3A;  /* CCL3 Event A */
+    register8_t USERCCLLUT3B;  /* CCL3 Event B */
+    register8_t USERADC0START;  /* ADC0 Start */
+    register8_t USEREVSYSEVOUTA;  /* EVOUTA */
+    register8_t USEREVSYSEVOUTC;  /* EVOUTC */
+    register8_t USEREVSYSEVOUTD;  /* EVOUTD */
+    register8_t USEREVSYSEVOUTF;  /* EVOUTF */
+    register8_t USERUSART0IRDA;  /* USART0 IrDA Event */
+    register8_t USERTCE0CNTA;  /* TCE0 Event A */
+    register8_t USERTCE0CNTB;  /* TCE0 Event B */
+    register8_t USERTCB0CAPT;  /* TCB0 Event A */
+    register8_t USERTCB0COUNT;  /* TCB0 Event B */
+    register8_t USERTCB1CAPT;  /* TCB1 Event A */
+    register8_t USERTCB1COUNT;  /* TCB1 Event B */
+    register8_t USERTCF0CNT;  /* TCF0 Clock Event */
+    register8_t USERTCF0ACT;  /* TCF0 Action Event */
+    register8_t USERWEXA;  /* WEX Event A */
+    register8_t USERWEXB;  /* WEX Event B */
+    register8_t USERWEXC;  /* WEX Event C */
+    register8_t reserved_3[7];
+} EVSYS_t;
+
+/* Channel generator select */
+typedef enum EVSYS_CHANNEL_enum
+{
+    EVSYS_CHANNEL_OFF_gc = (0x00<<0),  /* Off */
+    EVSYS_CHANNEL_UPDI_SYNCH_gc = (0x01<<0),  /* UPDI SYNCH character */
+    EVSYS_CHANNEL_RTC_OVF_gc = (0x06<<0),  /* Real Time Counter overflow */
+    EVSYS_CHANNEL_RTC_CMP_gc = (0x07<<0),  /* Real Time Counter compare */
+    EVSYS_CHANNEL_RTC_PITEV0_gc = (0x08<<0),  /* Periodic Interrupt Timer Event 0 */
+    EVSYS_CHANNEL_RTC_PITEV1_gc = (0x09<<0),  /* Periodic Interrupt Timer Event 1 */
+    EVSYS_CHANNEL_CCL_LUT0_gc = (0x10<<0),  /* Configurable Custom Logic LUT0 */
+    EVSYS_CHANNEL_CCL_LUT1_gc = (0x11<<0),  /* Configurable Custom Logic LUT1 */
+    EVSYS_CHANNEL_CCL_LUT2_gc = (0x12<<0),  /* Configurable Custom Logic LUT2 */
+    EVSYS_CHANNEL_CCL_LUT3_gc = (0x13<<0),  /* Configurable Custom Logic LUT3 */
+    EVSYS_CHANNEL_AC0_OUT_gc = (0x20<<0),  /* Analog Comparator 0 out */
+    EVSYS_CHANNEL_AC1_OUT_gc = (0x21<<0),  /* Analog Comparator 1 out */
+    EVSYS_CHANNEL_ADC0_RES_gc = (0x24<<0),  /* ADC 0 Result Ready */
+    EVSYS_CHANNEL_ADC0_SAMP_gc = (0x25<<0),  /* ADC 0 Sample Ready */
+    EVSYS_CHANNEL_ADC0_WCMP_gc = (0x26<<0),  /* ADC 0 Window Compare */
+    EVSYS_CHANNEL_PORTA_EV0_gc = (0x40<<0),  /* Port A Event 0 */
+    EVSYS_CHANNEL_PORTA_EV1_gc = (0x41<<0),  /* Port A Event 1 */
+    EVSYS_CHANNEL_PORTC_EV0_gc = (0x44<<0),  /* Port C Event 0 */
+    EVSYS_CHANNEL_PORTC_EV1_gc = (0x45<<0),  /* Port C Event 1 */
+    EVSYS_CHANNEL_PORTD_EV0_gc = (0x46<<0),  /* Port D Event 0 */
+    EVSYS_CHANNEL_PORTD_EV1_gc = (0x47<<0),  /* Port D Event 1 */
+    EVSYS_CHANNEL_PORTF_EV0_gc = (0x4A<<0),  /* Port F Event 0 */
+    EVSYS_CHANNEL_PORTF_EV1_gc = (0x4B<<0),  /* Port F Event 1 */
+    EVSYS_CHANNEL_USART0_XCK_gc = (0x60<<0),  /* USART 0 XCK */
+    EVSYS_CHANNEL_SPI0_SCK_gc = (0x68<<0),  /* SPI 0 SCK */
+    EVSYS_CHANNEL_TCE0_OVF_gc = (0x80<<0),  /* Timer/Counter E0 overflow */
+    EVSYS_CHANNEL_TCE0_CMP0_gc = (0x84<<0),  /* Timer/Counter E0 compare 0 */
+    EVSYS_CHANNEL_TCE0_CMP1_gc = (0x85<<0),  /* Timer/Counter E0 compare 1 */
+    EVSYS_CHANNEL_TCE0_CMP2_gc = (0x86<<0),  /* Timer/Counter E0 compare 2 */
+    EVSYS_CHANNEL_TCE0_CMP3_gc = (0x87<<0),  /* Timer/Counter E0 compare 3 */
+    EVSYS_CHANNEL_TCB0_CAPT_gc = (0xA0<<0),  /* Timer/Counter B0 capture */
+    EVSYS_CHANNEL_TCB0_OVF_gc = (0xA1<<0),  /* Timer/Counter B0 overflow */
+    EVSYS_CHANNEL_TCB1_CAPT_gc = (0xA2<<0),  /* Timer/Counter B1 capture */
+    EVSYS_CHANNEL_TCB1_OVF_gc = (0xA3<<0),  /* Timer/Counter B1 overflow */
+    EVSYS_CHANNEL_TCF0_OVF_gc = (0xB8<<0),  /* Timer/Counter F0 Overflow */
+    EVSYS_CHANNEL_TCF0_CMP0_gc = (0xB9<<0),  /* Timer/Counter F0 compare 0 */
+    EVSYS_CHANNEL_TCF0_CMP1_gc = (0xBA<<0)  /* Timer/Counter F0 compare 1 */
+} EVSYS_CHANNEL_t;
+
+/* Software event on channel select */
+typedef enum EVSYS_SWEVENTA_enum
+{
+    EVSYS_SWEVENTA_CH0_gc = (0x01<<0),  /* Software event on channel 0 */
+    EVSYS_SWEVENTA_CH1_gc = (0x02<<0),  /* Software event on channel 1 */
+    EVSYS_SWEVENTA_CH2_gc = (0x04<<0),  /* Software event on channel 2 */
+    EVSYS_SWEVENTA_CH3_gc = (0x08<<0),  /* Software event on channel 3 */
+    EVSYS_SWEVENTA_CH4_gc = (0x10<<0),  /* Software event on channel 4 */
+    EVSYS_SWEVENTA_CH5_gc = (0x20<<0),  /* Software event on channel 5 */
+    EVSYS_SWEVENTA_CH6_gc = (0x40<<0),  /* Software event on channel 6 */
+    EVSYS_SWEVENTA_CH7_gc = (0x80<<0)  /* Software event on channel 7 */
+} EVSYS_SWEVENTA_t;
+
+/* User channel select */
+typedef enum EVSYS_USER_enum
+{
+    EVSYS_USER_OFF_gc = (0x00<<0),  /* Off, No Eventsys Channel connected */
+    EVSYS_USER_CHANNEL0_gc = (0x01<<0),  /* Connect user to event channel 0 */
+    EVSYS_USER_CHANNEL1_gc = (0x02<<0),  /* Connect user to event channel 1 */
+    EVSYS_USER_CHANNEL2_gc = (0x03<<0),  /* Connect user to event channel 2 */
+    EVSYS_USER_CHANNEL3_gc = (0x04<<0),  /* Connect user to event channel 3 */
+    EVSYS_USER_CHANNEL4_gc = (0x05<<0),  /* Connect user to event channel 4 */
+    EVSYS_USER_CHANNEL5_gc = (0x06<<0)  /* Connect user to event channel 5 */
+} EVSYS_USER_t;
+
+/*
+--------------------------------------------------------------------------
+FUSE - Fuses
+--------------------------------------------------------------------------
+*/
+
+/* Fuses */
+typedef struct FUSE_struct
+{
+    register8_t WDTCFG;  /* Watchdog Configuration */
+    register8_t BODCFG;  /* BOD Configuration */
+    register8_t OSCCFG;  /* Oscillator Configuration */
+    register8_t reserved_1[2];
+    register8_t SYSCFG0;  /* System Configuration 0 */
+    register8_t SYSCFG1;  /* System Configuration 1 */
+    register8_t CODESIZE;  /* Code Section Size */
+    register8_t BOOTSIZE;  /* Boot Section Size */
+    register8_t reserved_2[1];
+    _WORDREGISTER(PDICFG);  /* Programming and Debugging Interface Configuration */
+} FUSE_t;
+
+/* avr-libc typedef for avr/fuse.h */
+typedef FUSE_t NVM_FUSES_t;
+
+/* BOD Operation in Active Mode select */
+typedef enum ACTIVE_enum
+{
+    ACTIVE_DISABLE_gc = (0x00<<2),  /* Disabled */
+    ACTIVE_ENABLED_gc = (0x01<<2),  /* Enabled in continuous mode */
+    ACTIVE_SAMPLED_gc = (0x02<<2),  /* Enabled in sampled mode */
+    ACTIVE_ENABLEWAIT_gc = (0x03<<2)  /* Enabled in continuous mode. Execution halted at wake-up until BOD is running */
+} ACTIVE_t;
+
+/* CRC Select */
+typedef enum CRCSEL_enum
+{
+    CRCSEL_CRC16_gc = (0x00<<5),  /* Enable CRC16 */
+    CRCSEL_CRC32_gc = (0x01<<5)  /* Enable CRC32 */
+} CRCSEL_t;
+
+/* CRC Source select */
+typedef enum CRCSRC_enum
+{
+    CRCSRC_FLASH_gc = (0x00<<6),  /* CRC of full Flash (boot, application code and application data) */
+    CRCSRC_BOOT_gc = (0x01<<6),  /* CRC of boot section */
+    CRCSRC_BOOTAPP_gc = (0x02<<6),  /* CRC of application code and boot sections */
+    CRCSRC_NOCRC_gc = (0x03<<6)  /* No CRC */
+} CRCSRC_t;
+
+/* EEPROM Save select */
+typedef enum EESAVE_enum
+{
+    EESAVE_DISABLE_gc = (0x00<<0),  /* EEPROM content is erased during chip erase */
+    EESAVE_ENABLE_gc = (0x01<<0)  /* EEPROM content is preserved during chip erase */
+} EESAVE_t;
+
+/* NVM Protection Activation Key select */
+typedef enum KEY_enum
+{
+    KEY_NOTACT_gc = (0x00<<4),  /* Not Active */
+    KEY_NVMACT_gc = (0xB45<<4)  /* NVM Protection Active */
+} KEY_t;
+
+/* Protection Level select */
+typedef enum LEVEL_enum
+{
+    LEVEL_NVMACCDIS_gc = (0x02<<0),  /* NVM Access through UPDI disabled */
+    LEVEL_BASIC_gc = (0x03<<0)  /* UPDI and UPDI pins working normally */
+} LEVEL_t;
+
+/* BOD Level select */
+typedef enum LVL_enum
+{
+    LVL_BODLEVEL0_gc = (0x00<<5),  /* BOD Disabled during normal operation */
+    LVL_BODLEVEL1_gc = (0x01<<5),  /* 1.9 V */
+    LVL_BODLEVEL2_gc = (0x02<<5),  /* 2.7 V */
+    LVL_BODLEVEL3_gc = (0x03<<5)  /* 4.5 V */
+} LVL_t;
+
+/* High-frequency Oscillator Frequency select */
+typedef enum OSCHFFRQ_enum
+{
+    OSCHFFRQ_20M_gc = (0x00<<3),  /* OSCHF running at 20 MHz */
+    OSCHFFRQ_16M_gc = (0x01<<3)  /* OSCHF running at 16 MHz */
+} OSCHFFRQ_t;
+
+/* Watchdog Timeout Period select */
+typedef enum PERIOD_enum
+{
+    PERIOD_OFF_gc = (0x00<<0),  /* Watch-Dog timer Off */
+    PERIOD_8CLK_gc = (0x01<<0),  /* 8 cycles (8ms) */
+    PERIOD_16CLK_gc = (0x02<<0),  /* 16 cycles (16ms) */
+    PERIOD_32CLK_gc = (0x03<<0),  /* 32 cycles (32ms) */
+    PERIOD_64CLK_gc = (0x04<<0),  /* 64 cycles (64ms) */
+    PERIOD_128CLK_gc = (0x05<<0),  /* 128 cycles (0.128s) */
+    PERIOD_256CLK_gc = (0x06<<0),  /* 256 cycles (0.256s) */
+    PERIOD_512CLK_gc = (0x07<<0),  /* 512 cycles (0.512s) */
+    PERIOD_1KCLK_gc = (0x08<<0),  /* 1K cycles (1.0s) */
+    PERIOD_2KCLK_gc = (0x09<<0),  /* 2K cycles (2.0s) */
+    PERIOD_4KCLK_gc = (0x0A<<0),  /* 4K cycles (4.0s) */
+    PERIOD_8KCLK_gc = (0x0B<<0)  /* 8K cycles (8.0s) */
+} PERIOD_t;
+
+/* Reset Pin Configuration select */
+typedef enum RSTPINCFG_enum
+{
+    RSTPINCFG_NONE_gc = (0x00<<3),  /* No External Reset */
+    RSTPINCFG_RESET_gc = (0x01<<3)  /* PF6 configured as RESET pin */
+} RSTPINCFG_t;
+
+/* BOD Sample Frequency select */
+typedef enum SAMPFREQ_enum
+{
+    SAMPFREQ_128HZ_gc = (0x00<<4),  /* Sampling frequency is 128 Hz */
+    SAMPFREQ_32HZ_gc = (0x01<<4)  /* Sample frequency is 32 Hz */
+} SAMPFREQ_t;
+
+/* BOD Operation in Sleep Mode select */
+typedef enum SLEEP_enum
+{
+    SLEEP_DISABLE_gc = (0x00<<0),  /* Disabled */
+    SLEEP_ENABLE_gc = (0x01<<0),  /* Enabled in continuous mode */
+    SLEEP_SAMPLE_gc = (0x02<<0)  /* Enabled in sampled mode */
+} SLEEP_t;
+
+/* Startup Time select */
+typedef enum SUT_enum
+{
+    SUT_0MS_gc = (0x00<<0),  /* 0 ms */
+    SUT_1MS_gc = (0x01<<0),  /* 1 ms */
+    SUT_2MS_gc = (0x02<<0),  /* 2 ms */
+    SUT_4MS_gc = (0x03<<0),  /* 4 ms */
+    SUT_8MS_gc = (0x04<<0),  /* 8 ms */
+    SUT_16MS_gc = (0x05<<0),  /* 16 ms */
+    SUT_32MS_gc = (0x06<<0),  /* 32 ms */
+    SUT_64MS_gc = (0x07<<0)  /* 64 ms */
+} SUT_t;
+
+/* UPDI Pin Configuration select */
+typedef enum UPDIPINCFG_enum
+{
+    UPDIPINCFG_GPIO_gc = (0x00<<4),  /* PF7 Configured as GPIO pin */
+    UPDIPINCFG_UPDI_gc = (0x01<<4)  /* PF7 Configured as UPDI pin */
+} UPDIPINCFG_t;
+
+/* Watchdog Window Timeout Period select */
+typedef enum WINDOW_enum
+{
+    WINDOW_OFF_gc = (0x00<<4),  /* Window mode off */
+    WINDOW_8CLK_gc = (0x01<<4),  /* 8 cycles (8ms) */
+    WINDOW_16CLK_gc = (0x02<<4),  /* 16 cycles (16ms) */
+    WINDOW_32CLK_gc = (0x03<<4),  /* 32 cycles (32ms) */
+    WINDOW_64CLK_gc = (0x04<<4),  /* 64 cycles (64ms) */
+    WINDOW_128CLK_gc = (0x05<<4),  /* 128 cycles (0.128s) */
+    WINDOW_256CLK_gc = (0x06<<4),  /* 256 cycles (0.256s) */
+    WINDOW_512CLK_gc = (0x07<<4),  /* 512 cycles (0.512s) */
+    WINDOW_1KCLK_gc = (0x08<<4),  /* 1K cycles (1.0s) */
+    WINDOW_2KCLK_gc = (0x09<<4),  /* 2K cycles (2.0s) */
+    WINDOW_4KCLK_gc = (0x0A<<4),  /* 4K cycles (4.0s) */
+    WINDOW_8KCLK_gc = (0x0B<<4)  /* 8K cycles (8.0s) */
+} WINDOW_t;
+
+/*
+--------------------------------------------------------------------------
+GPR - General Purpose Registers
+--------------------------------------------------------------------------
+*/
+
+/* General Purpose Registers */
+typedef struct GPR_struct
+{
+    register8_t GPR0;  /* General Purpose Register 0 */
+    register8_t GPR1;  /* General Purpose Register 1 */
+    register8_t GPR2;  /* General Purpose Register 2 */
+    register8_t GPR3;  /* General Purpose Register 3 */
+} GPR_t;
+
+
+/*
+--------------------------------------------------------------------------
+LOCK - Lockbits
+--------------------------------------------------------------------------
+*/
+
+/* Lockbits */
+typedef struct LOCK_struct
+{
+    _DWORDREGISTER(KEY);  /* Lock Key Bits */
+} LOCK_t;
+
+/* Lock Key select */
+typedef enum LOCK_KEY_enum
+{
+    LOCK_KEY_NOLOCK_gc = (0x5CC5C55C<<0),  /* No locks */
+    LOCK_KEY_RWLOCK_gc = (0xA33A3AA3<<0)  /* Read and write lock */
+} LOCK_KEY_t;
+
+/*
+--------------------------------------------------------------------------
+NVMCTRL - Non-volatile Memory Controller
+--------------------------------------------------------------------------
+*/
+
+/* Non-volatile Memory Controller */
+typedef struct NVMCTRL_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    register8_t reserved_1[1];
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t STATUS;  /* Status */
+    register8_t reserved_2[1];
+    _WORDREGISTER(DATA);  /* Data */
+    register8_t reserved_3[2];
+    _DWORDREGISTER(ADDR);  /* Address */
+    register8_t reserved_4[48];
+} NVMCTRL_t;
+
+/* Command select */
+typedef enum NVMCTRL_CMD_enum
+{
+    NVMCTRL_CMD_NOCMD_gc = (0x00<<0),  /* No Command */
+    NVMCTRL_CMD_NOOP_gc = (0x01<<0),  /* No Operation */
+    NVMCTRL_CMD_FLPW_gc = (0x04<<0),  /* Flash Page Write */
+    NVMCTRL_CMD_FLPERW_gc = (0x05<<0),  /* Flash Page Erase and Write */
+    NVMCTRL_CMD_FLPER_gc = (0x08<<0),  /* Flash Page Erase */
+    NVMCTRL_CMD_FLMPER2_gc = (0x09<<0),  /* Flash 2-page erase enable */
+    NVMCTRL_CMD_FLMPER4_gc = (0x0A<<0),  /* Flash 4-page erase enable */
+    NVMCTRL_CMD_FLMPER8_gc = (0x0B<<0),  /* Flash 8-page erase enable */
+    NVMCTRL_CMD_FLMPER16_gc = (0x0C<<0),  /* Flash 16-page erase enable */
+    NVMCTRL_CMD_FLMPER32_gc = (0x0D<<0),  /* Flash 32-page erase enable */
+    NVMCTRL_CMD_FLPBCLR_gc = (0x0F<<0),  /* Flash Page Buffer Clear */
+    NVMCTRL_CMD_EEPW_gc = (0x14<<0),  /* EEPROM Page Write */
+    NVMCTRL_CMD_EEPERW_gc = (0x15<<0),  /* EEPROM Page Erase and Write */
+    NVMCTRL_CMD_EEPER_gc = (0x17<<0),  /* EEPROM Page Erase */
+    NVMCTRL_CMD_EEPBCLR_gc = (0x1F<<0),  /* EEPROM Page Buffer Clear */
+    NVMCTRL_CMD_CHER_gc = (0x20<<0),  /* Chip Erase Command (UPDI only) */
+    NVMCTRL_CMD_EECHER_gc = (0x30<<0)  /* EEPROM Erase Command (UPDI only) */
+} NVMCTRL_CMD_t;
+
+/* Write error select */
+typedef enum NVMCTRL_ERROR_enum
+{
+    NVMCTRL_ERROR_NOERROR_gc = (0x00<<4),  /* No Error */
+    NVMCTRL_ERROR_WRITEPROTECT_gc = (0x02<<4),  /* Attempt to program write protected area */
+    NVMCTRL_ERROR_CMDCOLLISION_gc = (0x03<<4),  /* Selecting new write command while write command already seleted */
+    NVMCTRL_ERROR_WRONGSECTION_gc = (0x04<<4)  /* Address cannot be written with selected command */
+} NVMCTRL_ERROR_t;
+
+/* Flash Mapping in Data space select */
+typedef enum NVMCTRL_FLMAP_enum
+{
+    NVMCTRL_FLMAP_SECTION0_gc = (0x00<<4),  /* Flash section 0, 0 - 32KB */
+    NVMCTRL_FLMAP_SECTION1_gc = (0x01<<4),  /* Flash section 1, 32 - 64KB */
+    NVMCTRL_FLMAP_SECTION2_gc = (0x02<<4),  /* Flash section 2, 64 - 96KB */
+    NVMCTRL_FLMAP_SECTION3_gc = (0x03<<4)  /* Flash section 3, 96 - 128KB */
+} NVMCTRL_FLMAP_t;
+
+/*
+--------------------------------------------------------------------------
+PORT - I/O Ports
+--------------------------------------------------------------------------
+*/
+
+/* I/O Ports */
+typedef struct PORT_struct
+{
+    register8_t DIR;  /* Data Direction */
+    register8_t DIRSET;  /* Data Direction Set */
+    register8_t DIRCLR;  /* Data Direction Clear */
+    register8_t DIRTGL;  /* Data Direction Toggle */
+    register8_t OUT;  /* Output Value */
+    register8_t OUTSET;  /* Output Value Set */
+    register8_t OUTCLR;  /* Output Value Clear */
+    register8_t OUTTGL;  /* Output Value Toggle */
+    register8_t IN;  /* Input Value */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t PORTCTRL;  /* Port Control */
+    register8_t PINCONFIG;  /* Pin Control Config */
+    register8_t PINCTRLUPD;  /* Pin Control Update */
+    register8_t PINCTRLSET;  /* Pin Control Set */
+    register8_t PINCTRLCLR;  /* Pin Control Clear */
+    register8_t reserved_1[1];
+    register8_t PIN0CTRL;  /* Pin 0 Control */
+    register8_t PIN1CTRL;  /* Pin 1 Control */
+    register8_t PIN2CTRL;  /* Pin 2 Control */
+    register8_t PIN3CTRL;  /* Pin 3 Control */
+    register8_t PIN4CTRL;  /* Pin 4 Control */
+    register8_t PIN5CTRL;  /* Pin 5 Control */
+    register8_t PIN6CTRL;  /* Pin 6 Control */
+    register8_t PIN7CTRL;  /* Pin 7 Control */
+    register8_t EVGENCTRLA;  /* Event Generation Control A */
+    register8_t reserved_2[7];
+} PORT_t;
+
+/* Event Generator 0 Select */
+typedef enum PORT_EVGEN0SEL_enum
+{
+    PORT_EVGEN0SEL_PIN0_gc = (0x00<<0),  /* Pin 0 used as event generator */
+    PORT_EVGEN0SEL_PIN1_gc = (0x01<<0),  /* Pin 1 used as event generator */
+    PORT_EVGEN0SEL_PIN2_gc = (0x02<<0),  /* Pin 2 used as event generator */
+    PORT_EVGEN0SEL_PIN3_gc = (0x03<<0),  /* Pin 3 used as event generator */
+    PORT_EVGEN0SEL_PIN4_gc = (0x04<<0),  /* Pin 4 used as event generator */
+    PORT_EVGEN0SEL_PIN5_gc = (0x05<<0),  /* Pin 5 used as event generator */
+    PORT_EVGEN0SEL_PIN6_gc = (0x06<<0),  /* Pin 6 used as event generator */
+    PORT_EVGEN0SEL_PIN7_gc = (0x07<<0)  /* Pin 7 used as event generator */
+} PORT_EVGEN0SEL_t;
+
+/* Event Generator 1 Select */
+typedef enum PORT_EVGEN1SEL_enum
+{
+    PORT_EVGEN1SEL_PIN0_gc = (0x00<<4),  /* Pin 0 used as event generator */
+    PORT_EVGEN1SEL_PIN1_gc = (0x01<<4),  /* Pin 1 used as event generator */
+    PORT_EVGEN1SEL_PIN2_gc = (0x02<<4),  /* Pin 2 used as event generator */
+    PORT_EVGEN1SEL_PIN3_gc = (0x03<<4),  /* Pin 3 used as event generator */
+    PORT_EVGEN1SEL_PIN4_gc = (0x04<<4),  /* Pin 4 used as event generator */
+    PORT_EVGEN1SEL_PIN5_gc = (0x05<<4),  /* Pin 5 used as event generator */
+    PORT_EVGEN1SEL_PIN6_gc = (0x06<<4),  /* Pin 6 used as event generator */
+    PORT_EVGEN1SEL_PIN7_gc = (0x07<<4)  /* Pin 7 used as event generator */
+} PORT_EVGEN1SEL_t;
+
+/* Input Level Select */
+typedef enum PORT_INLVL_enum
+{
+    PORT_INLVL_ST_gc = (0x00<<6),  /* Schmitt-Trigger input level */
+    PORT_INLVL_TTL_gc = (0x01<<6)  /* TTL Input level */
+} PORT_INLVL_t;
+
+/* Input/Sense Configuration select */
+typedef enum PORT_ISC_enum
+{
+    PORT_ISC_INTDISABLE_gc = (0x00<<0),  /* Interrupt disabled but input buffer enabled */
+    PORT_ISC_BOTHEDGES_gc = (0x01<<0),  /* Sense Both Edges */
+    PORT_ISC_RISING_gc = (0x02<<0),  /* Sense Rising Edge */
+    PORT_ISC_FALLING_gc = (0x03<<0),  /* Sense Falling Edge */
+    PORT_ISC_INPUT_DISABLE_gc = (0x04<<0),  /* Digital Input Buffer disabled */
+    PORT_ISC_LEVEL_gc = (0x05<<0)  /* Sense low Level */
+} PORT_ISC_t;
+
+/*
+--------------------------------------------------------------------------
+PORTMUX - Port Multiplexer
+--------------------------------------------------------------------------
+*/
+
+/* Port Multiplexer */
+typedef struct PORTMUX_struct
+{
+    register8_t EVSYSROUTEA;  /* EVSYS route A */
+    register8_t CCLROUTEA;  /* CCL route A */
+    register8_t USARTROUTEA;  /* USART route A */
+    register8_t reserved_1[2];
+    register8_t SPIROUTEA;  /* SPI route A */
+    register8_t TWIROUTEA;  /* TWI route A */
+    register8_t TCEROUTEA;  /* TCE route A */
+    register8_t reserved_2[4];
+    register8_t TCFROUTEA;  /* TCF Route A */
+    register8_t reserved_3[19];
+} PORTMUX_t;
+
+/* Event Output C select */
+typedef enum PORTMUX_EVOUTC_enum
+{
+    PORTMUX_EVOUTC_DEFAULT_gc = (0x00<<2)  /* EVOUT on PC2 */
+} PORTMUX_EVOUTC_t;
+
+/* Event Output D select */
+typedef enum PORTMUX_EVOUTD_enum
+{
+    PORTMUX_EVOUTD_ALT1_gc = (0x01<<3)  /* EVOUT on PD7 */
+} PORTMUX_EVOUTD_t;
+
+/* Event Output F select */
+typedef enum PORTMUX_EVOUTF_enum
+{
+    PORTMUX_EVOUTF_ALT1_gc = (0x01<<5)  /* EVOUT on PF7 */
+} PORTMUX_EVOUTF_t;
+
+/* CCL Look-Up Table 0 Signals select */
+typedef enum PORTMUX_LUT0_enum
+{
+    PORTMUX_LUT0_DEFAULT_gc = (0x00<<0)  /* Out: PA3 In: PA0, PA1, PA2 */
+} PORTMUX_LUT0_t;
+
+/* CCL Look-Up Table 1 Signals select */
+typedef enum PORTMUX_LUT1_enum
+{
+    PORTMUX_LUT1_DEFAULT_gc = (0x00<<1)  /* Out: PC3 In: PC0, PC1, PC2 */
+} PORTMUX_LUT1_t;
+
+/* CCL Look-Up Table 2 Signals select */
+typedef enum PORTMUX_LUT2_enum
+{
+    PORTMUX_LUT2_ALT1_gc = (0x01<<2)  /* Out: PD6 In: PD0, PD1, PD2 */
+} PORTMUX_LUT2_t;
+
+/* SPI0 Signals select */
+typedef enum PORTMUX_SPI0_enum
+{
+    PORTMUX_SPI0_ALT3_gc = (0x03<<0),  /* PA0, PA1, PC0, PC1 */
+    PORTMUX_SPI0_ALT4_gc = (0x04<<0),  /* PD4, PD5, PD6, PD7 */
+    PORTMUX_SPI0_ALT5_gc = (0x05<<0),  /* PC0, PC1, PC2, PC3 */
+    PORTMUX_SPI0_ALT6_gc = (0x06<<0),  /* PC1, PC2, PC3, - */
+    PORTMUX_SPI0_NONE_gc = (0x07<<0)  /* Not connected to any pins, SS set to 1 */
+} PORTMUX_SPI0_t;
+
+/* TCE0 Signals select */
+typedef enum PORTMUX_TCE0_enum
+{
+    PORTMUX_TCE0_PORTA_gc = (0x00<<0),  /* PA0, PA1, PA2, PA3, PA4, PA5, PA6, PA7 */
+    PORTMUX_TCE0_PORTC_gc = (0x02<<0),  /* PC0, PC1, PC2, PC3, -, -, -, - */
+    PORTMUX_TCE0_PORTC2_gc = (0x08<<0)  /* PA0, PA1, PC0, PC1, PC2, PC3, -, - */
+} PORTMUX_TCE0_t;
+
+/* TCF0 Output select */
+typedef enum PORTMUX_TCF0_enum
+{
+    PORTMUX_TCF0_DEFAULT_gc = (0x00<<0)  /* PA0, PA1 */
+} PORTMUX_TCF0_t;
+
+/* TWI0 Signals select */
+typedef enum PORTMUX_TWI0_enum
+{
+    PORTMUX_TWI0_DEFAULT_gc = (0x00<<0),  /* {PA2, PA3}, {PC2, PC3} */
+    PORTMUX_TWI0_ALT2_gc = (0x02<<0),  /* {PC2, PC3}, {-, -} */
+    PORTMUX_TWI0_ALT3_gc = (0x03<<0)  /* {PA0, PA1}, {PC2, PC3} */
+} PORTMUX_TWI0_t;
+
+/* USART0 Routing select */
+typedef enum PORTMUX_USART0_enum
+{
+    PORTMUX_USART0_DEFAULT_gc = (0x00<<0),  /* {PA0, PA1, PA2, PA3} */
+    PORTMUX_USART0_ALT3_gc = (0x03<<0),  /* {PD4, PD5, PD6, PD7} */
+    PORTMUX_USART0_ALT4_gc = (0x04<<0),  /* {PC1, PC2, PC3, -} */
+    PORTMUX_USART0_ALT6_gc = (0x06<<0),  /* {PF7, PF6, -, -} */
+    PORTMUX_USART0_NONE_gc = (0x07<<0)  /* Not connected to any pins */
+} PORTMUX_USART0_t;
+
+/*
+--------------------------------------------------------------------------
+RSTCTRL - Reset controller
+--------------------------------------------------------------------------
+*/
+
+/* Reset controller */
+typedef struct RSTCTRL_struct
+{
+    register8_t RSTFR;  /* Reset Flags */
+    register8_t SWRR;  /* Software Reset */
+    register8_t reserved_1[14];
+} RSTCTRL_t;
+
+
+/*
+--------------------------------------------------------------------------
+RTC - Real-Time Counter
+--------------------------------------------------------------------------
+*/
+
+/* Real-Time Counter */
+typedef struct RTC_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t STATUS;  /* Status */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t TEMP;  /* Temporary */
+    register8_t DBGCTRL;  /* Debug control */
+    register8_t CALIB;  /* Calibration */
+    register8_t CLKSEL;  /* Clock Select */
+    _WORDREGISTER(CNT);  /* Counter */
+    _WORDREGISTER(PER);  /* Period */
+    _WORDREGISTER(CMP);  /* Compare */
+    register8_t reserved_1[2];
+    register8_t PITCTRLA;  /* PIT Control A */
+    register8_t PITSTATUS;  /* PIT Status */
+    register8_t PITINTCTRL;  /* PIT Interrupt Control */
+    register8_t PITINTFLAGS;  /* PIT Interrupt Flags */
+    register8_t reserved_2[1];
+    register8_t PITDBGCTRL;  /* PIT Debug control */
+    register8_t PITEVGENCTRLA;  /* PIT Event Generation Control A */
+    register8_t reserved_3[9];
+} RTC_t;
+
+/* Clock Select */
+typedef enum RTC_CLKSEL_enum
+{
+    RTC_CLKSEL_OSC32K_gc = (0x00<<0),  /* Internal 32.768 kHz Oscillator */
+    RTC_CLKSEL_OSC1K_gc = (0x01<<0),  /* Internal 32.768 kHz Oscillator Divided by 32 */
+    RTC_CLKSEL_XOSC32K_gc = (0x02<<0),  /* 32.768 kHz Crystal Oscillator */
+    RTC_CLKSEL_EXTCLK_gc = (0x03<<0)  /* External Clock */
+} RTC_CLKSEL_t;
+
+/* Event Generation 0 Select */
+typedef enum RTC_EVGEN0SEL_enum
+{
+    RTC_EVGEN0SEL_OFF_gc = (0x00<<0),  /* No Event Generated */
+    RTC_EVGEN0SEL_DIV4_gc = (0x01<<0),  /* CLK_RTC divided by 4 */
+    RTC_EVGEN0SEL_DIV8_gc = (0x02<<0),  /* CLK_RTC divided by 8 */
+    RTC_EVGEN0SEL_DIV16_gc = (0x03<<0),  /* CLK_RTC divided by 16 */
+    RTC_EVGEN0SEL_DIV32_gc = (0x04<<0),  /* CLK_RTC divided by 32 */
+    RTC_EVGEN0SEL_DIV64_gc = (0x05<<0),  /* CLK_RTC divided by 64 */
+    RTC_EVGEN0SEL_DIV128_gc = (0x06<<0),  /* CLK_RTC divided by 128 */
+    RTC_EVGEN0SEL_DIV256_gc = (0x07<<0),  /* CLK_RTC divided by 256 */
+    RTC_EVGEN0SEL_DIV512_gc = (0x08<<0),  /* CLK_RTC divided by 512 */
+    RTC_EVGEN0SEL_DIV1024_gc = (0x09<<0),  /* CLK_RTC divided by 1024 */
+    RTC_EVGEN0SEL_DIV2048_gc = (0x0A<<0),  /* CLK_RTC divided by 2048 */
+    RTC_EVGEN0SEL_DIV4096_gc = (0x0B<<0),  /* CLK_RTC divided by 4096 */
+    RTC_EVGEN0SEL_DIV8192_gc = (0x0C<<0),  /* CLK_RTC divided by 8192 */
+    RTC_EVGEN0SEL_DIV16384_gc = (0x0D<<0),  /* CLK_RTC divided by 16384 */
+    RTC_EVGEN0SEL_DIV32768_gc = (0x0E<<0)  /* CLK_RTC divided by 32768 */
+} RTC_EVGEN0SEL_t;
+
+/* Event Generation 1 Select */
+typedef enum RTC_EVGEN1SEL_enum
+{
+    RTC_EVGEN1SEL_OFF_gc = (0x00<<4),  /* No Event Generated */
+    RTC_EVGEN1SEL_DIV4_gc = (0x01<<4),  /* CLK_RTC divided by 4 */
+    RTC_EVGEN1SEL_DIV8_gc = (0x02<<4),  /* CLK_RTC divided by 8 */
+    RTC_EVGEN1SEL_DIV16_gc = (0x03<<4),  /* CLK_RTC divided by 16 */
+    RTC_EVGEN1SEL_DIV32_gc = (0x04<<4),  /* CLK_RTC divided by 32 */
+    RTC_EVGEN1SEL_DIV64_gc = (0x05<<4),  /* CLK_RTC divided by 64 */
+    RTC_EVGEN1SEL_DIV128_gc = (0x06<<4),  /* CLK_RTC divided by 128 */
+    RTC_EVGEN1SEL_DIV256_gc = (0x07<<4),  /* CLK_RTC divided by 256 */
+    RTC_EVGEN1SEL_DIV512_gc = (0x08<<4),  /* CLK_RTC divided by 512 */
+    RTC_EVGEN1SEL_DIV1024_gc = (0x09<<4),  /* CLK_RTC divided by 1024 */
+    RTC_EVGEN1SEL_DIV2048_gc = (0x0A<<4),  /* CLK_RTC divided by 2048 */
+    RTC_EVGEN1SEL_DIV4096_gc = (0x0B<<4),  /* CLK_RTC divided by 4096 */
+    RTC_EVGEN1SEL_DIV8192_gc = (0x0C<<4),  /* CLK_RTC divided by 8192 */
+    RTC_EVGEN1SEL_DIV16384_gc = (0x0D<<4),  /* CLK_RTC divided by 16384 */
+    RTC_EVGEN1SEL_DIV32768_gc = (0x0E<<4)  /* CLK_RTC divided by 32768 */
+} RTC_EVGEN1SEL_t;
+
+/* Period select */
+typedef enum RTC_PERIOD_enum
+{
+    RTC_PERIOD_OFF_gc = (0x00<<3),  /* Off */
+    RTC_PERIOD_CYC4_gc = (0x01<<3),  /* RTC Clock Cycles 4 */
+    RTC_PERIOD_CYC8_gc = (0x02<<3),  /* RTC Clock Cycles 8 */
+    RTC_PERIOD_CYC16_gc = (0x03<<3),  /* RTC Clock Cycles 16 */
+    RTC_PERIOD_CYC32_gc = (0x04<<3),  /* RTC Clock Cycles 32 */
+    RTC_PERIOD_CYC64_gc = (0x05<<3),  /* RTC Clock Cycles 64 */
+    RTC_PERIOD_CYC128_gc = (0x06<<3),  /* RTC Clock Cycles 128 */
+    RTC_PERIOD_CYC256_gc = (0x07<<3),  /* RTC Clock Cycles 256 */
+    RTC_PERIOD_CYC512_gc = (0x08<<3),  /* RTC Clock Cycles 512 */
+    RTC_PERIOD_CYC1024_gc = (0x09<<3),  /* RTC Clock Cycles 1024 */
+    RTC_PERIOD_CYC2048_gc = (0x0A<<3),  /* RTC Clock Cycles 2048 */
+    RTC_PERIOD_CYC4096_gc = (0x0B<<3),  /* RTC Clock Cycles 4096 */
+    RTC_PERIOD_CYC8192_gc = (0x0C<<3),  /* RTC Clock Cycles 8192 */
+    RTC_PERIOD_CYC16384_gc = (0x0D<<3),  /* RTC Clock Cycles 16384 */
+    RTC_PERIOD_CYC32768_gc = (0x0E<<3)  /* RTC Clock Cycles 32768 */
+} RTC_PERIOD_t;
+
+/* Prescaling Factor select */
+typedef enum RTC_PRESCALER_enum
+{
+    RTC_PRESCALER_DIV1_gc = (0x00<<3),  /* RTC Clock / 1 */
+    RTC_PRESCALER_DIV2_gc = (0x01<<3),  /* RTC Clock / 2 */
+    RTC_PRESCALER_DIV4_gc = (0x02<<3),  /* RTC Clock / 4 */
+    RTC_PRESCALER_DIV8_gc = (0x03<<3),  /* RTC Clock / 8 */
+    RTC_PRESCALER_DIV16_gc = (0x04<<3),  /* RTC Clock / 16 */
+    RTC_PRESCALER_DIV32_gc = (0x05<<3),  /* RTC Clock / 32 */
+    RTC_PRESCALER_DIV64_gc = (0x06<<3),  /* RTC Clock / 64 */
+    RTC_PRESCALER_DIV128_gc = (0x07<<3),  /* RTC Clock / 128 */
+    RTC_PRESCALER_DIV256_gc = (0x08<<3),  /* RTC Clock / 256 */
+    RTC_PRESCALER_DIV512_gc = (0x09<<3),  /* RTC Clock / 512 */
+    RTC_PRESCALER_DIV1024_gc = (0x0A<<3),  /* RTC Clock / 1024 */
+    RTC_PRESCALER_DIV2048_gc = (0x0B<<3),  /* RTC Clock / 2048 */
+    RTC_PRESCALER_DIV4096_gc = (0x0C<<3),  /* RTC Clock / 4096 */
+    RTC_PRESCALER_DIV8192_gc = (0x0D<<3),  /* RTC Clock / 8192 */
+    RTC_PRESCALER_DIV16384_gc = (0x0E<<3),  /* RTC Clock / 16384 */
+    RTC_PRESCALER_DIV32768_gc = (0x0F<<3)  /* RTC Clock / 32768 */
+} RTC_PRESCALER_t;
+
+/*
+--------------------------------------------------------------------------
+SIGROW - Signature row
+--------------------------------------------------------------------------
+*/
+
+/* Signature row */
+typedef struct SIGROW_struct
+{
+    register8_t DEVICEID0;  /* Device ID Byte 0 */
+    register8_t DEVICEID1;  /* Device ID Byte 1 */
+    register8_t DEVICEID2;  /* Device ID Byte 2 */
+    register8_t reserved_1[1];
+    _WORDREGISTER(TEMPSENSE0);  /* Temperature Calibration 0 */
+    _WORDREGISTER(TEMPSENSE1);  /* Temperature Calibration 1 */
+    register8_t reserved_2[8];
+    register8_t SERNUM0;  /* Serial Number Byte 0 */
+    register8_t SERNUM1;  /* Serial Number Byte 1 */
+    register8_t SERNUM2;  /* Serial Number Byte 2 */
+    register8_t SERNUM3;  /* Serial Number Byte 3 */
+    register8_t SERNUM4;  /* Serial Number Byte 4 */
+    register8_t SERNUM5;  /* Serial Number Byte 5 */
+    register8_t SERNUM6;  /* Serial Number Byte 6 */
+    register8_t SERNUM7;  /* Serial Number Byte 7 */
+    register8_t SERNUM8;  /* Serial Number Byte 8 */
+    register8_t SERNUM9;  /* Serial Number Byte 9 */
+    register8_t SERNUM10;  /* Serial Number Byte 10 */
+    register8_t SERNUM11;  /* Serial Number Byte 11 */
+    register8_t SERNUM12;  /* Serial Number Byte 12 */
+    register8_t SERNUM13;  /* Serial Number Byte 13 */
+    register8_t SERNUM14;  /* Serial Number Byte 14 */
+    register8_t SERNUM15;  /* Serial Number Byte 15 */
+    register8_t reserved_3[32];
+} SIGROW_t;
+
+
+/*
+--------------------------------------------------------------------------
+SLPCTRL - Sleep Controller
+--------------------------------------------------------------------------
+*/
+
+/* Sleep Controller */
+typedef struct SLPCTRL_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t reserved_1[15];
+} SLPCTRL_t;
+
+/* Sleep mode select */
+typedef enum SLPCTRL_SMODE_enum
+{
+    SLPCTRL_SMODE_IDLE_gc = (0x00<<1),  /* Idle mode */
+    SLPCTRL_SMODE_STDBY_gc = (0x01<<1),  /* Standby Mode */
+    SLPCTRL_SMODE_PDOWN_gc = (0x02<<1)  /* Power-down Mode */
+} SLPCTRL_SMODE_t;
+
+#define SLEEP_MODE_IDLE (0x00<<1)
+#define SLEEP_MODE_STANDBY (0x01<<1)
+#define SLEEP_MODE_PWR_DOWN (0x02<<1)
+/*
+--------------------------------------------------------------------------
+SPI - Serial Peripheral Interface
+--------------------------------------------------------------------------
+*/
+
+/* Serial Peripheral Interface */
+typedef struct SPI_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t DATA;  /* Data */
+    register8_t reserved_1[11];
+} SPI_t;
+
+/* SPI Mode select */
+typedef enum SPI_MODE_enum
+{
+    SPI_MODE_0_gc = (0x00<<0),  /* SPI Mode 0 */
+    SPI_MODE_1_gc = (0x01<<0),  /* SPI Mode 1 */
+    SPI_MODE_2_gc = (0x02<<0),  /* SPI Mode 2 */
+    SPI_MODE_3_gc = (0x03<<0)  /* SPI Mode 3 */
+} SPI_MODE_t;
+
+/* Prescaler select */
+typedef enum SPI_PRESC_enum
+{
+    SPI_PRESC_DIV4_gc = (0x00<<1),  /* CLK_PER / 4 */
+    SPI_PRESC_DIV16_gc = (0x01<<1),  /* CLK_PER / 16 */
+    SPI_PRESC_DIV64_gc = (0x02<<1),  /* CLK_PER / 64 */
+    SPI_PRESC_DIV128_gc = (0x03<<1)  /* CLK_PER / 128 */
+} SPI_PRESC_t;
+
+/*
+--------------------------------------------------------------------------
+SYSCFG - System Configuration Registers
+--------------------------------------------------------------------------
+*/
+
+/* System Configuration Registers */
+typedef struct SYSCFG_struct
+{
+    register8_t reserved_1[1];
+    register8_t REVID;  /* Revision ID */
+    register8_t reserved_2[62];
+} SYSCFG_t;
+
+
+/*
+--------------------------------------------------------------------------
+TCB - 16-bit Timer/Counter Type B
+--------------------------------------------------------------------------
+*/
+
+/* 16-bit Timer/Counter Type B */
+typedef struct TCB_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    register8_t reserved_1[1];
+    register8_t EVCTRL;  /* Event Control */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t STATUS;  /* Status */
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t TEMP;  /* Temporary Value */
+    _WORDREGISTER(CNT);  /* Count */
+    _WORDREGISTER(CCMP);  /* Compare or Capture */
+    register8_t reserved_2[2];
+} TCB_t;
+
+/* Clock Select */
+typedef enum TCB_CLKSEL_enum
+{
+    TCB_CLKSEL_DIV1_gc = (0x00<<1),  /* CLK_PER */
+    TCB_CLKSEL_DIV2_gc = (0x01<<1),  /* CLK_PER/2 */
+    TCB_CLKSEL_TCE0_gc = (0x02<<1),  /* Use CLK_TCE from TCE0 */
+    TCB_CLKSEL_EVENT_gc = (0x07<<1)  /* Count on event edge */
+} TCB_CLKSEL_t;
+
+/* Timer Mode select */
+typedef enum TCB_CNTMODE_enum
+{
+    TCB_CNTMODE_INT_gc = (0x00<<0),  /* Periodic Interrupt */
+    TCB_CNTMODE_TIMEOUT_gc = (0x01<<0),  /* Periodic Timeout */
+    TCB_CNTMODE_CAPT_gc = (0x02<<0),  /* Input Capture Event */
+    TCB_CNTMODE_FRQ_gc = (0x03<<0),  /* Input Capture Frequency measurement */
+    TCB_CNTMODE_PW_gc = (0x04<<0),  /* Input Capture Pulse-Width measurement */
+    TCB_CNTMODE_FRQPW_gc = (0x05<<0),  /* Input Capture Frequency and Pulse-Width measurement */
+    TCB_CNTMODE_SINGLE_gc = (0x06<<0),  /* Single Shot */
+    TCB_CNTMODE_PWM8_gc = (0x07<<0)  /* 8-bit PWM */
+} TCB_CNTMODE_t;
+
+/* Counter Size select */
+typedef enum TCB_CNTSIZE_enum
+{
+    TCB_CNTSIZE_16BITS_gc = (0x00<<0),  /* 16-bit CNT. MAX=16'hFFFF */
+    TCB_CNTSIZE_15BITS_gc = (0x01<<0),  /* 15-bit CNT. MAX=16'h7FFF */
+    TCB_CNTSIZE_14BITS_gc = (0x02<<0),  /* 14-bit CNT. MAX=16'h3FFF */
+    TCB_CNTSIZE_13BITS_gc = (0x03<<0),  /* 13-bit CNT. MAX=16'h1FFF */
+    TCB_CNTSIZE_12BITS_gc = (0x04<<0),  /* 12-bit CNT. MAX=16'h0FFF */
+    TCB_CNTSIZE_11BITS_gc = (0x05<<0),  /* 11-bit CNT. MAX=16'h07FF */
+    TCB_CNTSIZE_10BITS_gc = (0x06<<0),  /* 10-bit CNT. MAX=16'h03FF */
+    TCB_CNTSIZE_9BITS_gc = (0x07<<0)  /* 9-bit CNT. MAX=16'h01FF */
+} TCB_CNTSIZE_t;
+
+/* Event Generation select */
+typedef enum TCB_EVGEN_enum
+{
+    TCB_EVGEN_PULSE_gc = (0x00<<7),  /* Event is generated as pulse at compare match or capture */
+    TCB_EVGEN_WAVEFORM_gc = (0x01<<7)  /* Event is generated as waveform for modes with waveform */
+} TCB_EVGEN_t;
+
+/*
+--------------------------------------------------------------------------
+TCE - 16-bit Timer/Counter Type E
+--------------------------------------------------------------------------
+*/
+
+/* 16-bit Timer/Counter Type E */
+typedef struct TCE_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    register8_t CTRLD;  /* Control D */
+    register8_t CTRLECLR;  /* Control E Clear */
+    register8_t CTRLESET;  /* Control E Set */
+    register8_t CTRLFCLR;  /* Control F Clear */
+    register8_t CTRLFSET;  /* Control F Set */
+    register8_t EVGENCTRL;  /* Event Generation Control */
+    register8_t EVCTRL;  /* Event Control */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t reserved_1[2];
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t TEMP;  /* Temporary data for 16-bit Access */
+    register8_t reserved_2[16];
+    _WORDREGISTER(CNT);  /* Count */
+    _WORDREGISTER(AMP);  /* Amplitude */
+    _WORDREGISTER(OFFSET);  /* Offset */
+    _WORDREGISTER(PER);  /* Period */
+    _WORDREGISTER(CMP0);  /* Compare 0 */
+    _WORDREGISTER(CMP1);  /* Compare 1 */
+    _WORDREGISTER(CMP2);  /* Compare 2 */
+    _WORDREGISTER(CMP3);  /* Compare 3 */
+    register8_t reserved_3[6];
+    _WORDREGISTER(PERBUF);  /* Period Buffer */
+    _WORDREGISTER(CMP0BUF);  /* Compare 0 Buffer */
+    _WORDREGISTER(CMP1BUF);  /* Compare 1 Buffer */
+    _WORDREGISTER(CMP2BUF);  /* Compare 2 Buffer */
+    _WORDREGISTER(CMP3BUF);  /* Compare 3 Buffer */
+} TCE_t;
+
+/* Clock Selection */
+typedef enum TCE_CLKSEL_enum
+{
+    TCE_CLKSEL_DIV1_gc = (0x00<<1),  /* System Clock */
+    TCE_CLKSEL_DIV2_gc = (0x01<<1),  /* System Clock / 2 */
+    TCE_CLKSEL_DIV4_gc = (0x02<<1),  /* System Clock / 4 */
+    TCE_CLKSEL_DIV8_gc = (0x03<<1),  /* System Clock / 8 */
+    TCE_CLKSEL_DIV16_gc = (0x04<<1),  /* System Clock / 16 */
+    TCE_CLKSEL_DIV64_gc = (0x05<<1),  /* System Clock / 64 */
+    TCE_CLKSEL_DIV256_gc = (0x06<<1),  /* System Clock / 256 */
+    TCE_CLKSEL_DIV1024_gc = (0x07<<1)  /* System Clock / 1024 */
+} TCE_CLKSEL_t;
+
+/* Command select */
+typedef enum TCE_CMD_enum
+{
+    TCE_CMD_NONE_gc = (0x00<<2),  /* No Command */
+    TCE_CMD_UPDATE_gc = (0x01<<2),  /* Force Update */
+    TCE_CMD_RESTART_gc = (0x02<<2),  /* Force Restart */
+    TCE_CMD_RESET_gc = (0x03<<2)  /* Force Hard Reset */
+} TCE_CMD_t;
+
+/* Compare # Event select */
+typedef enum TCE_CMP0EV_enum
+{
+    TCE_CMP0EV_PULSE_gc = (0x00<<4),  /* Event output for CMP is a pulse */
+    TCE_CMP0EV_WAVEFORM_gc = (0x01<<4)  /* Event output for CMP is equal to waveform */
+} TCE_CMP0EV_t;
+
+/* Compare # Event select */
+typedef enum TCE_CMP1EV_enum
+{
+    TCE_CMP1EV_PULSE_gc = (0x00<<5),  /* Event output for CMP is a pulse */
+    TCE_CMP1EV_WAVEFORM_gc = (0x01<<5)  /* Event output for CMP is equal to waveform */
+} TCE_CMP1EV_t;
+
+/* Compare # Event select */
+typedef enum TCE_CMP2EV_enum
+{
+    TCE_CMP2EV_PULSE_gc = (0x00<<6),  /* Event output for CMP is a pulse */
+    TCE_CMP2EV_WAVEFORM_gc = (0x01<<6)  /* Event output for CMP is equal to waveform */
+} TCE_CMP2EV_t;
+
+/* Compare # Event select */
+typedef enum TCE_CMP3EV_enum
+{
+    TCE_CMP3EV_PULSE_gc = (0x00<<7),  /* Event output for CMP is a pulse */
+    TCE_CMP3EV_WAVEFORM_gc = (0x01<<7)  /* Event output for CMP is equal to waveform */
+} TCE_CMP3EV_t;
+
+/* Direction select */
+typedef enum TCE_DIR_enum
+{
+    TCE_DIR_UP_gc = (0x00<<0),  /* Count up */
+    TCE_DIR_DOWN_gc = (0x01<<0)  /* Count down */
+} TCE_DIR_t;
+
+/* Event Action A select */
+typedef enum TCE_EVACTA_enum
+{
+    TCE_EVACTA_CNT_POSEDGE_gc = (0x00<<1),  /* Count on positive edge event */
+    TCE_EVACTA_CNT_ANYEDGE_gc = (0x01<<1),  /* Count on any edge event */
+    TCE_EVACTA_CNT_HIGHLVL_gc = (0x02<<1),  /* Count on prescaled clock while event line is 1. */
+    TCE_EVACTA_UPDOWN_gc = (0x03<<1)  /* Count on prescaled clock. Event controls count direction. Up-count when event line is 0, down-count when event line is 1. */
+} TCE_EVACTA_t;
+
+/* Event Action B select */
+typedef enum TCE_EVACTB_enum
+{
+    TCE_EVACTB_NONE_gc = (0x00<<5),  /* No Action */
+    TCE_EVACTB_UPDOWN_gc = (0x03<<5),  /* Count on prescaled clock. Event controls count direction. Up-count when event line is 0, down-count when event line is 1. */
+    TCE_EVACTB_RESTART_POSEDGE_gc = (0x04<<5),  /* Restart counter at positive edge event */
+    TCE_EVACTB_RESTART_ANYEDGE_gc = (0x05<<5),  /* Restart counter on any edge event */
+    TCE_EVACTB_RESTART_HIGHLVL_gc = (0x06<<5)  /* Restart counter while event line is 1. */
+} TCE_EVACTB_t;
+
+/* High Resolution Enable select */
+typedef enum TCE_HREN_enum
+{
+    TCE_HREN_OFF_gc = (0x00<<6),  /* High Resolution Disable */
+    TCE_HREN_4X_gc = (0x01<<6),  /* Resolution increased by 4 (2 bits) */
+    TCE_HREN_8X_gc = (0x02<<6)  /* Resolution increased by 4 (3 bits) */
+} TCE_HREN_t;
+
+/* Scaled Write select */
+typedef enum TCE_SCALE_enum
+{
+    TCE_SCALE_NORMAL_gc = (0x00<<2),  /* Absolute values used when writing to CMPn, CMPnBUF and registers */
+    TCE_SCALE_FRACTIONAL_gc = (0x01<<2)  /* Fractional values used when writing to CMPn, CMPnBUF and registers */
+} TCE_SCALE_t;
+
+/* Scaling Mode select */
+typedef enum TCE_SCALEMODE_enum
+{
+    TCE_SCALEMODE_CENTER_gc = (0x00<<4),  /* CMPn registers scaled vs center (50% duty cycle) */
+    TCE_SCALEMODE_BOTTOM_gc = (0x01<<4),  /* CMPn registers scaled vs BOTTOM (0% duty cycle) */
+    TCE_SCALEMODE_TOP_gc = (0x02<<4),  /* CMPn registers scaled vs TOP (100% duty cycle) */
+    TCE_SCALEMODE_TOPBOTTOM_gc = (0x03<<4)  /* CMPn registers scaled vs TOP or BOTTOM depending on written value. */
+} TCE_SCALEMODE_t;
+
+/* Waveform generation mode select */
+typedef enum TCE_WGMODE_enum
+{
+    TCE_WGMODE_NORMAL_gc = (0x00<<0),  /* Normal Mode */
+    TCE_WGMODE_FRQ_gc = (0x01<<0),  /* Frequency Generation Mode */
+    TCE_WGMODE_SINGLESLOPE_gc = (0x03<<0),  /* Single Slope PWM */
+    TCE_WGMODE_DSTOP_gc = (0x05<<0),  /* Dual Slope PWM, overflow on TOP */
+    TCE_WGMODE_DSBOTH_gc = (0x06<<0),  /* Dual Slope PWM, overflow on TOP and BOTTOM */
+    TCE_WGMODE_DSBOTTOM_gc = (0x07<<0)  /* Dual Slope PWM, overflow on BOTTOM */
+} TCE_WGMODE_t;
+
+/*
+--------------------------------------------------------------------------
+TCF - 24-bit Timer/Counter for frequency generation
+--------------------------------------------------------------------------
+*/
+
+/* 24-bit Timer/Counter for frequency generation */
+typedef struct TCF_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    register8_t CTRLD;  /* Control D */
+    register8_t EVCTRL;  /* Event Control */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t STATUS;  /* Status */
+    register8_t reserved_1[5];
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t reserved_2[2];
+    _DWORDREGISTER(CNT);  /* Count */
+    _DWORDREGISTER(CMP);  /* Compare */
+    register8_t reserved_3[8];
+} TCF_t;
+
+/* Clock Select */
+typedef enum TCF_CLKSEL_enum
+{
+    TCF_CLKSEL_CLKPER_gc = (0x00<<3),  /* Peripheral Clock */
+    TCF_CLKSEL_EVENT_gc = (0x01<<3),  /* Event as clock source */
+    TCF_CLKSEL_OSCHF_gc = (0x02<<3),  /* Internal High Frequency Oscillator */
+    TCF_CLKSEL_OSC32K_gc = (0x03<<3),  /* Internal 32.768 kHz Oscillator */
+    TCF_CLKSEL_PLL_gc = (0x05<<3)  /* PLL */
+} TCF_CLKSEL_t;
+
+/* Command select */
+typedef enum TCF_CMD_enum
+{
+    TCF_CMD_NONE_gc = (0x00<<0),  /* No command */
+    TCF_CMD_UPDATE_gc = (0x01<<0),  /* Force update */
+    TCF_CMD_RESTART_gc = (0x02<<0)  /* Force restart */
+} TCF_CMD_t;
+
+/* Compare # Event Generation select */
+typedef enum TCF_CMP0EV_enum
+{
+    TCF_CMP0EV_PULSE_gc = (0x00<<6),  /* Event is generated as pulse */
+    TCF_CMP0EV_WAVEFORM_gc = (0x01<<6)  /* Waveform is used as event output */
+} TCF_CMP0EV_t;
+
+/* Compare # Event Generation select */
+typedef enum TCF_CMP1EV_enum
+{
+    TCF_CMP1EV_PULSE_gc = (0x00<<7),  /* Event is generated as pulse */
+    TCF_CMP1EV_WAVEFORM_gc = (0x01<<7)  /* Waveform is used as event output */
+} TCF_CMP1EV_t;
+
+/* Event Action A select */
+typedef enum TCF_EVACTA_enum
+{
+    TCF_EVACTA_RESTART_gc = (0x00<<1),  /* Restart Counter */
+    TCF_EVACTA_BLANK_gc = (0x01<<1)  /* Mask waveform output to '0' */
+} TCF_EVACTA_t;
+
+/* Clock Prescaler select */
+typedef enum TCF_PRESC_enum
+{
+    TCF_PRESC_DIV1_gc = (0x00<<1),  /* Runs directly on Clock Source */
+    TCF_PRESC_DIV2_gc = (0x01<<1),  /* Divide clock source by 2 */
+    TCF_PRESC_DIV4_gc = (0x02<<1),  /* Divide clock source by 4 */
+    TCF_PRESC_DIV8_gc = (0x03<<1),  /* Divide clock source by 8 */
+    TCF_PRESC_DIV16_gc = (0x04<<1),  /* Divide clock source by 16 */
+    TCF_PRESC_DIV32_gc = (0x05<<1),  /* Divide clock source by 32 */
+    TCF_PRESC_DIV64_gc = (0x06<<1),  /* Divide clock source by 64 */
+    TCF_PRESC_DIV128_gc = (0x07<<1)  /* Divide clock source by 128 */
+} TCF_PRESC_t;
+
+/* Waveform Generation Mode select */
+typedef enum TCF_WGMODE_enum
+{
+    TCF_WGMODE_FRQ_gc = (0x00<<0),  /* Frequency */
+    TCF_WGMODE_NCOPF_gc = (0x01<<0),  /* Numerically Controlled Oscillator Pulse-Frequency */
+    TCF_WGMODE_NCOFDC_gc = (0x02<<0),  /* Numerically Controlled Oscillator Fixed Duty Cycle */
+    TCF_WGMODE_PWM8_gc = (0x07<<0)  /* 8-bit PWM */
+} TCF_WGMODE_t;
+
+/* Waveform Generation Pulse Length select */
+typedef enum TCF_WGPULSE_enum
+{
+    TCF_WGPULSE_CLK1_gc = (0x00<<4),  /* High pulse duration is 1 clock period */
+    TCF_WGPULSE_CLK2_gc = (0x01<<4),  /* High pulse duration is 2 clock period */
+    TCF_WGPULSE_CLK4_gc = (0x02<<4),  /* High pulse duration is 4 clock period */
+    TCF_WGPULSE_CLK8_gc = (0x03<<4),  /* High pulse duration is 8 clock period */
+    TCF_WGPULSE_CLK16_gc = (0x04<<4),  /* High pulse duration is 16 clock period */
+    TCF_WGPULSE_CLK32_gc = (0x05<<4),  /* High pulse duration is 32 clock period */
+    TCF_WGPULSE_CLK64_gc = (0x06<<4),  /* High pulse duration is 64 clock period */
+    TCF_WGPULSE_CLK128_gc = (0x07<<4)  /* High pulse duration is 128 clock period */
+} TCF_WGPULSE_t;
+
+/* Waveform Output # Polarity select */
+typedef enum TCF_WO0POL_enum
+{
+    TCF_WO0POL_NORMAL_gc = (0x00<<2),  /* Waveform output set on update and cleared on match */
+    TCF_WO0POL_INVERSE_gc = (0x01<<2)  /* Waveform output cleared on update and set on match */
+} TCF_WO0POL_t;
+
+/* Waveform Output # Polarity select */
+typedef enum TCF_WO1POL_enum
+{
+    TCF_WO1POL_NORMAL_gc = (0x00<<3),  /* Waveform output set on update and cleared on match */
+    TCF_WO1POL_INVERSE_gc = (0x01<<3)  /* Waveform output cleared on update and set on match */
+} TCF_WO1POL_t;
+
+/*
+--------------------------------------------------------------------------
+TWI - Two-Wire Interface
+--------------------------------------------------------------------------
+*/
+
+/* Two-Wire Interface */
+typedef struct TWI_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t DUALCTRL;  /* Dual Mode Control */
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t MCTRLA;  /* Host Control A */
+    register8_t MCTRLB;  /* Host Control B */
+    register8_t MSTATUS;  /* Host STATUS */
+    register8_t MBAUD;  /* Host Baud Rate */
+    register8_t MADDR;  /* Host Address */
+    register8_t MDATA;  /* Host Data */
+    register8_t SCTRLA;  /* Client Control A */
+    register8_t SCTRLB;  /* Client Control B */
+    register8_t SSTATUS;  /* Client Status */
+    register8_t SADDR;  /* Client Address */
+    register8_t SDATA;  /* Client Data */
+    register8_t SADDRMASK;  /* Client Address Mask */
+    register8_t reserved_1[1];
+} TWI_t;
+
+/* Acknowledge Action select */
+typedef enum TWI_ACKACT_enum
+{
+    TWI_ACKACT_ACK_gc = (0x00<<2),  /* Send ACK */
+    TWI_ACKACT_NACK_gc = (0x01<<2)  /* Send NACK */
+} TWI_ACKACT_t;
+
+/* Address or Stop select */
+typedef enum TWI_AP_enum
+{
+    TWI_AP_STOP_gc = (0x00<<0),  /* A Stop condition generated the interrupt on APIF flag */
+    TWI_AP_ADR_gc = (0x01<<0)  /* Address detection generated the interrupt on APIF flag */
+} TWI_AP_t;
+
+/* Bus State select */
+typedef enum TWI_BUSSTATE_enum
+{
+    TWI_BUSSTATE_UNKNOWN_gc = (0x00<<0),  /* Unknown bus state */
+    TWI_BUSSTATE_IDLE_gc = (0x01<<0),  /* Bus is idle */
+    TWI_BUSSTATE_OWNER_gc = (0x02<<0),  /* This TWI controls the bus */
+    TWI_BUSSTATE_BUSY_gc = (0x03<<0)  /* The bus is busy */
+} TWI_BUSSTATE_t;
+
+/* Debug Run select */
+typedef enum TWI_DBGRUN_enum
+{
+    TWI_DBGRUN_HALT_gc = (0x00<<0),  /* The peripheral is halted in Break Debug mode and ignores events */
+    TWI_DBGRUN_RUN_gc = (0x01<<0)  /* The peripheral will continue to run in Break Debug mode when the CPU is halted */
+} TWI_DBGRUN_t;
+
+/* Fast-mode Enable select */
+typedef enum TWI_FMEN_enum
+{
+    TWI_FMEN_OFF_gc = (0x00<<0),  /* SCL duty cycle operating according to Sm specification */
+    TWI_FMEN_ON_gc = (0x01<<0)  /* SCL duty cycle operating according to Fm specification */
+} TWI_FMEN_t;
+
+/* Fast-mode Plus Enable select */
+typedef enum TWI_FMPEN_enum
+{
+    TWI_FMPEN_OFF_gc = (0x00<<1),  /* Operating in Standard-mode or Fast-mode */
+    TWI_FMPEN_ON_gc = (0x01<<1)  /* Operating in Fast-mode Plus */
+} TWI_FMPEN_t;
+
+/* Input voltage transition level select */
+typedef enum TWI_INPUTLVL_enum
+{
+    TWI_INPUTLVL_I2C_gc = (0x00<<6),  /* I2C input voltage transition level */
+    TWI_INPUTLVL_SMBUS_gc = (0x01<<6)  /* SMBus 3.0 input voltage transition level */
+} TWI_INPUTLVL_t;
+
+/* Command select */
+typedef enum TWI_MCMD_enum
+{
+    TWI_MCMD_NOACT_gc = (0x00<<0),  /* No action */
+    TWI_MCMD_REPSTART_gc = (0x01<<0),  /* Execute Acknowledge Action followed by repeated Start. */
+    TWI_MCMD_RECVTRANS_gc = (0x02<<0),  /* Execute Acknowledge Action followed by a byte read/write operation. Read/write is defined by DIR. */
+    TWI_MCMD_STOP_gc = (0x03<<0)  /* Execute Acknowledge Action followed by issuing a Stop condition. */
+} TWI_MCMD_t;
+
+/* Command select */
+typedef enum TWI_SCMD_enum
+{
+    TWI_SCMD_NOACT_gc = (0x00<<0),  /* No Action */
+    TWI_SCMD_COMPTRANS_gc = (0x02<<0),  /* Complete transaction */
+    TWI_SCMD_RESPONSE_gc = (0x03<<0)  /* Used in response to an interrupt */
+} TWI_SCMD_t;
+
+/* SDA Hold Time select */
+typedef enum TWI_SDAHOLD_enum
+{
+    TWI_SDAHOLD_OFF_gc = (0x00<<2),  /* No SDA Hold Delay */
+    TWI_SDAHOLD_50NS_gc = (0x01<<2),  /* Short SDA hold time */
+    TWI_SDAHOLD_300NS_gc = (0x02<<2),  /* Meets SMBUS 2.0 specification under typical conditions */
+    TWI_SDAHOLD_500NS_gc = (0x03<<2)  /* Meets SMBUS 2.0 specificaiton across all corners */
+} TWI_SDAHOLD_t;
+
+/* SDA Setup Time select */
+typedef enum TWI_SDASETUP_enum
+{
+    TWI_SDASETUP_4CYC_gc = (0x00<<4),  /* SDA setup time is four clock cycles */
+    TWI_SDASETUP_8CYC_gc = (0x01<<4)  /* SDA setup time is eight clock cycle */
+} TWI_SDASETUP_t;
+
+/* Inactive Bus Time-Out select */
+typedef enum TWI_TIMEOUT_enum
+{
+    TWI_TIMEOUT_DISABLED_gc = (0x00<<2),  /* Bus time-out disabled. I2C. */
+    TWI_TIMEOUT_50US_gc = (0x01<<2),  /* 50us - SMBus */
+    TWI_TIMEOUT_100US_gc = (0x02<<2),  /* 100us */
+    TWI_TIMEOUT_200US_gc = (0x03<<2)  /* 200us */
+} TWI_TIMEOUT_t;
+
+/*
+--------------------------------------------------------------------------
+USART - Universal Synchronous and Asynchronous Receiver and Transmitter
+--------------------------------------------------------------------------
+*/
+
+/* Universal Synchronous and Asynchronous Receiver and Transmitter */
+typedef struct USART_struct
+{
+    register8_t RXDATAL;  /* Receive Data Low Byte */
+    register8_t RXDATAH;  /* Receive Data High Byte */
+    register8_t TXDATAL;  /* Transmit Data Low Byte */
+    register8_t TXDATAH;  /* Transmit Data High Byte */
+    register8_t STATUS;  /* Status */
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    _WORDREGISTER(BAUD);  /* Baud Rate */
+    register8_t CTRLD;  /* Control D */
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t EVCTRL;  /* Event Control */
+    register8_t TXPLCTRL;  /* IRCOM Transmitter Pulse Length Control */
+    register8_t RXPLCTRL;  /* IRCOM Receiver Pulse Length Control */
+    register8_t reserved_1[1];
+} USART_t;
+
+/* Auto Baud Window select */
+typedef enum USART_ABW_enum
+{
+    USART_ABW_WDW0_gc = (0x00<<6),  /* 18% tolerance */
+    USART_ABW_WDW1_gc = (0x01<<6),  /* 15% tolerance */
+    USART_ABW_WDW2_gc = (0x02<<6),  /* 21% tolerance */
+    USART_ABW_WDW3_gc = (0x03<<6)  /* 25% tolerance */
+} USART_ABW_t;
+
+/* Character Size select */
+typedef enum USART_CHSIZE_enum
+{
+    USART_CHSIZE_5BIT_gc = (0x00<<0),  /* Character size: 5 bit */
+    USART_CHSIZE_6BIT_gc = (0x01<<0),  /* Character size: 6 bit */
+    USART_CHSIZE_7BIT_gc = (0x02<<0),  /* Character size: 7 bit */
+    USART_CHSIZE_8BIT_gc = (0x03<<0),  /* Character size: 8 bit */
+    USART_CHSIZE_9BITL_gc = (0x06<<0),  /* Character size: 9 bit read low byte first */
+    USART_CHSIZE_9BITH_gc = (0x07<<0)  /* Character size: 9 bit read high byte first */
+} USART_CHSIZE_t;
+
+/* Communication Mode select */
+typedef enum USART_CMODE_enum
+{
+    USART_CMODE_ASYNCHRONOUS_gc = (0x00<<6),  /* Asynchronous Mode */
+    USART_CMODE_SYNCHRONOUS_gc = (0x01<<6),  /* Synchronous Mode */
+    USART_CMODE_IRCOM_gc = (0x02<<6),  /* Infrared Communication */
+    USART_CMODE_MSPI_gc = (0x03<<6)  /* SPI Host Mode */
+} USART_CMODE_t;
+
+/* Parity Mode select */
+typedef enum USART_PMODE_enum
+{
+    USART_PMODE_DISABLED_gc = (0x00<<4),  /* No Parity */
+    USART_PMODE_EVEN_gc = (0x02<<4),  /* Even Parity */
+    USART_PMODE_ODD_gc = (0x03<<4)  /* Odd Parity */
+} USART_PMODE_t;
+
+/* RS485 Mode internal transmitter select */
+typedef enum USART_RS485_enum
+{
+    USART_RS485_DISABLE_gc = (0x00<<0),  /* RS485 Mode disabled */
+    USART_RS485_ENABLE_gc = (0x01<<0)  /* RS485 Mode enabled */
+} USART_RS485_t;
+
+/* Receiver Mode select */
+typedef enum USART_RXMODE_enum
+{
+    USART_RXMODE_NORMAL_gc = (0x00<<1),  /* Normal mode */
+    USART_RXMODE_CLK2X_gc = (0x01<<1),  /* CLK2x mode */
+    USART_RXMODE_GENAUTO_gc = (0x02<<1),  /* Generic autobaud mode */
+    USART_RXMODE_LINAUTO_gc = (0x03<<1)  /* LIN constrained autobaud mode */
+} USART_RXMODE_t;
+
+/* Stop Bit Mode select */
+typedef enum USART_SBMODE_enum
+{
+    USART_SBMODE_1BIT_gc = (0x00<<3),  /* 1 stop bit */
+    USART_SBMODE_2BIT_gc = (0x01<<3)  /* 2 stop bits */
+} USART_SBMODE_t;
+
+/*
+--------------------------------------------------------------------------
+USERROW - User Row
+--------------------------------------------------------------------------
+*/
+
+/* User Row */
+typedef struct USERROW_struct
+{
+    register8_t USERROW0;  /* User Row Byte 0 */
+    register8_t USERROW1;  /* User Row Byte 1 */
+    register8_t USERROW2;  /* User Row Byte 2 */
+    register8_t USERROW3;  /* User Row Byte 3 */
+    register8_t USERROW4;  /* User Row Byte 4 */
+    register8_t USERROW5;  /* User Row Byte 5 */
+    register8_t USERROW6;  /* User Row Byte 6 */
+    register8_t USERROW7;  /* User Row Byte 7 */
+    register8_t USERROW8;  /* User Row Byte 8 */
+    register8_t USERROW9;  /* User Row Byte 9 */
+    register8_t USERROW10;  /* User Row Byte 10 */
+    register8_t USERROW11;  /* User Row Byte 11 */
+    register8_t USERROW12;  /* User Row Byte 12 */
+    register8_t USERROW13;  /* User Row Byte 13 */
+    register8_t USERROW14;  /* User Row Byte 14 */
+    register8_t USERROW15;  /* User Row Byte 15 */
+    register8_t USERROW16;  /* User Row Byte 16 */
+    register8_t USERROW17;  /* User Row Byte 17 */
+    register8_t USERROW18;  /* User Row Byte 18 */
+    register8_t USERROW19;  /* User Row Byte 19 */
+    register8_t USERROW20;  /* User Row Byte 20 */
+    register8_t USERROW21;  /* User Row Byte 21 */
+    register8_t USERROW22;  /* User Row Byte 22 */
+    register8_t USERROW23;  /* User Row Byte 23 */
+    register8_t USERROW24;  /* User Row Byte 24 */
+    register8_t USERROW25;  /* User Row Byte 25 */
+    register8_t USERROW26;  /* User Row Byte 26 */
+    register8_t USERROW27;  /* User Row Byte 27 */
+    register8_t USERROW28;  /* User Row Byte 28 */
+    register8_t USERROW29;  /* User Row Byte 29 */
+    register8_t USERROW30;  /* User Row Byte 30 */
+    register8_t USERROW31;  /* User Row Byte 31 */
+    register8_t USERROW32;  /* User Row Byte 32 */
+    register8_t USERROW33;  /* User Row Byte 33 */
+    register8_t USERROW34;  /* User Row Byte 34 */
+    register8_t USERROW35;  /* User Row Byte 35 */
+    register8_t USERROW36;  /* User Row Byte 36 */
+    register8_t USERROW37;  /* User Row Byte 37 */
+    register8_t USERROW38;  /* User Row Byte 38 */
+    register8_t USERROW39;  /* User Row Byte 39 */
+    register8_t USERROW40;  /* User Row Byte 40 */
+    register8_t USERROW41;  /* User Row Byte 41 */
+    register8_t USERROW42;  /* User Row Byte 42 */
+    register8_t USERROW43;  /* User Row Byte 43 */
+    register8_t USERROW44;  /* User Row Byte 44 */
+    register8_t USERROW45;  /* User Row Byte 45 */
+    register8_t USERROW46;  /* User Row Byte 46 */
+    register8_t USERROW47;  /* User Row Byte 47 */
+    register8_t USERROW48;  /* User Row Byte 48 */
+    register8_t USERROW49;  /* User Row Byte 49 */
+    register8_t USERROW50;  /* User Row Byte 50 */
+    register8_t USERROW51;  /* User Row Byte 51 */
+    register8_t USERROW52;  /* User Row Byte 52 */
+    register8_t USERROW53;  /* User Row Byte 53 */
+    register8_t USERROW54;  /* User Row Byte 54 */
+    register8_t USERROW55;  /* User Row Byte 55 */
+    register8_t USERROW56;  /* User Row Byte 56 */
+    register8_t USERROW57;  /* User Row Byte 57 */
+    register8_t USERROW58;  /* User Row Byte 58 */
+    register8_t USERROW59;  /* User Row Byte 59 */
+    register8_t USERROW60;  /* User Row Byte 60 */
+    register8_t USERROW61;  /* User Row Byte 61 */
+    register8_t USERROW62;  /* User Row Byte 62 */
+    register8_t USERROW63;  /* User Row Byte 63 */
+} USERROW_t;
+
+
+/*
+--------------------------------------------------------------------------
+VPORT - Virtual Ports
+--------------------------------------------------------------------------
+*/
+
+/* Virtual Ports */
+typedef struct VPORT_struct
+{
+    register8_t DIR;  /* Data Direction */
+    register8_t OUT;  /* Output Value */
+    register8_t IN;  /* Input Value */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+} VPORT_t;
+
+
+/*
+--------------------------------------------------------------------------
+VREF - Voltage reference
+--------------------------------------------------------------------------
+*/
+
+/* Voltage reference */
+typedef struct VREF_struct
+{
+    register8_t reserved_1[2];
+    register8_t DAC0REF;  /* DAC0 Reference */
+    register8_t reserved_2[1];
+    register8_t ACREF;  /* AC Reference */
+    register8_t reserved_3[11];
+} VREF_t;
+
+/* Reference select */
+typedef enum VREF_REFSEL_enum
+{
+    VREF_REFSEL_1V024_gc = (0x00<<0),  /* Internal 1.024V reference */
+    VREF_REFSEL_2V048_gc = (0x01<<0),  /* Internal 2.048V reference */
+    VREF_REFSEL_4V096_gc = (0x02<<0),  /* Internal 4.096V reference */
+    VREF_REFSEL_2V500_gc = (0x03<<0),  /* Internal 2.500V reference */
+    VREF_REFSEL_VDD_gc = (0x05<<0),  /* VDD as reference */
+    VREF_REFSEL_VREFA_gc = (0x06<<0)  /* External reference on VREFA pin */
+} VREF_REFSEL_t;
+
+/*
+--------------------------------------------------------------------------
+WDT - Watch-Dog Timer
+--------------------------------------------------------------------------
+*/
+
+/* Watch-Dog Timer */
+typedef struct WDT_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t STATUS;  /* Status */
+    register8_t reserved_1[14];
+} WDT_t;
+
+/* Period select */
+typedef enum WDT_PERIOD_enum
+{
+    WDT_PERIOD_OFF_gc = (0x00<<0),  /* Off */
+    WDT_PERIOD_8CLK_gc = (0x01<<0),  /* 8 cycles (8ms) */
+    WDT_PERIOD_16CLK_gc = (0x02<<0),  /* 16 cycles (16ms) */
+    WDT_PERIOD_32CLK_gc = (0x03<<0),  /* 32 cycles (32ms) */
+    WDT_PERIOD_64CLK_gc = (0x04<<0),  /* 64 cycles (64ms) */
+    WDT_PERIOD_128CLK_gc = (0x05<<0),  /* 128 cycles (0.128s) */
+    WDT_PERIOD_256CLK_gc = (0x06<<0),  /* 256 cycles (0.256s) */
+    WDT_PERIOD_512CLK_gc = (0x07<<0),  /* 512 cycles (0.512s) */
+    WDT_PERIOD_1KCLK_gc = (0x08<<0),  /* 1K cycles (1.0s) */
+    WDT_PERIOD_2KCLK_gc = (0x09<<0),  /* 2K cycles (2.0s) */
+    WDT_PERIOD_4KCLK_gc = (0x0A<<0),  /* 4K cycles (4.1s) */
+    WDT_PERIOD_8KCLK_gc = (0x0B<<0)  /* 8K cycles (8.2s) */
+} WDT_PERIOD_t;
+
+/* Window select */
+typedef enum WDT_WINDOW_enum
+{
+    WDT_WINDOW_OFF_gc = (0x00<<4),  /* Off */
+    WDT_WINDOW_8CLK_gc = (0x01<<4),  /* 8 cycles (8ms) */
+    WDT_WINDOW_16CLK_gc = (0x02<<4),  /* 16 cycles (16ms) */
+    WDT_WINDOW_32CLK_gc = (0x03<<4),  /* 32 cycles (32ms) */
+    WDT_WINDOW_64CLK_gc = (0x04<<4),  /* 64 cycles (64ms) */
+    WDT_WINDOW_128CLK_gc = (0x05<<4),  /* 128 cycles (0.128s) */
+    WDT_WINDOW_256CLK_gc = (0x06<<4),  /* 256 cycles (0.256s) */
+    WDT_WINDOW_512CLK_gc = (0x07<<4),  /* 512 cycles (0.512s) */
+    WDT_WINDOW_1KCLK_gc = (0x08<<4),  /* 1K cycles (1.0s) */
+    WDT_WINDOW_2KCLK_gc = (0x09<<4),  /* 2K cycles (2.0s) */
+    WDT_WINDOW_4KCLK_gc = (0x0A<<4),  /* 4K cycles (4.1s) */
+    WDT_WINDOW_8KCLK_gc = (0x0B<<4)  /* 8K cycles (8.2s) */
+} WDT_WINDOW_t;
+
+/*
+--------------------------------------------------------------------------
+WEX - Waveform Extension
+--------------------------------------------------------------------------
+*/
+
+/* Waveform Extension */
+typedef struct WEX_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    register8_t reserved_1[1];
+    register8_t EVCTRLA;  /* Event Control A */
+    register8_t EVCTRLB;  /* Event Control B */
+    register8_t EVCTRLC;  /* Event Control C */
+    register8_t BUFCTRL;  /* Buffer Valid Control */
+    register8_t BLANKCTRL;  /* Blanking Control */
+    register8_t BLANKTIME;  /* Blanking Time */
+    register8_t FAULTCTRL;  /* Fault Control */
+    register8_t FAULTDRV;  /* Fault Drive */
+    register8_t FAULTOUT;  /* Fault Output */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t STATUS;  /* Status */
+    register8_t DTLS;  /* Dead-time Low Side */
+    register8_t DTHS;  /* Dead-time High Side */
+    register8_t DTBOTH;  /* Dead-time Both Sides */
+    register8_t SWAP;  /* DTI Swap */
+    register8_t PGMOVR;  /* Pattern Generation Override */
+    register8_t PGMOUT;  /* Pattern Generation Output */
+    register8_t reserved_2[1];
+    register8_t OUTOVEN;  /* Output Override Enable */
+    register8_t DTLSBUF;  /* Dead-time Low Side Buffer */
+    register8_t DTHSBUF;  /* Dead-time High Side Buffer */
+    register8_t DTBOTHBUF;  /* Dead-time Both Sides Buffer */
+    register8_t SWAPBUF;  /* DTI Swap Buffer */
+    register8_t PGMOVRBUF;  /* Pattern Generation Override Buffer */
+    register8_t PGMOUTBUF;  /* Pattern Generation Output Buffer */
+    register8_t reserved_3[2];
+} WEX_t;
+
+/* Blanking Prescaler select */
+typedef enum WEX_BLANKPRESC_enum
+{
+    WEX_BLANKPRESC_DIV1_gc = (0x00<<5),  /* No prescaling */
+    WEX_BLANKPRESC_DIV4_gc = (0x01<<5),  /* Divide CLK_PER by 4 */
+    WEX_BLANKPRESC_DIV16_gc = (0x02<<5),  /* Divide CLK_PER by 16 */
+    WEX_BLANKPRESC_DIV64_gc = (0x03<<5)  /* Divide CLK_PER by 64 */
+} WEX_BLANKPRESC_t;
+
+/* Blanking State select */
+typedef enum WEX_BLANKSTATE_enum
+{
+    WEX_BLANKSTATE_OFF_gc = (0x00<<7),  /* Blanking off */
+    WEX_BLANKSTATE_ON_gc = (0x01<<7)  /* Blanking active */
+} WEX_BLANKSTATE_t;
+
+/* Blanking Trigger select */
+typedef enum WEX_BLANKTRIG_enum
+{
+    WEX_BLANKTRIG_NONE_gc = (0x00<<0),  /* No HW trigger (Software only) */
+    WEX_BLANKTRIG_TCE0UPD_gc = (0x04<<0),  /* TCE0 Update Condition */
+    WEX_BLANKTRIG_TCE0CMP0_gc = (0x08<<0),  /* TCE0 Compare 0 */
+    WEX_BLANKTRIG_TCE0CMP1_gc = (0x0C<<0),  /* TCE0 Compare 1 */
+    WEX_BLANKTRIG_TCE0CMP2_gc = (0x10<<0),  /* TCE0 Compare 2 */
+    WEX_BLANKTRIG_TCE0CMP3_gc = (0x14<<0)  /* TCE0 Compare 3 */
+} WEX_BLANKTRIG_t;
+
+/* Command select */
+typedef enum WEX_CMD_enum
+{
+    WEX_CMD_NONE_gc = (0x00<<0),  /* No Command */
+    WEX_CMD_UPDATE_gc = (0x01<<0),  /* Force update of Dead-time, SWAP and PGM buffer registers. */
+    WEX_CMD_FAULTSET_gc = (0x02<<0),  /* Set Fault Detection */
+    WEX_CMD_FAULTCLR_gc = (0x03<<0),  /* Clear Fault Detection */
+    WEX_CMD_BLANKSET_gc = (0x04<<0),  /* Set SW Blanking */
+    WEX_CMD_BLANKCLR_gc = (0x05<<0)  /* Clear SW Blanking */
+} WEX_CMD_t;
+
+/* Fault Detection Action select */
+typedef enum WEX_FDACT_enum
+{
+    WEX_FDACT_NONE_gc = (0x00<<0),  /* None. Fault Protection Disabled */
+    WEX_FDACT_LOW_gc = (0x01<<0),  /* Drive all pins low */
+    WEX_FDACT_CUSTOM_gc = (0x03<<0)  /* Drive all pins to setting defined by FAULTDRV and FAULTVAL */
+} WEX_FDACT_t;
+
+/* Fault Detection on Debug Break Detection select */
+typedef enum WEX_FDDBD_enum
+{
+    WEX_FDDBD_FAULT_gc = (0x00<<7),  /* OCD Break request is treated as a fault if fault protection is enabled */
+    WEX_FDDBD_IGNORE_gc = (0x01<<7)  /* OCD Breask request will not trigger a fault */
+} WEX_FDDBD_t;
+
+/* Fault Detection Restart Mode select */
+typedef enum WEX_FDMODE_enum
+{
+    WEX_FDMODE_LATCHED_gc = (0x00<<2),  /* Latched Mode. Output will remain in fault state until fault condition is no longer active and FDF is cleared by SW. */
+    WEX_FDMODE_CBC_gc = (0x01<<2)  /* Cycle-by-cycle mode. Waveform output will remain in fault state until fault condition is no longer active. */
+} WEX_FDMODE_t;
+
+/* Fault Detection State select */
+typedef enum WEX_FDSTATE_enum
+{
+    WEX_FDSTATE_NORMAL_gc = (0x00<<0),  /* Normal state */
+    WEX_FDSTATE_FAULT_gc = (0x01<<0)  /* Fault state */
+} WEX_FDSTATE_t;
+
+/* Fault Event Filter Enable select */
+typedef enum WEX_FILTER_enum
+{
+    WEX_FILTER_ZERO_gc = (0x00<<2),  /* No digital filter */
+    WEX_FILTER_SAMPLE1_gc = (0x01<<2),  /* One Sample */
+    WEX_FILTER_SAMPLE2_gc = (0x02<<2),  /* Two Samples */
+    WEX_FILTER_SAMPLE3_gc = (0x03<<2),  /* Three Samples */
+    WEX_FILTER_SAMPLE4_gc = (0x04<<2),  /* Four Samples */
+    WEX_FILTER_SAMPLE5_gc = (0x05<<2),  /* Five Samples */
+    WEX_FILTER_SAMPLE6_gc = (0x06<<2),  /* Six Samples */
+    WEX_FILTER_SAMPLE7_gc = (0x07<<2)  /* Seven Samples */
+} WEX_FILTER_t;
+
+/* Input Matrix select */
+typedef enum WEX_INMX_enum
+{
+    WEX_INMX_DIRECT_gc = (0x00<<4),  /* Direct from TCE0 */
+    WEX_INMX_CWCMA_gc = (0x02<<4),  /* Common Waveform Channel Mode A. Single WO */
+    WEX_INMX_CWCMB_gc = (0x03<<4)  /* Common Waveform Channel Mode B. WO from two PWM channels */
+} WEX_INMX_t;
+
+/* Update Source select */
+typedef enum WEX_UPDSRC_enum
+{
+    WEX_UPDSRC_TCPWM0_gc = (0x00<<0),  /* Timer/Counter for PWM 0 update condition */
+    WEX_UPDSRC_SW_gc = (0x03<<0)  /* Software update only. No hardware update condition */
+} WEX_UPDSRC_t;
+/*
+==========================================================================
+IO Module Instances. Mapped to memory.
+==========================================================================
+*/
+
+#define VPORTA              (*(VPORT_t *) 0x0000) /* Virtual Ports */
+#define VPORTC              (*(VPORT_t *) 0x0008) /* Virtual Ports */
+#define VPORTD              (*(VPORT_t *) 0x000C) /* Virtual Ports */
+#define VPORTF              (*(VPORT_t *) 0x0014) /* Virtual Ports */
+#define GPR                   (*(GPR_t *) 0x001C) /* General Purpose Registers */
+#define RSTCTRL           (*(RSTCTRL_t *) 0x0040) /* Reset controller */
+#define SLPCTRL           (*(SLPCTRL_t *) 0x0050) /* Sleep Controller */
+#define CLKCTRL           (*(CLKCTRL_t *) 0x0060) /* Clock controller */
+#define BOD                   (*(BOD_t *) 0x00A0) /* Bod interface */
+#define VREF                 (*(VREF_t *) 0x00B0) /* Voltage reference */
+#define WDT                   (*(WDT_t *) 0x0100) /* Watch-Dog Timer */
+#define CPUINT             (*(CPUINT_t *) 0x0110) /* Interrupt Controller */
+#define CRCSCAN           (*(CRCSCAN_t *) 0x0120) /* CRCSCAN */
+#define RTC                   (*(RTC_t *) 0x0140) /* Real-Time Counter */
+#define CCL                   (*(CCL_t *) 0x01C0) /* Configurable Custom Logic */
+#define EVSYS               (*(EVSYS_t *) 0x0200) /* Event System */
+#define PORTA                (*(PORT_t *) 0x0400) /* I/O Ports */
+#define PORTC                (*(PORT_t *) 0x0440) /* I/O Ports */
+#define PORTD                (*(PORT_t *) 0x0460) /* I/O Ports */
+#define PORTF                (*(PORT_t *) 0x04A0) /* I/O Ports */
+#define PORTMUX           (*(PORTMUX_t *) 0x05E0) /* Port Multiplexer */
+#define ADC0                  (*(ADC_t *) 0x0600) /* Analog to Digital Converter */
+#define AC0                    (*(AC_t *) 0x0680) /* Analog Comparator */
+#define AC1                    (*(AC_t *) 0x0688) /* Analog Comparator */
+#define USART0              (*(USART_t *) 0x0800) /* Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define TWI0                  (*(TWI_t *) 0x0900) /* Two-Wire Interface */
+#define SPI0                  (*(SPI_t *) 0x0940) /* Serial Peripheral Interface */
+#define TCE0                  (*(TCE_t *) 0x0A00) /* 16-bit Timer/Counter Type E */
+#define TCB0                  (*(TCB_t *) 0x0B00) /* 16-bit Timer/Counter Type B */
+#define TCB1                  (*(TCB_t *) 0x0B10) /* 16-bit Timer/Counter Type B */
+#define TCF0                  (*(TCF_t *) 0x0C00) /* 24-bit Timer/Counter for frequency generation */
+#define WEX0                  (*(WEX_t *) 0x0C80) /* Waveform Extension */
+#define SYSCFG             (*(SYSCFG_t *) 0x0F00) /* System Configuration Registers */
+#define NVMCTRL           (*(NVMCTRL_t *) 0x1000) /* Non-volatile Memory Controller */
+#define LOCK                 (*(LOCK_t *) 0x1040) /* Lockbits */
+#define FUSE                 (*(FUSE_t *) 0x1050) /* Fuses */
+#define SIGROW             (*(SIGROW_t *) 0x1080) /* Signature row */
+#define BOOTROW           (*(BOOTROW_t *) 0x1100) /* Boot Row */
+#define USERROW           (*(USERROW_t *) 0x1200) /* User Row */
+
+#endif /* !defined (__ASSEMBLER__) */
+
+
+/* ========== Flattened fully qualified IO register names ========== */
+
+
+/* VPORT (VPORTA) - Virtual Ports */
+#define VPORTA_DIR  _SFR_MEM8(0x0000)
+#define VPORTA_OUT  _SFR_MEM8(0x0001)
+#define VPORTA_IN  _SFR_MEM8(0x0002)
+#define VPORTA_INTFLAGS  _SFR_MEM8(0x0003)
+
+
+/* VPORT (VPORTC) - Virtual Ports */
+#define VPORTC_DIR  _SFR_MEM8(0x0008)
+#define VPORTC_OUT  _SFR_MEM8(0x0009)
+#define VPORTC_IN  _SFR_MEM8(0x000A)
+#define VPORTC_INTFLAGS  _SFR_MEM8(0x000B)
+
+
+/* VPORT (VPORTD) - Virtual Ports */
+#define VPORTD_DIR  _SFR_MEM8(0x000C)
+#define VPORTD_OUT  _SFR_MEM8(0x000D)
+#define VPORTD_IN  _SFR_MEM8(0x000E)
+#define VPORTD_INTFLAGS  _SFR_MEM8(0x000F)
+
+
+/* VPORT (VPORTF) - Virtual Ports */
+#define VPORTF_DIR  _SFR_MEM8(0x0014)
+#define VPORTF_OUT  _SFR_MEM8(0x0015)
+#define VPORTF_IN  _SFR_MEM8(0x0016)
+#define VPORTF_INTFLAGS  _SFR_MEM8(0x0017)
+
+
+/* GPR - General Purpose Registers */
+#define GPR_GPR0  _SFR_MEM8(0x001C)
+#define GPR_GPR1  _SFR_MEM8(0x001D)
+#define GPR_GPR2  _SFR_MEM8(0x001E)
+#define GPR_GPR3  _SFR_MEM8(0x001F)
+
+
+/* CPU - CPU */
+#define CPU_CCP  _SFR_MEM8(0x0034)
+#define CPU_RAMPZ  _SFR_MEM8(0x003B)
+#define CPU_SP  _SFR_MEM16(0x003D)
+#define CPU_SPL  _SFR_MEM8(0x003D)
+#define CPU_SPH  _SFR_MEM8(0x003E)
+#define CPU_SREG  _SFR_MEM8(0x003F)
+
+
+/* RSTCTRL - Reset controller */
+#define RSTCTRL_RSTFR  _SFR_MEM8(0x0040)
+#define RSTCTRL_SWRR  _SFR_MEM8(0x0041)
+
+
+/* SLPCTRL - Sleep Controller */
+#define SLPCTRL_CTRLA  _SFR_MEM8(0x0050)
+
+
+/* CLKCTRL - Clock controller */
+#define CLKCTRL_MCLKCTRLA  _SFR_MEM8(0x0060)
+#define CLKCTRL_MCLKCTRLB  _SFR_MEM8(0x0061)
+#define CLKCTRL_MCLKSTATUS  _SFR_MEM8(0x0065)
+#define CLKCTRL_MCLKTIMEBASE  _SFR_MEM8(0x0066)
+#define CLKCTRL_OSCHFCTRLA  _SFR_MEM8(0x0068)
+#define CLKCTRL_OSCHFTUNE  _SFR_MEM8(0x0069)
+#define CLKCTRL_PLLCTRLA  _SFR_MEM8(0x0070)
+#define CLKCTRL_PLLCTRLB  _SFR_MEM8(0x0071)
+#define CLKCTRL_OSC32KCTRLA  _SFR_MEM8(0x0078)
+#define CLKCTRL_XOSC32KCTRLA  _SFR_MEM8(0x007C)
+
+
+/* BOD - Bod interface */
+#define BOD_CTRLA  _SFR_MEM8(0x00A0)
+#define BOD_CTRLB  _SFR_MEM8(0x00A1)
+#define BOD_VLMCTRLA  _SFR_MEM8(0x00A8)
+#define BOD_INTCTRL  _SFR_MEM8(0x00A9)
+#define BOD_INTFLAGS  _SFR_MEM8(0x00AA)
+#define BOD_STATUS  _SFR_MEM8(0x00AB)
+
+
+/* VREF - Voltage reference */
+#define VREF_DAC0REF  _SFR_MEM8(0x00B2)
+#define VREF_ACREF  _SFR_MEM8(0x00B4)
+
+
+/* WDT - Watch-Dog Timer */
+#define WDT_CTRLA  _SFR_MEM8(0x0100)
+#define WDT_STATUS  _SFR_MEM8(0x0101)
+
+
+/* CPUINT - Interrupt Controller */
+#define CPUINT_CTRLA  _SFR_MEM8(0x0110)
+#define CPUINT_STATUS  _SFR_MEM8(0x0111)
+#define CPUINT_LVL0PRI  _SFR_MEM8(0x0112)
+#define CPUINT_LVL1VEC  _SFR_MEM8(0x0113)
+
+
+/* CRCSCAN - CRCSCAN */
+#define CRCSCAN_CTRLA  _SFR_MEM8(0x0120)
+#define CRCSCAN_CTRLB  _SFR_MEM8(0x0121)
+#define CRCSCAN_STATUS  _SFR_MEM8(0x0122)
+
+
+/* RTC - Real-Time Counter */
+#define RTC_CTRLA  _SFR_MEM8(0x0140)
+#define RTC_STATUS  _SFR_MEM8(0x0141)
+#define RTC_INTCTRL  _SFR_MEM8(0x0142)
+#define RTC_INTFLAGS  _SFR_MEM8(0x0143)
+#define RTC_TEMP  _SFR_MEM8(0x0144)
+#define RTC_DBGCTRL  _SFR_MEM8(0x0145)
+#define RTC_CALIB  _SFR_MEM8(0x0146)
+#define RTC_CLKSEL  _SFR_MEM8(0x0147)
+#define RTC_CNT  _SFR_MEM16(0x0148)
+#define RTC_CNTL  _SFR_MEM8(0x0148)
+#define RTC_CNTH  _SFR_MEM8(0x0149)
+#define RTC_PER  _SFR_MEM16(0x014A)
+#define RTC_PERL  _SFR_MEM8(0x014A)
+#define RTC_PERH  _SFR_MEM8(0x014B)
+#define RTC_CMP  _SFR_MEM16(0x014C)
+#define RTC_CMPL  _SFR_MEM8(0x014C)
+#define RTC_CMPH  _SFR_MEM8(0x014D)
+#define RTC_PITCTRLA  _SFR_MEM8(0x0150)
+#define RTC_PITSTATUS  _SFR_MEM8(0x0151)
+#define RTC_PITINTCTRL  _SFR_MEM8(0x0152)
+#define RTC_PITINTFLAGS  _SFR_MEM8(0x0153)
+#define RTC_PITDBGCTRL  _SFR_MEM8(0x0155)
+#define RTC_PITEVGENCTRLA  _SFR_MEM8(0x0156)
+
+
+/* CCL - Configurable Custom Logic */
+#define CCL_CTRLA  _SFR_MEM8(0x01C0)
+#define CCL_SEQCTRL0  _SFR_MEM8(0x01C1)
+#define CCL_SEQCTRL1  _SFR_MEM8(0x01C2)
+#define CCL_INTCTRL0  _SFR_MEM8(0x01C5)
+#define CCL_INTFLAGS  _SFR_MEM8(0x01C7)
+#define CCL_LUT0CTRLA  _SFR_MEM8(0x01C8)
+#define CCL_LUT0CTRLB  _SFR_MEM8(0x01C9)
+#define CCL_LUT0CTRLC  _SFR_MEM8(0x01CA)
+#define CCL_TRUTH0  _SFR_MEM8(0x01CB)
+#define CCL_LUT1CTRLA  _SFR_MEM8(0x01CC)
+#define CCL_LUT1CTRLB  _SFR_MEM8(0x01CD)
+#define CCL_LUT1CTRLC  _SFR_MEM8(0x01CE)
+#define CCL_TRUTH1  _SFR_MEM8(0x01CF)
+#define CCL_LUT2CTRLA  _SFR_MEM8(0x01D0)
+#define CCL_LUT2CTRLB  _SFR_MEM8(0x01D1)
+#define CCL_LUT2CTRLC  _SFR_MEM8(0x01D2)
+#define CCL_TRUTH2  _SFR_MEM8(0x01D3)
+#define CCL_LUT3CTRLA  _SFR_MEM8(0x01D4)
+#define CCL_LUT3CTRLB  _SFR_MEM8(0x01D5)
+#define CCL_LUT3CTRLC  _SFR_MEM8(0x01D6)
+#define CCL_TRUTH3  _SFR_MEM8(0x01D7)
+
+
+/* EVSYS - Event System */
+#define EVSYS_SWEVENTA  _SFR_MEM8(0x0200)
+#define EVSYS_CHANNEL0  _SFR_MEM8(0x0210)
+#define EVSYS_CHANNEL1  _SFR_MEM8(0x0211)
+#define EVSYS_CHANNEL2  _SFR_MEM8(0x0212)
+#define EVSYS_CHANNEL3  _SFR_MEM8(0x0213)
+#define EVSYS_CHANNEL4  _SFR_MEM8(0x0214)
+#define EVSYS_CHANNEL5  _SFR_MEM8(0x0215)
+#define EVSYS_USERCCLLUT0A  _SFR_MEM8(0x0220)
+#define EVSYS_USERCCLLUT0B  _SFR_MEM8(0x0221)
+#define EVSYS_USERCCLLUT1A  _SFR_MEM8(0x0222)
+#define EVSYS_USERCCLLUT1B  _SFR_MEM8(0x0223)
+#define EVSYS_USERCCLLUT2A  _SFR_MEM8(0x0224)
+#define EVSYS_USERCCLLUT2B  _SFR_MEM8(0x0225)
+#define EVSYS_USERCCLLUT3A  _SFR_MEM8(0x0226)
+#define EVSYS_USERCCLLUT3B  _SFR_MEM8(0x0227)
+#define EVSYS_USERADC0START  _SFR_MEM8(0x0228)
+#define EVSYS_USEREVSYSEVOUTA  _SFR_MEM8(0x0229)
+#define EVSYS_USEREVSYSEVOUTC  _SFR_MEM8(0x022A)
+#define EVSYS_USEREVSYSEVOUTD  _SFR_MEM8(0x022B)
+#define EVSYS_USEREVSYSEVOUTF  _SFR_MEM8(0x022C)
+#define EVSYS_USERUSART0IRDA  _SFR_MEM8(0x022D)
+#define EVSYS_USERTCE0CNTA  _SFR_MEM8(0x022E)
+#define EVSYS_USERTCE0CNTB  _SFR_MEM8(0x022F)
+#define EVSYS_USERTCB0CAPT  _SFR_MEM8(0x0230)
+#define EVSYS_USERTCB0COUNT  _SFR_MEM8(0x0231)
+#define EVSYS_USERTCB1CAPT  _SFR_MEM8(0x0232)
+#define EVSYS_USERTCB1COUNT  _SFR_MEM8(0x0233)
+#define EVSYS_USERTCF0CNT  _SFR_MEM8(0x0234)
+#define EVSYS_USERTCF0ACT  _SFR_MEM8(0x0235)
+#define EVSYS_USERWEXA  _SFR_MEM8(0x0236)
+#define EVSYS_USERWEXB  _SFR_MEM8(0x0237)
+#define EVSYS_USERWEXC  _SFR_MEM8(0x0238)
+
+
+/* PORT (PORTA) - I/O Ports */
+#define PORTA_DIR  _SFR_MEM8(0x0400)
+#define PORTA_DIRSET  _SFR_MEM8(0x0401)
+#define PORTA_DIRCLR  _SFR_MEM8(0x0402)
+#define PORTA_DIRTGL  _SFR_MEM8(0x0403)
+#define PORTA_OUT  _SFR_MEM8(0x0404)
+#define PORTA_OUTSET  _SFR_MEM8(0x0405)
+#define PORTA_OUTCLR  _SFR_MEM8(0x0406)
+#define PORTA_OUTTGL  _SFR_MEM8(0x0407)
+#define PORTA_IN  _SFR_MEM8(0x0408)
+#define PORTA_INTFLAGS  _SFR_MEM8(0x0409)
+#define PORTA_PORTCTRL  _SFR_MEM8(0x040A)
+#define PORTA_PINCONFIG  _SFR_MEM8(0x040B)
+#define PORTA_PINCTRLUPD  _SFR_MEM8(0x040C)
+#define PORTA_PINCTRLSET  _SFR_MEM8(0x040D)
+#define PORTA_PINCTRLCLR  _SFR_MEM8(0x040E)
+#define PORTA_PIN0CTRL  _SFR_MEM8(0x0410)
+#define PORTA_PIN1CTRL  _SFR_MEM8(0x0411)
+#define PORTA_PIN2CTRL  _SFR_MEM8(0x0412)
+#define PORTA_PIN3CTRL  _SFR_MEM8(0x0413)
+#define PORTA_PIN4CTRL  _SFR_MEM8(0x0414)
+#define PORTA_PIN5CTRL  _SFR_MEM8(0x0415)
+#define PORTA_PIN6CTRL  _SFR_MEM8(0x0416)
+#define PORTA_PIN7CTRL  _SFR_MEM8(0x0417)
+#define PORTA_EVGENCTRLA  _SFR_MEM8(0x0418)
+
+
+/* PORT (PORTC) - I/O Ports */
+#define PORTC_DIR  _SFR_MEM8(0x0440)
+#define PORTC_DIRSET  _SFR_MEM8(0x0441)
+#define PORTC_DIRCLR  _SFR_MEM8(0x0442)
+#define PORTC_DIRTGL  _SFR_MEM8(0x0443)
+#define PORTC_OUT  _SFR_MEM8(0x0444)
+#define PORTC_OUTSET  _SFR_MEM8(0x0445)
+#define PORTC_OUTCLR  _SFR_MEM8(0x0446)
+#define PORTC_OUTTGL  _SFR_MEM8(0x0447)
+#define PORTC_IN  _SFR_MEM8(0x0448)
+#define PORTC_INTFLAGS  _SFR_MEM8(0x0449)
+#define PORTC_PORTCTRL  _SFR_MEM8(0x044A)
+#define PORTC_PINCONFIG  _SFR_MEM8(0x044B)
+#define PORTC_PINCTRLUPD  _SFR_MEM8(0x044C)
+#define PORTC_PINCTRLSET  _SFR_MEM8(0x044D)
+#define PORTC_PINCTRLCLR  _SFR_MEM8(0x044E)
+#define PORTC_PIN0CTRL  _SFR_MEM8(0x0450)
+#define PORTC_PIN1CTRL  _SFR_MEM8(0x0451)
+#define PORTC_PIN2CTRL  _SFR_MEM8(0x0452)
+#define PORTC_PIN3CTRL  _SFR_MEM8(0x0453)
+#define PORTC_PIN4CTRL  _SFR_MEM8(0x0454)
+#define PORTC_PIN5CTRL  _SFR_MEM8(0x0455)
+#define PORTC_PIN6CTRL  _SFR_MEM8(0x0456)
+#define PORTC_PIN7CTRL  _SFR_MEM8(0x0457)
+#define PORTC_EVGENCTRLA  _SFR_MEM8(0x0458)
+
+
+/* PORT (PORTD) - I/O Ports */
+#define PORTD_DIR  _SFR_MEM8(0x0460)
+#define PORTD_DIRSET  _SFR_MEM8(0x0461)
+#define PORTD_DIRCLR  _SFR_MEM8(0x0462)
+#define PORTD_DIRTGL  _SFR_MEM8(0x0463)
+#define PORTD_OUT  _SFR_MEM8(0x0464)
+#define PORTD_OUTSET  _SFR_MEM8(0x0465)
+#define PORTD_OUTCLR  _SFR_MEM8(0x0466)
+#define PORTD_OUTTGL  _SFR_MEM8(0x0467)
+#define PORTD_IN  _SFR_MEM8(0x0468)
+#define PORTD_INTFLAGS  _SFR_MEM8(0x0469)
+#define PORTD_PORTCTRL  _SFR_MEM8(0x046A)
+#define PORTD_PINCONFIG  _SFR_MEM8(0x046B)
+#define PORTD_PINCTRLUPD  _SFR_MEM8(0x046C)
+#define PORTD_PINCTRLSET  _SFR_MEM8(0x046D)
+#define PORTD_PINCTRLCLR  _SFR_MEM8(0x046E)
+#define PORTD_PIN0CTRL  _SFR_MEM8(0x0470)
+#define PORTD_PIN1CTRL  _SFR_MEM8(0x0471)
+#define PORTD_PIN2CTRL  _SFR_MEM8(0x0472)
+#define PORTD_PIN3CTRL  _SFR_MEM8(0x0473)
+#define PORTD_PIN4CTRL  _SFR_MEM8(0x0474)
+#define PORTD_PIN5CTRL  _SFR_MEM8(0x0475)
+#define PORTD_PIN6CTRL  _SFR_MEM8(0x0476)
+#define PORTD_PIN7CTRL  _SFR_MEM8(0x0477)
+#define PORTD_EVGENCTRLA  _SFR_MEM8(0x0478)
+
+
+/* PORT (PORTF) - I/O Ports */
+#define PORTF_DIR  _SFR_MEM8(0x04A0)
+#define PORTF_DIRSET  _SFR_MEM8(0x04A1)
+#define PORTF_DIRCLR  _SFR_MEM8(0x04A2)
+#define PORTF_DIRTGL  _SFR_MEM8(0x04A3)
+#define PORTF_OUT  _SFR_MEM8(0x04A4)
+#define PORTF_OUTSET  _SFR_MEM8(0x04A5)
+#define PORTF_OUTCLR  _SFR_MEM8(0x04A6)
+#define PORTF_OUTTGL  _SFR_MEM8(0x04A7)
+#define PORTF_IN  _SFR_MEM8(0x04A8)
+#define PORTF_INTFLAGS  _SFR_MEM8(0x04A9)
+#define PORTF_PORTCTRL  _SFR_MEM8(0x04AA)
+#define PORTF_PINCONFIG  _SFR_MEM8(0x04AB)
+#define PORTF_PINCTRLUPD  _SFR_MEM8(0x04AC)
+#define PORTF_PINCTRLSET  _SFR_MEM8(0x04AD)
+#define PORTF_PINCTRLCLR  _SFR_MEM8(0x04AE)
+#define PORTF_PIN0CTRL  _SFR_MEM8(0x04B0)
+#define PORTF_PIN1CTRL  _SFR_MEM8(0x04B1)
+#define PORTF_PIN2CTRL  _SFR_MEM8(0x04B2)
+#define PORTF_PIN3CTRL  _SFR_MEM8(0x04B3)
+#define PORTF_PIN4CTRL  _SFR_MEM8(0x04B4)
+#define PORTF_PIN5CTRL  _SFR_MEM8(0x04B5)
+#define PORTF_PIN6CTRL  _SFR_MEM8(0x04B6)
+#define PORTF_PIN7CTRL  _SFR_MEM8(0x04B7)
+#define PORTF_EVGENCTRLA  _SFR_MEM8(0x04B8)
+
+
+/* PORTMUX - Port Multiplexer */
+#define PORTMUX_EVSYSROUTEA  _SFR_MEM8(0x05E0)
+#define PORTMUX_CCLROUTEA  _SFR_MEM8(0x05E1)
+#define PORTMUX_USARTROUTEA  _SFR_MEM8(0x05E2)
+#define PORTMUX_SPIROUTEA  _SFR_MEM8(0x05E5)
+#define PORTMUX_TWIROUTEA  _SFR_MEM8(0x05E6)
+#define PORTMUX_TCEROUTEA  _SFR_MEM8(0x05E7)
+#define PORTMUX_TCFROUTEA  _SFR_MEM8(0x05EC)
+
+
+/* ADC (ADC0) - Analog to Digital Converter */
+#define ADC0_CTRLA  _SFR_MEM8(0x0600)
+#define ADC0_CTRLB  _SFR_MEM8(0x0601)
+#define ADC0_CTRLC  _SFR_MEM8(0x0602)
+#define ADC0_CTRLD  _SFR_MEM8(0x0603)
+#define ADC0_INTCTRL  _SFR_MEM8(0x0604)
+#define ADC0_INTFLAGS  _SFR_MEM8(0x0605)
+#define ADC0_STATUS  _SFR_MEM8(0x0606)
+#define ADC0_DBGCTRL  _SFR_MEM8(0x0607)
+#define ADC0_CTRLE  _SFR_MEM8(0x0608)
+#define ADC0_CTRLF  _SFR_MEM8(0x0609)
+#define ADC0_COMMAND  _SFR_MEM8(0x060A)
+#define ADC0_PGACTRL  _SFR_MEM8(0x060B)
+#define ADC0_MUXPOS  _SFR_MEM8(0x060C)
+#define ADC0_MUXNEG  _SFR_MEM8(0x060D)
+#define ADC0_RESULT  _SFR_MEM32(0x0610)
+#define ADC0_RESULT0  _SFR_MEM8(0x0610)
+#define ADC0_RESULT1  _SFR_MEM8(0x0611)
+#define ADC0_RESULT2  _SFR_MEM8(0x0612)
+#define ADC0_RESULT3  _SFR_MEM8(0x0613)
+#define ADC0_SAMPLE  _SFR_MEM16(0x0614)
+#define ADC0_SAMPLEL  _SFR_MEM8(0x0614)
+#define ADC0_SAMPLEH  _SFR_MEM8(0x0615)
+#define ADC0_TEMP0  _SFR_MEM8(0x0618)
+#define ADC0_TEMP1  _SFR_MEM8(0x0619)
+#define ADC0_TEMP2  _SFR_MEM8(0x061A)
+#define ADC0_WINLT  _SFR_MEM16(0x061C)
+#define ADC0_WINLTL  _SFR_MEM8(0x061C)
+#define ADC0_WINLTH  _SFR_MEM8(0x061D)
+#define ADC0_WINHT  _SFR_MEM16(0x061E)
+#define ADC0_WINHTL  _SFR_MEM8(0x061E)
+#define ADC0_WINHTH  _SFR_MEM8(0x061F)
+
+
+/* AC (AC0) - Analog Comparator */
+#define AC0_CTRLA  _SFR_MEM8(0x0680)
+#define AC0_CTRLB  _SFR_MEM8(0x0681)
+#define AC0_MUXCTRL  _SFR_MEM8(0x0682)
+#define AC0_DACREF  _SFR_MEM8(0x0685)
+#define AC0_INTCTRL  _SFR_MEM8(0x0686)
+#define AC0_STATUS  _SFR_MEM8(0x0687)
+
+
+/* AC (AC1) - Analog Comparator */
+#define AC1_CTRLA  _SFR_MEM8(0x0688)
+#define AC1_CTRLB  _SFR_MEM8(0x0689)
+#define AC1_MUXCTRL  _SFR_MEM8(0x068A)
+#define AC1_DACREF  _SFR_MEM8(0x068D)
+#define AC1_INTCTRL  _SFR_MEM8(0x068E)
+#define AC1_STATUS  _SFR_MEM8(0x068F)
+
+
+/* USART (USART0) - Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define USART0_RXDATAL  _SFR_MEM8(0x0800)
+#define USART0_RXDATAH  _SFR_MEM8(0x0801)
+#define USART0_TXDATAL  _SFR_MEM8(0x0802)
+#define USART0_TXDATAH  _SFR_MEM8(0x0803)
+#define USART0_STATUS  _SFR_MEM8(0x0804)
+#define USART0_CTRLA  _SFR_MEM8(0x0805)
+#define USART0_CTRLB  _SFR_MEM8(0x0806)
+#define USART0_CTRLC  _SFR_MEM8(0x0807)
+#define USART0_BAUD  _SFR_MEM16(0x0808)
+#define USART0_BAUDL  _SFR_MEM8(0x0808)
+#define USART0_BAUDH  _SFR_MEM8(0x0809)
+#define USART0_CTRLD  _SFR_MEM8(0x080A)
+#define USART0_DBGCTRL  _SFR_MEM8(0x080B)
+#define USART0_EVCTRL  _SFR_MEM8(0x080C)
+#define USART0_TXPLCTRL  _SFR_MEM8(0x080D)
+#define USART0_RXPLCTRL  _SFR_MEM8(0x080E)
+
+
+/* TWI (TWI0) - Two-Wire Interface */
+#define TWI0_CTRLA  _SFR_MEM8(0x0900)
+#define TWI0_DUALCTRL  _SFR_MEM8(0x0901)
+#define TWI0_DBGCTRL  _SFR_MEM8(0x0902)
+#define TWI0_MCTRLA  _SFR_MEM8(0x0903)
+#define TWI0_MCTRLB  _SFR_MEM8(0x0904)
+#define TWI0_MSTATUS  _SFR_MEM8(0x0905)
+#define TWI0_MBAUD  _SFR_MEM8(0x0906)
+#define TWI0_MADDR  _SFR_MEM8(0x0907)
+#define TWI0_MDATA  _SFR_MEM8(0x0908)
+#define TWI0_SCTRLA  _SFR_MEM8(0x0909)
+#define TWI0_SCTRLB  _SFR_MEM8(0x090A)
+#define TWI0_SSTATUS  _SFR_MEM8(0x090B)
+#define TWI0_SADDR  _SFR_MEM8(0x090C)
+#define TWI0_SDATA  _SFR_MEM8(0x090D)
+#define TWI0_SADDRMASK  _SFR_MEM8(0x090E)
+
+
+/* SPI (SPI0) - Serial Peripheral Interface */
+#define SPI0_CTRLA  _SFR_MEM8(0x0940)
+#define SPI0_CTRLB  _SFR_MEM8(0x0941)
+#define SPI0_INTCTRL  _SFR_MEM8(0x0942)
+#define SPI0_INTFLAGS  _SFR_MEM8(0x0943)
+#define SPI0_DATA  _SFR_MEM8(0x0944)
+
+
+/* TCE (TCE0) - 16-bit Timer/Counter Type E */
+#define TCE0_CTRLA  _SFR_MEM8(0x0A00)
+#define TCE0_CTRLB  _SFR_MEM8(0x0A01)
+#define TCE0_CTRLC  _SFR_MEM8(0x0A02)
+#define TCE0_CTRLD  _SFR_MEM8(0x0A03)
+#define TCE0_CTRLECLR  _SFR_MEM8(0x0A04)
+#define TCE0_CTRLESET  _SFR_MEM8(0x0A05)
+#define TCE0_CTRLFCLR  _SFR_MEM8(0x0A06)
+#define TCE0_CTRLFSET  _SFR_MEM8(0x0A07)
+#define TCE0_EVGENCTRL  _SFR_MEM8(0x0A08)
+#define TCE0_EVCTRL  _SFR_MEM8(0x0A09)
+#define TCE0_INTCTRL  _SFR_MEM8(0x0A0A)
+#define TCE0_INTFLAGS  _SFR_MEM8(0x0A0B)
+#define TCE0_DBGCTRL  _SFR_MEM8(0x0A0E)
+#define TCE0_TEMP  _SFR_MEM8(0x0A0F)
+#define TCE0_CNT  _SFR_MEM16(0x0A20)
+#define TCE0_CNTL  _SFR_MEM8(0x0A20)
+#define TCE0_CNTH  _SFR_MEM8(0x0A21)
+#define TCE0_AMP  _SFR_MEM16(0x0A22)
+#define TCE0_AMPL  _SFR_MEM8(0x0A22)
+#define TCE0_AMPH  _SFR_MEM8(0x0A23)
+#define TCE0_OFFSET  _SFR_MEM16(0x0A24)
+#define TCE0_OFFSETL  _SFR_MEM8(0x0A24)
+#define TCE0_OFFSETH  _SFR_MEM8(0x0A25)
+#define TCE0_PER  _SFR_MEM16(0x0A26)
+#define TCE0_PERL  _SFR_MEM8(0x0A26)
+#define TCE0_PERH  _SFR_MEM8(0x0A27)
+#define TCE0_CMP0  _SFR_MEM16(0x0A28)
+#define TCE0_CMP0L  _SFR_MEM8(0x0A28)
+#define TCE0_CMP0H  _SFR_MEM8(0x0A29)
+#define TCE0_CMP1  _SFR_MEM16(0x0A2A)
+#define TCE0_CMP1L  _SFR_MEM8(0x0A2A)
+#define TCE0_CMP1H  _SFR_MEM8(0x0A2B)
+#define TCE0_CMP2  _SFR_MEM16(0x0A2C)
+#define TCE0_CMP2L  _SFR_MEM8(0x0A2C)
+#define TCE0_CMP2H  _SFR_MEM8(0x0A2D)
+#define TCE0_CMP3  _SFR_MEM16(0x0A2E)
+#define TCE0_CMP3L  _SFR_MEM8(0x0A2E)
+#define TCE0_CMP3H  _SFR_MEM8(0x0A2F)
+#define TCE0_PERBUF  _SFR_MEM16(0x0A36)
+#define TCE0_PERBUFL  _SFR_MEM8(0x0A36)
+#define TCE0_PERBUFH  _SFR_MEM8(0x0A37)
+#define TCE0_CMP0BUF  _SFR_MEM16(0x0A38)
+#define TCE0_CMP0BUFL  _SFR_MEM8(0x0A38)
+#define TCE0_CMP0BUFH  _SFR_MEM8(0x0A39)
+#define TCE0_CMP1BUF  _SFR_MEM16(0x0A3A)
+#define TCE0_CMP1BUFL  _SFR_MEM8(0x0A3A)
+#define TCE0_CMP1BUFH  _SFR_MEM8(0x0A3B)
+#define TCE0_CMP2BUF  _SFR_MEM16(0x0A3C)
+#define TCE0_CMP2BUFL  _SFR_MEM8(0x0A3C)
+#define TCE0_CMP2BUFH  _SFR_MEM8(0x0A3D)
+#define TCE0_CMP3BUF  _SFR_MEM16(0x0A3E)
+#define TCE0_CMP3BUFL  _SFR_MEM8(0x0A3E)
+#define TCE0_CMP3BUFH  _SFR_MEM8(0x0A3F)
+
+
+/* TCB (TCB0) - 16-bit Timer/Counter Type B */
+#define TCB0_CTRLA  _SFR_MEM8(0x0B00)
+#define TCB0_CTRLB  _SFR_MEM8(0x0B01)
+#define TCB0_CTRLC  _SFR_MEM8(0x0B02)
+#define TCB0_EVCTRL  _SFR_MEM8(0x0B04)
+#define TCB0_INTCTRL  _SFR_MEM8(0x0B05)
+#define TCB0_INTFLAGS  _SFR_MEM8(0x0B06)
+#define TCB0_STATUS  _SFR_MEM8(0x0B07)
+#define TCB0_DBGCTRL  _SFR_MEM8(0x0B08)
+#define TCB0_TEMP  _SFR_MEM8(0x0B09)
+#define TCB0_CNT  _SFR_MEM16(0x0B0A)
+#define TCB0_CNTL  _SFR_MEM8(0x0B0A)
+#define TCB0_CNTH  _SFR_MEM8(0x0B0B)
+#define TCB0_CCMP  _SFR_MEM16(0x0B0C)
+#define TCB0_CCMPL  _SFR_MEM8(0x0B0C)
+#define TCB0_CCMPH  _SFR_MEM8(0x0B0D)
+
+
+/* TCB (TCB1) - 16-bit Timer/Counter Type B */
+#define TCB1_CTRLA  _SFR_MEM8(0x0B10)
+#define TCB1_CTRLB  _SFR_MEM8(0x0B11)
+#define TCB1_CTRLC  _SFR_MEM8(0x0B12)
+#define TCB1_EVCTRL  _SFR_MEM8(0x0B14)
+#define TCB1_INTCTRL  _SFR_MEM8(0x0B15)
+#define TCB1_INTFLAGS  _SFR_MEM8(0x0B16)
+#define TCB1_STATUS  _SFR_MEM8(0x0B17)
+#define TCB1_DBGCTRL  _SFR_MEM8(0x0B18)
+#define TCB1_TEMP  _SFR_MEM8(0x0B19)
+#define TCB1_CNT  _SFR_MEM16(0x0B1A)
+#define TCB1_CNTL  _SFR_MEM8(0x0B1A)
+#define TCB1_CNTH  _SFR_MEM8(0x0B1B)
+#define TCB1_CCMP  _SFR_MEM16(0x0B1C)
+#define TCB1_CCMPL  _SFR_MEM8(0x0B1C)
+#define TCB1_CCMPH  _SFR_MEM8(0x0B1D)
+
+
+/* TCF (TCF0) - 24-bit Timer/Counter for frequency generation */
+#define TCF0_CTRLA  _SFR_MEM8(0x0C00)
+#define TCF0_CTRLB  _SFR_MEM8(0x0C01)
+#define TCF0_CTRLC  _SFR_MEM8(0x0C02)
+#define TCF0_CTRLD  _SFR_MEM8(0x0C03)
+#define TCF0_EVCTRL  _SFR_MEM8(0x0C04)
+#define TCF0_INTCTRL  _SFR_MEM8(0x0C05)
+#define TCF0_INTFLAGS  _SFR_MEM8(0x0C06)
+#define TCF0_STATUS  _SFR_MEM8(0x0C07)
+#define TCF0_DBGCTRL  _SFR_MEM8(0x0C0D)
+#define TCF0_CNT  _SFR_MEM32(0x0C10)
+#define TCF0_CNT0  _SFR_MEM8(0x0C10)
+#define TCF0_CNT1  _SFR_MEM8(0x0C11)
+#define TCF0_CNT2  _SFR_MEM8(0x0C12)
+#define TCF0_CNT3  _SFR_MEM8(0x0C13)
+#define TCF0_CMP  _SFR_MEM32(0x0C14)
+#define TCF0_CMP0  _SFR_MEM8(0x0C14)
+#define TCF0_CMP1  _SFR_MEM8(0x0C15)
+#define TCF0_CMP2  _SFR_MEM8(0x0C16)
+#define TCF0_CMP3  _SFR_MEM8(0x0C17)
+
+
+/* WEX (WEX0) - Waveform Extension */
+#define WEX0_CTRLA  _SFR_MEM8(0x0C80)
+#define WEX0_CTRLB  _SFR_MEM8(0x0C81)
+#define WEX0_CTRLC  _SFR_MEM8(0x0C82)
+#define WEX0_EVCTRLA  _SFR_MEM8(0x0C84)
+#define WEX0_EVCTRLB  _SFR_MEM8(0x0C85)
+#define WEX0_EVCTRLC  _SFR_MEM8(0x0C86)
+#define WEX0_BUFCTRL  _SFR_MEM8(0x0C87)
+#define WEX0_BLANKCTRL  _SFR_MEM8(0x0C88)
+#define WEX0_BLANKTIME  _SFR_MEM8(0x0C89)
+#define WEX0_FAULTCTRL  _SFR_MEM8(0x0C8A)
+#define WEX0_FAULTDRV  _SFR_MEM8(0x0C8B)
+#define WEX0_FAULTOUT  _SFR_MEM8(0x0C8C)
+#define WEX0_INTCTRL  _SFR_MEM8(0x0C8D)
+#define WEX0_INTFLAGS  _SFR_MEM8(0x0C8E)
+#define WEX0_STATUS  _SFR_MEM8(0x0C8F)
+#define WEX0_DTLS  _SFR_MEM8(0x0C90)
+#define WEX0_DTHS  _SFR_MEM8(0x0C91)
+#define WEX0_DTBOTH  _SFR_MEM8(0x0C92)
+#define WEX0_SWAP  _SFR_MEM8(0x0C93)
+#define WEX0_PGMOVR  _SFR_MEM8(0x0C94)
+#define WEX0_PGMOUT  _SFR_MEM8(0x0C95)
+#define WEX0_OUTOVEN  _SFR_MEM8(0x0C97)
+#define WEX0_DTLSBUF  _SFR_MEM8(0x0C98)
+#define WEX0_DTHSBUF  _SFR_MEM8(0x0C99)
+#define WEX0_DTBOTHBUF  _SFR_MEM8(0x0C9A)
+#define WEX0_SWAPBUF  _SFR_MEM8(0x0C9B)
+#define WEX0_PGMOVRBUF  _SFR_MEM8(0x0C9C)
+#define WEX0_PGMOUTBUF  _SFR_MEM8(0x0C9D)
+
+
+/* SYSCFG - System Configuration Registers */
+#define SYSCFG_REVID  _SFR_MEM8(0x0F01)
+
+
+/* NVMCTRL - Non-volatile Memory Controller */
+#define NVMCTRL_CTRLA  _SFR_MEM8(0x1000)
+#define NVMCTRL_CTRLB  _SFR_MEM8(0x1001)
+#define NVMCTRL_CTRLC  _SFR_MEM8(0x1002)
+#define NVMCTRL_INTCTRL  _SFR_MEM8(0x1004)
+#define NVMCTRL_INTFLAGS  _SFR_MEM8(0x1005)
+#define NVMCTRL_STATUS  _SFR_MEM8(0x1006)
+#define NVMCTRL_DATA  _SFR_MEM16(0x1008)
+#define NVMCTRL_DATAL  _SFR_MEM8(0x1008)
+#define NVMCTRL_DATAH  _SFR_MEM8(0x1009)
+#define NVMCTRL_ADDR  _SFR_MEM32(0x100C)
+#define NVMCTRL_ADDR0  _SFR_MEM8(0x100C)
+#define NVMCTRL_ADDR1  _SFR_MEM8(0x100D)
+#define NVMCTRL_ADDR2  _SFR_MEM8(0x100E)
+#define NVMCTRL_ADDR3  _SFR_MEM8(0x100F)
+
+
+/* LOCK - Lockbits */
+#define LOCK_KEY  _SFR_MEM32(0x1040)
+#define LOCK_KEY0  _SFR_MEM8(0x1040)
+#define LOCK_KEY1  _SFR_MEM8(0x1041)
+#define LOCK_KEY2  _SFR_MEM8(0x1042)
+#define LOCK_KEY3  _SFR_MEM8(0x1043)
+
+
+/* FUSE - Fuses */
+#define FUSE_WDTCFG  _SFR_MEM8(0x1050)
+#define FUSE_BODCFG  _SFR_MEM8(0x1051)
+#define FUSE_OSCCFG  _SFR_MEM8(0x1052)
+#define FUSE_SYSCFG0  _SFR_MEM8(0x1055)
+#define FUSE_SYSCFG1  _SFR_MEM8(0x1056)
+#define FUSE_CODESIZE  _SFR_MEM8(0x1057)
+#define FUSE_BOOTSIZE  _SFR_MEM8(0x1058)
+#define FUSE_PDICFG  _SFR_MEM16(0x105A)
+#define FUSE_PDICFGL  _SFR_MEM8(0x105A)
+#define FUSE_PDICFGH  _SFR_MEM8(0x105B)
+
+
+/* SIGROW - Signature row */
+#define SIGROW_DEVICEID0  _SFR_MEM8(0x1080)
+#define SIGROW_DEVICEID1  _SFR_MEM8(0x1081)
+#define SIGROW_DEVICEID2  _SFR_MEM8(0x1082)
+#define SIGROW_TEMPSENSE0  _SFR_MEM16(0x1084)
+#define SIGROW_TEMPSENSE0L  _SFR_MEM8(0x1084)
+#define SIGROW_TEMPSENSE0H  _SFR_MEM8(0x1085)
+#define SIGROW_TEMPSENSE1  _SFR_MEM16(0x1086)
+#define SIGROW_TEMPSENSE1L  _SFR_MEM8(0x1086)
+#define SIGROW_TEMPSENSE1H  _SFR_MEM8(0x1087)
+#define SIGROW_SERNUM0  _SFR_MEM8(0x1090)
+#define SIGROW_SERNUM1  _SFR_MEM8(0x1091)
+#define SIGROW_SERNUM2  _SFR_MEM8(0x1092)
+#define SIGROW_SERNUM3  _SFR_MEM8(0x1093)
+#define SIGROW_SERNUM4  _SFR_MEM8(0x1094)
+#define SIGROW_SERNUM5  _SFR_MEM8(0x1095)
+#define SIGROW_SERNUM6  _SFR_MEM8(0x1096)
+#define SIGROW_SERNUM7  _SFR_MEM8(0x1097)
+#define SIGROW_SERNUM8  _SFR_MEM8(0x1098)
+#define SIGROW_SERNUM9  _SFR_MEM8(0x1099)
+#define SIGROW_SERNUM10  _SFR_MEM8(0x109A)
+#define SIGROW_SERNUM11  _SFR_MEM8(0x109B)
+#define SIGROW_SERNUM12  _SFR_MEM8(0x109C)
+#define SIGROW_SERNUM13  _SFR_MEM8(0x109D)
+#define SIGROW_SERNUM14  _SFR_MEM8(0x109E)
+#define SIGROW_SERNUM15  _SFR_MEM8(0x109F)
+
+
+/* BOOTROW - Boot Row */
+#define BOOTROW_BOOTROW  _SFR_MEM8(0x1100)
+
+
+/* USERROW - User Row */
+#define USERROW_USERROW0  _SFR_MEM8(0x1200)
+#define USERROW_USERROW1  _SFR_MEM8(0x1201)
+#define USERROW_USERROW2  _SFR_MEM8(0x1202)
+#define USERROW_USERROW3  _SFR_MEM8(0x1203)
+#define USERROW_USERROW4  _SFR_MEM8(0x1204)
+#define USERROW_USERROW5  _SFR_MEM8(0x1205)
+#define USERROW_USERROW6  _SFR_MEM8(0x1206)
+#define USERROW_USERROW7  _SFR_MEM8(0x1207)
+#define USERROW_USERROW8  _SFR_MEM8(0x1208)
+#define USERROW_USERROW9  _SFR_MEM8(0x1209)
+#define USERROW_USERROW10  _SFR_MEM8(0x120A)
+#define USERROW_USERROW11  _SFR_MEM8(0x120B)
+#define USERROW_USERROW12  _SFR_MEM8(0x120C)
+#define USERROW_USERROW13  _SFR_MEM8(0x120D)
+#define USERROW_USERROW14  _SFR_MEM8(0x120E)
+#define USERROW_USERROW15  _SFR_MEM8(0x120F)
+#define USERROW_USERROW16  _SFR_MEM8(0x1210)
+#define USERROW_USERROW17  _SFR_MEM8(0x1211)
+#define USERROW_USERROW18  _SFR_MEM8(0x1212)
+#define USERROW_USERROW19  _SFR_MEM8(0x1213)
+#define USERROW_USERROW20  _SFR_MEM8(0x1214)
+#define USERROW_USERROW21  _SFR_MEM8(0x1215)
+#define USERROW_USERROW22  _SFR_MEM8(0x1216)
+#define USERROW_USERROW23  _SFR_MEM8(0x1217)
+#define USERROW_USERROW24  _SFR_MEM8(0x1218)
+#define USERROW_USERROW25  _SFR_MEM8(0x1219)
+#define USERROW_USERROW26  _SFR_MEM8(0x121A)
+#define USERROW_USERROW27  _SFR_MEM8(0x121B)
+#define USERROW_USERROW28  _SFR_MEM8(0x121C)
+#define USERROW_USERROW29  _SFR_MEM8(0x121D)
+#define USERROW_USERROW30  _SFR_MEM8(0x121E)
+#define USERROW_USERROW31  _SFR_MEM8(0x121F)
+#define USERROW_USERROW32  _SFR_MEM8(0x1220)
+#define USERROW_USERROW33  _SFR_MEM8(0x1221)
+#define USERROW_USERROW34  _SFR_MEM8(0x1222)
+#define USERROW_USERROW35  _SFR_MEM8(0x1223)
+#define USERROW_USERROW36  _SFR_MEM8(0x1224)
+#define USERROW_USERROW37  _SFR_MEM8(0x1225)
+#define USERROW_USERROW38  _SFR_MEM8(0x1226)
+#define USERROW_USERROW39  _SFR_MEM8(0x1227)
+#define USERROW_USERROW40  _SFR_MEM8(0x1228)
+#define USERROW_USERROW41  _SFR_MEM8(0x1229)
+#define USERROW_USERROW42  _SFR_MEM8(0x122A)
+#define USERROW_USERROW43  _SFR_MEM8(0x122B)
+#define USERROW_USERROW44  _SFR_MEM8(0x122C)
+#define USERROW_USERROW45  _SFR_MEM8(0x122D)
+#define USERROW_USERROW46  _SFR_MEM8(0x122E)
+#define USERROW_USERROW47  _SFR_MEM8(0x122F)
+#define USERROW_USERROW48  _SFR_MEM8(0x1230)
+#define USERROW_USERROW49  _SFR_MEM8(0x1231)
+#define USERROW_USERROW50  _SFR_MEM8(0x1232)
+#define USERROW_USERROW51  _SFR_MEM8(0x1233)
+#define USERROW_USERROW52  _SFR_MEM8(0x1234)
+#define USERROW_USERROW53  _SFR_MEM8(0x1235)
+#define USERROW_USERROW54  _SFR_MEM8(0x1236)
+#define USERROW_USERROW55  _SFR_MEM8(0x1237)
+#define USERROW_USERROW56  _SFR_MEM8(0x1238)
+#define USERROW_USERROW57  _SFR_MEM8(0x1239)
+#define USERROW_USERROW58  _SFR_MEM8(0x123A)
+#define USERROW_USERROW59  _SFR_MEM8(0x123B)
+#define USERROW_USERROW60  _SFR_MEM8(0x123C)
+#define USERROW_USERROW61  _SFR_MEM8(0x123D)
+#define USERROW_USERROW62  _SFR_MEM8(0x123E)
+#define USERROW_USERROW63  _SFR_MEM8(0x123F)
+
+
+
+/*================== Bitfield Definitions ================== */
+
+/* AC - Analog Comparator */
+/* AC.CTRLA  bit masks and bit positions */
+#define AC_ENABLE_bm  0x01  /* Enable bit mask. */
+#define AC_ENABLE_bp  0  /* Enable bit position. */
+#define AC_HYSMODE_gm  0x06  /* Hysteresis Mode group mask. */
+#define AC_HYSMODE_gp  1  /* Hysteresis Mode group position. */
+#define AC_HYSMODE_0_bm  (1<<1)  /* Hysteresis Mode bit 0 mask. */
+#define AC_HYSMODE_0_bp  1  /* Hysteresis Mode bit 0 position. */
+#define AC_HYSMODE_1_bm  (1<<2)  /* Hysteresis Mode bit 1 mask. */
+#define AC_HYSMODE_1_bp  2  /* Hysteresis Mode bit 1 position. */
+#define AC_POWER_gm  0x18  /* Power profile group mask. */
+#define AC_POWER_gp  3  /* Power profile group position. */
+#define AC_POWER_0_bm  (1<<3)  /* Power profile bit 0 mask. */
+#define AC_POWER_0_bp  3  /* Power profile bit 0 position. */
+#define AC_POWER_1_bm  (1<<4)  /* Power profile bit 1 mask. */
+#define AC_POWER_1_bp  4  /* Power profile bit 1 position. */
+#define AC_OUTEN_bm  0x40  /* Output Pad Enable bit mask. */
+#define AC_OUTEN_bp  6  /* Output Pad Enable bit position. */
+#define AC_RUNSTDBY_bm  0x80  /* Run in Standby Mode bit mask. */
+#define AC_RUNSTDBY_bp  7  /* Run in Standby Mode bit position. */
+
+/* AC.CTRLB  bit masks and bit positions */
+#define AC_WINSEL_gm  0x03  /* Window selection mode group mask. */
+#define AC_WINSEL_gp  0  /* Window selection mode group position. */
+#define AC_WINSEL_0_bm  (1<<0)  /* Window selection mode bit 0 mask. */
+#define AC_WINSEL_0_bp  0  /* Window selection mode bit 0 position. */
+#define AC_WINSEL_1_bm  (1<<1)  /* Window selection mode bit 1 mask. */
+#define AC_WINSEL_1_bp  1  /* Window selection mode bit 1 position. */
+
+/* AC.MUXCTRL  bit masks and bit positions */
+#define AC_MUXNEG_gm  0x07  /* Negative Input MUX Selection group mask. */
+#define AC_MUXNEG_gp  0  /* Negative Input MUX Selection group position. */
+#define AC_MUXNEG_0_bm  (1<<0)  /* Negative Input MUX Selection bit 0 mask. */
+#define AC_MUXNEG_0_bp  0  /* Negative Input MUX Selection bit 0 position. */
+#define AC_MUXNEG_1_bm  (1<<1)  /* Negative Input MUX Selection bit 1 mask. */
+#define AC_MUXNEG_1_bp  1  /* Negative Input MUX Selection bit 1 position. */
+#define AC_MUXNEG_2_bm  (1<<2)  /* Negative Input MUX Selection bit 2 mask. */
+#define AC_MUXNEG_2_bp  2  /* Negative Input MUX Selection bit 2 position. */
+#define AC_MUXPOS_gm  0x38  /* Positive Input MUX Selection group mask. */
+#define AC_MUXPOS_gp  3  /* Positive Input MUX Selection group position. */
+#define AC_MUXPOS_0_bm  (1<<3)  /* Positive Input MUX Selection bit 0 mask. */
+#define AC_MUXPOS_0_bp  3  /* Positive Input MUX Selection bit 0 position. */
+#define AC_MUXPOS_1_bm  (1<<4)  /* Positive Input MUX Selection bit 1 mask. */
+#define AC_MUXPOS_1_bp  4  /* Positive Input MUX Selection bit 1 position. */
+#define AC_MUXPOS_2_bm  (1<<5)  /* Positive Input MUX Selection bit 2 mask. */
+#define AC_MUXPOS_2_bp  5  /* Positive Input MUX Selection bit 2 position. */
+#define AC_INITVAL_bm  0x40  /* AC Output Initial Value bit mask. */
+#define AC_INITVAL_bp  6  /* AC Output Initial Value bit position. */
+#define AC_INVERT_bm  0x80  /* Invert AC Output bit mask. */
+#define AC_INVERT_bp  7  /* Invert AC Output bit position. */
+
+/* AC.DACREF  bit masks and bit positions */
+#define AC_DACREF_gm  0xFF  /* DACREF group mask. */
+#define AC_DACREF_gp  0  /* DACREF group position. */
+#define AC_DACREF_0_bm  (1<<0)  /* DACREF bit 0 mask. */
+#define AC_DACREF_0_bp  0  /* DACREF bit 0 position. */
+#define AC_DACREF_1_bm  (1<<1)  /* DACREF bit 1 mask. */
+#define AC_DACREF_1_bp  1  /* DACREF bit 1 position. */
+#define AC_DACREF_2_bm  (1<<2)  /* DACREF bit 2 mask. */
+#define AC_DACREF_2_bp  2  /* DACREF bit 2 position. */
+#define AC_DACREF_3_bm  (1<<3)  /* DACREF bit 3 mask. */
+#define AC_DACREF_3_bp  3  /* DACREF bit 3 position. */
+#define AC_DACREF_4_bm  (1<<4)  /* DACREF bit 4 mask. */
+#define AC_DACREF_4_bp  4  /* DACREF bit 4 position. */
+#define AC_DACREF_5_bm  (1<<5)  /* DACREF bit 5 mask. */
+#define AC_DACREF_5_bp  5  /* DACREF bit 5 position. */
+#define AC_DACREF_6_bm  (1<<6)  /* DACREF bit 6 mask. */
+#define AC_DACREF_6_bp  6  /* DACREF bit 6 position. */
+#define AC_DACREF_7_bm  (1<<7)  /* DACREF bit 7 mask. */
+#define AC_DACREF_7_bp  7  /* DACREF bit 7 position. */
+
+/* AC.INTCTRL  bit masks and bit positions */
+#define AC_CMP_bm  0x01  /* Interrupt Enable bit mask. */
+#define AC_CMP_bp  0  /* Interrupt Enable bit position. */
+#define AC_INTMODE_NORMAL_gm  0x30  /* Interrupt Mode group mask. */
+#define AC_INTMODE_NORMAL_gp  4  /* Interrupt Mode group position. */
+#define AC_INTMODE_NORMAL_0_bm  (1<<4)  /* Interrupt Mode bit 0 mask. */
+#define AC_INTMODE_NORMAL_0_bp  4  /* Interrupt Mode bit 0 position. */
+#define AC_INTMODE_NORMAL_1_bm  (1<<5)  /* Interrupt Mode bit 1 mask. */
+#define AC_INTMODE_NORMAL_1_bp  5  /* Interrupt Mode bit 1 position. */
+#define AC_INTMODE_WINDOW_gm  0x30  /* Interrupt Mode group mask. */
+#define AC_INTMODE_WINDOW_gp  4  /* Interrupt Mode group position. */
+#define AC_INTMODE_WINDOW_0_bm  (1<<4)  /* Interrupt Mode bit 0 mask. */
+#define AC_INTMODE_WINDOW_0_bp  4  /* Interrupt Mode bit 0 position. */
+#define AC_INTMODE_WINDOW_1_bm  (1<<5)  /* Interrupt Mode bit 1 mask. */
+#define AC_INTMODE_WINDOW_1_bp  5  /* Interrupt Mode bit 1 position. */
+
+/* AC.STATUS  bit masks and bit positions */
+#define AC_CMPIF_bm  0x01  /* Analog Comparator Interrupt Flag bit mask. */
+#define AC_CMPIF_bp  0  /* Analog Comparator Interrupt Flag bit position. */
+#define AC_CMPSTATE_bm  0x10  /* Analog Comparator State bit mask. */
+#define AC_CMPSTATE_bp  4  /* Analog Comparator State bit position. */
+#define AC_WINSTATE_gm  0xC0  /* Analog Comparator Window State group mask. */
+#define AC_WINSTATE_gp  6  /* Analog Comparator Window State group position. */
+#define AC_WINSTATE_0_bm  (1<<6)  /* Analog Comparator Window State bit 0 mask. */
+#define AC_WINSTATE_0_bp  6  /* Analog Comparator Window State bit 0 position. */
+#define AC_WINSTATE_1_bm  (1<<7)  /* Analog Comparator Window State bit 1 mask. */
+#define AC_WINSTATE_1_bp  7  /* Analog Comparator Window State bit 1 position. */
+
+
+/* ADC - Analog to Digital Converter */
+/* ADC.CTRLA  bit masks and bit positions */
+#define ADC_ENABLE_bm  0x01  /* ADC Enable bit mask. */
+#define ADC_ENABLE_bp  0  /* ADC Enable bit position. */
+#define ADC_LOWLAT_bm  0x20  /* Low Latency bit mask. */
+#define ADC_LOWLAT_bp  5  /* Low Latency bit position. */
+#define ADC_RUNSTDBY_bm  0x80  /* Run in Standby bit mask. */
+#define ADC_RUNSTDBY_bp  7  /* Run in Standby bit position. */
+
+/* ADC.CTRLB  bit masks and bit positions */
+#define ADC_PRESC_gm  0x0F  /* Prescaler Value group mask. */
+#define ADC_PRESC_gp  0  /* Prescaler Value group position. */
+#define ADC_PRESC_0_bm  (1<<0)  /* Prescaler Value bit 0 mask. */
+#define ADC_PRESC_0_bp  0  /* Prescaler Value bit 0 position. */
+#define ADC_PRESC_1_bm  (1<<1)  /* Prescaler Value bit 1 mask. */
+#define ADC_PRESC_1_bp  1  /* Prescaler Value bit 1 position. */
+#define ADC_PRESC_2_bm  (1<<2)  /* Prescaler Value bit 2 mask. */
+#define ADC_PRESC_2_bp  2  /* Prescaler Value bit 2 position. */
+#define ADC_PRESC_3_bm  (1<<3)  /* Prescaler Value bit 3 mask. */
+#define ADC_PRESC_3_bp  3  /* Prescaler Value bit 3 position. */
+
+/* ADC.CTRLC  bit masks and bit positions */
+#define ADC_REFSEL_gm  0x07  /* Reference select group mask. */
+#define ADC_REFSEL_gp  0  /* Reference select group position. */
+#define ADC_REFSEL_0_bm  (1<<0)  /* Reference select bit 0 mask. */
+#define ADC_REFSEL_0_bp  0  /* Reference select bit 0 position. */
+#define ADC_REFSEL_1_bm  (1<<1)  /* Reference select bit 1 mask. */
+#define ADC_REFSEL_1_bp  1  /* Reference select bit 1 position. */
+#define ADC_REFSEL_2_bm  (1<<2)  /* Reference select bit 2 mask. */
+#define ADC_REFSEL_2_bp  2  /* Reference select bit 2 position. */
+
+/* ADC.CTRLD  bit masks and bit positions */
+#define ADC_WINCM_gm  0x07  /* Window Comparator Mode group mask. */
+#define ADC_WINCM_gp  0  /* Window Comparator Mode group position. */
+#define ADC_WINCM_0_bm  (1<<0)  /* Window Comparator Mode bit 0 mask. */
+#define ADC_WINCM_0_bp  0  /* Window Comparator Mode bit 0 position. */
+#define ADC_WINCM_1_bm  (1<<1)  /* Window Comparator Mode bit 1 mask. */
+#define ADC_WINCM_1_bp  1  /* Window Comparator Mode bit 1 position. */
+#define ADC_WINCM_2_bm  (1<<2)  /* Window Comparator Mode bit 2 mask. */
+#define ADC_WINCM_2_bp  2  /* Window Comparator Mode bit 2 position. */
+#define ADC_WINSRC_bm  0x08  /* Window Mode Source bit mask. */
+#define ADC_WINSRC_bp  3  /* Window Mode Source bit position. */
+
+/* ADC.INTCTRL  bit masks and bit positions */
+#define ADC_RESRDY_bm  0x01  /* Result Ready Interrupt Enable bit mask. */
+#define ADC_RESRDY_bp  0  /* Result Ready Interrupt Enable bit position. */
+#define ADC_SAMPRDY_bm  0x02  /* Sample Ready Interrupt Enable bit mask. */
+#define ADC_SAMPRDY_bp  1  /* Sample Ready Interrupt Enable bit position. */
+#define ADC_WCMP_bm  0x04  /* Window Comparator Interrupt Enable bit mask. */
+#define ADC_WCMP_bp  2  /* Window Comparator Interrupt Enable bit position. */
+#define ADC_RESOVR_bm  0x08  /* Result Overwrite Interrupt Enable bit mask. */
+#define ADC_RESOVR_bp  3  /* Result Overwrite Interrupt Enable bit position. */
+#define ADC_SAMPOVR_bm  0x10  /* Sample Overwrite Interrupt Enable bit mask. */
+#define ADC_SAMPOVR_bp  4  /* Sample Overwrite Interrupt Enable bit position. */
+#define ADC_TRIGOVR_bm  0x20  /* Trigger Overrun Interrupt Enable bit mask. */
+#define ADC_TRIGOVR_bp  5  /* Trigger Overrun Interrupt Enable bit position. */
+
+/* ADC.INTFLAGS  bit masks and bit positions */
+/* ADC_RESRDY  is already defined. */
+/* ADC_SAMPRDY  is already defined. */
+/* ADC_WCMP  is already defined. */
+/* ADC_RESOVR  is already defined. */
+/* ADC_SAMPOVR  is already defined. */
+/* ADC_TRIGOVR  is already defined. */
+
+/* ADC.STATUS  bit masks and bit positions */
+#define ADC_ADCBUSY_bm  0x01  /* ADC Busy bit mask. */
+#define ADC_ADCBUSY_bp  0  /* ADC Busy bit position. */
+
+/* ADC.DBGCTRL  bit masks and bit positions */
+#define ADC_DBGRUN_bm  0x01  /* Run in Debug Mode bit mask. */
+#define ADC_DBGRUN_bp  0  /* Run in Debug Mode bit position. */
+
+/* ADC.CTRLE  bit masks and bit positions */
+#define ADC_SAMPDUR_gm  0xFF  /* Sample Duration group mask. */
+#define ADC_SAMPDUR_gp  0  /* Sample Duration group position. */
+#define ADC_SAMPDUR_0_bm  (1<<0)  /* Sample Duration bit 0 mask. */
+#define ADC_SAMPDUR_0_bp  0  /* Sample Duration bit 0 position. */
+#define ADC_SAMPDUR_1_bm  (1<<1)  /* Sample Duration bit 1 mask. */
+#define ADC_SAMPDUR_1_bp  1  /* Sample Duration bit 1 position. */
+#define ADC_SAMPDUR_2_bm  (1<<2)  /* Sample Duration bit 2 mask. */
+#define ADC_SAMPDUR_2_bp  2  /* Sample Duration bit 2 position. */
+#define ADC_SAMPDUR_3_bm  (1<<3)  /* Sample Duration bit 3 mask. */
+#define ADC_SAMPDUR_3_bp  3  /* Sample Duration bit 3 position. */
+#define ADC_SAMPDUR_4_bm  (1<<4)  /* Sample Duration bit 4 mask. */
+#define ADC_SAMPDUR_4_bp  4  /* Sample Duration bit 4 position. */
+#define ADC_SAMPDUR_5_bm  (1<<5)  /* Sample Duration bit 5 mask. */
+#define ADC_SAMPDUR_5_bp  5  /* Sample Duration bit 5 position. */
+#define ADC_SAMPDUR_6_bm  (1<<6)  /* Sample Duration bit 6 mask. */
+#define ADC_SAMPDUR_6_bp  6  /* Sample Duration bit 6 position. */
+#define ADC_SAMPDUR_7_bm  (1<<7)  /* Sample Duration bit 7 mask. */
+#define ADC_SAMPDUR_7_bp  7  /* Sample Duration bit 7 position. */
+
+/* ADC.CTRLF  bit masks and bit positions */
+#define ADC_SAMPNUM_gm  0x0F  /* Sample numbers group mask. */
+#define ADC_SAMPNUM_gp  0  /* Sample numbers group position. */
+#define ADC_SAMPNUM_0_bm  (1<<0)  /* Sample numbers bit 0 mask. */
+#define ADC_SAMPNUM_0_bp  0  /* Sample numbers bit 0 position. */
+#define ADC_SAMPNUM_1_bm  (1<<1)  /* Sample numbers bit 1 mask. */
+#define ADC_SAMPNUM_1_bp  1  /* Sample numbers bit 1 position. */
+#define ADC_SAMPNUM_2_bm  (1<<2)  /* Sample numbers bit 2 mask. */
+#define ADC_SAMPNUM_2_bp  2  /* Sample numbers bit 2 position. */
+#define ADC_SAMPNUM_3_bm  (1<<3)  /* Sample numbers bit 3 mask. */
+#define ADC_SAMPNUM_3_bp  3  /* Sample numbers bit 3 position. */
+#define ADC_LEFTADJ_bm  0x10  /* Left Adjust bit mask. */
+#define ADC_LEFTADJ_bp  4  /* Left Adjust bit position. */
+#define ADC_FREERUN_bm  0x20  /* Free-Running mode bit mask. */
+#define ADC_FREERUN_bp  5  /* Free-Running mode bit position. */
+#define ADC_CHOPPING_bm  0x40  /* Sign Chopping bit mask. */
+#define ADC_CHOPPING_bp  6  /* Sign Chopping bit position. */
+
+/* ADC.COMMAND  bit masks and bit positions */
+#define ADC_START_gm  0x07  /* Start command group mask. */
+#define ADC_START_gp  0  /* Start command group position. */
+#define ADC_START_0_bm  (1<<0)  /* Start command bit 0 mask. */
+#define ADC_START_0_bp  0  /* Start command bit 0 position. */
+#define ADC_START_1_bm  (1<<1)  /* Start command bit 1 mask. */
+#define ADC_START_1_bp  1  /* Start command bit 1 position. */
+#define ADC_START_2_bm  (1<<2)  /* Start command bit 2 mask. */
+#define ADC_START_2_bp  2  /* Start command bit 2 position. */
+#define ADC_MODE_gm  0x70  /* Mode group mask. */
+#define ADC_MODE_gp  4  /* Mode group position. */
+#define ADC_MODE_0_bm  (1<<4)  /* Mode bit 0 mask. */
+#define ADC_MODE_0_bp  4  /* Mode bit 0 position. */
+#define ADC_MODE_1_bm  (1<<5)  /* Mode bit 1 mask. */
+#define ADC_MODE_1_bp  5  /* Mode bit 1 position. */
+#define ADC_MODE_2_bm  (1<<6)  /* Mode bit 2 mask. */
+#define ADC_MODE_2_bp  6  /* Mode bit 2 position. */
+#define ADC_DIFF_bm  0x80  /* Differential mode bit mask. */
+#define ADC_DIFF_bp  7  /* Differential mode bit position. */
+
+/* ADC.PGACTRL  bit masks and bit positions */
+#define ADC_PGAEN_bm  0x01  /* PGA Enable bit mask. */
+#define ADC_PGAEN_bp  0  /* PGA Enable bit position. */
+#define ADC_PGABIASSEL_gm  0x18  /* PGA BIAS Select group mask. */
+#define ADC_PGABIASSEL_gp  3  /* PGA BIAS Select group position. */
+#define ADC_PGABIASSEL_0_bm  (1<<3)  /* PGA BIAS Select bit 0 mask. */
+#define ADC_PGABIASSEL_0_bp  3  /* PGA BIAS Select bit 0 position. */
+#define ADC_PGABIASSEL_1_bm  (1<<4)  /* PGA BIAS Select bit 1 mask. */
+#define ADC_PGABIASSEL_1_bp  4  /* PGA BIAS Select bit 1 position. */
+#define ADC_GAIN_gm  0xE0  /* Gain group mask. */
+#define ADC_GAIN_gp  5  /* Gain group position. */
+#define ADC_GAIN_0_bm  (1<<5)  /* Gain bit 0 mask. */
+#define ADC_GAIN_0_bp  5  /* Gain bit 0 position. */
+#define ADC_GAIN_1_bm  (1<<6)  /* Gain bit 1 mask. */
+#define ADC_GAIN_1_bp  6  /* Gain bit 1 position. */
+#define ADC_GAIN_2_bm  (1<<7)  /* Gain bit 2 mask. */
+#define ADC_GAIN_2_bp  7  /* Gain bit 2 position. */
+
+/* ADC.MUXPOS  bit masks and bit positions */
+#define ADC_MUXPOS_gm  0x3F  /* Analog Channel Selection Bits group mask. */
+#define ADC_MUXPOS_gp  0  /* Analog Channel Selection Bits group position. */
+#define ADC_MUXPOS_0_bm  (1<<0)  /* Analog Channel Selection Bits bit 0 mask. */
+#define ADC_MUXPOS_0_bp  0  /* Analog Channel Selection Bits bit 0 position. */
+#define ADC_MUXPOS_1_bm  (1<<1)  /* Analog Channel Selection Bits bit 1 mask. */
+#define ADC_MUXPOS_1_bp  1  /* Analog Channel Selection Bits bit 1 position. */
+#define ADC_MUXPOS_2_bm  (1<<2)  /* Analog Channel Selection Bits bit 2 mask. */
+#define ADC_MUXPOS_2_bp  2  /* Analog Channel Selection Bits bit 2 position. */
+#define ADC_MUXPOS_3_bm  (1<<3)  /* Analog Channel Selection Bits bit 3 mask. */
+#define ADC_MUXPOS_3_bp  3  /* Analog Channel Selection Bits bit 3 position. */
+#define ADC_MUXPOS_4_bm  (1<<4)  /* Analog Channel Selection Bits bit 4 mask. */
+#define ADC_MUXPOS_4_bp  4  /* Analog Channel Selection Bits bit 4 position. */
+#define ADC_MUXPOS_5_bm  (1<<5)  /* Analog Channel Selection Bits bit 5 mask. */
+#define ADC_MUXPOS_5_bp  5  /* Analog Channel Selection Bits bit 5 position. */
+#define ADC_VIA_gm  0xC0  /* VIA group mask. */
+#define ADC_VIA_gp  6  /* VIA group position. */
+#define ADC_VIA_0_bm  (1<<6)  /* VIA bit 0 mask. */
+#define ADC_VIA_0_bp  6  /* VIA bit 0 position. */
+#define ADC_VIA_1_bm  (1<<7)  /* VIA bit 1 mask. */
+#define ADC_VIA_1_bp  7  /* VIA bit 1 position. */
+
+/* ADC.MUXNEG  bit masks and bit positions */
+#define ADC_MUXNEG_gm  0x3F  /* Analog Channel Selection Bits group mask. */
+#define ADC_MUXNEG_gp  0  /* Analog Channel Selection Bits group position. */
+#define ADC_MUXNEG_0_bm  (1<<0)  /* Analog Channel Selection Bits bit 0 mask. */
+#define ADC_MUXNEG_0_bp  0  /* Analog Channel Selection Bits bit 0 position. */
+#define ADC_MUXNEG_1_bm  (1<<1)  /* Analog Channel Selection Bits bit 1 mask. */
+#define ADC_MUXNEG_1_bp  1  /* Analog Channel Selection Bits bit 1 position. */
+#define ADC_MUXNEG_2_bm  (1<<2)  /* Analog Channel Selection Bits bit 2 mask. */
+#define ADC_MUXNEG_2_bp  2  /* Analog Channel Selection Bits bit 2 position. */
+#define ADC_MUXNEG_3_bm  (1<<3)  /* Analog Channel Selection Bits bit 3 mask. */
+#define ADC_MUXNEG_3_bp  3  /* Analog Channel Selection Bits bit 3 position. */
+#define ADC_MUXNEG_4_bm  (1<<4)  /* Analog Channel Selection Bits bit 4 mask. */
+#define ADC_MUXNEG_4_bp  4  /* Analog Channel Selection Bits bit 4 position. */
+#define ADC_MUXNEG_5_bm  (1<<5)  /* Analog Channel Selection Bits bit 5 mask. */
+#define ADC_MUXNEG_5_bp  5  /* Analog Channel Selection Bits bit 5 position. */
+/* ADC_VIA  is already defined. */
+
+
+/* BOD - Bod interface */
+/* BOD.CTRLA  bit masks and bit positions */
+#define BOD_SLEEP_gm  0x03  /* Operation in sleep mode group mask. */
+#define BOD_SLEEP_gp  0  /* Operation in sleep mode group position. */
+#define BOD_SLEEP_0_bm  (1<<0)  /* Operation in sleep mode bit 0 mask. */
+#define BOD_SLEEP_0_bp  0  /* Operation in sleep mode bit 0 position. */
+#define BOD_SLEEP_1_bm  (1<<1)  /* Operation in sleep mode bit 1 mask. */
+#define BOD_SLEEP_1_bp  1  /* Operation in sleep mode bit 1 position. */
+#define BOD_ACTIVE_gm  0x0C  /* Operation in active mode group mask. */
+#define BOD_ACTIVE_gp  2  /* Operation in active mode group position. */
+#define BOD_ACTIVE_0_bm  (1<<2)  /* Operation in active mode bit 0 mask. */
+#define BOD_ACTIVE_0_bp  2  /* Operation in active mode bit 0 position. */
+#define BOD_ACTIVE_1_bm  (1<<3)  /* Operation in active mode bit 1 mask. */
+#define BOD_ACTIVE_1_bp  3  /* Operation in active mode bit 1 position. */
+#define BOD_SAMPFREQ_bm  0x10  /* Sample frequency bit mask. */
+#define BOD_SAMPFREQ_bp  4  /* Sample frequency bit position. */
+
+/* BOD.CTRLB  bit masks and bit positions */
+#define BOD_LVL_gm  0x07  /* Bod level group mask. */
+#define BOD_LVL_gp  0  /* Bod level group position. */
+#define BOD_LVL_0_bm  (1<<0)  /* Bod level bit 0 mask. */
+#define BOD_LVL_0_bp  0  /* Bod level bit 0 position. */
+#define BOD_LVL_1_bm  (1<<1)  /* Bod level bit 1 mask. */
+#define BOD_LVL_1_bp  1  /* Bod level bit 1 position. */
+#define BOD_LVL_2_bm  (1<<2)  /* Bod level bit 2 mask. */
+#define BOD_LVL_2_bp  2  /* Bod level bit 2 position. */
+
+/* BOD.VLMCTRLA  bit masks and bit positions */
+#define BOD_VLMLVL_gm  0x03  /* voltage level monitor level group mask. */
+#define BOD_VLMLVL_gp  0  /* voltage level monitor level group position. */
+#define BOD_VLMLVL_0_bm  (1<<0)  /* voltage level monitor level bit 0 mask. */
+#define BOD_VLMLVL_0_bp  0  /* voltage level monitor level bit 0 position. */
+#define BOD_VLMLVL_1_bm  (1<<1)  /* voltage level monitor level bit 1 mask. */
+#define BOD_VLMLVL_1_bp  1  /* voltage level monitor level bit 1 position. */
+
+/* BOD.INTCTRL  bit masks and bit positions */
+#define BOD_VLMIE_bm  0x01  /* voltage level monitor interrrupt enable bit mask. */
+#define BOD_VLMIE_bp  0  /* voltage level monitor interrrupt enable bit position. */
+#define BOD_VLMCFG_gm  0x06  /* Configuration group mask. */
+#define BOD_VLMCFG_gp  1  /* Configuration group position. */
+#define BOD_VLMCFG_0_bm  (1<<1)  /* Configuration bit 0 mask. */
+#define BOD_VLMCFG_0_bp  1  /* Configuration bit 0 position. */
+#define BOD_VLMCFG_1_bm  (1<<2)  /* Configuration bit 1 mask. */
+#define BOD_VLMCFG_1_bp  2  /* Configuration bit 1 position. */
+
+/* BOD.INTFLAGS  bit masks and bit positions */
+#define BOD_VLMIF_bm  0x01  /* Voltage level monitor interrupt flag bit mask. */
+#define BOD_VLMIF_bp  0  /* Voltage level monitor interrupt flag bit position. */
+
+/* BOD.STATUS  bit masks and bit positions */
+#define BOD_VLMS_bm  0x01  /* Voltage level monitor status bit mask. */
+#define BOD_VLMS_bp  0  /* Voltage level monitor status bit position. */
+
+
+
+/* CCL - Configurable Custom Logic */
+/* CCL.CTRLA  bit masks and bit positions */
+#define CCL_ENABLE_bm  0x01  /* Enable bit mask. */
+#define CCL_ENABLE_bp  0  /* Enable bit position. */
+#define CCL_RUNSTDBY_bm  0x40  /* Run in Standby bit mask. */
+#define CCL_RUNSTDBY_bp  6  /* Run in Standby bit position. */
+
+/* CCL.SEQCTRL0  bit masks and bit positions */
+#define CCL_SEQSEL_gm  0x0F  /* Sequential Selection group mask. */
+#define CCL_SEQSEL_gp  0  /* Sequential Selection group position. */
+#define CCL_SEQSEL_0_bm  (1<<0)  /* Sequential Selection bit 0 mask. */
+#define CCL_SEQSEL_0_bp  0  /* Sequential Selection bit 0 position. */
+#define CCL_SEQSEL_1_bm  (1<<1)  /* Sequential Selection bit 1 mask. */
+#define CCL_SEQSEL_1_bp  1  /* Sequential Selection bit 1 position. */
+#define CCL_SEQSEL_2_bm  (1<<2)  /* Sequential Selection bit 2 mask. */
+#define CCL_SEQSEL_2_bp  2  /* Sequential Selection bit 2 position. */
+#define CCL_SEQSEL_3_bm  (1<<3)  /* Sequential Selection bit 3 mask. */
+#define CCL_SEQSEL_3_bp  3  /* Sequential Selection bit 3 position. */
+
+/* CCL.SEQCTRL1  bit masks and bit positions */
+/* CCL_SEQSEL  is already defined. */
+
+/* CCL.INTCTRL0  bit masks and bit positions */
+#define CCL_INTMODE0_gm  0x03  /* Interrupt Mode for LUT0 group mask. */
+#define CCL_INTMODE0_gp  0  /* Interrupt Mode for LUT0 group position. */
+#define CCL_INTMODE0_0_bm  (1<<0)  /* Interrupt Mode for LUT0 bit 0 mask. */
+#define CCL_INTMODE0_0_bp  0  /* Interrupt Mode for LUT0 bit 0 position. */
+#define CCL_INTMODE0_1_bm  (1<<1)  /* Interrupt Mode for LUT0 bit 1 mask. */
+#define CCL_INTMODE0_1_bp  1  /* Interrupt Mode for LUT0 bit 1 position. */
+#define CCL_INTMODE1_gm  0x0C  /* Interrupt Mode for LUT1 group mask. */
+#define CCL_INTMODE1_gp  2  /* Interrupt Mode for LUT1 group position. */
+#define CCL_INTMODE1_0_bm  (1<<2)  /* Interrupt Mode for LUT1 bit 0 mask. */
+#define CCL_INTMODE1_0_bp  2  /* Interrupt Mode for LUT1 bit 0 position. */
+#define CCL_INTMODE1_1_bm  (1<<3)  /* Interrupt Mode for LUT1 bit 1 mask. */
+#define CCL_INTMODE1_1_bp  3  /* Interrupt Mode for LUT1 bit 1 position. */
+#define CCL_INTMODE2_gm  0x30  /* Interrupt Mode for LUT2 group mask. */
+#define CCL_INTMODE2_gp  4  /* Interrupt Mode for LUT2 group position. */
+#define CCL_INTMODE2_0_bm  (1<<4)  /* Interrupt Mode for LUT2 bit 0 mask. */
+#define CCL_INTMODE2_0_bp  4  /* Interrupt Mode for LUT2 bit 0 position. */
+#define CCL_INTMODE2_1_bm  (1<<5)  /* Interrupt Mode for LUT2 bit 1 mask. */
+#define CCL_INTMODE2_1_bp  5  /* Interrupt Mode for LUT2 bit 1 position. */
+#define CCL_INTMODE3_gm  0xC0  /* Interrupt Mode for LUT3 group mask. */
+#define CCL_INTMODE3_gp  6  /* Interrupt Mode for LUT3 group position. */
+#define CCL_INTMODE3_0_bm  (1<<6)  /* Interrupt Mode for LUT3 bit 0 mask. */
+#define CCL_INTMODE3_0_bp  6  /* Interrupt Mode for LUT3 bit 0 position. */
+#define CCL_INTMODE3_1_bm  (1<<7)  /* Interrupt Mode for LUT3 bit 1 mask. */
+#define CCL_INTMODE3_1_bp  7  /* Interrupt Mode for LUT3 bit 1 position. */
+
+/* CCL.INTFLAGS  bit masks and bit positions */
+#define CCL_INT_gm  0x0F  /* Interrupt Flag group mask. */
+#define CCL_INT_gp  0  /* Interrupt Flag group position. */
+#define CCL_INT_0_bm  (1<<0)  /* Interrupt Flag bit 0 mask. */
+#define CCL_INT_0_bp  0  /* Interrupt Flag bit 0 position. */
+#define CCL_INT0_bm  CCL_INT_0_bm  /* This define is deprecated and should not be used */
+#define CCL_INT0_bp  CCL_INT_0_bp  /* This define is deprecated and should not be used */
+#define CCL_INT_1_bm  (1<<1)  /* Interrupt Flag bit 1 mask. */
+#define CCL_INT_1_bp  1  /* Interrupt Flag bit 1 position. */
+#define CCL_INT1_bm  CCL_INT_1_bm  /* This define is deprecated and should not be used */
+#define CCL_INT1_bp  CCL_INT_1_bp  /* This define is deprecated and should not be used */
+#define CCL_INT_2_bm  (1<<2)  /* Interrupt Flag bit 2 mask. */
+#define CCL_INT_2_bp  2  /* Interrupt Flag bit 2 position. */
+#define CCL_INT2_bm  CCL_INT_2_bm  /* This define is deprecated and should not be used */
+#define CCL_INT2_bp  CCL_INT_2_bp  /* This define is deprecated and should not be used */
+#define CCL_INT_3_bm  (1<<3)  /* Interrupt Flag bit 3 mask. */
+#define CCL_INT_3_bp  3  /* Interrupt Flag bit 3 position. */
+#define CCL_INT3_bm  CCL_INT_3_bm  /* This define is deprecated and should not be used */
+#define CCL_INT3_bp  CCL_INT_3_bp  /* This define is deprecated and should not be used */
+
+/* CCL.LUT0CTRLA  bit masks and bit positions */
+/* CCL_ENABLE  is already defined. */
+#define CCL_CLKSRC_gm  0x0E  /* Clock Source Selection group mask. */
+#define CCL_CLKSRC_gp  1  /* Clock Source Selection group position. */
+#define CCL_CLKSRC_0_bm  (1<<1)  /* Clock Source Selection bit 0 mask. */
+#define CCL_CLKSRC_0_bp  1  /* Clock Source Selection bit 0 position. */
+#define CCL_CLKSRC_1_bm  (1<<2)  /* Clock Source Selection bit 1 mask. */
+#define CCL_CLKSRC_1_bp  2  /* Clock Source Selection bit 1 position. */
+#define CCL_CLKSRC_2_bm  (1<<3)  /* Clock Source Selection bit 2 mask. */
+#define CCL_CLKSRC_2_bp  3  /* Clock Source Selection bit 2 position. */
+#define CCL_FILTSEL_gm  0x30  /* Filter Selection group mask. */
+#define CCL_FILTSEL_gp  4  /* Filter Selection group position. */
+#define CCL_FILTSEL_0_bm  (1<<4)  /* Filter Selection bit 0 mask. */
+#define CCL_FILTSEL_0_bp  4  /* Filter Selection bit 0 position. */
+#define CCL_FILTSEL_1_bm  (1<<5)  /* Filter Selection bit 1 mask. */
+#define CCL_FILTSEL_1_bp  5  /* Filter Selection bit 1 position. */
+#define CCL_OUTEN_bm  0x40  /* Output Enable bit mask. */
+#define CCL_OUTEN_bp  6  /* Output Enable bit position. */
+#define CCL_EDGEDET_bm  0x80  /* Edge Detection Enable bit mask. */
+#define CCL_EDGEDET_bp  7  /* Edge Detection Enable bit position. */
+
+/* CCL.LUT0CTRLB  bit masks and bit positions */
+#define CCL_INSEL0_gm  0x0F  /* LUT Input 0 Source Selection group mask. */
+#define CCL_INSEL0_gp  0  /* LUT Input 0 Source Selection group position. */
+#define CCL_INSEL0_0_bm  (1<<0)  /* LUT Input 0 Source Selection bit 0 mask. */
+#define CCL_INSEL0_0_bp  0  /* LUT Input 0 Source Selection bit 0 position. */
+#define CCL_INSEL0_1_bm  (1<<1)  /* LUT Input 0 Source Selection bit 1 mask. */
+#define CCL_INSEL0_1_bp  1  /* LUT Input 0 Source Selection bit 1 position. */
+#define CCL_INSEL0_2_bm  (1<<2)  /* LUT Input 0 Source Selection bit 2 mask. */
+#define CCL_INSEL0_2_bp  2  /* LUT Input 0 Source Selection bit 2 position. */
+#define CCL_INSEL0_3_bm  (1<<3)  /* LUT Input 0 Source Selection bit 3 mask. */
+#define CCL_INSEL0_3_bp  3  /* LUT Input 0 Source Selection bit 3 position. */
+#define CCL_INSEL1_gm  0xF0  /* LUT Input 1 Source Selection group mask. */
+#define CCL_INSEL1_gp  4  /* LUT Input 1 Source Selection group position. */
+#define CCL_INSEL1_0_bm  (1<<4)  /* LUT Input 1 Source Selection bit 0 mask. */
+#define CCL_INSEL1_0_bp  4  /* LUT Input 1 Source Selection bit 0 position. */
+#define CCL_INSEL1_1_bm  (1<<5)  /* LUT Input 1 Source Selection bit 1 mask. */
+#define CCL_INSEL1_1_bp  5  /* LUT Input 1 Source Selection bit 1 position. */
+#define CCL_INSEL1_2_bm  (1<<6)  /* LUT Input 1 Source Selection bit 2 mask. */
+#define CCL_INSEL1_2_bp  6  /* LUT Input 1 Source Selection bit 2 position. */
+#define CCL_INSEL1_3_bm  (1<<7)  /* LUT Input 1 Source Selection bit 3 mask. */
+#define CCL_INSEL1_3_bp  7  /* LUT Input 1 Source Selection bit 3 position. */
+
+/* CCL.LUT0CTRLC  bit masks and bit positions */
+#define CCL_INSEL2_gm  0x0F  /* LUT Input 2 Source Selection group mask. */
+#define CCL_INSEL2_gp  0  /* LUT Input 2 Source Selection group position. */
+#define CCL_INSEL2_0_bm  (1<<0)  /* LUT Input 2 Source Selection bit 0 mask. */
+#define CCL_INSEL2_0_bp  0  /* LUT Input 2 Source Selection bit 0 position. */
+#define CCL_INSEL2_1_bm  (1<<1)  /* LUT Input 2 Source Selection bit 1 mask. */
+#define CCL_INSEL2_1_bp  1  /* LUT Input 2 Source Selection bit 1 position. */
+#define CCL_INSEL2_2_bm  (1<<2)  /* LUT Input 2 Source Selection bit 2 mask. */
+#define CCL_INSEL2_2_bp  2  /* LUT Input 2 Source Selection bit 2 position. */
+#define CCL_INSEL2_3_bm  (1<<3)  /* LUT Input 2 Source Selection bit 3 mask. */
+#define CCL_INSEL2_3_bp  3  /* LUT Input 2 Source Selection bit 3 position. */
+
+/* CCL.TRUTH0  bit masks and bit positions */
+#define CCL_TRUTH_gm  0xFF  /* Truth Table group mask. */
+#define CCL_TRUTH_gp  0  /* Truth Table group position. */
+#define CCL_TRUTH_0_bm  (1<<0)  /* Truth Table bit 0 mask. */
+#define CCL_TRUTH_0_bp  0  /* Truth Table bit 0 position. */
+#define CCL_TRUTH_1_bm  (1<<1)  /* Truth Table bit 1 mask. */
+#define CCL_TRUTH_1_bp  1  /* Truth Table bit 1 position. */
+#define CCL_TRUTH_2_bm  (1<<2)  /* Truth Table bit 2 mask. */
+#define CCL_TRUTH_2_bp  2  /* Truth Table bit 2 position. */
+#define CCL_TRUTH_3_bm  (1<<3)  /* Truth Table bit 3 mask. */
+#define CCL_TRUTH_3_bp  3  /* Truth Table bit 3 position. */
+#define CCL_TRUTH_4_bm  (1<<4)  /* Truth Table bit 4 mask. */
+#define CCL_TRUTH_4_bp  4  /* Truth Table bit 4 position. */
+#define CCL_TRUTH_5_bm  (1<<5)  /* Truth Table bit 5 mask. */
+#define CCL_TRUTH_5_bp  5  /* Truth Table bit 5 position. */
+#define CCL_TRUTH_6_bm  (1<<6)  /* Truth Table bit 6 mask. */
+#define CCL_TRUTH_6_bp  6  /* Truth Table bit 6 position. */
+#define CCL_TRUTH_7_bm  (1<<7)  /* Truth Table bit 7 mask. */
+#define CCL_TRUTH_7_bp  7  /* Truth Table bit 7 position. */
+
+/* CCL.LUT1CTRLA  bit masks and bit positions */
+/* CCL_ENABLE  is already defined. */
+/* CCL_CLKSRC  is already defined. */
+/* CCL_FILTSEL  is already defined. */
+/* CCL_OUTEN  is already defined. */
+/* CCL_EDGEDET  is already defined. */
+
+/* CCL.LUT1CTRLB  bit masks and bit positions */
+/* CCL_INSEL0  is already defined. */
+/* CCL_INSEL1  is already defined. */
+
+/* CCL.LUT1CTRLC  bit masks and bit positions */
+/* CCL_INSEL2  is already defined. */
+
+/* CCL.TRUTH1  bit masks and bit positions */
+/* CCL_TRUTH  is already defined. */
+
+/* CCL.LUT2CTRLA  bit masks and bit positions */
+/* CCL_ENABLE  is already defined. */
+/* CCL_CLKSRC  is already defined. */
+/* CCL_FILTSEL  is already defined. */
+/* CCL_OUTEN  is already defined. */
+/* CCL_EDGEDET  is already defined. */
+
+/* CCL.LUT2CTRLB  bit masks and bit positions */
+/* CCL_INSEL0  is already defined. */
+/* CCL_INSEL1  is already defined. */
+
+/* CCL.LUT2CTRLC  bit masks and bit positions */
+/* CCL_INSEL2  is already defined. */
+
+/* CCL.TRUTH2  bit masks and bit positions */
+/* CCL_TRUTH  is already defined. */
+
+/* CCL.LUT3CTRLA  bit masks and bit positions */
+/* CCL_ENABLE  is already defined. */
+/* CCL_CLKSRC  is already defined. */
+/* CCL_FILTSEL  is already defined. */
+/* CCL_OUTEN  is already defined. */
+/* CCL_EDGEDET  is already defined. */
+
+/* CCL.LUT3CTRLB  bit masks and bit positions */
+/* CCL_INSEL0  is already defined. */
+/* CCL_INSEL1  is already defined. */
+
+/* CCL.LUT3CTRLC  bit masks and bit positions */
+/* CCL_INSEL2  is already defined. */
+
+/* CCL.TRUTH3  bit masks and bit positions */
+/* CCL_TRUTH  is already defined. */
+
+
+/* CLKCTRL - Clock controller */
+/* CLKCTRL.MCLKCTRLA  bit masks and bit positions */
+#define CLKCTRL_CLKSEL_gm  0x0F  /* Clock select group mask. */
+#define CLKCTRL_CLKSEL_gp  0  /* Clock select group position. */
+#define CLKCTRL_CLKSEL_0_bm  (1<<0)  /* Clock select bit 0 mask. */
+#define CLKCTRL_CLKSEL_0_bp  0  /* Clock select bit 0 position. */
+#define CLKCTRL_CLKSEL_1_bm  (1<<1)  /* Clock select bit 1 mask. */
+#define CLKCTRL_CLKSEL_1_bp  1  /* Clock select bit 1 position. */
+#define CLKCTRL_CLKSEL_2_bm  (1<<2)  /* Clock select bit 2 mask. */
+#define CLKCTRL_CLKSEL_2_bp  2  /* Clock select bit 2 position. */
+#define CLKCTRL_CLKSEL_3_bm  (1<<3)  /* Clock select bit 3 mask. */
+#define CLKCTRL_CLKSEL_3_bp  3  /* Clock select bit 3 position. */
+#define CLKCTRL_CLKOUT_bm  0x80  /* System clock out bit mask. */
+#define CLKCTRL_CLKOUT_bp  7  /* System clock out bit position. */
+
+/* CLKCTRL.MCLKCTRLB  bit masks and bit positions */
+#define CLKCTRL_PEN_bm  0x01  /* Prescaler enable bit mask. */
+#define CLKCTRL_PEN_bp  0  /* Prescaler enable bit position. */
+#define CLKCTRL_PDIV_gm  0x1E  /* Prescaler division group mask. */
+#define CLKCTRL_PDIV_gp  1  /* Prescaler division group position. */
+#define CLKCTRL_PDIV_0_bm  (1<<1)  /* Prescaler division bit 0 mask. */
+#define CLKCTRL_PDIV_0_bp  1  /* Prescaler division bit 0 position. */
+#define CLKCTRL_PDIV_1_bm  (1<<2)  /* Prescaler division bit 1 mask. */
+#define CLKCTRL_PDIV_1_bp  2  /* Prescaler division bit 1 position. */
+#define CLKCTRL_PDIV_2_bm  (1<<3)  /* Prescaler division bit 2 mask. */
+#define CLKCTRL_PDIV_2_bp  3  /* Prescaler division bit 2 position. */
+#define CLKCTRL_PDIV_3_bm  (1<<4)  /* Prescaler division bit 3 mask. */
+#define CLKCTRL_PDIV_3_bp  4  /* Prescaler division bit 3 position. */
+#define CLKCTRL_PBDIV_bm  0x20  /* Prescaler B division bit mask. */
+#define CLKCTRL_PBDIV_bp  5  /* Prescaler B division bit position. */
+
+/* CLKCTRL.MCLKSTATUS  bit masks and bit positions */
+#define CLKCTRL_SOSC_bm  0x01  /* System Oscillator changing bit mask. */
+#define CLKCTRL_SOSC_bp  0  /* System Oscillator changing bit position. */
+#define CLKCTRL_OSCHFS_bm  0x02  /* High frequency oscillator status bit mask. */
+#define CLKCTRL_OSCHFS_bp  1  /* High frequency oscillator status bit position. */
+#define CLKCTRL_OSC32KS_bm  0x04  /* 32KHz oscillator status bit mask. */
+#define CLKCTRL_OSC32KS_bp  2  /* 32KHz oscillator status bit position. */
+#define CLKCTRL_XOSC32KS_bm  0x08  /* 32.768 kHz Crystal Oscillator status bit mask. */
+#define CLKCTRL_XOSC32KS_bp  3  /* 32.768 kHz Crystal Oscillator status bit position. */
+#define CLKCTRL_EXTS_bm  0x10  /* External Clock status bit mask. */
+#define CLKCTRL_EXTS_bp  4  /* External Clock status bit position. */
+#define CLKCTRL_PLLS_bm  0x20  /* PLL status bit mask. */
+#define CLKCTRL_PLLS_bp  5  /* PLL status bit position. */
+
+/* CLKCTRL.MCLKTIMEBASE  bit masks and bit positions */
+#define CLKCTRL_TIMEBASE_gm  0x1F  /* Timebase group mask. */
+#define CLKCTRL_TIMEBASE_gp  0  /* Timebase group position. */
+#define CLKCTRL_TIMEBASE_0_bm  (1<<0)  /* Timebase bit 0 mask. */
+#define CLKCTRL_TIMEBASE_0_bp  0  /* Timebase bit 0 position. */
+#define CLKCTRL_TIMEBASE_1_bm  (1<<1)  /* Timebase bit 1 mask. */
+#define CLKCTRL_TIMEBASE_1_bp  1  /* Timebase bit 1 position. */
+#define CLKCTRL_TIMEBASE_2_bm  (1<<2)  /* Timebase bit 2 mask. */
+#define CLKCTRL_TIMEBASE_2_bp  2  /* Timebase bit 2 position. */
+#define CLKCTRL_TIMEBASE_3_bm  (1<<3)  /* Timebase bit 3 mask. */
+#define CLKCTRL_TIMEBASE_3_bp  3  /* Timebase bit 3 position. */
+#define CLKCTRL_TIMEBASE_4_bm  (1<<4)  /* Timebase bit 4 mask. */
+#define CLKCTRL_TIMEBASE_4_bp  4  /* Timebase bit 4 position. */
+
+/* CLKCTRL.OSCHFCTRLA  bit masks and bit positions */
+#define CLKCTRL_AUTOTUNE_gm  0x03  /* Automatic Oscillator Tune group mask. */
+#define CLKCTRL_AUTOTUNE_gp  0  /* Automatic Oscillator Tune group position. */
+#define CLKCTRL_AUTOTUNE_0_bm  (1<<0)  /* Automatic Oscillator Tune bit 0 mask. */
+#define CLKCTRL_AUTOTUNE_0_bp  0  /* Automatic Oscillator Tune bit 0 position. */
+#define CLKCTRL_AUTOTUNE_1_bm  (1<<1)  /* Automatic Oscillator Tune bit 1 mask. */
+#define CLKCTRL_AUTOTUNE_1_bp  1  /* Automatic Oscillator Tune bit 1 position. */
+#define CLKCTRL_RUNSTDBY_bm  0x80  /* Run in standby bit mask. */
+#define CLKCTRL_RUNSTDBY_bp  7  /* Run in standby bit position. */
+
+/* CLKCTRL.OSCHFTUNE  bit masks and bit positions */
+#define CLKCTRL_TUNE_gm  0xFF  /* Oscillator Tune group mask. */
+#define CLKCTRL_TUNE_gp  0  /* Oscillator Tune group position. */
+#define CLKCTRL_TUNE_0_bm  (1<<0)  /* Oscillator Tune bit 0 mask. */
+#define CLKCTRL_TUNE_0_bp  0  /* Oscillator Tune bit 0 position. */
+#define CLKCTRL_TUNE_1_bm  (1<<1)  /* Oscillator Tune bit 1 mask. */
+#define CLKCTRL_TUNE_1_bp  1  /* Oscillator Tune bit 1 position. */
+#define CLKCTRL_TUNE_2_bm  (1<<2)  /* Oscillator Tune bit 2 mask. */
+#define CLKCTRL_TUNE_2_bp  2  /* Oscillator Tune bit 2 position. */
+#define CLKCTRL_TUNE_3_bm  (1<<3)  /* Oscillator Tune bit 3 mask. */
+#define CLKCTRL_TUNE_3_bp  3  /* Oscillator Tune bit 3 position. */
+#define CLKCTRL_TUNE_4_bm  (1<<4)  /* Oscillator Tune bit 4 mask. */
+#define CLKCTRL_TUNE_4_bp  4  /* Oscillator Tune bit 4 position. */
+#define CLKCTRL_TUNE_5_bm  (1<<5)  /* Oscillator Tune bit 5 mask. */
+#define CLKCTRL_TUNE_5_bp  5  /* Oscillator Tune bit 5 position. */
+#define CLKCTRL_TUNE_6_bm  (1<<6)  /* Oscillator Tune bit 6 mask. */
+#define CLKCTRL_TUNE_6_bp  6  /* Oscillator Tune bit 6 position. */
+#define CLKCTRL_TUNE_7_bm  (1<<7)  /* Oscillator Tune bit 7 mask. */
+#define CLKCTRL_TUNE_7_bp  7  /* Oscillator Tune bit 7 position. */
+
+/* CLKCTRL.PLLCTRLA  bit masks and bit positions */
+#define CLKCTRL_MULFAC_gm  0x03  /* PLL Multiplication Factor group mask. */
+#define CLKCTRL_MULFAC_gp  0  /* PLL Multiplication Factor group position. */
+#define CLKCTRL_MULFAC_0_bm  (1<<0)  /* PLL Multiplication Factor bit 0 mask. */
+#define CLKCTRL_MULFAC_0_bp  0  /* PLL Multiplication Factor bit 0 position. */
+#define CLKCTRL_MULFAC_1_bm  (1<<1)  /* PLL Multiplication Factor bit 1 mask. */
+#define CLKCTRL_MULFAC_1_bp  1  /* PLL Multiplication Factor bit 1 position. */
+#define CLKCTRL_SOURCEDIV_gm  0x18  /* PLL Source Division group mask. */
+#define CLKCTRL_SOURCEDIV_gp  3  /* PLL Source Division group position. */
+#define CLKCTRL_SOURCEDIV_0_bm  (1<<3)  /* PLL Source Division bit 0 mask. */
+#define CLKCTRL_SOURCEDIV_0_bp  3  /* PLL Source Division bit 0 position. */
+#define CLKCTRL_SOURCEDIV_1_bm  (1<<4)  /* PLL Source Division bit 1 mask. */
+#define CLKCTRL_SOURCEDIV_1_bp  4  /* PLL Source Division bit 1 position. */
+#define CLKCTRL_SOURCE_gm  0x60  /* PLL Source group mask. */
+#define CLKCTRL_SOURCE_gp  5  /* PLL Source group position. */
+#define CLKCTRL_SOURCE_0_bm  (1<<5)  /* PLL Source bit 0 mask. */
+#define CLKCTRL_SOURCE_0_bp  5  /* PLL Source bit 0 position. */
+#define CLKCTRL_SOURCE_1_bm  (1<<6)  /* PLL Source bit 1 mask. */
+#define CLKCTRL_SOURCE_1_bp  6  /* PLL Source bit 1 position. */
+/* CLKCTRL_RUNSTDBY  is already defined. */
+
+/* CLKCTRL.PLLCTRLB  bit masks and bit positions */
+#define CLKCTRL_CLKDIV_bm  0x01  /* PLL Output Clock Division bit mask. */
+#define CLKCTRL_CLKDIV_bp  0  /* PLL Output Clock Division bit position. */
+
+/* CLKCTRL.OSC32KCTRLA  bit masks and bit positions */
+/* CLKCTRL_RUNSTDBY  is already defined. */
+
+/* CLKCTRL.XOSC32KCTRLA  bit masks and bit positions */
+#define CLKCTRL_ENABLE_bm  0x01  /* Enable bit mask. */
+#define CLKCTRL_ENABLE_bp  0  /* Enable bit position. */
+#define CLKCTRL_LPMODE_bm  0x02  /* Low power mode bit mask. */
+#define CLKCTRL_LPMODE_bp  1  /* Low power mode bit position. */
+#define CLKCTRL_SEL_bm  0x04  /* Select bit mask. */
+#define CLKCTRL_SEL_bp  2  /* Select bit position. */
+#define CLKCTRL_CSUT_gm  0x30  /* Crystal startup time group mask. */
+#define CLKCTRL_CSUT_gp  4  /* Crystal startup time group position. */
+#define CLKCTRL_CSUT_0_bm  (1<<4)  /* Crystal startup time bit 0 mask. */
+#define CLKCTRL_CSUT_0_bp  4  /* Crystal startup time bit 0 position. */
+#define CLKCTRL_CSUT_1_bm  (1<<5)  /* Crystal startup time bit 1 mask. */
+#define CLKCTRL_CSUT_1_bp  5  /* Crystal startup time bit 1 position. */
+/* CLKCTRL_RUNSTDBY  is already defined. */
+
+
+/* CPU - CPU */
+/* CPU.CCP  bit masks and bit positions */
+#define CPU_CCP_gm  0xFF  /* CCP signature group mask. */
+#define CPU_CCP_gp  0  /* CCP signature group position. */
+#define CPU_CCP_0_bm  (1<<0)  /* CCP signature bit 0 mask. */
+#define CPU_CCP_0_bp  0  /* CCP signature bit 0 position. */
+#define CPU_CCP_1_bm  (1<<1)  /* CCP signature bit 1 mask. */
+#define CPU_CCP_1_bp  1  /* CCP signature bit 1 position. */
+#define CPU_CCP_2_bm  (1<<2)  /* CCP signature bit 2 mask. */
+#define CPU_CCP_2_bp  2  /* CCP signature bit 2 position. */
+#define CPU_CCP_3_bm  (1<<3)  /* CCP signature bit 3 mask. */
+#define CPU_CCP_3_bp  3  /* CCP signature bit 3 position. */
+#define CPU_CCP_4_bm  (1<<4)  /* CCP signature bit 4 mask. */
+#define CPU_CCP_4_bp  4  /* CCP signature bit 4 position. */
+#define CPU_CCP_5_bm  (1<<5)  /* CCP signature bit 5 mask. */
+#define CPU_CCP_5_bp  5  /* CCP signature bit 5 position. */
+#define CPU_CCP_6_bm  (1<<6)  /* CCP signature bit 6 mask. */
+#define CPU_CCP_6_bp  6  /* CCP signature bit 6 position. */
+#define CPU_CCP_7_bm  (1<<7)  /* CCP signature bit 7 mask. */
+#define CPU_CCP_7_bp  7  /* CCP signature bit 7 position. */
+
+/* CPU.SREG  bit masks and bit positions */
+#define CPU_C_bm  0x01  /* Carry Flag bit mask. */
+#define CPU_C_bp  0  /* Carry Flag bit position. */
+#define CPU_Z_bm  0x02  /* Zero Flag bit mask. */
+#define CPU_Z_bp  1  /* Zero Flag bit position. */
+#define CPU_N_bm  0x04  /* Negative Flag bit mask. */
+#define CPU_N_bp  2  /* Negative Flag bit position. */
+#define CPU_V_bm  0x08  /* Two's Complement Overflow Flag bit mask. */
+#define CPU_V_bp  3  /* Two's Complement Overflow Flag bit position. */
+#define CPU_S_bm  0x10  /* N Exclusive Or V Flag bit mask. */
+#define CPU_S_bp  4  /* N Exclusive Or V Flag bit position. */
+#define CPU_H_bm  0x20  /* Half Carry Flag bit mask. */
+#define CPU_H_bp  5  /* Half Carry Flag bit position. */
+#define CPU_T_bm  0x40  /* Transfer Bit bit mask. */
+#define CPU_T_bp  6  /* Transfer Bit bit position. */
+#define CPU_I_bm  0x80  /* Global Interrupt Enable Flag bit mask. */
+#define CPU_I_bp  7  /* Global Interrupt Enable Flag bit position. */
+
+
+/* CPUINT - Interrupt Controller */
+/* CPUINT.CTRLA  bit masks and bit positions */
+#define CPUINT_LVL0RR_bm  0x01  /* Round-robin Scheduling Enable bit mask. */
+#define CPUINT_LVL0RR_bp  0  /* Round-robin Scheduling Enable bit position. */
+#define CPUINT_CVT_bm  0x20  /* Compact Vector Table bit mask. */
+#define CPUINT_CVT_bp  5  /* Compact Vector Table bit position. */
+#define CPUINT_IVSEL_bm  0x40  /* Interrupt Vector Select bit mask. */
+#define CPUINT_IVSEL_bp  6  /* Interrupt Vector Select bit position. */
+
+/* CPUINT.STATUS  bit masks and bit positions */
+#define CPUINT_LVL0EX_bm  0x01  /* Level 0 Interrupt Executing bit mask. */
+#define CPUINT_LVL0EX_bp  0  /* Level 0 Interrupt Executing bit position. */
+#define CPUINT_LVL1EX_bm  0x02  /* Level 1 Interrupt Executing bit mask. */
+#define CPUINT_LVL1EX_bp  1  /* Level 1 Interrupt Executing bit position. */
+#define CPUINT_NMIEX_bm  0x80  /* Non-maskable Interrupt Executing bit mask. */
+#define CPUINT_NMIEX_bp  7  /* Non-maskable Interrupt Executing bit position. */
+
+/* CPUINT.LVL0PRI  bit masks and bit positions */
+#define CPUINT_LVL0PRI_gm  0xFF  /* Interrupt Level Priority group mask. */
+#define CPUINT_LVL0PRI_gp  0  /* Interrupt Level Priority group position. */
+#define CPUINT_LVL0PRI_0_bm  (1<<0)  /* Interrupt Level Priority bit 0 mask. */
+#define CPUINT_LVL0PRI_0_bp  0  /* Interrupt Level Priority bit 0 position. */
+#define CPUINT_LVL0PRI_1_bm  (1<<1)  /* Interrupt Level Priority bit 1 mask. */
+#define CPUINT_LVL0PRI_1_bp  1  /* Interrupt Level Priority bit 1 position. */
+#define CPUINT_LVL0PRI_2_bm  (1<<2)  /* Interrupt Level Priority bit 2 mask. */
+#define CPUINT_LVL0PRI_2_bp  2  /* Interrupt Level Priority bit 2 position. */
+#define CPUINT_LVL0PRI_3_bm  (1<<3)  /* Interrupt Level Priority bit 3 mask. */
+#define CPUINT_LVL0PRI_3_bp  3  /* Interrupt Level Priority bit 3 position. */
+#define CPUINT_LVL0PRI_4_bm  (1<<4)  /* Interrupt Level Priority bit 4 mask. */
+#define CPUINT_LVL0PRI_4_bp  4  /* Interrupt Level Priority bit 4 position. */
+#define CPUINT_LVL0PRI_5_bm  (1<<5)  /* Interrupt Level Priority bit 5 mask. */
+#define CPUINT_LVL0PRI_5_bp  5  /* Interrupt Level Priority bit 5 position. */
+#define CPUINT_LVL0PRI_6_bm  (1<<6)  /* Interrupt Level Priority bit 6 mask. */
+#define CPUINT_LVL0PRI_6_bp  6  /* Interrupt Level Priority bit 6 position. */
+#define CPUINT_LVL0PRI_7_bm  (1<<7)  /* Interrupt Level Priority bit 7 mask. */
+#define CPUINT_LVL0PRI_7_bp  7  /* Interrupt Level Priority bit 7 position. */
+
+/* CPUINT.LVL1VEC  bit masks and bit positions */
+#define CPUINT_LVL1VEC_gm  0xFF  /* Interrupt Vector with High Priority group mask. */
+#define CPUINT_LVL1VEC_gp  0  /* Interrupt Vector with High Priority group position. */
+#define CPUINT_LVL1VEC_0_bm  (1<<0)  /* Interrupt Vector with High Priority bit 0 mask. */
+#define CPUINT_LVL1VEC_0_bp  0  /* Interrupt Vector with High Priority bit 0 position. */
+#define CPUINT_LVL1VEC_1_bm  (1<<1)  /* Interrupt Vector with High Priority bit 1 mask. */
+#define CPUINT_LVL1VEC_1_bp  1  /* Interrupt Vector with High Priority bit 1 position. */
+#define CPUINT_LVL1VEC_2_bm  (1<<2)  /* Interrupt Vector with High Priority bit 2 mask. */
+#define CPUINT_LVL1VEC_2_bp  2  /* Interrupt Vector with High Priority bit 2 position. */
+#define CPUINT_LVL1VEC_3_bm  (1<<3)  /* Interrupt Vector with High Priority bit 3 mask. */
+#define CPUINT_LVL1VEC_3_bp  3  /* Interrupt Vector with High Priority bit 3 position. */
+#define CPUINT_LVL1VEC_4_bm  (1<<4)  /* Interrupt Vector with High Priority bit 4 mask. */
+#define CPUINT_LVL1VEC_4_bp  4  /* Interrupt Vector with High Priority bit 4 position. */
+#define CPUINT_LVL1VEC_5_bm  (1<<5)  /* Interrupt Vector with High Priority bit 5 mask. */
+#define CPUINT_LVL1VEC_5_bp  5  /* Interrupt Vector with High Priority bit 5 position. */
+#define CPUINT_LVL1VEC_6_bm  (1<<6)  /* Interrupt Vector with High Priority bit 6 mask. */
+#define CPUINT_LVL1VEC_6_bp  6  /* Interrupt Vector with High Priority bit 6 position. */
+#define CPUINT_LVL1VEC_7_bm  (1<<7)  /* Interrupt Vector with High Priority bit 7 mask. */
+#define CPUINT_LVL1VEC_7_bp  7  /* Interrupt Vector with High Priority bit 7 position. */
+
+
+/* CRCSCAN - CRCSCAN */
+/* CRCSCAN.CTRLA  bit masks and bit positions */
+#define CRCSCAN_ENABLE_bm  0x01  /* Enable CRC scan bit mask. */
+#define CRCSCAN_ENABLE_bp  0  /* Enable CRC scan bit position. */
+#define CRCSCAN_NMIEN_bm  0x02  /* Enable NMI Trigger bit mask. */
+#define CRCSCAN_NMIEN_bp  1  /* Enable NMI Trigger bit position. */
+#define CRCSCAN_RESET_bm  0x80  /* Reset CRC scan bit mask. */
+#define CRCSCAN_RESET_bp  7  /* Reset CRC scan bit position. */
+
+/* CRCSCAN.CTRLB  bit masks and bit positions */
+#define CRCSCAN_SRC_gm  0x03  /* CRC Source group mask. */
+#define CRCSCAN_SRC_gp  0  /* CRC Source group position. */
+#define CRCSCAN_SRC_0_bm  (1<<0)  /* CRC Source bit 0 mask. */
+#define CRCSCAN_SRC_0_bp  0  /* CRC Source bit 0 position. */
+#define CRCSCAN_SRC_1_bm  (1<<1)  /* CRC Source bit 1 mask. */
+#define CRCSCAN_SRC_1_bp  1  /* CRC Source bit 1 position. */
+
+/* CRCSCAN.STATUS  bit masks and bit positions */
+#define CRCSCAN_BUSY_bm  0x01  /* CRC Busy bit mask. */
+#define CRCSCAN_BUSY_bp  0  /* CRC Busy bit position. */
+#define CRCSCAN_OK_bm  0x02  /* CRC Ok bit mask. */
+#define CRCSCAN_OK_bp  1  /* CRC Ok bit position. */
+
+
+/* EVSYS - Event System */
+/* EVSYS.SWEVENTA  bit masks and bit positions */
+#define EVSYS_SWEVENTA_gm  0xFF  /* Software event on channel select group mask. */
+#define EVSYS_SWEVENTA_gp  0  /* Software event on channel select group position. */
+#define EVSYS_SWEVENTA_0_bm  (1<<0)  /* Software event on channel select bit 0 mask. */
+#define EVSYS_SWEVENTA_0_bp  0  /* Software event on channel select bit 0 position. */
+#define EVSYS_SWEVENTA_1_bm  (1<<1)  /* Software event on channel select bit 1 mask. */
+#define EVSYS_SWEVENTA_1_bp  1  /* Software event on channel select bit 1 position. */
+#define EVSYS_SWEVENTA_2_bm  (1<<2)  /* Software event on channel select bit 2 mask. */
+#define EVSYS_SWEVENTA_2_bp  2  /* Software event on channel select bit 2 position. */
+#define EVSYS_SWEVENTA_3_bm  (1<<3)  /* Software event on channel select bit 3 mask. */
+#define EVSYS_SWEVENTA_3_bp  3  /* Software event on channel select bit 3 position. */
+#define EVSYS_SWEVENTA_4_bm  (1<<4)  /* Software event on channel select bit 4 mask. */
+#define EVSYS_SWEVENTA_4_bp  4  /* Software event on channel select bit 4 position. */
+#define EVSYS_SWEVENTA_5_bm  (1<<5)  /* Software event on channel select bit 5 mask. */
+#define EVSYS_SWEVENTA_5_bp  5  /* Software event on channel select bit 5 position. */
+#define EVSYS_SWEVENTA_6_bm  (1<<6)  /* Software event on channel select bit 6 mask. */
+#define EVSYS_SWEVENTA_6_bp  6  /* Software event on channel select bit 6 position. */
+#define EVSYS_SWEVENTA_7_bm  (1<<7)  /* Software event on channel select bit 7 mask. */
+#define EVSYS_SWEVENTA_7_bp  7  /* Software event on channel select bit 7 position. */
+
+/* EVSYS.CHANNEL0  bit masks and bit positions */
+#define EVSYS_CHANNEL_gm  0xFF  /* Channel generator select group mask. */
+#define EVSYS_CHANNEL_gp  0  /* Channel generator select group position. */
+#define EVSYS_CHANNEL_0_bm  (1<<0)  /* Channel generator select bit 0 mask. */
+#define EVSYS_CHANNEL_0_bp  0  /* Channel generator select bit 0 position. */
+#define EVSYS_CHANNEL_1_bm  (1<<1)  /* Channel generator select bit 1 mask. */
+#define EVSYS_CHANNEL_1_bp  1  /* Channel generator select bit 1 position. */
+#define EVSYS_CHANNEL_2_bm  (1<<2)  /* Channel generator select bit 2 mask. */
+#define EVSYS_CHANNEL_2_bp  2  /* Channel generator select bit 2 position. */
+#define EVSYS_CHANNEL_3_bm  (1<<3)  /* Channel generator select bit 3 mask. */
+#define EVSYS_CHANNEL_3_bp  3  /* Channel generator select bit 3 position. */
+#define EVSYS_CHANNEL_4_bm  (1<<4)  /* Channel generator select bit 4 mask. */
+#define EVSYS_CHANNEL_4_bp  4  /* Channel generator select bit 4 position. */
+#define EVSYS_CHANNEL_5_bm  (1<<5)  /* Channel generator select bit 5 mask. */
+#define EVSYS_CHANNEL_5_bp  5  /* Channel generator select bit 5 position. */
+#define EVSYS_CHANNEL_6_bm  (1<<6)  /* Channel generator select bit 6 mask. */
+#define EVSYS_CHANNEL_6_bp  6  /* Channel generator select bit 6 position. */
+#define EVSYS_CHANNEL_7_bm  (1<<7)  /* Channel generator select bit 7 mask. */
+#define EVSYS_CHANNEL_7_bp  7  /* Channel generator select bit 7 position. */
+
+/* EVSYS.CHANNEL1  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.CHANNEL2  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.CHANNEL3  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.CHANNEL4  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.CHANNEL5  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.USERCCLLUT0A  bit masks and bit positions */
+#define EVSYS_USER_gm  0xFF  /* User channel select group mask. */
+#define EVSYS_USER_gp  0  /* User channel select group position. */
+#define EVSYS_USER_0_bm  (1<<0)  /* User channel select bit 0 mask. */
+#define EVSYS_USER_0_bp  0  /* User channel select bit 0 position. */
+#define EVSYS_USER_1_bm  (1<<1)  /* User channel select bit 1 mask. */
+#define EVSYS_USER_1_bp  1  /* User channel select bit 1 position. */
+#define EVSYS_USER_2_bm  (1<<2)  /* User channel select bit 2 mask. */
+#define EVSYS_USER_2_bp  2  /* User channel select bit 2 position. */
+#define EVSYS_USER_3_bm  (1<<3)  /* User channel select bit 3 mask. */
+#define EVSYS_USER_3_bp  3  /* User channel select bit 3 position. */
+#define EVSYS_USER_4_bm  (1<<4)  /* User channel select bit 4 mask. */
+#define EVSYS_USER_4_bp  4  /* User channel select bit 4 position. */
+#define EVSYS_USER_5_bm  (1<<5)  /* User channel select bit 5 mask. */
+#define EVSYS_USER_5_bp  5  /* User channel select bit 5 position. */
+#define EVSYS_USER_6_bm  (1<<6)  /* User channel select bit 6 mask. */
+#define EVSYS_USER_6_bp  6  /* User channel select bit 6 position. */
+#define EVSYS_USER_7_bm  (1<<7)  /* User channel select bit 7 mask. */
+#define EVSYS_USER_7_bp  7  /* User channel select bit 7 position. */
+
+/* EVSYS.USERCCLLUT0B  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT1A  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT1B  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT2A  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT2B  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT3A  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT3B  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERADC0START  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTC  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTD  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTF  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERUSART0IRDA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCE0CNTA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCE0CNTB  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB0CAPT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB0COUNT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB1CAPT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB1COUNT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCF0CNT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCF0ACT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERWEXA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERWEXB  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERWEXC  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+
+/* FUSE - Fuses */
+/* FUSE.WDTCFG  bit masks and bit positions */
+#define FUSE_PERIOD_gm  0x0F  /* Watchdog Timeout Period group mask. */
+#define FUSE_PERIOD_gp  0  /* Watchdog Timeout Period group position. */
+#define FUSE_PERIOD_0_bm  (1<<0)  /* Watchdog Timeout Period bit 0 mask. */
+#define FUSE_PERIOD_0_bp  0  /* Watchdog Timeout Period bit 0 position. */
+#define FUSE_PERIOD_1_bm  (1<<1)  /* Watchdog Timeout Period bit 1 mask. */
+#define FUSE_PERIOD_1_bp  1  /* Watchdog Timeout Period bit 1 position. */
+#define FUSE_PERIOD_2_bm  (1<<2)  /* Watchdog Timeout Period bit 2 mask. */
+#define FUSE_PERIOD_2_bp  2  /* Watchdog Timeout Period bit 2 position. */
+#define FUSE_PERIOD_3_bm  (1<<3)  /* Watchdog Timeout Period bit 3 mask. */
+#define FUSE_PERIOD_3_bp  3  /* Watchdog Timeout Period bit 3 position. */
+#define FUSE_WINDOW_gm  0xF0  /* Watchdog Window Timeout Period group mask. */
+#define FUSE_WINDOW_gp  4  /* Watchdog Window Timeout Period group position. */
+#define FUSE_WINDOW_0_bm  (1<<4)  /* Watchdog Window Timeout Period bit 0 mask. */
+#define FUSE_WINDOW_0_bp  4  /* Watchdog Window Timeout Period bit 0 position. */
+#define FUSE_WINDOW_1_bm  (1<<5)  /* Watchdog Window Timeout Period bit 1 mask. */
+#define FUSE_WINDOW_1_bp  5  /* Watchdog Window Timeout Period bit 1 position. */
+#define FUSE_WINDOW_2_bm  (1<<6)  /* Watchdog Window Timeout Period bit 2 mask. */
+#define FUSE_WINDOW_2_bp  6  /* Watchdog Window Timeout Period bit 2 position. */
+#define FUSE_WINDOW_3_bm  (1<<7)  /* Watchdog Window Timeout Period bit 3 mask. */
+#define FUSE_WINDOW_3_bp  7  /* Watchdog Window Timeout Period bit 3 position. */
+
+/* FUSE.BODCFG  bit masks and bit positions */
+#define FUSE_SLEEP_gm  0x03  /* BOD Operation in Sleep Mode group mask. */
+#define FUSE_SLEEP_gp  0  /* BOD Operation in Sleep Mode group position. */
+#define FUSE_SLEEP_0_bm  (1<<0)  /* BOD Operation in Sleep Mode bit 0 mask. */
+#define FUSE_SLEEP_0_bp  0  /* BOD Operation in Sleep Mode bit 0 position. */
+#define FUSE_SLEEP_1_bm  (1<<1)  /* BOD Operation in Sleep Mode bit 1 mask. */
+#define FUSE_SLEEP_1_bp  1  /* BOD Operation in Sleep Mode bit 1 position. */
+#define FUSE_ACTIVE_gm  0x0C  /* BOD Operation in Active Mode group mask. */
+#define FUSE_ACTIVE_gp  2  /* BOD Operation in Active Mode group position. */
+#define FUSE_ACTIVE_0_bm  (1<<2)  /* BOD Operation in Active Mode bit 0 mask. */
+#define FUSE_ACTIVE_0_bp  2  /* BOD Operation in Active Mode bit 0 position. */
+#define FUSE_ACTIVE_1_bm  (1<<3)  /* BOD Operation in Active Mode bit 1 mask. */
+#define FUSE_ACTIVE_1_bp  3  /* BOD Operation in Active Mode bit 1 position. */
+#define FUSE_SAMPFREQ_bm  0x10  /* BOD Sample Frequency bit mask. */
+#define FUSE_SAMPFREQ_bp  4  /* BOD Sample Frequency bit position. */
+#define FUSE_LVL_gm  0xE0  /* BOD Level group mask. */
+#define FUSE_LVL_gp  5  /* BOD Level group position. */
+#define FUSE_LVL_0_bm  (1<<5)  /* BOD Level bit 0 mask. */
+#define FUSE_LVL_0_bp  5  /* BOD Level bit 0 position. */
+#define FUSE_LVL_1_bm  (1<<6)  /* BOD Level bit 1 mask. */
+#define FUSE_LVL_1_bp  6  /* BOD Level bit 1 position. */
+#define FUSE_LVL_2_bm  (1<<7)  /* BOD Level bit 2 mask. */
+#define FUSE_LVL_2_bp  7  /* BOD Level bit 2 position. */
+
+/* FUSE.OSCCFG  bit masks and bit positions */
+#define FUSE_OSCHFFRQ_bm  0x08  /* High-frequency Oscillator Frequency bit mask. */
+#define FUSE_OSCHFFRQ_bp  3  /* High-frequency Oscillator Frequency bit position. */
+
+/* FUSE.SYSCFG0  bit masks and bit positions */
+#define FUSE_EESAVE_bm  0x01  /* EEPROM Save bit mask. */
+#define FUSE_EESAVE_bp  0  /* EEPROM Save bit position. */
+#define FUSE_RSTPINCFG_bm  0x08  /* Reset Pin Configuration bit mask. */
+#define FUSE_RSTPINCFG_bp  3  /* Reset Pin Configuration bit position. */
+#define FUSE_UPDIPINCFG_bm  0x10  /* UPDI Pin Configuration bit mask. */
+#define FUSE_UPDIPINCFG_bp  4  /* UPDI Pin Configuration bit position. */
+#define FUSE_CRCSEL_bm  0x20  /* CRC Select bit mask. */
+#define FUSE_CRCSEL_bp  5  /* CRC Select bit position. */
+#define FUSE_CRCSRC_gm  0xC0  /* CRC Source group mask. */
+#define FUSE_CRCSRC_gp  6  /* CRC Source group position. */
+#define FUSE_CRCSRC_0_bm  (1<<6)  /* CRC Source bit 0 mask. */
+#define FUSE_CRCSRC_0_bp  6  /* CRC Source bit 0 position. */
+#define FUSE_CRCSRC_1_bm  (1<<7)  /* CRC Source bit 1 mask. */
+#define FUSE_CRCSRC_1_bp  7  /* CRC Source bit 1 position. */
+
+/* FUSE.SYSCFG1  bit masks and bit positions */
+#define FUSE_SUT_gm  0x07  /* Startup Time group mask. */
+#define FUSE_SUT_gp  0  /* Startup Time group position. */
+#define FUSE_SUT_0_bm  (1<<0)  /* Startup Time bit 0 mask. */
+#define FUSE_SUT_0_bp  0  /* Startup Time bit 0 position. */
+#define FUSE_SUT_1_bm  (1<<1)  /* Startup Time bit 1 mask. */
+#define FUSE_SUT_1_bp  1  /* Startup Time bit 1 position. */
+#define FUSE_SUT_2_bm  (1<<2)  /* Startup Time bit 2 mask. */
+#define FUSE_SUT_2_bp  2  /* Startup Time bit 2 position. */
+
+/* FUSE.PDICFG  bit masks and bit positions */
+#define FUSE_LEVEL_gm  0x03  /* Protection Level group mask. */
+#define FUSE_LEVEL_gp  0  /* Protection Level group position. */
+#define FUSE_LEVEL_0_bm  (1<<0)  /* Protection Level bit 0 mask. */
+#define FUSE_LEVEL_0_bp  0  /* Protection Level bit 0 position. */
+#define FUSE_LEVEL_1_bm  (1<<1)  /* Protection Level bit 1 mask. */
+#define FUSE_LEVEL_1_bp  1  /* Protection Level bit 1 position. */
+#define FUSE_KEY_gm  0xFFF0  /* NVM Protection Activation Key group mask. */
+#define FUSE_KEY_gp  4  /* NVM Protection Activation Key group position. */
+#define FUSE_KEY_0_bm  (1<<4)  /* NVM Protection Activation Key bit 0 mask. */
+#define FUSE_KEY_0_bp  4  /* NVM Protection Activation Key bit 0 position. */
+#define FUSE_KEY_1_bm  (1<<5)  /* NVM Protection Activation Key bit 1 mask. */
+#define FUSE_KEY_1_bp  5  /* NVM Protection Activation Key bit 1 position. */
+#define FUSE_KEY_2_bm  (1<<6)  /* NVM Protection Activation Key bit 2 mask. */
+#define FUSE_KEY_2_bp  6  /* NVM Protection Activation Key bit 2 position. */
+#define FUSE_KEY_3_bm  (1<<7)  /* NVM Protection Activation Key bit 3 mask. */
+#define FUSE_KEY_3_bp  7  /* NVM Protection Activation Key bit 3 position. */
+#define FUSE_KEY_4_bm  (1<<8)  /* NVM Protection Activation Key bit 4 mask. */
+#define FUSE_KEY_4_bp  8  /* NVM Protection Activation Key bit 4 position. */
+#define FUSE_KEY_5_bm  (1<<9)  /* NVM Protection Activation Key bit 5 mask. */
+#define FUSE_KEY_5_bp  9  /* NVM Protection Activation Key bit 5 position. */
+#define FUSE_KEY_6_bm  (1<<10)  /* NVM Protection Activation Key bit 6 mask. */
+#define FUSE_KEY_6_bp  10  /* NVM Protection Activation Key bit 6 position. */
+#define FUSE_KEY_7_bm  (1<<11)  /* NVM Protection Activation Key bit 7 mask. */
+#define FUSE_KEY_7_bp  11  /* NVM Protection Activation Key bit 7 position. */
+#define FUSE_KEY_8_bm  (1<<12)  /* NVM Protection Activation Key bit 8 mask. */
+#define FUSE_KEY_8_bp  12  /* NVM Protection Activation Key bit 8 position. */
+#define FUSE_KEY_9_bm  (1<<13)  /* NVM Protection Activation Key bit 9 mask. */
+#define FUSE_KEY_9_bp  13  /* NVM Protection Activation Key bit 9 position. */
+#define FUSE_KEY_10_bm  (1<<14)  /* NVM Protection Activation Key bit 10 mask. */
+#define FUSE_KEY_10_bp  14  /* NVM Protection Activation Key bit 10 position. */
+#define FUSE_KEY_11_bm  (1<<15)  /* NVM Protection Activation Key bit 11 mask. */
+#define FUSE_KEY_11_bp  15  /* NVM Protection Activation Key bit 11 position. */
+
+
+
+/* LOCK - Lockbits */
+/* LOCK.KEY  bit masks and bit positions */
+#define LOCK_KEY_gm  0xFFFFFFFF  /* Lock Key group mask. */
+#define LOCK_KEY_gp  0  /* Lock Key group position. */
+#define LOCK_KEY_0_bm  (1<<0)  /* Lock Key bit 0 mask. */
+#define LOCK_KEY_0_bp  0  /* Lock Key bit 0 position. */
+#define LOCK_KEY_1_bm  (1<<1)  /* Lock Key bit 1 mask. */
+#define LOCK_KEY_1_bp  1  /* Lock Key bit 1 position. */
+#define LOCK_KEY_2_bm  (1<<2)  /* Lock Key bit 2 mask. */
+#define LOCK_KEY_2_bp  2  /* Lock Key bit 2 position. */
+#define LOCK_KEY_3_bm  (1<<3)  /* Lock Key bit 3 mask. */
+#define LOCK_KEY_3_bp  3  /* Lock Key bit 3 position. */
+#define LOCK_KEY_4_bm  (1<<4)  /* Lock Key bit 4 mask. */
+#define LOCK_KEY_4_bp  4  /* Lock Key bit 4 position. */
+#define LOCK_KEY_5_bm  (1<<5)  /* Lock Key bit 5 mask. */
+#define LOCK_KEY_5_bp  5  /* Lock Key bit 5 position. */
+#define LOCK_KEY_6_bm  (1<<6)  /* Lock Key bit 6 mask. */
+#define LOCK_KEY_6_bp  6  /* Lock Key bit 6 position. */
+#define LOCK_KEY_7_bm  (1<<7)  /* Lock Key bit 7 mask. */
+#define LOCK_KEY_7_bp  7  /* Lock Key bit 7 position. */
+#define LOCK_KEY_8_bm  (1<<8)  /* Lock Key bit 8 mask. */
+#define LOCK_KEY_8_bp  8  /* Lock Key bit 8 position. */
+#define LOCK_KEY_9_bm  (1<<9)  /* Lock Key bit 9 mask. */
+#define LOCK_KEY_9_bp  9  /* Lock Key bit 9 position. */
+#define LOCK_KEY_10_bm  (1<<10)  /* Lock Key bit 10 mask. */
+#define LOCK_KEY_10_bp  10  /* Lock Key bit 10 position. */
+#define LOCK_KEY_11_bm  (1<<11)  /* Lock Key bit 11 mask. */
+#define LOCK_KEY_11_bp  11  /* Lock Key bit 11 position. */
+#define LOCK_KEY_12_bm  (1<<12)  /* Lock Key bit 12 mask. */
+#define LOCK_KEY_12_bp  12  /* Lock Key bit 12 position. */
+#define LOCK_KEY_13_bm  (1<<13)  /* Lock Key bit 13 mask. */
+#define LOCK_KEY_13_bp  13  /* Lock Key bit 13 position. */
+#define LOCK_KEY_14_bm  (1<<14)  /* Lock Key bit 14 mask. */
+#define LOCK_KEY_14_bp  14  /* Lock Key bit 14 position. */
+#define LOCK_KEY_15_bm  (1<<15)  /* Lock Key bit 15 mask. */
+#define LOCK_KEY_15_bp  15  /* Lock Key bit 15 position. */
+#define LOCK_KEY_16_bm  (1<<16)  /* Lock Key bit 16 mask. */
+#define LOCK_KEY_16_bp  16  /* Lock Key bit 16 position. */
+#define LOCK_KEY_17_bm  (1<<17)  /* Lock Key bit 17 mask. */
+#define LOCK_KEY_17_bp  17  /* Lock Key bit 17 position. */
+#define LOCK_KEY_18_bm  (1<<18)  /* Lock Key bit 18 mask. */
+#define LOCK_KEY_18_bp  18  /* Lock Key bit 18 position. */
+#define LOCK_KEY_19_bm  (1<<19)  /* Lock Key bit 19 mask. */
+#define LOCK_KEY_19_bp  19  /* Lock Key bit 19 position. */
+#define LOCK_KEY_20_bm  (1<<20)  /* Lock Key bit 20 mask. */
+#define LOCK_KEY_20_bp  20  /* Lock Key bit 20 position. */
+#define LOCK_KEY_21_bm  (1<<21)  /* Lock Key bit 21 mask. */
+#define LOCK_KEY_21_bp  21  /* Lock Key bit 21 position. */
+#define LOCK_KEY_22_bm  (1<<22)  /* Lock Key bit 22 mask. */
+#define LOCK_KEY_22_bp  22  /* Lock Key bit 22 position. */
+#define LOCK_KEY_23_bm  (1<<23)  /* Lock Key bit 23 mask. */
+#define LOCK_KEY_23_bp  23  /* Lock Key bit 23 position. */
+#define LOCK_KEY_24_bm  (1<<24)  /* Lock Key bit 24 mask. */
+#define LOCK_KEY_24_bp  24  /* Lock Key bit 24 position. */
+#define LOCK_KEY_25_bm  (1<<25)  /* Lock Key bit 25 mask. */
+#define LOCK_KEY_25_bp  25  /* Lock Key bit 25 position. */
+#define LOCK_KEY_26_bm  (1<<26)  /* Lock Key bit 26 mask. */
+#define LOCK_KEY_26_bp  26  /* Lock Key bit 26 position. */
+#define LOCK_KEY_27_bm  (1<<27)  /* Lock Key bit 27 mask. */
+#define LOCK_KEY_27_bp  27  /* Lock Key bit 27 position. */
+#define LOCK_KEY_28_bm  (1<<28)  /* Lock Key bit 28 mask. */
+#define LOCK_KEY_28_bp  28  /* Lock Key bit 28 position. */
+#define LOCK_KEY_29_bm  (1<<29)  /* Lock Key bit 29 mask. */
+#define LOCK_KEY_29_bp  29  /* Lock Key bit 29 position. */
+#define LOCK_KEY_30_bm  (1<<30)  /* Lock Key bit 30 mask. */
+#define LOCK_KEY_30_bp  30  /* Lock Key bit 30 position. */
+#define LOCK_KEY_31_bm  (1<<31)  /* Lock Key bit 31 mask. */
+#define LOCK_KEY_31_bp  31  /* Lock Key bit 31 position. */
+
+
+/* NVMCTRL - Non-volatile Memory Controller */
+/* NVMCTRL.CTRLA  bit masks and bit positions */
+#define NVMCTRL_CMD_gm  0x7F  /* Command group mask. */
+#define NVMCTRL_CMD_gp  0  /* Command group position. */
+#define NVMCTRL_CMD_0_bm  (1<<0)  /* Command bit 0 mask. */
+#define NVMCTRL_CMD_0_bp  0  /* Command bit 0 position. */
+#define NVMCTRL_CMD_1_bm  (1<<1)  /* Command bit 1 mask. */
+#define NVMCTRL_CMD_1_bp  1  /* Command bit 1 position. */
+#define NVMCTRL_CMD_2_bm  (1<<2)  /* Command bit 2 mask. */
+#define NVMCTRL_CMD_2_bp  2  /* Command bit 2 position. */
+#define NVMCTRL_CMD_3_bm  (1<<3)  /* Command bit 3 mask. */
+#define NVMCTRL_CMD_3_bp  3  /* Command bit 3 position. */
+#define NVMCTRL_CMD_4_bm  (1<<4)  /* Command bit 4 mask. */
+#define NVMCTRL_CMD_4_bp  4  /* Command bit 4 position. */
+#define NVMCTRL_CMD_5_bm  (1<<5)  /* Command bit 5 mask. */
+#define NVMCTRL_CMD_5_bp  5  /* Command bit 5 position. */
+#define NVMCTRL_CMD_6_bm  (1<<6)  /* Command bit 6 mask. */
+#define NVMCTRL_CMD_6_bp  6  /* Command bit 6 position. */
+
+/* NVMCTRL.CTRLB  bit masks and bit positions */
+#define NVMCTRL_APPCODEWP_bm  0x01  /* Application Code Write Protect bit mask. */
+#define NVMCTRL_APPCODEWP_bp  0  /* Application Code Write Protect bit position. */
+#define NVMCTRL_BOOTRP_bm  0x02  /* Boot Read Protect bit mask. */
+#define NVMCTRL_BOOTRP_bp  1  /* Boot Read Protect bit position. */
+#define NVMCTRL_APPDATAWP_bm  0x04  /* Application Data Write Protect bit mask. */
+#define NVMCTRL_APPDATAWP_bp  2  /* Application Data Write Protect bit position. */
+#define NVMCTRL_EEWP_bm  0x08  /* EEPROM Write Protect bit mask. */
+#define NVMCTRL_EEWP_bp  3  /* EEPROM Write Protect bit position. */
+#define NVMCTRL_FLMAP_gm  0x30  /* Flash Mapping in Data space group mask. */
+#define NVMCTRL_FLMAP_gp  4  /* Flash Mapping in Data space group position. */
+#define NVMCTRL_FLMAP_0_bm  (1<<4)  /* Flash Mapping in Data space bit 0 mask. */
+#define NVMCTRL_FLMAP_0_bp  4  /* Flash Mapping in Data space bit 0 position. */
+#define NVMCTRL_FLMAP_1_bm  (1<<5)  /* Flash Mapping in Data space bit 1 mask. */
+#define NVMCTRL_FLMAP_1_bp  5  /* Flash Mapping in Data space bit 1 position. */
+#define NVMCTRL_FLMAPLOCK_bm  0x80  /* Flash Mapping Lock bit mask. */
+#define NVMCTRL_FLMAPLOCK_bp  7  /* Flash Mapping Lock bit position. */
+
+/* NVMCTRL.CTRLC  bit masks and bit positions */
+#define NVMCTRL_UROWWP_bm  0x01  /* User Row Write Protect bit mask. */
+#define NVMCTRL_UROWWP_bp  0  /* User Row Write Protect bit position. */
+#define NVMCTRL_BOOTROWWP_bm  0x02  /* Boot Row Write Protect bit mask. */
+#define NVMCTRL_BOOTROWWP_bp  1  /* Boot Row Write Protect bit position. */
+
+/* NVMCTRL.INTCTRL  bit masks and bit positions */
+#define NVMCTRL_EEREADY_bm  0x01  /* EEPROM Ready bit mask. */
+#define NVMCTRL_EEREADY_bp  0  /* EEPROM Ready bit position. */
+#define NVMCTRL_FLREADY_bm  0x02  /* Flash Ready bit mask. */
+#define NVMCTRL_FLREADY_bp  1  /* Flash Ready bit position. */
+
+/* NVMCTRL.INTFLAGS  bit masks and bit positions */
+/* NVMCTRL_EEREADY  is already defined. */
+/* NVMCTRL_FLREADY  is already defined. */
+
+/* NVMCTRL.STATUS  bit masks and bit positions */
+#define NVMCTRL_EEBUSY_bm  0x01  /* EEPROM busy bit mask. */
+#define NVMCTRL_EEBUSY_bp  0  /* EEPROM busy bit position. */
+#define NVMCTRL_FLBUSY_bm  0x02  /* Flash busy bit mask. */
+#define NVMCTRL_FLBUSY_bp  1  /* Flash busy bit position. */
+#define NVMCTRL_ERROR_gm  0x70  /* Write error group mask. */
+#define NVMCTRL_ERROR_gp  4  /* Write error group position. */
+#define NVMCTRL_ERROR_0_bm  (1<<4)  /* Write error bit 0 mask. */
+#define NVMCTRL_ERROR_0_bp  4  /* Write error bit 0 position. */
+#define NVMCTRL_ERROR_1_bm  (1<<5)  /* Write error bit 1 mask. */
+#define NVMCTRL_ERROR_1_bp  5  /* Write error bit 1 position. */
+#define NVMCTRL_ERROR_2_bm  (1<<6)  /* Write error bit 2 mask. */
+#define NVMCTRL_ERROR_2_bp  6  /* Write error bit 2 position. */
+
+/* NVMCTRL.ADDR  bit masks and bit positions */
+#define NVMCTRL_ADDR_gm  0xFFFFFF  /* Address group mask. */
+#define NVMCTRL_ADDR_gp  0  /* Address group position. */
+#define NVMCTRL_ADDR_0_bm  (1<<0)  /* Address bit 0 mask. */
+#define NVMCTRL_ADDR_0_bp  0  /* Address bit 0 position. */
+#define NVMCTRL_ADDR_1_bm  (1<<1)  /* Address bit 1 mask. */
+#define NVMCTRL_ADDR_1_bp  1  /* Address bit 1 position. */
+#define NVMCTRL_ADDR_2_bm  (1<<2)  /* Address bit 2 mask. */
+#define NVMCTRL_ADDR_2_bp  2  /* Address bit 2 position. */
+#define NVMCTRL_ADDR_3_bm  (1<<3)  /* Address bit 3 mask. */
+#define NVMCTRL_ADDR_3_bp  3  /* Address bit 3 position. */
+#define NVMCTRL_ADDR_4_bm  (1<<4)  /* Address bit 4 mask. */
+#define NVMCTRL_ADDR_4_bp  4  /* Address bit 4 position. */
+#define NVMCTRL_ADDR_5_bm  (1<<5)  /* Address bit 5 mask. */
+#define NVMCTRL_ADDR_5_bp  5  /* Address bit 5 position. */
+#define NVMCTRL_ADDR_6_bm  (1<<6)  /* Address bit 6 mask. */
+#define NVMCTRL_ADDR_6_bp  6  /* Address bit 6 position. */
+#define NVMCTRL_ADDR_7_bm  (1<<7)  /* Address bit 7 mask. */
+#define NVMCTRL_ADDR_7_bp  7  /* Address bit 7 position. */
+#define NVMCTRL_ADDR_8_bm  (1<<8)  /* Address bit 8 mask. */
+#define NVMCTRL_ADDR_8_bp  8  /* Address bit 8 position. */
+#define NVMCTRL_ADDR_9_bm  (1<<9)  /* Address bit 9 mask. */
+#define NVMCTRL_ADDR_9_bp  9  /* Address bit 9 position. */
+#define NVMCTRL_ADDR_10_bm  (1<<10)  /* Address bit 10 mask. */
+#define NVMCTRL_ADDR_10_bp  10  /* Address bit 10 position. */
+#define NVMCTRL_ADDR_11_bm  (1<<11)  /* Address bit 11 mask. */
+#define NVMCTRL_ADDR_11_bp  11  /* Address bit 11 position. */
+#define NVMCTRL_ADDR_12_bm  (1<<12)  /* Address bit 12 mask. */
+#define NVMCTRL_ADDR_12_bp  12  /* Address bit 12 position. */
+#define NVMCTRL_ADDR_13_bm  (1<<13)  /* Address bit 13 mask. */
+#define NVMCTRL_ADDR_13_bp  13  /* Address bit 13 position. */
+#define NVMCTRL_ADDR_14_bm  (1<<14)  /* Address bit 14 mask. */
+#define NVMCTRL_ADDR_14_bp  14  /* Address bit 14 position. */
+#define NVMCTRL_ADDR_15_bm  (1<<15)  /* Address bit 15 mask. */
+#define NVMCTRL_ADDR_15_bp  15  /* Address bit 15 position. */
+#define NVMCTRL_ADDR_16_bm  (1<<16)  /* Address bit 16 mask. */
+#define NVMCTRL_ADDR_16_bp  16  /* Address bit 16 position. */
+#define NVMCTRL_ADDR_17_bm  (1<<17)  /* Address bit 17 mask. */
+#define NVMCTRL_ADDR_17_bp  17  /* Address bit 17 position. */
+#define NVMCTRL_ADDR_18_bm  (1<<18)  /* Address bit 18 mask. */
+#define NVMCTRL_ADDR_18_bp  18  /* Address bit 18 position. */
+#define NVMCTRL_ADDR_19_bm  (1<<19)  /* Address bit 19 mask. */
+#define NVMCTRL_ADDR_19_bp  19  /* Address bit 19 position. */
+#define NVMCTRL_ADDR_20_bm  (1<<20)  /* Address bit 20 mask. */
+#define NVMCTRL_ADDR_20_bp  20  /* Address bit 20 position. */
+#define NVMCTRL_ADDR_21_bm  (1<<21)  /* Address bit 21 mask. */
+#define NVMCTRL_ADDR_21_bp  21  /* Address bit 21 position. */
+#define NVMCTRL_ADDR_22_bm  (1<<22)  /* Address bit 22 mask. */
+#define NVMCTRL_ADDR_22_bp  22  /* Address bit 22 position. */
+#define NVMCTRL_ADDR_23_bm  (1<<23)  /* Address bit 23 mask. */
+#define NVMCTRL_ADDR_23_bp  23  /* Address bit 23 position. */
+
+
+/* PORT - I/O Ports */
+/* PORT.INTFLAGS  bit masks and bit positions */
+#define PORT_INT_gm  0xFF  /* Pin Interrupt Flag group mask. */
+#define PORT_INT_gp  0  /* Pin Interrupt Flag group position. */
+#define PORT_INT_0_bm  (1<<0)  /* Pin Interrupt Flag bit 0 mask. */
+#define PORT_INT_0_bp  0  /* Pin Interrupt Flag bit 0 position. */
+#define PORT_INT0_bm  PORT_INT_0_bm  /* This define is deprecated and should not be used */
+#define PORT_INT0_bp  PORT_INT_0_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_1_bm  (1<<1)  /* Pin Interrupt Flag bit 1 mask. */
+#define PORT_INT_1_bp  1  /* Pin Interrupt Flag bit 1 position. */
+#define PORT_INT1_bm  PORT_INT_1_bm  /* This define is deprecated and should not be used */
+#define PORT_INT1_bp  PORT_INT_1_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_2_bm  (1<<2)  /* Pin Interrupt Flag bit 2 mask. */
+#define PORT_INT_2_bp  2  /* Pin Interrupt Flag bit 2 position. */
+#define PORT_INT2_bm  PORT_INT_2_bm  /* This define is deprecated and should not be used */
+#define PORT_INT2_bp  PORT_INT_2_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_3_bm  (1<<3)  /* Pin Interrupt Flag bit 3 mask. */
+#define PORT_INT_3_bp  3  /* Pin Interrupt Flag bit 3 position. */
+#define PORT_INT3_bm  PORT_INT_3_bm  /* This define is deprecated and should not be used */
+#define PORT_INT3_bp  PORT_INT_3_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_4_bm  (1<<4)  /* Pin Interrupt Flag bit 4 mask. */
+#define PORT_INT_4_bp  4  /* Pin Interrupt Flag bit 4 position. */
+#define PORT_INT4_bm  PORT_INT_4_bm  /* This define is deprecated and should not be used */
+#define PORT_INT4_bp  PORT_INT_4_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_5_bm  (1<<5)  /* Pin Interrupt Flag bit 5 mask. */
+#define PORT_INT_5_bp  5  /* Pin Interrupt Flag bit 5 position. */
+#define PORT_INT5_bm  PORT_INT_5_bm  /* This define is deprecated and should not be used */
+#define PORT_INT5_bp  PORT_INT_5_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_6_bm  (1<<6)  /* Pin Interrupt Flag bit 6 mask. */
+#define PORT_INT_6_bp  6  /* Pin Interrupt Flag bit 6 position. */
+#define PORT_INT6_bm  PORT_INT_6_bm  /* This define is deprecated and should not be used */
+#define PORT_INT6_bp  PORT_INT_6_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_7_bm  (1<<7)  /* Pin Interrupt Flag bit 7 mask. */
+#define PORT_INT_7_bp  7  /* Pin Interrupt Flag bit 7 position. */
+#define PORT_INT7_bm  PORT_INT_7_bm  /* This define is deprecated and should not be used */
+#define PORT_INT7_bp  PORT_INT_7_bp  /* This define is deprecated and should not be used */
+
+/* PORT.PORTCTRL  bit masks and bit positions */
+#define PORT_SRL_bm  0x01  /* Slew Rate Limit Enable bit mask. */
+#define PORT_SRL_bp  0  /* Slew Rate Limit Enable bit position. */
+
+/* PORT.PINCONFIG  bit masks and bit positions */
+#define PORT_ISC_gm  0x07  /* Input/Sense Configuration group mask. */
+#define PORT_ISC_gp  0  /* Input/Sense Configuration group position. */
+#define PORT_ISC_0_bm  (1<<0)  /* Input/Sense Configuration bit 0 mask. */
+#define PORT_ISC_0_bp  0  /* Input/Sense Configuration bit 0 position. */
+#define PORT_ISC_1_bm  (1<<1)  /* Input/Sense Configuration bit 1 mask. */
+#define PORT_ISC_1_bp  1  /* Input/Sense Configuration bit 1 position. */
+#define PORT_ISC_2_bm  (1<<2)  /* Input/Sense Configuration bit 2 mask. */
+#define PORT_ISC_2_bp  2  /* Input/Sense Configuration bit 2 position. */
+#define PORT_PULLUPEN_bm  0x08  /* Pullup enable bit mask. */
+#define PORT_PULLUPEN_bp  3  /* Pullup enable bit position. */
+#define PORT_INLVL_bm  0x40  /* Input Level Select bit mask. */
+#define PORT_INLVL_bp  6  /* Input Level Select bit position. */
+#define PORT_INVEN_bm  0x80  /* Inverted I/O Enable bit mask. */
+#define PORT_INVEN_bp  7  /* Inverted I/O Enable bit position. */
+
+/* PORT.PIN0CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN1CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN2CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN3CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN4CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN5CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN6CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN7CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.EVGENCTRLA  bit masks and bit positions */
+#define PORT_EVGEN0SEL_gm  0x07  /* Event Generator 0 Select group mask. */
+#define PORT_EVGEN0SEL_gp  0  /* Event Generator 0 Select group position. */
+#define PORT_EVGEN0SEL_0_bm  (1<<0)  /* Event Generator 0 Select bit 0 mask. */
+#define PORT_EVGEN0SEL_0_bp  0  /* Event Generator 0 Select bit 0 position. */
+#define PORT_EVGEN0SEL_1_bm  (1<<1)  /* Event Generator 0 Select bit 1 mask. */
+#define PORT_EVGEN0SEL_1_bp  1  /* Event Generator 0 Select bit 1 position. */
+#define PORT_EVGEN0SEL_2_bm  (1<<2)  /* Event Generator 0 Select bit 2 mask. */
+#define PORT_EVGEN0SEL_2_bp  2  /* Event Generator 0 Select bit 2 position. */
+#define PORT_EVGEN1SEL_gm  0x70  /* Event Generator 1 Select group mask. */
+#define PORT_EVGEN1SEL_gp  4  /* Event Generator 1 Select group position. */
+#define PORT_EVGEN1SEL_0_bm  (1<<4)  /* Event Generator 1 Select bit 0 mask. */
+#define PORT_EVGEN1SEL_0_bp  4  /* Event Generator 1 Select bit 0 position. */
+#define PORT_EVGEN1SEL_1_bm  (1<<5)  /* Event Generator 1 Select bit 1 mask. */
+#define PORT_EVGEN1SEL_1_bp  5  /* Event Generator 1 Select bit 1 position. */
+#define PORT_EVGEN1SEL_2_bm  (1<<6)  /* Event Generator 1 Select bit 2 mask. */
+#define PORT_EVGEN1SEL_2_bp  6  /* Event Generator 1 Select bit 2 position. */
+
+
+/* PORTMUX - Port Multiplexer */
+/* PORTMUX.EVSYSROUTEA  bit masks and bit positions */
+#define PORTMUX_EVOUTC_bm  0x04  /* Event Output C bit mask. */
+#define PORTMUX_EVOUTC_bp  2  /* Event Output C bit position. */
+#define PORTMUX_EVOUTD_bm  0x08  /* Event Output D bit mask. */
+#define PORTMUX_EVOUTD_bp  3  /* Event Output D bit position. */
+#define PORTMUX_EVOUTF_bm  0x20  /* Event Output F bit mask. */
+#define PORTMUX_EVOUTF_bp  5  /* Event Output F bit position. */
+
+/* PORTMUX.CCLROUTEA  bit masks and bit positions */
+#define PORTMUX_LUT0_bm  0x01  /* CCL Look-Up Table 0 Signals bit mask. */
+#define PORTMUX_LUT0_bp  0  /* CCL Look-Up Table 0 Signals bit position. */
+#define PORTMUX_LUT1_bm  0x02  /* CCL Look-Up Table 1 Signals bit mask. */
+#define PORTMUX_LUT1_bp  1  /* CCL Look-Up Table 1 Signals bit position. */
+#define PORTMUX_LUT2_bm  0x04  /* CCL Look-Up Table 2 Signals bit mask. */
+#define PORTMUX_LUT2_bp  2  /* CCL Look-Up Table 2 Signals bit position. */
+
+/* PORTMUX.USARTROUTEA  bit masks and bit positions */
+#define PORTMUX_USART0_gm  0x07  /* USART0 Routing group mask. */
+#define PORTMUX_USART0_gp  0  /* USART0 Routing group position. */
+#define PORTMUX_USART0_0_bm  (1<<0)  /* USART0 Routing bit 0 mask. */
+#define PORTMUX_USART0_0_bp  0  /* USART0 Routing bit 0 position. */
+#define PORTMUX_USART0_1_bm  (1<<1)  /* USART0 Routing bit 1 mask. */
+#define PORTMUX_USART0_1_bp  1  /* USART0 Routing bit 1 position. */
+#define PORTMUX_USART0_2_bm  (1<<2)  /* USART0 Routing bit 2 mask. */
+#define PORTMUX_USART0_2_bp  2  /* USART0 Routing bit 2 position. */
+
+/* PORTMUX.SPIROUTEA  bit masks and bit positions */
+#define PORTMUX_SPI0_gm  0x07  /* SPI0 Signals group mask. */
+#define PORTMUX_SPI0_gp  0  /* SPI0 Signals group position. */
+#define PORTMUX_SPI0_0_bm  (1<<0)  /* SPI0 Signals bit 0 mask. */
+#define PORTMUX_SPI0_0_bp  0  /* SPI0 Signals bit 0 position. */
+#define PORTMUX_SPI0_1_bm  (1<<1)  /* SPI0 Signals bit 1 mask. */
+#define PORTMUX_SPI0_1_bp  1  /* SPI0 Signals bit 1 position. */
+#define PORTMUX_SPI0_2_bm  (1<<2)  /* SPI0 Signals bit 2 mask. */
+#define PORTMUX_SPI0_2_bp  2  /* SPI0 Signals bit 2 position. */
+
+/* PORTMUX.TWIROUTEA  bit masks and bit positions */
+#define PORTMUX_TWI0_gm  0x03  /* TWI0 Signals group mask. */
+#define PORTMUX_TWI0_gp  0  /* TWI0 Signals group position. */
+#define PORTMUX_TWI0_0_bm  (1<<0)  /* TWI0 Signals bit 0 mask. */
+#define PORTMUX_TWI0_0_bp  0  /* TWI0 Signals bit 0 position. */
+#define PORTMUX_TWI0_1_bm  (1<<1)  /* TWI0 Signals bit 1 mask. */
+#define PORTMUX_TWI0_1_bp  1  /* TWI0 Signals bit 1 position. */
+
+/* PORTMUX.TCEROUTEA  bit masks and bit positions */
+#define PORTMUX_TCE0_gm  0x0F  /* TCE0 Signals group mask. */
+#define PORTMUX_TCE0_gp  0  /* TCE0 Signals group position. */
+#define PORTMUX_TCE0_0_bm  (1<<0)  /* TCE0 Signals bit 0 mask. */
+#define PORTMUX_TCE0_0_bp  0  /* TCE0 Signals bit 0 position. */
+#define PORTMUX_TCE0_1_bm  (1<<1)  /* TCE0 Signals bit 1 mask. */
+#define PORTMUX_TCE0_1_bp  1  /* TCE0 Signals bit 1 position. */
+#define PORTMUX_TCE0_2_bm  (1<<2)  /* TCE0 Signals bit 2 mask. */
+#define PORTMUX_TCE0_2_bp  2  /* TCE0 Signals bit 2 position. */
+#define PORTMUX_TCE0_3_bm  (1<<3)  /* TCE0 Signals bit 3 mask. */
+#define PORTMUX_TCE0_3_bp  3  /* TCE0 Signals bit 3 position. */
+
+/* PORTMUX.TCFROUTEA  bit masks and bit positions */
+#define PORTMUX_TCF0_gm  0x03  /* TCF0 Output group mask. */
+#define PORTMUX_TCF0_gp  0  /* TCF0 Output group position. */
+#define PORTMUX_TCF0_0_bm  (1<<0)  /* TCF0 Output bit 0 mask. */
+#define PORTMUX_TCF0_0_bp  0  /* TCF0 Output bit 0 position. */
+#define PORTMUX_TCF0_1_bm  (1<<1)  /* TCF0 Output bit 1 mask. */
+#define PORTMUX_TCF0_1_bp  1  /* TCF0 Output bit 1 position. */
+
+
+/* RSTCTRL - Reset controller */
+/* RSTCTRL.RSTFR  bit masks and bit positions */
+#define RSTCTRL_PORF_bm  0x01  /* Power on Reset flag bit mask. */
+#define RSTCTRL_PORF_bp  0  /* Power on Reset flag bit position. */
+#define RSTCTRL_BORF_bm  0x02  /* Brown out detector Reset flag bit mask. */
+#define RSTCTRL_BORF_bp  1  /* Brown out detector Reset flag bit position. */
+#define RSTCTRL_EXTRF_bm  0x04  /* External Reset flag bit mask. */
+#define RSTCTRL_EXTRF_bp  2  /* External Reset flag bit position. */
+#define RSTCTRL_WDRF_bm  0x08  /* Watch dog Reset flag bit mask. */
+#define RSTCTRL_WDRF_bp  3  /* Watch dog Reset flag bit position. */
+#define RSTCTRL_SWRF_bm  0x10  /* Software Reset flag bit mask. */
+#define RSTCTRL_SWRF_bp  4  /* Software Reset flag bit position. */
+#define RSTCTRL_UPDIRF_bm  0x20  /* UPDI Reset flag bit mask. */
+#define RSTCTRL_UPDIRF_bp  5  /* UPDI Reset flag bit position. */
+
+/* RSTCTRL.SWRR  bit masks and bit positions */
+#define RSTCTRL_SWRE_bm  0x01  /* Software Reset Enable bit mask. */
+#define RSTCTRL_SWRE_bp  0  /* Software Reset Enable bit position. */
+
+
+/* RTC - Real-Time Counter */
+/* RTC.CTRLA  bit masks and bit positions */
+#define RTC_RTCEN_bm  0x01  /* Enable bit mask. */
+#define RTC_RTCEN_bp  0  /* Enable bit position. */
+#define RTC_CORREN_bm  0x04  /* Correction enable bit mask. */
+#define RTC_CORREN_bp  2  /* Correction enable bit position. */
+#define RTC_PRESCALER_gm  0x78  /* Prescaling Factor group mask. */
+#define RTC_PRESCALER_gp  3  /* Prescaling Factor group position. */
+#define RTC_PRESCALER_0_bm  (1<<3)  /* Prescaling Factor bit 0 mask. */
+#define RTC_PRESCALER_0_bp  3  /* Prescaling Factor bit 0 position. */
+#define RTC_PRESCALER_1_bm  (1<<4)  /* Prescaling Factor bit 1 mask. */
+#define RTC_PRESCALER_1_bp  4  /* Prescaling Factor bit 1 position. */
+#define RTC_PRESCALER_2_bm  (1<<5)  /* Prescaling Factor bit 2 mask. */
+#define RTC_PRESCALER_2_bp  5  /* Prescaling Factor bit 2 position. */
+#define RTC_PRESCALER_3_bm  (1<<6)  /* Prescaling Factor bit 3 mask. */
+#define RTC_PRESCALER_3_bp  6  /* Prescaling Factor bit 3 position. */
+#define RTC_RUNSTDBY_bm  0x80  /* Run In Standby bit mask. */
+#define RTC_RUNSTDBY_bp  7  /* Run In Standby bit position. */
+
+/* RTC.STATUS  bit masks and bit positions */
+#define RTC_CTRLABUSY_bm  0x01  /* CTRLA Synchronization Busy Flag bit mask. */
+#define RTC_CTRLABUSY_bp  0  /* CTRLA Synchronization Busy Flag bit position. */
+#define RTC_CNTBUSY_bm  0x02  /* Count Synchronization Busy Flag bit mask. */
+#define RTC_CNTBUSY_bp  1  /* Count Synchronization Busy Flag bit position. */
+#define RTC_PERBUSY_bm  0x04  /* Period Synchronization Busy Flag bit mask. */
+#define RTC_PERBUSY_bp  2  /* Period Synchronization Busy Flag bit position. */
+#define RTC_CMPBUSY_bm  0x08  /* Comparator Synchronization Busy Flag bit mask. */
+#define RTC_CMPBUSY_bp  3  /* Comparator Synchronization Busy Flag bit position. */
+
+/* RTC.INTCTRL  bit masks and bit positions */
+#define RTC_OVF_bm  0x01  /* Overflow Interrupt enable bit mask. */
+#define RTC_OVF_bp  0  /* Overflow Interrupt enable bit position. */
+#define RTC_CMP_bm  0x02  /* Compare Match Interrupt enable bit mask. */
+#define RTC_CMP_bp  1  /* Compare Match Interrupt enable bit position. */
+
+/* RTC.INTFLAGS  bit masks and bit positions */
+/* RTC_OVF  is already defined. */
+/* RTC_CMP  is already defined. */
+
+/* RTC.DBGCTRL  bit masks and bit positions */
+#define RTC_DBGRUN_bm  0x01  /* Run in debug bit mask. */
+#define RTC_DBGRUN_bp  0  /* Run in debug bit position. */
+
+/* RTC.CALIB  bit masks and bit positions */
+#define RTC_ERROR_gm  0x7F  /* Error Correction Value group mask. */
+#define RTC_ERROR_gp  0  /* Error Correction Value group position. */
+#define RTC_ERROR_0_bm  (1<<0)  /* Error Correction Value bit 0 mask. */
+#define RTC_ERROR_0_bp  0  /* Error Correction Value bit 0 position. */
+#define RTC_ERROR_1_bm  (1<<1)  /* Error Correction Value bit 1 mask. */
+#define RTC_ERROR_1_bp  1  /* Error Correction Value bit 1 position. */
+#define RTC_ERROR_2_bm  (1<<2)  /* Error Correction Value bit 2 mask. */
+#define RTC_ERROR_2_bp  2  /* Error Correction Value bit 2 position. */
+#define RTC_ERROR_3_bm  (1<<3)  /* Error Correction Value bit 3 mask. */
+#define RTC_ERROR_3_bp  3  /* Error Correction Value bit 3 position. */
+#define RTC_ERROR_4_bm  (1<<4)  /* Error Correction Value bit 4 mask. */
+#define RTC_ERROR_4_bp  4  /* Error Correction Value bit 4 position. */
+#define RTC_ERROR_5_bm  (1<<5)  /* Error Correction Value bit 5 mask. */
+#define RTC_ERROR_5_bp  5  /* Error Correction Value bit 5 position. */
+#define RTC_ERROR_6_bm  (1<<6)  /* Error Correction Value bit 6 mask. */
+#define RTC_ERROR_6_bp  6  /* Error Correction Value bit 6 position. */
+#define RTC_SIGN_bm  0x80  /* Error Correction Sign Bit bit mask. */
+#define RTC_SIGN_bp  7  /* Error Correction Sign Bit bit position. */
+
+/* RTC.CLKSEL  bit masks and bit positions */
+#define RTC_CLKSEL_gm  0x03  /* Clock Select group mask. */
+#define RTC_CLKSEL_gp  0  /* Clock Select group position. */
+#define RTC_CLKSEL_0_bm  (1<<0)  /* Clock Select bit 0 mask. */
+#define RTC_CLKSEL_0_bp  0  /* Clock Select bit 0 position. */
+#define RTC_CLKSEL_1_bm  (1<<1)  /* Clock Select bit 1 mask. */
+#define RTC_CLKSEL_1_bp  1  /* Clock Select bit 1 position. */
+
+/* RTC.PITCTRLA  bit masks and bit positions */
+#define RTC_PITEN_bm  0x01  /* Enable bit mask. */
+#define RTC_PITEN_bp  0  /* Enable bit position. */
+#define RTC_PERIOD_gm  0x78  /* Period group mask. */
+#define RTC_PERIOD_gp  3  /* Period group position. */
+#define RTC_PERIOD_0_bm  (1<<3)  /* Period bit 0 mask. */
+#define RTC_PERIOD_0_bp  3  /* Period bit 0 position. */
+#define RTC_PERIOD_1_bm  (1<<4)  /* Period bit 1 mask. */
+#define RTC_PERIOD_1_bp  4  /* Period bit 1 position. */
+#define RTC_PERIOD_2_bm  (1<<5)  /* Period bit 2 mask. */
+#define RTC_PERIOD_2_bp  5  /* Period bit 2 position. */
+#define RTC_PERIOD_3_bm  (1<<6)  /* Period bit 3 mask. */
+#define RTC_PERIOD_3_bp  6  /* Period bit 3 position. */
+
+/* RTC.PITSTATUS  bit masks and bit positions */
+#define RTC_CTRLBUSY_bm  0x01  /* CTRLA Synchronization Busy Flag bit mask. */
+#define RTC_CTRLBUSY_bp  0  /* CTRLA Synchronization Busy Flag bit position. */
+
+/* RTC.PITINTCTRL  bit masks and bit positions */
+#define RTC_PI_bm  0x01  /* Periodic Interrupt bit mask. */
+#define RTC_PI_bp  0  /* Periodic Interrupt bit position. */
+
+/* RTC.PITINTFLAGS  bit masks and bit positions */
+/* RTC_PI  is already defined. */
+
+/* RTC.PITDBGCTRL  bit masks and bit positions */
+/* RTC_DBGRUN  is already defined. */
+
+/* RTC.PITEVGENCTRLA  bit masks and bit positions */
+#define RTC_EVGEN0SEL_gm  0x0F  /* Event Generation 0 Select group mask. */
+#define RTC_EVGEN0SEL_gp  0  /* Event Generation 0 Select group position. */
+#define RTC_EVGEN0SEL_0_bm  (1<<0)  /* Event Generation 0 Select bit 0 mask. */
+#define RTC_EVGEN0SEL_0_bp  0  /* Event Generation 0 Select bit 0 position. */
+#define RTC_EVGEN0SEL_1_bm  (1<<1)  /* Event Generation 0 Select bit 1 mask. */
+#define RTC_EVGEN0SEL_1_bp  1  /* Event Generation 0 Select bit 1 position. */
+#define RTC_EVGEN0SEL_2_bm  (1<<2)  /* Event Generation 0 Select bit 2 mask. */
+#define RTC_EVGEN0SEL_2_bp  2  /* Event Generation 0 Select bit 2 position. */
+#define RTC_EVGEN0SEL_3_bm  (1<<3)  /* Event Generation 0 Select bit 3 mask. */
+#define RTC_EVGEN0SEL_3_bp  3  /* Event Generation 0 Select bit 3 position. */
+#define RTC_EVGEN1SEL_gm  0xF0  /* Event Generation 1 Select group mask. */
+#define RTC_EVGEN1SEL_gp  4  /* Event Generation 1 Select group position. */
+#define RTC_EVGEN1SEL_0_bm  (1<<4)  /* Event Generation 1 Select bit 0 mask. */
+#define RTC_EVGEN1SEL_0_bp  4  /* Event Generation 1 Select bit 0 position. */
+#define RTC_EVGEN1SEL_1_bm  (1<<5)  /* Event Generation 1 Select bit 1 mask. */
+#define RTC_EVGEN1SEL_1_bp  5  /* Event Generation 1 Select bit 1 position. */
+#define RTC_EVGEN1SEL_2_bm  (1<<6)  /* Event Generation 1 Select bit 2 mask. */
+#define RTC_EVGEN1SEL_2_bp  6  /* Event Generation 1 Select bit 2 position. */
+#define RTC_EVGEN1SEL_3_bm  (1<<7)  /* Event Generation 1 Select bit 3 mask. */
+#define RTC_EVGEN1SEL_3_bp  7  /* Event Generation 1 Select bit 3 position. */
+
+
+
+/* SLPCTRL - Sleep Controller */
+/* SLPCTRL.CTRLA  bit masks and bit positions */
+#define SLPCTRL_SEN_bm  0x01  /* Sleep enable bit mask. */
+#define SLPCTRL_SEN_bp  0  /* Sleep enable bit position. */
+#define SLPCTRL_SMODE_gm  0x06  /* Sleep mode group mask. */
+#define SLPCTRL_SMODE_gp  1  /* Sleep mode group position. */
+#define SLPCTRL_SMODE_0_bm  (1<<1)  /* Sleep mode bit 0 mask. */
+#define SLPCTRL_SMODE_0_bp  1  /* Sleep mode bit 0 position. */
+#define SLPCTRL_SMODE_1_bm  (1<<2)  /* Sleep mode bit 1 mask. */
+#define SLPCTRL_SMODE_1_bp  2  /* Sleep mode bit 1 position. */
+
+
+/* SPI - Serial Peripheral Interface */
+/* SPI.CTRLA  bit masks and bit positions */
+#define SPI_ENABLE_bm  0x01  /* Enable Module bit mask. */
+#define SPI_ENABLE_bp  0  /* Enable Module bit position. */
+#define SPI_PRESC_gm  0x06  /* Prescaler group mask. */
+#define SPI_PRESC_gp  1  /* Prescaler group position. */
+#define SPI_PRESC_0_bm  (1<<1)  /* Prescaler bit 0 mask. */
+#define SPI_PRESC_0_bp  1  /* Prescaler bit 0 position. */
+#define SPI_PRESC_1_bm  (1<<2)  /* Prescaler bit 1 mask. */
+#define SPI_PRESC_1_bp  2  /* Prescaler bit 1 position. */
+#define SPI_CLK2X_bm  0x10  /* Enable Double Speed bit mask. */
+#define SPI_CLK2X_bp  4  /* Enable Double Speed bit position. */
+#define SPI_MASTER_bm  0x20  /* Host Operation Enable bit mask. */
+#define SPI_MASTER_bp  5  /* Host Operation Enable bit position. */
+#define SPI_DORD_bm  0x40  /* Data Order Setting bit mask. */
+#define SPI_DORD_bp  6  /* Data Order Setting bit position. */
+
+/* SPI.CTRLB  bit masks and bit positions */
+#define SPI_MODE_gm  0x03  /* SPI Mode group mask. */
+#define SPI_MODE_gp  0  /* SPI Mode group position. */
+#define SPI_MODE_0_bm  (1<<0)  /* SPI Mode bit 0 mask. */
+#define SPI_MODE_0_bp  0  /* SPI Mode bit 0 position. */
+#define SPI_MODE_1_bm  (1<<1)  /* SPI Mode bit 1 mask. */
+#define SPI_MODE_1_bp  1  /* SPI Mode bit 1 position. */
+#define SPI_SSD_bm  0x04  /* SPI Select Disable bit mask. */
+#define SPI_SSD_bp  2  /* SPI Select Disable bit position. */
+#define SPI_BUFWR_bm  0x40  /* Buffer Mode Wait for Receive bit mask. */
+#define SPI_BUFWR_bp  6  /* Buffer Mode Wait for Receive bit position. */
+#define SPI_BUFEN_bm  0x80  /* Buffer Mode Enable bit mask. */
+#define SPI_BUFEN_bp  7  /* Buffer Mode Enable bit position. */
+
+/* SPI.INTCTRL  bit masks and bit positions */
+#define SPI_IE_bm  0x01  /* Interrupt Enable bit mask. */
+#define SPI_IE_bp  0  /* Interrupt Enable bit position. */
+#define SPI_SSIE_bm  0x10  /* SPI Select Trigger Interrupt Enable bit mask. */
+#define SPI_SSIE_bp  4  /* SPI Select Trigger Interrupt Enable bit position. */
+#define SPI_DREIE_bm  0x20  /* Data Register Empty Interrupt Enable bit mask. */
+#define SPI_DREIE_bp  5  /* Data Register Empty Interrupt Enable bit position. */
+#define SPI_TXCIE_bm  0x40  /* Transfer Complete Interrupt Enable bit mask. */
+#define SPI_TXCIE_bp  6  /* Transfer Complete Interrupt Enable bit position. */
+#define SPI_RXCIE_bm  0x80  /* Receive Complete Interrupt Enable bit mask. */
+#define SPI_RXCIE_bp  7  /* Receive Complete Interrupt Enable bit position. */
+
+/* SPI.INTFLAGS  bit masks and bit positions */
+#define SPI_BUFOVF_bm  0x01  /* Buffer Overflow bit mask. */
+#define SPI_BUFOVF_bp  0  /* Buffer Overflow bit position. */
+#define SPI_SSIF_bm  0x10  /* SPI Select Trigger Interrupt Flag bit mask. */
+#define SPI_SSIF_bp  4  /* SPI Select Trigger Interrupt Flag bit position. */
+#define SPI_DREIF_bm  0x20  /* Data Register Empty Interrupt Flag bit mask. */
+#define SPI_DREIF_bp  5  /* Data Register Empty Interrupt Flag bit position. */
+#define SPI_TXCIF_bm  0x40  /* Transfer Complete Interrupt Flag bit mask. */
+#define SPI_TXCIF_bp  6  /* Transfer Complete Interrupt Flag bit position. */
+#define SPI_WRCOL_bm  0x40  /* Write Collision bit mask. */
+#define SPI_WRCOL_bp  6  /* Write Collision bit position. */
+#define SPI_RXCIF_bm  0x80  /* Receive Complete Interrupt Flag bit mask. */
+#define SPI_RXCIF_bp  7  /* Receive Complete Interrupt Flag bit position. */
+#define SPI_IF_bm  0x80  /* Interrupt Flag bit mask. */
+#define SPI_IF_bp  7  /* Interrupt Flag bit position. */
+
+
+/* SYSCFG - System Configuration Registers */
+/* SYSCFG.REVID  bit masks and bit positions */
+#define SYSCFG_MINOR_gm  0x0F  /* Minor Revision group mask. */
+#define SYSCFG_MINOR_gp  0  /* Minor Revision group position. */
+#define SYSCFG_MINOR_0_bm  (1<<0)  /* Minor Revision bit 0 mask. */
+#define SYSCFG_MINOR_0_bp  0  /* Minor Revision bit 0 position. */
+#define SYSCFG_MINOR_1_bm  (1<<1)  /* Minor Revision bit 1 mask. */
+#define SYSCFG_MINOR_1_bp  1  /* Minor Revision bit 1 position. */
+#define SYSCFG_MINOR_2_bm  (1<<2)  /* Minor Revision bit 2 mask. */
+#define SYSCFG_MINOR_2_bp  2  /* Minor Revision bit 2 position. */
+#define SYSCFG_MINOR_3_bm  (1<<3)  /* Minor Revision bit 3 mask. */
+#define SYSCFG_MINOR_3_bp  3  /* Minor Revision bit 3 position. */
+#define SYSCFG_MAJOR_gm  0xF0  /* Major Revision group mask. */
+#define SYSCFG_MAJOR_gp  4  /* Major Revision group position. */
+#define SYSCFG_MAJOR_0_bm  (1<<4)  /* Major Revision bit 0 mask. */
+#define SYSCFG_MAJOR_0_bp  4  /* Major Revision bit 0 position. */
+#define SYSCFG_MAJOR_1_bm  (1<<5)  /* Major Revision bit 1 mask. */
+#define SYSCFG_MAJOR_1_bp  5  /* Major Revision bit 1 position. */
+#define SYSCFG_MAJOR_2_bm  (1<<6)  /* Major Revision bit 2 mask. */
+#define SYSCFG_MAJOR_2_bp  6  /* Major Revision bit 2 position. */
+#define SYSCFG_MAJOR_3_bm  (1<<7)  /* Major Revision bit 3 mask. */
+#define SYSCFG_MAJOR_3_bp  7  /* Major Revision bit 3 position. */
+
+
+/* TCB - 16-bit Timer/Counter Type B */
+/* TCB.CTRLA  bit masks and bit positions */
+#define TCB_ENABLE_bm  0x01  /* Enable bit mask. */
+#define TCB_ENABLE_bp  0  /* Enable bit position. */
+#define TCB_CLKSEL_gm  0x0E  /* Clock Select group mask. */
+#define TCB_CLKSEL_gp  1  /* Clock Select group position. */
+#define TCB_CLKSEL_0_bm  (1<<1)  /* Clock Select bit 0 mask. */
+#define TCB_CLKSEL_0_bp  1  /* Clock Select bit 0 position. */
+#define TCB_CLKSEL_1_bm  (1<<2)  /* Clock Select bit 1 mask. */
+#define TCB_CLKSEL_1_bp  2  /* Clock Select bit 1 position. */
+#define TCB_CLKSEL_2_bm  (1<<3)  /* Clock Select bit 2 mask. */
+#define TCB_CLKSEL_2_bp  3  /* Clock Select bit 2 position. */
+#define TCB_SYNCUPD_bm  0x10  /* Synchronize Update bit mask. */
+#define TCB_SYNCUPD_bp  4  /* Synchronize Update bit position. */
+#define TCB_CASCADE_bm  0x20  /* Cascade two timers bit mask. */
+#define TCB_CASCADE_bp  5  /* Cascade two timers bit position. */
+#define TCB_RUNSTDBY_bm  0x40  /* Run Standby bit mask. */
+#define TCB_RUNSTDBY_bp  6  /* Run Standby bit position. */
+
+/* TCB.CTRLB  bit masks and bit positions */
+#define TCB_CNTMODE_gm  0x07  /* Timer Mode group mask. */
+#define TCB_CNTMODE_gp  0  /* Timer Mode group position. */
+#define TCB_CNTMODE_0_bm  (1<<0)  /* Timer Mode bit 0 mask. */
+#define TCB_CNTMODE_0_bp  0  /* Timer Mode bit 0 position. */
+#define TCB_CNTMODE_1_bm  (1<<1)  /* Timer Mode bit 1 mask. */
+#define TCB_CNTMODE_1_bp  1  /* Timer Mode bit 1 position. */
+#define TCB_CNTMODE_2_bm  (1<<2)  /* Timer Mode bit 2 mask. */
+#define TCB_CNTMODE_2_bp  2  /* Timer Mode bit 2 position. */
+#define TCB_CCMPEN_bm  0x10  /* Pin Output Enable bit mask. */
+#define TCB_CCMPEN_bp  4  /* Pin Output Enable bit position. */
+#define TCB_CCMPINIT_bm  0x20  /* Pin Initial State bit mask. */
+#define TCB_CCMPINIT_bp  5  /* Pin Initial State bit position. */
+#define TCB_ASYNC_bm  0x40  /* Asynchronous Enable bit mask. */
+#define TCB_ASYNC_bp  6  /* Asynchronous Enable bit position. */
+#define TCB_EVGEN_bm  0x80  /* Event Generation bit mask. */
+#define TCB_EVGEN_bp  7  /* Event Generation bit position. */
+
+/* TCB.CTRLC  bit masks and bit positions */
+#define TCB_CNTSIZE_gm  0x07  /* Counter Size group mask. */
+#define TCB_CNTSIZE_gp  0  /* Counter Size group position. */
+#define TCB_CNTSIZE_0_bm  (1<<0)  /* Counter Size bit 0 mask. */
+#define TCB_CNTSIZE_0_bp  0  /* Counter Size bit 0 position. */
+#define TCB_CNTSIZE_1_bm  (1<<1)  /* Counter Size bit 1 mask. */
+#define TCB_CNTSIZE_1_bp  1  /* Counter Size bit 1 position. */
+#define TCB_CNTSIZE_2_bm  (1<<2)  /* Counter Size bit 2 mask. */
+#define TCB_CNTSIZE_2_bp  2  /* Counter Size bit 2 position. */
+
+/* TCB.EVCTRL  bit masks and bit positions */
+#define TCB_CAPTEI_bm  0x01  /* Event Input Enable bit mask. */
+#define TCB_CAPTEI_bp  0  /* Event Input Enable bit position. */
+#define TCB_EDGE_bm  0x10  /* Event Edge bit mask. */
+#define TCB_EDGE_bp  4  /* Event Edge bit position. */
+#define TCB_FILTER_bm  0x40  /* Input Capture Noise Cancellation Filter bit mask. */
+#define TCB_FILTER_bp  6  /* Input Capture Noise Cancellation Filter bit position. */
+
+/* TCB.INTCTRL  bit masks and bit positions */
+#define TCB_CAPT_bm  0x01  /* Capture or Timeout bit mask. */
+#define TCB_CAPT_bp  0  /* Capture or Timeout bit position. */
+#define TCB_OVF_bm  0x02  /* Overflow bit mask. */
+#define TCB_OVF_bp  1  /* Overflow bit position. */
+
+/* TCB.INTFLAGS  bit masks and bit positions */
+/* TCB_CAPT  is already defined. */
+/* TCB_OVF  is already defined. */
+
+/* TCB.STATUS  bit masks and bit positions */
+#define TCB_RUN_bm  0x01  /* Run bit mask. */
+#define TCB_RUN_bp  0  /* Run bit position. */
+
+/* TCB.DBGCTRL  bit masks and bit positions */
+#define TCB_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define TCB_DBGRUN_bp  0  /* Debug Run bit position. */
+
+
+/* TCE - 16-bit Timer/Counter Type E */
+/* TCE.CTRLA  bit masks and bit positions */
+#define TCE_ENABLE_bm  0x01  /* Module Enable bit mask. */
+#define TCE_ENABLE_bp  0  /* Module Enable bit position. */
+#define TCE_CLKSEL_gm  0x0E  /* Clock Selection group mask. */
+#define TCE_CLKSEL_gp  1  /* Clock Selection group position. */
+#define TCE_CLKSEL_0_bm  (1<<1)  /* Clock Selection bit 0 mask. */
+#define TCE_CLKSEL_0_bp  1  /* Clock Selection bit 0 position. */
+#define TCE_CLKSEL_1_bm  (1<<2)  /* Clock Selection bit 1 mask. */
+#define TCE_CLKSEL_1_bp  2  /* Clock Selection bit 1 position. */
+#define TCE_CLKSEL_2_bm  (1<<3)  /* Clock Selection bit 2 mask. */
+#define TCE_CLKSEL_2_bp  3  /* Clock Selection bit 2 position. */
+#define TCE_RUNSTDBY_bm  0x80  /* Run in Standby bit mask. */
+#define TCE_RUNSTDBY_bp  7  /* Run in Standby bit position. */
+
+/* TCE.CTRLB  bit masks and bit positions */
+#define TCE_WGMODE_gm  0x07  /* Waveform generation mode group mask. */
+#define TCE_WGMODE_gp  0  /* Waveform generation mode group position. */
+#define TCE_WGMODE_0_bm  (1<<0)  /* Waveform generation mode bit 0 mask. */
+#define TCE_WGMODE_0_bp  0  /* Waveform generation mode bit 0 position. */
+#define TCE_WGMODE_1_bm  (1<<1)  /* Waveform generation mode bit 1 mask. */
+#define TCE_WGMODE_1_bp  1  /* Waveform generation mode bit 1 position. */
+#define TCE_WGMODE_2_bm  (1<<2)  /* Waveform generation mode bit 2 mask. */
+#define TCE_WGMODE_2_bp  2  /* Waveform generation mode bit 2 position. */
+#define TCE_ALUPD_bm  0x08  /* Auto Lock Update bit mask. */
+#define TCE_ALUPD_bp  3  /* Auto Lock Update bit position. */
+#define TCE_CMP0EN_bm  0x10  /* Compare 0 Enable bit mask. */
+#define TCE_CMP0EN_bp  4  /* Compare 0 Enable bit position. */
+#define TCE_CMP1EN_bm  0x20  /* Compare 1 Enable bit mask. */
+#define TCE_CMP1EN_bp  5  /* Compare 1 Enable bit position. */
+#define TCE_CMP2EN_bm  0x40  /* Compare 2 Enable bit mask. */
+#define TCE_CMP2EN_bp  6  /* Compare 2 Enable bit position. */
+#define TCE_CMP3EN_bm  0x80  /* Compare 3 Enable bit mask. */
+#define TCE_CMP3EN_bp  7  /* Compare 3 Enable bit position. */
+
+/* TCE.CTRLC  bit masks and bit positions */
+#define TCE_CMP0OV_bm  0x01  /* Compare 0 Waveform Output Value bit mask. */
+#define TCE_CMP0OV_bp  0  /* Compare 0 Waveform Output Value bit position. */
+#define TCE_CMP1OV_bm  0x02  /* Compare 1 Waveform Output Value bit mask. */
+#define TCE_CMP1OV_bp  1  /* Compare 1 Waveform Output Value bit position. */
+#define TCE_CMP2OV_bm  0x04  /* Compare 2 Waveform Output Value bit mask. */
+#define TCE_CMP2OV_bp  2  /* Compare 2 Waveform Output Value bit position. */
+#define TCE_CMP3OV_bm  0x08  /* Compare 3 Waveform Output Value bit mask. */
+#define TCE_CMP3OV_bp  3  /* Compare 3 Waveform Output Value bit position. */
+#define TCE_CMP0POL_bm  0x10  /* Compare 0 Polarity bit mask. */
+#define TCE_CMP0POL_bp  4  /* Compare 0 Polarity bit position. */
+#define TCE_CMP1POL_bm  0x20  /* Compare 1 Polarity bit mask. */
+#define TCE_CMP1POL_bp  5  /* Compare 1 Polarity bit position. */
+#define TCE_CMP2POL_bm  0x40  /* Compare 2 Polarity bit mask. */
+#define TCE_CMP2POL_bp  6  /* Compare 2 Polarity bit position. */
+#define TCE_CMP3POL_bm  0x80  /* Compare 3 Polarity bit mask. */
+#define TCE_CMP3POL_bp  7  /* Compare 3 Polarity bit position. */
+
+/* TCE.CTRLD  bit masks and bit positions */
+#define TCE_SCALE_bm  0x04  /* Scaled Write bit mask. */
+#define TCE_SCALE_bp  2  /* Scaled Write bit position. */
+#define TCE_AMPEN_bm  0x08  /* Amplitude Control Enable bit mask. */
+#define TCE_AMPEN_bp  3  /* Amplitude Control Enable bit position. */
+#define TCE_SCALEMODE_gm  0x30  /* Scaling Mode group mask. */
+#define TCE_SCALEMODE_gp  4  /* Scaling Mode group position. */
+#define TCE_SCALEMODE_0_bm  (1<<4)  /* Scaling Mode bit 0 mask. */
+#define TCE_SCALEMODE_0_bp  4  /* Scaling Mode bit 0 position. */
+#define TCE_SCALEMODE_1_bm  (1<<5)  /* Scaling Mode bit 1 mask. */
+#define TCE_SCALEMODE_1_bp  5  /* Scaling Mode bit 1 position. */
+#define TCE_HREN_gm  0xC0  /* High Resolution Enable group mask. */
+#define TCE_HREN_gp  6  /* High Resolution Enable group position. */
+#define TCE_HREN_0_bm  (1<<6)  /* High Resolution Enable bit 0 mask. */
+#define TCE_HREN_0_bp  6  /* High Resolution Enable bit 0 position. */
+#define TCE_HREN_1_bm  (1<<7)  /* High Resolution Enable bit 1 mask. */
+#define TCE_HREN_1_bp  7  /* High Resolution Enable bit 1 position. */
+
+/* TCE.CTRLECLR  bit masks and bit positions */
+#define TCE_DIR_bm  0x01  /* Direction bit mask. */
+#define TCE_DIR_bp  0  /* Direction bit position. */
+#define TCE_LUPD_bm  0x02  /* Lock Update bit mask. */
+#define TCE_LUPD_bp  1  /* Lock Update bit position. */
+#define TCE_CMD_gm  0x0C  /* Command group mask. */
+#define TCE_CMD_gp  2  /* Command group position. */
+#define TCE_CMD_0_bm  (1<<2)  /* Command bit 0 mask. */
+#define TCE_CMD_0_bp  2  /* Command bit 0 position. */
+#define TCE_CMD_1_bm  (1<<3)  /* Command bit 1 mask. */
+#define TCE_CMD_1_bp  3  /* Command bit 1 position. */
+
+/* TCE.CTRLESET  bit masks and bit positions */
+/* TCE_DIR  is already defined. */
+/* TCE_LUPD  is already defined. */
+/* TCE_CMD  is already defined. */
+
+/* TCE.CTRLFCLR  bit masks and bit positions */
+#define TCE_PERBV_bm  0x01  /* Period Buffer Valid bit mask. */
+#define TCE_PERBV_bp  0  /* Period Buffer Valid bit position. */
+#define TCE_CMP0BV_bm  0x02  /* Compare 0 Buffer Valid bit mask. */
+#define TCE_CMP0BV_bp  1  /* Compare 0 Buffer Valid bit position. */
+#define TCE_CMP1BV_bm  0x04  /* Compare 1 Buffer Valid bit mask. */
+#define TCE_CMP1BV_bp  2  /* Compare 1 Buffer Valid bit position. */
+#define TCE_CMP2BV_bm  0x08  /* Compare 2 Buffer Valid bit mask. */
+#define TCE_CMP2BV_bp  3  /* Compare 2 Buffer Valid bit position. */
+#define TCE_CMP3BV_bm  0x10  /* Compare 3 Buffer Valid bit mask. */
+#define TCE_CMP3BV_bp  4  /* Compare 3 Buffer Valid bit position. */
+
+/* TCE.CTRLFSET  bit masks and bit positions */
+/* TCE_PERBV  is already defined. */
+/* TCE_CMP0BV  is already defined. */
+/* TCE_CMP1BV  is already defined. */
+/* TCE_CMP2BV  is already defined. */
+/* TCE_CMP3BV  is already defined. */
+
+/* TCE.EVGENCTRL  bit masks and bit positions */
+#define TCE_CMP0EV_bm  0x10  /* Compare 0 Event bit mask. */
+#define TCE_CMP0EV_bp  4  /* Compare 0 Event bit position. */
+#define TCE_CMP1EV_bm  0x20  /* Compare 1 Event bit mask. */
+#define TCE_CMP1EV_bp  5  /* Compare 1 Event bit position. */
+#define TCE_CMP2EV_bm  0x40  /* Compare 2 Event bit mask. */
+#define TCE_CMP2EV_bp  6  /* Compare 2 Event bit position. */
+#define TCE_CMP3EV_bm  0x80  /* Compare 3 Event bit mask. */
+#define TCE_CMP3EV_bp  7  /* Compare 3 Event bit position. */
+
+/* TCE.EVCTRL  bit masks and bit positions */
+#define TCE_CNTAEI_bm  0x01  /* Count on Event Input A bit mask. */
+#define TCE_CNTAEI_bp  0  /* Count on Event Input A bit position. */
+#define TCE_EVACTA_gm  0x0E  /* Event Action A group mask. */
+#define TCE_EVACTA_gp  1  /* Event Action A group position. */
+#define TCE_EVACTA_0_bm  (1<<1)  /* Event Action A bit 0 mask. */
+#define TCE_EVACTA_0_bp  1  /* Event Action A bit 0 position. */
+#define TCE_EVACTA_1_bm  (1<<2)  /* Event Action A bit 1 mask. */
+#define TCE_EVACTA_1_bp  2  /* Event Action A bit 1 position. */
+#define TCE_EVACTA_2_bm  (1<<3)  /* Event Action A bit 2 mask. */
+#define TCE_EVACTA_2_bp  3  /* Event Action A bit 2 position. */
+#define TCE_CNTBEI_bm  0x10  /* Count on Event Input B bit mask. */
+#define TCE_CNTBEI_bp  4  /* Count on Event Input B bit position. */
+#define TCE_EVACTB_gm  0xE0  /* Event Action B group mask. */
+#define TCE_EVACTB_gp  5  /* Event Action B group position. */
+#define TCE_EVACTB_0_bm  (1<<5)  /* Event Action B bit 0 mask. */
+#define TCE_EVACTB_0_bp  5  /* Event Action B bit 0 position. */
+#define TCE_EVACTB_1_bm  (1<<6)  /* Event Action B bit 1 mask. */
+#define TCE_EVACTB_1_bp  6  /* Event Action B bit 1 position. */
+#define TCE_EVACTB_2_bm  (1<<7)  /* Event Action B bit 2 mask. */
+#define TCE_EVACTB_2_bp  7  /* Event Action B bit 2 position. */
+
+/* TCE.INTCTRL  bit masks and bit positions */
+#define TCE_OVF_bm  0x01  /* Overflow Interrupt Enable bit mask. */
+#define TCE_OVF_bp  0  /* Overflow Interrupt Enable bit position. */
+#define TCE_CMP0_bm  0x10  /* Compare 0 Interrupt Enable bit mask. */
+#define TCE_CMP0_bp  4  /* Compare 0 Interrupt Enable bit position. */
+#define TCE_CMP1_bm  0x20  /* Compare 1 Interrupt Enable bit mask. */
+#define TCE_CMP1_bp  5  /* Compare 1 Interrupt Enable bit position. */
+#define TCE_CMP2_bm  0x40  /* Compare 2 Interrupt Enable bit mask. */
+#define TCE_CMP2_bp  6  /* Compare 2 Interrupt Enable bit position. */
+#define TCE_CMP3_bm  0x80  /* Compare 3 Interrupt Enable bit mask. */
+#define TCE_CMP3_bp  7  /* Compare 3 Interrupt Enable bit position. */
+
+/* TCE.INTFLAGS  bit masks and bit positions */
+/* TCE_OVF  is already defined. */
+/* TCE_CMP0  is already defined. */
+/* TCE_CMP1  is already defined. */
+/* TCE_CMP2  is already defined. */
+/* TCE_CMP3  is already defined. */
+
+/* TCE.DBGCTRL  bit masks and bit positions */
+#define TCE_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define TCE_DBGRUN_bp  0  /* Debug Run bit position. */
+
+
+/* TCF - 24-bit Timer/Counter for frequency generation */
+/* TCF.CTRLA  bit masks and bit positions */
+#define TCF_ENABLE_bm  0x01  /* Enable bit mask. */
+#define TCF_ENABLE_bp  0  /* Enable bit position. */
+#define TCF_PRESC_gm  0x0E  /* Clock Prescaler group mask. */
+#define TCF_PRESC_gp  1  /* Clock Prescaler group position. */
+#define TCF_PRESC_0_bm  (1<<1)  /* Clock Prescaler bit 0 mask. */
+#define TCF_PRESC_0_bp  1  /* Clock Prescaler bit 0 position. */
+#define TCF_PRESC_1_bm  (1<<2)  /* Clock Prescaler bit 1 mask. */
+#define TCF_PRESC_1_bp  2  /* Clock Prescaler bit 1 position. */
+#define TCF_PRESC_2_bm  (1<<3)  /* Clock Prescaler bit 2 mask. */
+#define TCF_PRESC_2_bp  3  /* Clock Prescaler bit 2 position. */
+#define TCF_RUNSTDBY_bm  0x80  /* Run Standby bit mask. */
+#define TCF_RUNSTDBY_bp  7  /* Run Standby bit position. */
+
+/* TCF.CTRLB  bit masks and bit positions */
+#define TCF_WGMODE_gm  0x07  /* Waveform Generation Mode group mask. */
+#define TCF_WGMODE_gp  0  /* Waveform Generation Mode group position. */
+#define TCF_WGMODE_0_bm  (1<<0)  /* Waveform Generation Mode bit 0 mask. */
+#define TCF_WGMODE_0_bp  0  /* Waveform Generation Mode bit 0 position. */
+#define TCF_WGMODE_1_bm  (1<<1)  /* Waveform Generation Mode bit 1 mask. */
+#define TCF_WGMODE_1_bp  1  /* Waveform Generation Mode bit 1 position. */
+#define TCF_WGMODE_2_bm  (1<<2)  /* Waveform Generation Mode bit 2 mask. */
+#define TCF_WGMODE_2_bp  2  /* Waveform Generation Mode bit 2 position. */
+#define TCF_CLKSEL_gm  0x38  /* Clock Select group mask. */
+#define TCF_CLKSEL_gp  3  /* Clock Select group position. */
+#define TCF_CLKSEL_0_bm  (1<<3)  /* Clock Select bit 0 mask. */
+#define TCF_CLKSEL_0_bp  3  /* Clock Select bit 0 position. */
+#define TCF_CLKSEL_1_bm  (1<<4)  /* Clock Select bit 1 mask. */
+#define TCF_CLKSEL_1_bp  4  /* Clock Select bit 1 position. */
+#define TCF_CLKSEL_2_bm  (1<<5)  /* Clock Select bit 2 mask. */
+#define TCF_CLKSEL_2_bp  5  /* Clock Select bit 2 position. */
+#define TCF_CMP0EV_bm  0x40  /* Compare 0 Event Generation bit mask. */
+#define TCF_CMP0EV_bp  6  /* Compare 0 Event Generation bit position. */
+#define TCF_CMP1EV_bm  0x80  /* Compare 1 Event Generation bit mask. */
+#define TCF_CMP1EV_bp  7  /* Compare 1 Event Generation bit position. */
+
+/* TCF.CTRLC  bit masks and bit positions */
+#define TCF_WO0EN_bm  0x01  /* Waveform Output 0 Enable bit mask. */
+#define TCF_WO0EN_bp  0  /* Waveform Output 0 Enable bit position. */
+#define TCF_WO1EN_bm  0x02  /* Waveform Output 1 Enable bit mask. */
+#define TCF_WO1EN_bp  1  /* Waveform Output 1 Enable bit position. */
+#define TCF_WO0POL_bm  0x04  /* Waveform Output 0 Polarity bit mask. */
+#define TCF_WO0POL_bp  2  /* Waveform Output 0 Polarity bit position. */
+#define TCF_WO1POL_bm  0x08  /* Waveform Output 1 Polarity bit mask. */
+#define TCF_WO1POL_bp  3  /* Waveform Output 1 Polarity bit position. */
+#define TCF_WGPULSE_gm  0x70  /* Waveform Generation Pulse Length group mask. */
+#define TCF_WGPULSE_gp  4  /* Waveform Generation Pulse Length group position. */
+#define TCF_WGPULSE_0_bm  (1<<4)  /* Waveform Generation Pulse Length bit 0 mask. */
+#define TCF_WGPULSE_0_bp  4  /* Waveform Generation Pulse Length bit 0 position. */
+#define TCF_WGPULSE_1_bm  (1<<5)  /* Waveform Generation Pulse Length bit 1 mask. */
+#define TCF_WGPULSE_1_bp  5  /* Waveform Generation Pulse Length bit 1 position. */
+#define TCF_WGPULSE_2_bm  (1<<6)  /* Waveform Generation Pulse Length bit 2 mask. */
+#define TCF_WGPULSE_2_bp  6  /* Waveform Generation Pulse Length bit 2 position. */
+
+/* TCF.CTRLD  bit masks and bit positions */
+#define TCF_CMD_gm  0x03  /* Command group mask. */
+#define TCF_CMD_gp  0  /* Command group position. */
+#define TCF_CMD_0_bm  (1<<0)  /* Command bit 0 mask. */
+#define TCF_CMD_0_bp  0  /* Command bit 0 position. */
+#define TCF_CMD_1_bm  (1<<1)  /* Command bit 1 mask. */
+#define TCF_CMD_1_bp  1  /* Command bit 1 position. */
+
+/* TCF.EVCTRL  bit masks and bit positions */
+#define TCF_CNTAEI_bm  0x01  /* Event A Input Enable bit mask. */
+#define TCF_CNTAEI_bp  0  /* Event A Input Enable bit position. */
+#define TCF_EVACTA_gm  0x06  /* Event Action A group mask. */
+#define TCF_EVACTA_gp  1  /* Event Action A group position. */
+#define TCF_EVACTA_0_bm  (1<<1)  /* Event Action A bit 0 mask. */
+#define TCF_EVACTA_0_bp  1  /* Event Action A bit 0 position. */
+#define TCF_EVACTA_1_bm  (1<<2)  /* Event Action A bit 1 mask. */
+#define TCF_EVACTA_1_bp  2  /* Event Action A bit 1 position. */
+#define TCF_FILTERA_bm  0x08  /* Event A Filter bit mask. */
+#define TCF_FILTERA_bp  3  /* Event A Filter bit position. */
+
+/* TCF.INTCTRL  bit masks and bit positions */
+#define TCF_OVF_bm  0x01  /* Overflow bit mask. */
+#define TCF_OVF_bp  0  /* Overflow bit position. */
+#define TCF_CMP0_bm  0x02  /* Compare 0 Interrupt Enable bit mask. */
+#define TCF_CMP0_bp  1  /* Compare 0 Interrupt Enable bit position. */
+#define TCF_CMP1_bm  0x04  /* Compare 1 Interrupt Enable bit mask. */
+#define TCF_CMP1_bp  2  /* Compare 1 Interrupt Enable bit position. */
+
+/* TCF.INTFLAGS  bit masks and bit positions */
+/* TCF_OVF  is already defined. */
+/* TCF_CMP0  is already defined. */
+/* TCF_CMP1  is already defined. */
+
+/* TCF.STATUS  bit masks and bit positions */
+#define TCF_CTRLABUSY_bm  0x02  /* Control A Synchronization Busy bit mask. */
+#define TCF_CTRLABUSY_bp  1  /* Control A Synchronization Busy bit position. */
+#define TCF_CTRLCBUSY_bm  0x04  /* Control B Synchronization Busy bit mask. */
+#define TCF_CTRLCBUSY_bp  2  /* Control B Synchronization Busy bit position. */
+#define TCF_CTRLDBUSY_bm  0x08  /* Control D Synchronization Busy bit mask. */
+#define TCF_CTRLDBUSY_bp  3  /* Control D Synchronization Busy bit position. */
+#define TCF_CNTBUSY_bm  0x10  /* Counter Synchronization Busy bit mask. */
+#define TCF_CNTBUSY_bp  4  /* Counter Synchronization Busy bit position. */
+#define TCF_PERBUSY_bm  0x20  /* Period Synchronization Busy bit mask. */
+#define TCF_PERBUSY_bp  5  /* Period Synchronization Busy bit position. */
+#define TCF_CMP0BUSY_bm  0x40  /* Compare 0 Synchronization Busy bit mask. */
+#define TCF_CMP0BUSY_bp  6  /* Compare 0 Synchronization Busy bit position. */
+#define TCF_CMP1BUSY_bm  0x80  /* Compare 1 Synchronization Busy bit mask. */
+#define TCF_CMP1BUSY_bp  7  /* Compare 1 Synchronization Busy bit position. */
+
+/* TCF.DBGCTRL  bit masks and bit positions */
+#define TCF_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define TCF_DBGRUN_bp  0  /* Debug Run bit position. */
+
+/* TCF.CNT  bit masks and bit positions */
+#define TCF_CNT_gm  0xFFFFFF  /* Counter group mask. */
+#define TCF_CNT_gp  0  /* Counter group position. */
+#define TCF_CNT_0_bm  (1<<0)  /* Counter bit 0 mask. */
+#define TCF_CNT_0_bp  0  /* Counter bit 0 position. */
+#define TCF_CNT_1_bm  (1<<1)  /* Counter bit 1 mask. */
+#define TCF_CNT_1_bp  1  /* Counter bit 1 position. */
+#define TCF_CNT_2_bm  (1<<2)  /* Counter bit 2 mask. */
+#define TCF_CNT_2_bp  2  /* Counter bit 2 position. */
+#define TCF_CNT_3_bm  (1<<3)  /* Counter bit 3 mask. */
+#define TCF_CNT_3_bp  3  /* Counter bit 3 position. */
+#define TCF_CNT_4_bm  (1<<4)  /* Counter bit 4 mask. */
+#define TCF_CNT_4_bp  4  /* Counter bit 4 position. */
+#define TCF_CNT_5_bm  (1<<5)  /* Counter bit 5 mask. */
+#define TCF_CNT_5_bp  5  /* Counter bit 5 position. */
+#define TCF_CNT_6_bm  (1<<6)  /* Counter bit 6 mask. */
+#define TCF_CNT_6_bp  6  /* Counter bit 6 position. */
+#define TCF_CNT_7_bm  (1<<7)  /* Counter bit 7 mask. */
+#define TCF_CNT_7_bp  7  /* Counter bit 7 position. */
+#define TCF_CNT_8_bm  (1<<8)  /* Counter bit 8 mask. */
+#define TCF_CNT_8_bp  8  /* Counter bit 8 position. */
+#define TCF_CNT_9_bm  (1<<9)  /* Counter bit 9 mask. */
+#define TCF_CNT_9_bp  9  /* Counter bit 9 position. */
+#define TCF_CNT_10_bm  (1<<10)  /* Counter bit 10 mask. */
+#define TCF_CNT_10_bp  10  /* Counter bit 10 position. */
+#define TCF_CNT_11_bm  (1<<11)  /* Counter bit 11 mask. */
+#define TCF_CNT_11_bp  11  /* Counter bit 11 position. */
+#define TCF_CNT_12_bm  (1<<12)  /* Counter bit 12 mask. */
+#define TCF_CNT_12_bp  12  /* Counter bit 12 position. */
+#define TCF_CNT_13_bm  (1<<13)  /* Counter bit 13 mask. */
+#define TCF_CNT_13_bp  13  /* Counter bit 13 position. */
+#define TCF_CNT_14_bm  (1<<14)  /* Counter bit 14 mask. */
+#define TCF_CNT_14_bp  14  /* Counter bit 14 position. */
+#define TCF_CNT_15_bm  (1<<15)  /* Counter bit 15 mask. */
+#define TCF_CNT_15_bp  15  /* Counter bit 15 position. */
+#define TCF_CNT_16_bm  (1<<16)  /* Counter bit 16 mask. */
+#define TCF_CNT_16_bp  16  /* Counter bit 16 position. */
+#define TCF_CNT_17_bm  (1<<17)  /* Counter bit 17 mask. */
+#define TCF_CNT_17_bp  17  /* Counter bit 17 position. */
+#define TCF_CNT_18_bm  (1<<18)  /* Counter bit 18 mask. */
+#define TCF_CNT_18_bp  18  /* Counter bit 18 position. */
+#define TCF_CNT_19_bm  (1<<19)  /* Counter bit 19 mask. */
+#define TCF_CNT_19_bp  19  /* Counter bit 19 position. */
+#define TCF_CNT_20_bm  (1<<20)  /* Counter bit 20 mask. */
+#define TCF_CNT_20_bp  20  /* Counter bit 20 position. */
+#define TCF_CNT_21_bm  (1<<21)  /* Counter bit 21 mask. */
+#define TCF_CNT_21_bp  21  /* Counter bit 21 position. */
+#define TCF_CNT_22_bm  (1<<22)  /* Counter bit 22 mask. */
+#define TCF_CNT_22_bp  22  /* Counter bit 22 position. */
+#define TCF_CNT_23_bm  (1<<23)  /* Counter bit 23 mask. */
+#define TCF_CNT_23_bp  23  /* Counter bit 23 position. */
+
+/* TCF.CMP  bit masks and bit positions */
+#define TCF_CMP_gm  0xFFFFFF  /* Compare group mask. */
+#define TCF_CMP_gp  0  /* Compare group position. */
+#define TCF_CMP_0_bm  (1<<0)  /* Compare bit 0 mask. */
+#define TCF_CMP_0_bp  0  /* Compare bit 0 position. */
+#define TCF_CMP_1_bm  (1<<1)  /* Compare bit 1 mask. */
+#define TCF_CMP_1_bp  1  /* Compare bit 1 position. */
+#define TCF_CMP_2_bm  (1<<2)  /* Compare bit 2 mask. */
+#define TCF_CMP_2_bp  2  /* Compare bit 2 position. */
+#define TCF_CMP_3_bm  (1<<3)  /* Compare bit 3 mask. */
+#define TCF_CMP_3_bp  3  /* Compare bit 3 position. */
+#define TCF_CMP_4_bm  (1<<4)  /* Compare bit 4 mask. */
+#define TCF_CMP_4_bp  4  /* Compare bit 4 position. */
+#define TCF_CMP_5_bm  (1<<5)  /* Compare bit 5 mask. */
+#define TCF_CMP_5_bp  5  /* Compare bit 5 position. */
+#define TCF_CMP_6_bm  (1<<6)  /* Compare bit 6 mask. */
+#define TCF_CMP_6_bp  6  /* Compare bit 6 position. */
+#define TCF_CMP_7_bm  (1<<7)  /* Compare bit 7 mask. */
+#define TCF_CMP_7_bp  7  /* Compare bit 7 position. */
+#define TCF_CMP_8_bm  (1<<8)  /* Compare bit 8 mask. */
+#define TCF_CMP_8_bp  8  /* Compare bit 8 position. */
+#define TCF_CMP_9_bm  (1<<9)  /* Compare bit 9 mask. */
+#define TCF_CMP_9_bp  9  /* Compare bit 9 position. */
+#define TCF_CMP_10_bm  (1<<10)  /* Compare bit 10 mask. */
+#define TCF_CMP_10_bp  10  /* Compare bit 10 position. */
+#define TCF_CMP_11_bm  (1<<11)  /* Compare bit 11 mask. */
+#define TCF_CMP_11_bp  11  /* Compare bit 11 position. */
+#define TCF_CMP_12_bm  (1<<12)  /* Compare bit 12 mask. */
+#define TCF_CMP_12_bp  12  /* Compare bit 12 position. */
+#define TCF_CMP_13_bm  (1<<13)  /* Compare bit 13 mask. */
+#define TCF_CMP_13_bp  13  /* Compare bit 13 position. */
+#define TCF_CMP_14_bm  (1<<14)  /* Compare bit 14 mask. */
+#define TCF_CMP_14_bp  14  /* Compare bit 14 position. */
+#define TCF_CMP_15_bm  (1<<15)  /* Compare bit 15 mask. */
+#define TCF_CMP_15_bp  15  /* Compare bit 15 position. */
+#define TCF_CMP_16_bm  (1<<16)  /* Compare bit 16 mask. */
+#define TCF_CMP_16_bp  16  /* Compare bit 16 position. */
+#define TCF_CMP_17_bm  (1<<17)  /* Compare bit 17 mask. */
+#define TCF_CMP_17_bp  17  /* Compare bit 17 position. */
+#define TCF_CMP_18_bm  (1<<18)  /* Compare bit 18 mask. */
+#define TCF_CMP_18_bp  18  /* Compare bit 18 position. */
+#define TCF_CMP_19_bm  (1<<19)  /* Compare bit 19 mask. */
+#define TCF_CMP_19_bp  19  /* Compare bit 19 position. */
+#define TCF_CMP_20_bm  (1<<20)  /* Compare bit 20 mask. */
+#define TCF_CMP_20_bp  20  /* Compare bit 20 position. */
+#define TCF_CMP_21_bm  (1<<21)  /* Compare bit 21 mask. */
+#define TCF_CMP_21_bp  21  /* Compare bit 21 position. */
+#define TCF_CMP_22_bm  (1<<22)  /* Compare bit 22 mask. */
+#define TCF_CMP_22_bp  22  /* Compare bit 22 position. */
+#define TCF_CMP_23_bm  (1<<23)  /* Compare bit 23 mask. */
+#define TCF_CMP_23_bp  23  /* Compare bit 23 position. */
+
+
+/* TWI - Two-Wire Interface */
+/* TWI.CTRLA  bit masks and bit positions */
+#define TWI_FMEN_bm  0x01  /* Fast-mode Enable bit mask. */
+#define TWI_FMEN_bp  0  /* Fast-mode Enable bit position. */
+#define TWI_FMPEN_bm  0x02  /* Fast-mode Plus Enable bit mask. */
+#define TWI_FMPEN_bp  1  /* Fast-mode Plus Enable bit position. */
+#define TWI_SDAHOLD_gm  0x0C  /* SDA Hold Time group mask. */
+#define TWI_SDAHOLD_gp  2  /* SDA Hold Time group position. */
+#define TWI_SDAHOLD_0_bm  (1<<2)  /* SDA Hold Time bit 0 mask. */
+#define TWI_SDAHOLD_0_bp  2  /* SDA Hold Time bit 0 position. */
+#define TWI_SDAHOLD_1_bm  (1<<3)  /* SDA Hold Time bit 1 mask. */
+#define TWI_SDAHOLD_1_bp  3  /* SDA Hold Time bit 1 position. */
+#define TWI_SDASETUP_bm  0x10  /* SDA Setup Time bit mask. */
+#define TWI_SDASETUP_bp  4  /* SDA Setup Time bit position. */
+#define TWI_INPUTLVL_bm  0x40  /* Input voltage transition level bit mask. */
+#define TWI_INPUTLVL_bp  6  /* Input voltage transition level bit position. */
+
+/* TWI.DUALCTRL  bit masks and bit positions */
+#define TWI_ENABLE_bm  0x01  /* Enable bit mask. */
+#define TWI_ENABLE_bp  0  /* Enable bit position. */
+/* TWI_FMPEN  is already defined. */
+/* TWI_SDAHOLD  is already defined. */
+/* TWI_INPUTLVL  is already defined. */
+
+/* TWI.DBGCTRL  bit masks and bit positions */
+#define TWI_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define TWI_DBGRUN_bp  0  /* Debug Run bit position. */
+
+/* TWI.MCTRLA  bit masks and bit positions */
+/* TWI_ENABLE  is already defined. */
+#define TWI_SMEN_bm  0x02  /* Smart Mode Enable bit mask. */
+#define TWI_SMEN_bp  1  /* Smart Mode Enable bit position. */
+#define TWI_TIMEOUT_gm  0x0C  /* Inactive Bus Time-Out group mask. */
+#define TWI_TIMEOUT_gp  2  /* Inactive Bus Time-Out group position. */
+#define TWI_TIMEOUT_0_bm  (1<<2)  /* Inactive Bus Time-Out bit 0 mask. */
+#define TWI_TIMEOUT_0_bp  2  /* Inactive Bus Time-Out bit 0 position. */
+#define TWI_TIMEOUT_1_bm  (1<<3)  /* Inactive Bus Time-Out bit 1 mask. */
+#define TWI_TIMEOUT_1_bp  3  /* Inactive Bus Time-Out bit 1 position. */
+#define TWI_QCEN_bm  0x10  /* Quick Command Enable bit mask. */
+#define TWI_QCEN_bp  4  /* Quick Command Enable bit position. */
+#define TWI_WIEN_bm  0x40  /* Write Interrupt Enable bit mask. */
+#define TWI_WIEN_bp  6  /* Write Interrupt Enable bit position. */
+#define TWI_RIEN_bm  0x80  /* Read Interrupt Enable bit mask. */
+#define TWI_RIEN_bp  7  /* Read Interrupt Enable bit position. */
+
+/* TWI.MCTRLB  bit masks and bit positions */
+#define TWI_MCMD_gm  0x03  /* Command group mask. */
+#define TWI_MCMD_gp  0  /* Command group position. */
+#define TWI_MCMD_0_bm  (1<<0)  /* Command bit 0 mask. */
+#define TWI_MCMD_0_bp  0  /* Command bit 0 position. */
+#define TWI_MCMD_1_bm  (1<<1)  /* Command bit 1 mask. */
+#define TWI_MCMD_1_bp  1  /* Command bit 1 position. */
+#define TWI_ACKACT_bm  0x04  /* Acknowledge Action bit mask. */
+#define TWI_ACKACT_bp  2  /* Acknowledge Action bit position. */
+#define TWI_FLUSH_bm  0x08  /* Flush bit mask. */
+#define TWI_FLUSH_bp  3  /* Flush bit position. */
+
+/* TWI.MSTATUS  bit masks and bit positions */
+#define TWI_BUSSTATE_gm  0x03  /* Bus State group mask. */
+#define TWI_BUSSTATE_gp  0  /* Bus State group position. */
+#define TWI_BUSSTATE_0_bm  (1<<0)  /* Bus State bit 0 mask. */
+#define TWI_BUSSTATE_0_bp  0  /* Bus State bit 0 position. */
+#define TWI_BUSSTATE_1_bm  (1<<1)  /* Bus State bit 1 mask. */
+#define TWI_BUSSTATE_1_bp  1  /* Bus State bit 1 position. */
+#define TWI_BUSERR_bm  0x04  /* Bus Error bit mask. */
+#define TWI_BUSERR_bp  2  /* Bus Error bit position. */
+#define TWI_ARBLOST_bm  0x08  /* Arbitration Lost bit mask. */
+#define TWI_ARBLOST_bp  3  /* Arbitration Lost bit position. */
+#define TWI_RXACK_bm  0x10  /* Received Acknowledge bit mask. */
+#define TWI_RXACK_bp  4  /* Received Acknowledge bit position. */
+#define TWI_CLKHOLD_bm  0x20  /* Clock Hold bit mask. */
+#define TWI_CLKHOLD_bp  5  /* Clock Hold bit position. */
+#define TWI_WIF_bm  0x40  /* Write Interrupt Flag bit mask. */
+#define TWI_WIF_bp  6  /* Write Interrupt Flag bit position. */
+#define TWI_RIF_bm  0x80  /* Read Interrupt Flag bit mask. */
+#define TWI_RIF_bp  7  /* Read Interrupt Flag bit position. */
+
+/* TWI.MBAUD  bit masks and bit positions */
+#define TWI_BAUD_gm  0xFF  /* Baud Rate group mask. */
+#define TWI_BAUD_gp  0  /* Baud Rate group position. */
+#define TWI_BAUD_0_bm  (1<<0)  /* Baud Rate bit 0 mask. */
+#define TWI_BAUD_0_bp  0  /* Baud Rate bit 0 position. */
+#define TWI_BAUD_1_bm  (1<<1)  /* Baud Rate bit 1 mask. */
+#define TWI_BAUD_1_bp  1  /* Baud Rate bit 1 position. */
+#define TWI_BAUD_2_bm  (1<<2)  /* Baud Rate bit 2 mask. */
+#define TWI_BAUD_2_bp  2  /* Baud Rate bit 2 position. */
+#define TWI_BAUD_3_bm  (1<<3)  /* Baud Rate bit 3 mask. */
+#define TWI_BAUD_3_bp  3  /* Baud Rate bit 3 position. */
+#define TWI_BAUD_4_bm  (1<<4)  /* Baud Rate bit 4 mask. */
+#define TWI_BAUD_4_bp  4  /* Baud Rate bit 4 position. */
+#define TWI_BAUD_5_bm  (1<<5)  /* Baud Rate bit 5 mask. */
+#define TWI_BAUD_5_bp  5  /* Baud Rate bit 5 position. */
+#define TWI_BAUD_6_bm  (1<<6)  /* Baud Rate bit 6 mask. */
+#define TWI_BAUD_6_bp  6  /* Baud Rate bit 6 position. */
+#define TWI_BAUD_7_bm  (1<<7)  /* Baud Rate bit 7 mask. */
+#define TWI_BAUD_7_bp  7  /* Baud Rate bit 7 position. */
+
+/* TWI.MADDR  bit masks and bit positions */
+#define TWI_ADDR_gm  0xFF  /* Address group mask. */
+#define TWI_ADDR_gp  0  /* Address group position. */
+#define TWI_ADDR_0_bm  (1<<0)  /* Address bit 0 mask. */
+#define TWI_ADDR_0_bp  0  /* Address bit 0 position. */
+#define TWI_ADDR_1_bm  (1<<1)  /* Address bit 1 mask. */
+#define TWI_ADDR_1_bp  1  /* Address bit 1 position. */
+#define TWI_ADDR_2_bm  (1<<2)  /* Address bit 2 mask. */
+#define TWI_ADDR_2_bp  2  /* Address bit 2 position. */
+#define TWI_ADDR_3_bm  (1<<3)  /* Address bit 3 mask. */
+#define TWI_ADDR_3_bp  3  /* Address bit 3 position. */
+#define TWI_ADDR_4_bm  (1<<4)  /* Address bit 4 mask. */
+#define TWI_ADDR_4_bp  4  /* Address bit 4 position. */
+#define TWI_ADDR_5_bm  (1<<5)  /* Address bit 5 mask. */
+#define TWI_ADDR_5_bp  5  /* Address bit 5 position. */
+#define TWI_ADDR_6_bm  (1<<6)  /* Address bit 6 mask. */
+#define TWI_ADDR_6_bp  6  /* Address bit 6 position. */
+#define TWI_ADDR_7_bm  (1<<7)  /* Address bit 7 mask. */
+#define TWI_ADDR_7_bp  7  /* Address bit 7 position. */
+
+/* TWI.MDATA  bit masks and bit positions */
+#define TWI_DATA_gm  0xFF  /* Data group mask. */
+#define TWI_DATA_gp  0  /* Data group position. */
+#define TWI_DATA_0_bm  (1<<0)  /* Data bit 0 mask. */
+#define TWI_DATA_0_bp  0  /* Data bit 0 position. */
+#define TWI_DATA_1_bm  (1<<1)  /* Data bit 1 mask. */
+#define TWI_DATA_1_bp  1  /* Data bit 1 position. */
+#define TWI_DATA_2_bm  (1<<2)  /* Data bit 2 mask. */
+#define TWI_DATA_2_bp  2  /* Data bit 2 position. */
+#define TWI_DATA_3_bm  (1<<3)  /* Data bit 3 mask. */
+#define TWI_DATA_3_bp  3  /* Data bit 3 position. */
+#define TWI_DATA_4_bm  (1<<4)  /* Data bit 4 mask. */
+#define TWI_DATA_4_bp  4  /* Data bit 4 position. */
+#define TWI_DATA_5_bm  (1<<5)  /* Data bit 5 mask. */
+#define TWI_DATA_5_bp  5  /* Data bit 5 position. */
+#define TWI_DATA_6_bm  (1<<6)  /* Data bit 6 mask. */
+#define TWI_DATA_6_bp  6  /* Data bit 6 position. */
+#define TWI_DATA_7_bm  (1<<7)  /* Data bit 7 mask. */
+#define TWI_DATA_7_bp  7  /* Data bit 7 position. */
+
+/* TWI.SCTRLA  bit masks and bit positions */
+/* TWI_ENABLE  is already defined. */
+/* TWI_SMEN  is already defined. */
+#define TWI_PMEN_bm  0x04  /* Address Recognition Mode bit mask. */
+#define TWI_PMEN_bp  2  /* Address Recognition Mode bit position. */
+#define TWI_PIEN_bm  0x20  /* Stop Interrupt Enable bit mask. */
+#define TWI_PIEN_bp  5  /* Stop Interrupt Enable bit position. */
+#define TWI_APIEN_bm  0x40  /* Address or Stop Interrupt Enable bit mask. */
+#define TWI_APIEN_bp  6  /* Address or Stop Interrupt Enable bit position. */
+#define TWI_DIEN_bm  0x80  /* Data Interrupt Enable bit mask. */
+#define TWI_DIEN_bp  7  /* Data Interrupt Enable bit position. */
+
+/* TWI.SCTRLB  bit masks and bit positions */
+#define TWI_SCMD_gm  0x03  /* Command group mask. */
+#define TWI_SCMD_gp  0  /* Command group position. */
+#define TWI_SCMD_0_bm  (1<<0)  /* Command bit 0 mask. */
+#define TWI_SCMD_0_bp  0  /* Command bit 0 position. */
+#define TWI_SCMD_1_bm  (1<<1)  /* Command bit 1 mask. */
+#define TWI_SCMD_1_bp  1  /* Command bit 1 position. */
+/* TWI_ACKACT  is already defined. */
+
+/* TWI.SSTATUS  bit masks and bit positions */
+#define TWI_AP_bm  0x01  /* Address or Stop bit mask. */
+#define TWI_AP_bp  0  /* Address or Stop bit position. */
+#define TWI_DIR_bm  0x02  /* Read/Write Direction bit mask. */
+#define TWI_DIR_bp  1  /* Read/Write Direction bit position. */
+/* TWI_BUSERR  is already defined. */
+#define TWI_COLL_bm  0x08  /* Collision bit mask. */
+#define TWI_COLL_bp  3  /* Collision bit position. */
+/* TWI_RXACK  is already defined. */
+/* TWI_CLKHOLD  is already defined. */
+#define TWI_APIF_bm  0x40  /* Address or Stop Interrupt Flag bit mask. */
+#define TWI_APIF_bp  6  /* Address or Stop Interrupt Flag bit position. */
+#define TWI_DIF_bm  0x80  /* Data Interrupt Flag bit mask. */
+#define TWI_DIF_bp  7  /* Data Interrupt Flag bit position. */
+
+/* TWI.SADDR  bit masks and bit positions */
+/* TWI_ADDR  is already defined. */
+
+/* TWI.SDATA  bit masks and bit positions */
+/* TWI_DATA  is already defined. */
+
+/* TWI.SADDRMASK  bit masks and bit positions */
+#define TWI_ADDREN_bm  0x01  /* Address Mask Enable bit mask. */
+#define TWI_ADDREN_bp  0  /* Address Mask Enable bit position. */
+#define TWI_ADDRMASK_gm  0xFE  /* Address Mask group mask. */
+#define TWI_ADDRMASK_gp  1  /* Address Mask group position. */
+#define TWI_ADDRMASK_0_bm  (1<<1)  /* Address Mask bit 0 mask. */
+#define TWI_ADDRMASK_0_bp  1  /* Address Mask bit 0 position. */
+#define TWI_ADDRMASK_1_bm  (1<<2)  /* Address Mask bit 1 mask. */
+#define TWI_ADDRMASK_1_bp  2  /* Address Mask bit 1 position. */
+#define TWI_ADDRMASK_2_bm  (1<<3)  /* Address Mask bit 2 mask. */
+#define TWI_ADDRMASK_2_bp  3  /* Address Mask bit 2 position. */
+#define TWI_ADDRMASK_3_bm  (1<<4)  /* Address Mask bit 3 mask. */
+#define TWI_ADDRMASK_3_bp  4  /* Address Mask bit 3 position. */
+#define TWI_ADDRMASK_4_bm  (1<<5)  /* Address Mask bit 4 mask. */
+#define TWI_ADDRMASK_4_bp  5  /* Address Mask bit 4 position. */
+#define TWI_ADDRMASK_5_bm  (1<<6)  /* Address Mask bit 5 mask. */
+#define TWI_ADDRMASK_5_bp  6  /* Address Mask bit 5 position. */
+#define TWI_ADDRMASK_6_bm  (1<<7)  /* Address Mask bit 6 mask. */
+#define TWI_ADDRMASK_6_bp  7  /* Address Mask bit 6 position. */
+
+
+/* USART - Universal Synchronous and Asynchronous Receiver and Transmitter */
+/* USART.RXDATAL  bit masks and bit positions */
+#define USART_DATA_gm  0xFF  /* RX Data group mask. */
+#define USART_DATA_gp  0  /* RX Data group position. */
+#define USART_DATA_0_bm  (1<<0)  /* RX Data bit 0 mask. */
+#define USART_DATA_0_bp  0  /* RX Data bit 0 position. */
+#define USART_DATA_1_bm  (1<<1)  /* RX Data bit 1 mask. */
+#define USART_DATA_1_bp  1  /* RX Data bit 1 position. */
+#define USART_DATA_2_bm  (1<<2)  /* RX Data bit 2 mask. */
+#define USART_DATA_2_bp  2  /* RX Data bit 2 position. */
+#define USART_DATA_3_bm  (1<<3)  /* RX Data bit 3 mask. */
+#define USART_DATA_3_bp  3  /* RX Data bit 3 position. */
+#define USART_DATA_4_bm  (1<<4)  /* RX Data bit 4 mask. */
+#define USART_DATA_4_bp  4  /* RX Data bit 4 position. */
+#define USART_DATA_5_bm  (1<<5)  /* RX Data bit 5 mask. */
+#define USART_DATA_5_bp  5  /* RX Data bit 5 position. */
+#define USART_DATA_6_bm  (1<<6)  /* RX Data bit 6 mask. */
+#define USART_DATA_6_bp  6  /* RX Data bit 6 position. */
+#define USART_DATA_7_bm  (1<<7)  /* RX Data bit 7 mask. */
+#define USART_DATA_7_bp  7  /* RX Data bit 7 position. */
+
+/* USART.RXDATAH  bit masks and bit positions */
+#define USART_DATA8_bm  0x01  /* Receiver Data Register bit mask. */
+#define USART_DATA8_bp  0  /* Receiver Data Register bit position. */
+#define USART_PERR_bm  0x02  /* Parity Error bit mask. */
+#define USART_PERR_bp  1  /* Parity Error bit position. */
+#define USART_FERR_bm  0x04  /* Frame Error bit mask. */
+#define USART_FERR_bp  2  /* Frame Error bit position. */
+#define USART_BUFOVF_bm  0x40  /* Buffer Overflow bit mask. */
+#define USART_BUFOVF_bp  6  /* Buffer Overflow bit position. */
+#define USART_RXCIF_bm  0x80  /* Receive Complete Interrupt Flag bit mask. */
+#define USART_RXCIF_bp  7  /* Receive Complete Interrupt Flag bit position. */
+
+/* USART.TXDATAL  bit masks and bit positions */
+/* USART_DATA  is already defined. */
+
+/* USART.TXDATAH  bit masks and bit positions */
+/* USART_DATA8  is already defined. */
+
+/* USART.STATUS  bit masks and bit positions */
+#define USART_WFB_bm  0x01  /* Wait For Break bit mask. */
+#define USART_WFB_bp  0  /* Wait For Break bit position. */
+#define USART_BDF_bm  0x02  /* Break Detected Flag bit mask. */
+#define USART_BDF_bp  1  /* Break Detected Flag bit position. */
+#define USART_ISFIF_bm  0x08  /* Inconsistent Sync Field Interrupt Flag bit mask. */
+#define USART_ISFIF_bp  3  /* Inconsistent Sync Field Interrupt Flag bit position. */
+#define USART_RXSIF_bm  0x10  /* Receive Start Interrupt bit mask. */
+#define USART_RXSIF_bp  4  /* Receive Start Interrupt bit position. */
+#define USART_DREIF_bm  0x20  /* Data Register Empty Flag bit mask. */
+#define USART_DREIF_bp  5  /* Data Register Empty Flag bit position. */
+#define USART_TXCIF_bm  0x40  /* Transmit Interrupt Flag bit mask. */
+#define USART_TXCIF_bp  6  /* Transmit Interrupt Flag bit position. */
+/* USART_RXCIF  is already defined. */
+
+/* USART.CTRLA  bit masks and bit positions */
+#define USART_RS485_bm  0x01  /* RS485 Mode internal transmitter bit mask. */
+#define USART_RS485_bp  0  /* RS485 Mode internal transmitter bit position. */
+#define USART_ABEIE_bm  0x04  /* Auto-baud Error Interrupt Enable bit mask. */
+#define USART_ABEIE_bp  2  /* Auto-baud Error Interrupt Enable bit position. */
+#define USART_LBME_bm  0x08  /* Loop-back Mode Enable bit mask. */
+#define USART_LBME_bp  3  /* Loop-back Mode Enable bit position. */
+#define USART_RXSIE_bm  0x10  /* Receiver Start Frame Interrupt Enable bit mask. */
+#define USART_RXSIE_bp  4  /* Receiver Start Frame Interrupt Enable bit position. */
+#define USART_DREIE_bm  0x20  /* Data Register Empty Interrupt Enable bit mask. */
+#define USART_DREIE_bp  5  /* Data Register Empty Interrupt Enable bit position. */
+#define USART_TXCIE_bm  0x40  /* Transmit Complete Interrupt Enable bit mask. */
+#define USART_TXCIE_bp  6  /* Transmit Complete Interrupt Enable bit position. */
+#define USART_RXCIE_bm  0x80  /* Receive Complete Interrupt Enable bit mask. */
+#define USART_RXCIE_bp  7  /* Receive Complete Interrupt Enable bit position. */
+
+/* USART.CTRLB  bit masks and bit positions */
+#define USART_MPCM_bm  0x01  /* Multi-processor Communication Mode bit mask. */
+#define USART_MPCM_bp  0  /* Multi-processor Communication Mode bit position. */
+#define USART_RXMODE_gm  0x06  /* Receiver Mode group mask. */
+#define USART_RXMODE_gp  1  /* Receiver Mode group position. */
+#define USART_RXMODE_0_bm  (1<<1)  /* Receiver Mode bit 0 mask. */
+#define USART_RXMODE_0_bp  1  /* Receiver Mode bit 0 position. */
+#define USART_RXMODE_1_bm  (1<<2)  /* Receiver Mode bit 1 mask. */
+#define USART_RXMODE_1_bp  2  /* Receiver Mode bit 1 position. */
+#define USART_ODME_bm  0x08  /* Open Drain Mode Enable bit mask. */
+#define USART_ODME_bp  3  /* Open Drain Mode Enable bit position. */
+#define USART_SFDEN_bm  0x10  /* Start Frame Detection Enable bit mask. */
+#define USART_SFDEN_bp  4  /* Start Frame Detection Enable bit position. */
+#define USART_TXEN_bm  0x40  /* Transmitter Enable bit mask. */
+#define USART_TXEN_bp  6  /* Transmitter Enable bit position. */
+#define USART_RXEN_bm  0x80  /* Reciever enable bit mask. */
+#define USART_RXEN_bp  7  /* Reciever enable bit position. */
+
+/* USART.CTRLC  bit masks and bit positions */
+#define USART_UCPHA_bm  0x02  /* SPI Host Mode, Clock Phase bit mask. */
+#define USART_UCPHA_bp  1  /* SPI Host Mode, Clock Phase bit position. */
+#define USART_UDORD_bm  0x04  /* SPI Host Mode, Data Order bit mask. */
+#define USART_UDORD_bp  2  /* SPI Host Mode, Data Order bit position. */
+#define USART_CHSIZE_gm  0x07  /* Character Size group mask. */
+#define USART_CHSIZE_gp  0  /* Character Size group position. */
+#define USART_CHSIZE_0_bm  (1<<0)  /* Character Size bit 0 mask. */
+#define USART_CHSIZE_0_bp  0  /* Character Size bit 0 position. */
+#define USART_CHSIZE_1_bm  (1<<1)  /* Character Size bit 1 mask. */
+#define USART_CHSIZE_1_bp  1  /* Character Size bit 1 position. */
+#define USART_CHSIZE_2_bm  (1<<2)  /* Character Size bit 2 mask. */
+#define USART_CHSIZE_2_bp  2  /* Character Size bit 2 position. */
+#define USART_SBMODE_bm  0x08  /* Stop Bit Mode bit mask. */
+#define USART_SBMODE_bp  3  /* Stop Bit Mode bit position. */
+#define USART_PMODE_gm  0x30  /* Parity Mode group mask. */
+#define USART_PMODE_gp  4  /* Parity Mode group position. */
+#define USART_PMODE_0_bm  (1<<4)  /* Parity Mode bit 0 mask. */
+#define USART_PMODE_0_bp  4  /* Parity Mode bit 0 position. */
+#define USART_PMODE_1_bm  (1<<5)  /* Parity Mode bit 1 mask. */
+#define USART_PMODE_1_bp  5  /* Parity Mode bit 1 position. */
+#define USART_CMODE_gm  0xC0  /* Communication Mode group mask. */
+#define USART_CMODE_gp  6  /* Communication Mode group position. */
+#define USART_CMODE_0_bm  (1<<6)  /* Communication Mode bit 0 mask. */
+#define USART_CMODE_0_bp  6  /* Communication Mode bit 0 position. */
+#define USART_CMODE_1_bm  (1<<7)  /* Communication Mode bit 1 mask. */
+#define USART_CMODE_1_bp  7  /* Communication Mode bit 1 position. */
+
+/* USART.CTRLD  bit masks and bit positions */
+#define USART_ABW_gm  0xC0  /* Auto Baud Window group mask. */
+#define USART_ABW_gp  6  /* Auto Baud Window group position. */
+#define USART_ABW_0_bm  (1<<6)  /* Auto Baud Window bit 0 mask. */
+#define USART_ABW_0_bp  6  /* Auto Baud Window bit 0 position. */
+#define USART_ABW_1_bm  (1<<7)  /* Auto Baud Window bit 1 mask. */
+#define USART_ABW_1_bp  7  /* Auto Baud Window bit 1 position. */
+
+/* USART.DBGCTRL  bit masks and bit positions */
+#define USART_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define USART_DBGRUN_bp  0  /* Debug Run bit position. */
+
+/* USART.EVCTRL  bit masks and bit positions */
+#define USART_IREI_bm  0x01  /* IrDA Event Input Enable bit mask. */
+#define USART_IREI_bp  0  /* IrDA Event Input Enable bit position. */
+
+/* USART.TXPLCTRL  bit masks and bit positions */
+#define USART_TXPL_gm  0xFF  /* Transmit pulse length group mask. */
+#define USART_TXPL_gp  0  /* Transmit pulse length group position. */
+#define USART_TXPL_0_bm  (1<<0)  /* Transmit pulse length bit 0 mask. */
+#define USART_TXPL_0_bp  0  /* Transmit pulse length bit 0 position. */
+#define USART_TXPL_1_bm  (1<<1)  /* Transmit pulse length bit 1 mask. */
+#define USART_TXPL_1_bp  1  /* Transmit pulse length bit 1 position. */
+#define USART_TXPL_2_bm  (1<<2)  /* Transmit pulse length bit 2 mask. */
+#define USART_TXPL_2_bp  2  /* Transmit pulse length bit 2 position. */
+#define USART_TXPL_3_bm  (1<<3)  /* Transmit pulse length bit 3 mask. */
+#define USART_TXPL_3_bp  3  /* Transmit pulse length bit 3 position. */
+#define USART_TXPL_4_bm  (1<<4)  /* Transmit pulse length bit 4 mask. */
+#define USART_TXPL_4_bp  4  /* Transmit pulse length bit 4 position. */
+#define USART_TXPL_5_bm  (1<<5)  /* Transmit pulse length bit 5 mask. */
+#define USART_TXPL_5_bp  5  /* Transmit pulse length bit 5 position. */
+#define USART_TXPL_6_bm  (1<<6)  /* Transmit pulse length bit 6 mask. */
+#define USART_TXPL_6_bp  6  /* Transmit pulse length bit 6 position. */
+#define USART_TXPL_7_bm  (1<<7)  /* Transmit pulse length bit 7 mask. */
+#define USART_TXPL_7_bp  7  /* Transmit pulse length bit 7 position. */
+
+/* USART.RXPLCTRL  bit masks and bit positions */
+#define USART_RXPL_gm  0x7F  /* Receiver Pulse Lenght group mask. */
+#define USART_RXPL_gp  0  /* Receiver Pulse Lenght group position. */
+#define USART_RXPL_0_bm  (1<<0)  /* Receiver Pulse Lenght bit 0 mask. */
+#define USART_RXPL_0_bp  0  /* Receiver Pulse Lenght bit 0 position. */
+#define USART_RXPL_1_bm  (1<<1)  /* Receiver Pulse Lenght bit 1 mask. */
+#define USART_RXPL_1_bp  1  /* Receiver Pulse Lenght bit 1 position. */
+#define USART_RXPL_2_bm  (1<<2)  /* Receiver Pulse Lenght bit 2 mask. */
+#define USART_RXPL_2_bp  2  /* Receiver Pulse Lenght bit 2 position. */
+#define USART_RXPL_3_bm  (1<<3)  /* Receiver Pulse Lenght bit 3 mask. */
+#define USART_RXPL_3_bp  3  /* Receiver Pulse Lenght bit 3 position. */
+#define USART_RXPL_4_bm  (1<<4)  /* Receiver Pulse Lenght bit 4 mask. */
+#define USART_RXPL_4_bp  4  /* Receiver Pulse Lenght bit 4 position. */
+#define USART_RXPL_5_bm  (1<<5)  /* Receiver Pulse Lenght bit 5 mask. */
+#define USART_RXPL_5_bp  5  /* Receiver Pulse Lenght bit 5 position. */
+#define USART_RXPL_6_bm  (1<<6)  /* Receiver Pulse Lenght bit 6 mask. */
+#define USART_RXPL_6_bp  6  /* Receiver Pulse Lenght bit 6 position. */
+
+
+
+/* VPORT - Virtual Ports */
+/* VPORT.INTFLAGS  bit masks and bit positions */
+#define VPORT_INT_gm  0xFF  /* Pin Interrupt Flag group mask. */
+#define VPORT_INT_gp  0  /* Pin Interrupt Flag group position. */
+#define VPORT_INT_0_bm  (1<<0)  /* Pin Interrupt Flag bit 0 mask. */
+#define VPORT_INT_0_bp  0  /* Pin Interrupt Flag bit 0 position. */
+#define VPORT_INT_1_bm  (1<<1)  /* Pin Interrupt Flag bit 1 mask. */
+#define VPORT_INT_1_bp  1  /* Pin Interrupt Flag bit 1 position. */
+#define VPORT_INT_2_bm  (1<<2)  /* Pin Interrupt Flag bit 2 mask. */
+#define VPORT_INT_2_bp  2  /* Pin Interrupt Flag bit 2 position. */
+#define VPORT_INT_3_bm  (1<<3)  /* Pin Interrupt Flag bit 3 mask. */
+#define VPORT_INT_3_bp  3  /* Pin Interrupt Flag bit 3 position. */
+#define VPORT_INT_4_bm  (1<<4)  /* Pin Interrupt Flag bit 4 mask. */
+#define VPORT_INT_4_bp  4  /* Pin Interrupt Flag bit 4 position. */
+#define VPORT_INT_5_bm  (1<<5)  /* Pin Interrupt Flag bit 5 mask. */
+#define VPORT_INT_5_bp  5  /* Pin Interrupt Flag bit 5 position. */
+#define VPORT_INT_6_bm  (1<<6)  /* Pin Interrupt Flag bit 6 mask. */
+#define VPORT_INT_6_bp  6  /* Pin Interrupt Flag bit 6 position. */
+#define VPORT_INT_7_bm  (1<<7)  /* Pin Interrupt Flag bit 7 mask. */
+#define VPORT_INT_7_bp  7  /* Pin Interrupt Flag bit 7 position. */
+
+
+/* VREF - Voltage reference */
+/* VREF.DAC0REF  bit masks and bit positions */
+#define VREF_REFSEL_gm  0x07  /* Reference select group mask. */
+#define VREF_REFSEL_gp  0  /* Reference select group position. */
+#define VREF_REFSEL_0_bm  (1<<0)  /* Reference select bit 0 mask. */
+#define VREF_REFSEL_0_bp  0  /* Reference select bit 0 position. */
+#define VREF_REFSEL_1_bm  (1<<1)  /* Reference select bit 1 mask. */
+#define VREF_REFSEL_1_bp  1  /* Reference select bit 1 position. */
+#define VREF_REFSEL_2_bm  (1<<2)  /* Reference select bit 2 mask. */
+#define VREF_REFSEL_2_bp  2  /* Reference select bit 2 position. */
+#define VREF_ALWAYSON_bm  0x80  /* Always on bit mask. */
+#define VREF_ALWAYSON_bp  7  /* Always on bit position. */
+
+/* VREF.ACREF  bit masks and bit positions */
+/* VREF_REFSEL  is already defined. */
+/* VREF_ALWAYSON  is already defined. */
+
+
+/* WDT - Watch-Dog Timer */
+/* WDT.CTRLA  bit masks and bit positions */
+#define WDT_PERIOD_gm  0x0F  /* Period group mask. */
+#define WDT_PERIOD_gp  0  /* Period group position. */
+#define WDT_PERIOD_0_bm  (1<<0)  /* Period bit 0 mask. */
+#define WDT_PERIOD_0_bp  0  /* Period bit 0 position. */
+#define WDT_PERIOD_1_bm  (1<<1)  /* Period bit 1 mask. */
+#define WDT_PERIOD_1_bp  1  /* Period bit 1 position. */
+#define WDT_PERIOD_2_bm  (1<<2)  /* Period bit 2 mask. */
+#define WDT_PERIOD_2_bp  2  /* Period bit 2 position. */
+#define WDT_PERIOD_3_bm  (1<<3)  /* Period bit 3 mask. */
+#define WDT_PERIOD_3_bp  3  /* Period bit 3 position. */
+#define WDT_WINDOW_gm  0xF0  /* Window group mask. */
+#define WDT_WINDOW_gp  4  /* Window group position. */
+#define WDT_WINDOW_0_bm  (1<<4)  /* Window bit 0 mask. */
+#define WDT_WINDOW_0_bp  4  /* Window bit 0 position. */
+#define WDT_WINDOW_1_bm  (1<<5)  /* Window bit 1 mask. */
+#define WDT_WINDOW_1_bp  5  /* Window bit 1 position. */
+#define WDT_WINDOW_2_bm  (1<<6)  /* Window bit 2 mask. */
+#define WDT_WINDOW_2_bp  6  /* Window bit 2 position. */
+#define WDT_WINDOW_3_bm  (1<<7)  /* Window bit 3 mask. */
+#define WDT_WINDOW_3_bp  7  /* Window bit 3 position. */
+
+/* WDT.STATUS  bit masks and bit positions */
+#define WDT_SYNCBUSY_bm  0x01  /* Syncronization busy bit mask. */
+#define WDT_SYNCBUSY_bp  0  /* Syncronization busy bit position. */
+#define WDT_LOCK_bm  0x80  /* Lock enable bit mask. */
+#define WDT_LOCK_bp  7  /* Lock enable bit position. */
+
+
+/* WEX - Waveform Extension */
+/* WEX.CTRLA  bit masks and bit positions */
+#define WEX_DTI0EN_bm  0x01  /* Dead-Time Insertion CMP0 Enable bit mask. */
+#define WEX_DTI0EN_bp  0  /* Dead-Time Insertion CMP0 Enable bit position. */
+#define WEX_DTI1EN_bm  0x02  /* Dead-Time Insertion CMP1 Enable bit mask. */
+#define WEX_DTI1EN_bp  1  /* Dead-Time Insertion CMP1 Enable bit position. */
+#define WEX_DTI2EN_bm  0x04  /* Dead-Time Insertion CMP2 Enable bit mask. */
+#define WEX_DTI2EN_bp  2  /* Dead-Time Insertion CMP2 Enable bit position. */
+#define WEX_DTI3EN_bm  0x08  /* Dead-Time Insertion CMP3 Enable bit mask. */
+#define WEX_DTI3EN_bp  3  /* Dead-Time Insertion CMP3 Enable bit position. */
+#define WEX_INMX_gm  0x70  /* Input Matrix group mask. */
+#define WEX_INMX_gp  4  /* Input Matrix group position. */
+#define WEX_INMX_0_bm  (1<<4)  /* Input Matrix bit 0 mask. */
+#define WEX_INMX_0_bp  4  /* Input Matrix bit 0 position. */
+#define WEX_INMX_1_bm  (1<<5)  /* Input Matrix bit 1 mask. */
+#define WEX_INMX_1_bp  5  /* Input Matrix bit 1 position. */
+#define WEX_INMX_2_bm  (1<<6)  /* Input Matrix bit 2 mask. */
+#define WEX_INMX_2_bp  6  /* Input Matrix bit 2 position. */
+#define WEX_PGM_bm  0x80  /* Pattern Generation Mode bit mask. */
+#define WEX_PGM_bp  7  /* Pattern Generation Mode bit position. */
+
+/* WEX.CTRLB  bit masks and bit positions */
+#define WEX_UPDSRC_gm  0x03  /* Update Source group mask. */
+#define WEX_UPDSRC_gp  0  /* Update Source group position. */
+#define WEX_UPDSRC_0_bm  (1<<0)  /* Update Source bit 0 mask. */
+#define WEX_UPDSRC_0_bp  0  /* Update Source bit 0 position. */
+#define WEX_UPDSRC_1_bm  (1<<1)  /* Update Source bit 1 mask. */
+#define WEX_UPDSRC_1_bp  1  /* Update Source bit 1 position. */
+
+/* WEX.CTRLC  bit masks and bit positions */
+#define WEX_CMD_gm  0x07  /* Command group mask. */
+#define WEX_CMD_gp  0  /* Command group position. */
+#define WEX_CMD_0_bm  (1<<0)  /* Command bit 0 mask. */
+#define WEX_CMD_0_bp  0  /* Command bit 0 position. */
+#define WEX_CMD_1_bm  (1<<1)  /* Command bit 1 mask. */
+#define WEX_CMD_1_bp  1  /* Command bit 1 position. */
+#define WEX_CMD_2_bm  (1<<2)  /* Command bit 2 mask. */
+#define WEX_CMD_2_bp  2  /* Command bit 2 position. */
+
+/* WEX.EVCTRLA  bit masks and bit positions */
+#define WEX_FAULTEI_bm  0x01  /* Fault Event Input Enable bit mask. */
+#define WEX_FAULTEI_bp  0  /* Fault Event Input Enable bit position. */
+#define WEX_BLANK_bm  0x02  /* Fault Event Blanking Enable bit mask. */
+#define WEX_BLANK_bp  1  /* Fault Event Blanking Enable bit position. */
+#define WEX_FILTER_gm  0x1C  /* Fault Event Filter Enable group mask. */
+#define WEX_FILTER_gp  2  /* Fault Event Filter Enable group position. */
+#define WEX_FILTER_0_bm  (1<<2)  /* Fault Event Filter Enable bit 0 mask. */
+#define WEX_FILTER_0_bp  2  /* Fault Event Filter Enable bit 0 position. */
+#define WEX_FILTER_1_bm  (1<<3)  /* Fault Event Filter Enable bit 1 mask. */
+#define WEX_FILTER_1_bp  3  /* Fault Event Filter Enable bit 1 position. */
+#define WEX_FILTER_2_bm  (1<<4)  /* Fault Event Filter Enable bit 2 mask. */
+#define WEX_FILTER_2_bp  4  /* Fault Event Filter Enable bit 2 position. */
+
+/* WEX.EVCTRLB  bit masks and bit positions */
+/* WEX_FAULTEI  is already defined. */
+/* WEX_BLANK  is already defined. */
+/* WEX_FILTER  is already defined. */
+
+/* WEX.EVCTRLC  bit masks and bit positions */
+/* WEX_FAULTEI  is already defined. */
+/* WEX_BLANK  is already defined. */
+/* WEX_FILTER  is already defined. */
+
+/* WEX.BUFCTRL  bit masks and bit positions */
+#define WEX_DTLSBV_bm  0x01  /* Dead-time Low Side Buffer Valid bit mask. */
+#define WEX_DTLSBV_bp  0  /* Dead-time Low Side Buffer Valid bit position. */
+#define WEX_DTHSBV_bm  0x02  /* Dead-time High Side Buffer Valid bit mask. */
+#define WEX_DTHSBV_bp  1  /* Dead-time High Side Buffer Valid bit position. */
+#define WEX_SWAPBV_bm  0x04  /* Swap Buffer Valid bit mask. */
+#define WEX_SWAPBV_bp  2  /* Swap Buffer Valid bit position. */
+#define WEX_PGMOVRBV_bm  0x08  /* PGM Override Buffer Valid bit mask. */
+#define WEX_PGMOVRBV_bp  3  /* PGM Override Buffer Valid bit position. */
+#define WEX_PGMOUTBV_bm  0x10  /* PGM Output Value Buffer Valid bit mask. */
+#define WEX_PGMOUTBV_bp  4  /* PGM Output Value Buffer Valid bit position. */
+
+/* WEX.BLANKCTRL  bit masks and bit positions */
+#define WEX_BLANKTRIG_gm  0x1F  /* Blanking Trigger group mask. */
+#define WEX_BLANKTRIG_gp  0  /* Blanking Trigger group position. */
+#define WEX_BLANKTRIG_0_bm  (1<<0)  /* Blanking Trigger bit 0 mask. */
+#define WEX_BLANKTRIG_0_bp  0  /* Blanking Trigger bit 0 position. */
+#define WEX_BLANKTRIG_1_bm  (1<<1)  /* Blanking Trigger bit 1 mask. */
+#define WEX_BLANKTRIG_1_bp  1  /* Blanking Trigger bit 1 position. */
+#define WEX_BLANKTRIG_2_bm  (1<<2)  /* Blanking Trigger bit 2 mask. */
+#define WEX_BLANKTRIG_2_bp  2  /* Blanking Trigger bit 2 position. */
+#define WEX_BLANKTRIG_3_bm  (1<<3)  /* Blanking Trigger bit 3 mask. */
+#define WEX_BLANKTRIG_3_bp  3  /* Blanking Trigger bit 3 position. */
+#define WEX_BLANKTRIG_4_bm  (1<<4)  /* Blanking Trigger bit 4 mask. */
+#define WEX_BLANKTRIG_4_bp  4  /* Blanking Trigger bit 4 position. */
+#define WEX_BLANKPRESC_gm  0x60  /* Blanking Prescaler group mask. */
+#define WEX_BLANKPRESC_gp  5  /* Blanking Prescaler group position. */
+#define WEX_BLANKPRESC_0_bm  (1<<5)  /* Blanking Prescaler bit 0 mask. */
+#define WEX_BLANKPRESC_0_bp  5  /* Blanking Prescaler bit 0 position. */
+#define WEX_BLANKPRESC_1_bm  (1<<6)  /* Blanking Prescaler bit 1 mask. */
+#define WEX_BLANKPRESC_1_bp  6  /* Blanking Prescaler bit 1 position. */
+
+/* WEX.FAULTCTRL  bit masks and bit positions */
+#define WEX_FDACT_gm  0x03  /* Fault Detection Action group mask. */
+#define WEX_FDACT_gp  0  /* Fault Detection Action group position. */
+#define WEX_FDACT_0_bm  (1<<0)  /* Fault Detection Action bit 0 mask. */
+#define WEX_FDACT_0_bp  0  /* Fault Detection Action bit 0 position. */
+#define WEX_FDACT_1_bm  (1<<1)  /* Fault Detection Action bit 1 mask. */
+#define WEX_FDACT_1_bp  1  /* Fault Detection Action bit 1 position. */
+#define WEX_FDMODE_bm  0x04  /* Fault Detection Restart Mode bit mask. */
+#define WEX_FDMODE_bp  2  /* Fault Detection Restart Mode bit position. */
+#define WEX_FDDBD_bm  0x80  /* Fault Detection on Debug Break Detection bit mask. */
+#define WEX_FDDBD_bp  7  /* Fault Detection on Debug Break Detection bit position. */
+
+/* WEX.FAULTDRV  bit masks and bit positions */
+#define WEX_FAULTDRV0_bm  0x01  /* Fault Drive Enable Bit 0 bit mask. */
+#define WEX_FAULTDRV0_bp  0  /* Fault Drive Enable Bit 0 bit position. */
+#define WEX_FAULTDRV1_bm  0x02  /* Fault Drive Enable Bit 1 bit mask. */
+#define WEX_FAULTDRV1_bp  1  /* Fault Drive Enable Bit 1 bit position. */
+#define WEX_FAULTDRV2_bm  0x04  /* Fault Drive Enable Bit 2 bit mask. */
+#define WEX_FAULTDRV2_bp  2  /* Fault Drive Enable Bit 2 bit position. */
+#define WEX_FAULTDRV3_bm  0x08  /* Fault Drive Enable Bit 3 bit mask. */
+#define WEX_FAULTDRV3_bp  3  /* Fault Drive Enable Bit 3 bit position. */
+#define WEX_FAULTDRV4_bm  0x10  /* Fault Drive Enable Bit 4 bit mask. */
+#define WEX_FAULTDRV4_bp  4  /* Fault Drive Enable Bit 4 bit position. */
+#define WEX_FAULTDRV5_bm  0x20  /* Fault Drive Enable Bit 5 bit mask. */
+#define WEX_FAULTDRV5_bp  5  /* Fault Drive Enable Bit 5 bit position. */
+#define WEX_FAULTDRV6_bm  0x40  /* Fault Drive Enable Bit 6 bit mask. */
+#define WEX_FAULTDRV6_bp  6  /* Fault Drive Enable Bit 6 bit position. */
+#define WEX_FAULTDRV7_bm  0x80  /* Fault Drive Enable Bit 7 bit mask. */
+#define WEX_FAULTDRV7_bp  7  /* Fault Drive Enable Bit 7 bit position. */
+
+/* WEX.FAULTOUT  bit masks and bit positions */
+#define WEX_FAULTOUT0_bm  0x01  /* Fault Output Value Bit 0 bit mask. */
+#define WEX_FAULTOUT0_bp  0  /* Fault Output Value Bit 0 bit position. */
+#define WEX_FAULTOUT1_bm  0x02  /* Fault Output Value Bit 1 bit mask. */
+#define WEX_FAULTOUT1_bp  1  /* Fault Output Value Bit 1 bit position. */
+#define WEX_FAULTOUT2_bm  0x04  /* Fault Output Value Bit 2 bit mask. */
+#define WEX_FAULTOUT2_bp  2  /* Fault Output Value Bit 2 bit position. */
+#define WEX_FAULTOUT3_bm  0x08  /* Fault Output Value Bit 3 bit mask. */
+#define WEX_FAULTOUT3_bp  3  /* Fault Output Value Bit 3 bit position. */
+#define WEX_FAULTOUT4_bm  0x10  /* Fault Output Value Bit 4 bit mask. */
+#define WEX_FAULTOUT4_bp  4  /* Fault Output Value Bit 4 bit position. */
+#define WEX_FAULTOUT5_bm  0x20  /* Fault Output Value Bit 5 bit mask. */
+#define WEX_FAULTOUT5_bp  5  /* Fault Output Value Bit 5 bit position. */
+#define WEX_FAULTOUT6_bm  0x40  /* Fault Output Value Bit 6 bit mask. */
+#define WEX_FAULTOUT6_bp  6  /* Fault Output Value Bit 6 bit position. */
+#define WEX_FAULTOUT7_bm  0x80  /* Fault Output Value Bit 7 bit mask. */
+#define WEX_FAULTOUT7_bp  7  /* Fault Output Value Bit 7 bit position. */
+
+/* WEX.INTCTRL  bit masks and bit positions */
+#define WEX_FAULTDET_bm  0x01  /* Fault Detection Interrupt Enable bit mask. */
+#define WEX_FAULTDET_bp  0  /* Fault Detection Interrupt Enable bit position. */
+
+/* WEX.INTFLAGS  bit masks and bit positions */
+/* WEX_FAULTDET  is already defined. */
+#define WEX_FDFEVA_bm  0x04  /* Fault Detection Flag Event Input A bit mask. */
+#define WEX_FDFEVA_bp  2  /* Fault Detection Flag Event Input A bit position. */
+#define WEX_FDFEVB_bm  0x08  /* Fault Detection Flag Event Input B bit mask. */
+#define WEX_FDFEVB_bp  3  /* Fault Detection Flag Event Input B bit position. */
+#define WEX_FDFEVC_bm  0x10  /* Fault Detection Flag Event Input C bit mask. */
+#define WEX_FDFEVC_bp  4  /* Fault Detection Flag Event Input C bit position. */
+
+/* WEX.STATUS  bit masks and bit positions */
+#define WEX_FDSTATE_bm  0x01  /* Fault Detection State bit mask. */
+#define WEX_FDSTATE_bp  0  /* Fault Detection State bit position. */
+#define WEX_FDSEVA_bm  0x04  /* Fault Detection State Event A bit mask. */
+#define WEX_FDSEVA_bp  2  /* Fault Detection State Event A bit position. */
+#define WEX_FDSEVB_bm  0x08  /* Fault Detection State Event B bit mask. */
+#define WEX_FDSEVB_bp  3  /* Fault Detection State Event B bit position. */
+#define WEX_FDSEVC_bm  0x10  /* Fault Detection State Event C bit mask. */
+#define WEX_FDSEVC_bp  4  /* Fault Detection State Event C bit position. */
+#define WEX_BLANKSTATE_bm  0x80  /* Blanking State bit mask. */
+#define WEX_BLANKSTATE_bp  7  /* Blanking State bit position. */
+
+/* WEX.SWAP  bit masks and bit positions */
+#define WEX_SWAP0_bm  0x01  /* Swap DTI Output Pair 0 bit mask. */
+#define WEX_SWAP0_bp  0  /* Swap DTI Output Pair 0 bit position. */
+#define WEX_SWAP1_bm  0x02  /* Swap DTI Output Pair 1 bit mask. */
+#define WEX_SWAP1_bp  1  /* Swap DTI Output Pair 1 bit position. */
+#define WEX_SWAP2_bm  0x04  /* Swap DTI Output Pair 2 bit mask. */
+#define WEX_SWAP2_bp  2  /* Swap DTI Output Pair 2 bit position. */
+#define WEX_SWAP3_bm  0x08  /* Swap DTI Output Pair 3 bit mask. */
+#define WEX_SWAP3_bp  3  /* Swap DTI Output Pair 3 bit position. */
+
+/* WEX.PGMOVR  bit masks and bit positions */
+#define WEX_PGMOVR0_bm  0x01  /* Pattern Generation Override Enable Bit 0 bit mask. */
+#define WEX_PGMOVR0_bp  0  /* Pattern Generation Override Enable Bit 0 bit position. */
+#define WEX_PGMOVR1_bm  0x02  /* Pattern Generation Override Enable Bit 1 bit mask. */
+#define WEX_PGMOVR1_bp  1  /* Pattern Generation Override Enable Bit 1 bit position. */
+#define WEX_PGMOVR2_bm  0x04  /* Pattern Generation Override Enable Bit 2 bit mask. */
+#define WEX_PGMOVR2_bp  2  /* Pattern Generation Override Enable Bit 2 bit position. */
+#define WEX_PGMOVR3_bm  0x08  /* Pattern Generation Override Enable Bit 3 bit mask. */
+#define WEX_PGMOVR3_bp  3  /* Pattern Generation Override Enable Bit 3 bit position. */
+#define WEX_PGMOVR4_bm  0x10  /* Pattern Generation Override Enable Bit 4 bit mask. */
+#define WEX_PGMOVR4_bp  4  /* Pattern Generation Override Enable Bit 4 bit position. */
+#define WEX_PGMOVR5_bm  0x20  /* Pattern Generation Override Enable Bit 5 bit mask. */
+#define WEX_PGMOVR5_bp  5  /* Pattern Generation Override Enable Bit 5 bit position. */
+#define WEX_PGMOVR6_bm  0x40  /* Pattern Generation Override Enable Bit 6 bit mask. */
+#define WEX_PGMOVR6_bp  6  /* Pattern Generation Override Enable Bit 6 bit position. */
+#define WEX_PGMOVR7_bm  0x80  /* Pattern Generation Override Enable Bit 7 bit mask. */
+#define WEX_PGMOVR7_bp  7  /* Pattern Generation Override Enable Bit 7 bit position. */
+
+/* WEX.PGMOUT  bit masks and bit positions */
+#define WEX_PGMOUT0_bm  0x01  /* Pattern Generation Output Value Bit 0 bit mask. */
+#define WEX_PGMOUT0_bp  0  /* Pattern Generation Output Value Bit 0 bit position. */
+#define WEX_PGMOUT1_bm  0x02  /* Pattern Generation Output Value Bit 1 bit mask. */
+#define WEX_PGMOUT1_bp  1  /* Pattern Generation Output Value Bit 1 bit position. */
+#define WEX_PGMOUT2_bm  0x04  /* Pattern Generation Output Value Bit 2 bit mask. */
+#define WEX_PGMOUT2_bp  2  /* Pattern Generation Output Value Bit 2 bit position. */
+#define WEX_PGMOUT3_bm  0x08  /* Pattern Generation Output Value Bit 3 bit mask. */
+#define WEX_PGMOUT3_bp  3  /* Pattern Generation Output Value Bit 3 bit position. */
+#define WEX_PGMOUT4_bm  0x10  /* Pattern Generation Output Value Bit 4 bit mask. */
+#define WEX_PGMOUT4_bp  4  /* Pattern Generation Output Value Bit 4 bit position. */
+#define WEX_PGMOUT5_bm  0x20  /* Pattern Generation Output Value Bit 5 bit mask. */
+#define WEX_PGMOUT5_bp  5  /* Pattern Generation Output Value Bit 5 bit position. */
+#define WEX_PGMOUT6_bm  0x40  /* Pattern Generation Output Value Bit 6 bit mask. */
+#define WEX_PGMOUT6_bp  6  /* Pattern Generation Output Value Bit 6 bit position. */
+#define WEX_PGMOUT7_bm  0x80  /* Pattern Generation Output Value Bit 7 bit mask. */
+#define WEX_PGMOUT7_bp  7  /* Pattern Generation Output Value Bit 7 bit position. */
+
+/* WEX.OUTOVEN  bit masks and bit positions */
+#define WEX_OUTOVEN0_bm  0x01  /* Output Override Enable Bit 0 bit mask. */
+#define WEX_OUTOVEN0_bp  0  /* Output Override Enable Bit 0 bit position. */
+#define WEX_OUTOVEN1_bm  0x02  /* Output Override Enable Bit 1 bit mask. */
+#define WEX_OUTOVEN1_bp  1  /* Output Override Enable Bit 1 bit position. */
+#define WEX_OUTOVEN2_bm  0x04  /* Output Override Enable Bit 2 bit mask. */
+#define WEX_OUTOVEN2_bp  2  /* Output Override Enable Bit 2 bit position. */
+#define WEX_OUTOVEN3_bm  0x08  /* Output Override Enable Bit 3 bit mask. */
+#define WEX_OUTOVEN3_bp  3  /* Output Override Enable Bit 3 bit position. */
+#define WEX_OUTOVEN4_bm  0x10  /* Output Override Enable Bit 4 bit mask. */
+#define WEX_OUTOVEN4_bp  4  /* Output Override Enable Bit 4 bit position. */
+#define WEX_OUTOVEN5_bm  0x20  /* Output Override Enable Bit 5 bit mask. */
+#define WEX_OUTOVEN5_bp  5  /* Output Override Enable Bit 5 bit position. */
+#define WEX_OUTOVEN6_bm  0x40  /* Output Override Enable Bit 6 bit mask. */
+#define WEX_OUTOVEN6_bp  6  /* Output Override Enable Bit 6 bit position. */
+#define WEX_OUTOVEN7_bm  0x80  /* Output Override Enable Bit 7 bit mask. */
+#define WEX_OUTOVEN7_bp  7  /* Output Override Enable Bit 7 bit position. */
+
+/* WEX.SWAPBUF  bit masks and bit positions */
+#define WEX_SWAPBUF0_bm  0x01  /* Swap DTI Output Pair 0 Buffer bit mask. */
+#define WEX_SWAPBUF0_bp  0  /* Swap DTI Output Pair 0 Buffer bit position. */
+#define WEX_SWAPBUF1_bm  0x02  /* Swap DTI Output Pair 1 Buffer bit mask. */
+#define WEX_SWAPBUF1_bp  1  /* Swap DTI Output Pair 1 Buffer bit position. */
+#define WEX_SWAPBUF2_bm  0x04  /* Swap DTI Output Pair 2 Buffer bit mask. */
+#define WEX_SWAPBUF2_bp  2  /* Swap DTI Output Pair 2 Buffer bit position. */
+#define WEX_SWAPBUF3_bm  0x08  /* Swap DTI Output Pair 3 Buffer bit mask. */
+#define WEX_SWAPBUF3_bp  3  /* Swap DTI Output Pair 3 Buffer bit position. */
+
+/* WEX.PGMOVRBUF  bit masks and bit positions */
+#define WEX_PGMOVRBUF0_bm  0x01  /* Pattern Generation Override Enable Buffer Bit 0 bit mask. */
+#define WEX_PGMOVRBUF0_bp  0  /* Pattern Generation Override Enable Buffer Bit 0 bit position. */
+#define WEX_PGMOVRBUF1_bm  0x02  /* Pattern Generation Override Enable Buffer Bit 1 bit mask. */
+#define WEX_PGMOVRBUF1_bp  1  /* Pattern Generation Override Enable Buffer Bit 1 bit position. */
+#define WEX_PGMOVRBUF2_bm  0x04  /* Pattern Generation Override Enable Buffer Bit 2 bit mask. */
+#define WEX_PGMOVRBUF2_bp  2  /* Pattern Generation Override Enable Buffer Bit 2 bit position. */
+#define WEX_PGMOVRBUF3_bm  0x08  /* Pattern Generation Override Enable Buffer Bit 3 bit mask. */
+#define WEX_PGMOVRBUF3_bp  3  /* Pattern Generation Override Enable Buffer Bit 3 bit position. */
+#define WEX_PGMOVRBUF4_bm  0x10  /* Pattern Generation Override Enable Buffer Bit 4 bit mask. */
+#define WEX_PGMOVRBUF4_bp  4  /* Pattern Generation Override Enable Buffer Bit 4 bit position. */
+#define WEX_PGMOVRBUF5_bm  0x20  /* Pattern Generation Override Enable Buffer Bit 5 bit mask. */
+#define WEX_PGMOVRBUF5_bp  5  /* Pattern Generation Override Enable Buffer Bit 5 bit position. */
+#define WEX_PGMOVRBUF6_bm  0x40  /* Pattern Generation Override Enable Buffer Bit 6 bit mask. */
+#define WEX_PGMOVRBUF6_bp  6  /* Pattern Generation Override Enable Buffer Bit 6 bit position. */
+#define WEX_PGMOVRBUF7_bm  0x80  /* Pattern Generation Override Enable Buffer Bit 7 bit mask. */
+#define WEX_PGMOVRBUF7_bp  7  /* Pattern Generation Override Enable Buffer Bit 7 bit position. */
+
+/* WEX.PGMOUTBUF  bit masks and bit positions */
+#define WEX_PGMOUTBUF0_bm  0x01  /* Pattern Generation Output Value Buffer Bit 0 bit mask. */
+#define WEX_PGMOUTBUF0_bp  0  /* Pattern Generation Output Value Buffer Bit 0 bit position. */
+#define WEX_PGMOUTBUF1_bm  0x02  /* Pattern Generation Output Value Buffer Bit 1 bit mask. */
+#define WEX_PGMOUTBUF1_bp  1  /* Pattern Generation Output Value Buffer Bit 1 bit position. */
+#define WEX_PGMOUTBUF2_bm  0x04  /* Pattern Generation Output Value Buffer Bit 2 bit mask. */
+#define WEX_PGMOUTBUF2_bp  2  /* Pattern Generation Output Value Buffer Bit 2 bit position. */
+#define WEX_PGMOUTBUF3_bm  0x08  /* Pattern Generation Output Value Buffer Bit 3 bit mask. */
+#define WEX_PGMOUTBUF3_bp  3  /* Pattern Generation Output Value Buffer Bit 3 bit position. */
+#define WEX_PGMOUTBUF4_bm  0x10  /* Pattern Generation Output Value Buffer Bit 4 bit mask. */
+#define WEX_PGMOUTBUF4_bp  4  /* Pattern Generation Output Value Buffer Bit 4 bit position. */
+#define WEX_PGMOUTBUF5_bm  0x20  /* Pattern Generation Output Value Buffer Bit 5 bit mask. */
+#define WEX_PGMOUTBUF5_bp  5  /* Pattern Generation Output Value Buffer Bit 5 bit position. */
+#define WEX_PGMOUTBUF6_bm  0x40  /* Pattern Generation Output Value Buffer Bit 6 bit mask. */
+#define WEX_PGMOUTBUF6_bp  6  /* Pattern Generation Output Value Buffer Bit 6 bit position. */
+#define WEX_PGMOUTBUF7_bm  0x80  /* Pattern Generation Output Value Buffer Bit 7 bit mask. */
+#define WEX_PGMOUTBUF7_bp  7  /* Pattern Generation Output Value Buffer Bit 7 bit position. */
+
+
+/* ========== Generic Port Pins ========== */
+#define PIN0_bm 0x01
+#define PIN0_bp 0
+#define PIN1_bm 0x02
+#define PIN1_bp 1
+#define PIN2_bm 0x04
+#define PIN2_bp 2
+#define PIN3_bm 0x08
+#define PIN3_bp 3
+#define PIN4_bm 0x10
+#define PIN4_bp 4
+#define PIN5_bm 0x20
+#define PIN5_bp 5
+#define PIN6_bm 0x40
+#define PIN6_bp 6
+#define PIN7_bm 0x80
+#define PIN7_bp 7
+
+/* ========== Interrupt Vector Definitions ========== */
+/* Vector 0 is the reset vector */
+
+/* NMI interrupt vectors */
+#define NMI_vect_num  1
+#define NMI_vect      _VECTOR(1)  /*  */
+
+/* BOD interrupt vectors */
+#define BOD_VLM_vect_num  2
+#define BOD_VLM_vect      _VECTOR(2)  /*  */
+
+/* RTC interrupt vectors */
+#define RTC_CNT_vect_num  3
+#define RTC_CNT_vect      _VECTOR(3)  /*  */
+#define RTC_PIT_vect_num  4
+#define RTC_PIT_vect      _VECTOR(4)  /*  */
+
+/* CCL interrupt vectors */
+#define CCL_CCL_vect_num  5
+#define CCL_CCL_vect      _VECTOR(5)  /*  */
+
+/* PORTA interrupt vectors */
+#define PORTA_PORT_vect_num  6
+#define PORTA_PORT_vect      _VECTOR(6)  /*  */
+
+/* WEX0 interrupt vectors */
+#define WEX0_FDFEVA_vect_num  7
+#define WEX0_FDFEVA_vect      _VECTOR(7)  /*  */
+#define WEX0_FDFEVB_vect_num  7
+#define WEX0_FDFEVB_vect      _VECTOR(7)  /*  */
+#define WEX0_FDFEVC_vect_num  7
+#define WEX0_FDFEVC_vect      _VECTOR(7)  /*  */
+
+/* TCE0 interrupt vectors */
+#define TCE0_OVF_vect_num  8
+#define TCE0_OVF_vect      _VECTOR(8)  /*  */
+#define TCE0_CMP0_vect_num  9
+#define TCE0_CMP0_vect      _VECTOR(9)  /*  */
+#define TCE0_CMP1_vect_num  10
+#define TCE0_CMP1_vect      _VECTOR(10)  /*  */
+#define TCE0_CMP2_vect_num  11
+#define TCE0_CMP2_vect      _VECTOR(11)  /*  */
+#define TCE0_CMP3_vect_num  12
+#define TCE0_CMP3_vect      _VECTOR(12)  /*  */
+
+/* TCB0 interrupt vectors */
+#define TCB0_INT_vect_num  13
+#define TCB0_INT_vect      _VECTOR(13)  /*  */
+
+/* TCB1 interrupt vectors */
+#define TCB1_INT_vect_num  14
+#define TCB1_INT_vect      _VECTOR(14)  /*  */
+
+/* TWI0 interrupt vectors */
+#define TWI0_TWIS_vect_num  15
+#define TWI0_TWIS_vect      _VECTOR(15)  /*  */
+#define TWI0_TWIM_vect_num  16
+#define TWI0_TWIM_vect      _VECTOR(16)  /*  */
+
+/* SPI0 interrupt vectors */
+#define SPI0_INT_vect_num  17
+#define SPI0_INT_vect      _VECTOR(17)  /*  */
+
+/* USART0 interrupt vectors */
+#define USART0_RXC_vect_num  18
+#define USART0_RXC_vect      _VECTOR(18)  /*  */
+#define USART0_DRE_vect_num  19
+#define USART0_DRE_vect      _VECTOR(19)  /*  */
+#define USART0_TXC_vect_num  20
+#define USART0_TXC_vect      _VECTOR(20)  /*  */
+
+/* PORTD interrupt vectors */
+#define PORTD_PORT_vect_num  21
+#define PORTD_PORT_vect      _VECTOR(21)  /*  */
+
+/* TCF0 interrupt vectors */
+#define TCF0_INT_vect_num  22
+#define TCF0_INT_vect      _VECTOR(22)  /*  */
+
+/* AC0 interrupt vectors */
+#define AC0_AC_vect_num  23
+#define AC0_AC_vect      _VECTOR(23)  /*  */
+
+/* ADC0 interrupt vectors */
+#define ADC0_ERROR_vect_num  24
+#define ADC0_ERROR_vect      _VECTOR(24)  /*  */
+#define ADC0_RESRDY_vect_num  25
+#define ADC0_RESRDY_vect      _VECTOR(25)  /*  */
+#define ADC0_SAMPRDY_vect_num  26
+#define ADC0_SAMPRDY_vect      _VECTOR(26)  /*  */
+
+/* AC1 interrupt vectors */
+#define AC1_AC_vect_num  27
+#define AC1_AC_vect      _VECTOR(27)  /*  */
+
+/* PORTC interrupt vectors */
+#define PORTC_PORT_vect_num  28
+#define PORTC_PORT_vect      _VECTOR(28)  /*  */
+
+/* PORTF interrupt vectors */
+#define PORTF_PORT_vect_num  29
+#define PORTF_PORT_vect      _VECTOR(29)  /*  */
+
+/* NVMCTRL interrupt vectors */
+#define NVMCTRL_EEREADY_vect_num  30
+#define NVMCTRL_EEREADY_vect      _VECTOR(30)  /*  */
+#define NVMCTRL_FLREADY_vect_num  30
+#define NVMCTRL_FLREADY_vect      _VECTOR(30)  /*  */
+#define NVMCTRL_NVMREADY_vect_num  30
+#define NVMCTRL_NVMREADY_vect      _VECTOR(30)  /*  */
+
+#define _VECTOR_SIZE 4 /* Size of individual vector. */
+#define _VECTORS_SIZE (31 * _VECTOR_SIZE)
+
+
+/* ========== Constants ========== */
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define DATAMEM_START     (0x0000)
+#  define DATAMEM_SIZE      (65536)
+#else
+#  define DATAMEM_START     (0x0000U)
+#  define DATAMEM_SIZE      (65536U)
+#endif
+#define DATAMEM_END       (DATAMEM_START + DATAMEM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define IO_START     (0x0000)
+#  define IO_SIZE      (4159)
+#  define IO_PAGE_SIZE (0)
+#else
+#  define IO_START     (0x0000U)
+#  define IO_SIZE      (4159U)
+#  define IO_PAGE_SIZE (0U)
+#endif
+#define IO_END       (IO_START + IO_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define LOCKBITS_START     (0x1040)
+#  define LOCKBITS_SIZE      (4)
+#  define LOCKBITS_PAGE_SIZE (4)
+#else
+#  define LOCKBITS_START     (0x1040U)
+#  define LOCKBITS_SIZE      (4U)
+#  define LOCKBITS_PAGE_SIZE (4U)
+#endif
+#define LOCKBITS_END       (LOCKBITS_START + LOCKBITS_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define FUSES_START     (0x1050)
+#  define FUSES_SIZE      (16)
+#  define FUSES_PAGE_SIZE (8)
+#else
+#  define FUSES_START     (0x1050U)
+#  define FUSES_SIZE      (16U)
+#  define FUSES_PAGE_SIZE (8U)
+#endif
+#define FUSES_END       (FUSES_START + FUSES_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define SIGNATURES_START     (0x1080)
+#  define SIGNATURES_SIZE      (3)
+#  define SIGNATURES_PAGE_SIZE (128)
+#else
+#  define SIGNATURES_START     (0x1080U)
+#  define SIGNATURES_SIZE      (3U)
+#  define SIGNATURES_PAGE_SIZE (128U)
+#endif
+#define SIGNATURES_END       (SIGNATURES_START + SIGNATURES_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define PROD_SIGNATURES_START     (0x1083)
+#  define PROD_SIGNATURES_SIZE      (125)
+#  define PROD_SIGNATURES_PAGE_SIZE (128)
+#else
+#  define PROD_SIGNATURES_START     (0x1083U)
+#  define PROD_SIGNATURES_SIZE      (125U)
+#  define PROD_SIGNATURES_PAGE_SIZE (128U)
+#endif
+#define PROD_SIGNATURES_END       (PROD_SIGNATURES_START + PROD_SIGNATURES_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define BOOTROW_START     (0x1100)
+#  define BOOTROW_SIZE      (64)
+#  define BOOTROW_PAGE_SIZE (64)
+#else
+#  define BOOTROW_START     (0x1100U)
+#  define BOOTROW_SIZE      (64U)
+#  define BOOTROW_PAGE_SIZE (64U)
+#endif
+#define BOOTROW_END       (BOOTROW_START + BOOTROW_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define USER_SIGNATURES_START     (0x1200)
+#  define USER_SIGNATURES_SIZE      (64)
+#  define USER_SIGNATURES_PAGE_SIZE (64)
+#else
+#  define USER_SIGNATURES_START     (0x1200U)
+#  define USER_SIGNATURES_SIZE      (64U)
+#  define USER_SIGNATURES_PAGE_SIZE (64U)
+#endif
+#define USER_SIGNATURES_END       (USER_SIGNATURES_START + USER_SIGNATURES_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define EEPROM_START     (0x1400)
+#  define EEPROM_SIZE      (512)
+#  define EEPROM_PAGE_SIZE (8)
+#else
+#  define EEPROM_START     (0x1400U)
+#  define EEPROM_SIZE      (512U)
+#  define EEPROM_PAGE_SIZE (8U)
+#endif
+#define EEPROM_END       (EEPROM_START + EEPROM_SIZE - 1)
+
+/* Added MAPPED_EEPROM segment names for avr-libc */
+#define MAPPED_EEPROM_START     (EEPROM_START)
+#define MAPPED_EEPROM_SIZE      (EEPROM_SIZE)
+#define MAPPED_EEPROM_PAGE_SIZE (EEPROM_PAGE_SIZE)
+#define MAPPED_EEPROM_END       (MAPPED_EEPROM_START + MAPPED_EEPROM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define INTERNAL_SRAM_START     (0x7800)
+#  define INTERNAL_SRAM_SIZE      (2048)
+#  define INTERNAL_SRAM_PAGE_SIZE (0)
+#else
+#  define INTERNAL_SRAM_START     (0x7800U)
+#  define INTERNAL_SRAM_SIZE      (2048U)
+#  define INTERNAL_SRAM_PAGE_SIZE (0U)
+#endif
+#define INTERNAL_SRAM_END       (INTERNAL_SRAM_START + INTERNAL_SRAM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define MAPPED_PROGMEM_START     (0x8000)
+#  define MAPPED_PROGMEM_SIZE      (16384)
+#  define MAPPED_PROGMEM_PAGE_SIZE (64)
+#else
+#  define MAPPED_PROGMEM_START     (0x8000U)
+#  define MAPPED_PROGMEM_SIZE      (16384U)
+#  define MAPPED_PROGMEM_PAGE_SIZE (64U)
+#endif
+#define MAPPED_PROGMEM_END       (MAPPED_PROGMEM_START + MAPPED_PROGMEM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define PROGMEM_START     (0x0000)
+#  define PROGMEM_SIZE      (16384)
+#  define PROGMEM_PAGE_SIZE (64)
+#else
+#  define PROGMEM_START     (0x0000U)
+#  define PROGMEM_SIZE      (16384U)
+#  define PROGMEM_PAGE_SIZE (64U)
+#endif
+#define PROGMEM_END       (PROGMEM_START + PROGMEM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define PROGMEM_NRWW_START     (0x0000)
+#  define PROGMEM_NRWW_SIZE      (4096)
+#  define PROGMEM_NRWW_PAGE_SIZE (64)
+#else
+#  define PROGMEM_NRWW_START     (0x0000U)
+#  define PROGMEM_NRWW_SIZE      (4096U)
+#  define PROGMEM_NRWW_PAGE_SIZE (64U)
+#endif
+#define PROGMEM_NRWW_END       (PROGMEM_NRWW_START + PROGMEM_NRWW_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define PROGMEM_RWW_START     (0x1000)
+#  define PROGMEM_RWW_SIZE      (12288)
+#  define PROGMEM_RWW_PAGE_SIZE (64)
+#else
+#  define PROGMEM_RWW_START     (0x1000U)
+#  define PROGMEM_RWW_SIZE      (12288U)
+#  define PROGMEM_RWW_PAGE_SIZE (64U)
+#endif
+#define PROGMEM_RWW_END       (PROGMEM_RWW_START + PROGMEM_RWW_SIZE - 1)
+
+#define FLASHSTART   PROGMEM_START
+#define FLASHEND     PROGMEM_END
+#define RAMSTART     INTERNAL_SRAM_START
+#define RAMSIZE      INTERNAL_SRAM_SIZE
+#define RAMEND       INTERNAL_SRAM_END
+#define E2END        EEPROM_END
+#define E2PAGESIZE   EEPROM_PAGE_SIZE
+
+/* ========== Fuses ========== */
+#define FUSE_MEMORY_SIZE 16
+
+/* Fuse Byte 0 (WDTCFG) */
+#define FUSE_PERIOD0  (unsigned char)_BV(0)  /* Watchdog Timeout Period Bit 0 */
+#define FUSE_PERIOD1  (unsigned char)_BV(1)  /* Watchdog Timeout Period Bit 1 */
+#define FUSE_PERIOD2  (unsigned char)_BV(2)  /* Watchdog Timeout Period Bit 2 */
+#define FUSE_PERIOD3  (unsigned char)_BV(3)  /* Watchdog Timeout Period Bit 3 */
+#define FUSE_WINDOW0  (unsigned char)_BV(4)  /* Watchdog Window Timeout Period Bit 0 */
+#define FUSE_WINDOW1  (unsigned char)_BV(5)  /* Watchdog Window Timeout Period Bit 1 */
+#define FUSE_WINDOW2  (unsigned char)_BV(6)  /* Watchdog Window Timeout Period Bit 2 */
+#define FUSE_WINDOW3  (unsigned char)_BV(7)  /* Watchdog Window Timeout Period Bit 3 */
+#define FUSE0_DEFAULT  (0x0)
+#define FUSE_WDTCFG_DEFAULT  (0x0)
+
+/* Fuse Byte 1 (BODCFG) */
+#define FUSE_SLEEP0  (unsigned char)_BV(0)  /* BOD Operation in Sleep Mode Bit 0 */
+#define FUSE_SLEEP1  (unsigned char)_BV(1)  /* BOD Operation in Sleep Mode Bit 1 */
+#define FUSE_ACTIVE0  (unsigned char)_BV(2)  /* BOD Operation in Active Mode Bit 0 */
+#define FUSE_ACTIVE1  (unsigned char)_BV(3)  /* BOD Operation in Active Mode Bit 1 */
+#define FUSE_SAMPFREQ  (unsigned char)_BV(4)  /* BOD Sample Frequency */
+#define FUSE_LVL0  (unsigned char)_BV(5)  /* BOD Level Bit 0 */
+#define FUSE_LVL1  (unsigned char)_BV(6)  /* BOD Level Bit 1 */
+#define FUSE_LVL2  (unsigned char)_BV(7)  /* BOD Level Bit 2 */
+#define FUSE1_DEFAULT  (0x0)
+#define FUSE_BODCFG_DEFAULT  (0x0)
+
+/* Fuse Byte 2 (OSCCFG) */
+#define FUSE_OSCHFFRQ  (unsigned char)_BV(3)  /* High-frequency Oscillator Frequency */
+#define FUSE2_DEFAULT  (0x0)
+#define FUSE_OSCCFG_DEFAULT  (0x0)
+
+/* Fuse Byte 3 Reserved */
+
+/* Fuse Byte 4 Reserved */
+
+/* Fuse Byte 5 (SYSCFG0) */
+#define FUSE_EESAVE  (unsigned char)_BV(0)  /* EEPROM Save */
+#define FUSE_RSTPINCFG  (unsigned char)_BV(3)  /* Reset Pin Configuration */
+#define FUSE_UPDIPINCFG  (unsigned char)_BV(4)  /* UPDI Pin Configuration */
+#define FUSE_CRCSEL  (unsigned char)_BV(5)  /* CRC Select */
+#define FUSE_CRCSRC0  (unsigned char)_BV(6)  /* CRC Source Bit 0 */
+#define FUSE_CRCSRC1  (unsigned char)_BV(7)  /* CRC Source Bit 1 */
+#define FUSE5_DEFAULT  (0xD0)
+#define FUSE_SYSCFG0_DEFAULT  (0xD0)
+
+/* Fuse Byte 6 (SYSCFG1) */
+#define FUSE_SUT0  (unsigned char)_BV(0)  /* Startup Time Bit 0 */
+#define FUSE_SUT1  (unsigned char)_BV(1)  /* Startup Time Bit 1 */
+#define FUSE_SUT2  (unsigned char)_BV(2)  /* Startup Time Bit 2 */
+#define FUSE6_DEFAULT  (0x7)
+#define FUSE_SYSCFG1_DEFAULT  (0x7)
+
+/* Fuse Byte 7 (CODESIZE) */
+#define FUSE7_DEFAULT  (0x0)
+#define FUSE_CODESIZE_DEFAULT  (0x0)
+
+/* Fuse Byte 8 (BOOTSIZE) */
+#define FUSE8_DEFAULT  (0x0)
+#define FUSE_BOOTSIZE_DEFAULT  (0x0)
+
+/* Fuse Byte 9 Reserved */
+
+/* Fuse Byte 10 (PDICFG) */
+#define FUSE_LEVEL0  (unsigned char)_BV(0)  /* Protection Level Bit 0 */
+#define FUSE_LEVEL1  (unsigned char)_BV(1)  /* Protection Level Bit 1 */
+#define FUSE_KEY0  (unsigned char)_BV(4)  /* NVM Protection Activation Key Bit 0 */
+#define FUSE_KEY1  (unsigned char)_BV(5)  /* NVM Protection Activation Key Bit 1 */
+#define FUSE_KEY2  (unsigned char)_BV(6)  /* NVM Protection Activation Key Bit 2 */
+#define FUSE_KEY3  (unsigned char)_BV(7)  /* NVM Protection Activation Key Bit 3 */
+#define FUSE_KEY4  (unsigned char)_BV(8)  /* NVM Protection Activation Key Bit 4 */
+#define FUSE_KEY5  (unsigned char)_BV(9)  /* NVM Protection Activation Key Bit 5 */
+#define FUSE_KEY6  (unsigned char)_BV(10)  /* NVM Protection Activation Key Bit 6 */
+#define FUSE_KEY7  (unsigned char)_BV(11)  /* NVM Protection Activation Key Bit 7 */
+#define FUSE_KEY8  (unsigned char)_BV(12)  /* NVM Protection Activation Key Bit 8 */
+#define FUSE_KEY9  (unsigned char)_BV(13)  /* NVM Protection Activation Key Bit 9 */
+#define FUSE_KEY10  (unsigned char)_BV(14)  /* NVM Protection Activation Key Bit 10 */
+#define FUSE_KEY11  (unsigned char)_BV(15)  /* NVM Protection Activation Key Bit 11 */
+#define FUSE10_DEFAULT  (0x3)
+#define FUSE_PDICFG_DEFAULT  (0x3)
+
+/* ========== Lock Bits ========== */
+#define __LOCK_KEY_EXIST
+#ifdef LOCKBITS_DEFAULT
+#undef LOCKBITS_DEFAULT
+#endif //LOCKBITS_DEFAULT
+#define LOCKBITS_DEFAULT  (0x5CC5C55C)
+
+/* ========== Signature ========== */
+#define SIGNATURE_0 0x1E
+#define SIGNATURE_1 0x94
+#define SIGNATURE_2 0x49
+
+#endif /* #ifdef _AVR_AVR16EB14_H_INCLUDED */
+

--- a/include/avr/ioavr16eb20.h
+++ b/include/avr/ioavr16eb20.h
@@ -1,0 +1,6460 @@
+/*
+ * Copyright (C) 2023, Microchip Technology Inc. and its subsidiaries ("Microchip")
+ * All rights reserved.
+ *
+ * This software is developed by Microchip Technology Inc. and its subsidiaries ("Microchip").
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other
+ *        materials provided with the distribution. Publication is not required when
+ *        this file is used in an embedded application.
+ *
+ *     3. Microchip's name may not be used to endorse or promote products derived from this
+ *        software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY MICROCHIP "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL MICROCHIP BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING BUT NOT LIMITED TO
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWSOEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _AVR_IO_H_
+#  error "Include <avr/io.h> instead of this file."
+#endif
+
+#ifndef _AVR_IOXXX_H_
+#  define _AVR_IOXXX_H_ "ioavr16eb20.h"
+#else
+#  error "Attempt to include more than one <avr/ioXXX.h> file."
+#endif
+
+#ifndef _AVR_AVR16EB20_H_INCLUDED
+#define _AVR_AVR16EB20_H_INCLUDED
+
+/* Ungrouped common registers */
+#define CCP  _SFR_MEM8(0x0034)  /* Configuration Change Protection */
+#define RAMPZ  _SFR_MEM8(0x003B)  /* Extended Z-pointer Register */
+#define SP  _SFR_MEM16(0x003D)  /* Stack Pointer */
+#define SPL  _SFR_MEM8(0x003D)  /* Stack Pointer Low */
+#define SPH  _SFR_MEM8(0x003E)  /* Stack Pointer High */
+#define SREG  _SFR_MEM8(0x003F)  /* Status Register */
+
+/* C Language Only */
+#if !defined (__ASSEMBLER__)
+
+#include <stdint.h>
+
+typedef volatile uint8_t register8_t;
+typedef volatile uint16_t register16_t;
+typedef volatile uint32_t register32_t;
+
+
+#ifdef _WORDREGISTER
+#undef _WORDREGISTER
+#endif
+#define _WORDREGISTER(regname)   \
+    __extension__ union \
+    { \
+        register16_t regname; \
+        struct \
+        { \
+            register8_t regname ## L; \
+            register8_t regname ## H; \
+        }; \
+    }
+
+#ifdef _DWORDREGISTER
+#undef _DWORDREGISTER
+#endif
+#define _DWORDREGISTER(regname)  \
+    __extension__ union \
+    { \
+        register32_t regname; \
+        struct \
+        { \
+            register8_t regname ## 0; \
+            register8_t regname ## 1; \
+            register8_t regname ## 2; \
+            register8_t regname ## 3; \
+        }; \
+    }
+
+
+/*
+==========================================================================
+IO Module Structures
+==========================================================================
+*/
+
+
+/*
+--------------------------------------------------------------------------
+AC - Analog Comparator
+--------------------------------------------------------------------------
+*/
+
+/* Analog Comparator */
+typedef struct AC_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t MUXCTRL;  /* Mux Control A */
+    register8_t reserved_1[2];
+    register8_t DACREF;  /* DAC Voltage Reference */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t STATUS;  /* Status */
+} AC_t;
+
+/* Hysteresis Mode select */
+typedef enum AC_HYSMODE_enum
+{
+    AC_HYSMODE_NONE_gc = (0x00<<1),  /* No hysteresis */
+    AC_HYSMODE_SMALL_gc = (0x01<<1),  /* Small hysteresis */
+    AC_HYSMODE_MEDIUM_gc = (0x02<<1),  /* Medium hysteresis */
+    AC_HYSMODE_LARGE_gc = (0x03<<1)  /* Large hysteresis */
+} AC_HYSMODE_t;
+
+/* AC Output Initial Value select */
+typedef enum AC_INITVAL_enum
+{
+    AC_INITVAL_LOW_gc = (0x00<<6),  /* Output initialized to 0 */
+    AC_INITVAL_HIGH_gc = (0x01<<6)  /* Output initialized to 1 */
+} AC_INITVAL_t;
+
+/* Interrupt Mode select */
+typedef enum AC_INTMODE_NORMAL_enum
+{
+    AC_INTMODE_NORMAL_BOTHEDGE_gc = (0x00<<4),  /* Positive and negative inputs crosses */
+    AC_INTMODE_NORMAL_NEGEDGE_gc = (0x02<<4),  /* Positive input goes below negative input */
+    AC_INTMODE_NORMAL_POSEDGE_gc = (0x03<<4)  /* Positive input goes above negative input */
+} AC_INTMODE_NORMAL_t;
+
+/* Interrupt Mode select */
+typedef enum AC_INTMODE_WINDOW_enum
+{
+    AC_INTMODE_WINDOW_ABOVE_gc = (0x00<<4),  /* Window interrupt when input above both references */
+    AC_INTMODE_WINDOW_INSIDE_gc = (0x01<<4),  /* Window interrupt when input betweeen references */
+    AC_INTMODE_WINDOW_BELOW_gc = (0x02<<4),  /* Window interrupt when input below both references */
+    AC_INTMODE_WINDOW_OUTSIDE_gc = (0x03<<4)  /* Window interrupt when input outside reference */
+} AC_INTMODE_WINDOW_t;
+
+/* Negative Input MUX Selection */
+typedef enum AC_MUXNEG_enum
+{
+    AC_MUXNEG_AINN0_gc = (0x00<<0),  /* Negative Pin 0 */
+    AC_MUXNEG_AINN1_gc = (0x01<<0),  /* Negative Pin 1 */
+    AC_MUXNEG_AINN2_gc = (0x02<<0),  /* Negative Pin 2 */
+    AC_MUXNEG_AINN3_gc = (0x03<<0),  /* Negative Pin 3 */
+    AC_MUXNEG_DACREF_gc = (0x04<<0)  /* DAC Reference */
+} AC_MUXNEG_t;
+
+/* Positive Input MUX Selection */
+typedef enum AC_MUXPOS_enum
+{
+    AC_MUXPOS_AINP0_gc = (0x00<<3),  /* Positive Pin 0 */
+    AC_MUXPOS_AINP1_gc = (0x01<<3),  /* Positive Pin 1 */
+    AC_MUXPOS_AINP2_gc = (0x02<<3),  /* Positive Pin 2 */
+    AC_MUXPOS_AINP3_gc = (0x03<<3),  /* Positive Pin 3 */
+    AC_MUXPOS_AINP4_gc = (0x04<<3),  /* Positive Pin 4 */
+    AC_MUXPOS_AINP5_gc = (0x05<<3),  /* Positive Pin 5 */
+    AC_MUXPOS_AINP6_gc = (0x06<<3)  /* Positive Pin 6 */
+} AC_MUXPOS_t;
+
+/* Power profile select */
+typedef enum AC_POWER_enum
+{
+    AC_POWER_PROFILE0_gc = (0x00<<3),  /* Power profile 0, Fastest response time, highest consumption */
+    AC_POWER_PROFILE1_gc = (0x01<<3)  /* Power profile 1 */
+} AC_POWER_t;
+
+/* Window selection mode */
+typedef enum AC_WINSEL_enum
+{
+    AC_WINSEL_DISABLED_gc = (0x00<<0),  /* Window function disabled */
+    AC_WINSEL_UPSEL1_gc = (0x01<<0)  /* Select ACn+1 as upper limit in window compare */
+} AC_WINSEL_t;
+
+/* Analog Comparator Window State select */
+typedef enum AC_WINSTATE_enum
+{
+    AC_WINSTATE_ABOVE_gc = (0x00<<6),  /* Above window */
+    AC_WINSTATE_INSIDE_gc = (0x01<<6),  /* Inside window */
+    AC_WINSTATE_BELOW_gc = (0x02<<6)  /* Below window */
+} AC_WINSTATE_t;
+
+/*
+--------------------------------------------------------------------------
+ADC - Analog to Digital Converter
+--------------------------------------------------------------------------
+*/
+
+/* Analog to Digital Converter */
+typedef struct ADC_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    register8_t CTRLD;  /* Control D */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t STATUS;  /* Status register */
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t CTRLE;  /* Control E */
+    register8_t CTRLF;  /* Control F */
+    register8_t COMMAND;  /* Command register */
+    register8_t PGACTRL;  /* PGA Control */
+    register8_t MUXPOS;  /* Positive Input Multiplexer */
+    register8_t MUXNEG;  /* Negative Input Multiplexer */
+    register8_t reserved_1[2];
+    _DWORDREGISTER(RESULT);  /* Result */
+    _WORDREGISTER(SAMPLE);  /* Sample */
+    register8_t reserved_2[2];
+    register8_t TEMP0;  /* Temporary Data 0 */
+    register8_t TEMP1;  /* Temporary Data 1 */
+    register8_t TEMP2;  /* Temporary Data 2 */
+    register8_t reserved_3[1];
+    _WORDREGISTER(WINLT);  /* Window Low Threshold */
+    _WORDREGISTER(WINHT);  /* Window High Threshold */
+    register8_t reserved_4[32];
+} ADC_t;
+
+/* Sign Chopping select */
+typedef enum ADC_CHOPPING_enum
+{
+    ADC_CHOPPING_DISABLE_gc = (0x00<<6),  /* Sign Chopping Disabled */
+    ADC_CHOPPING_ENABLE_gc = (0x01<<6)  /* Sign Chopping Enabled */
+} ADC_CHOPPING_t;
+
+/* Gain select */
+typedef enum ADC_GAIN_enum
+{
+    ADC_GAIN_1X_gc = (0x00<<5),  /* 1x gain */
+    ADC_GAIN_2X_gc = (0x01<<5),  /* 2x gain */
+    ADC_GAIN_4X_gc = (0x02<<5),  /* 4x gain */
+    ADC_GAIN_8X_gc = (0x03<<5),  /* 8x gain */
+    ADC_GAIN_16X_gc = (0x04<<5)  /* 16x gain */
+} ADC_GAIN_t;
+
+/* Mode select */
+typedef enum ADC_MODE_enum
+{
+    ADC_MODE_SINGLE_8BIT_gc = (0x00<<4),  /* Single Conversion with 8-bit resolution */
+    ADC_MODE_SINGLE_12BIT_gc = (0x01<<4),  /* Single Conversion with 12-bit resolution */
+    ADC_MODE_SERIES_gc = (0x02<<4),  /* Series with accumulation, separate trigger for every 12-bit conversion */
+    ADC_MODE_SERIES_SCALING_gc = (0x03<<4),  /* Series with accumulation and scaling, separate trigger for every 12-bit conversion */
+    ADC_MODE_BURST_gc = (0x04<<4),  /* Burst with accumulation, one trigger will run SAMPNUM 12-bit conversions */
+    ADC_MODE_BURST_SCALING_gc = (0x05<<4)  /* Burst with accumulation and scaling, one trigger will run SAMPNUM 12-bit conversions */
+} ADC_MODE_t;
+
+/* Analog Channel Selection Bits */
+typedef enum ADC_MUXNEG_enum
+{
+    ADC_MUXNEG_AIN4_gc = (0x04<<0),  /* ADC input pin 4 */
+    ADC_MUXNEG_AIN5_gc = (0x05<<0),  /* ADC input pin 5 */
+    ADC_MUXNEG_AIN6_gc = (0x06<<0),  /* ADC input pin 6 */
+    ADC_MUXNEG_AIN7_gc = (0x07<<0),  /* ADC input pin 7 */
+    ADC_MUXNEG_AIN22_gc = (0x16<<0),  /* ADC input pin 22 */
+    ADC_MUXNEG_AIN23_gc = (0x17<<0),  /* ADC input pin 23 */
+    ADC_MUXNEG_AIN24_gc = (0x18<<0),  /* ADC input pin 24 */
+    ADC_MUXNEG_AIN25_gc = (0x19<<0),  /* ADC input pin 25 */
+    ADC_MUXNEG_AIN26_gc = (0x1A<<0),  /* ADC input pin 26 */
+    ADC_MUXNEG_AIN27_gc = (0x1B<<0),  /* ADC input pin 27 */
+    ADC_MUXNEG_AIN28_gc = (0x1C<<0),  /* ADC input pin 28 */
+    ADC_MUXNEG_AIN29_gc = (0x1D<<0),  /* ADC input pin 29 */
+    ADC_MUXNEG_AIN30_gc = (0x1E<<0),  /* ADC input pin 30 */
+    ADC_MUXNEG_AIN31_gc = (0x1F<<0),  /* ADC input pin 31 */
+    ADC_MUXNEG_GND_gc = (0x30<<0),  /* Ground */
+    ADC_MUXNEG_DAC0_gc = (0x38<<0),  /* Digital to Analog Converter 0 */
+    ADC_MUXNEG_DACREF0_gc = (0x39<<0),  /* AC0 DAC reference */
+    ADC_MUXNEG_DACREF1_gc = (0x3A<<0)  /* AC1 DAC reference */
+} ADC_MUXNEG_t;
+
+/* Analog Channel Selection Bits */
+typedef enum ADC_MUXPOS_enum
+{
+    ADC_MUXPOS_AIN4_gc = (0x04<<0),  /* ADC input pin 4 */
+    ADC_MUXPOS_AIN5_gc = (0x05<<0),  /* ADC input pin 5 */
+    ADC_MUXPOS_AIN6_gc = (0x06<<0),  /* ADC input pin 6 */
+    ADC_MUXPOS_AIN7_gc = (0x07<<0),  /* ADC input pin 7 */
+    ADC_MUXPOS_AIN22_gc = (0x16<<0),  /* ADC input pin 22 */
+    ADC_MUXPOS_AIN23_gc = (0x17<<0),  /* ADC input pin 23 */
+    ADC_MUXPOS_AIN24_gc = (0x18<<0),  /* ADC input pin 24 */
+    ADC_MUXPOS_AIN25_gc = (0x19<<0),  /* ADC input pin 25 */
+    ADC_MUXPOS_AIN26_gc = (0x1A<<0),  /* ADC input pin 26 */
+    ADC_MUXPOS_AIN27_gc = (0x1B<<0),  /* ADC input pin 27 */
+    ADC_MUXPOS_AIN28_gc = (0x1C<<0),  /* ADC input pin 28 */
+    ADC_MUXPOS_AIN29_gc = (0x1D<<0),  /* ADC input pin 29 */
+    ADC_MUXPOS_AIN30_gc = (0x1E<<0),  /* ADC input pin 30 */
+    ADC_MUXPOS_AIN31_gc = (0x1F<<0),  /* ADC input pin 31 */
+    ADC_MUXPOS_GND_gc = (0x30<<0),  /* Ground */
+    ADC_MUXPOS_VDD10_gc = (0x31<<0),  /* VDD Divided by 10 */
+    ADC_MUXPOS_TEMPSENSE_gc = (0x32<<0)  /* Temperature Sensor */
+} ADC_MUXPOS_t;
+
+/* PGA BIAS Select */
+typedef enum ADC_PGABIASSEL_enum
+{
+    ADC_PGABIASSEL_100PCT_gc = (0x00<<3),  /* 100% BIAS current. */
+    ADC_PGABIASSEL_75PCT_gc = (0x01<<3),  /* 75% BIAS current. Usable for CLK_ADC<4.5MHz */
+    ADC_PGABIASSEL_50PCT_gc = (0x02<<3),  /* 50% BIAS current. Usable for CLK_ADC<3MHz */
+    ADC_PGABIASSEL_25PCT_gc = (0x03<<3)  /* 25% BIAS current. Usable for CLK_ADC<1.5MHz */
+} ADC_PGABIASSEL_t;
+
+/* Prescaler Value select */
+typedef enum ADC_PRESC_enum
+{
+    ADC_PRESC_DIV2_gc = (0x00<<0),  /* System clock divided by 2 */
+    ADC_PRESC_DIV4_gc = (0x01<<0),  /* System clock divided by 4 */
+    ADC_PRESC_DIV6_gc = (0x02<<0),  /* System clock divided by 6 */
+    ADC_PRESC_DIV8_gc = (0x03<<0),  /* System clock divided by 8 */
+    ADC_PRESC_DIV10_gc = (0x04<<0),  /* System clock divided by 10 */
+    ADC_PRESC_DIV12_gc = (0x05<<0),  /* System clock divided by 12 */
+    ADC_PRESC_DIV14_gc = (0x06<<0),  /* System clock divided by 14 */
+    ADC_PRESC_DIV16_gc = (0x07<<0),  /* System clock divided by 16 */
+    ADC_PRESC_DIV20_gc = (0x08<<0),  /* System clock divided by 20 */
+    ADC_PRESC_DIV24_gc = (0x09<<0),  /* System clock divided by 24 */
+    ADC_PRESC_DIV28_gc = (0x0A<<0),  /* System clock divided by 28 */
+    ADC_PRESC_DIV32_gc = (0x0B<<0),  /* System clock divided by 32 */
+    ADC_PRESC_DIV40_gc = (0x0C<<0),  /* System clock divided by 40 */
+    ADC_PRESC_DIV48_gc = (0x0D<<0),  /* System clock divided by 48 */
+    ADC_PRESC_DIV56_gc = (0x0E<<0),  /* System clock divided by 56 */
+    ADC_PRESC_DIV64_gc = (0x0F<<0)  /* System clock divided by 64 */
+} ADC_PRESC_t;
+
+/* Reference select */
+typedef enum ADC_REFSEL_enum
+{
+    ADC_REFSEL_VDD_gc = (0x00<<0),  /* VDD */
+    ADC_REFSEL_VREFA_gc = (0x02<<0),  /* External Reference */
+    ADC_REFSEL_1V024_gc = (0x04<<0),  /* Internal 1.024V Reference */
+    ADC_REFSEL_2V048_gc = (0x05<<0),  /* Internal 2.048V Reference */
+    ADC_REFSEL_4V096_gc = (0x06<<0),  /* Internal 4.096V Reference */
+    ADC_REFSEL_2V500_gc = (0x07<<0)  /* Internal 2.500V Reference */
+} ADC_REFSEL_t;
+
+/* Sample numbers select */
+typedef enum ADC_SAMPNUM_enum
+{
+    ADC_SAMPNUM_NONE_gc = (0x00<<0),  /* No accumulation */
+    ADC_SAMPNUM_ACC2_gc = (0x01<<0),  /* 2 samples accumulated */
+    ADC_SAMPNUM_ACC4_gc = (0x02<<0),  /* 4 samples accumulated */
+    ADC_SAMPNUM_ACC8_gc = (0x03<<0),  /* 8 samples accumulated */
+    ADC_SAMPNUM_ACC16_gc = (0x04<<0),  /* 16 samples accumulated */
+    ADC_SAMPNUM_ACC32_gc = (0x05<<0),  /* 32 samples accumulated */
+    ADC_SAMPNUM_ACC64_gc = (0x06<<0),  /* 64 samples accumulated */
+    ADC_SAMPNUM_ACC128_gc = (0x07<<0),  /* 128 samples accumulated */
+    ADC_SAMPNUM_ACC256_gc = (0x08<<0),  /* 256 samples accumulated */
+    ADC_SAMPNUM_ACC512_gc = (0x09<<0),  /* 512 samples accumulated */
+    ADC_SAMPNUM_ACC1024_gc = (0x0A<<0)  /* 1024 samples accumulated */
+} ADC_SAMPNUM_t;
+
+/* Start command select */
+typedef enum ADC_START_enum
+{
+    ADC_START_STOP_gc = (0x00<<0),  /* Stop an ongoing conversion */
+    ADC_START_IMMEDIATE_gc = (0x01<<0),  /* Start a conversion immediately. This will be set back to STOP when the first conversion is done, unless Free-Running mode is enabled */
+    ADC_START_MUXPOS_WRITE_gc = (0x02<<0),  /* Start when MUXPOS register is written */
+    ADC_START_MUXNEG_WRITE_gc = (0x03<<0),  /* Start when MUXNEG register is written */
+    ADC_START_EVENT_TRIGGER_gc = (0x04<<0)  /* Start when an event is received */
+} ADC_START_t;
+
+/* VIA select */
+typedef enum ADC_VIA_enum
+{
+    ADC_VIA_DIRECT_gc = (0x00<<6),  /* Inputs connected directly to ADC */
+    ADC_VIA_PGA_gc = (0x01<<6)  /* Inputs connected via PGA */
+} ADC_VIA_t;
+
+/* Window Comparator Mode select */
+typedef enum ADC_WINCM_enum
+{
+    ADC_WINCM_NONE_gc = (0x00<<0),  /* No Window Comparison */
+    ADC_WINCM_BELOW_gc = (0x01<<0),  /* Below Window */
+    ADC_WINCM_ABOVE_gc = (0x02<<0),  /* Above Window */
+    ADC_WINCM_INSIDE_gc = (0x03<<0),  /* Inside Window */
+    ADC_WINCM_OUTSIDE_gc = (0x04<<0)  /* Outside Window */
+} ADC_WINCM_t;
+
+/* Window Mode Source select */
+typedef enum ADC_WINSRC_enum
+{
+    ADC_WINSRC_RESULT_gc = (0x00<<3),  /* Result register used as Window Comparator Source */
+    ADC_WINSRC_SAMPLE_gc = (0x01<<3)  /* Sample register used as Window Comparator Source */
+} ADC_WINSRC_t;
+
+/*
+--------------------------------------------------------------------------
+BOD - Bod interface
+--------------------------------------------------------------------------
+*/
+
+/* Bod interface */
+typedef struct BOD_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t reserved_1[6];
+    register8_t VLMCTRLA;  /* Voltage level monitor Control */
+    register8_t INTCTRL;  /* Voltage level monitor interrupt Control */
+    register8_t INTFLAGS;  /* Voltage level monitor interrupt Flags */
+    register8_t STATUS;  /* Voltage level monitor status */
+    register8_t reserved_2[4];
+} BOD_t;
+
+/* Operation in active mode select */
+typedef enum BOD_ACTIVE_enum
+{
+    BOD_ACTIVE_DISABLE_gc = (0x00<<2),  /* Disabled */
+    BOD_ACTIVE_ENABLED_gc = (0x01<<2),  /* Enabled in continuous mode */
+    BOD_ACTIVE_SAMPLED_gc = (0x02<<2),  /* Enabled in sampled mode */
+    BOD_ACTIVE_ENABLEWAIT_gc = (0x03<<2)  /* Enabled in continuous mode. Execution halted at wake-up until BOD is running */
+} BOD_ACTIVE_t;
+
+/* Bod level select */
+typedef enum BOD_LVL_enum
+{
+    BOD_LVL_BODLEVEL0_gc = (0x00<<0),  /* BOD Disabled during normal operation */
+    BOD_LVL_BODLEVEL1_gc = (0x01<<0),  /* 1.9 V */
+    BOD_LVL_BODLEVEL2_gc = (0x02<<0),  /* 2.7 V */
+    BOD_LVL_BODLEVEL3_gc = (0x03<<0)  /* 4.5 V */
+} BOD_LVL_t;
+
+/* Sample frequency select */
+typedef enum BOD_SAMPFREQ_enum
+{
+    BOD_SAMPFREQ_128HZ_gc = (0x00<<4),  /* Sampling frequency is 128 Hz */
+    BOD_SAMPFREQ_32HZ_gc = (0x01<<4)  /* Sample frequency is 32 Hz */
+} BOD_SAMPFREQ_t;
+
+/* Operation in sleep mode select */
+typedef enum BOD_SLEEP_enum
+{
+    BOD_SLEEP_DISABLE_gc = (0x00<<0),  /* Disabled */
+    BOD_SLEEP_ENABLE_gc = (0x01<<0),  /* Enabled in continuous mode */
+    BOD_SLEEP_SAMPLE_gc = (0x02<<0)  /* Enabled in sampled mode */
+} BOD_SLEEP_t;
+
+/* Configuration select */
+typedef enum BOD_VLMCFG_enum
+{
+    BOD_VLMCFG_FALLING_gc = (0x00<<1),  /* VDD falls below VLM threshold */
+    BOD_VLMCFG_RISING_gc = (0x01<<1),  /* VDD rises above VLM threshold */
+    BOD_VLMCFG_BOTH_gc = (0x02<<1)  /* VDD crosses VLM threshold */
+} BOD_VLMCFG_t;
+
+/* voltage level monitor level select */
+typedef enum BOD_VLMLVL_enum
+{
+    BOD_VLMLVL_OFF_gc = (0x00<<0),  /* VLM Disabled */
+    BOD_VLMLVL_5ABOVE_gc = (0x01<<0),  /* VLM threshold 5% above BOD level */
+    BOD_VLMLVL_15ABOVE_gc = (0x02<<0),  /* VLM threshold 15% above BOD level */
+    BOD_VLMLVL_25ABOVE_gc = (0x03<<0)  /* VLM threshold 25% above BOD level */
+} BOD_VLMLVL_t;
+
+/* Voltage level monitor status select */
+typedef enum BOD_VLMS_enum
+{
+    BOD_VLMS_ABOVE_gc = (0x00<<0),  /* The voltage is above the VLM threshold level */
+    BOD_VLMS_BELOW_gc = (0x01<<0)  /* The voltage is below the VLM threshold level */
+} BOD_VLMS_t;
+
+/*
+--------------------------------------------------------------------------
+BOOTROW - Boot Row
+--------------------------------------------------------------------------
+*/
+
+/* Boot Row */
+typedef struct BOOTROW_struct
+{
+    register8_t BOOTROW[64];  /* Boot Row */
+} BOOTROW_t;
+
+
+/*
+--------------------------------------------------------------------------
+CCL - Configurable Custom Logic
+--------------------------------------------------------------------------
+*/
+
+/* Configurable Custom Logic */
+typedef struct CCL_struct
+{
+    register8_t CTRLA;  /* Control Register A */
+    register8_t SEQCTRL0;  /* Sequential Control 0 */
+    register8_t SEQCTRL1;  /* Sequential Control 1 */
+    register8_t reserved_1[2];
+    register8_t INTCTRL0;  /* Interrupt Control 0 */
+    register8_t reserved_2[1];
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t LUT0CTRLA;  /* LUT 0 Control A */
+    register8_t LUT0CTRLB;  /* LUT 0 Control B */
+    register8_t LUT0CTRLC;  /* LUT 0 Control C */
+    register8_t TRUTH0;  /* Truth 0 */
+    register8_t LUT1CTRLA;  /* LUT 1 Control A */
+    register8_t LUT1CTRLB;  /* LUT 1 Control B */
+    register8_t LUT1CTRLC;  /* LUT 1 Control C */
+    register8_t TRUTH1;  /* Truth 1 */
+    register8_t LUT2CTRLA;  /* LUT 2 Control A */
+    register8_t LUT2CTRLB;  /* LUT 2 Control B */
+    register8_t LUT2CTRLC;  /* LUT 2 Control C */
+    register8_t TRUTH2;  /* Truth 2 */
+    register8_t LUT3CTRLA;  /* LUT 3 Control A */
+    register8_t LUT3CTRLB;  /* LUT 3 Control B */
+    register8_t LUT3CTRLC;  /* LUT 3 Control C */
+    register8_t TRUTH3;  /* Truth 3 */
+    register8_t reserved_3[40];
+} CCL_t;
+
+/* Clock Source Selection */
+typedef enum CCL_CLKSRC_enum
+{
+    CCL_CLKSRC_CLKPER_gc = (0x00<<1),  /* Peripheral Clock */
+    CCL_CLKSRC_IN2_gc = (0x01<<1),  /* INSEL2 selection */
+    CCL_CLKSRC_OSCHF_gc = (0x04<<1),  /* Internal High Frequency oscillator */
+    CCL_CLKSRC_OSC32K_gc = (0x05<<1),  /* Internal 32.768 kHz oscillator */
+    CCL_CLKSRC_OSC1K_gc = (0x06<<1),  /* Internal 32.768 kHz oscillator divided by 32 */
+    CCL_CLKSRC_PLL_gc = (0x07<<1)  /* PLL */
+} CCL_CLKSRC_t;
+
+/* Edge Detection Enable select */
+typedef enum CCL_EDGEDET_enum
+{
+    CCL_EDGEDET_DIS_gc = (0x00<<7),  /* Edge detector is disabled */
+    CCL_EDGEDET_EN_gc = (0x01<<7)  /* Edge detector is enabled */
+} CCL_EDGEDET_t;
+
+/* Filter Selection */
+typedef enum CCL_FILTSEL_enum
+{
+    CCL_FILTSEL_DISABLE_gc = (0x00<<4),  /* Filter disabled */
+    CCL_FILTSEL_SYNCH_gc = (0x01<<4),  /* Synchronizer enabled */
+    CCL_FILTSEL_FILTER_gc = (0x02<<4)  /* Filter enabled */
+} CCL_FILTSEL_t;
+
+/* LUT Input 0 Source Selection */
+typedef enum CCL_INSEL0_enum
+{
+    CCL_INSEL0_MASK_gc = (0x00<<0),  /* Masked input */
+    CCL_INSEL0_FEEDBACK_gc = (0x01<<0),  /* Feedback input */
+    CCL_INSEL0_LINK_gc = (0x02<<0),  /* Output from LUT[n+1] as input source */
+    CCL_INSEL0_EVENTA_gc = (0x03<<0),  /* Event A as input source */
+    CCL_INSEL0_EVENTB_gc = (0x04<<0),  /* Event B as input source */
+    CCL_INSEL0_IN0_gc = (0x05<<0),  /* IN0 input source */
+    CCL_INSEL0_AC0_gc = (0x06<<0),  /* AC0 output input source */
+    CCL_INSEL0_USART0_gc = (0x07<<0),  /* USART0 TxD input source */
+    CCL_INSEL0_SPI0_gc = (0x08<<0),  /* SPI0 MOSI input source */
+    CCL_INSEL0_TCE0_gc = (0x09<<0),  /* TCE0 WO0 input source */
+    CCL_INSEL0_TCB0_gc = (0x0A<<0),  /* TCB0 WO input source */
+    CCL_INSEL0_TCF0_gc = (0x0B<<0),  /* TCF0 WO0 input source */
+    CCL_INSEL0_WEX0_gc = (0x0C<<0)  /* Blanking input source */
+} CCL_INSEL0_t;
+
+/* LUT Input 1 Source Selection */
+typedef enum CCL_INSEL1_enum
+{
+    CCL_INSEL1_MASK_gc = (0x00<<4),  /* Masked input */
+    CCL_INSEL1_FEEDBACK_gc = (0x01<<4),  /* Feedback input */
+    CCL_INSEL1_LINK_gc = (0x02<<4),  /* Output from LUT[n+1] as input source */
+    CCL_INSEL1_EVENTA_gc = (0x03<<4),  /* Event A as input source */
+    CCL_INSEL1_EVENTB_gc = (0x04<<4),  /* Event B as input source */
+    CCL_INSEL1_IN1_gc = (0x05<<4),  /* IN1 input source */
+    CCL_INSEL1_AC1_gc = (0x06<<4),  /* AC1 output input source */
+    CCL_INSEL1_USART0_gc = (0x07<<4),  /* USART0 TxD input source */
+    CCL_INSEL1_SPI0_gc = (0x08<<4),  /* SPI0 MOSI input source */
+    CCL_INSEL1_TCE0_gc = (0x09<<4),  /* TCE0 WO1 input source */
+    CCL_INSEL1_TCB1_gc = (0x0A<<4),  /* TCB1 WO input source */
+    CCL_INSEL1_TCF0_gc = (0x0B<<4),  /* TCF0 WO1 input source */
+    CCL_INSEL1_WEX0_gc = (0x0C<<4)  /* Blanking input source */
+} CCL_INSEL1_t;
+
+/* LUT Input 2 Source Selection */
+typedef enum CCL_INSEL2_enum
+{
+    CCL_INSEL2_MASK_gc = (0x00<<0),  /* Masked input */
+    CCL_INSEL2_FEEDBACK_gc = (0x01<<0),  /* Feedback input */
+    CCL_INSEL2_LINK_gc = (0x02<<0),  /* Output from LUT[n+1] as input source */
+    CCL_INSEL2_EVENTA_gc = (0x03<<0),  /* Event A as input source */
+    CCL_INSEL2_EVENTB_gc = (0x04<<0),  /* Event B as input source */
+    CCL_INSEL2_IN2_gc = (0x05<<0),  /* IN2 input source */
+    CCL_INSEL2_AC1_gc = (0x06<<0),  /* AC1 output input source */
+    CCL_INSEL2_USART0_gc = (0x07<<0),  /* USART0 TxD input source */
+    CCL_INSEL2_SPI0_gc = (0x08<<0),  /* SPI0 SCK input source */
+    CCL_INSEL2_TCE0_gc = (0x09<<0),  /* TCE0 WO2 input source */
+    CCL_INSEL2_TCB1_gc = (0x0A<<0),  /* TCB1 WO input source */
+    CCL_INSEL2_TCF0_gc = (0x0B<<0),  /* TCF0 WO0 input source */
+    CCL_INSEL2_WEX0_gc = (0x0C<<0)  /* Blanking input source */
+} CCL_INSEL2_t;
+
+/* Interrupt Mode for LUT0 select */
+typedef enum CCL_INTMODE0_enum
+{
+    CCL_INTMODE0_INTDISABLE_gc = (0x00<<0),  /* Interrupt disabled */
+    CCL_INTMODE0_RISING_gc = (0x01<<0),  /* Sense rising edge */
+    CCL_INTMODE0_FALLING_gc = (0x02<<0),  /* Sense falling edge */
+    CCL_INTMODE0_BOTH_gc = (0x03<<0)  /* Sense both edges */
+} CCL_INTMODE0_t;
+
+/* Interrupt Mode for LUT1 select */
+typedef enum CCL_INTMODE1_enum
+{
+    CCL_INTMODE1_INTDISABLE_gc = (0x00<<2),  /* Interrupt disabled */
+    CCL_INTMODE1_RISING_gc = (0x01<<2),  /* Sense rising edge */
+    CCL_INTMODE1_FALLING_gc = (0x02<<2),  /* Sense falling edge */
+    CCL_INTMODE1_BOTH_gc = (0x03<<2)  /* Sense both edges */
+} CCL_INTMODE1_t;
+
+/* Interrupt Mode for LUT2 select */
+typedef enum CCL_INTMODE2_enum
+{
+    CCL_INTMODE2_INTDISABLE_gc = (0x00<<4),  /* Interrupt disabled */
+    CCL_INTMODE2_RISING_gc = (0x01<<4),  /* Sense rising edge */
+    CCL_INTMODE2_FALLING_gc = (0x02<<4),  /* Sense falling edge */
+    CCL_INTMODE2_BOTH_gc = (0x03<<4)  /* Sense both edges */
+} CCL_INTMODE2_t;
+
+/* Interrupt Mode for LUT3 select */
+typedef enum CCL_INTMODE3_enum
+{
+    CCL_INTMODE3_INTDISABLE_gc = (0x00<<6),  /* Interrupt disabled */
+    CCL_INTMODE3_RISING_gc = (0x01<<6),  /* Sense rising edge */
+    CCL_INTMODE3_FALLING_gc = (0x02<<6),  /* Sense falling edge */
+    CCL_INTMODE3_BOTH_gc = (0x03<<6)  /* Sense both edges */
+} CCL_INTMODE3_t;
+
+/* Sequential Selection */
+typedef enum CCL_SEQSEL_enum
+{
+    CCL_SEQSEL_DISABLE_gc = (0x00<<0),  /* Sequential logic disabled */
+    CCL_SEQSEL_DFF_gc = (0x01<<0),  /* D FlipFlop */
+    CCL_SEQSEL_JK_gc = (0x02<<0),  /* JK FlipFlop */
+    CCL_SEQSEL_LATCH_gc = (0x03<<0),  /* D Latch */
+    CCL_SEQSEL_RS_gc = (0x04<<0)  /* RS Latch */
+} CCL_SEQSEL_t;
+
+/*
+--------------------------------------------------------------------------
+CLKCTRL - Clock controller
+--------------------------------------------------------------------------
+*/
+
+/* Clock controller */
+typedef struct CLKCTRL_struct
+{
+    register8_t MCLKCTRLA;  /* MCLK Control A */
+    register8_t MCLKCTRLB;  /* MCLK Control B */
+    register8_t reserved_1[3];
+    register8_t MCLKSTATUS;  /* MCLK Status */
+    register8_t MCLKTIMEBASE;  /* MCLK Timebase */
+    register8_t reserved_2[1];
+    register8_t OSCHFCTRLA;  /* OSCHF Control A */
+    register8_t OSCHFTUNE;  /* OSCHF Tune */
+    register8_t reserved_3[6];
+    register8_t PLLCTRLA;  /* PLL Control A */
+    register8_t PLLCTRLB;  /* PLL Control B */
+    register8_t reserved_4[6];
+    register8_t OSC32KCTRLA;  /* OSC32K Control A */
+    register8_t reserved_5[3];
+    register8_t XOSC32KCTRLA;  /* XOSC32K Control A */
+    register8_t reserved_6[35];
+} CLKCTRL_t;
+
+/* Automatic Oscillator Tune select */
+typedef enum CLKCTRL_AUTOTUNE_enum
+{
+    CLKCTRL_AUTOTUNE_OFF_gc = (0x00<<0),  /* Disabled */
+    CLKCTRL_AUTOTUNE_XOSC32K_gc = (0x01<<0)  /* Tune against 32.768 kHz Crystal Oscillator */
+} CLKCTRL_AUTOTUNE_t;
+
+/* PLL Output Clock Division select */
+typedef enum CLKCTRL_CLKDIV_enum
+{
+    CLKCTRL_CLKDIV_NONE_gc = (0x00<<0),  /* PLL output clock undivided */
+    CLKCTRL_CLKDIV_DIV2_gc = (0x01<<0)  /* PLL output clock divided by 2 */
+} CLKCTRL_CLKDIV_t;
+
+/* Clock select */
+typedef enum CLKCTRL_CLKSEL_enum
+{
+    CLKCTRL_CLKSEL_OSCHF_gc = (0x00<<0),  /* Internal high-frequency oscillator */
+    CLKCTRL_CLKSEL_OSC32K_gc = (0x01<<0),  /* Internal 32.768 kHz oscillator */
+    CLKCTRL_CLKSEL_XOSC32K_gc = (0x02<<0),  /* 32.768 kHz crystal oscillator */
+    CLKCTRL_CLKSEL_EXTCLK_gc = (0x03<<0),  /* External clock */
+    CLKCTRL_CLKSEL_PLL_gc = (0x04<<0)  /* PLL Oscillator */
+} CLKCTRL_CLKSEL_t;
+
+/* Crystal startup time select */
+typedef enum CLKCTRL_CSUT_enum
+{
+    CLKCTRL_CSUT_1K_gc = (0x00<<4),  /* 1k cycles */
+    CLKCTRL_CSUT_16K_gc = (0x01<<4),  /* 16k cycles */
+    CLKCTRL_CSUT_32K_gc = (0x02<<4),  /* 32k cycles */
+    CLKCTRL_CSUT_64K_gc = (0x03<<4)  /* 64k cycles */
+} CLKCTRL_CSUT_t;
+
+/* PLL Multiplication Factor select */
+typedef enum CLKCTRL_MULFAC_enum
+{
+    CLKCTRL_MULFAC_OFF_gc = (0x00<<0),  /* PLL Disabled */
+    CLKCTRL_MULFAC_8X_gc = (0x02<<0),  /* Multiply by 8 */
+    CLKCTRL_MULFAC_16X_gc = (0x03<<0)  /* Multiply by 16 */
+} CLKCTRL_MULFAC_t;
+
+/* Prescaler B division select */
+typedef enum CLKCTRL_PBDIV_enum
+{
+    CLKCTRL_PBDIV_NONE_gc = (0x00<<5),  /* No division */
+    CLKCTRL_PBDIV_DIV4_gc = (0x01<<5)  /* Divide by 4 */
+} CLKCTRL_PBDIV_t;
+
+/* Prescaler division select */
+typedef enum CLKCTRL_PDIV_enum
+{
+    CLKCTRL_PDIV_DIV2_gc = (0x00<<1),  /* Divide by 2 */
+    CLKCTRL_PDIV_DIV4_gc = (0x01<<1),  /* Divide by 4 */
+    CLKCTRL_PDIV_DIV8_gc = (0x02<<1),  /* Divide by 8 */
+    CLKCTRL_PDIV_DIV16_gc = (0x03<<1),  /* Divide by 16 */
+    CLKCTRL_PDIV_DIV32_gc = (0x04<<1),  /* Divide by 32 */
+    CLKCTRL_PDIV_DIV64_gc = (0x05<<1),  /* Divide by 64 */
+    CLKCTRL_PDIV_DIV6_gc = (0x08<<1),  /* Divide by 6 */
+    CLKCTRL_PDIV_DIV10_gc = (0x09<<1),  /* Divide by 10 */
+    CLKCTRL_PDIV_DIV12_gc = (0x0A<<1),  /* Divide by 12 */
+    CLKCTRL_PDIV_DIV24_gc = (0x0B<<1),  /* Divide by 24 */
+    CLKCTRL_PDIV_DIV48_gc = (0x0C<<1)  /* Divide by 48 */
+} CLKCTRL_PDIV_t;
+
+/* PLL Source select */
+typedef enum CLKCTRL_SOURCE_enum
+{
+    CLKCTRL_SOURCE_OSCHF_gc = (0x00<<5),  /* Internal High Frequency Oscillator */
+    CLKCTRL_SOURCE_EXTCLK_gc = (0x01<<5)  /* External Clock */
+} CLKCTRL_SOURCE_t;
+
+/* PLL Source Division select */
+typedef enum CLKCTRL_SOURCEDIV_enum
+{
+    CLKCTRL_SOURCEDIV_DIV1_gc = (0x00<<3),  /* Source undivided */
+    CLKCTRL_SOURCEDIV_DIV2_gc = (0x01<<3),  /* Divide source by 2 */
+    CLKCTRL_SOURCEDIV_DIV4_gc = (0x02<<3),  /* Divide source by 4 */
+    CLKCTRL_SOURCEDIV_DIV6_gc = (0x03<<3)  /* Divide source by 6 */
+} CLKCTRL_SOURCEDIV_t;
+
+/*
+--------------------------------------------------------------------------
+CPU - CPU
+--------------------------------------------------------------------------
+*/
+
+#define CORE_VERSION  V4S
+
+/* CCP signature select */
+typedef enum CCP_enum
+{
+    CCP_SPM_gc = (0x9D<<0),  /* SPM Instruction Protection */
+    CCP_IOREG_gc = (0xD8<<0)  /* IO Register Protection */
+} CCP_t;
+
+/*
+--------------------------------------------------------------------------
+CPUINT - Interrupt Controller
+--------------------------------------------------------------------------
+*/
+
+/* Interrupt Controller */
+typedef struct CPUINT_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t STATUS;  /* Status */
+    register8_t LVL0PRI;  /* Interrupt Level 0 Priority */
+    register8_t LVL1VEC;  /* Interrupt Level 1 Priority Vector */
+} CPUINT_t;
+
+
+/*
+--------------------------------------------------------------------------
+CRCSCAN - CRCSCAN
+--------------------------------------------------------------------------
+*/
+
+/* CRCSCAN */
+typedef struct CRCSCAN_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t STATUS;  /* Status */
+    register8_t reserved_1[13];
+} CRCSCAN_t;
+
+/* CRC Source select */
+typedef enum CRCSCAN_SRC_enum
+{
+    CRCSCAN_SRC_FLASH_gc = (0x00<<0),  /* CRC on entire flash */
+    CRCSCAN_SRC_APPLICATION_gc = (0x01<<0),  /* CRC on boot and appl section of flash */
+    CRCSCAN_SRC_BOOT_gc = (0x02<<0)  /* CRC on boot section of flash */
+} CRCSCAN_SRC_t;
+
+/*
+--------------------------------------------------------------------------
+EVSYS - Event System
+--------------------------------------------------------------------------
+*/
+
+/* Event System */
+typedef struct EVSYS_struct
+{
+    register8_t SWEVENTA;  /* Software Event A */
+    register8_t reserved_1[15];
+    register8_t CHANNEL0;  /* Multiplexer Channel 0 */
+    register8_t CHANNEL1;  /* Multiplexer Channel 1 */
+    register8_t CHANNEL2;  /* Multiplexer Channel 2 */
+    register8_t CHANNEL3;  /* Multiplexer Channel 3 */
+    register8_t CHANNEL4;  /* Multiplexer Channel 4 */
+    register8_t CHANNEL5;  /* Multiplexer Channel 5 */
+    register8_t reserved_2[10];
+    register8_t USERCCLLUT0A;  /* CCL0 Event A */
+    register8_t USERCCLLUT0B;  /* CCL0 Event B */
+    register8_t USERCCLLUT1A;  /* CCL1 Event A */
+    register8_t USERCCLLUT1B;  /* CCL1 Event B */
+    register8_t USERCCLLUT2A;  /* CCL2 Event A */
+    register8_t USERCCLLUT2B;  /* CCL2 Event B */
+    register8_t USERCCLLUT3A;  /* CCL3 Event A */
+    register8_t USERCCLLUT3B;  /* CCL3 Event B */
+    register8_t USERADC0START;  /* ADC0 Start */
+    register8_t USEREVSYSEVOUTA;  /* EVOUTA */
+    register8_t USEREVSYSEVOUTC;  /* EVOUTC */
+    register8_t USEREVSYSEVOUTD;  /* EVOUTD */
+    register8_t USEREVSYSEVOUTF;  /* EVOUTF */
+    register8_t USERUSART0IRDA;  /* USART0 IrDA Event */
+    register8_t USERTCE0CNTA;  /* TCE0 Event A */
+    register8_t USERTCE0CNTB;  /* TCE0 Event B */
+    register8_t USERTCB0CAPT;  /* TCB0 Event A */
+    register8_t USERTCB0COUNT;  /* TCB0 Event B */
+    register8_t USERTCB1CAPT;  /* TCB1 Event A */
+    register8_t USERTCB1COUNT;  /* TCB1 Event B */
+    register8_t USERTCF0CNT;  /* TCF0 Clock Event */
+    register8_t USERTCF0ACT;  /* TCF0 Action Event */
+    register8_t USERWEXA;  /* WEX Event A */
+    register8_t USERWEXB;  /* WEX Event B */
+    register8_t USERWEXC;  /* WEX Event C */
+    register8_t reserved_3[7];
+} EVSYS_t;
+
+/* Channel generator select */
+typedef enum EVSYS_CHANNEL_enum
+{
+    EVSYS_CHANNEL_OFF_gc = (0x00<<0),  /* Off */
+    EVSYS_CHANNEL_UPDI_SYNCH_gc = (0x01<<0),  /* UPDI SYNCH character */
+    EVSYS_CHANNEL_RTC_OVF_gc = (0x06<<0),  /* Real Time Counter overflow */
+    EVSYS_CHANNEL_RTC_CMP_gc = (0x07<<0),  /* Real Time Counter compare */
+    EVSYS_CHANNEL_RTC_PITEV0_gc = (0x08<<0),  /* Periodic Interrupt Timer Event 0 */
+    EVSYS_CHANNEL_RTC_PITEV1_gc = (0x09<<0),  /* Periodic Interrupt Timer Event 1 */
+    EVSYS_CHANNEL_CCL_LUT0_gc = (0x10<<0),  /* Configurable Custom Logic LUT0 */
+    EVSYS_CHANNEL_CCL_LUT1_gc = (0x11<<0),  /* Configurable Custom Logic LUT1 */
+    EVSYS_CHANNEL_CCL_LUT2_gc = (0x12<<0),  /* Configurable Custom Logic LUT2 */
+    EVSYS_CHANNEL_CCL_LUT3_gc = (0x13<<0),  /* Configurable Custom Logic LUT3 */
+    EVSYS_CHANNEL_AC0_OUT_gc = (0x20<<0),  /* Analog Comparator 0 out */
+    EVSYS_CHANNEL_AC1_OUT_gc = (0x21<<0),  /* Analog Comparator 1 out */
+    EVSYS_CHANNEL_ADC0_RES_gc = (0x24<<0),  /* ADC 0 Result Ready */
+    EVSYS_CHANNEL_ADC0_SAMP_gc = (0x25<<0),  /* ADC 0 Sample Ready */
+    EVSYS_CHANNEL_ADC0_WCMP_gc = (0x26<<0),  /* ADC 0 Window Compare */
+    EVSYS_CHANNEL_PORTA_EV0_gc = (0x40<<0),  /* Port A Event 0 */
+    EVSYS_CHANNEL_PORTA_EV1_gc = (0x41<<0),  /* Port A Event 1 */
+    EVSYS_CHANNEL_PORTC_EV0_gc = (0x44<<0),  /* Port C Event 0 */
+    EVSYS_CHANNEL_PORTC_EV1_gc = (0x45<<0),  /* Port C Event 1 */
+    EVSYS_CHANNEL_PORTD_EV0_gc = (0x46<<0),  /* Port D Event 0 */
+    EVSYS_CHANNEL_PORTD_EV1_gc = (0x47<<0),  /* Port D Event 1 */
+    EVSYS_CHANNEL_PORTF_EV0_gc = (0x4A<<0),  /* Port F Event 0 */
+    EVSYS_CHANNEL_PORTF_EV1_gc = (0x4B<<0),  /* Port F Event 1 */
+    EVSYS_CHANNEL_USART0_XCK_gc = (0x60<<0),  /* USART 0 XCK */
+    EVSYS_CHANNEL_SPI0_SCK_gc = (0x68<<0),  /* SPI 0 SCK */
+    EVSYS_CHANNEL_TCE0_OVF_gc = (0x80<<0),  /* Timer/Counter E0 overflow */
+    EVSYS_CHANNEL_TCE0_CMP0_gc = (0x84<<0),  /* Timer/Counter E0 compare 0 */
+    EVSYS_CHANNEL_TCE0_CMP1_gc = (0x85<<0),  /* Timer/Counter E0 compare 1 */
+    EVSYS_CHANNEL_TCE0_CMP2_gc = (0x86<<0),  /* Timer/Counter E0 compare 2 */
+    EVSYS_CHANNEL_TCE0_CMP3_gc = (0x87<<0),  /* Timer/Counter E0 compare 3 */
+    EVSYS_CHANNEL_TCB0_CAPT_gc = (0xA0<<0),  /* Timer/Counter B0 capture */
+    EVSYS_CHANNEL_TCB0_OVF_gc = (0xA1<<0),  /* Timer/Counter B0 overflow */
+    EVSYS_CHANNEL_TCB1_CAPT_gc = (0xA2<<0),  /* Timer/Counter B1 capture */
+    EVSYS_CHANNEL_TCB1_OVF_gc = (0xA3<<0),  /* Timer/Counter B1 overflow */
+    EVSYS_CHANNEL_TCF0_OVF_gc = (0xB8<<0),  /* Timer/Counter F0 Overflow */
+    EVSYS_CHANNEL_TCF0_CMP0_gc = (0xB9<<0),  /* Timer/Counter F0 compare 0 */
+    EVSYS_CHANNEL_TCF0_CMP1_gc = (0xBA<<0)  /* Timer/Counter F0 compare 1 */
+} EVSYS_CHANNEL_t;
+
+/* Software event on channel select */
+typedef enum EVSYS_SWEVENTA_enum
+{
+    EVSYS_SWEVENTA_CH0_gc = (0x01<<0),  /* Software event on channel 0 */
+    EVSYS_SWEVENTA_CH1_gc = (0x02<<0),  /* Software event on channel 1 */
+    EVSYS_SWEVENTA_CH2_gc = (0x04<<0),  /* Software event on channel 2 */
+    EVSYS_SWEVENTA_CH3_gc = (0x08<<0),  /* Software event on channel 3 */
+    EVSYS_SWEVENTA_CH4_gc = (0x10<<0),  /* Software event on channel 4 */
+    EVSYS_SWEVENTA_CH5_gc = (0x20<<0),  /* Software event on channel 5 */
+    EVSYS_SWEVENTA_CH6_gc = (0x40<<0),  /* Software event on channel 6 */
+    EVSYS_SWEVENTA_CH7_gc = (0x80<<0)  /* Software event on channel 7 */
+} EVSYS_SWEVENTA_t;
+
+/* User channel select */
+typedef enum EVSYS_USER_enum
+{
+    EVSYS_USER_OFF_gc = (0x00<<0),  /* Off, No Eventsys Channel connected */
+    EVSYS_USER_CHANNEL0_gc = (0x01<<0),  /* Connect user to event channel 0 */
+    EVSYS_USER_CHANNEL1_gc = (0x02<<0),  /* Connect user to event channel 1 */
+    EVSYS_USER_CHANNEL2_gc = (0x03<<0),  /* Connect user to event channel 2 */
+    EVSYS_USER_CHANNEL3_gc = (0x04<<0),  /* Connect user to event channel 3 */
+    EVSYS_USER_CHANNEL4_gc = (0x05<<0),  /* Connect user to event channel 4 */
+    EVSYS_USER_CHANNEL5_gc = (0x06<<0)  /* Connect user to event channel 5 */
+} EVSYS_USER_t;
+
+/*
+--------------------------------------------------------------------------
+FUSE - Fuses
+--------------------------------------------------------------------------
+*/
+
+/* Fuses */
+typedef struct FUSE_struct
+{
+    register8_t WDTCFG;  /* Watchdog Configuration */
+    register8_t BODCFG;  /* BOD Configuration */
+    register8_t OSCCFG;  /* Oscillator Configuration */
+    register8_t reserved_1[2];
+    register8_t SYSCFG0;  /* System Configuration 0 */
+    register8_t SYSCFG1;  /* System Configuration 1 */
+    register8_t CODESIZE;  /* Code Section Size */
+    register8_t BOOTSIZE;  /* Boot Section Size */
+    register8_t reserved_2[1];
+    _WORDREGISTER(PDICFG);  /* Programming and Debugging Interface Configuration */
+} FUSE_t;
+
+/* avr-libc typedef for avr/fuse.h */
+typedef FUSE_t NVM_FUSES_t;
+
+/* BOD Operation in Active Mode select */
+typedef enum ACTIVE_enum
+{
+    ACTIVE_DISABLE_gc = (0x00<<2),  /* Disabled */
+    ACTIVE_ENABLED_gc = (0x01<<2),  /* Enabled in continuous mode */
+    ACTIVE_SAMPLED_gc = (0x02<<2),  /* Enabled in sampled mode */
+    ACTIVE_ENABLEWAIT_gc = (0x03<<2)  /* Enabled in continuous mode. Execution halted at wake-up until BOD is running */
+} ACTIVE_t;
+
+/* CRC Select */
+typedef enum CRCSEL_enum
+{
+    CRCSEL_CRC16_gc = (0x00<<5),  /* Enable CRC16 */
+    CRCSEL_CRC32_gc = (0x01<<5)  /* Enable CRC32 */
+} CRCSEL_t;
+
+/* CRC Source select */
+typedef enum CRCSRC_enum
+{
+    CRCSRC_FLASH_gc = (0x00<<6),  /* CRC of full Flash (boot, application code and application data) */
+    CRCSRC_BOOT_gc = (0x01<<6),  /* CRC of boot section */
+    CRCSRC_BOOTAPP_gc = (0x02<<6),  /* CRC of application code and boot sections */
+    CRCSRC_NOCRC_gc = (0x03<<6)  /* No CRC */
+} CRCSRC_t;
+
+/* EEPROM Save select */
+typedef enum EESAVE_enum
+{
+    EESAVE_DISABLE_gc = (0x00<<0),  /* EEPROM content is erased during chip erase */
+    EESAVE_ENABLE_gc = (0x01<<0)  /* EEPROM content is preserved during chip erase */
+} EESAVE_t;
+
+/* NVM Protection Activation Key select */
+typedef enum KEY_enum
+{
+    KEY_NOTACT_gc = (0x00<<4),  /* Not Active */
+    KEY_NVMACT_gc = (0xB45<<4)  /* NVM Protection Active */
+} KEY_t;
+
+/* Protection Level select */
+typedef enum LEVEL_enum
+{
+    LEVEL_NVMACCDIS_gc = (0x02<<0),  /* NVM Access through UPDI disabled */
+    LEVEL_BASIC_gc = (0x03<<0)  /* UPDI and UPDI pins working normally */
+} LEVEL_t;
+
+/* BOD Level select */
+typedef enum LVL_enum
+{
+    LVL_BODLEVEL0_gc = (0x00<<5),  /* BOD Disabled during normal operation */
+    LVL_BODLEVEL1_gc = (0x01<<5),  /* 1.9 V */
+    LVL_BODLEVEL2_gc = (0x02<<5),  /* 2.7 V */
+    LVL_BODLEVEL3_gc = (0x03<<5)  /* 4.5 V */
+} LVL_t;
+
+/* High-frequency Oscillator Frequency select */
+typedef enum OSCHFFRQ_enum
+{
+    OSCHFFRQ_20M_gc = (0x00<<3),  /* OSCHF running at 20 MHz */
+    OSCHFFRQ_16M_gc = (0x01<<3)  /* OSCHF running at 16 MHz */
+} OSCHFFRQ_t;
+
+/* Watchdog Timeout Period select */
+typedef enum PERIOD_enum
+{
+    PERIOD_OFF_gc = (0x00<<0),  /* Watch-Dog timer Off */
+    PERIOD_8CLK_gc = (0x01<<0),  /* 8 cycles (8ms) */
+    PERIOD_16CLK_gc = (0x02<<0),  /* 16 cycles (16ms) */
+    PERIOD_32CLK_gc = (0x03<<0),  /* 32 cycles (32ms) */
+    PERIOD_64CLK_gc = (0x04<<0),  /* 64 cycles (64ms) */
+    PERIOD_128CLK_gc = (0x05<<0),  /* 128 cycles (0.128s) */
+    PERIOD_256CLK_gc = (0x06<<0),  /* 256 cycles (0.256s) */
+    PERIOD_512CLK_gc = (0x07<<0),  /* 512 cycles (0.512s) */
+    PERIOD_1KCLK_gc = (0x08<<0),  /* 1K cycles (1.0s) */
+    PERIOD_2KCLK_gc = (0x09<<0),  /* 2K cycles (2.0s) */
+    PERIOD_4KCLK_gc = (0x0A<<0),  /* 4K cycles (4.0s) */
+    PERIOD_8KCLK_gc = (0x0B<<0)  /* 8K cycles (8.0s) */
+} PERIOD_t;
+
+/* Reset Pin Configuration select */
+typedef enum RSTPINCFG_enum
+{
+    RSTPINCFG_NONE_gc = (0x00<<3),  /* No External Reset */
+    RSTPINCFG_RESET_gc = (0x01<<3)  /* PF6 configured as RESET pin */
+} RSTPINCFG_t;
+
+/* BOD Sample Frequency select */
+typedef enum SAMPFREQ_enum
+{
+    SAMPFREQ_128HZ_gc = (0x00<<4),  /* Sampling frequency is 128 Hz */
+    SAMPFREQ_32HZ_gc = (0x01<<4)  /* Sample frequency is 32 Hz */
+} SAMPFREQ_t;
+
+/* BOD Operation in Sleep Mode select */
+typedef enum SLEEP_enum
+{
+    SLEEP_DISABLE_gc = (0x00<<0),  /* Disabled */
+    SLEEP_ENABLE_gc = (0x01<<0),  /* Enabled in continuous mode */
+    SLEEP_SAMPLE_gc = (0x02<<0)  /* Enabled in sampled mode */
+} SLEEP_t;
+
+/* Startup Time select */
+typedef enum SUT_enum
+{
+    SUT_0MS_gc = (0x00<<0),  /* 0 ms */
+    SUT_1MS_gc = (0x01<<0),  /* 1 ms */
+    SUT_2MS_gc = (0x02<<0),  /* 2 ms */
+    SUT_4MS_gc = (0x03<<0),  /* 4 ms */
+    SUT_8MS_gc = (0x04<<0),  /* 8 ms */
+    SUT_16MS_gc = (0x05<<0),  /* 16 ms */
+    SUT_32MS_gc = (0x06<<0),  /* 32 ms */
+    SUT_64MS_gc = (0x07<<0)  /* 64 ms */
+} SUT_t;
+
+/* UPDI Pin Configuration select */
+typedef enum UPDIPINCFG_enum
+{
+    UPDIPINCFG_GPIO_gc = (0x00<<4),  /* PF7 Configured as GPIO pin */
+    UPDIPINCFG_UPDI_gc = (0x01<<4)  /* PF7 Configured as UPDI pin */
+} UPDIPINCFG_t;
+
+/* Watchdog Window Timeout Period select */
+typedef enum WINDOW_enum
+{
+    WINDOW_OFF_gc = (0x00<<4),  /* Window mode off */
+    WINDOW_8CLK_gc = (0x01<<4),  /* 8 cycles (8ms) */
+    WINDOW_16CLK_gc = (0x02<<4),  /* 16 cycles (16ms) */
+    WINDOW_32CLK_gc = (0x03<<4),  /* 32 cycles (32ms) */
+    WINDOW_64CLK_gc = (0x04<<4),  /* 64 cycles (64ms) */
+    WINDOW_128CLK_gc = (0x05<<4),  /* 128 cycles (0.128s) */
+    WINDOW_256CLK_gc = (0x06<<4),  /* 256 cycles (0.256s) */
+    WINDOW_512CLK_gc = (0x07<<4),  /* 512 cycles (0.512s) */
+    WINDOW_1KCLK_gc = (0x08<<4),  /* 1K cycles (1.0s) */
+    WINDOW_2KCLK_gc = (0x09<<4),  /* 2K cycles (2.0s) */
+    WINDOW_4KCLK_gc = (0x0A<<4),  /* 4K cycles (4.0s) */
+    WINDOW_8KCLK_gc = (0x0B<<4)  /* 8K cycles (8.0s) */
+} WINDOW_t;
+
+/*
+--------------------------------------------------------------------------
+GPR - General Purpose Registers
+--------------------------------------------------------------------------
+*/
+
+/* General Purpose Registers */
+typedef struct GPR_struct
+{
+    register8_t GPR0;  /* General Purpose Register 0 */
+    register8_t GPR1;  /* General Purpose Register 1 */
+    register8_t GPR2;  /* General Purpose Register 2 */
+    register8_t GPR3;  /* General Purpose Register 3 */
+} GPR_t;
+
+
+/*
+--------------------------------------------------------------------------
+LOCK - Lockbits
+--------------------------------------------------------------------------
+*/
+
+/* Lockbits */
+typedef struct LOCK_struct
+{
+    _DWORDREGISTER(KEY);  /* Lock Key Bits */
+} LOCK_t;
+
+/* Lock Key select */
+typedef enum LOCK_KEY_enum
+{
+    LOCK_KEY_NOLOCK_gc = (0x5CC5C55C<<0),  /* No locks */
+    LOCK_KEY_RWLOCK_gc = (0xA33A3AA3<<0)  /* Read and write lock */
+} LOCK_KEY_t;
+
+/*
+--------------------------------------------------------------------------
+NVMCTRL - Non-volatile Memory Controller
+--------------------------------------------------------------------------
+*/
+
+/* Non-volatile Memory Controller */
+typedef struct NVMCTRL_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    register8_t reserved_1[1];
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t STATUS;  /* Status */
+    register8_t reserved_2[1];
+    _WORDREGISTER(DATA);  /* Data */
+    register8_t reserved_3[2];
+    _DWORDREGISTER(ADDR);  /* Address */
+    register8_t reserved_4[48];
+} NVMCTRL_t;
+
+/* Command select */
+typedef enum NVMCTRL_CMD_enum
+{
+    NVMCTRL_CMD_NOCMD_gc = (0x00<<0),  /* No Command */
+    NVMCTRL_CMD_NOOP_gc = (0x01<<0),  /* No Operation */
+    NVMCTRL_CMD_FLPW_gc = (0x04<<0),  /* Flash Page Write */
+    NVMCTRL_CMD_FLPERW_gc = (0x05<<0),  /* Flash Page Erase and Write */
+    NVMCTRL_CMD_FLPER_gc = (0x08<<0),  /* Flash Page Erase */
+    NVMCTRL_CMD_FLMPER2_gc = (0x09<<0),  /* Flash 2-page erase enable */
+    NVMCTRL_CMD_FLMPER4_gc = (0x0A<<0),  /* Flash 4-page erase enable */
+    NVMCTRL_CMD_FLMPER8_gc = (0x0B<<0),  /* Flash 8-page erase enable */
+    NVMCTRL_CMD_FLMPER16_gc = (0x0C<<0),  /* Flash 16-page erase enable */
+    NVMCTRL_CMD_FLMPER32_gc = (0x0D<<0),  /* Flash 32-page erase enable */
+    NVMCTRL_CMD_FLPBCLR_gc = (0x0F<<0),  /* Flash Page Buffer Clear */
+    NVMCTRL_CMD_EEPW_gc = (0x14<<0),  /* EEPROM Page Write */
+    NVMCTRL_CMD_EEPERW_gc = (0x15<<0),  /* EEPROM Page Erase and Write */
+    NVMCTRL_CMD_EEPER_gc = (0x17<<0),  /* EEPROM Page Erase */
+    NVMCTRL_CMD_EEPBCLR_gc = (0x1F<<0),  /* EEPROM Page Buffer Clear */
+    NVMCTRL_CMD_CHER_gc = (0x20<<0),  /* Chip Erase Command (UPDI only) */
+    NVMCTRL_CMD_EECHER_gc = (0x30<<0)  /* EEPROM Erase Command (UPDI only) */
+} NVMCTRL_CMD_t;
+
+/* Write error select */
+typedef enum NVMCTRL_ERROR_enum
+{
+    NVMCTRL_ERROR_NOERROR_gc = (0x00<<4),  /* No Error */
+    NVMCTRL_ERROR_WRITEPROTECT_gc = (0x02<<4),  /* Attempt to program write protected area */
+    NVMCTRL_ERROR_CMDCOLLISION_gc = (0x03<<4),  /* Selecting new write command while write command already seleted */
+    NVMCTRL_ERROR_WRONGSECTION_gc = (0x04<<4)  /* Address cannot be written with selected command */
+} NVMCTRL_ERROR_t;
+
+/* Flash Mapping in Data space select */
+typedef enum NVMCTRL_FLMAP_enum
+{
+    NVMCTRL_FLMAP_SECTION0_gc = (0x00<<4),  /* Flash section 0, 0 - 32KB */
+    NVMCTRL_FLMAP_SECTION1_gc = (0x01<<4),  /* Flash section 1, 32 - 64KB */
+    NVMCTRL_FLMAP_SECTION2_gc = (0x02<<4),  /* Flash section 2, 64 - 96KB */
+    NVMCTRL_FLMAP_SECTION3_gc = (0x03<<4)  /* Flash section 3, 96 - 128KB */
+} NVMCTRL_FLMAP_t;
+
+/*
+--------------------------------------------------------------------------
+PORT - I/O Ports
+--------------------------------------------------------------------------
+*/
+
+/* I/O Ports */
+typedef struct PORT_struct
+{
+    register8_t DIR;  /* Data Direction */
+    register8_t DIRSET;  /* Data Direction Set */
+    register8_t DIRCLR;  /* Data Direction Clear */
+    register8_t DIRTGL;  /* Data Direction Toggle */
+    register8_t OUT;  /* Output Value */
+    register8_t OUTSET;  /* Output Value Set */
+    register8_t OUTCLR;  /* Output Value Clear */
+    register8_t OUTTGL;  /* Output Value Toggle */
+    register8_t IN;  /* Input Value */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t PORTCTRL;  /* Port Control */
+    register8_t PINCONFIG;  /* Pin Control Config */
+    register8_t PINCTRLUPD;  /* Pin Control Update */
+    register8_t PINCTRLSET;  /* Pin Control Set */
+    register8_t PINCTRLCLR;  /* Pin Control Clear */
+    register8_t reserved_1[1];
+    register8_t PIN0CTRL;  /* Pin 0 Control */
+    register8_t PIN1CTRL;  /* Pin 1 Control */
+    register8_t PIN2CTRL;  /* Pin 2 Control */
+    register8_t PIN3CTRL;  /* Pin 3 Control */
+    register8_t PIN4CTRL;  /* Pin 4 Control */
+    register8_t PIN5CTRL;  /* Pin 5 Control */
+    register8_t PIN6CTRL;  /* Pin 6 Control */
+    register8_t PIN7CTRL;  /* Pin 7 Control */
+    register8_t EVGENCTRLA;  /* Event Generation Control A */
+    register8_t reserved_2[7];
+} PORT_t;
+
+/* Event Generator 0 Select */
+typedef enum PORT_EVGEN0SEL_enum
+{
+    PORT_EVGEN0SEL_PIN0_gc = (0x00<<0),  /* Pin 0 used as event generator */
+    PORT_EVGEN0SEL_PIN1_gc = (0x01<<0),  /* Pin 1 used as event generator */
+    PORT_EVGEN0SEL_PIN2_gc = (0x02<<0),  /* Pin 2 used as event generator */
+    PORT_EVGEN0SEL_PIN3_gc = (0x03<<0),  /* Pin 3 used as event generator */
+    PORT_EVGEN0SEL_PIN4_gc = (0x04<<0),  /* Pin 4 used as event generator */
+    PORT_EVGEN0SEL_PIN5_gc = (0x05<<0),  /* Pin 5 used as event generator */
+    PORT_EVGEN0SEL_PIN6_gc = (0x06<<0),  /* Pin 6 used as event generator */
+    PORT_EVGEN0SEL_PIN7_gc = (0x07<<0)  /* Pin 7 used as event generator */
+} PORT_EVGEN0SEL_t;
+
+/* Event Generator 1 Select */
+typedef enum PORT_EVGEN1SEL_enum
+{
+    PORT_EVGEN1SEL_PIN0_gc = (0x00<<4),  /* Pin 0 used as event generator */
+    PORT_EVGEN1SEL_PIN1_gc = (0x01<<4),  /* Pin 1 used as event generator */
+    PORT_EVGEN1SEL_PIN2_gc = (0x02<<4),  /* Pin 2 used as event generator */
+    PORT_EVGEN1SEL_PIN3_gc = (0x03<<4),  /* Pin 3 used as event generator */
+    PORT_EVGEN1SEL_PIN4_gc = (0x04<<4),  /* Pin 4 used as event generator */
+    PORT_EVGEN1SEL_PIN5_gc = (0x05<<4),  /* Pin 5 used as event generator */
+    PORT_EVGEN1SEL_PIN6_gc = (0x06<<4),  /* Pin 6 used as event generator */
+    PORT_EVGEN1SEL_PIN7_gc = (0x07<<4)  /* Pin 7 used as event generator */
+} PORT_EVGEN1SEL_t;
+
+/* Input Level Select */
+typedef enum PORT_INLVL_enum
+{
+    PORT_INLVL_ST_gc = (0x00<<6),  /* Schmitt-Trigger input level */
+    PORT_INLVL_TTL_gc = (0x01<<6)  /* TTL Input level */
+} PORT_INLVL_t;
+
+/* Input/Sense Configuration select */
+typedef enum PORT_ISC_enum
+{
+    PORT_ISC_INTDISABLE_gc = (0x00<<0),  /* Interrupt disabled but input buffer enabled */
+    PORT_ISC_BOTHEDGES_gc = (0x01<<0),  /* Sense Both Edges */
+    PORT_ISC_RISING_gc = (0x02<<0),  /* Sense Rising Edge */
+    PORT_ISC_FALLING_gc = (0x03<<0),  /* Sense Falling Edge */
+    PORT_ISC_INPUT_DISABLE_gc = (0x04<<0),  /* Digital Input Buffer disabled */
+    PORT_ISC_LEVEL_gc = (0x05<<0)  /* Sense low Level */
+} PORT_ISC_t;
+
+/*
+--------------------------------------------------------------------------
+PORTMUX - Port Multiplexer
+--------------------------------------------------------------------------
+*/
+
+/* Port Multiplexer */
+typedef struct PORTMUX_struct
+{
+    register8_t EVSYSROUTEA;  /* EVSYS route A */
+    register8_t CCLROUTEA;  /* CCL route A */
+    register8_t USARTROUTEA;  /* USART route A */
+    register8_t reserved_1[2];
+    register8_t SPIROUTEA;  /* SPI route A */
+    register8_t TWIROUTEA;  /* TWI route A */
+    register8_t TCEROUTEA;  /* TCE route A */
+    register8_t TCBROUTEA;  /* TCB route A */
+    register8_t reserved_2[3];
+    register8_t TCFROUTEA;  /* TCF Route A */
+    register8_t reserved_3[19];
+} PORTMUX_t;
+
+/* Event Output A select */
+typedef enum PORTMUX_EVOUTA_enum
+{
+    PORTMUX_EVOUTA_DEFAULT_gc = (0x00<<0),  /* EVOUT on PA2 */
+    PORTMUX_EVOUTA_ALT1_gc = (0x01<<0)  /* EVOUT on PA7 */
+} PORTMUX_EVOUTA_t;
+
+/* Event Output C select */
+typedef enum PORTMUX_EVOUTC_enum
+{
+    PORTMUX_EVOUTC_DEFAULT_gc = (0x00<<2)  /* EVOUT on PC2 */
+} PORTMUX_EVOUTC_t;
+
+/* Event Output D select */
+typedef enum PORTMUX_EVOUTD_enum
+{
+    PORTMUX_EVOUTD_ALT1_gc = (0x01<<3)  /* EVOUT on PD7 */
+} PORTMUX_EVOUTD_t;
+
+/* Event Output F select */
+typedef enum PORTMUX_EVOUTF_enum
+{
+    PORTMUX_EVOUTF_ALT1_gc = (0x01<<5)  /* EVOUT on PF7 */
+} PORTMUX_EVOUTF_t;
+
+/* CCL Look-Up Table 0 Signals select */
+typedef enum PORTMUX_LUT0_enum
+{
+    PORTMUX_LUT0_DEFAULT_gc = (0x00<<0),  /* Out: PA3 In: PA0, PA1, PA2 */
+    PORTMUX_LUT0_ALT1_gc = (0x01<<0)  /* Out: PA6 In: PA0, PA1, PA2 */
+} PORTMUX_LUT0_t;
+
+/* CCL Look-Up Table 1 Signals select */
+typedef enum PORTMUX_LUT1_enum
+{
+    PORTMUX_LUT1_DEFAULT_gc = (0x00<<1)  /* Out: PC3 In: PC0, PC1, PC2 */
+} PORTMUX_LUT1_t;
+
+/* CCL Look-Up Table 2 Signals select */
+typedef enum PORTMUX_LUT2_enum
+{
+    PORTMUX_LUT2_ALT1_gc = (0x01<<2)  /* Out: PD6 In: PD0, PD1, PD2 */
+} PORTMUX_LUT2_t;
+
+/* SPI0 Signals select */
+typedef enum PORTMUX_SPI0_enum
+{
+    PORTMUX_SPI0_DEFAULT_gc = (0x00<<0),  /* PA4, PA5, PA6, PA7 */
+    PORTMUX_SPI0_ALT3_gc = (0x03<<0),  /* PA0, PA1, PC0, PC1 */
+    PORTMUX_SPI0_ALT4_gc = (0x04<<0),  /* PD4, PD5, PD6, PD7 */
+    PORTMUX_SPI0_ALT5_gc = (0x05<<0),  /* PC0, PC1, PC2, PC3 */
+    PORTMUX_SPI0_ALT6_gc = (0x06<<0),  /* PC1, PC2, PC3, - */
+    PORTMUX_SPI0_NONE_gc = (0x07<<0)  /* Not connected to any pins, SS set to 1 */
+} PORTMUX_SPI0_t;
+
+/* TCB0 Output select */
+typedef enum PORTMUX_TCB0_enum
+{
+    PORTMUX_TCB0_DEFAULT_gc = (0x00<<0)  /* PA2 */
+} PORTMUX_TCB0_t;
+
+/* TCB1 Output select */
+typedef enum PORTMUX_TCB1_enum
+{
+    PORTMUX_TCB1_DEFAULT_gc = (0x00<<1)  /* PA3 */
+} PORTMUX_TCB1_t;
+
+/* TCE0 Signals select */
+typedef enum PORTMUX_TCE0_enum
+{
+    PORTMUX_TCE0_PORTA_gc = (0x00<<0),  /* PA0, PA1, PA2, PA3, PA4, PA5, PA6, PA7 */
+    PORTMUX_TCE0_PORTC_gc = (0x02<<0),  /* PC0, PC1, PC2, PC3, -, -, -, - */
+    PORTMUX_TCE0_PORTC2_gc = (0x08<<0),  /* PA0, PA1, PC0, PC1, PC2, PC3, -, - */
+    PORTMUX_TCE0_PORTA2_gc = (0x09<<0)  /* PA2, PA3, PA4, PA5, PA6, PA7, -, - */
+} PORTMUX_TCE0_t;
+
+/* TCF0 Output select */
+typedef enum PORTMUX_TCF0_enum
+{
+    PORTMUX_TCF0_DEFAULT_gc = (0x00<<0),  /* PA0, PA1 */
+    PORTMUX_TCF0_ALT1_gc = (0x01<<0)  /* PA6, PA7 */
+} PORTMUX_TCF0_t;
+
+/* TWI0 Signals select */
+typedef enum PORTMUX_TWI0_enum
+{
+    PORTMUX_TWI0_DEFAULT_gc = (0x00<<0),  /* {PA2, PA3}, {PC2, PC3} */
+    PORTMUX_TWI0_ALT2_gc = (0x02<<0),  /* {PC2, PC3}, {-, -} */
+    PORTMUX_TWI0_ALT3_gc = (0x03<<0)  /* {PA0, PA1}, {PC2, PC3} */
+} PORTMUX_TWI0_t;
+
+/* USART0 Routing select */
+typedef enum PORTMUX_USART0_enum
+{
+    PORTMUX_USART0_DEFAULT_gc = (0x00<<0),  /* {PA0, PA1, PA2, PA3} */
+    PORTMUX_USART0_ALT1_gc = (0x01<<0),  /* {PA4, PA5, PA6, PA7} */
+    PORTMUX_USART0_ALT2_gc = (0x02<<0),  /* {PA2,PA3, -, -} */
+    PORTMUX_USART0_ALT3_gc = (0x03<<0),  /* {PD4, PD5, PD6, PD7} */
+    PORTMUX_USART0_ALT4_gc = (0x04<<0),  /* {PC1, PC2, PC3, -} */
+    PORTMUX_USART0_ALT6_gc = (0x06<<0),  /* {PF7, PF6, -, -} */
+    PORTMUX_USART0_NONE_gc = (0x07<<0)  /* Not connected to any pins */
+} PORTMUX_USART0_t;
+
+/*
+--------------------------------------------------------------------------
+RSTCTRL - Reset controller
+--------------------------------------------------------------------------
+*/
+
+/* Reset controller */
+typedef struct RSTCTRL_struct
+{
+    register8_t RSTFR;  /* Reset Flags */
+    register8_t SWRR;  /* Software Reset */
+    register8_t reserved_1[14];
+} RSTCTRL_t;
+
+
+/*
+--------------------------------------------------------------------------
+RTC - Real-Time Counter
+--------------------------------------------------------------------------
+*/
+
+/* Real-Time Counter */
+typedef struct RTC_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t STATUS;  /* Status */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t TEMP;  /* Temporary */
+    register8_t DBGCTRL;  /* Debug control */
+    register8_t CALIB;  /* Calibration */
+    register8_t CLKSEL;  /* Clock Select */
+    _WORDREGISTER(CNT);  /* Counter */
+    _WORDREGISTER(PER);  /* Period */
+    _WORDREGISTER(CMP);  /* Compare */
+    register8_t reserved_1[2];
+    register8_t PITCTRLA;  /* PIT Control A */
+    register8_t PITSTATUS;  /* PIT Status */
+    register8_t PITINTCTRL;  /* PIT Interrupt Control */
+    register8_t PITINTFLAGS;  /* PIT Interrupt Flags */
+    register8_t reserved_2[1];
+    register8_t PITDBGCTRL;  /* PIT Debug control */
+    register8_t PITEVGENCTRLA;  /* PIT Event Generation Control A */
+    register8_t reserved_3[9];
+} RTC_t;
+
+/* Clock Select */
+typedef enum RTC_CLKSEL_enum
+{
+    RTC_CLKSEL_OSC32K_gc = (0x00<<0),  /* Internal 32.768 kHz Oscillator */
+    RTC_CLKSEL_OSC1K_gc = (0x01<<0),  /* Internal 32.768 kHz Oscillator Divided by 32 */
+    RTC_CLKSEL_XOSC32K_gc = (0x02<<0),  /* 32.768 kHz Crystal Oscillator */
+    RTC_CLKSEL_EXTCLK_gc = (0x03<<0)  /* External Clock */
+} RTC_CLKSEL_t;
+
+/* Event Generation 0 Select */
+typedef enum RTC_EVGEN0SEL_enum
+{
+    RTC_EVGEN0SEL_OFF_gc = (0x00<<0),  /* No Event Generated */
+    RTC_EVGEN0SEL_DIV4_gc = (0x01<<0),  /* CLK_RTC divided by 4 */
+    RTC_EVGEN0SEL_DIV8_gc = (0x02<<0),  /* CLK_RTC divided by 8 */
+    RTC_EVGEN0SEL_DIV16_gc = (0x03<<0),  /* CLK_RTC divided by 16 */
+    RTC_EVGEN0SEL_DIV32_gc = (0x04<<0),  /* CLK_RTC divided by 32 */
+    RTC_EVGEN0SEL_DIV64_gc = (0x05<<0),  /* CLK_RTC divided by 64 */
+    RTC_EVGEN0SEL_DIV128_gc = (0x06<<0),  /* CLK_RTC divided by 128 */
+    RTC_EVGEN0SEL_DIV256_gc = (0x07<<0),  /* CLK_RTC divided by 256 */
+    RTC_EVGEN0SEL_DIV512_gc = (0x08<<0),  /* CLK_RTC divided by 512 */
+    RTC_EVGEN0SEL_DIV1024_gc = (0x09<<0),  /* CLK_RTC divided by 1024 */
+    RTC_EVGEN0SEL_DIV2048_gc = (0x0A<<0),  /* CLK_RTC divided by 2048 */
+    RTC_EVGEN0SEL_DIV4096_gc = (0x0B<<0),  /* CLK_RTC divided by 4096 */
+    RTC_EVGEN0SEL_DIV8192_gc = (0x0C<<0),  /* CLK_RTC divided by 8192 */
+    RTC_EVGEN0SEL_DIV16384_gc = (0x0D<<0),  /* CLK_RTC divided by 16384 */
+    RTC_EVGEN0SEL_DIV32768_gc = (0x0E<<0)  /* CLK_RTC divided by 32768 */
+} RTC_EVGEN0SEL_t;
+
+/* Event Generation 1 Select */
+typedef enum RTC_EVGEN1SEL_enum
+{
+    RTC_EVGEN1SEL_OFF_gc = (0x00<<4),  /* No Event Generated */
+    RTC_EVGEN1SEL_DIV4_gc = (0x01<<4),  /* CLK_RTC divided by 4 */
+    RTC_EVGEN1SEL_DIV8_gc = (0x02<<4),  /* CLK_RTC divided by 8 */
+    RTC_EVGEN1SEL_DIV16_gc = (0x03<<4),  /* CLK_RTC divided by 16 */
+    RTC_EVGEN1SEL_DIV32_gc = (0x04<<4),  /* CLK_RTC divided by 32 */
+    RTC_EVGEN1SEL_DIV64_gc = (0x05<<4),  /* CLK_RTC divided by 64 */
+    RTC_EVGEN1SEL_DIV128_gc = (0x06<<4),  /* CLK_RTC divided by 128 */
+    RTC_EVGEN1SEL_DIV256_gc = (0x07<<4),  /* CLK_RTC divided by 256 */
+    RTC_EVGEN1SEL_DIV512_gc = (0x08<<4),  /* CLK_RTC divided by 512 */
+    RTC_EVGEN1SEL_DIV1024_gc = (0x09<<4),  /* CLK_RTC divided by 1024 */
+    RTC_EVGEN1SEL_DIV2048_gc = (0x0A<<4),  /* CLK_RTC divided by 2048 */
+    RTC_EVGEN1SEL_DIV4096_gc = (0x0B<<4),  /* CLK_RTC divided by 4096 */
+    RTC_EVGEN1SEL_DIV8192_gc = (0x0C<<4),  /* CLK_RTC divided by 8192 */
+    RTC_EVGEN1SEL_DIV16384_gc = (0x0D<<4),  /* CLK_RTC divided by 16384 */
+    RTC_EVGEN1SEL_DIV32768_gc = (0x0E<<4)  /* CLK_RTC divided by 32768 */
+} RTC_EVGEN1SEL_t;
+
+/* Period select */
+typedef enum RTC_PERIOD_enum
+{
+    RTC_PERIOD_OFF_gc = (0x00<<3),  /* Off */
+    RTC_PERIOD_CYC4_gc = (0x01<<3),  /* RTC Clock Cycles 4 */
+    RTC_PERIOD_CYC8_gc = (0x02<<3),  /* RTC Clock Cycles 8 */
+    RTC_PERIOD_CYC16_gc = (0x03<<3),  /* RTC Clock Cycles 16 */
+    RTC_PERIOD_CYC32_gc = (0x04<<3),  /* RTC Clock Cycles 32 */
+    RTC_PERIOD_CYC64_gc = (0x05<<3),  /* RTC Clock Cycles 64 */
+    RTC_PERIOD_CYC128_gc = (0x06<<3),  /* RTC Clock Cycles 128 */
+    RTC_PERIOD_CYC256_gc = (0x07<<3),  /* RTC Clock Cycles 256 */
+    RTC_PERIOD_CYC512_gc = (0x08<<3),  /* RTC Clock Cycles 512 */
+    RTC_PERIOD_CYC1024_gc = (0x09<<3),  /* RTC Clock Cycles 1024 */
+    RTC_PERIOD_CYC2048_gc = (0x0A<<3),  /* RTC Clock Cycles 2048 */
+    RTC_PERIOD_CYC4096_gc = (0x0B<<3),  /* RTC Clock Cycles 4096 */
+    RTC_PERIOD_CYC8192_gc = (0x0C<<3),  /* RTC Clock Cycles 8192 */
+    RTC_PERIOD_CYC16384_gc = (0x0D<<3),  /* RTC Clock Cycles 16384 */
+    RTC_PERIOD_CYC32768_gc = (0x0E<<3)  /* RTC Clock Cycles 32768 */
+} RTC_PERIOD_t;
+
+/* Prescaling Factor select */
+typedef enum RTC_PRESCALER_enum
+{
+    RTC_PRESCALER_DIV1_gc = (0x00<<3),  /* RTC Clock / 1 */
+    RTC_PRESCALER_DIV2_gc = (0x01<<3),  /* RTC Clock / 2 */
+    RTC_PRESCALER_DIV4_gc = (0x02<<3),  /* RTC Clock / 4 */
+    RTC_PRESCALER_DIV8_gc = (0x03<<3),  /* RTC Clock / 8 */
+    RTC_PRESCALER_DIV16_gc = (0x04<<3),  /* RTC Clock / 16 */
+    RTC_PRESCALER_DIV32_gc = (0x05<<3),  /* RTC Clock / 32 */
+    RTC_PRESCALER_DIV64_gc = (0x06<<3),  /* RTC Clock / 64 */
+    RTC_PRESCALER_DIV128_gc = (0x07<<3),  /* RTC Clock / 128 */
+    RTC_PRESCALER_DIV256_gc = (0x08<<3),  /* RTC Clock / 256 */
+    RTC_PRESCALER_DIV512_gc = (0x09<<3),  /* RTC Clock / 512 */
+    RTC_PRESCALER_DIV1024_gc = (0x0A<<3),  /* RTC Clock / 1024 */
+    RTC_PRESCALER_DIV2048_gc = (0x0B<<3),  /* RTC Clock / 2048 */
+    RTC_PRESCALER_DIV4096_gc = (0x0C<<3),  /* RTC Clock / 4096 */
+    RTC_PRESCALER_DIV8192_gc = (0x0D<<3),  /* RTC Clock / 8192 */
+    RTC_PRESCALER_DIV16384_gc = (0x0E<<3),  /* RTC Clock / 16384 */
+    RTC_PRESCALER_DIV32768_gc = (0x0F<<3)  /* RTC Clock / 32768 */
+} RTC_PRESCALER_t;
+
+/*
+--------------------------------------------------------------------------
+SIGROW - Signature row
+--------------------------------------------------------------------------
+*/
+
+/* Signature row */
+typedef struct SIGROW_struct
+{
+    register8_t DEVICEID0;  /* Device ID Byte 0 */
+    register8_t DEVICEID1;  /* Device ID Byte 1 */
+    register8_t DEVICEID2;  /* Device ID Byte 2 */
+    register8_t reserved_1[1];
+    _WORDREGISTER(TEMPSENSE0);  /* Temperature Calibration 0 */
+    _WORDREGISTER(TEMPSENSE1);  /* Temperature Calibration 1 */
+    register8_t reserved_2[8];
+    register8_t SERNUM0;  /* Serial Number Byte 0 */
+    register8_t SERNUM1;  /* Serial Number Byte 1 */
+    register8_t SERNUM2;  /* Serial Number Byte 2 */
+    register8_t SERNUM3;  /* Serial Number Byte 3 */
+    register8_t SERNUM4;  /* Serial Number Byte 4 */
+    register8_t SERNUM5;  /* Serial Number Byte 5 */
+    register8_t SERNUM6;  /* Serial Number Byte 6 */
+    register8_t SERNUM7;  /* Serial Number Byte 7 */
+    register8_t SERNUM8;  /* Serial Number Byte 8 */
+    register8_t SERNUM9;  /* Serial Number Byte 9 */
+    register8_t SERNUM10;  /* Serial Number Byte 10 */
+    register8_t SERNUM11;  /* Serial Number Byte 11 */
+    register8_t SERNUM12;  /* Serial Number Byte 12 */
+    register8_t SERNUM13;  /* Serial Number Byte 13 */
+    register8_t SERNUM14;  /* Serial Number Byte 14 */
+    register8_t SERNUM15;  /* Serial Number Byte 15 */
+    register8_t reserved_3[32];
+} SIGROW_t;
+
+
+/*
+--------------------------------------------------------------------------
+SLPCTRL - Sleep Controller
+--------------------------------------------------------------------------
+*/
+
+/* Sleep Controller */
+typedef struct SLPCTRL_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t reserved_1[15];
+} SLPCTRL_t;
+
+/* Sleep mode select */
+typedef enum SLPCTRL_SMODE_enum
+{
+    SLPCTRL_SMODE_IDLE_gc = (0x00<<1),  /* Idle mode */
+    SLPCTRL_SMODE_STDBY_gc = (0x01<<1),  /* Standby Mode */
+    SLPCTRL_SMODE_PDOWN_gc = (0x02<<1)  /* Power-down Mode */
+} SLPCTRL_SMODE_t;
+
+#define SLEEP_MODE_IDLE (0x00<<1)
+#define SLEEP_MODE_STANDBY (0x01<<1)
+#define SLEEP_MODE_PWR_DOWN (0x02<<1)
+/*
+--------------------------------------------------------------------------
+SPI - Serial Peripheral Interface
+--------------------------------------------------------------------------
+*/
+
+/* Serial Peripheral Interface */
+typedef struct SPI_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t DATA;  /* Data */
+    register8_t reserved_1[11];
+} SPI_t;
+
+/* SPI Mode select */
+typedef enum SPI_MODE_enum
+{
+    SPI_MODE_0_gc = (0x00<<0),  /* SPI Mode 0 */
+    SPI_MODE_1_gc = (0x01<<0),  /* SPI Mode 1 */
+    SPI_MODE_2_gc = (0x02<<0),  /* SPI Mode 2 */
+    SPI_MODE_3_gc = (0x03<<0)  /* SPI Mode 3 */
+} SPI_MODE_t;
+
+/* Prescaler select */
+typedef enum SPI_PRESC_enum
+{
+    SPI_PRESC_DIV4_gc = (0x00<<1),  /* CLK_PER / 4 */
+    SPI_PRESC_DIV16_gc = (0x01<<1),  /* CLK_PER / 16 */
+    SPI_PRESC_DIV64_gc = (0x02<<1),  /* CLK_PER / 64 */
+    SPI_PRESC_DIV128_gc = (0x03<<1)  /* CLK_PER / 128 */
+} SPI_PRESC_t;
+
+/*
+--------------------------------------------------------------------------
+SYSCFG - System Configuration Registers
+--------------------------------------------------------------------------
+*/
+
+/* System Configuration Registers */
+typedef struct SYSCFG_struct
+{
+    register8_t reserved_1[1];
+    register8_t REVID;  /* Revision ID */
+    register8_t reserved_2[62];
+} SYSCFG_t;
+
+
+/*
+--------------------------------------------------------------------------
+TCB - 16-bit Timer/Counter Type B
+--------------------------------------------------------------------------
+*/
+
+/* 16-bit Timer/Counter Type B */
+typedef struct TCB_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    register8_t reserved_1[1];
+    register8_t EVCTRL;  /* Event Control */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t STATUS;  /* Status */
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t TEMP;  /* Temporary Value */
+    _WORDREGISTER(CNT);  /* Count */
+    _WORDREGISTER(CCMP);  /* Compare or Capture */
+    register8_t reserved_2[2];
+} TCB_t;
+
+/* Clock Select */
+typedef enum TCB_CLKSEL_enum
+{
+    TCB_CLKSEL_DIV1_gc = (0x00<<1),  /* CLK_PER */
+    TCB_CLKSEL_DIV2_gc = (0x01<<1),  /* CLK_PER/2 */
+    TCB_CLKSEL_TCE0_gc = (0x02<<1),  /* Use CLK_TCE from TCE0 */
+    TCB_CLKSEL_EVENT_gc = (0x07<<1)  /* Count on event edge */
+} TCB_CLKSEL_t;
+
+/* Timer Mode select */
+typedef enum TCB_CNTMODE_enum
+{
+    TCB_CNTMODE_INT_gc = (0x00<<0),  /* Periodic Interrupt */
+    TCB_CNTMODE_TIMEOUT_gc = (0x01<<0),  /* Periodic Timeout */
+    TCB_CNTMODE_CAPT_gc = (0x02<<0),  /* Input Capture Event */
+    TCB_CNTMODE_FRQ_gc = (0x03<<0),  /* Input Capture Frequency measurement */
+    TCB_CNTMODE_PW_gc = (0x04<<0),  /* Input Capture Pulse-Width measurement */
+    TCB_CNTMODE_FRQPW_gc = (0x05<<0),  /* Input Capture Frequency and Pulse-Width measurement */
+    TCB_CNTMODE_SINGLE_gc = (0x06<<0),  /* Single Shot */
+    TCB_CNTMODE_PWM8_gc = (0x07<<0)  /* 8-bit PWM */
+} TCB_CNTMODE_t;
+
+/* Counter Size select */
+typedef enum TCB_CNTSIZE_enum
+{
+    TCB_CNTSIZE_16BITS_gc = (0x00<<0),  /* 16-bit CNT. MAX=16'hFFFF */
+    TCB_CNTSIZE_15BITS_gc = (0x01<<0),  /* 15-bit CNT. MAX=16'h7FFF */
+    TCB_CNTSIZE_14BITS_gc = (0x02<<0),  /* 14-bit CNT. MAX=16'h3FFF */
+    TCB_CNTSIZE_13BITS_gc = (0x03<<0),  /* 13-bit CNT. MAX=16'h1FFF */
+    TCB_CNTSIZE_12BITS_gc = (0x04<<0),  /* 12-bit CNT. MAX=16'h0FFF */
+    TCB_CNTSIZE_11BITS_gc = (0x05<<0),  /* 11-bit CNT. MAX=16'h07FF */
+    TCB_CNTSIZE_10BITS_gc = (0x06<<0),  /* 10-bit CNT. MAX=16'h03FF */
+    TCB_CNTSIZE_9BITS_gc = (0x07<<0)  /* 9-bit CNT. MAX=16'h01FF */
+} TCB_CNTSIZE_t;
+
+/* Event Generation select */
+typedef enum TCB_EVGEN_enum
+{
+    TCB_EVGEN_PULSE_gc = (0x00<<7),  /* Event is generated as pulse at compare match or capture */
+    TCB_EVGEN_WAVEFORM_gc = (0x01<<7)  /* Event is generated as waveform for modes with waveform */
+} TCB_EVGEN_t;
+
+/*
+--------------------------------------------------------------------------
+TCE - 16-bit Timer/Counter Type E
+--------------------------------------------------------------------------
+*/
+
+/* 16-bit Timer/Counter Type E */
+typedef struct TCE_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    register8_t CTRLD;  /* Control D */
+    register8_t CTRLECLR;  /* Control E Clear */
+    register8_t CTRLESET;  /* Control E Set */
+    register8_t CTRLFCLR;  /* Control F Clear */
+    register8_t CTRLFSET;  /* Control F Set */
+    register8_t EVGENCTRL;  /* Event Generation Control */
+    register8_t EVCTRL;  /* Event Control */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t reserved_1[2];
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t TEMP;  /* Temporary data for 16-bit Access */
+    register8_t reserved_2[16];
+    _WORDREGISTER(CNT);  /* Count */
+    _WORDREGISTER(AMP);  /* Amplitude */
+    _WORDREGISTER(OFFSET);  /* Offset */
+    _WORDREGISTER(PER);  /* Period */
+    _WORDREGISTER(CMP0);  /* Compare 0 */
+    _WORDREGISTER(CMP1);  /* Compare 1 */
+    _WORDREGISTER(CMP2);  /* Compare 2 */
+    _WORDREGISTER(CMP3);  /* Compare 3 */
+    register8_t reserved_3[6];
+    _WORDREGISTER(PERBUF);  /* Period Buffer */
+    _WORDREGISTER(CMP0BUF);  /* Compare 0 Buffer */
+    _WORDREGISTER(CMP1BUF);  /* Compare 1 Buffer */
+    _WORDREGISTER(CMP2BUF);  /* Compare 2 Buffer */
+    _WORDREGISTER(CMP3BUF);  /* Compare 3 Buffer */
+} TCE_t;
+
+/* Clock Selection */
+typedef enum TCE_CLKSEL_enum
+{
+    TCE_CLKSEL_DIV1_gc = (0x00<<1),  /* System Clock */
+    TCE_CLKSEL_DIV2_gc = (0x01<<1),  /* System Clock / 2 */
+    TCE_CLKSEL_DIV4_gc = (0x02<<1),  /* System Clock / 4 */
+    TCE_CLKSEL_DIV8_gc = (0x03<<1),  /* System Clock / 8 */
+    TCE_CLKSEL_DIV16_gc = (0x04<<1),  /* System Clock / 16 */
+    TCE_CLKSEL_DIV64_gc = (0x05<<1),  /* System Clock / 64 */
+    TCE_CLKSEL_DIV256_gc = (0x06<<1),  /* System Clock / 256 */
+    TCE_CLKSEL_DIV1024_gc = (0x07<<1)  /* System Clock / 1024 */
+} TCE_CLKSEL_t;
+
+/* Command select */
+typedef enum TCE_CMD_enum
+{
+    TCE_CMD_NONE_gc = (0x00<<2),  /* No Command */
+    TCE_CMD_UPDATE_gc = (0x01<<2),  /* Force Update */
+    TCE_CMD_RESTART_gc = (0x02<<2),  /* Force Restart */
+    TCE_CMD_RESET_gc = (0x03<<2)  /* Force Hard Reset */
+} TCE_CMD_t;
+
+/* Compare # Event select */
+typedef enum TCE_CMP0EV_enum
+{
+    TCE_CMP0EV_PULSE_gc = (0x00<<4),  /* Event output for CMP is a pulse */
+    TCE_CMP0EV_WAVEFORM_gc = (0x01<<4)  /* Event output for CMP is equal to waveform */
+} TCE_CMP0EV_t;
+
+/* Compare # Event select */
+typedef enum TCE_CMP1EV_enum
+{
+    TCE_CMP1EV_PULSE_gc = (0x00<<5),  /* Event output for CMP is a pulse */
+    TCE_CMP1EV_WAVEFORM_gc = (0x01<<5)  /* Event output for CMP is equal to waveform */
+} TCE_CMP1EV_t;
+
+/* Compare # Event select */
+typedef enum TCE_CMP2EV_enum
+{
+    TCE_CMP2EV_PULSE_gc = (0x00<<6),  /* Event output for CMP is a pulse */
+    TCE_CMP2EV_WAVEFORM_gc = (0x01<<6)  /* Event output for CMP is equal to waveform */
+} TCE_CMP2EV_t;
+
+/* Compare # Event select */
+typedef enum TCE_CMP3EV_enum
+{
+    TCE_CMP3EV_PULSE_gc = (0x00<<7),  /* Event output for CMP is a pulse */
+    TCE_CMP3EV_WAVEFORM_gc = (0x01<<7)  /* Event output for CMP is equal to waveform */
+} TCE_CMP3EV_t;
+
+/* Direction select */
+typedef enum TCE_DIR_enum
+{
+    TCE_DIR_UP_gc = (0x00<<0),  /* Count up */
+    TCE_DIR_DOWN_gc = (0x01<<0)  /* Count down */
+} TCE_DIR_t;
+
+/* Event Action A select */
+typedef enum TCE_EVACTA_enum
+{
+    TCE_EVACTA_CNT_POSEDGE_gc = (0x00<<1),  /* Count on positive edge event */
+    TCE_EVACTA_CNT_ANYEDGE_gc = (0x01<<1),  /* Count on any edge event */
+    TCE_EVACTA_CNT_HIGHLVL_gc = (0x02<<1),  /* Count on prescaled clock while event line is 1. */
+    TCE_EVACTA_UPDOWN_gc = (0x03<<1)  /* Count on prescaled clock. Event controls count direction. Up-count when event line is 0, down-count when event line is 1. */
+} TCE_EVACTA_t;
+
+/* Event Action B select */
+typedef enum TCE_EVACTB_enum
+{
+    TCE_EVACTB_NONE_gc = (0x00<<5),  /* No Action */
+    TCE_EVACTB_UPDOWN_gc = (0x03<<5),  /* Count on prescaled clock. Event controls count direction. Up-count when event line is 0, down-count when event line is 1. */
+    TCE_EVACTB_RESTART_POSEDGE_gc = (0x04<<5),  /* Restart counter at positive edge event */
+    TCE_EVACTB_RESTART_ANYEDGE_gc = (0x05<<5),  /* Restart counter on any edge event */
+    TCE_EVACTB_RESTART_HIGHLVL_gc = (0x06<<5)  /* Restart counter while event line is 1. */
+} TCE_EVACTB_t;
+
+/* High Resolution Enable select */
+typedef enum TCE_HREN_enum
+{
+    TCE_HREN_OFF_gc = (0x00<<6),  /* High Resolution Disable */
+    TCE_HREN_4X_gc = (0x01<<6),  /* Resolution increased by 4 (2 bits) */
+    TCE_HREN_8X_gc = (0x02<<6)  /* Resolution increased by 4 (3 bits) */
+} TCE_HREN_t;
+
+/* Scaled Write select */
+typedef enum TCE_SCALE_enum
+{
+    TCE_SCALE_NORMAL_gc = (0x00<<2),  /* Absolute values used when writing to CMPn, CMPnBUF and registers */
+    TCE_SCALE_FRACTIONAL_gc = (0x01<<2)  /* Fractional values used when writing to CMPn, CMPnBUF and registers */
+} TCE_SCALE_t;
+
+/* Scaling Mode select */
+typedef enum TCE_SCALEMODE_enum
+{
+    TCE_SCALEMODE_CENTER_gc = (0x00<<4),  /* CMPn registers scaled vs center (50% duty cycle) */
+    TCE_SCALEMODE_BOTTOM_gc = (0x01<<4),  /* CMPn registers scaled vs BOTTOM (0% duty cycle) */
+    TCE_SCALEMODE_TOP_gc = (0x02<<4),  /* CMPn registers scaled vs TOP (100% duty cycle) */
+    TCE_SCALEMODE_TOPBOTTOM_gc = (0x03<<4)  /* CMPn registers scaled vs TOP or BOTTOM depending on written value. */
+} TCE_SCALEMODE_t;
+
+/* Waveform generation mode select */
+typedef enum TCE_WGMODE_enum
+{
+    TCE_WGMODE_NORMAL_gc = (0x00<<0),  /* Normal Mode */
+    TCE_WGMODE_FRQ_gc = (0x01<<0),  /* Frequency Generation Mode */
+    TCE_WGMODE_SINGLESLOPE_gc = (0x03<<0),  /* Single Slope PWM */
+    TCE_WGMODE_DSTOP_gc = (0x05<<0),  /* Dual Slope PWM, overflow on TOP */
+    TCE_WGMODE_DSBOTH_gc = (0x06<<0),  /* Dual Slope PWM, overflow on TOP and BOTTOM */
+    TCE_WGMODE_DSBOTTOM_gc = (0x07<<0)  /* Dual Slope PWM, overflow on BOTTOM */
+} TCE_WGMODE_t;
+
+/*
+--------------------------------------------------------------------------
+TCF - 24-bit Timer/Counter for frequency generation
+--------------------------------------------------------------------------
+*/
+
+/* 24-bit Timer/Counter for frequency generation */
+typedef struct TCF_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    register8_t CTRLD;  /* Control D */
+    register8_t EVCTRL;  /* Event Control */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t STATUS;  /* Status */
+    register8_t reserved_1[5];
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t reserved_2[2];
+    _DWORDREGISTER(CNT);  /* Count */
+    _DWORDREGISTER(CMP);  /* Compare */
+    register8_t reserved_3[8];
+} TCF_t;
+
+/* Clock Select */
+typedef enum TCF_CLKSEL_enum
+{
+    TCF_CLKSEL_CLKPER_gc = (0x00<<3),  /* Peripheral Clock */
+    TCF_CLKSEL_EVENT_gc = (0x01<<3),  /* Event as clock source */
+    TCF_CLKSEL_OSCHF_gc = (0x02<<3),  /* Internal High Frequency Oscillator */
+    TCF_CLKSEL_OSC32K_gc = (0x03<<3),  /* Internal 32.768 kHz Oscillator */
+    TCF_CLKSEL_PLL_gc = (0x05<<3)  /* PLL */
+} TCF_CLKSEL_t;
+
+/* Command select */
+typedef enum TCF_CMD_enum
+{
+    TCF_CMD_NONE_gc = (0x00<<0),  /* No command */
+    TCF_CMD_UPDATE_gc = (0x01<<0),  /* Force update */
+    TCF_CMD_RESTART_gc = (0x02<<0)  /* Force restart */
+} TCF_CMD_t;
+
+/* Compare # Event Generation select */
+typedef enum TCF_CMP0EV_enum
+{
+    TCF_CMP0EV_PULSE_gc = (0x00<<6),  /* Event is generated as pulse */
+    TCF_CMP0EV_WAVEFORM_gc = (0x01<<6)  /* Waveform is used as event output */
+} TCF_CMP0EV_t;
+
+/* Compare # Event Generation select */
+typedef enum TCF_CMP1EV_enum
+{
+    TCF_CMP1EV_PULSE_gc = (0x00<<7),  /* Event is generated as pulse */
+    TCF_CMP1EV_WAVEFORM_gc = (0x01<<7)  /* Waveform is used as event output */
+} TCF_CMP1EV_t;
+
+/* Event Action A select */
+typedef enum TCF_EVACTA_enum
+{
+    TCF_EVACTA_RESTART_gc = (0x00<<1),  /* Restart Counter */
+    TCF_EVACTA_BLANK_gc = (0x01<<1)  /* Mask waveform output to '0' */
+} TCF_EVACTA_t;
+
+/* Clock Prescaler select */
+typedef enum TCF_PRESC_enum
+{
+    TCF_PRESC_DIV1_gc = (0x00<<1),  /* Runs directly on Clock Source */
+    TCF_PRESC_DIV2_gc = (0x01<<1),  /* Divide clock source by 2 */
+    TCF_PRESC_DIV4_gc = (0x02<<1),  /* Divide clock source by 4 */
+    TCF_PRESC_DIV8_gc = (0x03<<1),  /* Divide clock source by 8 */
+    TCF_PRESC_DIV16_gc = (0x04<<1),  /* Divide clock source by 16 */
+    TCF_PRESC_DIV32_gc = (0x05<<1),  /* Divide clock source by 32 */
+    TCF_PRESC_DIV64_gc = (0x06<<1),  /* Divide clock source by 64 */
+    TCF_PRESC_DIV128_gc = (0x07<<1)  /* Divide clock source by 128 */
+} TCF_PRESC_t;
+
+/* Waveform Generation Mode select */
+typedef enum TCF_WGMODE_enum
+{
+    TCF_WGMODE_FRQ_gc = (0x00<<0),  /* Frequency */
+    TCF_WGMODE_NCOPF_gc = (0x01<<0),  /* Numerically Controlled Oscillator Pulse-Frequency */
+    TCF_WGMODE_NCOFDC_gc = (0x02<<0),  /* Numerically Controlled Oscillator Fixed Duty Cycle */
+    TCF_WGMODE_PWM8_gc = (0x07<<0)  /* 8-bit PWM */
+} TCF_WGMODE_t;
+
+/* Waveform Generation Pulse Length select */
+typedef enum TCF_WGPULSE_enum
+{
+    TCF_WGPULSE_CLK1_gc = (0x00<<4),  /* High pulse duration is 1 clock period */
+    TCF_WGPULSE_CLK2_gc = (0x01<<4),  /* High pulse duration is 2 clock period */
+    TCF_WGPULSE_CLK4_gc = (0x02<<4),  /* High pulse duration is 4 clock period */
+    TCF_WGPULSE_CLK8_gc = (0x03<<4),  /* High pulse duration is 8 clock period */
+    TCF_WGPULSE_CLK16_gc = (0x04<<4),  /* High pulse duration is 16 clock period */
+    TCF_WGPULSE_CLK32_gc = (0x05<<4),  /* High pulse duration is 32 clock period */
+    TCF_WGPULSE_CLK64_gc = (0x06<<4),  /* High pulse duration is 64 clock period */
+    TCF_WGPULSE_CLK128_gc = (0x07<<4)  /* High pulse duration is 128 clock period */
+} TCF_WGPULSE_t;
+
+/* Waveform Output # Polarity select */
+typedef enum TCF_WO0POL_enum
+{
+    TCF_WO0POL_NORMAL_gc = (0x00<<2),  /* Waveform output set on update and cleared on match */
+    TCF_WO0POL_INVERSE_gc = (0x01<<2)  /* Waveform output cleared on update and set on match */
+} TCF_WO0POL_t;
+
+/* Waveform Output # Polarity select */
+typedef enum TCF_WO1POL_enum
+{
+    TCF_WO1POL_NORMAL_gc = (0x00<<3),  /* Waveform output set on update and cleared on match */
+    TCF_WO1POL_INVERSE_gc = (0x01<<3)  /* Waveform output cleared on update and set on match */
+} TCF_WO1POL_t;
+
+/*
+--------------------------------------------------------------------------
+TWI - Two-Wire Interface
+--------------------------------------------------------------------------
+*/
+
+/* Two-Wire Interface */
+typedef struct TWI_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t DUALCTRL;  /* Dual Mode Control */
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t MCTRLA;  /* Host Control A */
+    register8_t MCTRLB;  /* Host Control B */
+    register8_t MSTATUS;  /* Host STATUS */
+    register8_t MBAUD;  /* Host Baud Rate */
+    register8_t MADDR;  /* Host Address */
+    register8_t MDATA;  /* Host Data */
+    register8_t SCTRLA;  /* Client Control A */
+    register8_t SCTRLB;  /* Client Control B */
+    register8_t SSTATUS;  /* Client Status */
+    register8_t SADDR;  /* Client Address */
+    register8_t SDATA;  /* Client Data */
+    register8_t SADDRMASK;  /* Client Address Mask */
+    register8_t reserved_1[1];
+} TWI_t;
+
+/* Acknowledge Action select */
+typedef enum TWI_ACKACT_enum
+{
+    TWI_ACKACT_ACK_gc = (0x00<<2),  /* Send ACK */
+    TWI_ACKACT_NACK_gc = (0x01<<2)  /* Send NACK */
+} TWI_ACKACT_t;
+
+/* Address or Stop select */
+typedef enum TWI_AP_enum
+{
+    TWI_AP_STOP_gc = (0x00<<0),  /* A Stop condition generated the interrupt on APIF flag */
+    TWI_AP_ADR_gc = (0x01<<0)  /* Address detection generated the interrupt on APIF flag */
+} TWI_AP_t;
+
+/* Bus State select */
+typedef enum TWI_BUSSTATE_enum
+{
+    TWI_BUSSTATE_UNKNOWN_gc = (0x00<<0),  /* Unknown bus state */
+    TWI_BUSSTATE_IDLE_gc = (0x01<<0),  /* Bus is idle */
+    TWI_BUSSTATE_OWNER_gc = (0x02<<0),  /* This TWI controls the bus */
+    TWI_BUSSTATE_BUSY_gc = (0x03<<0)  /* The bus is busy */
+} TWI_BUSSTATE_t;
+
+/* Debug Run select */
+typedef enum TWI_DBGRUN_enum
+{
+    TWI_DBGRUN_HALT_gc = (0x00<<0),  /* The peripheral is halted in Break Debug mode and ignores events */
+    TWI_DBGRUN_RUN_gc = (0x01<<0)  /* The peripheral will continue to run in Break Debug mode when the CPU is halted */
+} TWI_DBGRUN_t;
+
+/* Fast-mode Enable select */
+typedef enum TWI_FMEN_enum
+{
+    TWI_FMEN_OFF_gc = (0x00<<0),  /* SCL duty cycle operating according to Sm specification */
+    TWI_FMEN_ON_gc = (0x01<<0)  /* SCL duty cycle operating according to Fm specification */
+} TWI_FMEN_t;
+
+/* Fast-mode Plus Enable select */
+typedef enum TWI_FMPEN_enum
+{
+    TWI_FMPEN_OFF_gc = (0x00<<1),  /* Operating in Standard-mode or Fast-mode */
+    TWI_FMPEN_ON_gc = (0x01<<1)  /* Operating in Fast-mode Plus */
+} TWI_FMPEN_t;
+
+/* Input voltage transition level select */
+typedef enum TWI_INPUTLVL_enum
+{
+    TWI_INPUTLVL_I2C_gc = (0x00<<6),  /* I2C input voltage transition level */
+    TWI_INPUTLVL_SMBUS_gc = (0x01<<6)  /* SMBus 3.0 input voltage transition level */
+} TWI_INPUTLVL_t;
+
+/* Command select */
+typedef enum TWI_MCMD_enum
+{
+    TWI_MCMD_NOACT_gc = (0x00<<0),  /* No action */
+    TWI_MCMD_REPSTART_gc = (0x01<<0),  /* Execute Acknowledge Action followed by repeated Start. */
+    TWI_MCMD_RECVTRANS_gc = (0x02<<0),  /* Execute Acknowledge Action followed by a byte read/write operation. Read/write is defined by DIR. */
+    TWI_MCMD_STOP_gc = (0x03<<0)  /* Execute Acknowledge Action followed by issuing a Stop condition. */
+} TWI_MCMD_t;
+
+/* Command select */
+typedef enum TWI_SCMD_enum
+{
+    TWI_SCMD_NOACT_gc = (0x00<<0),  /* No Action */
+    TWI_SCMD_COMPTRANS_gc = (0x02<<0),  /* Complete transaction */
+    TWI_SCMD_RESPONSE_gc = (0x03<<0)  /* Used in response to an interrupt */
+} TWI_SCMD_t;
+
+/* SDA Hold Time select */
+typedef enum TWI_SDAHOLD_enum
+{
+    TWI_SDAHOLD_OFF_gc = (0x00<<2),  /* No SDA Hold Delay */
+    TWI_SDAHOLD_50NS_gc = (0x01<<2),  /* Short SDA hold time */
+    TWI_SDAHOLD_300NS_gc = (0x02<<2),  /* Meets SMBUS 2.0 specification under typical conditions */
+    TWI_SDAHOLD_500NS_gc = (0x03<<2)  /* Meets SMBUS 2.0 specificaiton across all corners */
+} TWI_SDAHOLD_t;
+
+/* SDA Setup Time select */
+typedef enum TWI_SDASETUP_enum
+{
+    TWI_SDASETUP_4CYC_gc = (0x00<<4),  /* SDA setup time is four clock cycles */
+    TWI_SDASETUP_8CYC_gc = (0x01<<4)  /* SDA setup time is eight clock cycle */
+} TWI_SDASETUP_t;
+
+/* Inactive Bus Time-Out select */
+typedef enum TWI_TIMEOUT_enum
+{
+    TWI_TIMEOUT_DISABLED_gc = (0x00<<2),  /* Bus time-out disabled. I2C. */
+    TWI_TIMEOUT_50US_gc = (0x01<<2),  /* 50us - SMBus */
+    TWI_TIMEOUT_100US_gc = (0x02<<2),  /* 100us */
+    TWI_TIMEOUT_200US_gc = (0x03<<2)  /* 200us */
+} TWI_TIMEOUT_t;
+
+/*
+--------------------------------------------------------------------------
+USART - Universal Synchronous and Asynchronous Receiver and Transmitter
+--------------------------------------------------------------------------
+*/
+
+/* Universal Synchronous and Asynchronous Receiver and Transmitter */
+typedef struct USART_struct
+{
+    register8_t RXDATAL;  /* Receive Data Low Byte */
+    register8_t RXDATAH;  /* Receive Data High Byte */
+    register8_t TXDATAL;  /* Transmit Data Low Byte */
+    register8_t TXDATAH;  /* Transmit Data High Byte */
+    register8_t STATUS;  /* Status */
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    _WORDREGISTER(BAUD);  /* Baud Rate */
+    register8_t CTRLD;  /* Control D */
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t EVCTRL;  /* Event Control */
+    register8_t TXPLCTRL;  /* IRCOM Transmitter Pulse Length Control */
+    register8_t RXPLCTRL;  /* IRCOM Receiver Pulse Length Control */
+    register8_t reserved_1[1];
+} USART_t;
+
+/* Auto Baud Window select */
+typedef enum USART_ABW_enum
+{
+    USART_ABW_WDW0_gc = (0x00<<6),  /* 18% tolerance */
+    USART_ABW_WDW1_gc = (0x01<<6),  /* 15% tolerance */
+    USART_ABW_WDW2_gc = (0x02<<6),  /* 21% tolerance */
+    USART_ABW_WDW3_gc = (0x03<<6)  /* 25% tolerance */
+} USART_ABW_t;
+
+/* Character Size select */
+typedef enum USART_CHSIZE_enum
+{
+    USART_CHSIZE_5BIT_gc = (0x00<<0),  /* Character size: 5 bit */
+    USART_CHSIZE_6BIT_gc = (0x01<<0),  /* Character size: 6 bit */
+    USART_CHSIZE_7BIT_gc = (0x02<<0),  /* Character size: 7 bit */
+    USART_CHSIZE_8BIT_gc = (0x03<<0),  /* Character size: 8 bit */
+    USART_CHSIZE_9BITL_gc = (0x06<<0),  /* Character size: 9 bit read low byte first */
+    USART_CHSIZE_9BITH_gc = (0x07<<0)  /* Character size: 9 bit read high byte first */
+} USART_CHSIZE_t;
+
+/* Communication Mode select */
+typedef enum USART_CMODE_enum
+{
+    USART_CMODE_ASYNCHRONOUS_gc = (0x00<<6),  /* Asynchronous Mode */
+    USART_CMODE_SYNCHRONOUS_gc = (0x01<<6),  /* Synchronous Mode */
+    USART_CMODE_IRCOM_gc = (0x02<<6),  /* Infrared Communication */
+    USART_CMODE_MSPI_gc = (0x03<<6)  /* SPI Host Mode */
+} USART_CMODE_t;
+
+/* Parity Mode select */
+typedef enum USART_PMODE_enum
+{
+    USART_PMODE_DISABLED_gc = (0x00<<4),  /* No Parity */
+    USART_PMODE_EVEN_gc = (0x02<<4),  /* Even Parity */
+    USART_PMODE_ODD_gc = (0x03<<4)  /* Odd Parity */
+} USART_PMODE_t;
+
+/* RS485 Mode internal transmitter select */
+typedef enum USART_RS485_enum
+{
+    USART_RS485_DISABLE_gc = (0x00<<0),  /* RS485 Mode disabled */
+    USART_RS485_ENABLE_gc = (0x01<<0)  /* RS485 Mode enabled */
+} USART_RS485_t;
+
+/* Receiver Mode select */
+typedef enum USART_RXMODE_enum
+{
+    USART_RXMODE_NORMAL_gc = (0x00<<1),  /* Normal mode */
+    USART_RXMODE_CLK2X_gc = (0x01<<1),  /* CLK2x mode */
+    USART_RXMODE_GENAUTO_gc = (0x02<<1),  /* Generic autobaud mode */
+    USART_RXMODE_LINAUTO_gc = (0x03<<1)  /* LIN constrained autobaud mode */
+} USART_RXMODE_t;
+
+/* Stop Bit Mode select */
+typedef enum USART_SBMODE_enum
+{
+    USART_SBMODE_1BIT_gc = (0x00<<3),  /* 1 stop bit */
+    USART_SBMODE_2BIT_gc = (0x01<<3)  /* 2 stop bits */
+} USART_SBMODE_t;
+
+/*
+--------------------------------------------------------------------------
+USERROW - User Row
+--------------------------------------------------------------------------
+*/
+
+/* User Row */
+typedef struct USERROW_struct
+{
+    register8_t USERROW0;  /* User Row Byte 0 */
+    register8_t USERROW1;  /* User Row Byte 1 */
+    register8_t USERROW2;  /* User Row Byte 2 */
+    register8_t USERROW3;  /* User Row Byte 3 */
+    register8_t USERROW4;  /* User Row Byte 4 */
+    register8_t USERROW5;  /* User Row Byte 5 */
+    register8_t USERROW6;  /* User Row Byte 6 */
+    register8_t USERROW7;  /* User Row Byte 7 */
+    register8_t USERROW8;  /* User Row Byte 8 */
+    register8_t USERROW9;  /* User Row Byte 9 */
+    register8_t USERROW10;  /* User Row Byte 10 */
+    register8_t USERROW11;  /* User Row Byte 11 */
+    register8_t USERROW12;  /* User Row Byte 12 */
+    register8_t USERROW13;  /* User Row Byte 13 */
+    register8_t USERROW14;  /* User Row Byte 14 */
+    register8_t USERROW15;  /* User Row Byte 15 */
+    register8_t USERROW16;  /* User Row Byte 16 */
+    register8_t USERROW17;  /* User Row Byte 17 */
+    register8_t USERROW18;  /* User Row Byte 18 */
+    register8_t USERROW19;  /* User Row Byte 19 */
+    register8_t USERROW20;  /* User Row Byte 20 */
+    register8_t USERROW21;  /* User Row Byte 21 */
+    register8_t USERROW22;  /* User Row Byte 22 */
+    register8_t USERROW23;  /* User Row Byte 23 */
+    register8_t USERROW24;  /* User Row Byte 24 */
+    register8_t USERROW25;  /* User Row Byte 25 */
+    register8_t USERROW26;  /* User Row Byte 26 */
+    register8_t USERROW27;  /* User Row Byte 27 */
+    register8_t USERROW28;  /* User Row Byte 28 */
+    register8_t USERROW29;  /* User Row Byte 29 */
+    register8_t USERROW30;  /* User Row Byte 30 */
+    register8_t USERROW31;  /* User Row Byte 31 */
+    register8_t USERROW32;  /* User Row Byte 32 */
+    register8_t USERROW33;  /* User Row Byte 33 */
+    register8_t USERROW34;  /* User Row Byte 34 */
+    register8_t USERROW35;  /* User Row Byte 35 */
+    register8_t USERROW36;  /* User Row Byte 36 */
+    register8_t USERROW37;  /* User Row Byte 37 */
+    register8_t USERROW38;  /* User Row Byte 38 */
+    register8_t USERROW39;  /* User Row Byte 39 */
+    register8_t USERROW40;  /* User Row Byte 40 */
+    register8_t USERROW41;  /* User Row Byte 41 */
+    register8_t USERROW42;  /* User Row Byte 42 */
+    register8_t USERROW43;  /* User Row Byte 43 */
+    register8_t USERROW44;  /* User Row Byte 44 */
+    register8_t USERROW45;  /* User Row Byte 45 */
+    register8_t USERROW46;  /* User Row Byte 46 */
+    register8_t USERROW47;  /* User Row Byte 47 */
+    register8_t USERROW48;  /* User Row Byte 48 */
+    register8_t USERROW49;  /* User Row Byte 49 */
+    register8_t USERROW50;  /* User Row Byte 50 */
+    register8_t USERROW51;  /* User Row Byte 51 */
+    register8_t USERROW52;  /* User Row Byte 52 */
+    register8_t USERROW53;  /* User Row Byte 53 */
+    register8_t USERROW54;  /* User Row Byte 54 */
+    register8_t USERROW55;  /* User Row Byte 55 */
+    register8_t USERROW56;  /* User Row Byte 56 */
+    register8_t USERROW57;  /* User Row Byte 57 */
+    register8_t USERROW58;  /* User Row Byte 58 */
+    register8_t USERROW59;  /* User Row Byte 59 */
+    register8_t USERROW60;  /* User Row Byte 60 */
+    register8_t USERROW61;  /* User Row Byte 61 */
+    register8_t USERROW62;  /* User Row Byte 62 */
+    register8_t USERROW63;  /* User Row Byte 63 */
+} USERROW_t;
+
+
+/*
+--------------------------------------------------------------------------
+VPORT - Virtual Ports
+--------------------------------------------------------------------------
+*/
+
+/* Virtual Ports */
+typedef struct VPORT_struct
+{
+    register8_t DIR;  /* Data Direction */
+    register8_t OUT;  /* Output Value */
+    register8_t IN;  /* Input Value */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+} VPORT_t;
+
+
+/*
+--------------------------------------------------------------------------
+VREF - Voltage reference
+--------------------------------------------------------------------------
+*/
+
+/* Voltage reference */
+typedef struct VREF_struct
+{
+    register8_t reserved_1[2];
+    register8_t DAC0REF;  /* DAC0 Reference */
+    register8_t reserved_2[1];
+    register8_t ACREF;  /* AC Reference */
+    register8_t reserved_3[11];
+} VREF_t;
+
+/* Reference select */
+typedef enum VREF_REFSEL_enum
+{
+    VREF_REFSEL_1V024_gc = (0x00<<0),  /* Internal 1.024V reference */
+    VREF_REFSEL_2V048_gc = (0x01<<0),  /* Internal 2.048V reference */
+    VREF_REFSEL_4V096_gc = (0x02<<0),  /* Internal 4.096V reference */
+    VREF_REFSEL_2V500_gc = (0x03<<0),  /* Internal 2.500V reference */
+    VREF_REFSEL_VDD_gc = (0x05<<0),  /* VDD as reference */
+    VREF_REFSEL_VREFA_gc = (0x06<<0)  /* External reference on VREFA pin */
+} VREF_REFSEL_t;
+
+/*
+--------------------------------------------------------------------------
+WDT - Watch-Dog Timer
+--------------------------------------------------------------------------
+*/
+
+/* Watch-Dog Timer */
+typedef struct WDT_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t STATUS;  /* Status */
+    register8_t reserved_1[14];
+} WDT_t;
+
+/* Period select */
+typedef enum WDT_PERIOD_enum
+{
+    WDT_PERIOD_OFF_gc = (0x00<<0),  /* Off */
+    WDT_PERIOD_8CLK_gc = (0x01<<0),  /* 8 cycles (8ms) */
+    WDT_PERIOD_16CLK_gc = (0x02<<0),  /* 16 cycles (16ms) */
+    WDT_PERIOD_32CLK_gc = (0x03<<0),  /* 32 cycles (32ms) */
+    WDT_PERIOD_64CLK_gc = (0x04<<0),  /* 64 cycles (64ms) */
+    WDT_PERIOD_128CLK_gc = (0x05<<0),  /* 128 cycles (0.128s) */
+    WDT_PERIOD_256CLK_gc = (0x06<<0),  /* 256 cycles (0.256s) */
+    WDT_PERIOD_512CLK_gc = (0x07<<0),  /* 512 cycles (0.512s) */
+    WDT_PERIOD_1KCLK_gc = (0x08<<0),  /* 1K cycles (1.0s) */
+    WDT_PERIOD_2KCLK_gc = (0x09<<0),  /* 2K cycles (2.0s) */
+    WDT_PERIOD_4KCLK_gc = (0x0A<<0),  /* 4K cycles (4.1s) */
+    WDT_PERIOD_8KCLK_gc = (0x0B<<0)  /* 8K cycles (8.2s) */
+} WDT_PERIOD_t;
+
+/* Window select */
+typedef enum WDT_WINDOW_enum
+{
+    WDT_WINDOW_OFF_gc = (0x00<<4),  /* Off */
+    WDT_WINDOW_8CLK_gc = (0x01<<4),  /* 8 cycles (8ms) */
+    WDT_WINDOW_16CLK_gc = (0x02<<4),  /* 16 cycles (16ms) */
+    WDT_WINDOW_32CLK_gc = (0x03<<4),  /* 32 cycles (32ms) */
+    WDT_WINDOW_64CLK_gc = (0x04<<4),  /* 64 cycles (64ms) */
+    WDT_WINDOW_128CLK_gc = (0x05<<4),  /* 128 cycles (0.128s) */
+    WDT_WINDOW_256CLK_gc = (0x06<<4),  /* 256 cycles (0.256s) */
+    WDT_WINDOW_512CLK_gc = (0x07<<4),  /* 512 cycles (0.512s) */
+    WDT_WINDOW_1KCLK_gc = (0x08<<4),  /* 1K cycles (1.0s) */
+    WDT_WINDOW_2KCLK_gc = (0x09<<4),  /* 2K cycles (2.0s) */
+    WDT_WINDOW_4KCLK_gc = (0x0A<<4),  /* 4K cycles (4.1s) */
+    WDT_WINDOW_8KCLK_gc = (0x0B<<4)  /* 8K cycles (8.2s) */
+} WDT_WINDOW_t;
+
+/*
+--------------------------------------------------------------------------
+WEX - Waveform Extension
+--------------------------------------------------------------------------
+*/
+
+/* Waveform Extension */
+typedef struct WEX_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    register8_t reserved_1[1];
+    register8_t EVCTRLA;  /* Event Control A */
+    register8_t EVCTRLB;  /* Event Control B */
+    register8_t EVCTRLC;  /* Event Control C */
+    register8_t BUFCTRL;  /* Buffer Valid Control */
+    register8_t BLANKCTRL;  /* Blanking Control */
+    register8_t BLANKTIME;  /* Blanking Time */
+    register8_t FAULTCTRL;  /* Fault Control */
+    register8_t FAULTDRV;  /* Fault Drive */
+    register8_t FAULTOUT;  /* Fault Output */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t STATUS;  /* Status */
+    register8_t DTLS;  /* Dead-time Low Side */
+    register8_t DTHS;  /* Dead-time High Side */
+    register8_t DTBOTH;  /* Dead-time Both Sides */
+    register8_t SWAP;  /* DTI Swap */
+    register8_t PGMOVR;  /* Pattern Generation Override */
+    register8_t PGMOUT;  /* Pattern Generation Output */
+    register8_t reserved_2[1];
+    register8_t OUTOVEN;  /* Output Override Enable */
+    register8_t DTLSBUF;  /* Dead-time Low Side Buffer */
+    register8_t DTHSBUF;  /* Dead-time High Side Buffer */
+    register8_t DTBOTHBUF;  /* Dead-time Both Sides Buffer */
+    register8_t SWAPBUF;  /* DTI Swap Buffer */
+    register8_t PGMOVRBUF;  /* Pattern Generation Override Buffer */
+    register8_t PGMOUTBUF;  /* Pattern Generation Output Buffer */
+    register8_t reserved_3[2];
+} WEX_t;
+
+/* Blanking Prescaler select */
+typedef enum WEX_BLANKPRESC_enum
+{
+    WEX_BLANKPRESC_DIV1_gc = (0x00<<5),  /* No prescaling */
+    WEX_BLANKPRESC_DIV4_gc = (0x01<<5),  /* Divide CLK_PER by 4 */
+    WEX_BLANKPRESC_DIV16_gc = (0x02<<5),  /* Divide CLK_PER by 16 */
+    WEX_BLANKPRESC_DIV64_gc = (0x03<<5)  /* Divide CLK_PER by 64 */
+} WEX_BLANKPRESC_t;
+
+/* Blanking State select */
+typedef enum WEX_BLANKSTATE_enum
+{
+    WEX_BLANKSTATE_OFF_gc = (0x00<<7),  /* Blanking off */
+    WEX_BLANKSTATE_ON_gc = (0x01<<7)  /* Blanking active */
+} WEX_BLANKSTATE_t;
+
+/* Blanking Trigger select */
+typedef enum WEX_BLANKTRIG_enum
+{
+    WEX_BLANKTRIG_NONE_gc = (0x00<<0),  /* No HW trigger (Software only) */
+    WEX_BLANKTRIG_TCE0UPD_gc = (0x04<<0),  /* TCE0 Update Condition */
+    WEX_BLANKTRIG_TCE0CMP0_gc = (0x08<<0),  /* TCE0 Compare 0 */
+    WEX_BLANKTRIG_TCE0CMP1_gc = (0x0C<<0),  /* TCE0 Compare 1 */
+    WEX_BLANKTRIG_TCE0CMP2_gc = (0x10<<0),  /* TCE0 Compare 2 */
+    WEX_BLANKTRIG_TCE0CMP3_gc = (0x14<<0)  /* TCE0 Compare 3 */
+} WEX_BLANKTRIG_t;
+
+/* Command select */
+typedef enum WEX_CMD_enum
+{
+    WEX_CMD_NONE_gc = (0x00<<0),  /* No Command */
+    WEX_CMD_UPDATE_gc = (0x01<<0),  /* Force update of Dead-time, SWAP and PGM buffer registers. */
+    WEX_CMD_FAULTSET_gc = (0x02<<0),  /* Set Fault Detection */
+    WEX_CMD_FAULTCLR_gc = (0x03<<0),  /* Clear Fault Detection */
+    WEX_CMD_BLANKSET_gc = (0x04<<0),  /* Set SW Blanking */
+    WEX_CMD_BLANKCLR_gc = (0x05<<0)  /* Clear SW Blanking */
+} WEX_CMD_t;
+
+/* Fault Detection Action select */
+typedef enum WEX_FDACT_enum
+{
+    WEX_FDACT_NONE_gc = (0x00<<0),  /* None. Fault Protection Disabled */
+    WEX_FDACT_LOW_gc = (0x01<<0),  /* Drive all pins low */
+    WEX_FDACT_CUSTOM_gc = (0x03<<0)  /* Drive all pins to setting defined by FAULTDRV and FAULTVAL */
+} WEX_FDACT_t;
+
+/* Fault Detection on Debug Break Detection select */
+typedef enum WEX_FDDBD_enum
+{
+    WEX_FDDBD_FAULT_gc = (0x00<<7),  /* OCD Break request is treated as a fault if fault protection is enabled */
+    WEX_FDDBD_IGNORE_gc = (0x01<<7)  /* OCD Breask request will not trigger a fault */
+} WEX_FDDBD_t;
+
+/* Fault Detection Restart Mode select */
+typedef enum WEX_FDMODE_enum
+{
+    WEX_FDMODE_LATCHED_gc = (0x00<<2),  /* Latched Mode. Output will remain in fault state until fault condition is no longer active and FDF is cleared by SW. */
+    WEX_FDMODE_CBC_gc = (0x01<<2)  /* Cycle-by-cycle mode. Waveform output will remain in fault state until fault condition is no longer active. */
+} WEX_FDMODE_t;
+
+/* Fault Detection State select */
+typedef enum WEX_FDSTATE_enum
+{
+    WEX_FDSTATE_NORMAL_gc = (0x00<<0),  /* Normal state */
+    WEX_FDSTATE_FAULT_gc = (0x01<<0)  /* Fault state */
+} WEX_FDSTATE_t;
+
+/* Fault Event Filter Enable select */
+typedef enum WEX_FILTER_enum
+{
+    WEX_FILTER_ZERO_gc = (0x00<<2),  /* No digital filter */
+    WEX_FILTER_SAMPLE1_gc = (0x01<<2),  /* One Sample */
+    WEX_FILTER_SAMPLE2_gc = (0x02<<2),  /* Two Samples */
+    WEX_FILTER_SAMPLE3_gc = (0x03<<2),  /* Three Samples */
+    WEX_FILTER_SAMPLE4_gc = (0x04<<2),  /* Four Samples */
+    WEX_FILTER_SAMPLE5_gc = (0x05<<2),  /* Five Samples */
+    WEX_FILTER_SAMPLE6_gc = (0x06<<2),  /* Six Samples */
+    WEX_FILTER_SAMPLE7_gc = (0x07<<2)  /* Seven Samples */
+} WEX_FILTER_t;
+
+/* Input Matrix select */
+typedef enum WEX_INMX_enum
+{
+    WEX_INMX_DIRECT_gc = (0x00<<4),  /* Direct from TCE0 */
+    WEX_INMX_CWCMA_gc = (0x02<<4),  /* Common Waveform Channel Mode A. Single WO */
+    WEX_INMX_CWCMB_gc = (0x03<<4)  /* Common Waveform Channel Mode B. WO from two PWM channels */
+} WEX_INMX_t;
+
+/* Update Source select */
+typedef enum WEX_UPDSRC_enum
+{
+    WEX_UPDSRC_TCPWM0_gc = (0x00<<0),  /* Timer/Counter for PWM 0 update condition */
+    WEX_UPDSRC_SW_gc = (0x03<<0)  /* Software update only. No hardware update condition */
+} WEX_UPDSRC_t;
+/*
+==========================================================================
+IO Module Instances. Mapped to memory.
+==========================================================================
+*/
+
+#define VPORTA              (*(VPORT_t *) 0x0000) /* Virtual Ports */
+#define VPORTC              (*(VPORT_t *) 0x0008) /* Virtual Ports */
+#define VPORTD              (*(VPORT_t *) 0x000C) /* Virtual Ports */
+#define VPORTF              (*(VPORT_t *) 0x0014) /* Virtual Ports */
+#define GPR                   (*(GPR_t *) 0x001C) /* General Purpose Registers */
+#define RSTCTRL           (*(RSTCTRL_t *) 0x0040) /* Reset controller */
+#define SLPCTRL           (*(SLPCTRL_t *) 0x0050) /* Sleep Controller */
+#define CLKCTRL           (*(CLKCTRL_t *) 0x0060) /* Clock controller */
+#define BOD                   (*(BOD_t *) 0x00A0) /* Bod interface */
+#define VREF                 (*(VREF_t *) 0x00B0) /* Voltage reference */
+#define WDT                   (*(WDT_t *) 0x0100) /* Watch-Dog Timer */
+#define CPUINT             (*(CPUINT_t *) 0x0110) /* Interrupt Controller */
+#define CRCSCAN           (*(CRCSCAN_t *) 0x0120) /* CRCSCAN */
+#define RTC                   (*(RTC_t *) 0x0140) /* Real-Time Counter */
+#define CCL                   (*(CCL_t *) 0x01C0) /* Configurable Custom Logic */
+#define EVSYS               (*(EVSYS_t *) 0x0200) /* Event System */
+#define PORTA                (*(PORT_t *) 0x0400) /* I/O Ports */
+#define PORTC                (*(PORT_t *) 0x0440) /* I/O Ports */
+#define PORTD                (*(PORT_t *) 0x0460) /* I/O Ports */
+#define PORTF                (*(PORT_t *) 0x04A0) /* I/O Ports */
+#define PORTMUX           (*(PORTMUX_t *) 0x05E0) /* Port Multiplexer */
+#define ADC0                  (*(ADC_t *) 0x0600) /* Analog to Digital Converter */
+#define AC0                    (*(AC_t *) 0x0680) /* Analog Comparator */
+#define AC1                    (*(AC_t *) 0x0688) /* Analog Comparator */
+#define USART0              (*(USART_t *) 0x0800) /* Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define TWI0                  (*(TWI_t *) 0x0900) /* Two-Wire Interface */
+#define SPI0                  (*(SPI_t *) 0x0940) /* Serial Peripheral Interface */
+#define TCE0                  (*(TCE_t *) 0x0A00) /* 16-bit Timer/Counter Type E */
+#define TCB0                  (*(TCB_t *) 0x0B00) /* 16-bit Timer/Counter Type B */
+#define TCB1                  (*(TCB_t *) 0x0B10) /* 16-bit Timer/Counter Type B */
+#define TCF0                  (*(TCF_t *) 0x0C00) /* 24-bit Timer/Counter for frequency generation */
+#define WEX0                  (*(WEX_t *) 0x0C80) /* Waveform Extension */
+#define SYSCFG             (*(SYSCFG_t *) 0x0F00) /* System Configuration Registers */
+#define NVMCTRL           (*(NVMCTRL_t *) 0x1000) /* Non-volatile Memory Controller */
+#define LOCK                 (*(LOCK_t *) 0x1040) /* Lockbits */
+#define FUSE                 (*(FUSE_t *) 0x1050) /* Fuses */
+#define SIGROW             (*(SIGROW_t *) 0x1080) /* Signature row */
+#define BOOTROW           (*(BOOTROW_t *) 0x1100) /* Boot Row */
+#define USERROW           (*(USERROW_t *) 0x1200) /* User Row */
+
+#endif /* !defined (__ASSEMBLER__) */
+
+
+/* ========== Flattened fully qualified IO register names ========== */
+
+
+/* VPORT (VPORTA) - Virtual Ports */
+#define VPORTA_DIR  _SFR_MEM8(0x0000)
+#define VPORTA_OUT  _SFR_MEM8(0x0001)
+#define VPORTA_IN  _SFR_MEM8(0x0002)
+#define VPORTA_INTFLAGS  _SFR_MEM8(0x0003)
+
+
+/* VPORT (VPORTC) - Virtual Ports */
+#define VPORTC_DIR  _SFR_MEM8(0x0008)
+#define VPORTC_OUT  _SFR_MEM8(0x0009)
+#define VPORTC_IN  _SFR_MEM8(0x000A)
+#define VPORTC_INTFLAGS  _SFR_MEM8(0x000B)
+
+
+/* VPORT (VPORTD) - Virtual Ports */
+#define VPORTD_DIR  _SFR_MEM8(0x000C)
+#define VPORTD_OUT  _SFR_MEM8(0x000D)
+#define VPORTD_IN  _SFR_MEM8(0x000E)
+#define VPORTD_INTFLAGS  _SFR_MEM8(0x000F)
+
+
+/* VPORT (VPORTF) - Virtual Ports */
+#define VPORTF_DIR  _SFR_MEM8(0x0014)
+#define VPORTF_OUT  _SFR_MEM8(0x0015)
+#define VPORTF_IN  _SFR_MEM8(0x0016)
+#define VPORTF_INTFLAGS  _SFR_MEM8(0x0017)
+
+
+/* GPR - General Purpose Registers */
+#define GPR_GPR0  _SFR_MEM8(0x001C)
+#define GPR_GPR1  _SFR_MEM8(0x001D)
+#define GPR_GPR2  _SFR_MEM8(0x001E)
+#define GPR_GPR3  _SFR_MEM8(0x001F)
+
+
+/* CPU - CPU */
+#define CPU_CCP  _SFR_MEM8(0x0034)
+#define CPU_RAMPZ  _SFR_MEM8(0x003B)
+#define CPU_SP  _SFR_MEM16(0x003D)
+#define CPU_SPL  _SFR_MEM8(0x003D)
+#define CPU_SPH  _SFR_MEM8(0x003E)
+#define CPU_SREG  _SFR_MEM8(0x003F)
+
+
+/* RSTCTRL - Reset controller */
+#define RSTCTRL_RSTFR  _SFR_MEM8(0x0040)
+#define RSTCTRL_SWRR  _SFR_MEM8(0x0041)
+
+
+/* SLPCTRL - Sleep Controller */
+#define SLPCTRL_CTRLA  _SFR_MEM8(0x0050)
+
+
+/* CLKCTRL - Clock controller */
+#define CLKCTRL_MCLKCTRLA  _SFR_MEM8(0x0060)
+#define CLKCTRL_MCLKCTRLB  _SFR_MEM8(0x0061)
+#define CLKCTRL_MCLKSTATUS  _SFR_MEM8(0x0065)
+#define CLKCTRL_MCLKTIMEBASE  _SFR_MEM8(0x0066)
+#define CLKCTRL_OSCHFCTRLA  _SFR_MEM8(0x0068)
+#define CLKCTRL_OSCHFTUNE  _SFR_MEM8(0x0069)
+#define CLKCTRL_PLLCTRLA  _SFR_MEM8(0x0070)
+#define CLKCTRL_PLLCTRLB  _SFR_MEM8(0x0071)
+#define CLKCTRL_OSC32KCTRLA  _SFR_MEM8(0x0078)
+#define CLKCTRL_XOSC32KCTRLA  _SFR_MEM8(0x007C)
+
+
+/* BOD - Bod interface */
+#define BOD_CTRLA  _SFR_MEM8(0x00A0)
+#define BOD_CTRLB  _SFR_MEM8(0x00A1)
+#define BOD_VLMCTRLA  _SFR_MEM8(0x00A8)
+#define BOD_INTCTRL  _SFR_MEM8(0x00A9)
+#define BOD_INTFLAGS  _SFR_MEM8(0x00AA)
+#define BOD_STATUS  _SFR_MEM8(0x00AB)
+
+
+/* VREF - Voltage reference */
+#define VREF_DAC0REF  _SFR_MEM8(0x00B2)
+#define VREF_ACREF  _SFR_MEM8(0x00B4)
+
+
+/* WDT - Watch-Dog Timer */
+#define WDT_CTRLA  _SFR_MEM8(0x0100)
+#define WDT_STATUS  _SFR_MEM8(0x0101)
+
+
+/* CPUINT - Interrupt Controller */
+#define CPUINT_CTRLA  _SFR_MEM8(0x0110)
+#define CPUINT_STATUS  _SFR_MEM8(0x0111)
+#define CPUINT_LVL0PRI  _SFR_MEM8(0x0112)
+#define CPUINT_LVL1VEC  _SFR_MEM8(0x0113)
+
+
+/* CRCSCAN - CRCSCAN */
+#define CRCSCAN_CTRLA  _SFR_MEM8(0x0120)
+#define CRCSCAN_CTRLB  _SFR_MEM8(0x0121)
+#define CRCSCAN_STATUS  _SFR_MEM8(0x0122)
+
+
+/* RTC - Real-Time Counter */
+#define RTC_CTRLA  _SFR_MEM8(0x0140)
+#define RTC_STATUS  _SFR_MEM8(0x0141)
+#define RTC_INTCTRL  _SFR_MEM8(0x0142)
+#define RTC_INTFLAGS  _SFR_MEM8(0x0143)
+#define RTC_TEMP  _SFR_MEM8(0x0144)
+#define RTC_DBGCTRL  _SFR_MEM8(0x0145)
+#define RTC_CALIB  _SFR_MEM8(0x0146)
+#define RTC_CLKSEL  _SFR_MEM8(0x0147)
+#define RTC_CNT  _SFR_MEM16(0x0148)
+#define RTC_CNTL  _SFR_MEM8(0x0148)
+#define RTC_CNTH  _SFR_MEM8(0x0149)
+#define RTC_PER  _SFR_MEM16(0x014A)
+#define RTC_PERL  _SFR_MEM8(0x014A)
+#define RTC_PERH  _SFR_MEM8(0x014B)
+#define RTC_CMP  _SFR_MEM16(0x014C)
+#define RTC_CMPL  _SFR_MEM8(0x014C)
+#define RTC_CMPH  _SFR_MEM8(0x014D)
+#define RTC_PITCTRLA  _SFR_MEM8(0x0150)
+#define RTC_PITSTATUS  _SFR_MEM8(0x0151)
+#define RTC_PITINTCTRL  _SFR_MEM8(0x0152)
+#define RTC_PITINTFLAGS  _SFR_MEM8(0x0153)
+#define RTC_PITDBGCTRL  _SFR_MEM8(0x0155)
+#define RTC_PITEVGENCTRLA  _SFR_MEM8(0x0156)
+
+
+/* CCL - Configurable Custom Logic */
+#define CCL_CTRLA  _SFR_MEM8(0x01C0)
+#define CCL_SEQCTRL0  _SFR_MEM8(0x01C1)
+#define CCL_SEQCTRL1  _SFR_MEM8(0x01C2)
+#define CCL_INTCTRL0  _SFR_MEM8(0x01C5)
+#define CCL_INTFLAGS  _SFR_MEM8(0x01C7)
+#define CCL_LUT0CTRLA  _SFR_MEM8(0x01C8)
+#define CCL_LUT0CTRLB  _SFR_MEM8(0x01C9)
+#define CCL_LUT0CTRLC  _SFR_MEM8(0x01CA)
+#define CCL_TRUTH0  _SFR_MEM8(0x01CB)
+#define CCL_LUT1CTRLA  _SFR_MEM8(0x01CC)
+#define CCL_LUT1CTRLB  _SFR_MEM8(0x01CD)
+#define CCL_LUT1CTRLC  _SFR_MEM8(0x01CE)
+#define CCL_TRUTH1  _SFR_MEM8(0x01CF)
+#define CCL_LUT2CTRLA  _SFR_MEM8(0x01D0)
+#define CCL_LUT2CTRLB  _SFR_MEM8(0x01D1)
+#define CCL_LUT2CTRLC  _SFR_MEM8(0x01D2)
+#define CCL_TRUTH2  _SFR_MEM8(0x01D3)
+#define CCL_LUT3CTRLA  _SFR_MEM8(0x01D4)
+#define CCL_LUT3CTRLB  _SFR_MEM8(0x01D5)
+#define CCL_LUT3CTRLC  _SFR_MEM8(0x01D6)
+#define CCL_TRUTH3  _SFR_MEM8(0x01D7)
+
+
+/* EVSYS - Event System */
+#define EVSYS_SWEVENTA  _SFR_MEM8(0x0200)
+#define EVSYS_CHANNEL0  _SFR_MEM8(0x0210)
+#define EVSYS_CHANNEL1  _SFR_MEM8(0x0211)
+#define EVSYS_CHANNEL2  _SFR_MEM8(0x0212)
+#define EVSYS_CHANNEL3  _SFR_MEM8(0x0213)
+#define EVSYS_CHANNEL4  _SFR_MEM8(0x0214)
+#define EVSYS_CHANNEL5  _SFR_MEM8(0x0215)
+#define EVSYS_USERCCLLUT0A  _SFR_MEM8(0x0220)
+#define EVSYS_USERCCLLUT0B  _SFR_MEM8(0x0221)
+#define EVSYS_USERCCLLUT1A  _SFR_MEM8(0x0222)
+#define EVSYS_USERCCLLUT1B  _SFR_MEM8(0x0223)
+#define EVSYS_USERCCLLUT2A  _SFR_MEM8(0x0224)
+#define EVSYS_USERCCLLUT2B  _SFR_MEM8(0x0225)
+#define EVSYS_USERCCLLUT3A  _SFR_MEM8(0x0226)
+#define EVSYS_USERCCLLUT3B  _SFR_MEM8(0x0227)
+#define EVSYS_USERADC0START  _SFR_MEM8(0x0228)
+#define EVSYS_USEREVSYSEVOUTA  _SFR_MEM8(0x0229)
+#define EVSYS_USEREVSYSEVOUTC  _SFR_MEM8(0x022A)
+#define EVSYS_USEREVSYSEVOUTD  _SFR_MEM8(0x022B)
+#define EVSYS_USEREVSYSEVOUTF  _SFR_MEM8(0x022C)
+#define EVSYS_USERUSART0IRDA  _SFR_MEM8(0x022D)
+#define EVSYS_USERTCE0CNTA  _SFR_MEM8(0x022E)
+#define EVSYS_USERTCE0CNTB  _SFR_MEM8(0x022F)
+#define EVSYS_USERTCB0CAPT  _SFR_MEM8(0x0230)
+#define EVSYS_USERTCB0COUNT  _SFR_MEM8(0x0231)
+#define EVSYS_USERTCB1CAPT  _SFR_MEM8(0x0232)
+#define EVSYS_USERTCB1COUNT  _SFR_MEM8(0x0233)
+#define EVSYS_USERTCF0CNT  _SFR_MEM8(0x0234)
+#define EVSYS_USERTCF0ACT  _SFR_MEM8(0x0235)
+#define EVSYS_USERWEXA  _SFR_MEM8(0x0236)
+#define EVSYS_USERWEXB  _SFR_MEM8(0x0237)
+#define EVSYS_USERWEXC  _SFR_MEM8(0x0238)
+
+
+/* PORT (PORTA) - I/O Ports */
+#define PORTA_DIR  _SFR_MEM8(0x0400)
+#define PORTA_DIRSET  _SFR_MEM8(0x0401)
+#define PORTA_DIRCLR  _SFR_MEM8(0x0402)
+#define PORTA_DIRTGL  _SFR_MEM8(0x0403)
+#define PORTA_OUT  _SFR_MEM8(0x0404)
+#define PORTA_OUTSET  _SFR_MEM8(0x0405)
+#define PORTA_OUTCLR  _SFR_MEM8(0x0406)
+#define PORTA_OUTTGL  _SFR_MEM8(0x0407)
+#define PORTA_IN  _SFR_MEM8(0x0408)
+#define PORTA_INTFLAGS  _SFR_MEM8(0x0409)
+#define PORTA_PORTCTRL  _SFR_MEM8(0x040A)
+#define PORTA_PINCONFIG  _SFR_MEM8(0x040B)
+#define PORTA_PINCTRLUPD  _SFR_MEM8(0x040C)
+#define PORTA_PINCTRLSET  _SFR_MEM8(0x040D)
+#define PORTA_PINCTRLCLR  _SFR_MEM8(0x040E)
+#define PORTA_PIN0CTRL  _SFR_MEM8(0x0410)
+#define PORTA_PIN1CTRL  _SFR_MEM8(0x0411)
+#define PORTA_PIN2CTRL  _SFR_MEM8(0x0412)
+#define PORTA_PIN3CTRL  _SFR_MEM8(0x0413)
+#define PORTA_PIN4CTRL  _SFR_MEM8(0x0414)
+#define PORTA_PIN5CTRL  _SFR_MEM8(0x0415)
+#define PORTA_PIN6CTRL  _SFR_MEM8(0x0416)
+#define PORTA_PIN7CTRL  _SFR_MEM8(0x0417)
+#define PORTA_EVGENCTRLA  _SFR_MEM8(0x0418)
+
+
+/* PORT (PORTC) - I/O Ports */
+#define PORTC_DIR  _SFR_MEM8(0x0440)
+#define PORTC_DIRSET  _SFR_MEM8(0x0441)
+#define PORTC_DIRCLR  _SFR_MEM8(0x0442)
+#define PORTC_DIRTGL  _SFR_MEM8(0x0443)
+#define PORTC_OUT  _SFR_MEM8(0x0444)
+#define PORTC_OUTSET  _SFR_MEM8(0x0445)
+#define PORTC_OUTCLR  _SFR_MEM8(0x0446)
+#define PORTC_OUTTGL  _SFR_MEM8(0x0447)
+#define PORTC_IN  _SFR_MEM8(0x0448)
+#define PORTC_INTFLAGS  _SFR_MEM8(0x0449)
+#define PORTC_PORTCTRL  _SFR_MEM8(0x044A)
+#define PORTC_PINCONFIG  _SFR_MEM8(0x044B)
+#define PORTC_PINCTRLUPD  _SFR_MEM8(0x044C)
+#define PORTC_PINCTRLSET  _SFR_MEM8(0x044D)
+#define PORTC_PINCTRLCLR  _SFR_MEM8(0x044E)
+#define PORTC_PIN0CTRL  _SFR_MEM8(0x0450)
+#define PORTC_PIN1CTRL  _SFR_MEM8(0x0451)
+#define PORTC_PIN2CTRL  _SFR_MEM8(0x0452)
+#define PORTC_PIN3CTRL  _SFR_MEM8(0x0453)
+#define PORTC_PIN4CTRL  _SFR_MEM8(0x0454)
+#define PORTC_PIN5CTRL  _SFR_MEM8(0x0455)
+#define PORTC_PIN6CTRL  _SFR_MEM8(0x0456)
+#define PORTC_PIN7CTRL  _SFR_MEM8(0x0457)
+#define PORTC_EVGENCTRLA  _SFR_MEM8(0x0458)
+
+
+/* PORT (PORTD) - I/O Ports */
+#define PORTD_DIR  _SFR_MEM8(0x0460)
+#define PORTD_DIRSET  _SFR_MEM8(0x0461)
+#define PORTD_DIRCLR  _SFR_MEM8(0x0462)
+#define PORTD_DIRTGL  _SFR_MEM8(0x0463)
+#define PORTD_OUT  _SFR_MEM8(0x0464)
+#define PORTD_OUTSET  _SFR_MEM8(0x0465)
+#define PORTD_OUTCLR  _SFR_MEM8(0x0466)
+#define PORTD_OUTTGL  _SFR_MEM8(0x0467)
+#define PORTD_IN  _SFR_MEM8(0x0468)
+#define PORTD_INTFLAGS  _SFR_MEM8(0x0469)
+#define PORTD_PORTCTRL  _SFR_MEM8(0x046A)
+#define PORTD_PINCONFIG  _SFR_MEM8(0x046B)
+#define PORTD_PINCTRLUPD  _SFR_MEM8(0x046C)
+#define PORTD_PINCTRLSET  _SFR_MEM8(0x046D)
+#define PORTD_PINCTRLCLR  _SFR_MEM8(0x046E)
+#define PORTD_PIN0CTRL  _SFR_MEM8(0x0470)
+#define PORTD_PIN1CTRL  _SFR_MEM8(0x0471)
+#define PORTD_PIN2CTRL  _SFR_MEM8(0x0472)
+#define PORTD_PIN3CTRL  _SFR_MEM8(0x0473)
+#define PORTD_PIN4CTRL  _SFR_MEM8(0x0474)
+#define PORTD_PIN5CTRL  _SFR_MEM8(0x0475)
+#define PORTD_PIN6CTRL  _SFR_MEM8(0x0476)
+#define PORTD_PIN7CTRL  _SFR_MEM8(0x0477)
+#define PORTD_EVGENCTRLA  _SFR_MEM8(0x0478)
+
+
+/* PORT (PORTF) - I/O Ports */
+#define PORTF_DIR  _SFR_MEM8(0x04A0)
+#define PORTF_DIRSET  _SFR_MEM8(0x04A1)
+#define PORTF_DIRCLR  _SFR_MEM8(0x04A2)
+#define PORTF_DIRTGL  _SFR_MEM8(0x04A3)
+#define PORTF_OUT  _SFR_MEM8(0x04A4)
+#define PORTF_OUTSET  _SFR_MEM8(0x04A5)
+#define PORTF_OUTCLR  _SFR_MEM8(0x04A6)
+#define PORTF_OUTTGL  _SFR_MEM8(0x04A7)
+#define PORTF_IN  _SFR_MEM8(0x04A8)
+#define PORTF_INTFLAGS  _SFR_MEM8(0x04A9)
+#define PORTF_PORTCTRL  _SFR_MEM8(0x04AA)
+#define PORTF_PINCONFIG  _SFR_MEM8(0x04AB)
+#define PORTF_PINCTRLUPD  _SFR_MEM8(0x04AC)
+#define PORTF_PINCTRLSET  _SFR_MEM8(0x04AD)
+#define PORTF_PINCTRLCLR  _SFR_MEM8(0x04AE)
+#define PORTF_PIN0CTRL  _SFR_MEM8(0x04B0)
+#define PORTF_PIN1CTRL  _SFR_MEM8(0x04B1)
+#define PORTF_PIN2CTRL  _SFR_MEM8(0x04B2)
+#define PORTF_PIN3CTRL  _SFR_MEM8(0x04B3)
+#define PORTF_PIN4CTRL  _SFR_MEM8(0x04B4)
+#define PORTF_PIN5CTRL  _SFR_MEM8(0x04B5)
+#define PORTF_PIN6CTRL  _SFR_MEM8(0x04B6)
+#define PORTF_PIN7CTRL  _SFR_MEM8(0x04B7)
+#define PORTF_EVGENCTRLA  _SFR_MEM8(0x04B8)
+
+
+/* PORTMUX - Port Multiplexer */
+#define PORTMUX_EVSYSROUTEA  _SFR_MEM8(0x05E0)
+#define PORTMUX_CCLROUTEA  _SFR_MEM8(0x05E1)
+#define PORTMUX_USARTROUTEA  _SFR_MEM8(0x05E2)
+#define PORTMUX_SPIROUTEA  _SFR_MEM8(0x05E5)
+#define PORTMUX_TWIROUTEA  _SFR_MEM8(0x05E6)
+#define PORTMUX_TCEROUTEA  _SFR_MEM8(0x05E7)
+#define PORTMUX_TCBROUTEA  _SFR_MEM8(0x05E8)
+#define PORTMUX_TCFROUTEA  _SFR_MEM8(0x05EC)
+
+
+/* ADC (ADC0) - Analog to Digital Converter */
+#define ADC0_CTRLA  _SFR_MEM8(0x0600)
+#define ADC0_CTRLB  _SFR_MEM8(0x0601)
+#define ADC0_CTRLC  _SFR_MEM8(0x0602)
+#define ADC0_CTRLD  _SFR_MEM8(0x0603)
+#define ADC0_INTCTRL  _SFR_MEM8(0x0604)
+#define ADC0_INTFLAGS  _SFR_MEM8(0x0605)
+#define ADC0_STATUS  _SFR_MEM8(0x0606)
+#define ADC0_DBGCTRL  _SFR_MEM8(0x0607)
+#define ADC0_CTRLE  _SFR_MEM8(0x0608)
+#define ADC0_CTRLF  _SFR_MEM8(0x0609)
+#define ADC0_COMMAND  _SFR_MEM8(0x060A)
+#define ADC0_PGACTRL  _SFR_MEM8(0x060B)
+#define ADC0_MUXPOS  _SFR_MEM8(0x060C)
+#define ADC0_MUXNEG  _SFR_MEM8(0x060D)
+#define ADC0_RESULT  _SFR_MEM32(0x0610)
+#define ADC0_RESULT0  _SFR_MEM8(0x0610)
+#define ADC0_RESULT1  _SFR_MEM8(0x0611)
+#define ADC0_RESULT2  _SFR_MEM8(0x0612)
+#define ADC0_RESULT3  _SFR_MEM8(0x0613)
+#define ADC0_SAMPLE  _SFR_MEM16(0x0614)
+#define ADC0_SAMPLEL  _SFR_MEM8(0x0614)
+#define ADC0_SAMPLEH  _SFR_MEM8(0x0615)
+#define ADC0_TEMP0  _SFR_MEM8(0x0618)
+#define ADC0_TEMP1  _SFR_MEM8(0x0619)
+#define ADC0_TEMP2  _SFR_MEM8(0x061A)
+#define ADC0_WINLT  _SFR_MEM16(0x061C)
+#define ADC0_WINLTL  _SFR_MEM8(0x061C)
+#define ADC0_WINLTH  _SFR_MEM8(0x061D)
+#define ADC0_WINHT  _SFR_MEM16(0x061E)
+#define ADC0_WINHTL  _SFR_MEM8(0x061E)
+#define ADC0_WINHTH  _SFR_MEM8(0x061F)
+
+
+/* AC (AC0) - Analog Comparator */
+#define AC0_CTRLA  _SFR_MEM8(0x0680)
+#define AC0_CTRLB  _SFR_MEM8(0x0681)
+#define AC0_MUXCTRL  _SFR_MEM8(0x0682)
+#define AC0_DACREF  _SFR_MEM8(0x0685)
+#define AC0_INTCTRL  _SFR_MEM8(0x0686)
+#define AC0_STATUS  _SFR_MEM8(0x0687)
+
+
+/* AC (AC1) - Analog Comparator */
+#define AC1_CTRLA  _SFR_MEM8(0x0688)
+#define AC1_CTRLB  _SFR_MEM8(0x0689)
+#define AC1_MUXCTRL  _SFR_MEM8(0x068A)
+#define AC1_DACREF  _SFR_MEM8(0x068D)
+#define AC1_INTCTRL  _SFR_MEM8(0x068E)
+#define AC1_STATUS  _SFR_MEM8(0x068F)
+
+
+/* USART (USART0) - Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define USART0_RXDATAL  _SFR_MEM8(0x0800)
+#define USART0_RXDATAH  _SFR_MEM8(0x0801)
+#define USART0_TXDATAL  _SFR_MEM8(0x0802)
+#define USART0_TXDATAH  _SFR_MEM8(0x0803)
+#define USART0_STATUS  _SFR_MEM8(0x0804)
+#define USART0_CTRLA  _SFR_MEM8(0x0805)
+#define USART0_CTRLB  _SFR_MEM8(0x0806)
+#define USART0_CTRLC  _SFR_MEM8(0x0807)
+#define USART0_BAUD  _SFR_MEM16(0x0808)
+#define USART0_BAUDL  _SFR_MEM8(0x0808)
+#define USART0_BAUDH  _SFR_MEM8(0x0809)
+#define USART0_CTRLD  _SFR_MEM8(0x080A)
+#define USART0_DBGCTRL  _SFR_MEM8(0x080B)
+#define USART0_EVCTRL  _SFR_MEM8(0x080C)
+#define USART0_TXPLCTRL  _SFR_MEM8(0x080D)
+#define USART0_RXPLCTRL  _SFR_MEM8(0x080E)
+
+
+/* TWI (TWI0) - Two-Wire Interface */
+#define TWI0_CTRLA  _SFR_MEM8(0x0900)
+#define TWI0_DUALCTRL  _SFR_MEM8(0x0901)
+#define TWI0_DBGCTRL  _SFR_MEM8(0x0902)
+#define TWI0_MCTRLA  _SFR_MEM8(0x0903)
+#define TWI0_MCTRLB  _SFR_MEM8(0x0904)
+#define TWI0_MSTATUS  _SFR_MEM8(0x0905)
+#define TWI0_MBAUD  _SFR_MEM8(0x0906)
+#define TWI0_MADDR  _SFR_MEM8(0x0907)
+#define TWI0_MDATA  _SFR_MEM8(0x0908)
+#define TWI0_SCTRLA  _SFR_MEM8(0x0909)
+#define TWI0_SCTRLB  _SFR_MEM8(0x090A)
+#define TWI0_SSTATUS  _SFR_MEM8(0x090B)
+#define TWI0_SADDR  _SFR_MEM8(0x090C)
+#define TWI0_SDATA  _SFR_MEM8(0x090D)
+#define TWI0_SADDRMASK  _SFR_MEM8(0x090E)
+
+
+/* SPI (SPI0) - Serial Peripheral Interface */
+#define SPI0_CTRLA  _SFR_MEM8(0x0940)
+#define SPI0_CTRLB  _SFR_MEM8(0x0941)
+#define SPI0_INTCTRL  _SFR_MEM8(0x0942)
+#define SPI0_INTFLAGS  _SFR_MEM8(0x0943)
+#define SPI0_DATA  _SFR_MEM8(0x0944)
+
+
+/* TCE (TCE0) - 16-bit Timer/Counter Type E */
+#define TCE0_CTRLA  _SFR_MEM8(0x0A00)
+#define TCE0_CTRLB  _SFR_MEM8(0x0A01)
+#define TCE0_CTRLC  _SFR_MEM8(0x0A02)
+#define TCE0_CTRLD  _SFR_MEM8(0x0A03)
+#define TCE0_CTRLECLR  _SFR_MEM8(0x0A04)
+#define TCE0_CTRLESET  _SFR_MEM8(0x0A05)
+#define TCE0_CTRLFCLR  _SFR_MEM8(0x0A06)
+#define TCE0_CTRLFSET  _SFR_MEM8(0x0A07)
+#define TCE0_EVGENCTRL  _SFR_MEM8(0x0A08)
+#define TCE0_EVCTRL  _SFR_MEM8(0x0A09)
+#define TCE0_INTCTRL  _SFR_MEM8(0x0A0A)
+#define TCE0_INTFLAGS  _SFR_MEM8(0x0A0B)
+#define TCE0_DBGCTRL  _SFR_MEM8(0x0A0E)
+#define TCE0_TEMP  _SFR_MEM8(0x0A0F)
+#define TCE0_CNT  _SFR_MEM16(0x0A20)
+#define TCE0_CNTL  _SFR_MEM8(0x0A20)
+#define TCE0_CNTH  _SFR_MEM8(0x0A21)
+#define TCE0_AMP  _SFR_MEM16(0x0A22)
+#define TCE0_AMPL  _SFR_MEM8(0x0A22)
+#define TCE0_AMPH  _SFR_MEM8(0x0A23)
+#define TCE0_OFFSET  _SFR_MEM16(0x0A24)
+#define TCE0_OFFSETL  _SFR_MEM8(0x0A24)
+#define TCE0_OFFSETH  _SFR_MEM8(0x0A25)
+#define TCE0_PER  _SFR_MEM16(0x0A26)
+#define TCE0_PERL  _SFR_MEM8(0x0A26)
+#define TCE0_PERH  _SFR_MEM8(0x0A27)
+#define TCE0_CMP0  _SFR_MEM16(0x0A28)
+#define TCE0_CMP0L  _SFR_MEM8(0x0A28)
+#define TCE0_CMP0H  _SFR_MEM8(0x0A29)
+#define TCE0_CMP1  _SFR_MEM16(0x0A2A)
+#define TCE0_CMP1L  _SFR_MEM8(0x0A2A)
+#define TCE0_CMP1H  _SFR_MEM8(0x0A2B)
+#define TCE0_CMP2  _SFR_MEM16(0x0A2C)
+#define TCE0_CMP2L  _SFR_MEM8(0x0A2C)
+#define TCE0_CMP2H  _SFR_MEM8(0x0A2D)
+#define TCE0_CMP3  _SFR_MEM16(0x0A2E)
+#define TCE0_CMP3L  _SFR_MEM8(0x0A2E)
+#define TCE0_CMP3H  _SFR_MEM8(0x0A2F)
+#define TCE0_PERBUF  _SFR_MEM16(0x0A36)
+#define TCE0_PERBUFL  _SFR_MEM8(0x0A36)
+#define TCE0_PERBUFH  _SFR_MEM8(0x0A37)
+#define TCE0_CMP0BUF  _SFR_MEM16(0x0A38)
+#define TCE0_CMP0BUFL  _SFR_MEM8(0x0A38)
+#define TCE0_CMP0BUFH  _SFR_MEM8(0x0A39)
+#define TCE0_CMP1BUF  _SFR_MEM16(0x0A3A)
+#define TCE0_CMP1BUFL  _SFR_MEM8(0x0A3A)
+#define TCE0_CMP1BUFH  _SFR_MEM8(0x0A3B)
+#define TCE0_CMP2BUF  _SFR_MEM16(0x0A3C)
+#define TCE0_CMP2BUFL  _SFR_MEM8(0x0A3C)
+#define TCE0_CMP2BUFH  _SFR_MEM8(0x0A3D)
+#define TCE0_CMP3BUF  _SFR_MEM16(0x0A3E)
+#define TCE0_CMP3BUFL  _SFR_MEM8(0x0A3E)
+#define TCE0_CMP3BUFH  _SFR_MEM8(0x0A3F)
+
+
+/* TCB (TCB0) - 16-bit Timer/Counter Type B */
+#define TCB0_CTRLA  _SFR_MEM8(0x0B00)
+#define TCB0_CTRLB  _SFR_MEM8(0x0B01)
+#define TCB0_CTRLC  _SFR_MEM8(0x0B02)
+#define TCB0_EVCTRL  _SFR_MEM8(0x0B04)
+#define TCB0_INTCTRL  _SFR_MEM8(0x0B05)
+#define TCB0_INTFLAGS  _SFR_MEM8(0x0B06)
+#define TCB0_STATUS  _SFR_MEM8(0x0B07)
+#define TCB0_DBGCTRL  _SFR_MEM8(0x0B08)
+#define TCB0_TEMP  _SFR_MEM8(0x0B09)
+#define TCB0_CNT  _SFR_MEM16(0x0B0A)
+#define TCB0_CNTL  _SFR_MEM8(0x0B0A)
+#define TCB0_CNTH  _SFR_MEM8(0x0B0B)
+#define TCB0_CCMP  _SFR_MEM16(0x0B0C)
+#define TCB0_CCMPL  _SFR_MEM8(0x0B0C)
+#define TCB0_CCMPH  _SFR_MEM8(0x0B0D)
+
+
+/* TCB (TCB1) - 16-bit Timer/Counter Type B */
+#define TCB1_CTRLA  _SFR_MEM8(0x0B10)
+#define TCB1_CTRLB  _SFR_MEM8(0x0B11)
+#define TCB1_CTRLC  _SFR_MEM8(0x0B12)
+#define TCB1_EVCTRL  _SFR_MEM8(0x0B14)
+#define TCB1_INTCTRL  _SFR_MEM8(0x0B15)
+#define TCB1_INTFLAGS  _SFR_MEM8(0x0B16)
+#define TCB1_STATUS  _SFR_MEM8(0x0B17)
+#define TCB1_DBGCTRL  _SFR_MEM8(0x0B18)
+#define TCB1_TEMP  _SFR_MEM8(0x0B19)
+#define TCB1_CNT  _SFR_MEM16(0x0B1A)
+#define TCB1_CNTL  _SFR_MEM8(0x0B1A)
+#define TCB1_CNTH  _SFR_MEM8(0x0B1B)
+#define TCB1_CCMP  _SFR_MEM16(0x0B1C)
+#define TCB1_CCMPL  _SFR_MEM8(0x0B1C)
+#define TCB1_CCMPH  _SFR_MEM8(0x0B1D)
+
+
+/* TCF (TCF0) - 24-bit Timer/Counter for frequency generation */
+#define TCF0_CTRLA  _SFR_MEM8(0x0C00)
+#define TCF0_CTRLB  _SFR_MEM8(0x0C01)
+#define TCF0_CTRLC  _SFR_MEM8(0x0C02)
+#define TCF0_CTRLD  _SFR_MEM8(0x0C03)
+#define TCF0_EVCTRL  _SFR_MEM8(0x0C04)
+#define TCF0_INTCTRL  _SFR_MEM8(0x0C05)
+#define TCF0_INTFLAGS  _SFR_MEM8(0x0C06)
+#define TCF0_STATUS  _SFR_MEM8(0x0C07)
+#define TCF0_DBGCTRL  _SFR_MEM8(0x0C0D)
+#define TCF0_CNT  _SFR_MEM32(0x0C10)
+#define TCF0_CNT0  _SFR_MEM8(0x0C10)
+#define TCF0_CNT1  _SFR_MEM8(0x0C11)
+#define TCF0_CNT2  _SFR_MEM8(0x0C12)
+#define TCF0_CNT3  _SFR_MEM8(0x0C13)
+#define TCF0_CMP  _SFR_MEM32(0x0C14)
+#define TCF0_CMP0  _SFR_MEM8(0x0C14)
+#define TCF0_CMP1  _SFR_MEM8(0x0C15)
+#define TCF0_CMP2  _SFR_MEM8(0x0C16)
+#define TCF0_CMP3  _SFR_MEM8(0x0C17)
+
+
+/* WEX (WEX0) - Waveform Extension */
+#define WEX0_CTRLA  _SFR_MEM8(0x0C80)
+#define WEX0_CTRLB  _SFR_MEM8(0x0C81)
+#define WEX0_CTRLC  _SFR_MEM8(0x0C82)
+#define WEX0_EVCTRLA  _SFR_MEM8(0x0C84)
+#define WEX0_EVCTRLB  _SFR_MEM8(0x0C85)
+#define WEX0_EVCTRLC  _SFR_MEM8(0x0C86)
+#define WEX0_BUFCTRL  _SFR_MEM8(0x0C87)
+#define WEX0_BLANKCTRL  _SFR_MEM8(0x0C88)
+#define WEX0_BLANKTIME  _SFR_MEM8(0x0C89)
+#define WEX0_FAULTCTRL  _SFR_MEM8(0x0C8A)
+#define WEX0_FAULTDRV  _SFR_MEM8(0x0C8B)
+#define WEX0_FAULTOUT  _SFR_MEM8(0x0C8C)
+#define WEX0_INTCTRL  _SFR_MEM8(0x0C8D)
+#define WEX0_INTFLAGS  _SFR_MEM8(0x0C8E)
+#define WEX0_STATUS  _SFR_MEM8(0x0C8F)
+#define WEX0_DTLS  _SFR_MEM8(0x0C90)
+#define WEX0_DTHS  _SFR_MEM8(0x0C91)
+#define WEX0_DTBOTH  _SFR_MEM8(0x0C92)
+#define WEX0_SWAP  _SFR_MEM8(0x0C93)
+#define WEX0_PGMOVR  _SFR_MEM8(0x0C94)
+#define WEX0_PGMOUT  _SFR_MEM8(0x0C95)
+#define WEX0_OUTOVEN  _SFR_MEM8(0x0C97)
+#define WEX0_DTLSBUF  _SFR_MEM8(0x0C98)
+#define WEX0_DTHSBUF  _SFR_MEM8(0x0C99)
+#define WEX0_DTBOTHBUF  _SFR_MEM8(0x0C9A)
+#define WEX0_SWAPBUF  _SFR_MEM8(0x0C9B)
+#define WEX0_PGMOVRBUF  _SFR_MEM8(0x0C9C)
+#define WEX0_PGMOUTBUF  _SFR_MEM8(0x0C9D)
+
+
+/* SYSCFG - System Configuration Registers */
+#define SYSCFG_REVID  _SFR_MEM8(0x0F01)
+
+
+/* NVMCTRL - Non-volatile Memory Controller */
+#define NVMCTRL_CTRLA  _SFR_MEM8(0x1000)
+#define NVMCTRL_CTRLB  _SFR_MEM8(0x1001)
+#define NVMCTRL_CTRLC  _SFR_MEM8(0x1002)
+#define NVMCTRL_INTCTRL  _SFR_MEM8(0x1004)
+#define NVMCTRL_INTFLAGS  _SFR_MEM8(0x1005)
+#define NVMCTRL_STATUS  _SFR_MEM8(0x1006)
+#define NVMCTRL_DATA  _SFR_MEM16(0x1008)
+#define NVMCTRL_DATAL  _SFR_MEM8(0x1008)
+#define NVMCTRL_DATAH  _SFR_MEM8(0x1009)
+#define NVMCTRL_ADDR  _SFR_MEM32(0x100C)
+#define NVMCTRL_ADDR0  _SFR_MEM8(0x100C)
+#define NVMCTRL_ADDR1  _SFR_MEM8(0x100D)
+#define NVMCTRL_ADDR2  _SFR_MEM8(0x100E)
+#define NVMCTRL_ADDR3  _SFR_MEM8(0x100F)
+
+
+/* LOCK - Lockbits */
+#define LOCK_KEY  _SFR_MEM32(0x1040)
+#define LOCK_KEY0  _SFR_MEM8(0x1040)
+#define LOCK_KEY1  _SFR_MEM8(0x1041)
+#define LOCK_KEY2  _SFR_MEM8(0x1042)
+#define LOCK_KEY3  _SFR_MEM8(0x1043)
+
+
+/* FUSE - Fuses */
+#define FUSE_WDTCFG  _SFR_MEM8(0x1050)
+#define FUSE_BODCFG  _SFR_MEM8(0x1051)
+#define FUSE_OSCCFG  _SFR_MEM8(0x1052)
+#define FUSE_SYSCFG0  _SFR_MEM8(0x1055)
+#define FUSE_SYSCFG1  _SFR_MEM8(0x1056)
+#define FUSE_CODESIZE  _SFR_MEM8(0x1057)
+#define FUSE_BOOTSIZE  _SFR_MEM8(0x1058)
+#define FUSE_PDICFG  _SFR_MEM16(0x105A)
+#define FUSE_PDICFGL  _SFR_MEM8(0x105A)
+#define FUSE_PDICFGH  _SFR_MEM8(0x105B)
+
+
+/* SIGROW - Signature row */
+#define SIGROW_DEVICEID0  _SFR_MEM8(0x1080)
+#define SIGROW_DEVICEID1  _SFR_MEM8(0x1081)
+#define SIGROW_DEVICEID2  _SFR_MEM8(0x1082)
+#define SIGROW_TEMPSENSE0  _SFR_MEM16(0x1084)
+#define SIGROW_TEMPSENSE0L  _SFR_MEM8(0x1084)
+#define SIGROW_TEMPSENSE0H  _SFR_MEM8(0x1085)
+#define SIGROW_TEMPSENSE1  _SFR_MEM16(0x1086)
+#define SIGROW_TEMPSENSE1L  _SFR_MEM8(0x1086)
+#define SIGROW_TEMPSENSE1H  _SFR_MEM8(0x1087)
+#define SIGROW_SERNUM0  _SFR_MEM8(0x1090)
+#define SIGROW_SERNUM1  _SFR_MEM8(0x1091)
+#define SIGROW_SERNUM2  _SFR_MEM8(0x1092)
+#define SIGROW_SERNUM3  _SFR_MEM8(0x1093)
+#define SIGROW_SERNUM4  _SFR_MEM8(0x1094)
+#define SIGROW_SERNUM5  _SFR_MEM8(0x1095)
+#define SIGROW_SERNUM6  _SFR_MEM8(0x1096)
+#define SIGROW_SERNUM7  _SFR_MEM8(0x1097)
+#define SIGROW_SERNUM8  _SFR_MEM8(0x1098)
+#define SIGROW_SERNUM9  _SFR_MEM8(0x1099)
+#define SIGROW_SERNUM10  _SFR_MEM8(0x109A)
+#define SIGROW_SERNUM11  _SFR_MEM8(0x109B)
+#define SIGROW_SERNUM12  _SFR_MEM8(0x109C)
+#define SIGROW_SERNUM13  _SFR_MEM8(0x109D)
+#define SIGROW_SERNUM14  _SFR_MEM8(0x109E)
+#define SIGROW_SERNUM15  _SFR_MEM8(0x109F)
+
+
+/* BOOTROW - Boot Row */
+#define BOOTROW_BOOTROW  _SFR_MEM8(0x1100)
+
+
+/* USERROW - User Row */
+#define USERROW_USERROW0  _SFR_MEM8(0x1200)
+#define USERROW_USERROW1  _SFR_MEM8(0x1201)
+#define USERROW_USERROW2  _SFR_MEM8(0x1202)
+#define USERROW_USERROW3  _SFR_MEM8(0x1203)
+#define USERROW_USERROW4  _SFR_MEM8(0x1204)
+#define USERROW_USERROW5  _SFR_MEM8(0x1205)
+#define USERROW_USERROW6  _SFR_MEM8(0x1206)
+#define USERROW_USERROW7  _SFR_MEM8(0x1207)
+#define USERROW_USERROW8  _SFR_MEM8(0x1208)
+#define USERROW_USERROW9  _SFR_MEM8(0x1209)
+#define USERROW_USERROW10  _SFR_MEM8(0x120A)
+#define USERROW_USERROW11  _SFR_MEM8(0x120B)
+#define USERROW_USERROW12  _SFR_MEM8(0x120C)
+#define USERROW_USERROW13  _SFR_MEM8(0x120D)
+#define USERROW_USERROW14  _SFR_MEM8(0x120E)
+#define USERROW_USERROW15  _SFR_MEM8(0x120F)
+#define USERROW_USERROW16  _SFR_MEM8(0x1210)
+#define USERROW_USERROW17  _SFR_MEM8(0x1211)
+#define USERROW_USERROW18  _SFR_MEM8(0x1212)
+#define USERROW_USERROW19  _SFR_MEM8(0x1213)
+#define USERROW_USERROW20  _SFR_MEM8(0x1214)
+#define USERROW_USERROW21  _SFR_MEM8(0x1215)
+#define USERROW_USERROW22  _SFR_MEM8(0x1216)
+#define USERROW_USERROW23  _SFR_MEM8(0x1217)
+#define USERROW_USERROW24  _SFR_MEM8(0x1218)
+#define USERROW_USERROW25  _SFR_MEM8(0x1219)
+#define USERROW_USERROW26  _SFR_MEM8(0x121A)
+#define USERROW_USERROW27  _SFR_MEM8(0x121B)
+#define USERROW_USERROW28  _SFR_MEM8(0x121C)
+#define USERROW_USERROW29  _SFR_MEM8(0x121D)
+#define USERROW_USERROW30  _SFR_MEM8(0x121E)
+#define USERROW_USERROW31  _SFR_MEM8(0x121F)
+#define USERROW_USERROW32  _SFR_MEM8(0x1220)
+#define USERROW_USERROW33  _SFR_MEM8(0x1221)
+#define USERROW_USERROW34  _SFR_MEM8(0x1222)
+#define USERROW_USERROW35  _SFR_MEM8(0x1223)
+#define USERROW_USERROW36  _SFR_MEM8(0x1224)
+#define USERROW_USERROW37  _SFR_MEM8(0x1225)
+#define USERROW_USERROW38  _SFR_MEM8(0x1226)
+#define USERROW_USERROW39  _SFR_MEM8(0x1227)
+#define USERROW_USERROW40  _SFR_MEM8(0x1228)
+#define USERROW_USERROW41  _SFR_MEM8(0x1229)
+#define USERROW_USERROW42  _SFR_MEM8(0x122A)
+#define USERROW_USERROW43  _SFR_MEM8(0x122B)
+#define USERROW_USERROW44  _SFR_MEM8(0x122C)
+#define USERROW_USERROW45  _SFR_MEM8(0x122D)
+#define USERROW_USERROW46  _SFR_MEM8(0x122E)
+#define USERROW_USERROW47  _SFR_MEM8(0x122F)
+#define USERROW_USERROW48  _SFR_MEM8(0x1230)
+#define USERROW_USERROW49  _SFR_MEM8(0x1231)
+#define USERROW_USERROW50  _SFR_MEM8(0x1232)
+#define USERROW_USERROW51  _SFR_MEM8(0x1233)
+#define USERROW_USERROW52  _SFR_MEM8(0x1234)
+#define USERROW_USERROW53  _SFR_MEM8(0x1235)
+#define USERROW_USERROW54  _SFR_MEM8(0x1236)
+#define USERROW_USERROW55  _SFR_MEM8(0x1237)
+#define USERROW_USERROW56  _SFR_MEM8(0x1238)
+#define USERROW_USERROW57  _SFR_MEM8(0x1239)
+#define USERROW_USERROW58  _SFR_MEM8(0x123A)
+#define USERROW_USERROW59  _SFR_MEM8(0x123B)
+#define USERROW_USERROW60  _SFR_MEM8(0x123C)
+#define USERROW_USERROW61  _SFR_MEM8(0x123D)
+#define USERROW_USERROW62  _SFR_MEM8(0x123E)
+#define USERROW_USERROW63  _SFR_MEM8(0x123F)
+
+
+
+/*================== Bitfield Definitions ================== */
+
+/* AC - Analog Comparator */
+/* AC.CTRLA  bit masks and bit positions */
+#define AC_ENABLE_bm  0x01  /* Enable bit mask. */
+#define AC_ENABLE_bp  0  /* Enable bit position. */
+#define AC_HYSMODE_gm  0x06  /* Hysteresis Mode group mask. */
+#define AC_HYSMODE_gp  1  /* Hysteresis Mode group position. */
+#define AC_HYSMODE_0_bm  (1<<1)  /* Hysteresis Mode bit 0 mask. */
+#define AC_HYSMODE_0_bp  1  /* Hysteresis Mode bit 0 position. */
+#define AC_HYSMODE_1_bm  (1<<2)  /* Hysteresis Mode bit 1 mask. */
+#define AC_HYSMODE_1_bp  2  /* Hysteresis Mode bit 1 position. */
+#define AC_POWER_gm  0x18  /* Power profile group mask. */
+#define AC_POWER_gp  3  /* Power profile group position. */
+#define AC_POWER_0_bm  (1<<3)  /* Power profile bit 0 mask. */
+#define AC_POWER_0_bp  3  /* Power profile bit 0 position. */
+#define AC_POWER_1_bm  (1<<4)  /* Power profile bit 1 mask. */
+#define AC_POWER_1_bp  4  /* Power profile bit 1 position. */
+#define AC_OUTEN_bm  0x40  /* Output Pad Enable bit mask. */
+#define AC_OUTEN_bp  6  /* Output Pad Enable bit position. */
+#define AC_RUNSTDBY_bm  0x80  /* Run in Standby Mode bit mask. */
+#define AC_RUNSTDBY_bp  7  /* Run in Standby Mode bit position. */
+
+/* AC.CTRLB  bit masks and bit positions */
+#define AC_WINSEL_gm  0x03  /* Window selection mode group mask. */
+#define AC_WINSEL_gp  0  /* Window selection mode group position. */
+#define AC_WINSEL_0_bm  (1<<0)  /* Window selection mode bit 0 mask. */
+#define AC_WINSEL_0_bp  0  /* Window selection mode bit 0 position. */
+#define AC_WINSEL_1_bm  (1<<1)  /* Window selection mode bit 1 mask. */
+#define AC_WINSEL_1_bp  1  /* Window selection mode bit 1 position. */
+
+/* AC.MUXCTRL  bit masks and bit positions */
+#define AC_MUXNEG_gm  0x07  /* Negative Input MUX Selection group mask. */
+#define AC_MUXNEG_gp  0  /* Negative Input MUX Selection group position. */
+#define AC_MUXNEG_0_bm  (1<<0)  /* Negative Input MUX Selection bit 0 mask. */
+#define AC_MUXNEG_0_bp  0  /* Negative Input MUX Selection bit 0 position. */
+#define AC_MUXNEG_1_bm  (1<<1)  /* Negative Input MUX Selection bit 1 mask. */
+#define AC_MUXNEG_1_bp  1  /* Negative Input MUX Selection bit 1 position. */
+#define AC_MUXNEG_2_bm  (1<<2)  /* Negative Input MUX Selection bit 2 mask. */
+#define AC_MUXNEG_2_bp  2  /* Negative Input MUX Selection bit 2 position. */
+#define AC_MUXPOS_gm  0x38  /* Positive Input MUX Selection group mask. */
+#define AC_MUXPOS_gp  3  /* Positive Input MUX Selection group position. */
+#define AC_MUXPOS_0_bm  (1<<3)  /* Positive Input MUX Selection bit 0 mask. */
+#define AC_MUXPOS_0_bp  3  /* Positive Input MUX Selection bit 0 position. */
+#define AC_MUXPOS_1_bm  (1<<4)  /* Positive Input MUX Selection bit 1 mask. */
+#define AC_MUXPOS_1_bp  4  /* Positive Input MUX Selection bit 1 position. */
+#define AC_MUXPOS_2_bm  (1<<5)  /* Positive Input MUX Selection bit 2 mask. */
+#define AC_MUXPOS_2_bp  5  /* Positive Input MUX Selection bit 2 position. */
+#define AC_INITVAL_bm  0x40  /* AC Output Initial Value bit mask. */
+#define AC_INITVAL_bp  6  /* AC Output Initial Value bit position. */
+#define AC_INVERT_bm  0x80  /* Invert AC Output bit mask. */
+#define AC_INVERT_bp  7  /* Invert AC Output bit position. */
+
+/* AC.DACREF  bit masks and bit positions */
+#define AC_DACREF_gm  0xFF  /* DACREF group mask. */
+#define AC_DACREF_gp  0  /* DACREF group position. */
+#define AC_DACREF_0_bm  (1<<0)  /* DACREF bit 0 mask. */
+#define AC_DACREF_0_bp  0  /* DACREF bit 0 position. */
+#define AC_DACREF_1_bm  (1<<1)  /* DACREF bit 1 mask. */
+#define AC_DACREF_1_bp  1  /* DACREF bit 1 position. */
+#define AC_DACREF_2_bm  (1<<2)  /* DACREF bit 2 mask. */
+#define AC_DACREF_2_bp  2  /* DACREF bit 2 position. */
+#define AC_DACREF_3_bm  (1<<3)  /* DACREF bit 3 mask. */
+#define AC_DACREF_3_bp  3  /* DACREF bit 3 position. */
+#define AC_DACREF_4_bm  (1<<4)  /* DACREF bit 4 mask. */
+#define AC_DACREF_4_bp  4  /* DACREF bit 4 position. */
+#define AC_DACREF_5_bm  (1<<5)  /* DACREF bit 5 mask. */
+#define AC_DACREF_5_bp  5  /* DACREF bit 5 position. */
+#define AC_DACREF_6_bm  (1<<6)  /* DACREF bit 6 mask. */
+#define AC_DACREF_6_bp  6  /* DACREF bit 6 position. */
+#define AC_DACREF_7_bm  (1<<7)  /* DACREF bit 7 mask. */
+#define AC_DACREF_7_bp  7  /* DACREF bit 7 position. */
+
+/* AC.INTCTRL  bit masks and bit positions */
+#define AC_CMP_bm  0x01  /* Interrupt Enable bit mask. */
+#define AC_CMP_bp  0  /* Interrupt Enable bit position. */
+#define AC_INTMODE_NORMAL_gm  0x30  /* Interrupt Mode group mask. */
+#define AC_INTMODE_NORMAL_gp  4  /* Interrupt Mode group position. */
+#define AC_INTMODE_NORMAL_0_bm  (1<<4)  /* Interrupt Mode bit 0 mask. */
+#define AC_INTMODE_NORMAL_0_bp  4  /* Interrupt Mode bit 0 position. */
+#define AC_INTMODE_NORMAL_1_bm  (1<<5)  /* Interrupt Mode bit 1 mask. */
+#define AC_INTMODE_NORMAL_1_bp  5  /* Interrupt Mode bit 1 position. */
+#define AC_INTMODE_WINDOW_gm  0x30  /* Interrupt Mode group mask. */
+#define AC_INTMODE_WINDOW_gp  4  /* Interrupt Mode group position. */
+#define AC_INTMODE_WINDOW_0_bm  (1<<4)  /* Interrupt Mode bit 0 mask. */
+#define AC_INTMODE_WINDOW_0_bp  4  /* Interrupt Mode bit 0 position. */
+#define AC_INTMODE_WINDOW_1_bm  (1<<5)  /* Interrupt Mode bit 1 mask. */
+#define AC_INTMODE_WINDOW_1_bp  5  /* Interrupt Mode bit 1 position. */
+
+/* AC.STATUS  bit masks and bit positions */
+#define AC_CMPIF_bm  0x01  /* Analog Comparator Interrupt Flag bit mask. */
+#define AC_CMPIF_bp  0  /* Analog Comparator Interrupt Flag bit position. */
+#define AC_CMPSTATE_bm  0x10  /* Analog Comparator State bit mask. */
+#define AC_CMPSTATE_bp  4  /* Analog Comparator State bit position. */
+#define AC_WINSTATE_gm  0xC0  /* Analog Comparator Window State group mask. */
+#define AC_WINSTATE_gp  6  /* Analog Comparator Window State group position. */
+#define AC_WINSTATE_0_bm  (1<<6)  /* Analog Comparator Window State bit 0 mask. */
+#define AC_WINSTATE_0_bp  6  /* Analog Comparator Window State bit 0 position. */
+#define AC_WINSTATE_1_bm  (1<<7)  /* Analog Comparator Window State bit 1 mask. */
+#define AC_WINSTATE_1_bp  7  /* Analog Comparator Window State bit 1 position. */
+
+
+/* ADC - Analog to Digital Converter */
+/* ADC.CTRLA  bit masks and bit positions */
+#define ADC_ENABLE_bm  0x01  /* ADC Enable bit mask. */
+#define ADC_ENABLE_bp  0  /* ADC Enable bit position. */
+#define ADC_LOWLAT_bm  0x20  /* Low Latency bit mask. */
+#define ADC_LOWLAT_bp  5  /* Low Latency bit position. */
+#define ADC_RUNSTDBY_bm  0x80  /* Run in Standby bit mask. */
+#define ADC_RUNSTDBY_bp  7  /* Run in Standby bit position. */
+
+/* ADC.CTRLB  bit masks and bit positions */
+#define ADC_PRESC_gm  0x0F  /* Prescaler Value group mask. */
+#define ADC_PRESC_gp  0  /* Prescaler Value group position. */
+#define ADC_PRESC_0_bm  (1<<0)  /* Prescaler Value bit 0 mask. */
+#define ADC_PRESC_0_bp  0  /* Prescaler Value bit 0 position. */
+#define ADC_PRESC_1_bm  (1<<1)  /* Prescaler Value bit 1 mask. */
+#define ADC_PRESC_1_bp  1  /* Prescaler Value bit 1 position. */
+#define ADC_PRESC_2_bm  (1<<2)  /* Prescaler Value bit 2 mask. */
+#define ADC_PRESC_2_bp  2  /* Prescaler Value bit 2 position. */
+#define ADC_PRESC_3_bm  (1<<3)  /* Prescaler Value bit 3 mask. */
+#define ADC_PRESC_3_bp  3  /* Prescaler Value bit 3 position. */
+
+/* ADC.CTRLC  bit masks and bit positions */
+#define ADC_REFSEL_gm  0x07  /* Reference select group mask. */
+#define ADC_REFSEL_gp  0  /* Reference select group position. */
+#define ADC_REFSEL_0_bm  (1<<0)  /* Reference select bit 0 mask. */
+#define ADC_REFSEL_0_bp  0  /* Reference select bit 0 position. */
+#define ADC_REFSEL_1_bm  (1<<1)  /* Reference select bit 1 mask. */
+#define ADC_REFSEL_1_bp  1  /* Reference select bit 1 position. */
+#define ADC_REFSEL_2_bm  (1<<2)  /* Reference select bit 2 mask. */
+#define ADC_REFSEL_2_bp  2  /* Reference select bit 2 position. */
+
+/* ADC.CTRLD  bit masks and bit positions */
+#define ADC_WINCM_gm  0x07  /* Window Comparator Mode group mask. */
+#define ADC_WINCM_gp  0  /* Window Comparator Mode group position. */
+#define ADC_WINCM_0_bm  (1<<0)  /* Window Comparator Mode bit 0 mask. */
+#define ADC_WINCM_0_bp  0  /* Window Comparator Mode bit 0 position. */
+#define ADC_WINCM_1_bm  (1<<1)  /* Window Comparator Mode bit 1 mask. */
+#define ADC_WINCM_1_bp  1  /* Window Comparator Mode bit 1 position. */
+#define ADC_WINCM_2_bm  (1<<2)  /* Window Comparator Mode bit 2 mask. */
+#define ADC_WINCM_2_bp  2  /* Window Comparator Mode bit 2 position. */
+#define ADC_WINSRC_bm  0x08  /* Window Mode Source bit mask. */
+#define ADC_WINSRC_bp  3  /* Window Mode Source bit position. */
+
+/* ADC.INTCTRL  bit masks and bit positions */
+#define ADC_RESRDY_bm  0x01  /* Result Ready Interrupt Enable bit mask. */
+#define ADC_RESRDY_bp  0  /* Result Ready Interrupt Enable bit position. */
+#define ADC_SAMPRDY_bm  0x02  /* Sample Ready Interrupt Enable bit mask. */
+#define ADC_SAMPRDY_bp  1  /* Sample Ready Interrupt Enable bit position. */
+#define ADC_WCMP_bm  0x04  /* Window Comparator Interrupt Enable bit mask. */
+#define ADC_WCMP_bp  2  /* Window Comparator Interrupt Enable bit position. */
+#define ADC_RESOVR_bm  0x08  /* Result Overwrite Interrupt Enable bit mask. */
+#define ADC_RESOVR_bp  3  /* Result Overwrite Interrupt Enable bit position. */
+#define ADC_SAMPOVR_bm  0x10  /* Sample Overwrite Interrupt Enable bit mask. */
+#define ADC_SAMPOVR_bp  4  /* Sample Overwrite Interrupt Enable bit position. */
+#define ADC_TRIGOVR_bm  0x20  /* Trigger Overrun Interrupt Enable bit mask. */
+#define ADC_TRIGOVR_bp  5  /* Trigger Overrun Interrupt Enable bit position. */
+
+/* ADC.INTFLAGS  bit masks and bit positions */
+/* ADC_RESRDY  is already defined. */
+/* ADC_SAMPRDY  is already defined. */
+/* ADC_WCMP  is already defined. */
+/* ADC_RESOVR  is already defined. */
+/* ADC_SAMPOVR  is already defined. */
+/* ADC_TRIGOVR  is already defined. */
+
+/* ADC.STATUS  bit masks and bit positions */
+#define ADC_ADCBUSY_bm  0x01  /* ADC Busy bit mask. */
+#define ADC_ADCBUSY_bp  0  /* ADC Busy bit position. */
+
+/* ADC.DBGCTRL  bit masks and bit positions */
+#define ADC_DBGRUN_bm  0x01  /* Run in Debug Mode bit mask. */
+#define ADC_DBGRUN_bp  0  /* Run in Debug Mode bit position. */
+
+/* ADC.CTRLE  bit masks and bit positions */
+#define ADC_SAMPDUR_gm  0xFF  /* Sample Duration group mask. */
+#define ADC_SAMPDUR_gp  0  /* Sample Duration group position. */
+#define ADC_SAMPDUR_0_bm  (1<<0)  /* Sample Duration bit 0 mask. */
+#define ADC_SAMPDUR_0_bp  0  /* Sample Duration bit 0 position. */
+#define ADC_SAMPDUR_1_bm  (1<<1)  /* Sample Duration bit 1 mask. */
+#define ADC_SAMPDUR_1_bp  1  /* Sample Duration bit 1 position. */
+#define ADC_SAMPDUR_2_bm  (1<<2)  /* Sample Duration bit 2 mask. */
+#define ADC_SAMPDUR_2_bp  2  /* Sample Duration bit 2 position. */
+#define ADC_SAMPDUR_3_bm  (1<<3)  /* Sample Duration bit 3 mask. */
+#define ADC_SAMPDUR_3_bp  3  /* Sample Duration bit 3 position. */
+#define ADC_SAMPDUR_4_bm  (1<<4)  /* Sample Duration bit 4 mask. */
+#define ADC_SAMPDUR_4_bp  4  /* Sample Duration bit 4 position. */
+#define ADC_SAMPDUR_5_bm  (1<<5)  /* Sample Duration bit 5 mask. */
+#define ADC_SAMPDUR_5_bp  5  /* Sample Duration bit 5 position. */
+#define ADC_SAMPDUR_6_bm  (1<<6)  /* Sample Duration bit 6 mask. */
+#define ADC_SAMPDUR_6_bp  6  /* Sample Duration bit 6 position. */
+#define ADC_SAMPDUR_7_bm  (1<<7)  /* Sample Duration bit 7 mask. */
+#define ADC_SAMPDUR_7_bp  7  /* Sample Duration bit 7 position. */
+
+/* ADC.CTRLF  bit masks and bit positions */
+#define ADC_SAMPNUM_gm  0x0F  /* Sample numbers group mask. */
+#define ADC_SAMPNUM_gp  0  /* Sample numbers group position. */
+#define ADC_SAMPNUM_0_bm  (1<<0)  /* Sample numbers bit 0 mask. */
+#define ADC_SAMPNUM_0_bp  0  /* Sample numbers bit 0 position. */
+#define ADC_SAMPNUM_1_bm  (1<<1)  /* Sample numbers bit 1 mask. */
+#define ADC_SAMPNUM_1_bp  1  /* Sample numbers bit 1 position. */
+#define ADC_SAMPNUM_2_bm  (1<<2)  /* Sample numbers bit 2 mask. */
+#define ADC_SAMPNUM_2_bp  2  /* Sample numbers bit 2 position. */
+#define ADC_SAMPNUM_3_bm  (1<<3)  /* Sample numbers bit 3 mask. */
+#define ADC_SAMPNUM_3_bp  3  /* Sample numbers bit 3 position. */
+#define ADC_LEFTADJ_bm  0x10  /* Left Adjust bit mask. */
+#define ADC_LEFTADJ_bp  4  /* Left Adjust bit position. */
+#define ADC_FREERUN_bm  0x20  /* Free-Running mode bit mask. */
+#define ADC_FREERUN_bp  5  /* Free-Running mode bit position. */
+#define ADC_CHOPPING_bm  0x40  /* Sign Chopping bit mask. */
+#define ADC_CHOPPING_bp  6  /* Sign Chopping bit position. */
+
+/* ADC.COMMAND  bit masks and bit positions */
+#define ADC_START_gm  0x07  /* Start command group mask. */
+#define ADC_START_gp  0  /* Start command group position. */
+#define ADC_START_0_bm  (1<<0)  /* Start command bit 0 mask. */
+#define ADC_START_0_bp  0  /* Start command bit 0 position. */
+#define ADC_START_1_bm  (1<<1)  /* Start command bit 1 mask. */
+#define ADC_START_1_bp  1  /* Start command bit 1 position. */
+#define ADC_START_2_bm  (1<<2)  /* Start command bit 2 mask. */
+#define ADC_START_2_bp  2  /* Start command bit 2 position. */
+#define ADC_MODE_gm  0x70  /* Mode group mask. */
+#define ADC_MODE_gp  4  /* Mode group position. */
+#define ADC_MODE_0_bm  (1<<4)  /* Mode bit 0 mask. */
+#define ADC_MODE_0_bp  4  /* Mode bit 0 position. */
+#define ADC_MODE_1_bm  (1<<5)  /* Mode bit 1 mask. */
+#define ADC_MODE_1_bp  5  /* Mode bit 1 position. */
+#define ADC_MODE_2_bm  (1<<6)  /* Mode bit 2 mask. */
+#define ADC_MODE_2_bp  6  /* Mode bit 2 position. */
+#define ADC_DIFF_bm  0x80  /* Differential mode bit mask. */
+#define ADC_DIFF_bp  7  /* Differential mode bit position. */
+
+/* ADC.PGACTRL  bit masks and bit positions */
+#define ADC_PGAEN_bm  0x01  /* PGA Enable bit mask. */
+#define ADC_PGAEN_bp  0  /* PGA Enable bit position. */
+#define ADC_PGABIASSEL_gm  0x18  /* PGA BIAS Select group mask. */
+#define ADC_PGABIASSEL_gp  3  /* PGA BIAS Select group position. */
+#define ADC_PGABIASSEL_0_bm  (1<<3)  /* PGA BIAS Select bit 0 mask. */
+#define ADC_PGABIASSEL_0_bp  3  /* PGA BIAS Select bit 0 position. */
+#define ADC_PGABIASSEL_1_bm  (1<<4)  /* PGA BIAS Select bit 1 mask. */
+#define ADC_PGABIASSEL_1_bp  4  /* PGA BIAS Select bit 1 position. */
+#define ADC_GAIN_gm  0xE0  /* Gain group mask. */
+#define ADC_GAIN_gp  5  /* Gain group position. */
+#define ADC_GAIN_0_bm  (1<<5)  /* Gain bit 0 mask. */
+#define ADC_GAIN_0_bp  5  /* Gain bit 0 position. */
+#define ADC_GAIN_1_bm  (1<<6)  /* Gain bit 1 mask. */
+#define ADC_GAIN_1_bp  6  /* Gain bit 1 position. */
+#define ADC_GAIN_2_bm  (1<<7)  /* Gain bit 2 mask. */
+#define ADC_GAIN_2_bp  7  /* Gain bit 2 position. */
+
+/* ADC.MUXPOS  bit masks and bit positions */
+#define ADC_MUXPOS_gm  0x3F  /* Analog Channel Selection Bits group mask. */
+#define ADC_MUXPOS_gp  0  /* Analog Channel Selection Bits group position. */
+#define ADC_MUXPOS_0_bm  (1<<0)  /* Analog Channel Selection Bits bit 0 mask. */
+#define ADC_MUXPOS_0_bp  0  /* Analog Channel Selection Bits bit 0 position. */
+#define ADC_MUXPOS_1_bm  (1<<1)  /* Analog Channel Selection Bits bit 1 mask. */
+#define ADC_MUXPOS_1_bp  1  /* Analog Channel Selection Bits bit 1 position. */
+#define ADC_MUXPOS_2_bm  (1<<2)  /* Analog Channel Selection Bits bit 2 mask. */
+#define ADC_MUXPOS_2_bp  2  /* Analog Channel Selection Bits bit 2 position. */
+#define ADC_MUXPOS_3_bm  (1<<3)  /* Analog Channel Selection Bits bit 3 mask. */
+#define ADC_MUXPOS_3_bp  3  /* Analog Channel Selection Bits bit 3 position. */
+#define ADC_MUXPOS_4_bm  (1<<4)  /* Analog Channel Selection Bits bit 4 mask. */
+#define ADC_MUXPOS_4_bp  4  /* Analog Channel Selection Bits bit 4 position. */
+#define ADC_MUXPOS_5_bm  (1<<5)  /* Analog Channel Selection Bits bit 5 mask. */
+#define ADC_MUXPOS_5_bp  5  /* Analog Channel Selection Bits bit 5 position. */
+#define ADC_VIA_gm  0xC0  /* VIA group mask. */
+#define ADC_VIA_gp  6  /* VIA group position. */
+#define ADC_VIA_0_bm  (1<<6)  /* VIA bit 0 mask. */
+#define ADC_VIA_0_bp  6  /* VIA bit 0 position. */
+#define ADC_VIA_1_bm  (1<<7)  /* VIA bit 1 mask. */
+#define ADC_VIA_1_bp  7  /* VIA bit 1 position. */
+
+/* ADC.MUXNEG  bit masks and bit positions */
+#define ADC_MUXNEG_gm  0x3F  /* Analog Channel Selection Bits group mask. */
+#define ADC_MUXNEG_gp  0  /* Analog Channel Selection Bits group position. */
+#define ADC_MUXNEG_0_bm  (1<<0)  /* Analog Channel Selection Bits bit 0 mask. */
+#define ADC_MUXNEG_0_bp  0  /* Analog Channel Selection Bits bit 0 position. */
+#define ADC_MUXNEG_1_bm  (1<<1)  /* Analog Channel Selection Bits bit 1 mask. */
+#define ADC_MUXNEG_1_bp  1  /* Analog Channel Selection Bits bit 1 position. */
+#define ADC_MUXNEG_2_bm  (1<<2)  /* Analog Channel Selection Bits bit 2 mask. */
+#define ADC_MUXNEG_2_bp  2  /* Analog Channel Selection Bits bit 2 position. */
+#define ADC_MUXNEG_3_bm  (1<<3)  /* Analog Channel Selection Bits bit 3 mask. */
+#define ADC_MUXNEG_3_bp  3  /* Analog Channel Selection Bits bit 3 position. */
+#define ADC_MUXNEG_4_bm  (1<<4)  /* Analog Channel Selection Bits bit 4 mask. */
+#define ADC_MUXNEG_4_bp  4  /* Analog Channel Selection Bits bit 4 position. */
+#define ADC_MUXNEG_5_bm  (1<<5)  /* Analog Channel Selection Bits bit 5 mask. */
+#define ADC_MUXNEG_5_bp  5  /* Analog Channel Selection Bits bit 5 position. */
+/* ADC_VIA  is already defined. */
+
+
+/* BOD - Bod interface */
+/* BOD.CTRLA  bit masks and bit positions */
+#define BOD_SLEEP_gm  0x03  /* Operation in sleep mode group mask. */
+#define BOD_SLEEP_gp  0  /* Operation in sleep mode group position. */
+#define BOD_SLEEP_0_bm  (1<<0)  /* Operation in sleep mode bit 0 mask. */
+#define BOD_SLEEP_0_bp  0  /* Operation in sleep mode bit 0 position. */
+#define BOD_SLEEP_1_bm  (1<<1)  /* Operation in sleep mode bit 1 mask. */
+#define BOD_SLEEP_1_bp  1  /* Operation in sleep mode bit 1 position. */
+#define BOD_ACTIVE_gm  0x0C  /* Operation in active mode group mask. */
+#define BOD_ACTIVE_gp  2  /* Operation in active mode group position. */
+#define BOD_ACTIVE_0_bm  (1<<2)  /* Operation in active mode bit 0 mask. */
+#define BOD_ACTIVE_0_bp  2  /* Operation in active mode bit 0 position. */
+#define BOD_ACTIVE_1_bm  (1<<3)  /* Operation in active mode bit 1 mask. */
+#define BOD_ACTIVE_1_bp  3  /* Operation in active mode bit 1 position. */
+#define BOD_SAMPFREQ_bm  0x10  /* Sample frequency bit mask. */
+#define BOD_SAMPFREQ_bp  4  /* Sample frequency bit position. */
+
+/* BOD.CTRLB  bit masks and bit positions */
+#define BOD_LVL_gm  0x07  /* Bod level group mask. */
+#define BOD_LVL_gp  0  /* Bod level group position. */
+#define BOD_LVL_0_bm  (1<<0)  /* Bod level bit 0 mask. */
+#define BOD_LVL_0_bp  0  /* Bod level bit 0 position. */
+#define BOD_LVL_1_bm  (1<<1)  /* Bod level bit 1 mask. */
+#define BOD_LVL_1_bp  1  /* Bod level bit 1 position. */
+#define BOD_LVL_2_bm  (1<<2)  /* Bod level bit 2 mask. */
+#define BOD_LVL_2_bp  2  /* Bod level bit 2 position. */
+
+/* BOD.VLMCTRLA  bit masks and bit positions */
+#define BOD_VLMLVL_gm  0x03  /* voltage level monitor level group mask. */
+#define BOD_VLMLVL_gp  0  /* voltage level monitor level group position. */
+#define BOD_VLMLVL_0_bm  (1<<0)  /* voltage level monitor level bit 0 mask. */
+#define BOD_VLMLVL_0_bp  0  /* voltage level monitor level bit 0 position. */
+#define BOD_VLMLVL_1_bm  (1<<1)  /* voltage level monitor level bit 1 mask. */
+#define BOD_VLMLVL_1_bp  1  /* voltage level monitor level bit 1 position. */
+
+/* BOD.INTCTRL  bit masks and bit positions */
+#define BOD_VLMIE_bm  0x01  /* voltage level monitor interrrupt enable bit mask. */
+#define BOD_VLMIE_bp  0  /* voltage level monitor interrrupt enable bit position. */
+#define BOD_VLMCFG_gm  0x06  /* Configuration group mask. */
+#define BOD_VLMCFG_gp  1  /* Configuration group position. */
+#define BOD_VLMCFG_0_bm  (1<<1)  /* Configuration bit 0 mask. */
+#define BOD_VLMCFG_0_bp  1  /* Configuration bit 0 position. */
+#define BOD_VLMCFG_1_bm  (1<<2)  /* Configuration bit 1 mask. */
+#define BOD_VLMCFG_1_bp  2  /* Configuration bit 1 position. */
+
+/* BOD.INTFLAGS  bit masks and bit positions */
+#define BOD_VLMIF_bm  0x01  /* Voltage level monitor interrupt flag bit mask. */
+#define BOD_VLMIF_bp  0  /* Voltage level monitor interrupt flag bit position. */
+
+/* BOD.STATUS  bit masks and bit positions */
+#define BOD_VLMS_bm  0x01  /* Voltage level monitor status bit mask. */
+#define BOD_VLMS_bp  0  /* Voltage level monitor status bit position. */
+
+
+
+/* CCL - Configurable Custom Logic */
+/* CCL.CTRLA  bit masks and bit positions */
+#define CCL_ENABLE_bm  0x01  /* Enable bit mask. */
+#define CCL_ENABLE_bp  0  /* Enable bit position. */
+#define CCL_RUNSTDBY_bm  0x40  /* Run in Standby bit mask. */
+#define CCL_RUNSTDBY_bp  6  /* Run in Standby bit position. */
+
+/* CCL.SEQCTRL0  bit masks and bit positions */
+#define CCL_SEQSEL_gm  0x0F  /* Sequential Selection group mask. */
+#define CCL_SEQSEL_gp  0  /* Sequential Selection group position. */
+#define CCL_SEQSEL_0_bm  (1<<0)  /* Sequential Selection bit 0 mask. */
+#define CCL_SEQSEL_0_bp  0  /* Sequential Selection bit 0 position. */
+#define CCL_SEQSEL_1_bm  (1<<1)  /* Sequential Selection bit 1 mask. */
+#define CCL_SEQSEL_1_bp  1  /* Sequential Selection bit 1 position. */
+#define CCL_SEQSEL_2_bm  (1<<2)  /* Sequential Selection bit 2 mask. */
+#define CCL_SEQSEL_2_bp  2  /* Sequential Selection bit 2 position. */
+#define CCL_SEQSEL_3_bm  (1<<3)  /* Sequential Selection bit 3 mask. */
+#define CCL_SEQSEL_3_bp  3  /* Sequential Selection bit 3 position. */
+
+/* CCL.SEQCTRL1  bit masks and bit positions */
+/* CCL_SEQSEL  is already defined. */
+
+/* CCL.INTCTRL0  bit masks and bit positions */
+#define CCL_INTMODE0_gm  0x03  /* Interrupt Mode for LUT0 group mask. */
+#define CCL_INTMODE0_gp  0  /* Interrupt Mode for LUT0 group position. */
+#define CCL_INTMODE0_0_bm  (1<<0)  /* Interrupt Mode for LUT0 bit 0 mask. */
+#define CCL_INTMODE0_0_bp  0  /* Interrupt Mode for LUT0 bit 0 position. */
+#define CCL_INTMODE0_1_bm  (1<<1)  /* Interrupt Mode for LUT0 bit 1 mask. */
+#define CCL_INTMODE0_1_bp  1  /* Interrupt Mode for LUT0 bit 1 position. */
+#define CCL_INTMODE1_gm  0x0C  /* Interrupt Mode for LUT1 group mask. */
+#define CCL_INTMODE1_gp  2  /* Interrupt Mode for LUT1 group position. */
+#define CCL_INTMODE1_0_bm  (1<<2)  /* Interrupt Mode for LUT1 bit 0 mask. */
+#define CCL_INTMODE1_0_bp  2  /* Interrupt Mode for LUT1 bit 0 position. */
+#define CCL_INTMODE1_1_bm  (1<<3)  /* Interrupt Mode for LUT1 bit 1 mask. */
+#define CCL_INTMODE1_1_bp  3  /* Interrupt Mode for LUT1 bit 1 position. */
+#define CCL_INTMODE2_gm  0x30  /* Interrupt Mode for LUT2 group mask. */
+#define CCL_INTMODE2_gp  4  /* Interrupt Mode for LUT2 group position. */
+#define CCL_INTMODE2_0_bm  (1<<4)  /* Interrupt Mode for LUT2 bit 0 mask. */
+#define CCL_INTMODE2_0_bp  4  /* Interrupt Mode for LUT2 bit 0 position. */
+#define CCL_INTMODE2_1_bm  (1<<5)  /* Interrupt Mode for LUT2 bit 1 mask. */
+#define CCL_INTMODE2_1_bp  5  /* Interrupt Mode for LUT2 bit 1 position. */
+#define CCL_INTMODE3_gm  0xC0  /* Interrupt Mode for LUT3 group mask. */
+#define CCL_INTMODE3_gp  6  /* Interrupt Mode for LUT3 group position. */
+#define CCL_INTMODE3_0_bm  (1<<6)  /* Interrupt Mode for LUT3 bit 0 mask. */
+#define CCL_INTMODE3_0_bp  6  /* Interrupt Mode for LUT3 bit 0 position. */
+#define CCL_INTMODE3_1_bm  (1<<7)  /* Interrupt Mode for LUT3 bit 1 mask. */
+#define CCL_INTMODE3_1_bp  7  /* Interrupt Mode for LUT3 bit 1 position. */
+
+/* CCL.INTFLAGS  bit masks and bit positions */
+#define CCL_INT_gm  0x0F  /* Interrupt Flag group mask. */
+#define CCL_INT_gp  0  /* Interrupt Flag group position. */
+#define CCL_INT_0_bm  (1<<0)  /* Interrupt Flag bit 0 mask. */
+#define CCL_INT_0_bp  0  /* Interrupt Flag bit 0 position. */
+#define CCL_INT0_bm  CCL_INT_0_bm  /* This define is deprecated and should not be used */
+#define CCL_INT0_bp  CCL_INT_0_bp  /* This define is deprecated and should not be used */
+#define CCL_INT_1_bm  (1<<1)  /* Interrupt Flag bit 1 mask. */
+#define CCL_INT_1_bp  1  /* Interrupt Flag bit 1 position. */
+#define CCL_INT1_bm  CCL_INT_1_bm  /* This define is deprecated and should not be used */
+#define CCL_INT1_bp  CCL_INT_1_bp  /* This define is deprecated and should not be used */
+#define CCL_INT_2_bm  (1<<2)  /* Interrupt Flag bit 2 mask. */
+#define CCL_INT_2_bp  2  /* Interrupt Flag bit 2 position. */
+#define CCL_INT2_bm  CCL_INT_2_bm  /* This define is deprecated and should not be used */
+#define CCL_INT2_bp  CCL_INT_2_bp  /* This define is deprecated and should not be used */
+#define CCL_INT_3_bm  (1<<3)  /* Interrupt Flag bit 3 mask. */
+#define CCL_INT_3_bp  3  /* Interrupt Flag bit 3 position. */
+#define CCL_INT3_bm  CCL_INT_3_bm  /* This define is deprecated and should not be used */
+#define CCL_INT3_bp  CCL_INT_3_bp  /* This define is deprecated and should not be used */
+
+/* CCL.LUT0CTRLA  bit masks and bit positions */
+/* CCL_ENABLE  is already defined. */
+#define CCL_CLKSRC_gm  0x0E  /* Clock Source Selection group mask. */
+#define CCL_CLKSRC_gp  1  /* Clock Source Selection group position. */
+#define CCL_CLKSRC_0_bm  (1<<1)  /* Clock Source Selection bit 0 mask. */
+#define CCL_CLKSRC_0_bp  1  /* Clock Source Selection bit 0 position. */
+#define CCL_CLKSRC_1_bm  (1<<2)  /* Clock Source Selection bit 1 mask. */
+#define CCL_CLKSRC_1_bp  2  /* Clock Source Selection bit 1 position. */
+#define CCL_CLKSRC_2_bm  (1<<3)  /* Clock Source Selection bit 2 mask. */
+#define CCL_CLKSRC_2_bp  3  /* Clock Source Selection bit 2 position. */
+#define CCL_FILTSEL_gm  0x30  /* Filter Selection group mask. */
+#define CCL_FILTSEL_gp  4  /* Filter Selection group position. */
+#define CCL_FILTSEL_0_bm  (1<<4)  /* Filter Selection bit 0 mask. */
+#define CCL_FILTSEL_0_bp  4  /* Filter Selection bit 0 position. */
+#define CCL_FILTSEL_1_bm  (1<<5)  /* Filter Selection bit 1 mask. */
+#define CCL_FILTSEL_1_bp  5  /* Filter Selection bit 1 position. */
+#define CCL_OUTEN_bm  0x40  /* Output Enable bit mask. */
+#define CCL_OUTEN_bp  6  /* Output Enable bit position. */
+#define CCL_EDGEDET_bm  0x80  /* Edge Detection Enable bit mask. */
+#define CCL_EDGEDET_bp  7  /* Edge Detection Enable bit position. */
+
+/* CCL.LUT0CTRLB  bit masks and bit positions */
+#define CCL_INSEL0_gm  0x0F  /* LUT Input 0 Source Selection group mask. */
+#define CCL_INSEL0_gp  0  /* LUT Input 0 Source Selection group position. */
+#define CCL_INSEL0_0_bm  (1<<0)  /* LUT Input 0 Source Selection bit 0 mask. */
+#define CCL_INSEL0_0_bp  0  /* LUT Input 0 Source Selection bit 0 position. */
+#define CCL_INSEL0_1_bm  (1<<1)  /* LUT Input 0 Source Selection bit 1 mask. */
+#define CCL_INSEL0_1_bp  1  /* LUT Input 0 Source Selection bit 1 position. */
+#define CCL_INSEL0_2_bm  (1<<2)  /* LUT Input 0 Source Selection bit 2 mask. */
+#define CCL_INSEL0_2_bp  2  /* LUT Input 0 Source Selection bit 2 position. */
+#define CCL_INSEL0_3_bm  (1<<3)  /* LUT Input 0 Source Selection bit 3 mask. */
+#define CCL_INSEL0_3_bp  3  /* LUT Input 0 Source Selection bit 3 position. */
+#define CCL_INSEL1_gm  0xF0  /* LUT Input 1 Source Selection group mask. */
+#define CCL_INSEL1_gp  4  /* LUT Input 1 Source Selection group position. */
+#define CCL_INSEL1_0_bm  (1<<4)  /* LUT Input 1 Source Selection bit 0 mask. */
+#define CCL_INSEL1_0_bp  4  /* LUT Input 1 Source Selection bit 0 position. */
+#define CCL_INSEL1_1_bm  (1<<5)  /* LUT Input 1 Source Selection bit 1 mask. */
+#define CCL_INSEL1_1_bp  5  /* LUT Input 1 Source Selection bit 1 position. */
+#define CCL_INSEL1_2_bm  (1<<6)  /* LUT Input 1 Source Selection bit 2 mask. */
+#define CCL_INSEL1_2_bp  6  /* LUT Input 1 Source Selection bit 2 position. */
+#define CCL_INSEL1_3_bm  (1<<7)  /* LUT Input 1 Source Selection bit 3 mask. */
+#define CCL_INSEL1_3_bp  7  /* LUT Input 1 Source Selection bit 3 position. */
+
+/* CCL.LUT0CTRLC  bit masks and bit positions */
+#define CCL_INSEL2_gm  0x0F  /* LUT Input 2 Source Selection group mask. */
+#define CCL_INSEL2_gp  0  /* LUT Input 2 Source Selection group position. */
+#define CCL_INSEL2_0_bm  (1<<0)  /* LUT Input 2 Source Selection bit 0 mask. */
+#define CCL_INSEL2_0_bp  0  /* LUT Input 2 Source Selection bit 0 position. */
+#define CCL_INSEL2_1_bm  (1<<1)  /* LUT Input 2 Source Selection bit 1 mask. */
+#define CCL_INSEL2_1_bp  1  /* LUT Input 2 Source Selection bit 1 position. */
+#define CCL_INSEL2_2_bm  (1<<2)  /* LUT Input 2 Source Selection bit 2 mask. */
+#define CCL_INSEL2_2_bp  2  /* LUT Input 2 Source Selection bit 2 position. */
+#define CCL_INSEL2_3_bm  (1<<3)  /* LUT Input 2 Source Selection bit 3 mask. */
+#define CCL_INSEL2_3_bp  3  /* LUT Input 2 Source Selection bit 3 position. */
+
+/* CCL.TRUTH0  bit masks and bit positions */
+#define CCL_TRUTH_gm  0xFF  /* Truth Table group mask. */
+#define CCL_TRUTH_gp  0  /* Truth Table group position. */
+#define CCL_TRUTH_0_bm  (1<<0)  /* Truth Table bit 0 mask. */
+#define CCL_TRUTH_0_bp  0  /* Truth Table bit 0 position. */
+#define CCL_TRUTH_1_bm  (1<<1)  /* Truth Table bit 1 mask. */
+#define CCL_TRUTH_1_bp  1  /* Truth Table bit 1 position. */
+#define CCL_TRUTH_2_bm  (1<<2)  /* Truth Table bit 2 mask. */
+#define CCL_TRUTH_2_bp  2  /* Truth Table bit 2 position. */
+#define CCL_TRUTH_3_bm  (1<<3)  /* Truth Table bit 3 mask. */
+#define CCL_TRUTH_3_bp  3  /* Truth Table bit 3 position. */
+#define CCL_TRUTH_4_bm  (1<<4)  /* Truth Table bit 4 mask. */
+#define CCL_TRUTH_4_bp  4  /* Truth Table bit 4 position. */
+#define CCL_TRUTH_5_bm  (1<<5)  /* Truth Table bit 5 mask. */
+#define CCL_TRUTH_5_bp  5  /* Truth Table bit 5 position. */
+#define CCL_TRUTH_6_bm  (1<<6)  /* Truth Table bit 6 mask. */
+#define CCL_TRUTH_6_bp  6  /* Truth Table bit 6 position. */
+#define CCL_TRUTH_7_bm  (1<<7)  /* Truth Table bit 7 mask. */
+#define CCL_TRUTH_7_bp  7  /* Truth Table bit 7 position. */
+
+/* CCL.LUT1CTRLA  bit masks and bit positions */
+/* CCL_ENABLE  is already defined. */
+/* CCL_CLKSRC  is already defined. */
+/* CCL_FILTSEL  is already defined. */
+/* CCL_OUTEN  is already defined. */
+/* CCL_EDGEDET  is already defined. */
+
+/* CCL.LUT1CTRLB  bit masks and bit positions */
+/* CCL_INSEL0  is already defined. */
+/* CCL_INSEL1  is already defined. */
+
+/* CCL.LUT1CTRLC  bit masks and bit positions */
+/* CCL_INSEL2  is already defined. */
+
+/* CCL.TRUTH1  bit masks and bit positions */
+/* CCL_TRUTH  is already defined. */
+
+/* CCL.LUT2CTRLA  bit masks and bit positions */
+/* CCL_ENABLE  is already defined. */
+/* CCL_CLKSRC  is already defined. */
+/* CCL_FILTSEL  is already defined. */
+/* CCL_OUTEN  is already defined. */
+/* CCL_EDGEDET  is already defined. */
+
+/* CCL.LUT2CTRLB  bit masks and bit positions */
+/* CCL_INSEL0  is already defined. */
+/* CCL_INSEL1  is already defined. */
+
+/* CCL.LUT2CTRLC  bit masks and bit positions */
+/* CCL_INSEL2  is already defined. */
+
+/* CCL.TRUTH2  bit masks and bit positions */
+/* CCL_TRUTH  is already defined. */
+
+/* CCL.LUT3CTRLA  bit masks and bit positions */
+/* CCL_ENABLE  is already defined. */
+/* CCL_CLKSRC  is already defined. */
+/* CCL_FILTSEL  is already defined. */
+/* CCL_OUTEN  is already defined. */
+/* CCL_EDGEDET  is already defined. */
+
+/* CCL.LUT3CTRLB  bit masks and bit positions */
+/* CCL_INSEL0  is already defined. */
+/* CCL_INSEL1  is already defined. */
+
+/* CCL.LUT3CTRLC  bit masks and bit positions */
+/* CCL_INSEL2  is already defined. */
+
+/* CCL.TRUTH3  bit masks and bit positions */
+/* CCL_TRUTH  is already defined. */
+
+
+/* CLKCTRL - Clock controller */
+/* CLKCTRL.MCLKCTRLA  bit masks and bit positions */
+#define CLKCTRL_CLKSEL_gm  0x0F  /* Clock select group mask. */
+#define CLKCTRL_CLKSEL_gp  0  /* Clock select group position. */
+#define CLKCTRL_CLKSEL_0_bm  (1<<0)  /* Clock select bit 0 mask. */
+#define CLKCTRL_CLKSEL_0_bp  0  /* Clock select bit 0 position. */
+#define CLKCTRL_CLKSEL_1_bm  (1<<1)  /* Clock select bit 1 mask. */
+#define CLKCTRL_CLKSEL_1_bp  1  /* Clock select bit 1 position. */
+#define CLKCTRL_CLKSEL_2_bm  (1<<2)  /* Clock select bit 2 mask. */
+#define CLKCTRL_CLKSEL_2_bp  2  /* Clock select bit 2 position. */
+#define CLKCTRL_CLKSEL_3_bm  (1<<3)  /* Clock select bit 3 mask. */
+#define CLKCTRL_CLKSEL_3_bp  3  /* Clock select bit 3 position. */
+#define CLKCTRL_CLKOUT_bm  0x80  /* System clock out bit mask. */
+#define CLKCTRL_CLKOUT_bp  7  /* System clock out bit position. */
+
+/* CLKCTRL.MCLKCTRLB  bit masks and bit positions */
+#define CLKCTRL_PEN_bm  0x01  /* Prescaler enable bit mask. */
+#define CLKCTRL_PEN_bp  0  /* Prescaler enable bit position. */
+#define CLKCTRL_PDIV_gm  0x1E  /* Prescaler division group mask. */
+#define CLKCTRL_PDIV_gp  1  /* Prescaler division group position. */
+#define CLKCTRL_PDIV_0_bm  (1<<1)  /* Prescaler division bit 0 mask. */
+#define CLKCTRL_PDIV_0_bp  1  /* Prescaler division bit 0 position. */
+#define CLKCTRL_PDIV_1_bm  (1<<2)  /* Prescaler division bit 1 mask. */
+#define CLKCTRL_PDIV_1_bp  2  /* Prescaler division bit 1 position. */
+#define CLKCTRL_PDIV_2_bm  (1<<3)  /* Prescaler division bit 2 mask. */
+#define CLKCTRL_PDIV_2_bp  3  /* Prescaler division bit 2 position. */
+#define CLKCTRL_PDIV_3_bm  (1<<4)  /* Prescaler division bit 3 mask. */
+#define CLKCTRL_PDIV_3_bp  4  /* Prescaler division bit 3 position. */
+#define CLKCTRL_PBDIV_bm  0x20  /* Prescaler B division bit mask. */
+#define CLKCTRL_PBDIV_bp  5  /* Prescaler B division bit position. */
+
+/* CLKCTRL.MCLKSTATUS  bit masks and bit positions */
+#define CLKCTRL_SOSC_bm  0x01  /* System Oscillator changing bit mask. */
+#define CLKCTRL_SOSC_bp  0  /* System Oscillator changing bit position. */
+#define CLKCTRL_OSCHFS_bm  0x02  /* High frequency oscillator status bit mask. */
+#define CLKCTRL_OSCHFS_bp  1  /* High frequency oscillator status bit position. */
+#define CLKCTRL_OSC32KS_bm  0x04  /* 32KHz oscillator status bit mask. */
+#define CLKCTRL_OSC32KS_bp  2  /* 32KHz oscillator status bit position. */
+#define CLKCTRL_XOSC32KS_bm  0x08  /* 32.768 kHz Crystal Oscillator status bit mask. */
+#define CLKCTRL_XOSC32KS_bp  3  /* 32.768 kHz Crystal Oscillator status bit position. */
+#define CLKCTRL_EXTS_bm  0x10  /* External Clock status bit mask. */
+#define CLKCTRL_EXTS_bp  4  /* External Clock status bit position. */
+#define CLKCTRL_PLLS_bm  0x20  /* PLL status bit mask. */
+#define CLKCTRL_PLLS_bp  5  /* PLL status bit position. */
+
+/* CLKCTRL.MCLKTIMEBASE  bit masks and bit positions */
+#define CLKCTRL_TIMEBASE_gm  0x1F  /* Timebase group mask. */
+#define CLKCTRL_TIMEBASE_gp  0  /* Timebase group position. */
+#define CLKCTRL_TIMEBASE_0_bm  (1<<0)  /* Timebase bit 0 mask. */
+#define CLKCTRL_TIMEBASE_0_bp  0  /* Timebase bit 0 position. */
+#define CLKCTRL_TIMEBASE_1_bm  (1<<1)  /* Timebase bit 1 mask. */
+#define CLKCTRL_TIMEBASE_1_bp  1  /* Timebase bit 1 position. */
+#define CLKCTRL_TIMEBASE_2_bm  (1<<2)  /* Timebase bit 2 mask. */
+#define CLKCTRL_TIMEBASE_2_bp  2  /* Timebase bit 2 position. */
+#define CLKCTRL_TIMEBASE_3_bm  (1<<3)  /* Timebase bit 3 mask. */
+#define CLKCTRL_TIMEBASE_3_bp  3  /* Timebase bit 3 position. */
+#define CLKCTRL_TIMEBASE_4_bm  (1<<4)  /* Timebase bit 4 mask. */
+#define CLKCTRL_TIMEBASE_4_bp  4  /* Timebase bit 4 position. */
+
+/* CLKCTRL.OSCHFCTRLA  bit masks and bit positions */
+#define CLKCTRL_AUTOTUNE_gm  0x03  /* Automatic Oscillator Tune group mask. */
+#define CLKCTRL_AUTOTUNE_gp  0  /* Automatic Oscillator Tune group position. */
+#define CLKCTRL_AUTOTUNE_0_bm  (1<<0)  /* Automatic Oscillator Tune bit 0 mask. */
+#define CLKCTRL_AUTOTUNE_0_bp  0  /* Automatic Oscillator Tune bit 0 position. */
+#define CLKCTRL_AUTOTUNE_1_bm  (1<<1)  /* Automatic Oscillator Tune bit 1 mask. */
+#define CLKCTRL_AUTOTUNE_1_bp  1  /* Automatic Oscillator Tune bit 1 position. */
+#define CLKCTRL_RUNSTDBY_bm  0x80  /* Run in standby bit mask. */
+#define CLKCTRL_RUNSTDBY_bp  7  /* Run in standby bit position. */
+
+/* CLKCTRL.OSCHFTUNE  bit masks and bit positions */
+#define CLKCTRL_TUNE_gm  0xFF  /* Oscillator Tune group mask. */
+#define CLKCTRL_TUNE_gp  0  /* Oscillator Tune group position. */
+#define CLKCTRL_TUNE_0_bm  (1<<0)  /* Oscillator Tune bit 0 mask. */
+#define CLKCTRL_TUNE_0_bp  0  /* Oscillator Tune bit 0 position. */
+#define CLKCTRL_TUNE_1_bm  (1<<1)  /* Oscillator Tune bit 1 mask. */
+#define CLKCTRL_TUNE_1_bp  1  /* Oscillator Tune bit 1 position. */
+#define CLKCTRL_TUNE_2_bm  (1<<2)  /* Oscillator Tune bit 2 mask. */
+#define CLKCTRL_TUNE_2_bp  2  /* Oscillator Tune bit 2 position. */
+#define CLKCTRL_TUNE_3_bm  (1<<3)  /* Oscillator Tune bit 3 mask. */
+#define CLKCTRL_TUNE_3_bp  3  /* Oscillator Tune bit 3 position. */
+#define CLKCTRL_TUNE_4_bm  (1<<4)  /* Oscillator Tune bit 4 mask. */
+#define CLKCTRL_TUNE_4_bp  4  /* Oscillator Tune bit 4 position. */
+#define CLKCTRL_TUNE_5_bm  (1<<5)  /* Oscillator Tune bit 5 mask. */
+#define CLKCTRL_TUNE_5_bp  5  /* Oscillator Tune bit 5 position. */
+#define CLKCTRL_TUNE_6_bm  (1<<6)  /* Oscillator Tune bit 6 mask. */
+#define CLKCTRL_TUNE_6_bp  6  /* Oscillator Tune bit 6 position. */
+#define CLKCTRL_TUNE_7_bm  (1<<7)  /* Oscillator Tune bit 7 mask. */
+#define CLKCTRL_TUNE_7_bp  7  /* Oscillator Tune bit 7 position. */
+
+/* CLKCTRL.PLLCTRLA  bit masks and bit positions */
+#define CLKCTRL_MULFAC_gm  0x03  /* PLL Multiplication Factor group mask. */
+#define CLKCTRL_MULFAC_gp  0  /* PLL Multiplication Factor group position. */
+#define CLKCTRL_MULFAC_0_bm  (1<<0)  /* PLL Multiplication Factor bit 0 mask. */
+#define CLKCTRL_MULFAC_0_bp  0  /* PLL Multiplication Factor bit 0 position. */
+#define CLKCTRL_MULFAC_1_bm  (1<<1)  /* PLL Multiplication Factor bit 1 mask. */
+#define CLKCTRL_MULFAC_1_bp  1  /* PLL Multiplication Factor bit 1 position. */
+#define CLKCTRL_SOURCEDIV_gm  0x18  /* PLL Source Division group mask. */
+#define CLKCTRL_SOURCEDIV_gp  3  /* PLL Source Division group position. */
+#define CLKCTRL_SOURCEDIV_0_bm  (1<<3)  /* PLL Source Division bit 0 mask. */
+#define CLKCTRL_SOURCEDIV_0_bp  3  /* PLL Source Division bit 0 position. */
+#define CLKCTRL_SOURCEDIV_1_bm  (1<<4)  /* PLL Source Division bit 1 mask. */
+#define CLKCTRL_SOURCEDIV_1_bp  4  /* PLL Source Division bit 1 position. */
+#define CLKCTRL_SOURCE_gm  0x60  /* PLL Source group mask. */
+#define CLKCTRL_SOURCE_gp  5  /* PLL Source group position. */
+#define CLKCTRL_SOURCE_0_bm  (1<<5)  /* PLL Source bit 0 mask. */
+#define CLKCTRL_SOURCE_0_bp  5  /* PLL Source bit 0 position. */
+#define CLKCTRL_SOURCE_1_bm  (1<<6)  /* PLL Source bit 1 mask. */
+#define CLKCTRL_SOURCE_1_bp  6  /* PLL Source bit 1 position. */
+/* CLKCTRL_RUNSTDBY  is already defined. */
+
+/* CLKCTRL.PLLCTRLB  bit masks and bit positions */
+#define CLKCTRL_CLKDIV_bm  0x01  /* PLL Output Clock Division bit mask. */
+#define CLKCTRL_CLKDIV_bp  0  /* PLL Output Clock Division bit position. */
+
+/* CLKCTRL.OSC32KCTRLA  bit masks and bit positions */
+/* CLKCTRL_RUNSTDBY  is already defined. */
+
+/* CLKCTRL.XOSC32KCTRLA  bit masks and bit positions */
+#define CLKCTRL_ENABLE_bm  0x01  /* Enable bit mask. */
+#define CLKCTRL_ENABLE_bp  0  /* Enable bit position. */
+#define CLKCTRL_LPMODE_bm  0x02  /* Low power mode bit mask. */
+#define CLKCTRL_LPMODE_bp  1  /* Low power mode bit position. */
+#define CLKCTRL_SEL_bm  0x04  /* Select bit mask. */
+#define CLKCTRL_SEL_bp  2  /* Select bit position. */
+#define CLKCTRL_CSUT_gm  0x30  /* Crystal startup time group mask. */
+#define CLKCTRL_CSUT_gp  4  /* Crystal startup time group position. */
+#define CLKCTRL_CSUT_0_bm  (1<<4)  /* Crystal startup time bit 0 mask. */
+#define CLKCTRL_CSUT_0_bp  4  /* Crystal startup time bit 0 position. */
+#define CLKCTRL_CSUT_1_bm  (1<<5)  /* Crystal startup time bit 1 mask. */
+#define CLKCTRL_CSUT_1_bp  5  /* Crystal startup time bit 1 position. */
+/* CLKCTRL_RUNSTDBY  is already defined. */
+
+
+/* CPU - CPU */
+/* CPU.CCP  bit masks and bit positions */
+#define CPU_CCP_gm  0xFF  /* CCP signature group mask. */
+#define CPU_CCP_gp  0  /* CCP signature group position. */
+#define CPU_CCP_0_bm  (1<<0)  /* CCP signature bit 0 mask. */
+#define CPU_CCP_0_bp  0  /* CCP signature bit 0 position. */
+#define CPU_CCP_1_bm  (1<<1)  /* CCP signature bit 1 mask. */
+#define CPU_CCP_1_bp  1  /* CCP signature bit 1 position. */
+#define CPU_CCP_2_bm  (1<<2)  /* CCP signature bit 2 mask. */
+#define CPU_CCP_2_bp  2  /* CCP signature bit 2 position. */
+#define CPU_CCP_3_bm  (1<<3)  /* CCP signature bit 3 mask. */
+#define CPU_CCP_3_bp  3  /* CCP signature bit 3 position. */
+#define CPU_CCP_4_bm  (1<<4)  /* CCP signature bit 4 mask. */
+#define CPU_CCP_4_bp  4  /* CCP signature bit 4 position. */
+#define CPU_CCP_5_bm  (1<<5)  /* CCP signature bit 5 mask. */
+#define CPU_CCP_5_bp  5  /* CCP signature bit 5 position. */
+#define CPU_CCP_6_bm  (1<<6)  /* CCP signature bit 6 mask. */
+#define CPU_CCP_6_bp  6  /* CCP signature bit 6 position. */
+#define CPU_CCP_7_bm  (1<<7)  /* CCP signature bit 7 mask. */
+#define CPU_CCP_7_bp  7  /* CCP signature bit 7 position. */
+
+/* CPU.SREG  bit masks and bit positions */
+#define CPU_C_bm  0x01  /* Carry Flag bit mask. */
+#define CPU_C_bp  0  /* Carry Flag bit position. */
+#define CPU_Z_bm  0x02  /* Zero Flag bit mask. */
+#define CPU_Z_bp  1  /* Zero Flag bit position. */
+#define CPU_N_bm  0x04  /* Negative Flag bit mask. */
+#define CPU_N_bp  2  /* Negative Flag bit position. */
+#define CPU_V_bm  0x08  /* Two's Complement Overflow Flag bit mask. */
+#define CPU_V_bp  3  /* Two's Complement Overflow Flag bit position. */
+#define CPU_S_bm  0x10  /* N Exclusive Or V Flag bit mask. */
+#define CPU_S_bp  4  /* N Exclusive Or V Flag bit position. */
+#define CPU_H_bm  0x20  /* Half Carry Flag bit mask. */
+#define CPU_H_bp  5  /* Half Carry Flag bit position. */
+#define CPU_T_bm  0x40  /* Transfer Bit bit mask. */
+#define CPU_T_bp  6  /* Transfer Bit bit position. */
+#define CPU_I_bm  0x80  /* Global Interrupt Enable Flag bit mask. */
+#define CPU_I_bp  7  /* Global Interrupt Enable Flag bit position. */
+
+
+/* CPUINT - Interrupt Controller */
+/* CPUINT.CTRLA  bit masks and bit positions */
+#define CPUINT_LVL0RR_bm  0x01  /* Round-robin Scheduling Enable bit mask. */
+#define CPUINT_LVL0RR_bp  0  /* Round-robin Scheduling Enable bit position. */
+#define CPUINT_CVT_bm  0x20  /* Compact Vector Table bit mask. */
+#define CPUINT_CVT_bp  5  /* Compact Vector Table bit position. */
+#define CPUINT_IVSEL_bm  0x40  /* Interrupt Vector Select bit mask. */
+#define CPUINT_IVSEL_bp  6  /* Interrupt Vector Select bit position. */
+
+/* CPUINT.STATUS  bit masks and bit positions */
+#define CPUINT_LVL0EX_bm  0x01  /* Level 0 Interrupt Executing bit mask. */
+#define CPUINT_LVL0EX_bp  0  /* Level 0 Interrupt Executing bit position. */
+#define CPUINT_LVL1EX_bm  0x02  /* Level 1 Interrupt Executing bit mask. */
+#define CPUINT_LVL1EX_bp  1  /* Level 1 Interrupt Executing bit position. */
+#define CPUINT_NMIEX_bm  0x80  /* Non-maskable Interrupt Executing bit mask. */
+#define CPUINT_NMIEX_bp  7  /* Non-maskable Interrupt Executing bit position. */
+
+/* CPUINT.LVL0PRI  bit masks and bit positions */
+#define CPUINT_LVL0PRI_gm  0xFF  /* Interrupt Level Priority group mask. */
+#define CPUINT_LVL0PRI_gp  0  /* Interrupt Level Priority group position. */
+#define CPUINT_LVL0PRI_0_bm  (1<<0)  /* Interrupt Level Priority bit 0 mask. */
+#define CPUINT_LVL0PRI_0_bp  0  /* Interrupt Level Priority bit 0 position. */
+#define CPUINT_LVL0PRI_1_bm  (1<<1)  /* Interrupt Level Priority bit 1 mask. */
+#define CPUINT_LVL0PRI_1_bp  1  /* Interrupt Level Priority bit 1 position. */
+#define CPUINT_LVL0PRI_2_bm  (1<<2)  /* Interrupt Level Priority bit 2 mask. */
+#define CPUINT_LVL0PRI_2_bp  2  /* Interrupt Level Priority bit 2 position. */
+#define CPUINT_LVL0PRI_3_bm  (1<<3)  /* Interrupt Level Priority bit 3 mask. */
+#define CPUINT_LVL0PRI_3_bp  3  /* Interrupt Level Priority bit 3 position. */
+#define CPUINT_LVL0PRI_4_bm  (1<<4)  /* Interrupt Level Priority bit 4 mask. */
+#define CPUINT_LVL0PRI_4_bp  4  /* Interrupt Level Priority bit 4 position. */
+#define CPUINT_LVL0PRI_5_bm  (1<<5)  /* Interrupt Level Priority bit 5 mask. */
+#define CPUINT_LVL0PRI_5_bp  5  /* Interrupt Level Priority bit 5 position. */
+#define CPUINT_LVL0PRI_6_bm  (1<<6)  /* Interrupt Level Priority bit 6 mask. */
+#define CPUINT_LVL0PRI_6_bp  6  /* Interrupt Level Priority bit 6 position. */
+#define CPUINT_LVL0PRI_7_bm  (1<<7)  /* Interrupt Level Priority bit 7 mask. */
+#define CPUINT_LVL0PRI_7_bp  7  /* Interrupt Level Priority bit 7 position. */
+
+/* CPUINT.LVL1VEC  bit masks and bit positions */
+#define CPUINT_LVL1VEC_gm  0xFF  /* Interrupt Vector with High Priority group mask. */
+#define CPUINT_LVL1VEC_gp  0  /* Interrupt Vector with High Priority group position. */
+#define CPUINT_LVL1VEC_0_bm  (1<<0)  /* Interrupt Vector with High Priority bit 0 mask. */
+#define CPUINT_LVL1VEC_0_bp  0  /* Interrupt Vector with High Priority bit 0 position. */
+#define CPUINT_LVL1VEC_1_bm  (1<<1)  /* Interrupt Vector with High Priority bit 1 mask. */
+#define CPUINT_LVL1VEC_1_bp  1  /* Interrupt Vector with High Priority bit 1 position. */
+#define CPUINT_LVL1VEC_2_bm  (1<<2)  /* Interrupt Vector with High Priority bit 2 mask. */
+#define CPUINT_LVL1VEC_2_bp  2  /* Interrupt Vector with High Priority bit 2 position. */
+#define CPUINT_LVL1VEC_3_bm  (1<<3)  /* Interrupt Vector with High Priority bit 3 mask. */
+#define CPUINT_LVL1VEC_3_bp  3  /* Interrupt Vector with High Priority bit 3 position. */
+#define CPUINT_LVL1VEC_4_bm  (1<<4)  /* Interrupt Vector with High Priority bit 4 mask. */
+#define CPUINT_LVL1VEC_4_bp  4  /* Interrupt Vector with High Priority bit 4 position. */
+#define CPUINT_LVL1VEC_5_bm  (1<<5)  /* Interrupt Vector with High Priority bit 5 mask. */
+#define CPUINT_LVL1VEC_5_bp  5  /* Interrupt Vector with High Priority bit 5 position. */
+#define CPUINT_LVL1VEC_6_bm  (1<<6)  /* Interrupt Vector with High Priority bit 6 mask. */
+#define CPUINT_LVL1VEC_6_bp  6  /* Interrupt Vector with High Priority bit 6 position. */
+#define CPUINT_LVL1VEC_7_bm  (1<<7)  /* Interrupt Vector with High Priority bit 7 mask. */
+#define CPUINT_LVL1VEC_7_bp  7  /* Interrupt Vector with High Priority bit 7 position. */
+
+
+/* CRCSCAN - CRCSCAN */
+/* CRCSCAN.CTRLA  bit masks and bit positions */
+#define CRCSCAN_ENABLE_bm  0x01  /* Enable CRC scan bit mask. */
+#define CRCSCAN_ENABLE_bp  0  /* Enable CRC scan bit position. */
+#define CRCSCAN_NMIEN_bm  0x02  /* Enable NMI Trigger bit mask. */
+#define CRCSCAN_NMIEN_bp  1  /* Enable NMI Trigger bit position. */
+#define CRCSCAN_RESET_bm  0x80  /* Reset CRC scan bit mask. */
+#define CRCSCAN_RESET_bp  7  /* Reset CRC scan bit position. */
+
+/* CRCSCAN.CTRLB  bit masks and bit positions */
+#define CRCSCAN_SRC_gm  0x03  /* CRC Source group mask. */
+#define CRCSCAN_SRC_gp  0  /* CRC Source group position. */
+#define CRCSCAN_SRC_0_bm  (1<<0)  /* CRC Source bit 0 mask. */
+#define CRCSCAN_SRC_0_bp  0  /* CRC Source bit 0 position. */
+#define CRCSCAN_SRC_1_bm  (1<<1)  /* CRC Source bit 1 mask. */
+#define CRCSCAN_SRC_1_bp  1  /* CRC Source bit 1 position. */
+
+/* CRCSCAN.STATUS  bit masks and bit positions */
+#define CRCSCAN_BUSY_bm  0x01  /* CRC Busy bit mask. */
+#define CRCSCAN_BUSY_bp  0  /* CRC Busy bit position. */
+#define CRCSCAN_OK_bm  0x02  /* CRC Ok bit mask. */
+#define CRCSCAN_OK_bp  1  /* CRC Ok bit position. */
+
+
+/* EVSYS - Event System */
+/* EVSYS.SWEVENTA  bit masks and bit positions */
+#define EVSYS_SWEVENTA_gm  0xFF  /* Software event on channel select group mask. */
+#define EVSYS_SWEVENTA_gp  0  /* Software event on channel select group position. */
+#define EVSYS_SWEVENTA_0_bm  (1<<0)  /* Software event on channel select bit 0 mask. */
+#define EVSYS_SWEVENTA_0_bp  0  /* Software event on channel select bit 0 position. */
+#define EVSYS_SWEVENTA_1_bm  (1<<1)  /* Software event on channel select bit 1 mask. */
+#define EVSYS_SWEVENTA_1_bp  1  /* Software event on channel select bit 1 position. */
+#define EVSYS_SWEVENTA_2_bm  (1<<2)  /* Software event on channel select bit 2 mask. */
+#define EVSYS_SWEVENTA_2_bp  2  /* Software event on channel select bit 2 position. */
+#define EVSYS_SWEVENTA_3_bm  (1<<3)  /* Software event on channel select bit 3 mask. */
+#define EVSYS_SWEVENTA_3_bp  3  /* Software event on channel select bit 3 position. */
+#define EVSYS_SWEVENTA_4_bm  (1<<4)  /* Software event on channel select bit 4 mask. */
+#define EVSYS_SWEVENTA_4_bp  4  /* Software event on channel select bit 4 position. */
+#define EVSYS_SWEVENTA_5_bm  (1<<5)  /* Software event on channel select bit 5 mask. */
+#define EVSYS_SWEVENTA_5_bp  5  /* Software event on channel select bit 5 position. */
+#define EVSYS_SWEVENTA_6_bm  (1<<6)  /* Software event on channel select bit 6 mask. */
+#define EVSYS_SWEVENTA_6_bp  6  /* Software event on channel select bit 6 position. */
+#define EVSYS_SWEVENTA_7_bm  (1<<7)  /* Software event on channel select bit 7 mask. */
+#define EVSYS_SWEVENTA_7_bp  7  /* Software event on channel select bit 7 position. */
+
+/* EVSYS.CHANNEL0  bit masks and bit positions */
+#define EVSYS_CHANNEL_gm  0xFF  /* Channel generator select group mask. */
+#define EVSYS_CHANNEL_gp  0  /* Channel generator select group position. */
+#define EVSYS_CHANNEL_0_bm  (1<<0)  /* Channel generator select bit 0 mask. */
+#define EVSYS_CHANNEL_0_bp  0  /* Channel generator select bit 0 position. */
+#define EVSYS_CHANNEL_1_bm  (1<<1)  /* Channel generator select bit 1 mask. */
+#define EVSYS_CHANNEL_1_bp  1  /* Channel generator select bit 1 position. */
+#define EVSYS_CHANNEL_2_bm  (1<<2)  /* Channel generator select bit 2 mask. */
+#define EVSYS_CHANNEL_2_bp  2  /* Channel generator select bit 2 position. */
+#define EVSYS_CHANNEL_3_bm  (1<<3)  /* Channel generator select bit 3 mask. */
+#define EVSYS_CHANNEL_3_bp  3  /* Channel generator select bit 3 position. */
+#define EVSYS_CHANNEL_4_bm  (1<<4)  /* Channel generator select bit 4 mask. */
+#define EVSYS_CHANNEL_4_bp  4  /* Channel generator select bit 4 position. */
+#define EVSYS_CHANNEL_5_bm  (1<<5)  /* Channel generator select bit 5 mask. */
+#define EVSYS_CHANNEL_5_bp  5  /* Channel generator select bit 5 position. */
+#define EVSYS_CHANNEL_6_bm  (1<<6)  /* Channel generator select bit 6 mask. */
+#define EVSYS_CHANNEL_6_bp  6  /* Channel generator select bit 6 position. */
+#define EVSYS_CHANNEL_7_bm  (1<<7)  /* Channel generator select bit 7 mask. */
+#define EVSYS_CHANNEL_7_bp  7  /* Channel generator select bit 7 position. */
+
+/* EVSYS.CHANNEL1  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.CHANNEL2  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.CHANNEL3  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.CHANNEL4  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.CHANNEL5  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.USERCCLLUT0A  bit masks and bit positions */
+#define EVSYS_USER_gm  0xFF  /* User channel select group mask. */
+#define EVSYS_USER_gp  0  /* User channel select group position. */
+#define EVSYS_USER_0_bm  (1<<0)  /* User channel select bit 0 mask. */
+#define EVSYS_USER_0_bp  0  /* User channel select bit 0 position. */
+#define EVSYS_USER_1_bm  (1<<1)  /* User channel select bit 1 mask. */
+#define EVSYS_USER_1_bp  1  /* User channel select bit 1 position. */
+#define EVSYS_USER_2_bm  (1<<2)  /* User channel select bit 2 mask. */
+#define EVSYS_USER_2_bp  2  /* User channel select bit 2 position. */
+#define EVSYS_USER_3_bm  (1<<3)  /* User channel select bit 3 mask. */
+#define EVSYS_USER_3_bp  3  /* User channel select bit 3 position. */
+#define EVSYS_USER_4_bm  (1<<4)  /* User channel select bit 4 mask. */
+#define EVSYS_USER_4_bp  4  /* User channel select bit 4 position. */
+#define EVSYS_USER_5_bm  (1<<5)  /* User channel select bit 5 mask. */
+#define EVSYS_USER_5_bp  5  /* User channel select bit 5 position. */
+#define EVSYS_USER_6_bm  (1<<6)  /* User channel select bit 6 mask. */
+#define EVSYS_USER_6_bp  6  /* User channel select bit 6 position. */
+#define EVSYS_USER_7_bm  (1<<7)  /* User channel select bit 7 mask. */
+#define EVSYS_USER_7_bp  7  /* User channel select bit 7 position. */
+
+/* EVSYS.USERCCLLUT0B  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT1A  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT1B  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT2A  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT2B  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT3A  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT3B  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERADC0START  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTC  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTD  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTF  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERUSART0IRDA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCE0CNTA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCE0CNTB  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB0CAPT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB0COUNT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB1CAPT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB1COUNT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCF0CNT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCF0ACT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERWEXA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERWEXB  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERWEXC  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+
+/* FUSE - Fuses */
+/* FUSE.WDTCFG  bit masks and bit positions */
+#define FUSE_PERIOD_gm  0x0F  /* Watchdog Timeout Period group mask. */
+#define FUSE_PERIOD_gp  0  /* Watchdog Timeout Period group position. */
+#define FUSE_PERIOD_0_bm  (1<<0)  /* Watchdog Timeout Period bit 0 mask. */
+#define FUSE_PERIOD_0_bp  0  /* Watchdog Timeout Period bit 0 position. */
+#define FUSE_PERIOD_1_bm  (1<<1)  /* Watchdog Timeout Period bit 1 mask. */
+#define FUSE_PERIOD_1_bp  1  /* Watchdog Timeout Period bit 1 position. */
+#define FUSE_PERIOD_2_bm  (1<<2)  /* Watchdog Timeout Period bit 2 mask. */
+#define FUSE_PERIOD_2_bp  2  /* Watchdog Timeout Period bit 2 position. */
+#define FUSE_PERIOD_3_bm  (1<<3)  /* Watchdog Timeout Period bit 3 mask. */
+#define FUSE_PERIOD_3_bp  3  /* Watchdog Timeout Period bit 3 position. */
+#define FUSE_WINDOW_gm  0xF0  /* Watchdog Window Timeout Period group mask. */
+#define FUSE_WINDOW_gp  4  /* Watchdog Window Timeout Period group position. */
+#define FUSE_WINDOW_0_bm  (1<<4)  /* Watchdog Window Timeout Period bit 0 mask. */
+#define FUSE_WINDOW_0_bp  4  /* Watchdog Window Timeout Period bit 0 position. */
+#define FUSE_WINDOW_1_bm  (1<<5)  /* Watchdog Window Timeout Period bit 1 mask. */
+#define FUSE_WINDOW_1_bp  5  /* Watchdog Window Timeout Period bit 1 position. */
+#define FUSE_WINDOW_2_bm  (1<<6)  /* Watchdog Window Timeout Period bit 2 mask. */
+#define FUSE_WINDOW_2_bp  6  /* Watchdog Window Timeout Period bit 2 position. */
+#define FUSE_WINDOW_3_bm  (1<<7)  /* Watchdog Window Timeout Period bit 3 mask. */
+#define FUSE_WINDOW_3_bp  7  /* Watchdog Window Timeout Period bit 3 position. */
+
+/* FUSE.BODCFG  bit masks and bit positions */
+#define FUSE_SLEEP_gm  0x03  /* BOD Operation in Sleep Mode group mask. */
+#define FUSE_SLEEP_gp  0  /* BOD Operation in Sleep Mode group position. */
+#define FUSE_SLEEP_0_bm  (1<<0)  /* BOD Operation in Sleep Mode bit 0 mask. */
+#define FUSE_SLEEP_0_bp  0  /* BOD Operation in Sleep Mode bit 0 position. */
+#define FUSE_SLEEP_1_bm  (1<<1)  /* BOD Operation in Sleep Mode bit 1 mask. */
+#define FUSE_SLEEP_1_bp  1  /* BOD Operation in Sleep Mode bit 1 position. */
+#define FUSE_ACTIVE_gm  0x0C  /* BOD Operation in Active Mode group mask. */
+#define FUSE_ACTIVE_gp  2  /* BOD Operation in Active Mode group position. */
+#define FUSE_ACTIVE_0_bm  (1<<2)  /* BOD Operation in Active Mode bit 0 mask. */
+#define FUSE_ACTIVE_0_bp  2  /* BOD Operation in Active Mode bit 0 position. */
+#define FUSE_ACTIVE_1_bm  (1<<3)  /* BOD Operation in Active Mode bit 1 mask. */
+#define FUSE_ACTIVE_1_bp  3  /* BOD Operation in Active Mode bit 1 position. */
+#define FUSE_SAMPFREQ_bm  0x10  /* BOD Sample Frequency bit mask. */
+#define FUSE_SAMPFREQ_bp  4  /* BOD Sample Frequency bit position. */
+#define FUSE_LVL_gm  0xE0  /* BOD Level group mask. */
+#define FUSE_LVL_gp  5  /* BOD Level group position. */
+#define FUSE_LVL_0_bm  (1<<5)  /* BOD Level bit 0 mask. */
+#define FUSE_LVL_0_bp  5  /* BOD Level bit 0 position. */
+#define FUSE_LVL_1_bm  (1<<6)  /* BOD Level bit 1 mask. */
+#define FUSE_LVL_1_bp  6  /* BOD Level bit 1 position. */
+#define FUSE_LVL_2_bm  (1<<7)  /* BOD Level bit 2 mask. */
+#define FUSE_LVL_2_bp  7  /* BOD Level bit 2 position. */
+
+/* FUSE.OSCCFG  bit masks and bit positions */
+#define FUSE_OSCHFFRQ_bm  0x08  /* High-frequency Oscillator Frequency bit mask. */
+#define FUSE_OSCHFFRQ_bp  3  /* High-frequency Oscillator Frequency bit position. */
+
+/* FUSE.SYSCFG0  bit masks and bit positions */
+#define FUSE_EESAVE_bm  0x01  /* EEPROM Save bit mask. */
+#define FUSE_EESAVE_bp  0  /* EEPROM Save bit position. */
+#define FUSE_RSTPINCFG_bm  0x08  /* Reset Pin Configuration bit mask. */
+#define FUSE_RSTPINCFG_bp  3  /* Reset Pin Configuration bit position. */
+#define FUSE_UPDIPINCFG_bm  0x10  /* UPDI Pin Configuration bit mask. */
+#define FUSE_UPDIPINCFG_bp  4  /* UPDI Pin Configuration bit position. */
+#define FUSE_CRCSEL_bm  0x20  /* CRC Select bit mask. */
+#define FUSE_CRCSEL_bp  5  /* CRC Select bit position. */
+#define FUSE_CRCSRC_gm  0xC0  /* CRC Source group mask. */
+#define FUSE_CRCSRC_gp  6  /* CRC Source group position. */
+#define FUSE_CRCSRC_0_bm  (1<<6)  /* CRC Source bit 0 mask. */
+#define FUSE_CRCSRC_0_bp  6  /* CRC Source bit 0 position. */
+#define FUSE_CRCSRC_1_bm  (1<<7)  /* CRC Source bit 1 mask. */
+#define FUSE_CRCSRC_1_bp  7  /* CRC Source bit 1 position. */
+
+/* FUSE.SYSCFG1  bit masks and bit positions */
+#define FUSE_SUT_gm  0x07  /* Startup Time group mask. */
+#define FUSE_SUT_gp  0  /* Startup Time group position. */
+#define FUSE_SUT_0_bm  (1<<0)  /* Startup Time bit 0 mask. */
+#define FUSE_SUT_0_bp  0  /* Startup Time bit 0 position. */
+#define FUSE_SUT_1_bm  (1<<1)  /* Startup Time bit 1 mask. */
+#define FUSE_SUT_1_bp  1  /* Startup Time bit 1 position. */
+#define FUSE_SUT_2_bm  (1<<2)  /* Startup Time bit 2 mask. */
+#define FUSE_SUT_2_bp  2  /* Startup Time bit 2 position. */
+
+/* FUSE.PDICFG  bit masks and bit positions */
+#define FUSE_LEVEL_gm  0x03  /* Protection Level group mask. */
+#define FUSE_LEVEL_gp  0  /* Protection Level group position. */
+#define FUSE_LEVEL_0_bm  (1<<0)  /* Protection Level bit 0 mask. */
+#define FUSE_LEVEL_0_bp  0  /* Protection Level bit 0 position. */
+#define FUSE_LEVEL_1_bm  (1<<1)  /* Protection Level bit 1 mask. */
+#define FUSE_LEVEL_1_bp  1  /* Protection Level bit 1 position. */
+#define FUSE_KEY_gm  0xFFF0  /* NVM Protection Activation Key group mask. */
+#define FUSE_KEY_gp  4  /* NVM Protection Activation Key group position. */
+#define FUSE_KEY_0_bm  (1<<4)  /* NVM Protection Activation Key bit 0 mask. */
+#define FUSE_KEY_0_bp  4  /* NVM Protection Activation Key bit 0 position. */
+#define FUSE_KEY_1_bm  (1<<5)  /* NVM Protection Activation Key bit 1 mask. */
+#define FUSE_KEY_1_bp  5  /* NVM Protection Activation Key bit 1 position. */
+#define FUSE_KEY_2_bm  (1<<6)  /* NVM Protection Activation Key bit 2 mask. */
+#define FUSE_KEY_2_bp  6  /* NVM Protection Activation Key bit 2 position. */
+#define FUSE_KEY_3_bm  (1<<7)  /* NVM Protection Activation Key bit 3 mask. */
+#define FUSE_KEY_3_bp  7  /* NVM Protection Activation Key bit 3 position. */
+#define FUSE_KEY_4_bm  (1<<8)  /* NVM Protection Activation Key bit 4 mask. */
+#define FUSE_KEY_4_bp  8  /* NVM Protection Activation Key bit 4 position. */
+#define FUSE_KEY_5_bm  (1<<9)  /* NVM Protection Activation Key bit 5 mask. */
+#define FUSE_KEY_5_bp  9  /* NVM Protection Activation Key bit 5 position. */
+#define FUSE_KEY_6_bm  (1<<10)  /* NVM Protection Activation Key bit 6 mask. */
+#define FUSE_KEY_6_bp  10  /* NVM Protection Activation Key bit 6 position. */
+#define FUSE_KEY_7_bm  (1<<11)  /* NVM Protection Activation Key bit 7 mask. */
+#define FUSE_KEY_7_bp  11  /* NVM Protection Activation Key bit 7 position. */
+#define FUSE_KEY_8_bm  (1<<12)  /* NVM Protection Activation Key bit 8 mask. */
+#define FUSE_KEY_8_bp  12  /* NVM Protection Activation Key bit 8 position. */
+#define FUSE_KEY_9_bm  (1<<13)  /* NVM Protection Activation Key bit 9 mask. */
+#define FUSE_KEY_9_bp  13  /* NVM Protection Activation Key bit 9 position. */
+#define FUSE_KEY_10_bm  (1<<14)  /* NVM Protection Activation Key bit 10 mask. */
+#define FUSE_KEY_10_bp  14  /* NVM Protection Activation Key bit 10 position. */
+#define FUSE_KEY_11_bm  (1<<15)  /* NVM Protection Activation Key bit 11 mask. */
+#define FUSE_KEY_11_bp  15  /* NVM Protection Activation Key bit 11 position. */
+
+
+
+/* LOCK - Lockbits */
+/* LOCK.KEY  bit masks and bit positions */
+#define LOCK_KEY_gm  0xFFFFFFFF  /* Lock Key group mask. */
+#define LOCK_KEY_gp  0  /* Lock Key group position. */
+#define LOCK_KEY_0_bm  (1<<0)  /* Lock Key bit 0 mask. */
+#define LOCK_KEY_0_bp  0  /* Lock Key bit 0 position. */
+#define LOCK_KEY_1_bm  (1<<1)  /* Lock Key bit 1 mask. */
+#define LOCK_KEY_1_bp  1  /* Lock Key bit 1 position. */
+#define LOCK_KEY_2_bm  (1<<2)  /* Lock Key bit 2 mask. */
+#define LOCK_KEY_2_bp  2  /* Lock Key bit 2 position. */
+#define LOCK_KEY_3_bm  (1<<3)  /* Lock Key bit 3 mask. */
+#define LOCK_KEY_3_bp  3  /* Lock Key bit 3 position. */
+#define LOCK_KEY_4_bm  (1<<4)  /* Lock Key bit 4 mask. */
+#define LOCK_KEY_4_bp  4  /* Lock Key bit 4 position. */
+#define LOCK_KEY_5_bm  (1<<5)  /* Lock Key bit 5 mask. */
+#define LOCK_KEY_5_bp  5  /* Lock Key bit 5 position. */
+#define LOCK_KEY_6_bm  (1<<6)  /* Lock Key bit 6 mask. */
+#define LOCK_KEY_6_bp  6  /* Lock Key bit 6 position. */
+#define LOCK_KEY_7_bm  (1<<7)  /* Lock Key bit 7 mask. */
+#define LOCK_KEY_7_bp  7  /* Lock Key bit 7 position. */
+#define LOCK_KEY_8_bm  (1<<8)  /* Lock Key bit 8 mask. */
+#define LOCK_KEY_8_bp  8  /* Lock Key bit 8 position. */
+#define LOCK_KEY_9_bm  (1<<9)  /* Lock Key bit 9 mask. */
+#define LOCK_KEY_9_bp  9  /* Lock Key bit 9 position. */
+#define LOCK_KEY_10_bm  (1<<10)  /* Lock Key bit 10 mask. */
+#define LOCK_KEY_10_bp  10  /* Lock Key bit 10 position. */
+#define LOCK_KEY_11_bm  (1<<11)  /* Lock Key bit 11 mask. */
+#define LOCK_KEY_11_bp  11  /* Lock Key bit 11 position. */
+#define LOCK_KEY_12_bm  (1<<12)  /* Lock Key bit 12 mask. */
+#define LOCK_KEY_12_bp  12  /* Lock Key bit 12 position. */
+#define LOCK_KEY_13_bm  (1<<13)  /* Lock Key bit 13 mask. */
+#define LOCK_KEY_13_bp  13  /* Lock Key bit 13 position. */
+#define LOCK_KEY_14_bm  (1<<14)  /* Lock Key bit 14 mask. */
+#define LOCK_KEY_14_bp  14  /* Lock Key bit 14 position. */
+#define LOCK_KEY_15_bm  (1<<15)  /* Lock Key bit 15 mask. */
+#define LOCK_KEY_15_bp  15  /* Lock Key bit 15 position. */
+#define LOCK_KEY_16_bm  (1<<16)  /* Lock Key bit 16 mask. */
+#define LOCK_KEY_16_bp  16  /* Lock Key bit 16 position. */
+#define LOCK_KEY_17_bm  (1<<17)  /* Lock Key bit 17 mask. */
+#define LOCK_KEY_17_bp  17  /* Lock Key bit 17 position. */
+#define LOCK_KEY_18_bm  (1<<18)  /* Lock Key bit 18 mask. */
+#define LOCK_KEY_18_bp  18  /* Lock Key bit 18 position. */
+#define LOCK_KEY_19_bm  (1<<19)  /* Lock Key bit 19 mask. */
+#define LOCK_KEY_19_bp  19  /* Lock Key bit 19 position. */
+#define LOCK_KEY_20_bm  (1<<20)  /* Lock Key bit 20 mask. */
+#define LOCK_KEY_20_bp  20  /* Lock Key bit 20 position. */
+#define LOCK_KEY_21_bm  (1<<21)  /* Lock Key bit 21 mask. */
+#define LOCK_KEY_21_bp  21  /* Lock Key bit 21 position. */
+#define LOCK_KEY_22_bm  (1<<22)  /* Lock Key bit 22 mask. */
+#define LOCK_KEY_22_bp  22  /* Lock Key bit 22 position. */
+#define LOCK_KEY_23_bm  (1<<23)  /* Lock Key bit 23 mask. */
+#define LOCK_KEY_23_bp  23  /* Lock Key bit 23 position. */
+#define LOCK_KEY_24_bm  (1<<24)  /* Lock Key bit 24 mask. */
+#define LOCK_KEY_24_bp  24  /* Lock Key bit 24 position. */
+#define LOCK_KEY_25_bm  (1<<25)  /* Lock Key bit 25 mask. */
+#define LOCK_KEY_25_bp  25  /* Lock Key bit 25 position. */
+#define LOCK_KEY_26_bm  (1<<26)  /* Lock Key bit 26 mask. */
+#define LOCK_KEY_26_bp  26  /* Lock Key bit 26 position. */
+#define LOCK_KEY_27_bm  (1<<27)  /* Lock Key bit 27 mask. */
+#define LOCK_KEY_27_bp  27  /* Lock Key bit 27 position. */
+#define LOCK_KEY_28_bm  (1<<28)  /* Lock Key bit 28 mask. */
+#define LOCK_KEY_28_bp  28  /* Lock Key bit 28 position. */
+#define LOCK_KEY_29_bm  (1<<29)  /* Lock Key bit 29 mask. */
+#define LOCK_KEY_29_bp  29  /* Lock Key bit 29 position. */
+#define LOCK_KEY_30_bm  (1<<30)  /* Lock Key bit 30 mask. */
+#define LOCK_KEY_30_bp  30  /* Lock Key bit 30 position. */
+#define LOCK_KEY_31_bm  (1<<31)  /* Lock Key bit 31 mask. */
+#define LOCK_KEY_31_bp  31  /* Lock Key bit 31 position. */
+
+
+/* NVMCTRL - Non-volatile Memory Controller */
+/* NVMCTRL.CTRLA  bit masks and bit positions */
+#define NVMCTRL_CMD_gm  0x7F  /* Command group mask. */
+#define NVMCTRL_CMD_gp  0  /* Command group position. */
+#define NVMCTRL_CMD_0_bm  (1<<0)  /* Command bit 0 mask. */
+#define NVMCTRL_CMD_0_bp  0  /* Command bit 0 position. */
+#define NVMCTRL_CMD_1_bm  (1<<1)  /* Command bit 1 mask. */
+#define NVMCTRL_CMD_1_bp  1  /* Command bit 1 position. */
+#define NVMCTRL_CMD_2_bm  (1<<2)  /* Command bit 2 mask. */
+#define NVMCTRL_CMD_2_bp  2  /* Command bit 2 position. */
+#define NVMCTRL_CMD_3_bm  (1<<3)  /* Command bit 3 mask. */
+#define NVMCTRL_CMD_3_bp  3  /* Command bit 3 position. */
+#define NVMCTRL_CMD_4_bm  (1<<4)  /* Command bit 4 mask. */
+#define NVMCTRL_CMD_4_bp  4  /* Command bit 4 position. */
+#define NVMCTRL_CMD_5_bm  (1<<5)  /* Command bit 5 mask. */
+#define NVMCTRL_CMD_5_bp  5  /* Command bit 5 position. */
+#define NVMCTRL_CMD_6_bm  (1<<6)  /* Command bit 6 mask. */
+#define NVMCTRL_CMD_6_bp  6  /* Command bit 6 position. */
+
+/* NVMCTRL.CTRLB  bit masks and bit positions */
+#define NVMCTRL_APPCODEWP_bm  0x01  /* Application Code Write Protect bit mask. */
+#define NVMCTRL_APPCODEWP_bp  0  /* Application Code Write Protect bit position. */
+#define NVMCTRL_BOOTRP_bm  0x02  /* Boot Read Protect bit mask. */
+#define NVMCTRL_BOOTRP_bp  1  /* Boot Read Protect bit position. */
+#define NVMCTRL_APPDATAWP_bm  0x04  /* Application Data Write Protect bit mask. */
+#define NVMCTRL_APPDATAWP_bp  2  /* Application Data Write Protect bit position. */
+#define NVMCTRL_EEWP_bm  0x08  /* EEPROM Write Protect bit mask. */
+#define NVMCTRL_EEWP_bp  3  /* EEPROM Write Protect bit position. */
+#define NVMCTRL_FLMAP_gm  0x30  /* Flash Mapping in Data space group mask. */
+#define NVMCTRL_FLMAP_gp  4  /* Flash Mapping in Data space group position. */
+#define NVMCTRL_FLMAP_0_bm  (1<<4)  /* Flash Mapping in Data space bit 0 mask. */
+#define NVMCTRL_FLMAP_0_bp  4  /* Flash Mapping in Data space bit 0 position. */
+#define NVMCTRL_FLMAP_1_bm  (1<<5)  /* Flash Mapping in Data space bit 1 mask. */
+#define NVMCTRL_FLMAP_1_bp  5  /* Flash Mapping in Data space bit 1 position. */
+#define NVMCTRL_FLMAPLOCK_bm  0x80  /* Flash Mapping Lock bit mask. */
+#define NVMCTRL_FLMAPLOCK_bp  7  /* Flash Mapping Lock bit position. */
+
+/* NVMCTRL.CTRLC  bit masks and bit positions */
+#define NVMCTRL_UROWWP_bm  0x01  /* User Row Write Protect bit mask. */
+#define NVMCTRL_UROWWP_bp  0  /* User Row Write Protect bit position. */
+#define NVMCTRL_BOOTROWWP_bm  0x02  /* Boot Row Write Protect bit mask. */
+#define NVMCTRL_BOOTROWWP_bp  1  /* Boot Row Write Protect bit position. */
+
+/* NVMCTRL.INTCTRL  bit masks and bit positions */
+#define NVMCTRL_EEREADY_bm  0x01  /* EEPROM Ready bit mask. */
+#define NVMCTRL_EEREADY_bp  0  /* EEPROM Ready bit position. */
+#define NVMCTRL_FLREADY_bm  0x02  /* Flash Ready bit mask. */
+#define NVMCTRL_FLREADY_bp  1  /* Flash Ready bit position. */
+
+/* NVMCTRL.INTFLAGS  bit masks and bit positions */
+/* NVMCTRL_EEREADY  is already defined. */
+/* NVMCTRL_FLREADY  is already defined. */
+
+/* NVMCTRL.STATUS  bit masks and bit positions */
+#define NVMCTRL_EEBUSY_bm  0x01  /* EEPROM busy bit mask. */
+#define NVMCTRL_EEBUSY_bp  0  /* EEPROM busy bit position. */
+#define NVMCTRL_FLBUSY_bm  0x02  /* Flash busy bit mask. */
+#define NVMCTRL_FLBUSY_bp  1  /* Flash busy bit position. */
+#define NVMCTRL_ERROR_gm  0x70  /* Write error group mask. */
+#define NVMCTRL_ERROR_gp  4  /* Write error group position. */
+#define NVMCTRL_ERROR_0_bm  (1<<4)  /* Write error bit 0 mask. */
+#define NVMCTRL_ERROR_0_bp  4  /* Write error bit 0 position. */
+#define NVMCTRL_ERROR_1_bm  (1<<5)  /* Write error bit 1 mask. */
+#define NVMCTRL_ERROR_1_bp  5  /* Write error bit 1 position. */
+#define NVMCTRL_ERROR_2_bm  (1<<6)  /* Write error bit 2 mask. */
+#define NVMCTRL_ERROR_2_bp  6  /* Write error bit 2 position. */
+
+/* NVMCTRL.ADDR  bit masks and bit positions */
+#define NVMCTRL_ADDR_gm  0xFFFFFF  /* Address group mask. */
+#define NVMCTRL_ADDR_gp  0  /* Address group position. */
+#define NVMCTRL_ADDR_0_bm  (1<<0)  /* Address bit 0 mask. */
+#define NVMCTRL_ADDR_0_bp  0  /* Address bit 0 position. */
+#define NVMCTRL_ADDR_1_bm  (1<<1)  /* Address bit 1 mask. */
+#define NVMCTRL_ADDR_1_bp  1  /* Address bit 1 position. */
+#define NVMCTRL_ADDR_2_bm  (1<<2)  /* Address bit 2 mask. */
+#define NVMCTRL_ADDR_2_bp  2  /* Address bit 2 position. */
+#define NVMCTRL_ADDR_3_bm  (1<<3)  /* Address bit 3 mask. */
+#define NVMCTRL_ADDR_3_bp  3  /* Address bit 3 position. */
+#define NVMCTRL_ADDR_4_bm  (1<<4)  /* Address bit 4 mask. */
+#define NVMCTRL_ADDR_4_bp  4  /* Address bit 4 position. */
+#define NVMCTRL_ADDR_5_bm  (1<<5)  /* Address bit 5 mask. */
+#define NVMCTRL_ADDR_5_bp  5  /* Address bit 5 position. */
+#define NVMCTRL_ADDR_6_bm  (1<<6)  /* Address bit 6 mask. */
+#define NVMCTRL_ADDR_6_bp  6  /* Address bit 6 position. */
+#define NVMCTRL_ADDR_7_bm  (1<<7)  /* Address bit 7 mask. */
+#define NVMCTRL_ADDR_7_bp  7  /* Address bit 7 position. */
+#define NVMCTRL_ADDR_8_bm  (1<<8)  /* Address bit 8 mask. */
+#define NVMCTRL_ADDR_8_bp  8  /* Address bit 8 position. */
+#define NVMCTRL_ADDR_9_bm  (1<<9)  /* Address bit 9 mask. */
+#define NVMCTRL_ADDR_9_bp  9  /* Address bit 9 position. */
+#define NVMCTRL_ADDR_10_bm  (1<<10)  /* Address bit 10 mask. */
+#define NVMCTRL_ADDR_10_bp  10  /* Address bit 10 position. */
+#define NVMCTRL_ADDR_11_bm  (1<<11)  /* Address bit 11 mask. */
+#define NVMCTRL_ADDR_11_bp  11  /* Address bit 11 position. */
+#define NVMCTRL_ADDR_12_bm  (1<<12)  /* Address bit 12 mask. */
+#define NVMCTRL_ADDR_12_bp  12  /* Address bit 12 position. */
+#define NVMCTRL_ADDR_13_bm  (1<<13)  /* Address bit 13 mask. */
+#define NVMCTRL_ADDR_13_bp  13  /* Address bit 13 position. */
+#define NVMCTRL_ADDR_14_bm  (1<<14)  /* Address bit 14 mask. */
+#define NVMCTRL_ADDR_14_bp  14  /* Address bit 14 position. */
+#define NVMCTRL_ADDR_15_bm  (1<<15)  /* Address bit 15 mask. */
+#define NVMCTRL_ADDR_15_bp  15  /* Address bit 15 position. */
+#define NVMCTRL_ADDR_16_bm  (1<<16)  /* Address bit 16 mask. */
+#define NVMCTRL_ADDR_16_bp  16  /* Address bit 16 position. */
+#define NVMCTRL_ADDR_17_bm  (1<<17)  /* Address bit 17 mask. */
+#define NVMCTRL_ADDR_17_bp  17  /* Address bit 17 position. */
+#define NVMCTRL_ADDR_18_bm  (1<<18)  /* Address bit 18 mask. */
+#define NVMCTRL_ADDR_18_bp  18  /* Address bit 18 position. */
+#define NVMCTRL_ADDR_19_bm  (1<<19)  /* Address bit 19 mask. */
+#define NVMCTRL_ADDR_19_bp  19  /* Address bit 19 position. */
+#define NVMCTRL_ADDR_20_bm  (1<<20)  /* Address bit 20 mask. */
+#define NVMCTRL_ADDR_20_bp  20  /* Address bit 20 position. */
+#define NVMCTRL_ADDR_21_bm  (1<<21)  /* Address bit 21 mask. */
+#define NVMCTRL_ADDR_21_bp  21  /* Address bit 21 position. */
+#define NVMCTRL_ADDR_22_bm  (1<<22)  /* Address bit 22 mask. */
+#define NVMCTRL_ADDR_22_bp  22  /* Address bit 22 position. */
+#define NVMCTRL_ADDR_23_bm  (1<<23)  /* Address bit 23 mask. */
+#define NVMCTRL_ADDR_23_bp  23  /* Address bit 23 position. */
+
+
+/* PORT - I/O Ports */
+/* PORT.INTFLAGS  bit masks and bit positions */
+#define PORT_INT_gm  0xFF  /* Pin Interrupt Flag group mask. */
+#define PORT_INT_gp  0  /* Pin Interrupt Flag group position. */
+#define PORT_INT_0_bm  (1<<0)  /* Pin Interrupt Flag bit 0 mask. */
+#define PORT_INT_0_bp  0  /* Pin Interrupt Flag bit 0 position. */
+#define PORT_INT0_bm  PORT_INT_0_bm  /* This define is deprecated and should not be used */
+#define PORT_INT0_bp  PORT_INT_0_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_1_bm  (1<<1)  /* Pin Interrupt Flag bit 1 mask. */
+#define PORT_INT_1_bp  1  /* Pin Interrupt Flag bit 1 position. */
+#define PORT_INT1_bm  PORT_INT_1_bm  /* This define is deprecated and should not be used */
+#define PORT_INT1_bp  PORT_INT_1_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_2_bm  (1<<2)  /* Pin Interrupt Flag bit 2 mask. */
+#define PORT_INT_2_bp  2  /* Pin Interrupt Flag bit 2 position. */
+#define PORT_INT2_bm  PORT_INT_2_bm  /* This define is deprecated and should not be used */
+#define PORT_INT2_bp  PORT_INT_2_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_3_bm  (1<<3)  /* Pin Interrupt Flag bit 3 mask. */
+#define PORT_INT_3_bp  3  /* Pin Interrupt Flag bit 3 position. */
+#define PORT_INT3_bm  PORT_INT_3_bm  /* This define is deprecated and should not be used */
+#define PORT_INT3_bp  PORT_INT_3_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_4_bm  (1<<4)  /* Pin Interrupt Flag bit 4 mask. */
+#define PORT_INT_4_bp  4  /* Pin Interrupt Flag bit 4 position. */
+#define PORT_INT4_bm  PORT_INT_4_bm  /* This define is deprecated and should not be used */
+#define PORT_INT4_bp  PORT_INT_4_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_5_bm  (1<<5)  /* Pin Interrupt Flag bit 5 mask. */
+#define PORT_INT_5_bp  5  /* Pin Interrupt Flag bit 5 position. */
+#define PORT_INT5_bm  PORT_INT_5_bm  /* This define is deprecated and should not be used */
+#define PORT_INT5_bp  PORT_INT_5_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_6_bm  (1<<6)  /* Pin Interrupt Flag bit 6 mask. */
+#define PORT_INT_6_bp  6  /* Pin Interrupt Flag bit 6 position. */
+#define PORT_INT6_bm  PORT_INT_6_bm  /* This define is deprecated and should not be used */
+#define PORT_INT6_bp  PORT_INT_6_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_7_bm  (1<<7)  /* Pin Interrupt Flag bit 7 mask. */
+#define PORT_INT_7_bp  7  /* Pin Interrupt Flag bit 7 position. */
+#define PORT_INT7_bm  PORT_INT_7_bm  /* This define is deprecated and should not be used */
+#define PORT_INT7_bp  PORT_INT_7_bp  /* This define is deprecated and should not be used */
+
+/* PORT.PORTCTRL  bit masks and bit positions */
+#define PORT_SRL_bm  0x01  /* Slew Rate Limit Enable bit mask. */
+#define PORT_SRL_bp  0  /* Slew Rate Limit Enable bit position. */
+
+/* PORT.PINCONFIG  bit masks and bit positions */
+#define PORT_ISC_gm  0x07  /* Input/Sense Configuration group mask. */
+#define PORT_ISC_gp  0  /* Input/Sense Configuration group position. */
+#define PORT_ISC_0_bm  (1<<0)  /* Input/Sense Configuration bit 0 mask. */
+#define PORT_ISC_0_bp  0  /* Input/Sense Configuration bit 0 position. */
+#define PORT_ISC_1_bm  (1<<1)  /* Input/Sense Configuration bit 1 mask. */
+#define PORT_ISC_1_bp  1  /* Input/Sense Configuration bit 1 position. */
+#define PORT_ISC_2_bm  (1<<2)  /* Input/Sense Configuration bit 2 mask. */
+#define PORT_ISC_2_bp  2  /* Input/Sense Configuration bit 2 position. */
+#define PORT_PULLUPEN_bm  0x08  /* Pullup enable bit mask. */
+#define PORT_PULLUPEN_bp  3  /* Pullup enable bit position. */
+#define PORT_INLVL_bm  0x40  /* Input Level Select bit mask. */
+#define PORT_INLVL_bp  6  /* Input Level Select bit position. */
+#define PORT_INVEN_bm  0x80  /* Inverted I/O Enable bit mask. */
+#define PORT_INVEN_bp  7  /* Inverted I/O Enable bit position. */
+
+/* PORT.PIN0CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN1CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN2CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN3CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN4CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN5CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN6CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN7CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.EVGENCTRLA  bit masks and bit positions */
+#define PORT_EVGEN0SEL_gm  0x07  /* Event Generator 0 Select group mask. */
+#define PORT_EVGEN0SEL_gp  0  /* Event Generator 0 Select group position. */
+#define PORT_EVGEN0SEL_0_bm  (1<<0)  /* Event Generator 0 Select bit 0 mask. */
+#define PORT_EVGEN0SEL_0_bp  0  /* Event Generator 0 Select bit 0 position. */
+#define PORT_EVGEN0SEL_1_bm  (1<<1)  /* Event Generator 0 Select bit 1 mask. */
+#define PORT_EVGEN0SEL_1_bp  1  /* Event Generator 0 Select bit 1 position. */
+#define PORT_EVGEN0SEL_2_bm  (1<<2)  /* Event Generator 0 Select bit 2 mask. */
+#define PORT_EVGEN0SEL_2_bp  2  /* Event Generator 0 Select bit 2 position. */
+#define PORT_EVGEN1SEL_gm  0x70  /* Event Generator 1 Select group mask. */
+#define PORT_EVGEN1SEL_gp  4  /* Event Generator 1 Select group position. */
+#define PORT_EVGEN1SEL_0_bm  (1<<4)  /* Event Generator 1 Select bit 0 mask. */
+#define PORT_EVGEN1SEL_0_bp  4  /* Event Generator 1 Select bit 0 position. */
+#define PORT_EVGEN1SEL_1_bm  (1<<5)  /* Event Generator 1 Select bit 1 mask. */
+#define PORT_EVGEN1SEL_1_bp  5  /* Event Generator 1 Select bit 1 position. */
+#define PORT_EVGEN1SEL_2_bm  (1<<6)  /* Event Generator 1 Select bit 2 mask. */
+#define PORT_EVGEN1SEL_2_bp  6  /* Event Generator 1 Select bit 2 position. */
+
+
+/* PORTMUX - Port Multiplexer */
+/* PORTMUX.EVSYSROUTEA  bit masks and bit positions */
+#define PORTMUX_EVOUTA_bm  0x01  /* Event Output A bit mask. */
+#define PORTMUX_EVOUTA_bp  0  /* Event Output A bit position. */
+#define PORTMUX_EVOUTC_bm  0x04  /* Event Output C bit mask. */
+#define PORTMUX_EVOUTC_bp  2  /* Event Output C bit position. */
+#define PORTMUX_EVOUTD_bm  0x08  /* Event Output D bit mask. */
+#define PORTMUX_EVOUTD_bp  3  /* Event Output D bit position. */
+#define PORTMUX_EVOUTF_bm  0x20  /* Event Output F bit mask. */
+#define PORTMUX_EVOUTF_bp  5  /* Event Output F bit position. */
+
+/* PORTMUX.CCLROUTEA  bit masks and bit positions */
+#define PORTMUX_LUT0_bm  0x01  /* CCL Look-Up Table 0 Signals bit mask. */
+#define PORTMUX_LUT0_bp  0  /* CCL Look-Up Table 0 Signals bit position. */
+#define PORTMUX_LUT1_bm  0x02  /* CCL Look-Up Table 1 Signals bit mask. */
+#define PORTMUX_LUT1_bp  1  /* CCL Look-Up Table 1 Signals bit position. */
+#define PORTMUX_LUT2_bm  0x04  /* CCL Look-Up Table 2 Signals bit mask. */
+#define PORTMUX_LUT2_bp  2  /* CCL Look-Up Table 2 Signals bit position. */
+
+/* PORTMUX.USARTROUTEA  bit masks and bit positions */
+#define PORTMUX_USART0_gm  0x07  /* USART0 Routing group mask. */
+#define PORTMUX_USART0_gp  0  /* USART0 Routing group position. */
+#define PORTMUX_USART0_0_bm  (1<<0)  /* USART0 Routing bit 0 mask. */
+#define PORTMUX_USART0_0_bp  0  /* USART0 Routing bit 0 position. */
+#define PORTMUX_USART0_1_bm  (1<<1)  /* USART0 Routing bit 1 mask. */
+#define PORTMUX_USART0_1_bp  1  /* USART0 Routing bit 1 position. */
+#define PORTMUX_USART0_2_bm  (1<<2)  /* USART0 Routing bit 2 mask. */
+#define PORTMUX_USART0_2_bp  2  /* USART0 Routing bit 2 position. */
+
+/* PORTMUX.SPIROUTEA  bit masks and bit positions */
+#define PORTMUX_SPI0_gm  0x07  /* SPI0 Signals group mask. */
+#define PORTMUX_SPI0_gp  0  /* SPI0 Signals group position. */
+#define PORTMUX_SPI0_0_bm  (1<<0)  /* SPI0 Signals bit 0 mask. */
+#define PORTMUX_SPI0_0_bp  0  /* SPI0 Signals bit 0 position. */
+#define PORTMUX_SPI0_1_bm  (1<<1)  /* SPI0 Signals bit 1 mask. */
+#define PORTMUX_SPI0_1_bp  1  /* SPI0 Signals bit 1 position. */
+#define PORTMUX_SPI0_2_bm  (1<<2)  /* SPI0 Signals bit 2 mask. */
+#define PORTMUX_SPI0_2_bp  2  /* SPI0 Signals bit 2 position. */
+
+/* PORTMUX.TWIROUTEA  bit masks and bit positions */
+#define PORTMUX_TWI0_gm  0x03  /* TWI0 Signals group mask. */
+#define PORTMUX_TWI0_gp  0  /* TWI0 Signals group position. */
+#define PORTMUX_TWI0_0_bm  (1<<0)  /* TWI0 Signals bit 0 mask. */
+#define PORTMUX_TWI0_0_bp  0  /* TWI0 Signals bit 0 position. */
+#define PORTMUX_TWI0_1_bm  (1<<1)  /* TWI0 Signals bit 1 mask. */
+#define PORTMUX_TWI0_1_bp  1  /* TWI0 Signals bit 1 position. */
+
+/* PORTMUX.TCEROUTEA  bit masks and bit positions */
+#define PORTMUX_TCE0_gm  0x0F  /* TCE0 Signals group mask. */
+#define PORTMUX_TCE0_gp  0  /* TCE0 Signals group position. */
+#define PORTMUX_TCE0_0_bm  (1<<0)  /* TCE0 Signals bit 0 mask. */
+#define PORTMUX_TCE0_0_bp  0  /* TCE0 Signals bit 0 position. */
+#define PORTMUX_TCE0_1_bm  (1<<1)  /* TCE0 Signals bit 1 mask. */
+#define PORTMUX_TCE0_1_bp  1  /* TCE0 Signals bit 1 position. */
+#define PORTMUX_TCE0_2_bm  (1<<2)  /* TCE0 Signals bit 2 mask. */
+#define PORTMUX_TCE0_2_bp  2  /* TCE0 Signals bit 2 position. */
+#define PORTMUX_TCE0_3_bm  (1<<3)  /* TCE0 Signals bit 3 mask. */
+#define PORTMUX_TCE0_3_bp  3  /* TCE0 Signals bit 3 position. */
+
+/* PORTMUX.TCBROUTEA  bit masks and bit positions */
+#define PORTMUX_TCB0_bm  0x01  /* TCB0 Output bit mask. */
+#define PORTMUX_TCB0_bp  0  /* TCB0 Output bit position. */
+#define PORTMUX_TCB1_bm  0x02  /* TCB1 Output bit mask. */
+#define PORTMUX_TCB1_bp  1  /* TCB1 Output bit position. */
+
+/* PORTMUX.TCFROUTEA  bit masks and bit positions */
+#define PORTMUX_TCF0_gm  0x03  /* TCF0 Output group mask. */
+#define PORTMUX_TCF0_gp  0  /* TCF0 Output group position. */
+#define PORTMUX_TCF0_0_bm  (1<<0)  /* TCF0 Output bit 0 mask. */
+#define PORTMUX_TCF0_0_bp  0  /* TCF0 Output bit 0 position. */
+#define PORTMUX_TCF0_1_bm  (1<<1)  /* TCF0 Output bit 1 mask. */
+#define PORTMUX_TCF0_1_bp  1  /* TCF0 Output bit 1 position. */
+
+
+/* RSTCTRL - Reset controller */
+/* RSTCTRL.RSTFR  bit masks and bit positions */
+#define RSTCTRL_PORF_bm  0x01  /* Power on Reset flag bit mask. */
+#define RSTCTRL_PORF_bp  0  /* Power on Reset flag bit position. */
+#define RSTCTRL_BORF_bm  0x02  /* Brown out detector Reset flag bit mask. */
+#define RSTCTRL_BORF_bp  1  /* Brown out detector Reset flag bit position. */
+#define RSTCTRL_EXTRF_bm  0x04  /* External Reset flag bit mask. */
+#define RSTCTRL_EXTRF_bp  2  /* External Reset flag bit position. */
+#define RSTCTRL_WDRF_bm  0x08  /* Watch dog Reset flag bit mask. */
+#define RSTCTRL_WDRF_bp  3  /* Watch dog Reset flag bit position. */
+#define RSTCTRL_SWRF_bm  0x10  /* Software Reset flag bit mask. */
+#define RSTCTRL_SWRF_bp  4  /* Software Reset flag bit position. */
+#define RSTCTRL_UPDIRF_bm  0x20  /* UPDI Reset flag bit mask. */
+#define RSTCTRL_UPDIRF_bp  5  /* UPDI Reset flag bit position. */
+
+/* RSTCTRL.SWRR  bit masks and bit positions */
+#define RSTCTRL_SWRE_bm  0x01  /* Software Reset Enable bit mask. */
+#define RSTCTRL_SWRE_bp  0  /* Software Reset Enable bit position. */
+
+
+/* RTC - Real-Time Counter */
+/* RTC.CTRLA  bit masks and bit positions */
+#define RTC_RTCEN_bm  0x01  /* Enable bit mask. */
+#define RTC_RTCEN_bp  0  /* Enable bit position. */
+#define RTC_CORREN_bm  0x04  /* Correction enable bit mask. */
+#define RTC_CORREN_bp  2  /* Correction enable bit position. */
+#define RTC_PRESCALER_gm  0x78  /* Prescaling Factor group mask. */
+#define RTC_PRESCALER_gp  3  /* Prescaling Factor group position. */
+#define RTC_PRESCALER_0_bm  (1<<3)  /* Prescaling Factor bit 0 mask. */
+#define RTC_PRESCALER_0_bp  3  /* Prescaling Factor bit 0 position. */
+#define RTC_PRESCALER_1_bm  (1<<4)  /* Prescaling Factor bit 1 mask. */
+#define RTC_PRESCALER_1_bp  4  /* Prescaling Factor bit 1 position. */
+#define RTC_PRESCALER_2_bm  (1<<5)  /* Prescaling Factor bit 2 mask. */
+#define RTC_PRESCALER_2_bp  5  /* Prescaling Factor bit 2 position. */
+#define RTC_PRESCALER_3_bm  (1<<6)  /* Prescaling Factor bit 3 mask. */
+#define RTC_PRESCALER_3_bp  6  /* Prescaling Factor bit 3 position. */
+#define RTC_RUNSTDBY_bm  0x80  /* Run In Standby bit mask. */
+#define RTC_RUNSTDBY_bp  7  /* Run In Standby bit position. */
+
+/* RTC.STATUS  bit masks and bit positions */
+#define RTC_CTRLABUSY_bm  0x01  /* CTRLA Synchronization Busy Flag bit mask. */
+#define RTC_CTRLABUSY_bp  0  /* CTRLA Synchronization Busy Flag bit position. */
+#define RTC_CNTBUSY_bm  0x02  /* Count Synchronization Busy Flag bit mask. */
+#define RTC_CNTBUSY_bp  1  /* Count Synchronization Busy Flag bit position. */
+#define RTC_PERBUSY_bm  0x04  /* Period Synchronization Busy Flag bit mask. */
+#define RTC_PERBUSY_bp  2  /* Period Synchronization Busy Flag bit position. */
+#define RTC_CMPBUSY_bm  0x08  /* Comparator Synchronization Busy Flag bit mask. */
+#define RTC_CMPBUSY_bp  3  /* Comparator Synchronization Busy Flag bit position. */
+
+/* RTC.INTCTRL  bit masks and bit positions */
+#define RTC_OVF_bm  0x01  /* Overflow Interrupt enable bit mask. */
+#define RTC_OVF_bp  0  /* Overflow Interrupt enable bit position. */
+#define RTC_CMP_bm  0x02  /* Compare Match Interrupt enable bit mask. */
+#define RTC_CMP_bp  1  /* Compare Match Interrupt enable bit position. */
+
+/* RTC.INTFLAGS  bit masks and bit positions */
+/* RTC_OVF  is already defined. */
+/* RTC_CMP  is already defined. */
+
+/* RTC.DBGCTRL  bit masks and bit positions */
+#define RTC_DBGRUN_bm  0x01  /* Run in debug bit mask. */
+#define RTC_DBGRUN_bp  0  /* Run in debug bit position. */
+
+/* RTC.CALIB  bit masks and bit positions */
+#define RTC_ERROR_gm  0x7F  /* Error Correction Value group mask. */
+#define RTC_ERROR_gp  0  /* Error Correction Value group position. */
+#define RTC_ERROR_0_bm  (1<<0)  /* Error Correction Value bit 0 mask. */
+#define RTC_ERROR_0_bp  0  /* Error Correction Value bit 0 position. */
+#define RTC_ERROR_1_bm  (1<<1)  /* Error Correction Value bit 1 mask. */
+#define RTC_ERROR_1_bp  1  /* Error Correction Value bit 1 position. */
+#define RTC_ERROR_2_bm  (1<<2)  /* Error Correction Value bit 2 mask. */
+#define RTC_ERROR_2_bp  2  /* Error Correction Value bit 2 position. */
+#define RTC_ERROR_3_bm  (1<<3)  /* Error Correction Value bit 3 mask. */
+#define RTC_ERROR_3_bp  3  /* Error Correction Value bit 3 position. */
+#define RTC_ERROR_4_bm  (1<<4)  /* Error Correction Value bit 4 mask. */
+#define RTC_ERROR_4_bp  4  /* Error Correction Value bit 4 position. */
+#define RTC_ERROR_5_bm  (1<<5)  /* Error Correction Value bit 5 mask. */
+#define RTC_ERROR_5_bp  5  /* Error Correction Value bit 5 position. */
+#define RTC_ERROR_6_bm  (1<<6)  /* Error Correction Value bit 6 mask. */
+#define RTC_ERROR_6_bp  6  /* Error Correction Value bit 6 position. */
+#define RTC_SIGN_bm  0x80  /* Error Correction Sign Bit bit mask. */
+#define RTC_SIGN_bp  7  /* Error Correction Sign Bit bit position. */
+
+/* RTC.CLKSEL  bit masks and bit positions */
+#define RTC_CLKSEL_gm  0x03  /* Clock Select group mask. */
+#define RTC_CLKSEL_gp  0  /* Clock Select group position. */
+#define RTC_CLKSEL_0_bm  (1<<0)  /* Clock Select bit 0 mask. */
+#define RTC_CLKSEL_0_bp  0  /* Clock Select bit 0 position. */
+#define RTC_CLKSEL_1_bm  (1<<1)  /* Clock Select bit 1 mask. */
+#define RTC_CLKSEL_1_bp  1  /* Clock Select bit 1 position. */
+
+/* RTC.PITCTRLA  bit masks and bit positions */
+#define RTC_PITEN_bm  0x01  /* Enable bit mask. */
+#define RTC_PITEN_bp  0  /* Enable bit position. */
+#define RTC_PERIOD_gm  0x78  /* Period group mask. */
+#define RTC_PERIOD_gp  3  /* Period group position. */
+#define RTC_PERIOD_0_bm  (1<<3)  /* Period bit 0 mask. */
+#define RTC_PERIOD_0_bp  3  /* Period bit 0 position. */
+#define RTC_PERIOD_1_bm  (1<<4)  /* Period bit 1 mask. */
+#define RTC_PERIOD_1_bp  4  /* Period bit 1 position. */
+#define RTC_PERIOD_2_bm  (1<<5)  /* Period bit 2 mask. */
+#define RTC_PERIOD_2_bp  5  /* Period bit 2 position. */
+#define RTC_PERIOD_3_bm  (1<<6)  /* Period bit 3 mask. */
+#define RTC_PERIOD_3_bp  6  /* Period bit 3 position. */
+
+/* RTC.PITSTATUS  bit masks and bit positions */
+#define RTC_CTRLBUSY_bm  0x01  /* CTRLA Synchronization Busy Flag bit mask. */
+#define RTC_CTRLBUSY_bp  0  /* CTRLA Synchronization Busy Flag bit position. */
+
+/* RTC.PITINTCTRL  bit masks and bit positions */
+#define RTC_PI_bm  0x01  /* Periodic Interrupt bit mask. */
+#define RTC_PI_bp  0  /* Periodic Interrupt bit position. */
+
+/* RTC.PITINTFLAGS  bit masks and bit positions */
+/* RTC_PI  is already defined. */
+
+/* RTC.PITDBGCTRL  bit masks and bit positions */
+/* RTC_DBGRUN  is already defined. */
+
+/* RTC.PITEVGENCTRLA  bit masks and bit positions */
+#define RTC_EVGEN0SEL_gm  0x0F  /* Event Generation 0 Select group mask. */
+#define RTC_EVGEN0SEL_gp  0  /* Event Generation 0 Select group position. */
+#define RTC_EVGEN0SEL_0_bm  (1<<0)  /* Event Generation 0 Select bit 0 mask. */
+#define RTC_EVGEN0SEL_0_bp  0  /* Event Generation 0 Select bit 0 position. */
+#define RTC_EVGEN0SEL_1_bm  (1<<1)  /* Event Generation 0 Select bit 1 mask. */
+#define RTC_EVGEN0SEL_1_bp  1  /* Event Generation 0 Select bit 1 position. */
+#define RTC_EVGEN0SEL_2_bm  (1<<2)  /* Event Generation 0 Select bit 2 mask. */
+#define RTC_EVGEN0SEL_2_bp  2  /* Event Generation 0 Select bit 2 position. */
+#define RTC_EVGEN0SEL_3_bm  (1<<3)  /* Event Generation 0 Select bit 3 mask. */
+#define RTC_EVGEN0SEL_3_bp  3  /* Event Generation 0 Select bit 3 position. */
+#define RTC_EVGEN1SEL_gm  0xF0  /* Event Generation 1 Select group mask. */
+#define RTC_EVGEN1SEL_gp  4  /* Event Generation 1 Select group position. */
+#define RTC_EVGEN1SEL_0_bm  (1<<4)  /* Event Generation 1 Select bit 0 mask. */
+#define RTC_EVGEN1SEL_0_bp  4  /* Event Generation 1 Select bit 0 position. */
+#define RTC_EVGEN1SEL_1_bm  (1<<5)  /* Event Generation 1 Select bit 1 mask. */
+#define RTC_EVGEN1SEL_1_bp  5  /* Event Generation 1 Select bit 1 position. */
+#define RTC_EVGEN1SEL_2_bm  (1<<6)  /* Event Generation 1 Select bit 2 mask. */
+#define RTC_EVGEN1SEL_2_bp  6  /* Event Generation 1 Select bit 2 position. */
+#define RTC_EVGEN1SEL_3_bm  (1<<7)  /* Event Generation 1 Select bit 3 mask. */
+#define RTC_EVGEN1SEL_3_bp  7  /* Event Generation 1 Select bit 3 position. */
+
+
+
+/* SLPCTRL - Sleep Controller */
+/* SLPCTRL.CTRLA  bit masks and bit positions */
+#define SLPCTRL_SEN_bm  0x01  /* Sleep enable bit mask. */
+#define SLPCTRL_SEN_bp  0  /* Sleep enable bit position. */
+#define SLPCTRL_SMODE_gm  0x06  /* Sleep mode group mask. */
+#define SLPCTRL_SMODE_gp  1  /* Sleep mode group position. */
+#define SLPCTRL_SMODE_0_bm  (1<<1)  /* Sleep mode bit 0 mask. */
+#define SLPCTRL_SMODE_0_bp  1  /* Sleep mode bit 0 position. */
+#define SLPCTRL_SMODE_1_bm  (1<<2)  /* Sleep mode bit 1 mask. */
+#define SLPCTRL_SMODE_1_bp  2  /* Sleep mode bit 1 position. */
+
+
+/* SPI - Serial Peripheral Interface */
+/* SPI.CTRLA  bit masks and bit positions */
+#define SPI_ENABLE_bm  0x01  /* Enable Module bit mask. */
+#define SPI_ENABLE_bp  0  /* Enable Module bit position. */
+#define SPI_PRESC_gm  0x06  /* Prescaler group mask. */
+#define SPI_PRESC_gp  1  /* Prescaler group position. */
+#define SPI_PRESC_0_bm  (1<<1)  /* Prescaler bit 0 mask. */
+#define SPI_PRESC_0_bp  1  /* Prescaler bit 0 position. */
+#define SPI_PRESC_1_bm  (1<<2)  /* Prescaler bit 1 mask. */
+#define SPI_PRESC_1_bp  2  /* Prescaler bit 1 position. */
+#define SPI_CLK2X_bm  0x10  /* Enable Double Speed bit mask. */
+#define SPI_CLK2X_bp  4  /* Enable Double Speed bit position. */
+#define SPI_MASTER_bm  0x20  /* Host Operation Enable bit mask. */
+#define SPI_MASTER_bp  5  /* Host Operation Enable bit position. */
+#define SPI_DORD_bm  0x40  /* Data Order Setting bit mask. */
+#define SPI_DORD_bp  6  /* Data Order Setting bit position. */
+
+/* SPI.CTRLB  bit masks and bit positions */
+#define SPI_MODE_gm  0x03  /* SPI Mode group mask. */
+#define SPI_MODE_gp  0  /* SPI Mode group position. */
+#define SPI_MODE_0_bm  (1<<0)  /* SPI Mode bit 0 mask. */
+#define SPI_MODE_0_bp  0  /* SPI Mode bit 0 position. */
+#define SPI_MODE_1_bm  (1<<1)  /* SPI Mode bit 1 mask. */
+#define SPI_MODE_1_bp  1  /* SPI Mode bit 1 position. */
+#define SPI_SSD_bm  0x04  /* SPI Select Disable bit mask. */
+#define SPI_SSD_bp  2  /* SPI Select Disable bit position. */
+#define SPI_BUFWR_bm  0x40  /* Buffer Mode Wait for Receive bit mask. */
+#define SPI_BUFWR_bp  6  /* Buffer Mode Wait for Receive bit position. */
+#define SPI_BUFEN_bm  0x80  /* Buffer Mode Enable bit mask. */
+#define SPI_BUFEN_bp  7  /* Buffer Mode Enable bit position. */
+
+/* SPI.INTCTRL  bit masks and bit positions */
+#define SPI_IE_bm  0x01  /* Interrupt Enable bit mask. */
+#define SPI_IE_bp  0  /* Interrupt Enable bit position. */
+#define SPI_SSIE_bm  0x10  /* SPI Select Trigger Interrupt Enable bit mask. */
+#define SPI_SSIE_bp  4  /* SPI Select Trigger Interrupt Enable bit position. */
+#define SPI_DREIE_bm  0x20  /* Data Register Empty Interrupt Enable bit mask. */
+#define SPI_DREIE_bp  5  /* Data Register Empty Interrupt Enable bit position. */
+#define SPI_TXCIE_bm  0x40  /* Transfer Complete Interrupt Enable bit mask. */
+#define SPI_TXCIE_bp  6  /* Transfer Complete Interrupt Enable bit position. */
+#define SPI_RXCIE_bm  0x80  /* Receive Complete Interrupt Enable bit mask. */
+#define SPI_RXCIE_bp  7  /* Receive Complete Interrupt Enable bit position. */
+
+/* SPI.INTFLAGS  bit masks and bit positions */
+#define SPI_BUFOVF_bm  0x01  /* Buffer Overflow bit mask. */
+#define SPI_BUFOVF_bp  0  /* Buffer Overflow bit position. */
+#define SPI_SSIF_bm  0x10  /* SPI Select Trigger Interrupt Flag bit mask. */
+#define SPI_SSIF_bp  4  /* SPI Select Trigger Interrupt Flag bit position. */
+#define SPI_DREIF_bm  0x20  /* Data Register Empty Interrupt Flag bit mask. */
+#define SPI_DREIF_bp  5  /* Data Register Empty Interrupt Flag bit position. */
+#define SPI_TXCIF_bm  0x40  /* Transfer Complete Interrupt Flag bit mask. */
+#define SPI_TXCIF_bp  6  /* Transfer Complete Interrupt Flag bit position. */
+#define SPI_WRCOL_bm  0x40  /* Write Collision bit mask. */
+#define SPI_WRCOL_bp  6  /* Write Collision bit position. */
+#define SPI_RXCIF_bm  0x80  /* Receive Complete Interrupt Flag bit mask. */
+#define SPI_RXCIF_bp  7  /* Receive Complete Interrupt Flag bit position. */
+#define SPI_IF_bm  0x80  /* Interrupt Flag bit mask. */
+#define SPI_IF_bp  7  /* Interrupt Flag bit position. */
+
+
+/* SYSCFG - System Configuration Registers */
+/* SYSCFG.REVID  bit masks and bit positions */
+#define SYSCFG_MINOR_gm  0x0F  /* Minor Revision group mask. */
+#define SYSCFG_MINOR_gp  0  /* Minor Revision group position. */
+#define SYSCFG_MINOR_0_bm  (1<<0)  /* Minor Revision bit 0 mask. */
+#define SYSCFG_MINOR_0_bp  0  /* Minor Revision bit 0 position. */
+#define SYSCFG_MINOR_1_bm  (1<<1)  /* Minor Revision bit 1 mask. */
+#define SYSCFG_MINOR_1_bp  1  /* Minor Revision bit 1 position. */
+#define SYSCFG_MINOR_2_bm  (1<<2)  /* Minor Revision bit 2 mask. */
+#define SYSCFG_MINOR_2_bp  2  /* Minor Revision bit 2 position. */
+#define SYSCFG_MINOR_3_bm  (1<<3)  /* Minor Revision bit 3 mask. */
+#define SYSCFG_MINOR_3_bp  3  /* Minor Revision bit 3 position. */
+#define SYSCFG_MAJOR_gm  0xF0  /* Major Revision group mask. */
+#define SYSCFG_MAJOR_gp  4  /* Major Revision group position. */
+#define SYSCFG_MAJOR_0_bm  (1<<4)  /* Major Revision bit 0 mask. */
+#define SYSCFG_MAJOR_0_bp  4  /* Major Revision bit 0 position. */
+#define SYSCFG_MAJOR_1_bm  (1<<5)  /* Major Revision bit 1 mask. */
+#define SYSCFG_MAJOR_1_bp  5  /* Major Revision bit 1 position. */
+#define SYSCFG_MAJOR_2_bm  (1<<6)  /* Major Revision bit 2 mask. */
+#define SYSCFG_MAJOR_2_bp  6  /* Major Revision bit 2 position. */
+#define SYSCFG_MAJOR_3_bm  (1<<7)  /* Major Revision bit 3 mask. */
+#define SYSCFG_MAJOR_3_bp  7  /* Major Revision bit 3 position. */
+
+
+/* TCB - 16-bit Timer/Counter Type B */
+/* TCB.CTRLA  bit masks and bit positions */
+#define TCB_ENABLE_bm  0x01  /* Enable bit mask. */
+#define TCB_ENABLE_bp  0  /* Enable bit position. */
+#define TCB_CLKSEL_gm  0x0E  /* Clock Select group mask. */
+#define TCB_CLKSEL_gp  1  /* Clock Select group position. */
+#define TCB_CLKSEL_0_bm  (1<<1)  /* Clock Select bit 0 mask. */
+#define TCB_CLKSEL_0_bp  1  /* Clock Select bit 0 position. */
+#define TCB_CLKSEL_1_bm  (1<<2)  /* Clock Select bit 1 mask. */
+#define TCB_CLKSEL_1_bp  2  /* Clock Select bit 1 position. */
+#define TCB_CLKSEL_2_bm  (1<<3)  /* Clock Select bit 2 mask. */
+#define TCB_CLKSEL_2_bp  3  /* Clock Select bit 2 position. */
+#define TCB_SYNCUPD_bm  0x10  /* Synchronize Update bit mask. */
+#define TCB_SYNCUPD_bp  4  /* Synchronize Update bit position. */
+#define TCB_CASCADE_bm  0x20  /* Cascade two timers bit mask. */
+#define TCB_CASCADE_bp  5  /* Cascade two timers bit position. */
+#define TCB_RUNSTDBY_bm  0x40  /* Run Standby bit mask. */
+#define TCB_RUNSTDBY_bp  6  /* Run Standby bit position. */
+
+/* TCB.CTRLB  bit masks and bit positions */
+#define TCB_CNTMODE_gm  0x07  /* Timer Mode group mask. */
+#define TCB_CNTMODE_gp  0  /* Timer Mode group position. */
+#define TCB_CNTMODE_0_bm  (1<<0)  /* Timer Mode bit 0 mask. */
+#define TCB_CNTMODE_0_bp  0  /* Timer Mode bit 0 position. */
+#define TCB_CNTMODE_1_bm  (1<<1)  /* Timer Mode bit 1 mask. */
+#define TCB_CNTMODE_1_bp  1  /* Timer Mode bit 1 position. */
+#define TCB_CNTMODE_2_bm  (1<<2)  /* Timer Mode bit 2 mask. */
+#define TCB_CNTMODE_2_bp  2  /* Timer Mode bit 2 position. */
+#define TCB_CCMPEN_bm  0x10  /* Pin Output Enable bit mask. */
+#define TCB_CCMPEN_bp  4  /* Pin Output Enable bit position. */
+#define TCB_CCMPINIT_bm  0x20  /* Pin Initial State bit mask. */
+#define TCB_CCMPINIT_bp  5  /* Pin Initial State bit position. */
+#define TCB_ASYNC_bm  0x40  /* Asynchronous Enable bit mask. */
+#define TCB_ASYNC_bp  6  /* Asynchronous Enable bit position. */
+#define TCB_EVGEN_bm  0x80  /* Event Generation bit mask. */
+#define TCB_EVGEN_bp  7  /* Event Generation bit position. */
+
+/* TCB.CTRLC  bit masks and bit positions */
+#define TCB_CNTSIZE_gm  0x07  /* Counter Size group mask. */
+#define TCB_CNTSIZE_gp  0  /* Counter Size group position. */
+#define TCB_CNTSIZE_0_bm  (1<<0)  /* Counter Size bit 0 mask. */
+#define TCB_CNTSIZE_0_bp  0  /* Counter Size bit 0 position. */
+#define TCB_CNTSIZE_1_bm  (1<<1)  /* Counter Size bit 1 mask. */
+#define TCB_CNTSIZE_1_bp  1  /* Counter Size bit 1 position. */
+#define TCB_CNTSIZE_2_bm  (1<<2)  /* Counter Size bit 2 mask. */
+#define TCB_CNTSIZE_2_bp  2  /* Counter Size bit 2 position. */
+
+/* TCB.EVCTRL  bit masks and bit positions */
+#define TCB_CAPTEI_bm  0x01  /* Event Input Enable bit mask. */
+#define TCB_CAPTEI_bp  0  /* Event Input Enable bit position. */
+#define TCB_EDGE_bm  0x10  /* Event Edge bit mask. */
+#define TCB_EDGE_bp  4  /* Event Edge bit position. */
+#define TCB_FILTER_bm  0x40  /* Input Capture Noise Cancellation Filter bit mask. */
+#define TCB_FILTER_bp  6  /* Input Capture Noise Cancellation Filter bit position. */
+
+/* TCB.INTCTRL  bit masks and bit positions */
+#define TCB_CAPT_bm  0x01  /* Capture or Timeout bit mask. */
+#define TCB_CAPT_bp  0  /* Capture or Timeout bit position. */
+#define TCB_OVF_bm  0x02  /* Overflow bit mask. */
+#define TCB_OVF_bp  1  /* Overflow bit position. */
+
+/* TCB.INTFLAGS  bit masks and bit positions */
+/* TCB_CAPT  is already defined. */
+/* TCB_OVF  is already defined. */
+
+/* TCB.STATUS  bit masks and bit positions */
+#define TCB_RUN_bm  0x01  /* Run bit mask. */
+#define TCB_RUN_bp  0  /* Run bit position. */
+
+/* TCB.DBGCTRL  bit masks and bit positions */
+#define TCB_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define TCB_DBGRUN_bp  0  /* Debug Run bit position. */
+
+
+/* TCE - 16-bit Timer/Counter Type E */
+/* TCE.CTRLA  bit masks and bit positions */
+#define TCE_ENABLE_bm  0x01  /* Module Enable bit mask. */
+#define TCE_ENABLE_bp  0  /* Module Enable bit position. */
+#define TCE_CLKSEL_gm  0x0E  /* Clock Selection group mask. */
+#define TCE_CLKSEL_gp  1  /* Clock Selection group position. */
+#define TCE_CLKSEL_0_bm  (1<<1)  /* Clock Selection bit 0 mask. */
+#define TCE_CLKSEL_0_bp  1  /* Clock Selection bit 0 position. */
+#define TCE_CLKSEL_1_bm  (1<<2)  /* Clock Selection bit 1 mask. */
+#define TCE_CLKSEL_1_bp  2  /* Clock Selection bit 1 position. */
+#define TCE_CLKSEL_2_bm  (1<<3)  /* Clock Selection bit 2 mask. */
+#define TCE_CLKSEL_2_bp  3  /* Clock Selection bit 2 position. */
+#define TCE_RUNSTDBY_bm  0x80  /* Run in Standby bit mask. */
+#define TCE_RUNSTDBY_bp  7  /* Run in Standby bit position. */
+
+/* TCE.CTRLB  bit masks and bit positions */
+#define TCE_WGMODE_gm  0x07  /* Waveform generation mode group mask. */
+#define TCE_WGMODE_gp  0  /* Waveform generation mode group position. */
+#define TCE_WGMODE_0_bm  (1<<0)  /* Waveform generation mode bit 0 mask. */
+#define TCE_WGMODE_0_bp  0  /* Waveform generation mode bit 0 position. */
+#define TCE_WGMODE_1_bm  (1<<1)  /* Waveform generation mode bit 1 mask. */
+#define TCE_WGMODE_1_bp  1  /* Waveform generation mode bit 1 position. */
+#define TCE_WGMODE_2_bm  (1<<2)  /* Waveform generation mode bit 2 mask. */
+#define TCE_WGMODE_2_bp  2  /* Waveform generation mode bit 2 position. */
+#define TCE_ALUPD_bm  0x08  /* Auto Lock Update bit mask. */
+#define TCE_ALUPD_bp  3  /* Auto Lock Update bit position. */
+#define TCE_CMP0EN_bm  0x10  /* Compare 0 Enable bit mask. */
+#define TCE_CMP0EN_bp  4  /* Compare 0 Enable bit position. */
+#define TCE_CMP1EN_bm  0x20  /* Compare 1 Enable bit mask. */
+#define TCE_CMP1EN_bp  5  /* Compare 1 Enable bit position. */
+#define TCE_CMP2EN_bm  0x40  /* Compare 2 Enable bit mask. */
+#define TCE_CMP2EN_bp  6  /* Compare 2 Enable bit position. */
+#define TCE_CMP3EN_bm  0x80  /* Compare 3 Enable bit mask. */
+#define TCE_CMP3EN_bp  7  /* Compare 3 Enable bit position. */
+
+/* TCE.CTRLC  bit masks and bit positions */
+#define TCE_CMP0OV_bm  0x01  /* Compare 0 Waveform Output Value bit mask. */
+#define TCE_CMP0OV_bp  0  /* Compare 0 Waveform Output Value bit position. */
+#define TCE_CMP1OV_bm  0x02  /* Compare 1 Waveform Output Value bit mask. */
+#define TCE_CMP1OV_bp  1  /* Compare 1 Waveform Output Value bit position. */
+#define TCE_CMP2OV_bm  0x04  /* Compare 2 Waveform Output Value bit mask. */
+#define TCE_CMP2OV_bp  2  /* Compare 2 Waveform Output Value bit position. */
+#define TCE_CMP3OV_bm  0x08  /* Compare 3 Waveform Output Value bit mask. */
+#define TCE_CMP3OV_bp  3  /* Compare 3 Waveform Output Value bit position. */
+#define TCE_CMP0POL_bm  0x10  /* Compare 0 Polarity bit mask. */
+#define TCE_CMP0POL_bp  4  /* Compare 0 Polarity bit position. */
+#define TCE_CMP1POL_bm  0x20  /* Compare 1 Polarity bit mask. */
+#define TCE_CMP1POL_bp  5  /* Compare 1 Polarity bit position. */
+#define TCE_CMP2POL_bm  0x40  /* Compare 2 Polarity bit mask. */
+#define TCE_CMP2POL_bp  6  /* Compare 2 Polarity bit position. */
+#define TCE_CMP3POL_bm  0x80  /* Compare 3 Polarity bit mask. */
+#define TCE_CMP3POL_bp  7  /* Compare 3 Polarity bit position. */
+
+/* TCE.CTRLD  bit masks and bit positions */
+#define TCE_SCALE_bm  0x04  /* Scaled Write bit mask. */
+#define TCE_SCALE_bp  2  /* Scaled Write bit position. */
+#define TCE_AMPEN_bm  0x08  /* Amplitude Control Enable bit mask. */
+#define TCE_AMPEN_bp  3  /* Amplitude Control Enable bit position. */
+#define TCE_SCALEMODE_gm  0x30  /* Scaling Mode group mask. */
+#define TCE_SCALEMODE_gp  4  /* Scaling Mode group position. */
+#define TCE_SCALEMODE_0_bm  (1<<4)  /* Scaling Mode bit 0 mask. */
+#define TCE_SCALEMODE_0_bp  4  /* Scaling Mode bit 0 position. */
+#define TCE_SCALEMODE_1_bm  (1<<5)  /* Scaling Mode bit 1 mask. */
+#define TCE_SCALEMODE_1_bp  5  /* Scaling Mode bit 1 position. */
+#define TCE_HREN_gm  0xC0  /* High Resolution Enable group mask. */
+#define TCE_HREN_gp  6  /* High Resolution Enable group position. */
+#define TCE_HREN_0_bm  (1<<6)  /* High Resolution Enable bit 0 mask. */
+#define TCE_HREN_0_bp  6  /* High Resolution Enable bit 0 position. */
+#define TCE_HREN_1_bm  (1<<7)  /* High Resolution Enable bit 1 mask. */
+#define TCE_HREN_1_bp  7  /* High Resolution Enable bit 1 position. */
+
+/* TCE.CTRLECLR  bit masks and bit positions */
+#define TCE_DIR_bm  0x01  /* Direction bit mask. */
+#define TCE_DIR_bp  0  /* Direction bit position. */
+#define TCE_LUPD_bm  0x02  /* Lock Update bit mask. */
+#define TCE_LUPD_bp  1  /* Lock Update bit position. */
+#define TCE_CMD_gm  0x0C  /* Command group mask. */
+#define TCE_CMD_gp  2  /* Command group position. */
+#define TCE_CMD_0_bm  (1<<2)  /* Command bit 0 mask. */
+#define TCE_CMD_0_bp  2  /* Command bit 0 position. */
+#define TCE_CMD_1_bm  (1<<3)  /* Command bit 1 mask. */
+#define TCE_CMD_1_bp  3  /* Command bit 1 position. */
+
+/* TCE.CTRLESET  bit masks and bit positions */
+/* TCE_DIR  is already defined. */
+/* TCE_LUPD  is already defined. */
+/* TCE_CMD  is already defined. */
+
+/* TCE.CTRLFCLR  bit masks and bit positions */
+#define TCE_PERBV_bm  0x01  /* Period Buffer Valid bit mask. */
+#define TCE_PERBV_bp  0  /* Period Buffer Valid bit position. */
+#define TCE_CMP0BV_bm  0x02  /* Compare 0 Buffer Valid bit mask. */
+#define TCE_CMP0BV_bp  1  /* Compare 0 Buffer Valid bit position. */
+#define TCE_CMP1BV_bm  0x04  /* Compare 1 Buffer Valid bit mask. */
+#define TCE_CMP1BV_bp  2  /* Compare 1 Buffer Valid bit position. */
+#define TCE_CMP2BV_bm  0x08  /* Compare 2 Buffer Valid bit mask. */
+#define TCE_CMP2BV_bp  3  /* Compare 2 Buffer Valid bit position. */
+#define TCE_CMP3BV_bm  0x10  /* Compare 3 Buffer Valid bit mask. */
+#define TCE_CMP3BV_bp  4  /* Compare 3 Buffer Valid bit position. */
+
+/* TCE.CTRLFSET  bit masks and bit positions */
+/* TCE_PERBV  is already defined. */
+/* TCE_CMP0BV  is already defined. */
+/* TCE_CMP1BV  is already defined. */
+/* TCE_CMP2BV  is already defined. */
+/* TCE_CMP3BV  is already defined. */
+
+/* TCE.EVGENCTRL  bit masks and bit positions */
+#define TCE_CMP0EV_bm  0x10  /* Compare 0 Event bit mask. */
+#define TCE_CMP0EV_bp  4  /* Compare 0 Event bit position. */
+#define TCE_CMP1EV_bm  0x20  /* Compare 1 Event bit mask. */
+#define TCE_CMP1EV_bp  5  /* Compare 1 Event bit position. */
+#define TCE_CMP2EV_bm  0x40  /* Compare 2 Event bit mask. */
+#define TCE_CMP2EV_bp  6  /* Compare 2 Event bit position. */
+#define TCE_CMP3EV_bm  0x80  /* Compare 3 Event bit mask. */
+#define TCE_CMP3EV_bp  7  /* Compare 3 Event bit position. */
+
+/* TCE.EVCTRL  bit masks and bit positions */
+#define TCE_CNTAEI_bm  0x01  /* Count on Event Input A bit mask. */
+#define TCE_CNTAEI_bp  0  /* Count on Event Input A bit position. */
+#define TCE_EVACTA_gm  0x0E  /* Event Action A group mask. */
+#define TCE_EVACTA_gp  1  /* Event Action A group position. */
+#define TCE_EVACTA_0_bm  (1<<1)  /* Event Action A bit 0 mask. */
+#define TCE_EVACTA_0_bp  1  /* Event Action A bit 0 position. */
+#define TCE_EVACTA_1_bm  (1<<2)  /* Event Action A bit 1 mask. */
+#define TCE_EVACTA_1_bp  2  /* Event Action A bit 1 position. */
+#define TCE_EVACTA_2_bm  (1<<3)  /* Event Action A bit 2 mask. */
+#define TCE_EVACTA_2_bp  3  /* Event Action A bit 2 position. */
+#define TCE_CNTBEI_bm  0x10  /* Count on Event Input B bit mask. */
+#define TCE_CNTBEI_bp  4  /* Count on Event Input B bit position. */
+#define TCE_EVACTB_gm  0xE0  /* Event Action B group mask. */
+#define TCE_EVACTB_gp  5  /* Event Action B group position. */
+#define TCE_EVACTB_0_bm  (1<<5)  /* Event Action B bit 0 mask. */
+#define TCE_EVACTB_0_bp  5  /* Event Action B bit 0 position. */
+#define TCE_EVACTB_1_bm  (1<<6)  /* Event Action B bit 1 mask. */
+#define TCE_EVACTB_1_bp  6  /* Event Action B bit 1 position. */
+#define TCE_EVACTB_2_bm  (1<<7)  /* Event Action B bit 2 mask. */
+#define TCE_EVACTB_2_bp  7  /* Event Action B bit 2 position. */
+
+/* TCE.INTCTRL  bit masks and bit positions */
+#define TCE_OVF_bm  0x01  /* Overflow Interrupt Enable bit mask. */
+#define TCE_OVF_bp  0  /* Overflow Interrupt Enable bit position. */
+#define TCE_CMP0_bm  0x10  /* Compare 0 Interrupt Enable bit mask. */
+#define TCE_CMP0_bp  4  /* Compare 0 Interrupt Enable bit position. */
+#define TCE_CMP1_bm  0x20  /* Compare 1 Interrupt Enable bit mask. */
+#define TCE_CMP1_bp  5  /* Compare 1 Interrupt Enable bit position. */
+#define TCE_CMP2_bm  0x40  /* Compare 2 Interrupt Enable bit mask. */
+#define TCE_CMP2_bp  6  /* Compare 2 Interrupt Enable bit position. */
+#define TCE_CMP3_bm  0x80  /* Compare 3 Interrupt Enable bit mask. */
+#define TCE_CMP3_bp  7  /* Compare 3 Interrupt Enable bit position. */
+
+/* TCE.INTFLAGS  bit masks and bit positions */
+/* TCE_OVF  is already defined. */
+/* TCE_CMP0  is already defined. */
+/* TCE_CMP1  is already defined. */
+/* TCE_CMP2  is already defined. */
+/* TCE_CMP3  is already defined. */
+
+/* TCE.DBGCTRL  bit masks and bit positions */
+#define TCE_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define TCE_DBGRUN_bp  0  /* Debug Run bit position. */
+
+
+/* TCF - 24-bit Timer/Counter for frequency generation */
+/* TCF.CTRLA  bit masks and bit positions */
+#define TCF_ENABLE_bm  0x01  /* Enable bit mask. */
+#define TCF_ENABLE_bp  0  /* Enable bit position. */
+#define TCF_PRESC_gm  0x0E  /* Clock Prescaler group mask. */
+#define TCF_PRESC_gp  1  /* Clock Prescaler group position. */
+#define TCF_PRESC_0_bm  (1<<1)  /* Clock Prescaler bit 0 mask. */
+#define TCF_PRESC_0_bp  1  /* Clock Prescaler bit 0 position. */
+#define TCF_PRESC_1_bm  (1<<2)  /* Clock Prescaler bit 1 mask. */
+#define TCF_PRESC_1_bp  2  /* Clock Prescaler bit 1 position. */
+#define TCF_PRESC_2_bm  (1<<3)  /* Clock Prescaler bit 2 mask. */
+#define TCF_PRESC_2_bp  3  /* Clock Prescaler bit 2 position. */
+#define TCF_RUNSTDBY_bm  0x80  /* Run Standby bit mask. */
+#define TCF_RUNSTDBY_bp  7  /* Run Standby bit position. */
+
+/* TCF.CTRLB  bit masks and bit positions */
+#define TCF_WGMODE_gm  0x07  /* Waveform Generation Mode group mask. */
+#define TCF_WGMODE_gp  0  /* Waveform Generation Mode group position. */
+#define TCF_WGMODE_0_bm  (1<<0)  /* Waveform Generation Mode bit 0 mask. */
+#define TCF_WGMODE_0_bp  0  /* Waveform Generation Mode bit 0 position. */
+#define TCF_WGMODE_1_bm  (1<<1)  /* Waveform Generation Mode bit 1 mask. */
+#define TCF_WGMODE_1_bp  1  /* Waveform Generation Mode bit 1 position. */
+#define TCF_WGMODE_2_bm  (1<<2)  /* Waveform Generation Mode bit 2 mask. */
+#define TCF_WGMODE_2_bp  2  /* Waveform Generation Mode bit 2 position. */
+#define TCF_CLKSEL_gm  0x38  /* Clock Select group mask. */
+#define TCF_CLKSEL_gp  3  /* Clock Select group position. */
+#define TCF_CLKSEL_0_bm  (1<<3)  /* Clock Select bit 0 mask. */
+#define TCF_CLKSEL_0_bp  3  /* Clock Select bit 0 position. */
+#define TCF_CLKSEL_1_bm  (1<<4)  /* Clock Select bit 1 mask. */
+#define TCF_CLKSEL_1_bp  4  /* Clock Select bit 1 position. */
+#define TCF_CLKSEL_2_bm  (1<<5)  /* Clock Select bit 2 mask. */
+#define TCF_CLKSEL_2_bp  5  /* Clock Select bit 2 position. */
+#define TCF_CMP0EV_bm  0x40  /* Compare 0 Event Generation bit mask. */
+#define TCF_CMP0EV_bp  6  /* Compare 0 Event Generation bit position. */
+#define TCF_CMP1EV_bm  0x80  /* Compare 1 Event Generation bit mask. */
+#define TCF_CMP1EV_bp  7  /* Compare 1 Event Generation bit position. */
+
+/* TCF.CTRLC  bit masks and bit positions */
+#define TCF_WO0EN_bm  0x01  /* Waveform Output 0 Enable bit mask. */
+#define TCF_WO0EN_bp  0  /* Waveform Output 0 Enable bit position. */
+#define TCF_WO1EN_bm  0x02  /* Waveform Output 1 Enable bit mask. */
+#define TCF_WO1EN_bp  1  /* Waveform Output 1 Enable bit position. */
+#define TCF_WO0POL_bm  0x04  /* Waveform Output 0 Polarity bit mask. */
+#define TCF_WO0POL_bp  2  /* Waveform Output 0 Polarity bit position. */
+#define TCF_WO1POL_bm  0x08  /* Waveform Output 1 Polarity bit mask. */
+#define TCF_WO1POL_bp  3  /* Waveform Output 1 Polarity bit position. */
+#define TCF_WGPULSE_gm  0x70  /* Waveform Generation Pulse Length group mask. */
+#define TCF_WGPULSE_gp  4  /* Waveform Generation Pulse Length group position. */
+#define TCF_WGPULSE_0_bm  (1<<4)  /* Waveform Generation Pulse Length bit 0 mask. */
+#define TCF_WGPULSE_0_bp  4  /* Waveform Generation Pulse Length bit 0 position. */
+#define TCF_WGPULSE_1_bm  (1<<5)  /* Waveform Generation Pulse Length bit 1 mask. */
+#define TCF_WGPULSE_1_bp  5  /* Waveform Generation Pulse Length bit 1 position. */
+#define TCF_WGPULSE_2_bm  (1<<6)  /* Waveform Generation Pulse Length bit 2 mask. */
+#define TCF_WGPULSE_2_bp  6  /* Waveform Generation Pulse Length bit 2 position. */
+
+/* TCF.CTRLD  bit masks and bit positions */
+#define TCF_CMD_gm  0x03  /* Command group mask. */
+#define TCF_CMD_gp  0  /* Command group position. */
+#define TCF_CMD_0_bm  (1<<0)  /* Command bit 0 mask. */
+#define TCF_CMD_0_bp  0  /* Command bit 0 position. */
+#define TCF_CMD_1_bm  (1<<1)  /* Command bit 1 mask. */
+#define TCF_CMD_1_bp  1  /* Command bit 1 position. */
+
+/* TCF.EVCTRL  bit masks and bit positions */
+#define TCF_CNTAEI_bm  0x01  /* Event A Input Enable bit mask. */
+#define TCF_CNTAEI_bp  0  /* Event A Input Enable bit position. */
+#define TCF_EVACTA_gm  0x06  /* Event Action A group mask. */
+#define TCF_EVACTA_gp  1  /* Event Action A group position. */
+#define TCF_EVACTA_0_bm  (1<<1)  /* Event Action A bit 0 mask. */
+#define TCF_EVACTA_0_bp  1  /* Event Action A bit 0 position. */
+#define TCF_EVACTA_1_bm  (1<<2)  /* Event Action A bit 1 mask. */
+#define TCF_EVACTA_1_bp  2  /* Event Action A bit 1 position. */
+#define TCF_FILTERA_bm  0x08  /* Event A Filter bit mask. */
+#define TCF_FILTERA_bp  3  /* Event A Filter bit position. */
+
+/* TCF.INTCTRL  bit masks and bit positions */
+#define TCF_OVF_bm  0x01  /* Overflow bit mask. */
+#define TCF_OVF_bp  0  /* Overflow bit position. */
+#define TCF_CMP0_bm  0x02  /* Compare 0 Interrupt Enable bit mask. */
+#define TCF_CMP0_bp  1  /* Compare 0 Interrupt Enable bit position. */
+#define TCF_CMP1_bm  0x04  /* Compare 1 Interrupt Enable bit mask. */
+#define TCF_CMP1_bp  2  /* Compare 1 Interrupt Enable bit position. */
+
+/* TCF.INTFLAGS  bit masks and bit positions */
+/* TCF_OVF  is already defined. */
+/* TCF_CMP0  is already defined. */
+/* TCF_CMP1  is already defined. */
+
+/* TCF.STATUS  bit masks and bit positions */
+#define TCF_CTRLABUSY_bm  0x02  /* Control A Synchronization Busy bit mask. */
+#define TCF_CTRLABUSY_bp  1  /* Control A Synchronization Busy bit position. */
+#define TCF_CTRLCBUSY_bm  0x04  /* Control B Synchronization Busy bit mask. */
+#define TCF_CTRLCBUSY_bp  2  /* Control B Synchronization Busy bit position. */
+#define TCF_CTRLDBUSY_bm  0x08  /* Control D Synchronization Busy bit mask. */
+#define TCF_CTRLDBUSY_bp  3  /* Control D Synchronization Busy bit position. */
+#define TCF_CNTBUSY_bm  0x10  /* Counter Synchronization Busy bit mask. */
+#define TCF_CNTBUSY_bp  4  /* Counter Synchronization Busy bit position. */
+#define TCF_PERBUSY_bm  0x20  /* Period Synchronization Busy bit mask. */
+#define TCF_PERBUSY_bp  5  /* Period Synchronization Busy bit position. */
+#define TCF_CMP0BUSY_bm  0x40  /* Compare 0 Synchronization Busy bit mask. */
+#define TCF_CMP0BUSY_bp  6  /* Compare 0 Synchronization Busy bit position. */
+#define TCF_CMP1BUSY_bm  0x80  /* Compare 1 Synchronization Busy bit mask. */
+#define TCF_CMP1BUSY_bp  7  /* Compare 1 Synchronization Busy bit position. */
+
+/* TCF.DBGCTRL  bit masks and bit positions */
+#define TCF_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define TCF_DBGRUN_bp  0  /* Debug Run bit position. */
+
+/* TCF.CNT  bit masks and bit positions */
+#define TCF_CNT_gm  0xFFFFFF  /* Counter group mask. */
+#define TCF_CNT_gp  0  /* Counter group position. */
+#define TCF_CNT_0_bm  (1<<0)  /* Counter bit 0 mask. */
+#define TCF_CNT_0_bp  0  /* Counter bit 0 position. */
+#define TCF_CNT_1_bm  (1<<1)  /* Counter bit 1 mask. */
+#define TCF_CNT_1_bp  1  /* Counter bit 1 position. */
+#define TCF_CNT_2_bm  (1<<2)  /* Counter bit 2 mask. */
+#define TCF_CNT_2_bp  2  /* Counter bit 2 position. */
+#define TCF_CNT_3_bm  (1<<3)  /* Counter bit 3 mask. */
+#define TCF_CNT_3_bp  3  /* Counter bit 3 position. */
+#define TCF_CNT_4_bm  (1<<4)  /* Counter bit 4 mask. */
+#define TCF_CNT_4_bp  4  /* Counter bit 4 position. */
+#define TCF_CNT_5_bm  (1<<5)  /* Counter bit 5 mask. */
+#define TCF_CNT_5_bp  5  /* Counter bit 5 position. */
+#define TCF_CNT_6_bm  (1<<6)  /* Counter bit 6 mask. */
+#define TCF_CNT_6_bp  6  /* Counter bit 6 position. */
+#define TCF_CNT_7_bm  (1<<7)  /* Counter bit 7 mask. */
+#define TCF_CNT_7_bp  7  /* Counter bit 7 position. */
+#define TCF_CNT_8_bm  (1<<8)  /* Counter bit 8 mask. */
+#define TCF_CNT_8_bp  8  /* Counter bit 8 position. */
+#define TCF_CNT_9_bm  (1<<9)  /* Counter bit 9 mask. */
+#define TCF_CNT_9_bp  9  /* Counter bit 9 position. */
+#define TCF_CNT_10_bm  (1<<10)  /* Counter bit 10 mask. */
+#define TCF_CNT_10_bp  10  /* Counter bit 10 position. */
+#define TCF_CNT_11_bm  (1<<11)  /* Counter bit 11 mask. */
+#define TCF_CNT_11_bp  11  /* Counter bit 11 position. */
+#define TCF_CNT_12_bm  (1<<12)  /* Counter bit 12 mask. */
+#define TCF_CNT_12_bp  12  /* Counter bit 12 position. */
+#define TCF_CNT_13_bm  (1<<13)  /* Counter bit 13 mask. */
+#define TCF_CNT_13_bp  13  /* Counter bit 13 position. */
+#define TCF_CNT_14_bm  (1<<14)  /* Counter bit 14 mask. */
+#define TCF_CNT_14_bp  14  /* Counter bit 14 position. */
+#define TCF_CNT_15_bm  (1<<15)  /* Counter bit 15 mask. */
+#define TCF_CNT_15_bp  15  /* Counter bit 15 position. */
+#define TCF_CNT_16_bm  (1<<16)  /* Counter bit 16 mask. */
+#define TCF_CNT_16_bp  16  /* Counter bit 16 position. */
+#define TCF_CNT_17_bm  (1<<17)  /* Counter bit 17 mask. */
+#define TCF_CNT_17_bp  17  /* Counter bit 17 position. */
+#define TCF_CNT_18_bm  (1<<18)  /* Counter bit 18 mask. */
+#define TCF_CNT_18_bp  18  /* Counter bit 18 position. */
+#define TCF_CNT_19_bm  (1<<19)  /* Counter bit 19 mask. */
+#define TCF_CNT_19_bp  19  /* Counter bit 19 position. */
+#define TCF_CNT_20_bm  (1<<20)  /* Counter bit 20 mask. */
+#define TCF_CNT_20_bp  20  /* Counter bit 20 position. */
+#define TCF_CNT_21_bm  (1<<21)  /* Counter bit 21 mask. */
+#define TCF_CNT_21_bp  21  /* Counter bit 21 position. */
+#define TCF_CNT_22_bm  (1<<22)  /* Counter bit 22 mask. */
+#define TCF_CNT_22_bp  22  /* Counter bit 22 position. */
+#define TCF_CNT_23_bm  (1<<23)  /* Counter bit 23 mask. */
+#define TCF_CNT_23_bp  23  /* Counter bit 23 position. */
+
+/* TCF.CMP  bit masks and bit positions */
+#define TCF_CMP_gm  0xFFFFFF  /* Compare group mask. */
+#define TCF_CMP_gp  0  /* Compare group position. */
+#define TCF_CMP_0_bm  (1<<0)  /* Compare bit 0 mask. */
+#define TCF_CMP_0_bp  0  /* Compare bit 0 position. */
+#define TCF_CMP_1_bm  (1<<1)  /* Compare bit 1 mask. */
+#define TCF_CMP_1_bp  1  /* Compare bit 1 position. */
+#define TCF_CMP_2_bm  (1<<2)  /* Compare bit 2 mask. */
+#define TCF_CMP_2_bp  2  /* Compare bit 2 position. */
+#define TCF_CMP_3_bm  (1<<3)  /* Compare bit 3 mask. */
+#define TCF_CMP_3_bp  3  /* Compare bit 3 position. */
+#define TCF_CMP_4_bm  (1<<4)  /* Compare bit 4 mask. */
+#define TCF_CMP_4_bp  4  /* Compare bit 4 position. */
+#define TCF_CMP_5_bm  (1<<5)  /* Compare bit 5 mask. */
+#define TCF_CMP_5_bp  5  /* Compare bit 5 position. */
+#define TCF_CMP_6_bm  (1<<6)  /* Compare bit 6 mask. */
+#define TCF_CMP_6_bp  6  /* Compare bit 6 position. */
+#define TCF_CMP_7_bm  (1<<7)  /* Compare bit 7 mask. */
+#define TCF_CMP_7_bp  7  /* Compare bit 7 position. */
+#define TCF_CMP_8_bm  (1<<8)  /* Compare bit 8 mask. */
+#define TCF_CMP_8_bp  8  /* Compare bit 8 position. */
+#define TCF_CMP_9_bm  (1<<9)  /* Compare bit 9 mask. */
+#define TCF_CMP_9_bp  9  /* Compare bit 9 position. */
+#define TCF_CMP_10_bm  (1<<10)  /* Compare bit 10 mask. */
+#define TCF_CMP_10_bp  10  /* Compare bit 10 position. */
+#define TCF_CMP_11_bm  (1<<11)  /* Compare bit 11 mask. */
+#define TCF_CMP_11_bp  11  /* Compare bit 11 position. */
+#define TCF_CMP_12_bm  (1<<12)  /* Compare bit 12 mask. */
+#define TCF_CMP_12_bp  12  /* Compare bit 12 position. */
+#define TCF_CMP_13_bm  (1<<13)  /* Compare bit 13 mask. */
+#define TCF_CMP_13_bp  13  /* Compare bit 13 position. */
+#define TCF_CMP_14_bm  (1<<14)  /* Compare bit 14 mask. */
+#define TCF_CMP_14_bp  14  /* Compare bit 14 position. */
+#define TCF_CMP_15_bm  (1<<15)  /* Compare bit 15 mask. */
+#define TCF_CMP_15_bp  15  /* Compare bit 15 position. */
+#define TCF_CMP_16_bm  (1<<16)  /* Compare bit 16 mask. */
+#define TCF_CMP_16_bp  16  /* Compare bit 16 position. */
+#define TCF_CMP_17_bm  (1<<17)  /* Compare bit 17 mask. */
+#define TCF_CMP_17_bp  17  /* Compare bit 17 position. */
+#define TCF_CMP_18_bm  (1<<18)  /* Compare bit 18 mask. */
+#define TCF_CMP_18_bp  18  /* Compare bit 18 position. */
+#define TCF_CMP_19_bm  (1<<19)  /* Compare bit 19 mask. */
+#define TCF_CMP_19_bp  19  /* Compare bit 19 position. */
+#define TCF_CMP_20_bm  (1<<20)  /* Compare bit 20 mask. */
+#define TCF_CMP_20_bp  20  /* Compare bit 20 position. */
+#define TCF_CMP_21_bm  (1<<21)  /* Compare bit 21 mask. */
+#define TCF_CMP_21_bp  21  /* Compare bit 21 position. */
+#define TCF_CMP_22_bm  (1<<22)  /* Compare bit 22 mask. */
+#define TCF_CMP_22_bp  22  /* Compare bit 22 position. */
+#define TCF_CMP_23_bm  (1<<23)  /* Compare bit 23 mask. */
+#define TCF_CMP_23_bp  23  /* Compare bit 23 position. */
+
+
+/* TWI - Two-Wire Interface */
+/* TWI.CTRLA  bit masks and bit positions */
+#define TWI_FMEN_bm  0x01  /* Fast-mode Enable bit mask. */
+#define TWI_FMEN_bp  0  /* Fast-mode Enable bit position. */
+#define TWI_FMPEN_bm  0x02  /* Fast-mode Plus Enable bit mask. */
+#define TWI_FMPEN_bp  1  /* Fast-mode Plus Enable bit position. */
+#define TWI_SDAHOLD_gm  0x0C  /* SDA Hold Time group mask. */
+#define TWI_SDAHOLD_gp  2  /* SDA Hold Time group position. */
+#define TWI_SDAHOLD_0_bm  (1<<2)  /* SDA Hold Time bit 0 mask. */
+#define TWI_SDAHOLD_0_bp  2  /* SDA Hold Time bit 0 position. */
+#define TWI_SDAHOLD_1_bm  (1<<3)  /* SDA Hold Time bit 1 mask. */
+#define TWI_SDAHOLD_1_bp  3  /* SDA Hold Time bit 1 position. */
+#define TWI_SDASETUP_bm  0x10  /* SDA Setup Time bit mask. */
+#define TWI_SDASETUP_bp  4  /* SDA Setup Time bit position. */
+#define TWI_INPUTLVL_bm  0x40  /* Input voltage transition level bit mask. */
+#define TWI_INPUTLVL_bp  6  /* Input voltage transition level bit position. */
+
+/* TWI.DUALCTRL  bit masks and bit positions */
+#define TWI_ENABLE_bm  0x01  /* Enable bit mask. */
+#define TWI_ENABLE_bp  0  /* Enable bit position. */
+/* TWI_FMPEN  is already defined. */
+/* TWI_SDAHOLD  is already defined. */
+/* TWI_INPUTLVL  is already defined. */
+
+/* TWI.DBGCTRL  bit masks and bit positions */
+#define TWI_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define TWI_DBGRUN_bp  0  /* Debug Run bit position. */
+
+/* TWI.MCTRLA  bit masks and bit positions */
+/* TWI_ENABLE  is already defined. */
+#define TWI_SMEN_bm  0x02  /* Smart Mode Enable bit mask. */
+#define TWI_SMEN_bp  1  /* Smart Mode Enable bit position. */
+#define TWI_TIMEOUT_gm  0x0C  /* Inactive Bus Time-Out group mask. */
+#define TWI_TIMEOUT_gp  2  /* Inactive Bus Time-Out group position. */
+#define TWI_TIMEOUT_0_bm  (1<<2)  /* Inactive Bus Time-Out bit 0 mask. */
+#define TWI_TIMEOUT_0_bp  2  /* Inactive Bus Time-Out bit 0 position. */
+#define TWI_TIMEOUT_1_bm  (1<<3)  /* Inactive Bus Time-Out bit 1 mask. */
+#define TWI_TIMEOUT_1_bp  3  /* Inactive Bus Time-Out bit 1 position. */
+#define TWI_QCEN_bm  0x10  /* Quick Command Enable bit mask. */
+#define TWI_QCEN_bp  4  /* Quick Command Enable bit position. */
+#define TWI_WIEN_bm  0x40  /* Write Interrupt Enable bit mask. */
+#define TWI_WIEN_bp  6  /* Write Interrupt Enable bit position. */
+#define TWI_RIEN_bm  0x80  /* Read Interrupt Enable bit mask. */
+#define TWI_RIEN_bp  7  /* Read Interrupt Enable bit position. */
+
+/* TWI.MCTRLB  bit masks and bit positions */
+#define TWI_MCMD_gm  0x03  /* Command group mask. */
+#define TWI_MCMD_gp  0  /* Command group position. */
+#define TWI_MCMD_0_bm  (1<<0)  /* Command bit 0 mask. */
+#define TWI_MCMD_0_bp  0  /* Command bit 0 position. */
+#define TWI_MCMD_1_bm  (1<<1)  /* Command bit 1 mask. */
+#define TWI_MCMD_1_bp  1  /* Command bit 1 position. */
+#define TWI_ACKACT_bm  0x04  /* Acknowledge Action bit mask. */
+#define TWI_ACKACT_bp  2  /* Acknowledge Action bit position. */
+#define TWI_FLUSH_bm  0x08  /* Flush bit mask. */
+#define TWI_FLUSH_bp  3  /* Flush bit position. */
+
+/* TWI.MSTATUS  bit masks and bit positions */
+#define TWI_BUSSTATE_gm  0x03  /* Bus State group mask. */
+#define TWI_BUSSTATE_gp  0  /* Bus State group position. */
+#define TWI_BUSSTATE_0_bm  (1<<0)  /* Bus State bit 0 mask. */
+#define TWI_BUSSTATE_0_bp  0  /* Bus State bit 0 position. */
+#define TWI_BUSSTATE_1_bm  (1<<1)  /* Bus State bit 1 mask. */
+#define TWI_BUSSTATE_1_bp  1  /* Bus State bit 1 position. */
+#define TWI_BUSERR_bm  0x04  /* Bus Error bit mask. */
+#define TWI_BUSERR_bp  2  /* Bus Error bit position. */
+#define TWI_ARBLOST_bm  0x08  /* Arbitration Lost bit mask. */
+#define TWI_ARBLOST_bp  3  /* Arbitration Lost bit position. */
+#define TWI_RXACK_bm  0x10  /* Received Acknowledge bit mask. */
+#define TWI_RXACK_bp  4  /* Received Acknowledge bit position. */
+#define TWI_CLKHOLD_bm  0x20  /* Clock Hold bit mask. */
+#define TWI_CLKHOLD_bp  5  /* Clock Hold bit position. */
+#define TWI_WIF_bm  0x40  /* Write Interrupt Flag bit mask. */
+#define TWI_WIF_bp  6  /* Write Interrupt Flag bit position. */
+#define TWI_RIF_bm  0x80  /* Read Interrupt Flag bit mask. */
+#define TWI_RIF_bp  7  /* Read Interrupt Flag bit position. */
+
+/* TWI.MBAUD  bit masks and bit positions */
+#define TWI_BAUD_gm  0xFF  /* Baud Rate group mask. */
+#define TWI_BAUD_gp  0  /* Baud Rate group position. */
+#define TWI_BAUD_0_bm  (1<<0)  /* Baud Rate bit 0 mask. */
+#define TWI_BAUD_0_bp  0  /* Baud Rate bit 0 position. */
+#define TWI_BAUD_1_bm  (1<<1)  /* Baud Rate bit 1 mask. */
+#define TWI_BAUD_1_bp  1  /* Baud Rate bit 1 position. */
+#define TWI_BAUD_2_bm  (1<<2)  /* Baud Rate bit 2 mask. */
+#define TWI_BAUD_2_bp  2  /* Baud Rate bit 2 position. */
+#define TWI_BAUD_3_bm  (1<<3)  /* Baud Rate bit 3 mask. */
+#define TWI_BAUD_3_bp  3  /* Baud Rate bit 3 position. */
+#define TWI_BAUD_4_bm  (1<<4)  /* Baud Rate bit 4 mask. */
+#define TWI_BAUD_4_bp  4  /* Baud Rate bit 4 position. */
+#define TWI_BAUD_5_bm  (1<<5)  /* Baud Rate bit 5 mask. */
+#define TWI_BAUD_5_bp  5  /* Baud Rate bit 5 position. */
+#define TWI_BAUD_6_bm  (1<<6)  /* Baud Rate bit 6 mask. */
+#define TWI_BAUD_6_bp  6  /* Baud Rate bit 6 position. */
+#define TWI_BAUD_7_bm  (1<<7)  /* Baud Rate bit 7 mask. */
+#define TWI_BAUD_7_bp  7  /* Baud Rate bit 7 position. */
+
+/* TWI.MADDR  bit masks and bit positions */
+#define TWI_ADDR_gm  0xFF  /* Address group mask. */
+#define TWI_ADDR_gp  0  /* Address group position. */
+#define TWI_ADDR_0_bm  (1<<0)  /* Address bit 0 mask. */
+#define TWI_ADDR_0_bp  0  /* Address bit 0 position. */
+#define TWI_ADDR_1_bm  (1<<1)  /* Address bit 1 mask. */
+#define TWI_ADDR_1_bp  1  /* Address bit 1 position. */
+#define TWI_ADDR_2_bm  (1<<2)  /* Address bit 2 mask. */
+#define TWI_ADDR_2_bp  2  /* Address bit 2 position. */
+#define TWI_ADDR_3_bm  (1<<3)  /* Address bit 3 mask. */
+#define TWI_ADDR_3_bp  3  /* Address bit 3 position. */
+#define TWI_ADDR_4_bm  (1<<4)  /* Address bit 4 mask. */
+#define TWI_ADDR_4_bp  4  /* Address bit 4 position. */
+#define TWI_ADDR_5_bm  (1<<5)  /* Address bit 5 mask. */
+#define TWI_ADDR_5_bp  5  /* Address bit 5 position. */
+#define TWI_ADDR_6_bm  (1<<6)  /* Address bit 6 mask. */
+#define TWI_ADDR_6_bp  6  /* Address bit 6 position. */
+#define TWI_ADDR_7_bm  (1<<7)  /* Address bit 7 mask. */
+#define TWI_ADDR_7_bp  7  /* Address bit 7 position. */
+
+/* TWI.MDATA  bit masks and bit positions */
+#define TWI_DATA_gm  0xFF  /* Data group mask. */
+#define TWI_DATA_gp  0  /* Data group position. */
+#define TWI_DATA_0_bm  (1<<0)  /* Data bit 0 mask. */
+#define TWI_DATA_0_bp  0  /* Data bit 0 position. */
+#define TWI_DATA_1_bm  (1<<1)  /* Data bit 1 mask. */
+#define TWI_DATA_1_bp  1  /* Data bit 1 position. */
+#define TWI_DATA_2_bm  (1<<2)  /* Data bit 2 mask. */
+#define TWI_DATA_2_bp  2  /* Data bit 2 position. */
+#define TWI_DATA_3_bm  (1<<3)  /* Data bit 3 mask. */
+#define TWI_DATA_3_bp  3  /* Data bit 3 position. */
+#define TWI_DATA_4_bm  (1<<4)  /* Data bit 4 mask. */
+#define TWI_DATA_4_bp  4  /* Data bit 4 position. */
+#define TWI_DATA_5_bm  (1<<5)  /* Data bit 5 mask. */
+#define TWI_DATA_5_bp  5  /* Data bit 5 position. */
+#define TWI_DATA_6_bm  (1<<6)  /* Data bit 6 mask. */
+#define TWI_DATA_6_bp  6  /* Data bit 6 position. */
+#define TWI_DATA_7_bm  (1<<7)  /* Data bit 7 mask. */
+#define TWI_DATA_7_bp  7  /* Data bit 7 position. */
+
+/* TWI.SCTRLA  bit masks and bit positions */
+/* TWI_ENABLE  is already defined. */
+/* TWI_SMEN  is already defined. */
+#define TWI_PMEN_bm  0x04  /* Address Recognition Mode bit mask. */
+#define TWI_PMEN_bp  2  /* Address Recognition Mode bit position. */
+#define TWI_PIEN_bm  0x20  /* Stop Interrupt Enable bit mask. */
+#define TWI_PIEN_bp  5  /* Stop Interrupt Enable bit position. */
+#define TWI_APIEN_bm  0x40  /* Address or Stop Interrupt Enable bit mask. */
+#define TWI_APIEN_bp  6  /* Address or Stop Interrupt Enable bit position. */
+#define TWI_DIEN_bm  0x80  /* Data Interrupt Enable bit mask. */
+#define TWI_DIEN_bp  7  /* Data Interrupt Enable bit position. */
+
+/* TWI.SCTRLB  bit masks and bit positions */
+#define TWI_SCMD_gm  0x03  /* Command group mask. */
+#define TWI_SCMD_gp  0  /* Command group position. */
+#define TWI_SCMD_0_bm  (1<<0)  /* Command bit 0 mask. */
+#define TWI_SCMD_0_bp  0  /* Command bit 0 position. */
+#define TWI_SCMD_1_bm  (1<<1)  /* Command bit 1 mask. */
+#define TWI_SCMD_1_bp  1  /* Command bit 1 position. */
+/* TWI_ACKACT  is already defined. */
+
+/* TWI.SSTATUS  bit masks and bit positions */
+#define TWI_AP_bm  0x01  /* Address or Stop bit mask. */
+#define TWI_AP_bp  0  /* Address or Stop bit position. */
+#define TWI_DIR_bm  0x02  /* Read/Write Direction bit mask. */
+#define TWI_DIR_bp  1  /* Read/Write Direction bit position. */
+/* TWI_BUSERR  is already defined. */
+#define TWI_COLL_bm  0x08  /* Collision bit mask. */
+#define TWI_COLL_bp  3  /* Collision bit position. */
+/* TWI_RXACK  is already defined. */
+/* TWI_CLKHOLD  is already defined. */
+#define TWI_APIF_bm  0x40  /* Address or Stop Interrupt Flag bit mask. */
+#define TWI_APIF_bp  6  /* Address or Stop Interrupt Flag bit position. */
+#define TWI_DIF_bm  0x80  /* Data Interrupt Flag bit mask. */
+#define TWI_DIF_bp  7  /* Data Interrupt Flag bit position. */
+
+/* TWI.SADDR  bit masks and bit positions */
+/* TWI_ADDR  is already defined. */
+
+/* TWI.SDATA  bit masks and bit positions */
+/* TWI_DATA  is already defined. */
+
+/* TWI.SADDRMASK  bit masks and bit positions */
+#define TWI_ADDREN_bm  0x01  /* Address Mask Enable bit mask. */
+#define TWI_ADDREN_bp  0  /* Address Mask Enable bit position. */
+#define TWI_ADDRMASK_gm  0xFE  /* Address Mask group mask. */
+#define TWI_ADDRMASK_gp  1  /* Address Mask group position. */
+#define TWI_ADDRMASK_0_bm  (1<<1)  /* Address Mask bit 0 mask. */
+#define TWI_ADDRMASK_0_bp  1  /* Address Mask bit 0 position. */
+#define TWI_ADDRMASK_1_bm  (1<<2)  /* Address Mask bit 1 mask. */
+#define TWI_ADDRMASK_1_bp  2  /* Address Mask bit 1 position. */
+#define TWI_ADDRMASK_2_bm  (1<<3)  /* Address Mask bit 2 mask. */
+#define TWI_ADDRMASK_2_bp  3  /* Address Mask bit 2 position. */
+#define TWI_ADDRMASK_3_bm  (1<<4)  /* Address Mask bit 3 mask. */
+#define TWI_ADDRMASK_3_bp  4  /* Address Mask bit 3 position. */
+#define TWI_ADDRMASK_4_bm  (1<<5)  /* Address Mask bit 4 mask. */
+#define TWI_ADDRMASK_4_bp  5  /* Address Mask bit 4 position. */
+#define TWI_ADDRMASK_5_bm  (1<<6)  /* Address Mask bit 5 mask. */
+#define TWI_ADDRMASK_5_bp  6  /* Address Mask bit 5 position. */
+#define TWI_ADDRMASK_6_bm  (1<<7)  /* Address Mask bit 6 mask. */
+#define TWI_ADDRMASK_6_bp  7  /* Address Mask bit 6 position. */
+
+
+/* USART - Universal Synchronous and Asynchronous Receiver and Transmitter */
+/* USART.RXDATAL  bit masks and bit positions */
+#define USART_DATA_gm  0xFF  /* RX Data group mask. */
+#define USART_DATA_gp  0  /* RX Data group position. */
+#define USART_DATA_0_bm  (1<<0)  /* RX Data bit 0 mask. */
+#define USART_DATA_0_bp  0  /* RX Data bit 0 position. */
+#define USART_DATA_1_bm  (1<<1)  /* RX Data bit 1 mask. */
+#define USART_DATA_1_bp  1  /* RX Data bit 1 position. */
+#define USART_DATA_2_bm  (1<<2)  /* RX Data bit 2 mask. */
+#define USART_DATA_2_bp  2  /* RX Data bit 2 position. */
+#define USART_DATA_3_bm  (1<<3)  /* RX Data bit 3 mask. */
+#define USART_DATA_3_bp  3  /* RX Data bit 3 position. */
+#define USART_DATA_4_bm  (1<<4)  /* RX Data bit 4 mask. */
+#define USART_DATA_4_bp  4  /* RX Data bit 4 position. */
+#define USART_DATA_5_bm  (1<<5)  /* RX Data bit 5 mask. */
+#define USART_DATA_5_bp  5  /* RX Data bit 5 position. */
+#define USART_DATA_6_bm  (1<<6)  /* RX Data bit 6 mask. */
+#define USART_DATA_6_bp  6  /* RX Data bit 6 position. */
+#define USART_DATA_7_bm  (1<<7)  /* RX Data bit 7 mask. */
+#define USART_DATA_7_bp  7  /* RX Data bit 7 position. */
+
+/* USART.RXDATAH  bit masks and bit positions */
+#define USART_DATA8_bm  0x01  /* Receiver Data Register bit mask. */
+#define USART_DATA8_bp  0  /* Receiver Data Register bit position. */
+#define USART_PERR_bm  0x02  /* Parity Error bit mask. */
+#define USART_PERR_bp  1  /* Parity Error bit position. */
+#define USART_FERR_bm  0x04  /* Frame Error bit mask. */
+#define USART_FERR_bp  2  /* Frame Error bit position. */
+#define USART_BUFOVF_bm  0x40  /* Buffer Overflow bit mask. */
+#define USART_BUFOVF_bp  6  /* Buffer Overflow bit position. */
+#define USART_RXCIF_bm  0x80  /* Receive Complete Interrupt Flag bit mask. */
+#define USART_RXCIF_bp  7  /* Receive Complete Interrupt Flag bit position. */
+
+/* USART.TXDATAL  bit masks and bit positions */
+/* USART_DATA  is already defined. */
+
+/* USART.TXDATAH  bit masks and bit positions */
+/* USART_DATA8  is already defined. */
+
+/* USART.STATUS  bit masks and bit positions */
+#define USART_WFB_bm  0x01  /* Wait For Break bit mask. */
+#define USART_WFB_bp  0  /* Wait For Break bit position. */
+#define USART_BDF_bm  0x02  /* Break Detected Flag bit mask. */
+#define USART_BDF_bp  1  /* Break Detected Flag bit position. */
+#define USART_ISFIF_bm  0x08  /* Inconsistent Sync Field Interrupt Flag bit mask. */
+#define USART_ISFIF_bp  3  /* Inconsistent Sync Field Interrupt Flag bit position. */
+#define USART_RXSIF_bm  0x10  /* Receive Start Interrupt bit mask. */
+#define USART_RXSIF_bp  4  /* Receive Start Interrupt bit position. */
+#define USART_DREIF_bm  0x20  /* Data Register Empty Flag bit mask. */
+#define USART_DREIF_bp  5  /* Data Register Empty Flag bit position. */
+#define USART_TXCIF_bm  0x40  /* Transmit Interrupt Flag bit mask. */
+#define USART_TXCIF_bp  6  /* Transmit Interrupt Flag bit position. */
+/* USART_RXCIF  is already defined. */
+
+/* USART.CTRLA  bit masks and bit positions */
+#define USART_RS485_bm  0x01  /* RS485 Mode internal transmitter bit mask. */
+#define USART_RS485_bp  0  /* RS485 Mode internal transmitter bit position. */
+#define USART_ABEIE_bm  0x04  /* Auto-baud Error Interrupt Enable bit mask. */
+#define USART_ABEIE_bp  2  /* Auto-baud Error Interrupt Enable bit position. */
+#define USART_LBME_bm  0x08  /* Loop-back Mode Enable bit mask. */
+#define USART_LBME_bp  3  /* Loop-back Mode Enable bit position. */
+#define USART_RXSIE_bm  0x10  /* Receiver Start Frame Interrupt Enable bit mask. */
+#define USART_RXSIE_bp  4  /* Receiver Start Frame Interrupt Enable bit position. */
+#define USART_DREIE_bm  0x20  /* Data Register Empty Interrupt Enable bit mask. */
+#define USART_DREIE_bp  5  /* Data Register Empty Interrupt Enable bit position. */
+#define USART_TXCIE_bm  0x40  /* Transmit Complete Interrupt Enable bit mask. */
+#define USART_TXCIE_bp  6  /* Transmit Complete Interrupt Enable bit position. */
+#define USART_RXCIE_bm  0x80  /* Receive Complete Interrupt Enable bit mask. */
+#define USART_RXCIE_bp  7  /* Receive Complete Interrupt Enable bit position. */
+
+/* USART.CTRLB  bit masks and bit positions */
+#define USART_MPCM_bm  0x01  /* Multi-processor Communication Mode bit mask. */
+#define USART_MPCM_bp  0  /* Multi-processor Communication Mode bit position. */
+#define USART_RXMODE_gm  0x06  /* Receiver Mode group mask. */
+#define USART_RXMODE_gp  1  /* Receiver Mode group position. */
+#define USART_RXMODE_0_bm  (1<<1)  /* Receiver Mode bit 0 mask. */
+#define USART_RXMODE_0_bp  1  /* Receiver Mode bit 0 position. */
+#define USART_RXMODE_1_bm  (1<<2)  /* Receiver Mode bit 1 mask. */
+#define USART_RXMODE_1_bp  2  /* Receiver Mode bit 1 position. */
+#define USART_ODME_bm  0x08  /* Open Drain Mode Enable bit mask. */
+#define USART_ODME_bp  3  /* Open Drain Mode Enable bit position. */
+#define USART_SFDEN_bm  0x10  /* Start Frame Detection Enable bit mask. */
+#define USART_SFDEN_bp  4  /* Start Frame Detection Enable bit position. */
+#define USART_TXEN_bm  0x40  /* Transmitter Enable bit mask. */
+#define USART_TXEN_bp  6  /* Transmitter Enable bit position. */
+#define USART_RXEN_bm  0x80  /* Reciever enable bit mask. */
+#define USART_RXEN_bp  7  /* Reciever enable bit position. */
+
+/* USART.CTRLC  bit masks and bit positions */
+#define USART_UCPHA_bm  0x02  /* SPI Host Mode, Clock Phase bit mask. */
+#define USART_UCPHA_bp  1  /* SPI Host Mode, Clock Phase bit position. */
+#define USART_UDORD_bm  0x04  /* SPI Host Mode, Data Order bit mask. */
+#define USART_UDORD_bp  2  /* SPI Host Mode, Data Order bit position. */
+#define USART_CHSIZE_gm  0x07  /* Character Size group mask. */
+#define USART_CHSIZE_gp  0  /* Character Size group position. */
+#define USART_CHSIZE_0_bm  (1<<0)  /* Character Size bit 0 mask. */
+#define USART_CHSIZE_0_bp  0  /* Character Size bit 0 position. */
+#define USART_CHSIZE_1_bm  (1<<1)  /* Character Size bit 1 mask. */
+#define USART_CHSIZE_1_bp  1  /* Character Size bit 1 position. */
+#define USART_CHSIZE_2_bm  (1<<2)  /* Character Size bit 2 mask. */
+#define USART_CHSIZE_2_bp  2  /* Character Size bit 2 position. */
+#define USART_SBMODE_bm  0x08  /* Stop Bit Mode bit mask. */
+#define USART_SBMODE_bp  3  /* Stop Bit Mode bit position. */
+#define USART_PMODE_gm  0x30  /* Parity Mode group mask. */
+#define USART_PMODE_gp  4  /* Parity Mode group position. */
+#define USART_PMODE_0_bm  (1<<4)  /* Parity Mode bit 0 mask. */
+#define USART_PMODE_0_bp  4  /* Parity Mode bit 0 position. */
+#define USART_PMODE_1_bm  (1<<5)  /* Parity Mode bit 1 mask. */
+#define USART_PMODE_1_bp  5  /* Parity Mode bit 1 position. */
+#define USART_CMODE_gm  0xC0  /* Communication Mode group mask. */
+#define USART_CMODE_gp  6  /* Communication Mode group position. */
+#define USART_CMODE_0_bm  (1<<6)  /* Communication Mode bit 0 mask. */
+#define USART_CMODE_0_bp  6  /* Communication Mode bit 0 position. */
+#define USART_CMODE_1_bm  (1<<7)  /* Communication Mode bit 1 mask. */
+#define USART_CMODE_1_bp  7  /* Communication Mode bit 1 position. */
+
+/* USART.CTRLD  bit masks and bit positions */
+#define USART_ABW_gm  0xC0  /* Auto Baud Window group mask. */
+#define USART_ABW_gp  6  /* Auto Baud Window group position. */
+#define USART_ABW_0_bm  (1<<6)  /* Auto Baud Window bit 0 mask. */
+#define USART_ABW_0_bp  6  /* Auto Baud Window bit 0 position. */
+#define USART_ABW_1_bm  (1<<7)  /* Auto Baud Window bit 1 mask. */
+#define USART_ABW_1_bp  7  /* Auto Baud Window bit 1 position. */
+
+/* USART.DBGCTRL  bit masks and bit positions */
+#define USART_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define USART_DBGRUN_bp  0  /* Debug Run bit position. */
+
+/* USART.EVCTRL  bit masks and bit positions */
+#define USART_IREI_bm  0x01  /* IrDA Event Input Enable bit mask. */
+#define USART_IREI_bp  0  /* IrDA Event Input Enable bit position. */
+
+/* USART.TXPLCTRL  bit masks and bit positions */
+#define USART_TXPL_gm  0xFF  /* Transmit pulse length group mask. */
+#define USART_TXPL_gp  0  /* Transmit pulse length group position. */
+#define USART_TXPL_0_bm  (1<<0)  /* Transmit pulse length bit 0 mask. */
+#define USART_TXPL_0_bp  0  /* Transmit pulse length bit 0 position. */
+#define USART_TXPL_1_bm  (1<<1)  /* Transmit pulse length bit 1 mask. */
+#define USART_TXPL_1_bp  1  /* Transmit pulse length bit 1 position. */
+#define USART_TXPL_2_bm  (1<<2)  /* Transmit pulse length bit 2 mask. */
+#define USART_TXPL_2_bp  2  /* Transmit pulse length bit 2 position. */
+#define USART_TXPL_3_bm  (1<<3)  /* Transmit pulse length bit 3 mask. */
+#define USART_TXPL_3_bp  3  /* Transmit pulse length bit 3 position. */
+#define USART_TXPL_4_bm  (1<<4)  /* Transmit pulse length bit 4 mask. */
+#define USART_TXPL_4_bp  4  /* Transmit pulse length bit 4 position. */
+#define USART_TXPL_5_bm  (1<<5)  /* Transmit pulse length bit 5 mask. */
+#define USART_TXPL_5_bp  5  /* Transmit pulse length bit 5 position. */
+#define USART_TXPL_6_bm  (1<<6)  /* Transmit pulse length bit 6 mask. */
+#define USART_TXPL_6_bp  6  /* Transmit pulse length bit 6 position. */
+#define USART_TXPL_7_bm  (1<<7)  /* Transmit pulse length bit 7 mask. */
+#define USART_TXPL_7_bp  7  /* Transmit pulse length bit 7 position. */
+
+/* USART.RXPLCTRL  bit masks and bit positions */
+#define USART_RXPL_gm  0x7F  /* Receiver Pulse Lenght group mask. */
+#define USART_RXPL_gp  0  /* Receiver Pulse Lenght group position. */
+#define USART_RXPL_0_bm  (1<<0)  /* Receiver Pulse Lenght bit 0 mask. */
+#define USART_RXPL_0_bp  0  /* Receiver Pulse Lenght bit 0 position. */
+#define USART_RXPL_1_bm  (1<<1)  /* Receiver Pulse Lenght bit 1 mask. */
+#define USART_RXPL_1_bp  1  /* Receiver Pulse Lenght bit 1 position. */
+#define USART_RXPL_2_bm  (1<<2)  /* Receiver Pulse Lenght bit 2 mask. */
+#define USART_RXPL_2_bp  2  /* Receiver Pulse Lenght bit 2 position. */
+#define USART_RXPL_3_bm  (1<<3)  /* Receiver Pulse Lenght bit 3 mask. */
+#define USART_RXPL_3_bp  3  /* Receiver Pulse Lenght bit 3 position. */
+#define USART_RXPL_4_bm  (1<<4)  /* Receiver Pulse Lenght bit 4 mask. */
+#define USART_RXPL_4_bp  4  /* Receiver Pulse Lenght bit 4 position. */
+#define USART_RXPL_5_bm  (1<<5)  /* Receiver Pulse Lenght bit 5 mask. */
+#define USART_RXPL_5_bp  5  /* Receiver Pulse Lenght bit 5 position. */
+#define USART_RXPL_6_bm  (1<<6)  /* Receiver Pulse Lenght bit 6 mask. */
+#define USART_RXPL_6_bp  6  /* Receiver Pulse Lenght bit 6 position. */
+
+
+
+/* VPORT - Virtual Ports */
+/* VPORT.INTFLAGS  bit masks and bit positions */
+#define VPORT_INT_gm  0xFF  /* Pin Interrupt Flag group mask. */
+#define VPORT_INT_gp  0  /* Pin Interrupt Flag group position. */
+#define VPORT_INT_0_bm  (1<<0)  /* Pin Interrupt Flag bit 0 mask. */
+#define VPORT_INT_0_bp  0  /* Pin Interrupt Flag bit 0 position. */
+#define VPORT_INT_1_bm  (1<<1)  /* Pin Interrupt Flag bit 1 mask. */
+#define VPORT_INT_1_bp  1  /* Pin Interrupt Flag bit 1 position. */
+#define VPORT_INT_2_bm  (1<<2)  /* Pin Interrupt Flag bit 2 mask. */
+#define VPORT_INT_2_bp  2  /* Pin Interrupt Flag bit 2 position. */
+#define VPORT_INT_3_bm  (1<<3)  /* Pin Interrupt Flag bit 3 mask. */
+#define VPORT_INT_3_bp  3  /* Pin Interrupt Flag bit 3 position. */
+#define VPORT_INT_4_bm  (1<<4)  /* Pin Interrupt Flag bit 4 mask. */
+#define VPORT_INT_4_bp  4  /* Pin Interrupt Flag bit 4 position. */
+#define VPORT_INT_5_bm  (1<<5)  /* Pin Interrupt Flag bit 5 mask. */
+#define VPORT_INT_5_bp  5  /* Pin Interrupt Flag bit 5 position. */
+#define VPORT_INT_6_bm  (1<<6)  /* Pin Interrupt Flag bit 6 mask. */
+#define VPORT_INT_6_bp  6  /* Pin Interrupt Flag bit 6 position. */
+#define VPORT_INT_7_bm  (1<<7)  /* Pin Interrupt Flag bit 7 mask. */
+#define VPORT_INT_7_bp  7  /* Pin Interrupt Flag bit 7 position. */
+
+
+/* VREF - Voltage reference */
+/* VREF.DAC0REF  bit masks and bit positions */
+#define VREF_REFSEL_gm  0x07  /* Reference select group mask. */
+#define VREF_REFSEL_gp  0  /* Reference select group position. */
+#define VREF_REFSEL_0_bm  (1<<0)  /* Reference select bit 0 mask. */
+#define VREF_REFSEL_0_bp  0  /* Reference select bit 0 position. */
+#define VREF_REFSEL_1_bm  (1<<1)  /* Reference select bit 1 mask. */
+#define VREF_REFSEL_1_bp  1  /* Reference select bit 1 position. */
+#define VREF_REFSEL_2_bm  (1<<2)  /* Reference select bit 2 mask. */
+#define VREF_REFSEL_2_bp  2  /* Reference select bit 2 position. */
+#define VREF_ALWAYSON_bm  0x80  /* Always on bit mask. */
+#define VREF_ALWAYSON_bp  7  /* Always on bit position. */
+
+/* VREF.ACREF  bit masks and bit positions */
+/* VREF_REFSEL  is already defined. */
+/* VREF_ALWAYSON  is already defined. */
+
+
+/* WDT - Watch-Dog Timer */
+/* WDT.CTRLA  bit masks and bit positions */
+#define WDT_PERIOD_gm  0x0F  /* Period group mask. */
+#define WDT_PERIOD_gp  0  /* Period group position. */
+#define WDT_PERIOD_0_bm  (1<<0)  /* Period bit 0 mask. */
+#define WDT_PERIOD_0_bp  0  /* Period bit 0 position. */
+#define WDT_PERIOD_1_bm  (1<<1)  /* Period bit 1 mask. */
+#define WDT_PERIOD_1_bp  1  /* Period bit 1 position. */
+#define WDT_PERIOD_2_bm  (1<<2)  /* Period bit 2 mask. */
+#define WDT_PERIOD_2_bp  2  /* Period bit 2 position. */
+#define WDT_PERIOD_3_bm  (1<<3)  /* Period bit 3 mask. */
+#define WDT_PERIOD_3_bp  3  /* Period bit 3 position. */
+#define WDT_WINDOW_gm  0xF0  /* Window group mask. */
+#define WDT_WINDOW_gp  4  /* Window group position. */
+#define WDT_WINDOW_0_bm  (1<<4)  /* Window bit 0 mask. */
+#define WDT_WINDOW_0_bp  4  /* Window bit 0 position. */
+#define WDT_WINDOW_1_bm  (1<<5)  /* Window bit 1 mask. */
+#define WDT_WINDOW_1_bp  5  /* Window bit 1 position. */
+#define WDT_WINDOW_2_bm  (1<<6)  /* Window bit 2 mask. */
+#define WDT_WINDOW_2_bp  6  /* Window bit 2 position. */
+#define WDT_WINDOW_3_bm  (1<<7)  /* Window bit 3 mask. */
+#define WDT_WINDOW_3_bp  7  /* Window bit 3 position. */
+
+/* WDT.STATUS  bit masks and bit positions */
+#define WDT_SYNCBUSY_bm  0x01  /* Syncronization busy bit mask. */
+#define WDT_SYNCBUSY_bp  0  /* Syncronization busy bit position. */
+#define WDT_LOCK_bm  0x80  /* Lock enable bit mask. */
+#define WDT_LOCK_bp  7  /* Lock enable bit position. */
+
+
+/* WEX - Waveform Extension */
+/* WEX.CTRLA  bit masks and bit positions */
+#define WEX_DTI0EN_bm  0x01  /* Dead-Time Insertion CMP0 Enable bit mask. */
+#define WEX_DTI0EN_bp  0  /* Dead-Time Insertion CMP0 Enable bit position. */
+#define WEX_DTI1EN_bm  0x02  /* Dead-Time Insertion CMP1 Enable bit mask. */
+#define WEX_DTI1EN_bp  1  /* Dead-Time Insertion CMP1 Enable bit position. */
+#define WEX_DTI2EN_bm  0x04  /* Dead-Time Insertion CMP2 Enable bit mask. */
+#define WEX_DTI2EN_bp  2  /* Dead-Time Insertion CMP2 Enable bit position. */
+#define WEX_DTI3EN_bm  0x08  /* Dead-Time Insertion CMP3 Enable bit mask. */
+#define WEX_DTI3EN_bp  3  /* Dead-Time Insertion CMP3 Enable bit position. */
+#define WEX_INMX_gm  0x70  /* Input Matrix group mask. */
+#define WEX_INMX_gp  4  /* Input Matrix group position. */
+#define WEX_INMX_0_bm  (1<<4)  /* Input Matrix bit 0 mask. */
+#define WEX_INMX_0_bp  4  /* Input Matrix bit 0 position. */
+#define WEX_INMX_1_bm  (1<<5)  /* Input Matrix bit 1 mask. */
+#define WEX_INMX_1_bp  5  /* Input Matrix bit 1 position. */
+#define WEX_INMX_2_bm  (1<<6)  /* Input Matrix bit 2 mask. */
+#define WEX_INMX_2_bp  6  /* Input Matrix bit 2 position. */
+#define WEX_PGM_bm  0x80  /* Pattern Generation Mode bit mask. */
+#define WEX_PGM_bp  7  /* Pattern Generation Mode bit position. */
+
+/* WEX.CTRLB  bit masks and bit positions */
+#define WEX_UPDSRC_gm  0x03  /* Update Source group mask. */
+#define WEX_UPDSRC_gp  0  /* Update Source group position. */
+#define WEX_UPDSRC_0_bm  (1<<0)  /* Update Source bit 0 mask. */
+#define WEX_UPDSRC_0_bp  0  /* Update Source bit 0 position. */
+#define WEX_UPDSRC_1_bm  (1<<1)  /* Update Source bit 1 mask. */
+#define WEX_UPDSRC_1_bp  1  /* Update Source bit 1 position. */
+
+/* WEX.CTRLC  bit masks and bit positions */
+#define WEX_CMD_gm  0x07  /* Command group mask. */
+#define WEX_CMD_gp  0  /* Command group position. */
+#define WEX_CMD_0_bm  (1<<0)  /* Command bit 0 mask. */
+#define WEX_CMD_0_bp  0  /* Command bit 0 position. */
+#define WEX_CMD_1_bm  (1<<1)  /* Command bit 1 mask. */
+#define WEX_CMD_1_bp  1  /* Command bit 1 position. */
+#define WEX_CMD_2_bm  (1<<2)  /* Command bit 2 mask. */
+#define WEX_CMD_2_bp  2  /* Command bit 2 position. */
+
+/* WEX.EVCTRLA  bit masks and bit positions */
+#define WEX_FAULTEI_bm  0x01  /* Fault Event Input Enable bit mask. */
+#define WEX_FAULTEI_bp  0  /* Fault Event Input Enable bit position. */
+#define WEX_BLANK_bm  0x02  /* Fault Event Blanking Enable bit mask. */
+#define WEX_BLANK_bp  1  /* Fault Event Blanking Enable bit position. */
+#define WEX_FILTER_gm  0x1C  /* Fault Event Filter Enable group mask. */
+#define WEX_FILTER_gp  2  /* Fault Event Filter Enable group position. */
+#define WEX_FILTER_0_bm  (1<<2)  /* Fault Event Filter Enable bit 0 mask. */
+#define WEX_FILTER_0_bp  2  /* Fault Event Filter Enable bit 0 position. */
+#define WEX_FILTER_1_bm  (1<<3)  /* Fault Event Filter Enable bit 1 mask. */
+#define WEX_FILTER_1_bp  3  /* Fault Event Filter Enable bit 1 position. */
+#define WEX_FILTER_2_bm  (1<<4)  /* Fault Event Filter Enable bit 2 mask. */
+#define WEX_FILTER_2_bp  4  /* Fault Event Filter Enable bit 2 position. */
+
+/* WEX.EVCTRLB  bit masks and bit positions */
+/* WEX_FAULTEI  is already defined. */
+/* WEX_BLANK  is already defined. */
+/* WEX_FILTER  is already defined. */
+
+/* WEX.EVCTRLC  bit masks and bit positions */
+/* WEX_FAULTEI  is already defined. */
+/* WEX_BLANK  is already defined. */
+/* WEX_FILTER  is already defined. */
+
+/* WEX.BUFCTRL  bit masks and bit positions */
+#define WEX_DTLSBV_bm  0x01  /* Dead-time Low Side Buffer Valid bit mask. */
+#define WEX_DTLSBV_bp  0  /* Dead-time Low Side Buffer Valid bit position. */
+#define WEX_DTHSBV_bm  0x02  /* Dead-time High Side Buffer Valid bit mask. */
+#define WEX_DTHSBV_bp  1  /* Dead-time High Side Buffer Valid bit position. */
+#define WEX_SWAPBV_bm  0x04  /* Swap Buffer Valid bit mask. */
+#define WEX_SWAPBV_bp  2  /* Swap Buffer Valid bit position. */
+#define WEX_PGMOVRBV_bm  0x08  /* PGM Override Buffer Valid bit mask. */
+#define WEX_PGMOVRBV_bp  3  /* PGM Override Buffer Valid bit position. */
+#define WEX_PGMOUTBV_bm  0x10  /* PGM Output Value Buffer Valid bit mask. */
+#define WEX_PGMOUTBV_bp  4  /* PGM Output Value Buffer Valid bit position. */
+
+/* WEX.BLANKCTRL  bit masks and bit positions */
+#define WEX_BLANKTRIG_gm  0x1F  /* Blanking Trigger group mask. */
+#define WEX_BLANKTRIG_gp  0  /* Blanking Trigger group position. */
+#define WEX_BLANKTRIG_0_bm  (1<<0)  /* Blanking Trigger bit 0 mask. */
+#define WEX_BLANKTRIG_0_bp  0  /* Blanking Trigger bit 0 position. */
+#define WEX_BLANKTRIG_1_bm  (1<<1)  /* Blanking Trigger bit 1 mask. */
+#define WEX_BLANKTRIG_1_bp  1  /* Blanking Trigger bit 1 position. */
+#define WEX_BLANKTRIG_2_bm  (1<<2)  /* Blanking Trigger bit 2 mask. */
+#define WEX_BLANKTRIG_2_bp  2  /* Blanking Trigger bit 2 position. */
+#define WEX_BLANKTRIG_3_bm  (1<<3)  /* Blanking Trigger bit 3 mask. */
+#define WEX_BLANKTRIG_3_bp  3  /* Blanking Trigger bit 3 position. */
+#define WEX_BLANKTRIG_4_bm  (1<<4)  /* Blanking Trigger bit 4 mask. */
+#define WEX_BLANKTRIG_4_bp  4  /* Blanking Trigger bit 4 position. */
+#define WEX_BLANKPRESC_gm  0x60  /* Blanking Prescaler group mask. */
+#define WEX_BLANKPRESC_gp  5  /* Blanking Prescaler group position. */
+#define WEX_BLANKPRESC_0_bm  (1<<5)  /* Blanking Prescaler bit 0 mask. */
+#define WEX_BLANKPRESC_0_bp  5  /* Blanking Prescaler bit 0 position. */
+#define WEX_BLANKPRESC_1_bm  (1<<6)  /* Blanking Prescaler bit 1 mask. */
+#define WEX_BLANKPRESC_1_bp  6  /* Blanking Prescaler bit 1 position. */
+
+/* WEX.FAULTCTRL  bit masks and bit positions */
+#define WEX_FDACT_gm  0x03  /* Fault Detection Action group mask. */
+#define WEX_FDACT_gp  0  /* Fault Detection Action group position. */
+#define WEX_FDACT_0_bm  (1<<0)  /* Fault Detection Action bit 0 mask. */
+#define WEX_FDACT_0_bp  0  /* Fault Detection Action bit 0 position. */
+#define WEX_FDACT_1_bm  (1<<1)  /* Fault Detection Action bit 1 mask. */
+#define WEX_FDACT_1_bp  1  /* Fault Detection Action bit 1 position. */
+#define WEX_FDMODE_bm  0x04  /* Fault Detection Restart Mode bit mask. */
+#define WEX_FDMODE_bp  2  /* Fault Detection Restart Mode bit position. */
+#define WEX_FDDBD_bm  0x80  /* Fault Detection on Debug Break Detection bit mask. */
+#define WEX_FDDBD_bp  7  /* Fault Detection on Debug Break Detection bit position. */
+
+/* WEX.FAULTDRV  bit masks and bit positions */
+#define WEX_FAULTDRV0_bm  0x01  /* Fault Drive Enable Bit 0 bit mask. */
+#define WEX_FAULTDRV0_bp  0  /* Fault Drive Enable Bit 0 bit position. */
+#define WEX_FAULTDRV1_bm  0x02  /* Fault Drive Enable Bit 1 bit mask. */
+#define WEX_FAULTDRV1_bp  1  /* Fault Drive Enable Bit 1 bit position. */
+#define WEX_FAULTDRV2_bm  0x04  /* Fault Drive Enable Bit 2 bit mask. */
+#define WEX_FAULTDRV2_bp  2  /* Fault Drive Enable Bit 2 bit position. */
+#define WEX_FAULTDRV3_bm  0x08  /* Fault Drive Enable Bit 3 bit mask. */
+#define WEX_FAULTDRV3_bp  3  /* Fault Drive Enable Bit 3 bit position. */
+#define WEX_FAULTDRV4_bm  0x10  /* Fault Drive Enable Bit 4 bit mask. */
+#define WEX_FAULTDRV4_bp  4  /* Fault Drive Enable Bit 4 bit position. */
+#define WEX_FAULTDRV5_bm  0x20  /* Fault Drive Enable Bit 5 bit mask. */
+#define WEX_FAULTDRV5_bp  5  /* Fault Drive Enable Bit 5 bit position. */
+#define WEX_FAULTDRV6_bm  0x40  /* Fault Drive Enable Bit 6 bit mask. */
+#define WEX_FAULTDRV6_bp  6  /* Fault Drive Enable Bit 6 bit position. */
+#define WEX_FAULTDRV7_bm  0x80  /* Fault Drive Enable Bit 7 bit mask. */
+#define WEX_FAULTDRV7_bp  7  /* Fault Drive Enable Bit 7 bit position. */
+
+/* WEX.FAULTOUT  bit masks and bit positions */
+#define WEX_FAULTOUT0_bm  0x01  /* Fault Output Value Bit 0 bit mask. */
+#define WEX_FAULTOUT0_bp  0  /* Fault Output Value Bit 0 bit position. */
+#define WEX_FAULTOUT1_bm  0x02  /* Fault Output Value Bit 1 bit mask. */
+#define WEX_FAULTOUT1_bp  1  /* Fault Output Value Bit 1 bit position. */
+#define WEX_FAULTOUT2_bm  0x04  /* Fault Output Value Bit 2 bit mask. */
+#define WEX_FAULTOUT2_bp  2  /* Fault Output Value Bit 2 bit position. */
+#define WEX_FAULTOUT3_bm  0x08  /* Fault Output Value Bit 3 bit mask. */
+#define WEX_FAULTOUT3_bp  3  /* Fault Output Value Bit 3 bit position. */
+#define WEX_FAULTOUT4_bm  0x10  /* Fault Output Value Bit 4 bit mask. */
+#define WEX_FAULTOUT4_bp  4  /* Fault Output Value Bit 4 bit position. */
+#define WEX_FAULTOUT5_bm  0x20  /* Fault Output Value Bit 5 bit mask. */
+#define WEX_FAULTOUT5_bp  5  /* Fault Output Value Bit 5 bit position. */
+#define WEX_FAULTOUT6_bm  0x40  /* Fault Output Value Bit 6 bit mask. */
+#define WEX_FAULTOUT6_bp  6  /* Fault Output Value Bit 6 bit position. */
+#define WEX_FAULTOUT7_bm  0x80  /* Fault Output Value Bit 7 bit mask. */
+#define WEX_FAULTOUT7_bp  7  /* Fault Output Value Bit 7 bit position. */
+
+/* WEX.INTCTRL  bit masks and bit positions */
+#define WEX_FAULTDET_bm  0x01  /* Fault Detection Interrupt Enable bit mask. */
+#define WEX_FAULTDET_bp  0  /* Fault Detection Interrupt Enable bit position. */
+
+/* WEX.INTFLAGS  bit masks and bit positions */
+/* WEX_FAULTDET  is already defined. */
+#define WEX_FDFEVA_bm  0x04  /* Fault Detection Flag Event Input A bit mask. */
+#define WEX_FDFEVA_bp  2  /* Fault Detection Flag Event Input A bit position. */
+#define WEX_FDFEVB_bm  0x08  /* Fault Detection Flag Event Input B bit mask. */
+#define WEX_FDFEVB_bp  3  /* Fault Detection Flag Event Input B bit position. */
+#define WEX_FDFEVC_bm  0x10  /* Fault Detection Flag Event Input C bit mask. */
+#define WEX_FDFEVC_bp  4  /* Fault Detection Flag Event Input C bit position. */
+
+/* WEX.STATUS  bit masks and bit positions */
+#define WEX_FDSTATE_bm  0x01  /* Fault Detection State bit mask. */
+#define WEX_FDSTATE_bp  0  /* Fault Detection State bit position. */
+#define WEX_FDSEVA_bm  0x04  /* Fault Detection State Event A bit mask. */
+#define WEX_FDSEVA_bp  2  /* Fault Detection State Event A bit position. */
+#define WEX_FDSEVB_bm  0x08  /* Fault Detection State Event B bit mask. */
+#define WEX_FDSEVB_bp  3  /* Fault Detection State Event B bit position. */
+#define WEX_FDSEVC_bm  0x10  /* Fault Detection State Event C bit mask. */
+#define WEX_FDSEVC_bp  4  /* Fault Detection State Event C bit position. */
+#define WEX_BLANKSTATE_bm  0x80  /* Blanking State bit mask. */
+#define WEX_BLANKSTATE_bp  7  /* Blanking State bit position. */
+
+/* WEX.SWAP  bit masks and bit positions */
+#define WEX_SWAP0_bm  0x01  /* Swap DTI Output Pair 0 bit mask. */
+#define WEX_SWAP0_bp  0  /* Swap DTI Output Pair 0 bit position. */
+#define WEX_SWAP1_bm  0x02  /* Swap DTI Output Pair 1 bit mask. */
+#define WEX_SWAP1_bp  1  /* Swap DTI Output Pair 1 bit position. */
+#define WEX_SWAP2_bm  0x04  /* Swap DTI Output Pair 2 bit mask. */
+#define WEX_SWAP2_bp  2  /* Swap DTI Output Pair 2 bit position. */
+#define WEX_SWAP3_bm  0x08  /* Swap DTI Output Pair 3 bit mask. */
+#define WEX_SWAP3_bp  3  /* Swap DTI Output Pair 3 bit position. */
+
+/* WEX.PGMOVR  bit masks and bit positions */
+#define WEX_PGMOVR0_bm  0x01  /* Pattern Generation Override Enable Bit 0 bit mask. */
+#define WEX_PGMOVR0_bp  0  /* Pattern Generation Override Enable Bit 0 bit position. */
+#define WEX_PGMOVR1_bm  0x02  /* Pattern Generation Override Enable Bit 1 bit mask. */
+#define WEX_PGMOVR1_bp  1  /* Pattern Generation Override Enable Bit 1 bit position. */
+#define WEX_PGMOVR2_bm  0x04  /* Pattern Generation Override Enable Bit 2 bit mask. */
+#define WEX_PGMOVR2_bp  2  /* Pattern Generation Override Enable Bit 2 bit position. */
+#define WEX_PGMOVR3_bm  0x08  /* Pattern Generation Override Enable Bit 3 bit mask. */
+#define WEX_PGMOVR3_bp  3  /* Pattern Generation Override Enable Bit 3 bit position. */
+#define WEX_PGMOVR4_bm  0x10  /* Pattern Generation Override Enable Bit 4 bit mask. */
+#define WEX_PGMOVR4_bp  4  /* Pattern Generation Override Enable Bit 4 bit position. */
+#define WEX_PGMOVR5_bm  0x20  /* Pattern Generation Override Enable Bit 5 bit mask. */
+#define WEX_PGMOVR5_bp  5  /* Pattern Generation Override Enable Bit 5 bit position. */
+#define WEX_PGMOVR6_bm  0x40  /* Pattern Generation Override Enable Bit 6 bit mask. */
+#define WEX_PGMOVR6_bp  6  /* Pattern Generation Override Enable Bit 6 bit position. */
+#define WEX_PGMOVR7_bm  0x80  /* Pattern Generation Override Enable Bit 7 bit mask. */
+#define WEX_PGMOVR7_bp  7  /* Pattern Generation Override Enable Bit 7 bit position. */
+
+/* WEX.PGMOUT  bit masks and bit positions */
+#define WEX_PGMOUT0_bm  0x01  /* Pattern Generation Output Value Bit 0 bit mask. */
+#define WEX_PGMOUT0_bp  0  /* Pattern Generation Output Value Bit 0 bit position. */
+#define WEX_PGMOUT1_bm  0x02  /* Pattern Generation Output Value Bit 1 bit mask. */
+#define WEX_PGMOUT1_bp  1  /* Pattern Generation Output Value Bit 1 bit position. */
+#define WEX_PGMOUT2_bm  0x04  /* Pattern Generation Output Value Bit 2 bit mask. */
+#define WEX_PGMOUT2_bp  2  /* Pattern Generation Output Value Bit 2 bit position. */
+#define WEX_PGMOUT3_bm  0x08  /* Pattern Generation Output Value Bit 3 bit mask. */
+#define WEX_PGMOUT3_bp  3  /* Pattern Generation Output Value Bit 3 bit position. */
+#define WEX_PGMOUT4_bm  0x10  /* Pattern Generation Output Value Bit 4 bit mask. */
+#define WEX_PGMOUT4_bp  4  /* Pattern Generation Output Value Bit 4 bit position. */
+#define WEX_PGMOUT5_bm  0x20  /* Pattern Generation Output Value Bit 5 bit mask. */
+#define WEX_PGMOUT5_bp  5  /* Pattern Generation Output Value Bit 5 bit position. */
+#define WEX_PGMOUT6_bm  0x40  /* Pattern Generation Output Value Bit 6 bit mask. */
+#define WEX_PGMOUT6_bp  6  /* Pattern Generation Output Value Bit 6 bit position. */
+#define WEX_PGMOUT7_bm  0x80  /* Pattern Generation Output Value Bit 7 bit mask. */
+#define WEX_PGMOUT7_bp  7  /* Pattern Generation Output Value Bit 7 bit position. */
+
+/* WEX.OUTOVEN  bit masks and bit positions */
+#define WEX_OUTOVEN0_bm  0x01  /* Output Override Enable Bit 0 bit mask. */
+#define WEX_OUTOVEN0_bp  0  /* Output Override Enable Bit 0 bit position. */
+#define WEX_OUTOVEN1_bm  0x02  /* Output Override Enable Bit 1 bit mask. */
+#define WEX_OUTOVEN1_bp  1  /* Output Override Enable Bit 1 bit position. */
+#define WEX_OUTOVEN2_bm  0x04  /* Output Override Enable Bit 2 bit mask. */
+#define WEX_OUTOVEN2_bp  2  /* Output Override Enable Bit 2 bit position. */
+#define WEX_OUTOVEN3_bm  0x08  /* Output Override Enable Bit 3 bit mask. */
+#define WEX_OUTOVEN3_bp  3  /* Output Override Enable Bit 3 bit position. */
+#define WEX_OUTOVEN4_bm  0x10  /* Output Override Enable Bit 4 bit mask. */
+#define WEX_OUTOVEN4_bp  4  /* Output Override Enable Bit 4 bit position. */
+#define WEX_OUTOVEN5_bm  0x20  /* Output Override Enable Bit 5 bit mask. */
+#define WEX_OUTOVEN5_bp  5  /* Output Override Enable Bit 5 bit position. */
+#define WEX_OUTOVEN6_bm  0x40  /* Output Override Enable Bit 6 bit mask. */
+#define WEX_OUTOVEN6_bp  6  /* Output Override Enable Bit 6 bit position. */
+#define WEX_OUTOVEN7_bm  0x80  /* Output Override Enable Bit 7 bit mask. */
+#define WEX_OUTOVEN7_bp  7  /* Output Override Enable Bit 7 bit position. */
+
+/* WEX.SWAPBUF  bit masks and bit positions */
+#define WEX_SWAPBUF0_bm  0x01  /* Swap DTI Output Pair 0 Buffer bit mask. */
+#define WEX_SWAPBUF0_bp  0  /* Swap DTI Output Pair 0 Buffer bit position. */
+#define WEX_SWAPBUF1_bm  0x02  /* Swap DTI Output Pair 1 Buffer bit mask. */
+#define WEX_SWAPBUF1_bp  1  /* Swap DTI Output Pair 1 Buffer bit position. */
+#define WEX_SWAPBUF2_bm  0x04  /* Swap DTI Output Pair 2 Buffer bit mask. */
+#define WEX_SWAPBUF2_bp  2  /* Swap DTI Output Pair 2 Buffer bit position. */
+#define WEX_SWAPBUF3_bm  0x08  /* Swap DTI Output Pair 3 Buffer bit mask. */
+#define WEX_SWAPBUF3_bp  3  /* Swap DTI Output Pair 3 Buffer bit position. */
+
+/* WEX.PGMOVRBUF  bit masks and bit positions */
+#define WEX_PGMOVRBUF0_bm  0x01  /* Pattern Generation Override Enable Buffer Bit 0 bit mask. */
+#define WEX_PGMOVRBUF0_bp  0  /* Pattern Generation Override Enable Buffer Bit 0 bit position. */
+#define WEX_PGMOVRBUF1_bm  0x02  /* Pattern Generation Override Enable Buffer Bit 1 bit mask. */
+#define WEX_PGMOVRBUF1_bp  1  /* Pattern Generation Override Enable Buffer Bit 1 bit position. */
+#define WEX_PGMOVRBUF2_bm  0x04  /* Pattern Generation Override Enable Buffer Bit 2 bit mask. */
+#define WEX_PGMOVRBUF2_bp  2  /* Pattern Generation Override Enable Buffer Bit 2 bit position. */
+#define WEX_PGMOVRBUF3_bm  0x08  /* Pattern Generation Override Enable Buffer Bit 3 bit mask. */
+#define WEX_PGMOVRBUF3_bp  3  /* Pattern Generation Override Enable Buffer Bit 3 bit position. */
+#define WEX_PGMOVRBUF4_bm  0x10  /* Pattern Generation Override Enable Buffer Bit 4 bit mask. */
+#define WEX_PGMOVRBUF4_bp  4  /* Pattern Generation Override Enable Buffer Bit 4 bit position. */
+#define WEX_PGMOVRBUF5_bm  0x20  /* Pattern Generation Override Enable Buffer Bit 5 bit mask. */
+#define WEX_PGMOVRBUF5_bp  5  /* Pattern Generation Override Enable Buffer Bit 5 bit position. */
+#define WEX_PGMOVRBUF6_bm  0x40  /* Pattern Generation Override Enable Buffer Bit 6 bit mask. */
+#define WEX_PGMOVRBUF6_bp  6  /* Pattern Generation Override Enable Buffer Bit 6 bit position. */
+#define WEX_PGMOVRBUF7_bm  0x80  /* Pattern Generation Override Enable Buffer Bit 7 bit mask. */
+#define WEX_PGMOVRBUF7_bp  7  /* Pattern Generation Override Enable Buffer Bit 7 bit position. */
+
+/* WEX.PGMOUTBUF  bit masks and bit positions */
+#define WEX_PGMOUTBUF0_bm  0x01  /* Pattern Generation Output Value Buffer Bit 0 bit mask. */
+#define WEX_PGMOUTBUF0_bp  0  /* Pattern Generation Output Value Buffer Bit 0 bit position. */
+#define WEX_PGMOUTBUF1_bm  0x02  /* Pattern Generation Output Value Buffer Bit 1 bit mask. */
+#define WEX_PGMOUTBUF1_bp  1  /* Pattern Generation Output Value Buffer Bit 1 bit position. */
+#define WEX_PGMOUTBUF2_bm  0x04  /* Pattern Generation Output Value Buffer Bit 2 bit mask. */
+#define WEX_PGMOUTBUF2_bp  2  /* Pattern Generation Output Value Buffer Bit 2 bit position. */
+#define WEX_PGMOUTBUF3_bm  0x08  /* Pattern Generation Output Value Buffer Bit 3 bit mask. */
+#define WEX_PGMOUTBUF3_bp  3  /* Pattern Generation Output Value Buffer Bit 3 bit position. */
+#define WEX_PGMOUTBUF4_bm  0x10  /* Pattern Generation Output Value Buffer Bit 4 bit mask. */
+#define WEX_PGMOUTBUF4_bp  4  /* Pattern Generation Output Value Buffer Bit 4 bit position. */
+#define WEX_PGMOUTBUF5_bm  0x20  /* Pattern Generation Output Value Buffer Bit 5 bit mask. */
+#define WEX_PGMOUTBUF5_bp  5  /* Pattern Generation Output Value Buffer Bit 5 bit position. */
+#define WEX_PGMOUTBUF6_bm  0x40  /* Pattern Generation Output Value Buffer Bit 6 bit mask. */
+#define WEX_PGMOUTBUF6_bp  6  /* Pattern Generation Output Value Buffer Bit 6 bit position. */
+#define WEX_PGMOUTBUF7_bm  0x80  /* Pattern Generation Output Value Buffer Bit 7 bit mask. */
+#define WEX_PGMOUTBUF7_bp  7  /* Pattern Generation Output Value Buffer Bit 7 bit position. */
+
+
+/* ========== Generic Port Pins ========== */
+#define PIN0_bm 0x01
+#define PIN0_bp 0
+#define PIN1_bm 0x02
+#define PIN1_bp 1
+#define PIN2_bm 0x04
+#define PIN2_bp 2
+#define PIN3_bm 0x08
+#define PIN3_bp 3
+#define PIN4_bm 0x10
+#define PIN4_bp 4
+#define PIN5_bm 0x20
+#define PIN5_bp 5
+#define PIN6_bm 0x40
+#define PIN6_bp 6
+#define PIN7_bm 0x80
+#define PIN7_bp 7
+
+/* ========== Interrupt Vector Definitions ========== */
+/* Vector 0 is the reset vector */
+
+/* NMI interrupt vectors */
+#define NMI_vect_num  1
+#define NMI_vect      _VECTOR(1)  /*  */
+
+/* BOD interrupt vectors */
+#define BOD_VLM_vect_num  2
+#define BOD_VLM_vect      _VECTOR(2)  /*  */
+
+/* RTC interrupt vectors */
+#define RTC_CNT_vect_num  3
+#define RTC_CNT_vect      _VECTOR(3)  /*  */
+#define RTC_PIT_vect_num  4
+#define RTC_PIT_vect      _VECTOR(4)  /*  */
+
+/* CCL interrupt vectors */
+#define CCL_CCL_vect_num  5
+#define CCL_CCL_vect      _VECTOR(5)  /*  */
+
+/* PORTA interrupt vectors */
+#define PORTA_PORT_vect_num  6
+#define PORTA_PORT_vect      _VECTOR(6)  /*  */
+
+/* WEX0 interrupt vectors */
+#define WEX0_FDFEVA_vect_num  7
+#define WEX0_FDFEVA_vect      _VECTOR(7)  /*  */
+#define WEX0_FDFEVB_vect_num  7
+#define WEX0_FDFEVB_vect      _VECTOR(7)  /*  */
+#define WEX0_FDFEVC_vect_num  7
+#define WEX0_FDFEVC_vect      _VECTOR(7)  /*  */
+
+/* TCE0 interrupt vectors */
+#define TCE0_OVF_vect_num  8
+#define TCE0_OVF_vect      _VECTOR(8)  /*  */
+#define TCE0_CMP0_vect_num  9
+#define TCE0_CMP0_vect      _VECTOR(9)  /*  */
+#define TCE0_CMP1_vect_num  10
+#define TCE0_CMP1_vect      _VECTOR(10)  /*  */
+#define TCE0_CMP2_vect_num  11
+#define TCE0_CMP2_vect      _VECTOR(11)  /*  */
+#define TCE0_CMP3_vect_num  12
+#define TCE0_CMP3_vect      _VECTOR(12)  /*  */
+
+/* TCB0 interrupt vectors */
+#define TCB0_INT_vect_num  13
+#define TCB0_INT_vect      _VECTOR(13)  /*  */
+
+/* TCB1 interrupt vectors */
+#define TCB1_INT_vect_num  14
+#define TCB1_INT_vect      _VECTOR(14)  /*  */
+
+/* TWI0 interrupt vectors */
+#define TWI0_TWIS_vect_num  15
+#define TWI0_TWIS_vect      _VECTOR(15)  /*  */
+#define TWI0_TWIM_vect_num  16
+#define TWI0_TWIM_vect      _VECTOR(16)  /*  */
+
+/* SPI0 interrupt vectors */
+#define SPI0_INT_vect_num  17
+#define SPI0_INT_vect      _VECTOR(17)  /*  */
+
+/* USART0 interrupt vectors */
+#define USART0_RXC_vect_num  18
+#define USART0_RXC_vect      _VECTOR(18)  /*  */
+#define USART0_DRE_vect_num  19
+#define USART0_DRE_vect      _VECTOR(19)  /*  */
+#define USART0_TXC_vect_num  20
+#define USART0_TXC_vect      _VECTOR(20)  /*  */
+
+/* PORTD interrupt vectors */
+#define PORTD_PORT_vect_num  21
+#define PORTD_PORT_vect      _VECTOR(21)  /*  */
+
+/* TCF0 interrupt vectors */
+#define TCF0_INT_vect_num  22
+#define TCF0_INT_vect      _VECTOR(22)  /*  */
+
+/* AC0 interrupt vectors */
+#define AC0_AC_vect_num  23
+#define AC0_AC_vect      _VECTOR(23)  /*  */
+
+/* ADC0 interrupt vectors */
+#define ADC0_ERROR_vect_num  24
+#define ADC0_ERROR_vect      _VECTOR(24)  /*  */
+#define ADC0_RESRDY_vect_num  25
+#define ADC0_RESRDY_vect      _VECTOR(25)  /*  */
+#define ADC0_SAMPRDY_vect_num  26
+#define ADC0_SAMPRDY_vect      _VECTOR(26)  /*  */
+
+/* AC1 interrupt vectors */
+#define AC1_AC_vect_num  27
+#define AC1_AC_vect      _VECTOR(27)  /*  */
+
+/* PORTC interrupt vectors */
+#define PORTC_PORT_vect_num  28
+#define PORTC_PORT_vect      _VECTOR(28)  /*  */
+
+/* PORTF interrupt vectors */
+#define PORTF_PORT_vect_num  29
+#define PORTF_PORT_vect      _VECTOR(29)  /*  */
+
+/* NVMCTRL interrupt vectors */
+#define NVMCTRL_EEREADY_vect_num  30
+#define NVMCTRL_EEREADY_vect      _VECTOR(30)  /*  */
+#define NVMCTRL_FLREADY_vect_num  30
+#define NVMCTRL_FLREADY_vect      _VECTOR(30)  /*  */
+#define NVMCTRL_NVMREADY_vect_num  30
+#define NVMCTRL_NVMREADY_vect      _VECTOR(30)  /*  */
+
+#define _VECTOR_SIZE 4 /* Size of individual vector. */
+#define _VECTORS_SIZE (31 * _VECTOR_SIZE)
+
+
+/* ========== Constants ========== */
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define DATAMEM_START     (0x0000)
+#  define DATAMEM_SIZE      (65536)
+#else
+#  define DATAMEM_START     (0x0000U)
+#  define DATAMEM_SIZE      (65536U)
+#endif
+#define DATAMEM_END       (DATAMEM_START + DATAMEM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define IO_START     (0x0000)
+#  define IO_SIZE      (4159)
+#  define IO_PAGE_SIZE (0)
+#else
+#  define IO_START     (0x0000U)
+#  define IO_SIZE      (4159U)
+#  define IO_PAGE_SIZE (0U)
+#endif
+#define IO_END       (IO_START + IO_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define LOCKBITS_START     (0x1040)
+#  define LOCKBITS_SIZE      (4)
+#  define LOCKBITS_PAGE_SIZE (4)
+#else
+#  define LOCKBITS_START     (0x1040U)
+#  define LOCKBITS_SIZE      (4U)
+#  define LOCKBITS_PAGE_SIZE (4U)
+#endif
+#define LOCKBITS_END       (LOCKBITS_START + LOCKBITS_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define FUSES_START     (0x1050)
+#  define FUSES_SIZE      (16)
+#  define FUSES_PAGE_SIZE (8)
+#else
+#  define FUSES_START     (0x1050U)
+#  define FUSES_SIZE      (16U)
+#  define FUSES_PAGE_SIZE (8U)
+#endif
+#define FUSES_END       (FUSES_START + FUSES_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define SIGNATURES_START     (0x1080)
+#  define SIGNATURES_SIZE      (3)
+#  define SIGNATURES_PAGE_SIZE (128)
+#else
+#  define SIGNATURES_START     (0x1080U)
+#  define SIGNATURES_SIZE      (3U)
+#  define SIGNATURES_PAGE_SIZE (128U)
+#endif
+#define SIGNATURES_END       (SIGNATURES_START + SIGNATURES_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define PROD_SIGNATURES_START     (0x1083)
+#  define PROD_SIGNATURES_SIZE      (125)
+#  define PROD_SIGNATURES_PAGE_SIZE (128)
+#else
+#  define PROD_SIGNATURES_START     (0x1083U)
+#  define PROD_SIGNATURES_SIZE      (125U)
+#  define PROD_SIGNATURES_PAGE_SIZE (128U)
+#endif
+#define PROD_SIGNATURES_END       (PROD_SIGNATURES_START + PROD_SIGNATURES_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define BOOTROW_START     (0x1100)
+#  define BOOTROW_SIZE      (64)
+#  define BOOTROW_PAGE_SIZE (64)
+#else
+#  define BOOTROW_START     (0x1100U)
+#  define BOOTROW_SIZE      (64U)
+#  define BOOTROW_PAGE_SIZE (64U)
+#endif
+#define BOOTROW_END       (BOOTROW_START + BOOTROW_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define USER_SIGNATURES_START     (0x1200)
+#  define USER_SIGNATURES_SIZE      (64)
+#  define USER_SIGNATURES_PAGE_SIZE (64)
+#else
+#  define USER_SIGNATURES_START     (0x1200U)
+#  define USER_SIGNATURES_SIZE      (64U)
+#  define USER_SIGNATURES_PAGE_SIZE (64U)
+#endif
+#define USER_SIGNATURES_END       (USER_SIGNATURES_START + USER_SIGNATURES_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define EEPROM_START     (0x1400)
+#  define EEPROM_SIZE      (512)
+#  define EEPROM_PAGE_SIZE (8)
+#else
+#  define EEPROM_START     (0x1400U)
+#  define EEPROM_SIZE      (512U)
+#  define EEPROM_PAGE_SIZE (8U)
+#endif
+#define EEPROM_END       (EEPROM_START + EEPROM_SIZE - 1)
+
+/* Added MAPPED_EEPROM segment names for avr-libc */
+#define MAPPED_EEPROM_START     (EEPROM_START)
+#define MAPPED_EEPROM_SIZE      (EEPROM_SIZE)
+#define MAPPED_EEPROM_PAGE_SIZE (EEPROM_PAGE_SIZE)
+#define MAPPED_EEPROM_END       (MAPPED_EEPROM_START + MAPPED_EEPROM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define INTERNAL_SRAM_START     (0x7800)
+#  define INTERNAL_SRAM_SIZE      (2048)
+#  define INTERNAL_SRAM_PAGE_SIZE (0)
+#else
+#  define INTERNAL_SRAM_START     (0x7800U)
+#  define INTERNAL_SRAM_SIZE      (2048U)
+#  define INTERNAL_SRAM_PAGE_SIZE (0U)
+#endif
+#define INTERNAL_SRAM_END       (INTERNAL_SRAM_START + INTERNAL_SRAM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define MAPPED_PROGMEM_START     (0x8000)
+#  define MAPPED_PROGMEM_SIZE      (16384)
+#  define MAPPED_PROGMEM_PAGE_SIZE (64)
+#else
+#  define MAPPED_PROGMEM_START     (0x8000U)
+#  define MAPPED_PROGMEM_SIZE      (16384U)
+#  define MAPPED_PROGMEM_PAGE_SIZE (64U)
+#endif
+#define MAPPED_PROGMEM_END       (MAPPED_PROGMEM_START + MAPPED_PROGMEM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define PROGMEM_START     (0x0000)
+#  define PROGMEM_SIZE      (16384)
+#  define PROGMEM_PAGE_SIZE (64)
+#else
+#  define PROGMEM_START     (0x0000U)
+#  define PROGMEM_SIZE      (16384U)
+#  define PROGMEM_PAGE_SIZE (64U)
+#endif
+#define PROGMEM_END       (PROGMEM_START + PROGMEM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define PROGMEM_NRWW_START     (0x0000)
+#  define PROGMEM_NRWW_SIZE      (4096)
+#  define PROGMEM_NRWW_PAGE_SIZE (64)
+#else
+#  define PROGMEM_NRWW_START     (0x0000U)
+#  define PROGMEM_NRWW_SIZE      (4096U)
+#  define PROGMEM_NRWW_PAGE_SIZE (64U)
+#endif
+#define PROGMEM_NRWW_END       (PROGMEM_NRWW_START + PROGMEM_NRWW_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define PROGMEM_RWW_START     (0x1000)
+#  define PROGMEM_RWW_SIZE      (12288)
+#  define PROGMEM_RWW_PAGE_SIZE (64)
+#else
+#  define PROGMEM_RWW_START     (0x1000U)
+#  define PROGMEM_RWW_SIZE      (12288U)
+#  define PROGMEM_RWW_PAGE_SIZE (64U)
+#endif
+#define PROGMEM_RWW_END       (PROGMEM_RWW_START + PROGMEM_RWW_SIZE - 1)
+
+#define FLASHSTART   PROGMEM_START
+#define FLASHEND     PROGMEM_END
+#define RAMSTART     INTERNAL_SRAM_START
+#define RAMSIZE      INTERNAL_SRAM_SIZE
+#define RAMEND       INTERNAL_SRAM_END
+#define E2END        EEPROM_END
+#define E2PAGESIZE   EEPROM_PAGE_SIZE
+
+/* ========== Fuses ========== */
+#define FUSE_MEMORY_SIZE 16
+
+/* Fuse Byte 0 (WDTCFG) */
+#define FUSE_PERIOD0  (unsigned char)_BV(0)  /* Watchdog Timeout Period Bit 0 */
+#define FUSE_PERIOD1  (unsigned char)_BV(1)  /* Watchdog Timeout Period Bit 1 */
+#define FUSE_PERIOD2  (unsigned char)_BV(2)  /* Watchdog Timeout Period Bit 2 */
+#define FUSE_PERIOD3  (unsigned char)_BV(3)  /* Watchdog Timeout Period Bit 3 */
+#define FUSE_WINDOW0  (unsigned char)_BV(4)  /* Watchdog Window Timeout Period Bit 0 */
+#define FUSE_WINDOW1  (unsigned char)_BV(5)  /* Watchdog Window Timeout Period Bit 1 */
+#define FUSE_WINDOW2  (unsigned char)_BV(6)  /* Watchdog Window Timeout Period Bit 2 */
+#define FUSE_WINDOW3  (unsigned char)_BV(7)  /* Watchdog Window Timeout Period Bit 3 */
+#define FUSE0_DEFAULT  (0x0)
+#define FUSE_WDTCFG_DEFAULT  (0x0)
+
+/* Fuse Byte 1 (BODCFG) */
+#define FUSE_SLEEP0  (unsigned char)_BV(0)  /* BOD Operation in Sleep Mode Bit 0 */
+#define FUSE_SLEEP1  (unsigned char)_BV(1)  /* BOD Operation in Sleep Mode Bit 1 */
+#define FUSE_ACTIVE0  (unsigned char)_BV(2)  /* BOD Operation in Active Mode Bit 0 */
+#define FUSE_ACTIVE1  (unsigned char)_BV(3)  /* BOD Operation in Active Mode Bit 1 */
+#define FUSE_SAMPFREQ  (unsigned char)_BV(4)  /* BOD Sample Frequency */
+#define FUSE_LVL0  (unsigned char)_BV(5)  /* BOD Level Bit 0 */
+#define FUSE_LVL1  (unsigned char)_BV(6)  /* BOD Level Bit 1 */
+#define FUSE_LVL2  (unsigned char)_BV(7)  /* BOD Level Bit 2 */
+#define FUSE1_DEFAULT  (0x0)
+#define FUSE_BODCFG_DEFAULT  (0x0)
+
+/* Fuse Byte 2 (OSCCFG) */
+#define FUSE_OSCHFFRQ  (unsigned char)_BV(3)  /* High-frequency Oscillator Frequency */
+#define FUSE2_DEFAULT  (0x0)
+#define FUSE_OSCCFG_DEFAULT  (0x0)
+
+/* Fuse Byte 3 Reserved */
+
+/* Fuse Byte 4 Reserved */
+
+/* Fuse Byte 5 (SYSCFG0) */
+#define FUSE_EESAVE  (unsigned char)_BV(0)  /* EEPROM Save */
+#define FUSE_RSTPINCFG  (unsigned char)_BV(3)  /* Reset Pin Configuration */
+#define FUSE_UPDIPINCFG  (unsigned char)_BV(4)  /* UPDI Pin Configuration */
+#define FUSE_CRCSEL  (unsigned char)_BV(5)  /* CRC Select */
+#define FUSE_CRCSRC0  (unsigned char)_BV(6)  /* CRC Source Bit 0 */
+#define FUSE_CRCSRC1  (unsigned char)_BV(7)  /* CRC Source Bit 1 */
+#define FUSE5_DEFAULT  (0xD0)
+#define FUSE_SYSCFG0_DEFAULT  (0xD0)
+
+/* Fuse Byte 6 (SYSCFG1) */
+#define FUSE_SUT0  (unsigned char)_BV(0)  /* Startup Time Bit 0 */
+#define FUSE_SUT1  (unsigned char)_BV(1)  /* Startup Time Bit 1 */
+#define FUSE_SUT2  (unsigned char)_BV(2)  /* Startup Time Bit 2 */
+#define FUSE6_DEFAULT  (0x7)
+#define FUSE_SYSCFG1_DEFAULT  (0x7)
+
+/* Fuse Byte 7 (CODESIZE) */
+#define FUSE7_DEFAULT  (0x0)
+#define FUSE_CODESIZE_DEFAULT  (0x0)
+
+/* Fuse Byte 8 (BOOTSIZE) */
+#define FUSE8_DEFAULT  (0x0)
+#define FUSE_BOOTSIZE_DEFAULT  (0x0)
+
+/* Fuse Byte 9 Reserved */
+
+/* Fuse Byte 10 (PDICFG) */
+#define FUSE_LEVEL0  (unsigned char)_BV(0)  /* Protection Level Bit 0 */
+#define FUSE_LEVEL1  (unsigned char)_BV(1)  /* Protection Level Bit 1 */
+#define FUSE_KEY0  (unsigned char)_BV(4)  /* NVM Protection Activation Key Bit 0 */
+#define FUSE_KEY1  (unsigned char)_BV(5)  /* NVM Protection Activation Key Bit 1 */
+#define FUSE_KEY2  (unsigned char)_BV(6)  /* NVM Protection Activation Key Bit 2 */
+#define FUSE_KEY3  (unsigned char)_BV(7)  /* NVM Protection Activation Key Bit 3 */
+#define FUSE_KEY4  (unsigned char)_BV(8)  /* NVM Protection Activation Key Bit 4 */
+#define FUSE_KEY5  (unsigned char)_BV(9)  /* NVM Protection Activation Key Bit 5 */
+#define FUSE_KEY6  (unsigned char)_BV(10)  /* NVM Protection Activation Key Bit 6 */
+#define FUSE_KEY7  (unsigned char)_BV(11)  /* NVM Protection Activation Key Bit 7 */
+#define FUSE_KEY8  (unsigned char)_BV(12)  /* NVM Protection Activation Key Bit 8 */
+#define FUSE_KEY9  (unsigned char)_BV(13)  /* NVM Protection Activation Key Bit 9 */
+#define FUSE_KEY10  (unsigned char)_BV(14)  /* NVM Protection Activation Key Bit 10 */
+#define FUSE_KEY11  (unsigned char)_BV(15)  /* NVM Protection Activation Key Bit 11 */
+#define FUSE10_DEFAULT  (0x3)
+#define FUSE_PDICFG_DEFAULT  (0x3)
+
+/* ========== Lock Bits ========== */
+#define __LOCK_KEY_EXIST
+#ifdef LOCKBITS_DEFAULT
+#undef LOCKBITS_DEFAULT
+#endif //LOCKBITS_DEFAULT
+#define LOCKBITS_DEFAULT  (0x5CC5C55C)
+
+/* ========== Signature ========== */
+#define SIGNATURE_0 0x1E
+#define SIGNATURE_1 0x94
+#define SIGNATURE_2 0x40
+
+#endif /* #ifdef _AVR_AVR16EB20_H_INCLUDED */
+

--- a/include/avr/ioavr16eb28.h
+++ b/include/avr/ioavr16eb28.h
@@ -1,0 +1,6484 @@
+/*
+ * Copyright (C) 2023, Microchip Technology Inc. and its subsidiaries ("Microchip")
+ * All rights reserved.
+ *
+ * This software is developed by Microchip Technology Inc. and its subsidiaries ("Microchip").
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other
+ *        materials provided with the distribution. Publication is not required when
+ *        this file is used in an embedded application.
+ *
+ *     3. Microchip's name may not be used to endorse or promote products derived from this
+ *        software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY MICROCHIP "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL MICROCHIP BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING BUT NOT LIMITED TO
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWSOEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _AVR_IO_H_
+#  error "Include <avr/io.h> instead of this file."
+#endif
+
+#ifndef _AVR_IOXXX_H_
+#  define _AVR_IOXXX_H_ "ioavr16eb28.h"
+#else
+#  error "Attempt to include more than one <avr/ioXXX.h> file."
+#endif
+
+#ifndef _AVR_AVR16EB28_H_INCLUDED
+#define _AVR_AVR16EB28_H_INCLUDED
+
+/* Ungrouped common registers */
+#define CCP  _SFR_MEM8(0x0034)  /* Configuration Change Protection */
+#define RAMPZ  _SFR_MEM8(0x003B)  /* Extended Z-pointer Register */
+#define SP  _SFR_MEM16(0x003D)  /* Stack Pointer */
+#define SPL  _SFR_MEM8(0x003D)  /* Stack Pointer Low */
+#define SPH  _SFR_MEM8(0x003E)  /* Stack Pointer High */
+#define SREG  _SFR_MEM8(0x003F)  /* Status Register */
+
+/* C Language Only */
+#if !defined (__ASSEMBLER__)
+
+#include <stdint.h>
+
+typedef volatile uint8_t register8_t;
+typedef volatile uint16_t register16_t;
+typedef volatile uint32_t register32_t;
+
+
+#ifdef _WORDREGISTER
+#undef _WORDREGISTER
+#endif
+#define _WORDREGISTER(regname)   \
+    __extension__ union \
+    { \
+        register16_t regname; \
+        struct \
+        { \
+            register8_t regname ## L; \
+            register8_t regname ## H; \
+        }; \
+    }
+
+#ifdef _DWORDREGISTER
+#undef _DWORDREGISTER
+#endif
+#define _DWORDREGISTER(regname)  \
+    __extension__ union \
+    { \
+        register32_t regname; \
+        struct \
+        { \
+            register8_t regname ## 0; \
+            register8_t regname ## 1; \
+            register8_t regname ## 2; \
+            register8_t regname ## 3; \
+        }; \
+    }
+
+
+/*
+==========================================================================
+IO Module Structures
+==========================================================================
+*/
+
+
+/*
+--------------------------------------------------------------------------
+AC - Analog Comparator
+--------------------------------------------------------------------------
+*/
+
+/* Analog Comparator */
+typedef struct AC_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t MUXCTRL;  /* Mux Control A */
+    register8_t reserved_1[2];
+    register8_t DACREF;  /* DAC Voltage Reference */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t STATUS;  /* Status */
+} AC_t;
+
+/* Hysteresis Mode select */
+typedef enum AC_HYSMODE_enum
+{
+    AC_HYSMODE_NONE_gc = (0x00<<1),  /* No hysteresis */
+    AC_HYSMODE_SMALL_gc = (0x01<<1),  /* Small hysteresis */
+    AC_HYSMODE_MEDIUM_gc = (0x02<<1),  /* Medium hysteresis */
+    AC_HYSMODE_LARGE_gc = (0x03<<1)  /* Large hysteresis */
+} AC_HYSMODE_t;
+
+/* AC Output Initial Value select */
+typedef enum AC_INITVAL_enum
+{
+    AC_INITVAL_LOW_gc = (0x00<<6),  /* Output initialized to 0 */
+    AC_INITVAL_HIGH_gc = (0x01<<6)  /* Output initialized to 1 */
+} AC_INITVAL_t;
+
+/* Interrupt Mode select */
+typedef enum AC_INTMODE_NORMAL_enum
+{
+    AC_INTMODE_NORMAL_BOTHEDGE_gc = (0x00<<4),  /* Positive and negative inputs crosses */
+    AC_INTMODE_NORMAL_NEGEDGE_gc = (0x02<<4),  /* Positive input goes below negative input */
+    AC_INTMODE_NORMAL_POSEDGE_gc = (0x03<<4)  /* Positive input goes above negative input */
+} AC_INTMODE_NORMAL_t;
+
+/* Interrupt Mode select */
+typedef enum AC_INTMODE_WINDOW_enum
+{
+    AC_INTMODE_WINDOW_ABOVE_gc = (0x00<<4),  /* Window interrupt when input above both references */
+    AC_INTMODE_WINDOW_INSIDE_gc = (0x01<<4),  /* Window interrupt when input betweeen references */
+    AC_INTMODE_WINDOW_BELOW_gc = (0x02<<4),  /* Window interrupt when input below both references */
+    AC_INTMODE_WINDOW_OUTSIDE_gc = (0x03<<4)  /* Window interrupt when input outside reference */
+} AC_INTMODE_WINDOW_t;
+
+/* Negative Input MUX Selection */
+typedef enum AC_MUXNEG_enum
+{
+    AC_MUXNEG_AINN0_gc = (0x00<<0),  /* Negative Pin 0 */
+    AC_MUXNEG_AINN1_gc = (0x01<<0),  /* Negative Pin 1 */
+    AC_MUXNEG_AINN2_gc = (0x02<<0),  /* Negative Pin 2 */
+    AC_MUXNEG_AINN3_gc = (0x03<<0),  /* Negative Pin 3 */
+    AC_MUXNEG_DACREF_gc = (0x04<<0)  /* DAC Reference */
+} AC_MUXNEG_t;
+
+/* Positive Input MUX Selection */
+typedef enum AC_MUXPOS_enum
+{
+    AC_MUXPOS_AINP0_gc = (0x00<<3),  /* Positive Pin 0 */
+    AC_MUXPOS_AINP1_gc = (0x01<<3),  /* Positive Pin 1 */
+    AC_MUXPOS_AINP2_gc = (0x02<<3),  /* Positive Pin 2 */
+    AC_MUXPOS_AINP3_gc = (0x03<<3),  /* Positive Pin 3 */
+    AC_MUXPOS_AINP4_gc = (0x04<<3),  /* Positive Pin 4 */
+    AC_MUXPOS_AINP5_gc = (0x05<<3),  /* Positive Pin 5 */
+    AC_MUXPOS_AINP6_gc = (0x06<<3)  /* Positive Pin 6 */
+} AC_MUXPOS_t;
+
+/* Power profile select */
+typedef enum AC_POWER_enum
+{
+    AC_POWER_PROFILE0_gc = (0x00<<3),  /* Power profile 0, Fastest response time, highest consumption */
+    AC_POWER_PROFILE1_gc = (0x01<<3)  /* Power profile 1 */
+} AC_POWER_t;
+
+/* Window selection mode */
+typedef enum AC_WINSEL_enum
+{
+    AC_WINSEL_DISABLED_gc = (0x00<<0),  /* Window function disabled */
+    AC_WINSEL_UPSEL1_gc = (0x01<<0)  /* Select ACn+1 as upper limit in window compare */
+} AC_WINSEL_t;
+
+/* Analog Comparator Window State select */
+typedef enum AC_WINSTATE_enum
+{
+    AC_WINSTATE_ABOVE_gc = (0x00<<6),  /* Above window */
+    AC_WINSTATE_INSIDE_gc = (0x01<<6),  /* Inside window */
+    AC_WINSTATE_BELOW_gc = (0x02<<6)  /* Below window */
+} AC_WINSTATE_t;
+
+/*
+--------------------------------------------------------------------------
+ADC - Analog to Digital Converter
+--------------------------------------------------------------------------
+*/
+
+/* Analog to Digital Converter */
+typedef struct ADC_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    register8_t CTRLD;  /* Control D */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t STATUS;  /* Status register */
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t CTRLE;  /* Control E */
+    register8_t CTRLF;  /* Control F */
+    register8_t COMMAND;  /* Command register */
+    register8_t PGACTRL;  /* PGA Control */
+    register8_t MUXPOS;  /* Positive Input Multiplexer */
+    register8_t MUXNEG;  /* Negative Input Multiplexer */
+    register8_t reserved_1[2];
+    _DWORDREGISTER(RESULT);  /* Result */
+    _WORDREGISTER(SAMPLE);  /* Sample */
+    register8_t reserved_2[2];
+    register8_t TEMP0;  /* Temporary Data 0 */
+    register8_t TEMP1;  /* Temporary Data 1 */
+    register8_t TEMP2;  /* Temporary Data 2 */
+    register8_t reserved_3[1];
+    _WORDREGISTER(WINLT);  /* Window Low Threshold */
+    _WORDREGISTER(WINHT);  /* Window High Threshold */
+    register8_t reserved_4[32];
+} ADC_t;
+
+/* Sign Chopping select */
+typedef enum ADC_CHOPPING_enum
+{
+    ADC_CHOPPING_DISABLE_gc = (0x00<<6),  /* Sign Chopping Disabled */
+    ADC_CHOPPING_ENABLE_gc = (0x01<<6)  /* Sign Chopping Enabled */
+} ADC_CHOPPING_t;
+
+/* Gain select */
+typedef enum ADC_GAIN_enum
+{
+    ADC_GAIN_1X_gc = (0x00<<5),  /* 1x gain */
+    ADC_GAIN_2X_gc = (0x01<<5),  /* 2x gain */
+    ADC_GAIN_4X_gc = (0x02<<5),  /* 4x gain */
+    ADC_GAIN_8X_gc = (0x03<<5),  /* 8x gain */
+    ADC_GAIN_16X_gc = (0x04<<5)  /* 16x gain */
+} ADC_GAIN_t;
+
+/* Mode select */
+typedef enum ADC_MODE_enum
+{
+    ADC_MODE_SINGLE_8BIT_gc = (0x00<<4),  /* Single Conversion with 8-bit resolution */
+    ADC_MODE_SINGLE_12BIT_gc = (0x01<<4),  /* Single Conversion with 12-bit resolution */
+    ADC_MODE_SERIES_gc = (0x02<<4),  /* Series with accumulation, separate trigger for every 12-bit conversion */
+    ADC_MODE_SERIES_SCALING_gc = (0x03<<4),  /* Series with accumulation and scaling, separate trigger for every 12-bit conversion */
+    ADC_MODE_BURST_gc = (0x04<<4),  /* Burst with accumulation, one trigger will run SAMPNUM 12-bit conversions */
+    ADC_MODE_BURST_SCALING_gc = (0x05<<4)  /* Burst with accumulation and scaling, one trigger will run SAMPNUM 12-bit conversions */
+} ADC_MODE_t;
+
+/* Analog Channel Selection Bits */
+typedef enum ADC_MUXNEG_enum
+{
+    ADC_MUXNEG_AIN0_gc = (0x00<<0),  /* ADC input pin 0 */
+    ADC_MUXNEG_AIN1_gc = (0x01<<0),  /* ADC input pin 1 */
+    ADC_MUXNEG_AIN2_gc = (0x02<<0),  /* ADC input pin 2 */
+    ADC_MUXNEG_AIN3_gc = (0x03<<0),  /* ADC input pin 3 */
+    ADC_MUXNEG_AIN4_gc = (0x04<<0),  /* ADC input pin 4 */
+    ADC_MUXNEG_AIN5_gc = (0x05<<0),  /* ADC input pin 5 */
+    ADC_MUXNEG_AIN6_gc = (0x06<<0),  /* ADC input pin 6 */
+    ADC_MUXNEG_AIN7_gc = (0x07<<0),  /* ADC input pin 7 */
+    ADC_MUXNEG_AIN16_gc = (0x10<<0),  /* ADC input pin 16 */
+    ADC_MUXNEG_AIN17_gc = (0x11<<0),  /* ADC input pin 17 */
+    ADC_MUXNEG_AIN22_gc = (0x16<<0),  /* ADC input pin 22 */
+    ADC_MUXNEG_AIN23_gc = (0x17<<0),  /* ADC input pin 23 */
+    ADC_MUXNEG_AIN24_gc = (0x18<<0),  /* ADC input pin 24 */
+    ADC_MUXNEG_AIN25_gc = (0x19<<0),  /* ADC input pin 25 */
+    ADC_MUXNEG_AIN26_gc = (0x1A<<0),  /* ADC input pin 26 */
+    ADC_MUXNEG_AIN27_gc = (0x1B<<0),  /* ADC input pin 27 */
+    ADC_MUXNEG_AIN28_gc = (0x1C<<0),  /* ADC input pin 28 */
+    ADC_MUXNEG_AIN29_gc = (0x1D<<0),  /* ADC input pin 29 */
+    ADC_MUXNEG_AIN30_gc = (0x1E<<0),  /* ADC input pin 30 */
+    ADC_MUXNEG_AIN31_gc = (0x1F<<0),  /* ADC input pin 31 */
+    ADC_MUXNEG_GND_gc = (0x30<<0),  /* Ground */
+    ADC_MUXNEG_DAC0_gc = (0x38<<0),  /* Digital to Analog Converter 0 */
+    ADC_MUXNEG_DACREF0_gc = (0x39<<0),  /* AC0 DAC reference */
+    ADC_MUXNEG_DACREF1_gc = (0x3A<<0)  /* AC1 DAC reference */
+} ADC_MUXNEG_t;
+
+/* Analog Channel Selection Bits */
+typedef enum ADC_MUXPOS_enum
+{
+    ADC_MUXPOS_AIN0_gc = (0x00<<0),  /* ADC input pin 0 */
+    ADC_MUXPOS_AIN1_gc = (0x01<<0),  /* ADC input pin 1 */
+    ADC_MUXPOS_AIN2_gc = (0x02<<0),  /* ADC input pin 2 */
+    ADC_MUXPOS_AIN3_gc = (0x03<<0),  /* ADC input pin 3 */
+    ADC_MUXPOS_AIN4_gc = (0x04<<0),  /* ADC input pin 4 */
+    ADC_MUXPOS_AIN5_gc = (0x05<<0),  /* ADC input pin 5 */
+    ADC_MUXPOS_AIN6_gc = (0x06<<0),  /* ADC input pin 6 */
+    ADC_MUXPOS_AIN7_gc = (0x07<<0),  /* ADC input pin 7 */
+    ADC_MUXPOS_AIN16_gc = (0x10<<0),  /* ADC input pin 16 */
+    ADC_MUXPOS_AIN17_gc = (0x11<<0),  /* ADC input pin 17 */
+    ADC_MUXPOS_AIN22_gc = (0x16<<0),  /* ADC input pin 22 */
+    ADC_MUXPOS_AIN23_gc = (0x17<<0),  /* ADC input pin 23 */
+    ADC_MUXPOS_AIN24_gc = (0x18<<0),  /* ADC input pin 24 */
+    ADC_MUXPOS_AIN25_gc = (0x19<<0),  /* ADC input pin 25 */
+    ADC_MUXPOS_AIN26_gc = (0x1A<<0),  /* ADC input pin 26 */
+    ADC_MUXPOS_AIN27_gc = (0x1B<<0),  /* ADC input pin 27 */
+    ADC_MUXPOS_AIN28_gc = (0x1C<<0),  /* ADC input pin 28 */
+    ADC_MUXPOS_AIN29_gc = (0x1D<<0),  /* ADC input pin 29 */
+    ADC_MUXPOS_AIN30_gc = (0x1E<<0),  /* ADC input pin 30 */
+    ADC_MUXPOS_AIN31_gc = (0x1F<<0),  /* ADC input pin 31 */
+    ADC_MUXPOS_GND_gc = (0x30<<0),  /* Ground */
+    ADC_MUXPOS_VDD10_gc = (0x31<<0),  /* VDD Divided by 10 */
+    ADC_MUXPOS_TEMPSENSE_gc = (0x32<<0)  /* Temperature Sensor */
+} ADC_MUXPOS_t;
+
+/* PGA BIAS Select */
+typedef enum ADC_PGABIASSEL_enum
+{
+    ADC_PGABIASSEL_100PCT_gc = (0x00<<3),  /* 100% BIAS current. */
+    ADC_PGABIASSEL_75PCT_gc = (0x01<<3),  /* 75% BIAS current. Usable for CLK_ADC<4.5MHz */
+    ADC_PGABIASSEL_50PCT_gc = (0x02<<3),  /* 50% BIAS current. Usable for CLK_ADC<3MHz */
+    ADC_PGABIASSEL_25PCT_gc = (0x03<<3)  /* 25% BIAS current. Usable for CLK_ADC<1.5MHz */
+} ADC_PGABIASSEL_t;
+
+/* Prescaler Value select */
+typedef enum ADC_PRESC_enum
+{
+    ADC_PRESC_DIV2_gc = (0x00<<0),  /* System clock divided by 2 */
+    ADC_PRESC_DIV4_gc = (0x01<<0),  /* System clock divided by 4 */
+    ADC_PRESC_DIV6_gc = (0x02<<0),  /* System clock divided by 6 */
+    ADC_PRESC_DIV8_gc = (0x03<<0),  /* System clock divided by 8 */
+    ADC_PRESC_DIV10_gc = (0x04<<0),  /* System clock divided by 10 */
+    ADC_PRESC_DIV12_gc = (0x05<<0),  /* System clock divided by 12 */
+    ADC_PRESC_DIV14_gc = (0x06<<0),  /* System clock divided by 14 */
+    ADC_PRESC_DIV16_gc = (0x07<<0),  /* System clock divided by 16 */
+    ADC_PRESC_DIV20_gc = (0x08<<0),  /* System clock divided by 20 */
+    ADC_PRESC_DIV24_gc = (0x09<<0),  /* System clock divided by 24 */
+    ADC_PRESC_DIV28_gc = (0x0A<<0),  /* System clock divided by 28 */
+    ADC_PRESC_DIV32_gc = (0x0B<<0),  /* System clock divided by 32 */
+    ADC_PRESC_DIV40_gc = (0x0C<<0),  /* System clock divided by 40 */
+    ADC_PRESC_DIV48_gc = (0x0D<<0),  /* System clock divided by 48 */
+    ADC_PRESC_DIV56_gc = (0x0E<<0),  /* System clock divided by 56 */
+    ADC_PRESC_DIV64_gc = (0x0F<<0)  /* System clock divided by 64 */
+} ADC_PRESC_t;
+
+/* Reference select */
+typedef enum ADC_REFSEL_enum
+{
+    ADC_REFSEL_VDD_gc = (0x00<<0),  /* VDD */
+    ADC_REFSEL_VREFA_gc = (0x02<<0),  /* External Reference */
+    ADC_REFSEL_1V024_gc = (0x04<<0),  /* Internal 1.024V Reference */
+    ADC_REFSEL_2V048_gc = (0x05<<0),  /* Internal 2.048V Reference */
+    ADC_REFSEL_4V096_gc = (0x06<<0),  /* Internal 4.096V Reference */
+    ADC_REFSEL_2V500_gc = (0x07<<0)  /* Internal 2.500V Reference */
+} ADC_REFSEL_t;
+
+/* Sample numbers select */
+typedef enum ADC_SAMPNUM_enum
+{
+    ADC_SAMPNUM_NONE_gc = (0x00<<0),  /* No accumulation */
+    ADC_SAMPNUM_ACC2_gc = (0x01<<0),  /* 2 samples accumulated */
+    ADC_SAMPNUM_ACC4_gc = (0x02<<0),  /* 4 samples accumulated */
+    ADC_SAMPNUM_ACC8_gc = (0x03<<0),  /* 8 samples accumulated */
+    ADC_SAMPNUM_ACC16_gc = (0x04<<0),  /* 16 samples accumulated */
+    ADC_SAMPNUM_ACC32_gc = (0x05<<0),  /* 32 samples accumulated */
+    ADC_SAMPNUM_ACC64_gc = (0x06<<0),  /* 64 samples accumulated */
+    ADC_SAMPNUM_ACC128_gc = (0x07<<0),  /* 128 samples accumulated */
+    ADC_SAMPNUM_ACC256_gc = (0x08<<0),  /* 256 samples accumulated */
+    ADC_SAMPNUM_ACC512_gc = (0x09<<0),  /* 512 samples accumulated */
+    ADC_SAMPNUM_ACC1024_gc = (0x0A<<0)  /* 1024 samples accumulated */
+} ADC_SAMPNUM_t;
+
+/* Start command select */
+typedef enum ADC_START_enum
+{
+    ADC_START_STOP_gc = (0x00<<0),  /* Stop an ongoing conversion */
+    ADC_START_IMMEDIATE_gc = (0x01<<0),  /* Start a conversion immediately. This will be set back to STOP when the first conversion is done, unless Free-Running mode is enabled */
+    ADC_START_MUXPOS_WRITE_gc = (0x02<<0),  /* Start when MUXPOS register is written */
+    ADC_START_MUXNEG_WRITE_gc = (0x03<<0),  /* Start when MUXNEG register is written */
+    ADC_START_EVENT_TRIGGER_gc = (0x04<<0)  /* Start when an event is received */
+} ADC_START_t;
+
+/* VIA select */
+typedef enum ADC_VIA_enum
+{
+    ADC_VIA_DIRECT_gc = (0x00<<6),  /* Inputs connected directly to ADC */
+    ADC_VIA_PGA_gc = (0x01<<6)  /* Inputs connected via PGA */
+} ADC_VIA_t;
+
+/* Window Comparator Mode select */
+typedef enum ADC_WINCM_enum
+{
+    ADC_WINCM_NONE_gc = (0x00<<0),  /* No Window Comparison */
+    ADC_WINCM_BELOW_gc = (0x01<<0),  /* Below Window */
+    ADC_WINCM_ABOVE_gc = (0x02<<0),  /* Above Window */
+    ADC_WINCM_INSIDE_gc = (0x03<<0),  /* Inside Window */
+    ADC_WINCM_OUTSIDE_gc = (0x04<<0)  /* Outside Window */
+} ADC_WINCM_t;
+
+/* Window Mode Source select */
+typedef enum ADC_WINSRC_enum
+{
+    ADC_WINSRC_RESULT_gc = (0x00<<3),  /* Result register used as Window Comparator Source */
+    ADC_WINSRC_SAMPLE_gc = (0x01<<3)  /* Sample register used as Window Comparator Source */
+} ADC_WINSRC_t;
+
+/*
+--------------------------------------------------------------------------
+BOD - Bod interface
+--------------------------------------------------------------------------
+*/
+
+/* Bod interface */
+typedef struct BOD_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t reserved_1[6];
+    register8_t VLMCTRLA;  /* Voltage level monitor Control */
+    register8_t INTCTRL;  /* Voltage level monitor interrupt Control */
+    register8_t INTFLAGS;  /* Voltage level monitor interrupt Flags */
+    register8_t STATUS;  /* Voltage level monitor status */
+    register8_t reserved_2[4];
+} BOD_t;
+
+/* Operation in active mode select */
+typedef enum BOD_ACTIVE_enum
+{
+    BOD_ACTIVE_DISABLE_gc = (0x00<<2),  /* Disabled */
+    BOD_ACTIVE_ENABLED_gc = (0x01<<2),  /* Enabled in continuous mode */
+    BOD_ACTIVE_SAMPLED_gc = (0x02<<2),  /* Enabled in sampled mode */
+    BOD_ACTIVE_ENABLEWAIT_gc = (0x03<<2)  /* Enabled in continuous mode. Execution halted at wake-up until BOD is running */
+} BOD_ACTIVE_t;
+
+/* Bod level select */
+typedef enum BOD_LVL_enum
+{
+    BOD_LVL_BODLEVEL0_gc = (0x00<<0),  /* BOD Disabled during normal operation */
+    BOD_LVL_BODLEVEL1_gc = (0x01<<0),  /* 1.9 V */
+    BOD_LVL_BODLEVEL2_gc = (0x02<<0),  /* 2.7 V */
+    BOD_LVL_BODLEVEL3_gc = (0x03<<0)  /* 4.5 V */
+} BOD_LVL_t;
+
+/* Sample frequency select */
+typedef enum BOD_SAMPFREQ_enum
+{
+    BOD_SAMPFREQ_128HZ_gc = (0x00<<4),  /* Sampling frequency is 128 Hz */
+    BOD_SAMPFREQ_32HZ_gc = (0x01<<4)  /* Sample frequency is 32 Hz */
+} BOD_SAMPFREQ_t;
+
+/* Operation in sleep mode select */
+typedef enum BOD_SLEEP_enum
+{
+    BOD_SLEEP_DISABLE_gc = (0x00<<0),  /* Disabled */
+    BOD_SLEEP_ENABLE_gc = (0x01<<0),  /* Enabled in continuous mode */
+    BOD_SLEEP_SAMPLE_gc = (0x02<<0)  /* Enabled in sampled mode */
+} BOD_SLEEP_t;
+
+/* Configuration select */
+typedef enum BOD_VLMCFG_enum
+{
+    BOD_VLMCFG_FALLING_gc = (0x00<<1),  /* VDD falls below VLM threshold */
+    BOD_VLMCFG_RISING_gc = (0x01<<1),  /* VDD rises above VLM threshold */
+    BOD_VLMCFG_BOTH_gc = (0x02<<1)  /* VDD crosses VLM threshold */
+} BOD_VLMCFG_t;
+
+/* voltage level monitor level select */
+typedef enum BOD_VLMLVL_enum
+{
+    BOD_VLMLVL_OFF_gc = (0x00<<0),  /* VLM Disabled */
+    BOD_VLMLVL_5ABOVE_gc = (0x01<<0),  /* VLM threshold 5% above BOD level */
+    BOD_VLMLVL_15ABOVE_gc = (0x02<<0),  /* VLM threshold 15% above BOD level */
+    BOD_VLMLVL_25ABOVE_gc = (0x03<<0)  /* VLM threshold 25% above BOD level */
+} BOD_VLMLVL_t;
+
+/* Voltage level monitor status select */
+typedef enum BOD_VLMS_enum
+{
+    BOD_VLMS_ABOVE_gc = (0x00<<0),  /* The voltage is above the VLM threshold level */
+    BOD_VLMS_BELOW_gc = (0x01<<0)  /* The voltage is below the VLM threshold level */
+} BOD_VLMS_t;
+
+/*
+--------------------------------------------------------------------------
+BOOTROW - Boot Row
+--------------------------------------------------------------------------
+*/
+
+/* Boot Row */
+typedef struct BOOTROW_struct
+{
+    register8_t BOOTROW[64];  /* Boot Row */
+} BOOTROW_t;
+
+
+/*
+--------------------------------------------------------------------------
+CCL - Configurable Custom Logic
+--------------------------------------------------------------------------
+*/
+
+/* Configurable Custom Logic */
+typedef struct CCL_struct
+{
+    register8_t CTRLA;  /* Control Register A */
+    register8_t SEQCTRL0;  /* Sequential Control 0 */
+    register8_t SEQCTRL1;  /* Sequential Control 1 */
+    register8_t reserved_1[2];
+    register8_t INTCTRL0;  /* Interrupt Control 0 */
+    register8_t reserved_2[1];
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t LUT0CTRLA;  /* LUT 0 Control A */
+    register8_t LUT0CTRLB;  /* LUT 0 Control B */
+    register8_t LUT0CTRLC;  /* LUT 0 Control C */
+    register8_t TRUTH0;  /* Truth 0 */
+    register8_t LUT1CTRLA;  /* LUT 1 Control A */
+    register8_t LUT1CTRLB;  /* LUT 1 Control B */
+    register8_t LUT1CTRLC;  /* LUT 1 Control C */
+    register8_t TRUTH1;  /* Truth 1 */
+    register8_t LUT2CTRLA;  /* LUT 2 Control A */
+    register8_t LUT2CTRLB;  /* LUT 2 Control B */
+    register8_t LUT2CTRLC;  /* LUT 2 Control C */
+    register8_t TRUTH2;  /* Truth 2 */
+    register8_t LUT3CTRLA;  /* LUT 3 Control A */
+    register8_t LUT3CTRLB;  /* LUT 3 Control B */
+    register8_t LUT3CTRLC;  /* LUT 3 Control C */
+    register8_t TRUTH3;  /* Truth 3 */
+    register8_t reserved_3[40];
+} CCL_t;
+
+/* Clock Source Selection */
+typedef enum CCL_CLKSRC_enum
+{
+    CCL_CLKSRC_CLKPER_gc = (0x00<<1),  /* Peripheral Clock */
+    CCL_CLKSRC_IN2_gc = (0x01<<1),  /* INSEL2 selection */
+    CCL_CLKSRC_OSCHF_gc = (0x04<<1),  /* Internal High Frequency oscillator */
+    CCL_CLKSRC_OSC32K_gc = (0x05<<1),  /* Internal 32.768 kHz oscillator */
+    CCL_CLKSRC_OSC1K_gc = (0x06<<1),  /* Internal 32.768 kHz oscillator divided by 32 */
+    CCL_CLKSRC_PLL_gc = (0x07<<1)  /* PLL */
+} CCL_CLKSRC_t;
+
+/* Edge Detection Enable select */
+typedef enum CCL_EDGEDET_enum
+{
+    CCL_EDGEDET_DIS_gc = (0x00<<7),  /* Edge detector is disabled */
+    CCL_EDGEDET_EN_gc = (0x01<<7)  /* Edge detector is enabled */
+} CCL_EDGEDET_t;
+
+/* Filter Selection */
+typedef enum CCL_FILTSEL_enum
+{
+    CCL_FILTSEL_DISABLE_gc = (0x00<<4),  /* Filter disabled */
+    CCL_FILTSEL_SYNCH_gc = (0x01<<4),  /* Synchronizer enabled */
+    CCL_FILTSEL_FILTER_gc = (0x02<<4)  /* Filter enabled */
+} CCL_FILTSEL_t;
+
+/* LUT Input 0 Source Selection */
+typedef enum CCL_INSEL0_enum
+{
+    CCL_INSEL0_MASK_gc = (0x00<<0),  /* Masked input */
+    CCL_INSEL0_FEEDBACK_gc = (0x01<<0),  /* Feedback input */
+    CCL_INSEL0_LINK_gc = (0x02<<0),  /* Output from LUT[n+1] as input source */
+    CCL_INSEL0_EVENTA_gc = (0x03<<0),  /* Event A as input source */
+    CCL_INSEL0_EVENTB_gc = (0x04<<0),  /* Event B as input source */
+    CCL_INSEL0_IN0_gc = (0x05<<0),  /* IN0 input source */
+    CCL_INSEL0_AC0_gc = (0x06<<0),  /* AC0 output input source */
+    CCL_INSEL0_USART0_gc = (0x07<<0),  /* USART0 TxD input source */
+    CCL_INSEL0_SPI0_gc = (0x08<<0),  /* SPI0 MOSI input source */
+    CCL_INSEL0_TCE0_gc = (0x09<<0),  /* TCE0 WO0 input source */
+    CCL_INSEL0_TCB0_gc = (0x0A<<0),  /* TCB0 WO input source */
+    CCL_INSEL0_TCF0_gc = (0x0B<<0),  /* TCF0 WO0 input source */
+    CCL_INSEL0_WEX0_gc = (0x0C<<0)  /* Blanking input source */
+} CCL_INSEL0_t;
+
+/* LUT Input 1 Source Selection */
+typedef enum CCL_INSEL1_enum
+{
+    CCL_INSEL1_MASK_gc = (0x00<<4),  /* Masked input */
+    CCL_INSEL1_FEEDBACK_gc = (0x01<<4),  /* Feedback input */
+    CCL_INSEL1_LINK_gc = (0x02<<4),  /* Output from LUT[n+1] as input source */
+    CCL_INSEL1_EVENTA_gc = (0x03<<4),  /* Event A as input source */
+    CCL_INSEL1_EVENTB_gc = (0x04<<4),  /* Event B as input source */
+    CCL_INSEL1_IN1_gc = (0x05<<4),  /* IN1 input source */
+    CCL_INSEL1_AC1_gc = (0x06<<4),  /* AC1 output input source */
+    CCL_INSEL1_USART0_gc = (0x07<<4),  /* USART0 TxD input source */
+    CCL_INSEL1_SPI0_gc = (0x08<<4),  /* SPI0 MOSI input source */
+    CCL_INSEL1_TCE0_gc = (0x09<<4),  /* TCE0 WO1 input source */
+    CCL_INSEL1_TCB1_gc = (0x0A<<4),  /* TCB1 WO input source */
+    CCL_INSEL1_TCF0_gc = (0x0B<<4),  /* TCF0 WO1 input source */
+    CCL_INSEL1_WEX0_gc = (0x0C<<4)  /* Blanking input source */
+} CCL_INSEL1_t;
+
+/* LUT Input 2 Source Selection */
+typedef enum CCL_INSEL2_enum
+{
+    CCL_INSEL2_MASK_gc = (0x00<<0),  /* Masked input */
+    CCL_INSEL2_FEEDBACK_gc = (0x01<<0),  /* Feedback input */
+    CCL_INSEL2_LINK_gc = (0x02<<0),  /* Output from LUT[n+1] as input source */
+    CCL_INSEL2_EVENTA_gc = (0x03<<0),  /* Event A as input source */
+    CCL_INSEL2_EVENTB_gc = (0x04<<0),  /* Event B as input source */
+    CCL_INSEL2_IN2_gc = (0x05<<0),  /* IN2 input source */
+    CCL_INSEL2_AC1_gc = (0x06<<0),  /* AC1 output input source */
+    CCL_INSEL2_USART0_gc = (0x07<<0),  /* USART0 TxD input source */
+    CCL_INSEL2_SPI0_gc = (0x08<<0),  /* SPI0 SCK input source */
+    CCL_INSEL2_TCE0_gc = (0x09<<0),  /* TCE0 WO2 input source */
+    CCL_INSEL2_TCB1_gc = (0x0A<<0),  /* TCB1 WO input source */
+    CCL_INSEL2_TCF0_gc = (0x0B<<0),  /* TCF0 WO0 input source */
+    CCL_INSEL2_WEX0_gc = (0x0C<<0)  /* Blanking input source */
+} CCL_INSEL2_t;
+
+/* Interrupt Mode for LUT0 select */
+typedef enum CCL_INTMODE0_enum
+{
+    CCL_INTMODE0_INTDISABLE_gc = (0x00<<0),  /* Interrupt disabled */
+    CCL_INTMODE0_RISING_gc = (0x01<<0),  /* Sense rising edge */
+    CCL_INTMODE0_FALLING_gc = (0x02<<0),  /* Sense falling edge */
+    CCL_INTMODE0_BOTH_gc = (0x03<<0)  /* Sense both edges */
+} CCL_INTMODE0_t;
+
+/* Interrupt Mode for LUT1 select */
+typedef enum CCL_INTMODE1_enum
+{
+    CCL_INTMODE1_INTDISABLE_gc = (0x00<<2),  /* Interrupt disabled */
+    CCL_INTMODE1_RISING_gc = (0x01<<2),  /* Sense rising edge */
+    CCL_INTMODE1_FALLING_gc = (0x02<<2),  /* Sense falling edge */
+    CCL_INTMODE1_BOTH_gc = (0x03<<2)  /* Sense both edges */
+} CCL_INTMODE1_t;
+
+/* Interrupt Mode for LUT2 select */
+typedef enum CCL_INTMODE2_enum
+{
+    CCL_INTMODE2_INTDISABLE_gc = (0x00<<4),  /* Interrupt disabled */
+    CCL_INTMODE2_RISING_gc = (0x01<<4),  /* Sense rising edge */
+    CCL_INTMODE2_FALLING_gc = (0x02<<4),  /* Sense falling edge */
+    CCL_INTMODE2_BOTH_gc = (0x03<<4)  /* Sense both edges */
+} CCL_INTMODE2_t;
+
+/* Interrupt Mode for LUT3 select */
+typedef enum CCL_INTMODE3_enum
+{
+    CCL_INTMODE3_INTDISABLE_gc = (0x00<<6),  /* Interrupt disabled */
+    CCL_INTMODE3_RISING_gc = (0x01<<6),  /* Sense rising edge */
+    CCL_INTMODE3_FALLING_gc = (0x02<<6),  /* Sense falling edge */
+    CCL_INTMODE3_BOTH_gc = (0x03<<6)  /* Sense both edges */
+} CCL_INTMODE3_t;
+
+/* Sequential Selection */
+typedef enum CCL_SEQSEL_enum
+{
+    CCL_SEQSEL_DISABLE_gc = (0x00<<0),  /* Sequential logic disabled */
+    CCL_SEQSEL_DFF_gc = (0x01<<0),  /* D FlipFlop */
+    CCL_SEQSEL_JK_gc = (0x02<<0),  /* JK FlipFlop */
+    CCL_SEQSEL_LATCH_gc = (0x03<<0),  /* D Latch */
+    CCL_SEQSEL_RS_gc = (0x04<<0)  /* RS Latch */
+} CCL_SEQSEL_t;
+
+/*
+--------------------------------------------------------------------------
+CLKCTRL - Clock controller
+--------------------------------------------------------------------------
+*/
+
+/* Clock controller */
+typedef struct CLKCTRL_struct
+{
+    register8_t MCLKCTRLA;  /* MCLK Control A */
+    register8_t MCLKCTRLB;  /* MCLK Control B */
+    register8_t reserved_1[3];
+    register8_t MCLKSTATUS;  /* MCLK Status */
+    register8_t MCLKTIMEBASE;  /* MCLK Timebase */
+    register8_t reserved_2[1];
+    register8_t OSCHFCTRLA;  /* OSCHF Control A */
+    register8_t OSCHFTUNE;  /* OSCHF Tune */
+    register8_t reserved_3[6];
+    register8_t PLLCTRLA;  /* PLL Control A */
+    register8_t PLLCTRLB;  /* PLL Control B */
+    register8_t reserved_4[6];
+    register8_t OSC32KCTRLA;  /* OSC32K Control A */
+    register8_t reserved_5[3];
+    register8_t XOSC32KCTRLA;  /* XOSC32K Control A */
+    register8_t reserved_6[35];
+} CLKCTRL_t;
+
+/* Automatic Oscillator Tune select */
+typedef enum CLKCTRL_AUTOTUNE_enum
+{
+    CLKCTRL_AUTOTUNE_OFF_gc = (0x00<<0),  /* Disabled */
+    CLKCTRL_AUTOTUNE_XOSC32K_gc = (0x01<<0)  /* Tune against 32.768 kHz Crystal Oscillator */
+} CLKCTRL_AUTOTUNE_t;
+
+/* PLL Output Clock Division select */
+typedef enum CLKCTRL_CLKDIV_enum
+{
+    CLKCTRL_CLKDIV_NONE_gc = (0x00<<0),  /* PLL output clock undivided */
+    CLKCTRL_CLKDIV_DIV2_gc = (0x01<<0)  /* PLL output clock divided by 2 */
+} CLKCTRL_CLKDIV_t;
+
+/* Clock select */
+typedef enum CLKCTRL_CLKSEL_enum
+{
+    CLKCTRL_CLKSEL_OSCHF_gc = (0x00<<0),  /* Internal high-frequency oscillator */
+    CLKCTRL_CLKSEL_OSC32K_gc = (0x01<<0),  /* Internal 32.768 kHz oscillator */
+    CLKCTRL_CLKSEL_XOSC32K_gc = (0x02<<0),  /* 32.768 kHz crystal oscillator */
+    CLKCTRL_CLKSEL_EXTCLK_gc = (0x03<<0),  /* External clock */
+    CLKCTRL_CLKSEL_PLL_gc = (0x04<<0)  /* PLL Oscillator */
+} CLKCTRL_CLKSEL_t;
+
+/* Crystal startup time select */
+typedef enum CLKCTRL_CSUT_enum
+{
+    CLKCTRL_CSUT_1K_gc = (0x00<<4),  /* 1k cycles */
+    CLKCTRL_CSUT_16K_gc = (0x01<<4),  /* 16k cycles */
+    CLKCTRL_CSUT_32K_gc = (0x02<<4),  /* 32k cycles */
+    CLKCTRL_CSUT_64K_gc = (0x03<<4)  /* 64k cycles */
+} CLKCTRL_CSUT_t;
+
+/* PLL Multiplication Factor select */
+typedef enum CLKCTRL_MULFAC_enum
+{
+    CLKCTRL_MULFAC_OFF_gc = (0x00<<0),  /* PLL Disabled */
+    CLKCTRL_MULFAC_8X_gc = (0x02<<0),  /* Multiply by 8 */
+    CLKCTRL_MULFAC_16X_gc = (0x03<<0)  /* Multiply by 16 */
+} CLKCTRL_MULFAC_t;
+
+/* Prescaler B division select */
+typedef enum CLKCTRL_PBDIV_enum
+{
+    CLKCTRL_PBDIV_NONE_gc = (0x00<<5),  /* No division */
+    CLKCTRL_PBDIV_DIV4_gc = (0x01<<5)  /* Divide by 4 */
+} CLKCTRL_PBDIV_t;
+
+/* Prescaler division select */
+typedef enum CLKCTRL_PDIV_enum
+{
+    CLKCTRL_PDIV_DIV2_gc = (0x00<<1),  /* Divide by 2 */
+    CLKCTRL_PDIV_DIV4_gc = (0x01<<1),  /* Divide by 4 */
+    CLKCTRL_PDIV_DIV8_gc = (0x02<<1),  /* Divide by 8 */
+    CLKCTRL_PDIV_DIV16_gc = (0x03<<1),  /* Divide by 16 */
+    CLKCTRL_PDIV_DIV32_gc = (0x04<<1),  /* Divide by 32 */
+    CLKCTRL_PDIV_DIV64_gc = (0x05<<1),  /* Divide by 64 */
+    CLKCTRL_PDIV_DIV6_gc = (0x08<<1),  /* Divide by 6 */
+    CLKCTRL_PDIV_DIV10_gc = (0x09<<1),  /* Divide by 10 */
+    CLKCTRL_PDIV_DIV12_gc = (0x0A<<1),  /* Divide by 12 */
+    CLKCTRL_PDIV_DIV24_gc = (0x0B<<1),  /* Divide by 24 */
+    CLKCTRL_PDIV_DIV48_gc = (0x0C<<1)  /* Divide by 48 */
+} CLKCTRL_PDIV_t;
+
+/* PLL Source select */
+typedef enum CLKCTRL_SOURCE_enum
+{
+    CLKCTRL_SOURCE_OSCHF_gc = (0x00<<5),  /* Internal High Frequency Oscillator */
+    CLKCTRL_SOURCE_EXTCLK_gc = (0x01<<5)  /* External Clock */
+} CLKCTRL_SOURCE_t;
+
+/* PLL Source Division select */
+typedef enum CLKCTRL_SOURCEDIV_enum
+{
+    CLKCTRL_SOURCEDIV_DIV1_gc = (0x00<<3),  /* Source undivided */
+    CLKCTRL_SOURCEDIV_DIV2_gc = (0x01<<3),  /* Divide source by 2 */
+    CLKCTRL_SOURCEDIV_DIV4_gc = (0x02<<3),  /* Divide source by 4 */
+    CLKCTRL_SOURCEDIV_DIV6_gc = (0x03<<3)  /* Divide source by 6 */
+} CLKCTRL_SOURCEDIV_t;
+
+/*
+--------------------------------------------------------------------------
+CPU - CPU
+--------------------------------------------------------------------------
+*/
+
+#define CORE_VERSION  V4S
+
+/* CCP signature select */
+typedef enum CCP_enum
+{
+    CCP_SPM_gc = (0x9D<<0),  /* SPM Instruction Protection */
+    CCP_IOREG_gc = (0xD8<<0)  /* IO Register Protection */
+} CCP_t;
+
+/*
+--------------------------------------------------------------------------
+CPUINT - Interrupt Controller
+--------------------------------------------------------------------------
+*/
+
+/* Interrupt Controller */
+typedef struct CPUINT_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t STATUS;  /* Status */
+    register8_t LVL0PRI;  /* Interrupt Level 0 Priority */
+    register8_t LVL1VEC;  /* Interrupt Level 1 Priority Vector */
+} CPUINT_t;
+
+
+/*
+--------------------------------------------------------------------------
+CRCSCAN - CRCSCAN
+--------------------------------------------------------------------------
+*/
+
+/* CRCSCAN */
+typedef struct CRCSCAN_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t STATUS;  /* Status */
+    register8_t reserved_1[13];
+} CRCSCAN_t;
+
+/* CRC Source select */
+typedef enum CRCSCAN_SRC_enum
+{
+    CRCSCAN_SRC_FLASH_gc = (0x00<<0),  /* CRC on entire flash */
+    CRCSCAN_SRC_APPLICATION_gc = (0x01<<0),  /* CRC on boot and appl section of flash */
+    CRCSCAN_SRC_BOOT_gc = (0x02<<0)  /* CRC on boot section of flash */
+} CRCSCAN_SRC_t;
+
+/*
+--------------------------------------------------------------------------
+EVSYS - Event System
+--------------------------------------------------------------------------
+*/
+
+/* Event System */
+typedef struct EVSYS_struct
+{
+    register8_t SWEVENTA;  /* Software Event A */
+    register8_t reserved_1[15];
+    register8_t CHANNEL0;  /* Multiplexer Channel 0 */
+    register8_t CHANNEL1;  /* Multiplexer Channel 1 */
+    register8_t CHANNEL2;  /* Multiplexer Channel 2 */
+    register8_t CHANNEL3;  /* Multiplexer Channel 3 */
+    register8_t CHANNEL4;  /* Multiplexer Channel 4 */
+    register8_t CHANNEL5;  /* Multiplexer Channel 5 */
+    register8_t reserved_2[10];
+    register8_t USERCCLLUT0A;  /* CCL0 Event A */
+    register8_t USERCCLLUT0B;  /* CCL0 Event B */
+    register8_t USERCCLLUT1A;  /* CCL1 Event A */
+    register8_t USERCCLLUT1B;  /* CCL1 Event B */
+    register8_t USERCCLLUT2A;  /* CCL2 Event A */
+    register8_t USERCCLLUT2B;  /* CCL2 Event B */
+    register8_t USERCCLLUT3A;  /* CCL3 Event A */
+    register8_t USERCCLLUT3B;  /* CCL3 Event B */
+    register8_t USERADC0START;  /* ADC0 Start */
+    register8_t USEREVSYSEVOUTA;  /* EVOUTA */
+    register8_t USEREVSYSEVOUTC;  /* EVOUTC */
+    register8_t USEREVSYSEVOUTD;  /* EVOUTD */
+    register8_t USEREVSYSEVOUTF;  /* EVOUTF */
+    register8_t USERUSART0IRDA;  /* USART0 IrDA Event */
+    register8_t USERTCE0CNTA;  /* TCE0 Event A */
+    register8_t USERTCE0CNTB;  /* TCE0 Event B */
+    register8_t USERTCB0CAPT;  /* TCB0 Event A */
+    register8_t USERTCB0COUNT;  /* TCB0 Event B */
+    register8_t USERTCB1CAPT;  /* TCB1 Event A */
+    register8_t USERTCB1COUNT;  /* TCB1 Event B */
+    register8_t USERTCF0CNT;  /* TCF0 Clock Event */
+    register8_t USERTCF0ACT;  /* TCF0 Action Event */
+    register8_t USERWEXA;  /* WEX Event A */
+    register8_t USERWEXB;  /* WEX Event B */
+    register8_t USERWEXC;  /* WEX Event C */
+    register8_t reserved_3[7];
+} EVSYS_t;
+
+/* Channel generator select */
+typedef enum EVSYS_CHANNEL_enum
+{
+    EVSYS_CHANNEL_OFF_gc = (0x00<<0),  /* Off */
+    EVSYS_CHANNEL_UPDI_SYNCH_gc = (0x01<<0),  /* UPDI SYNCH character */
+    EVSYS_CHANNEL_RTC_OVF_gc = (0x06<<0),  /* Real Time Counter overflow */
+    EVSYS_CHANNEL_RTC_CMP_gc = (0x07<<0),  /* Real Time Counter compare */
+    EVSYS_CHANNEL_RTC_PITEV0_gc = (0x08<<0),  /* Periodic Interrupt Timer Event 0 */
+    EVSYS_CHANNEL_RTC_PITEV1_gc = (0x09<<0),  /* Periodic Interrupt Timer Event 1 */
+    EVSYS_CHANNEL_CCL_LUT0_gc = (0x10<<0),  /* Configurable Custom Logic LUT0 */
+    EVSYS_CHANNEL_CCL_LUT1_gc = (0x11<<0),  /* Configurable Custom Logic LUT1 */
+    EVSYS_CHANNEL_CCL_LUT2_gc = (0x12<<0),  /* Configurable Custom Logic LUT2 */
+    EVSYS_CHANNEL_CCL_LUT3_gc = (0x13<<0),  /* Configurable Custom Logic LUT3 */
+    EVSYS_CHANNEL_AC0_OUT_gc = (0x20<<0),  /* Analog Comparator 0 out */
+    EVSYS_CHANNEL_AC1_OUT_gc = (0x21<<0),  /* Analog Comparator 1 out */
+    EVSYS_CHANNEL_ADC0_RES_gc = (0x24<<0),  /* ADC 0 Result Ready */
+    EVSYS_CHANNEL_ADC0_SAMP_gc = (0x25<<0),  /* ADC 0 Sample Ready */
+    EVSYS_CHANNEL_ADC0_WCMP_gc = (0x26<<0),  /* ADC 0 Window Compare */
+    EVSYS_CHANNEL_PORTA_EV0_gc = (0x40<<0),  /* Port A Event 0 */
+    EVSYS_CHANNEL_PORTA_EV1_gc = (0x41<<0),  /* Port A Event 1 */
+    EVSYS_CHANNEL_PORTC_EV0_gc = (0x44<<0),  /* Port C Event 0 */
+    EVSYS_CHANNEL_PORTC_EV1_gc = (0x45<<0),  /* Port C Event 1 */
+    EVSYS_CHANNEL_PORTD_EV0_gc = (0x46<<0),  /* Port D Event 0 */
+    EVSYS_CHANNEL_PORTD_EV1_gc = (0x47<<0),  /* Port D Event 1 */
+    EVSYS_CHANNEL_PORTF_EV0_gc = (0x4A<<0),  /* Port F Event 0 */
+    EVSYS_CHANNEL_PORTF_EV1_gc = (0x4B<<0),  /* Port F Event 1 */
+    EVSYS_CHANNEL_USART0_XCK_gc = (0x60<<0),  /* USART 0 XCK */
+    EVSYS_CHANNEL_SPI0_SCK_gc = (0x68<<0),  /* SPI 0 SCK */
+    EVSYS_CHANNEL_TCE0_OVF_gc = (0x80<<0),  /* Timer/Counter E0 overflow */
+    EVSYS_CHANNEL_TCE0_CMP0_gc = (0x84<<0),  /* Timer/Counter E0 compare 0 */
+    EVSYS_CHANNEL_TCE0_CMP1_gc = (0x85<<0),  /* Timer/Counter E0 compare 1 */
+    EVSYS_CHANNEL_TCE0_CMP2_gc = (0x86<<0),  /* Timer/Counter E0 compare 2 */
+    EVSYS_CHANNEL_TCE0_CMP3_gc = (0x87<<0),  /* Timer/Counter E0 compare 3 */
+    EVSYS_CHANNEL_TCB0_CAPT_gc = (0xA0<<0),  /* Timer/Counter B0 capture */
+    EVSYS_CHANNEL_TCB0_OVF_gc = (0xA1<<0),  /* Timer/Counter B0 overflow */
+    EVSYS_CHANNEL_TCB1_CAPT_gc = (0xA2<<0),  /* Timer/Counter B1 capture */
+    EVSYS_CHANNEL_TCB1_OVF_gc = (0xA3<<0),  /* Timer/Counter B1 overflow */
+    EVSYS_CHANNEL_TCF0_OVF_gc = (0xB8<<0),  /* Timer/Counter F0 Overflow */
+    EVSYS_CHANNEL_TCF0_CMP0_gc = (0xB9<<0),  /* Timer/Counter F0 compare 0 */
+    EVSYS_CHANNEL_TCF0_CMP1_gc = (0xBA<<0)  /* Timer/Counter F0 compare 1 */
+} EVSYS_CHANNEL_t;
+
+/* Software event on channel select */
+typedef enum EVSYS_SWEVENTA_enum
+{
+    EVSYS_SWEVENTA_CH0_gc = (0x01<<0),  /* Software event on channel 0 */
+    EVSYS_SWEVENTA_CH1_gc = (0x02<<0),  /* Software event on channel 1 */
+    EVSYS_SWEVENTA_CH2_gc = (0x04<<0),  /* Software event on channel 2 */
+    EVSYS_SWEVENTA_CH3_gc = (0x08<<0),  /* Software event on channel 3 */
+    EVSYS_SWEVENTA_CH4_gc = (0x10<<0),  /* Software event on channel 4 */
+    EVSYS_SWEVENTA_CH5_gc = (0x20<<0),  /* Software event on channel 5 */
+    EVSYS_SWEVENTA_CH6_gc = (0x40<<0),  /* Software event on channel 6 */
+    EVSYS_SWEVENTA_CH7_gc = (0x80<<0)  /* Software event on channel 7 */
+} EVSYS_SWEVENTA_t;
+
+/* User channel select */
+typedef enum EVSYS_USER_enum
+{
+    EVSYS_USER_OFF_gc = (0x00<<0),  /* Off, No Eventsys Channel connected */
+    EVSYS_USER_CHANNEL0_gc = (0x01<<0),  /* Connect user to event channel 0 */
+    EVSYS_USER_CHANNEL1_gc = (0x02<<0),  /* Connect user to event channel 1 */
+    EVSYS_USER_CHANNEL2_gc = (0x03<<0),  /* Connect user to event channel 2 */
+    EVSYS_USER_CHANNEL3_gc = (0x04<<0),  /* Connect user to event channel 3 */
+    EVSYS_USER_CHANNEL4_gc = (0x05<<0),  /* Connect user to event channel 4 */
+    EVSYS_USER_CHANNEL5_gc = (0x06<<0)  /* Connect user to event channel 5 */
+} EVSYS_USER_t;
+
+/*
+--------------------------------------------------------------------------
+FUSE - Fuses
+--------------------------------------------------------------------------
+*/
+
+/* Fuses */
+typedef struct FUSE_struct
+{
+    register8_t WDTCFG;  /* Watchdog Configuration */
+    register8_t BODCFG;  /* BOD Configuration */
+    register8_t OSCCFG;  /* Oscillator Configuration */
+    register8_t reserved_1[2];
+    register8_t SYSCFG0;  /* System Configuration 0 */
+    register8_t SYSCFG1;  /* System Configuration 1 */
+    register8_t CODESIZE;  /* Code Section Size */
+    register8_t BOOTSIZE;  /* Boot Section Size */
+    register8_t reserved_2[1];
+    _WORDREGISTER(PDICFG);  /* Programming and Debugging Interface Configuration */
+} FUSE_t;
+
+/* avr-libc typedef for avr/fuse.h */
+typedef FUSE_t NVM_FUSES_t;
+
+/* BOD Operation in Active Mode select */
+typedef enum ACTIVE_enum
+{
+    ACTIVE_DISABLE_gc = (0x00<<2),  /* Disabled */
+    ACTIVE_ENABLED_gc = (0x01<<2),  /* Enabled in continuous mode */
+    ACTIVE_SAMPLED_gc = (0x02<<2),  /* Enabled in sampled mode */
+    ACTIVE_ENABLEWAIT_gc = (0x03<<2)  /* Enabled in continuous mode. Execution halted at wake-up until BOD is running */
+} ACTIVE_t;
+
+/* CRC Select */
+typedef enum CRCSEL_enum
+{
+    CRCSEL_CRC16_gc = (0x00<<5),  /* Enable CRC16 */
+    CRCSEL_CRC32_gc = (0x01<<5)  /* Enable CRC32 */
+} CRCSEL_t;
+
+/* CRC Source select */
+typedef enum CRCSRC_enum
+{
+    CRCSRC_FLASH_gc = (0x00<<6),  /* CRC of full Flash (boot, application code and application data) */
+    CRCSRC_BOOT_gc = (0x01<<6),  /* CRC of boot section */
+    CRCSRC_BOOTAPP_gc = (0x02<<6),  /* CRC of application code and boot sections */
+    CRCSRC_NOCRC_gc = (0x03<<6)  /* No CRC */
+} CRCSRC_t;
+
+/* EEPROM Save select */
+typedef enum EESAVE_enum
+{
+    EESAVE_DISABLE_gc = (0x00<<0),  /* EEPROM content is erased during chip erase */
+    EESAVE_ENABLE_gc = (0x01<<0)  /* EEPROM content is preserved during chip erase */
+} EESAVE_t;
+
+/* NVM Protection Activation Key select */
+typedef enum KEY_enum
+{
+    KEY_NOTACT_gc = (0x00<<4),  /* Not Active */
+    KEY_NVMACT_gc = (0xB45<<4)  /* NVM Protection Active */
+} KEY_t;
+
+/* Protection Level select */
+typedef enum LEVEL_enum
+{
+    LEVEL_NVMACCDIS_gc = (0x02<<0),  /* NVM Access through UPDI disabled */
+    LEVEL_BASIC_gc = (0x03<<0)  /* UPDI and UPDI pins working normally */
+} LEVEL_t;
+
+/* BOD Level select */
+typedef enum LVL_enum
+{
+    LVL_BODLEVEL0_gc = (0x00<<5),  /* BOD Disabled during normal operation */
+    LVL_BODLEVEL1_gc = (0x01<<5),  /* 1.9 V */
+    LVL_BODLEVEL2_gc = (0x02<<5),  /* 2.7 V */
+    LVL_BODLEVEL3_gc = (0x03<<5)  /* 4.5 V */
+} LVL_t;
+
+/* High-frequency Oscillator Frequency select */
+typedef enum OSCHFFRQ_enum
+{
+    OSCHFFRQ_20M_gc = (0x00<<3),  /* OSCHF running at 20 MHz */
+    OSCHFFRQ_16M_gc = (0x01<<3)  /* OSCHF running at 16 MHz */
+} OSCHFFRQ_t;
+
+/* Watchdog Timeout Period select */
+typedef enum PERIOD_enum
+{
+    PERIOD_OFF_gc = (0x00<<0),  /* Watch-Dog timer Off */
+    PERIOD_8CLK_gc = (0x01<<0),  /* 8 cycles (8ms) */
+    PERIOD_16CLK_gc = (0x02<<0),  /* 16 cycles (16ms) */
+    PERIOD_32CLK_gc = (0x03<<0),  /* 32 cycles (32ms) */
+    PERIOD_64CLK_gc = (0x04<<0),  /* 64 cycles (64ms) */
+    PERIOD_128CLK_gc = (0x05<<0),  /* 128 cycles (0.128s) */
+    PERIOD_256CLK_gc = (0x06<<0),  /* 256 cycles (0.256s) */
+    PERIOD_512CLK_gc = (0x07<<0),  /* 512 cycles (0.512s) */
+    PERIOD_1KCLK_gc = (0x08<<0),  /* 1K cycles (1.0s) */
+    PERIOD_2KCLK_gc = (0x09<<0),  /* 2K cycles (2.0s) */
+    PERIOD_4KCLK_gc = (0x0A<<0),  /* 4K cycles (4.0s) */
+    PERIOD_8KCLK_gc = (0x0B<<0)  /* 8K cycles (8.0s) */
+} PERIOD_t;
+
+/* Reset Pin Configuration select */
+typedef enum RSTPINCFG_enum
+{
+    RSTPINCFG_NONE_gc = (0x00<<3),  /* No External Reset */
+    RSTPINCFG_RESET_gc = (0x01<<3)  /* PF6 configured as RESET pin */
+} RSTPINCFG_t;
+
+/* BOD Sample Frequency select */
+typedef enum SAMPFREQ_enum
+{
+    SAMPFREQ_128HZ_gc = (0x00<<4),  /* Sampling frequency is 128 Hz */
+    SAMPFREQ_32HZ_gc = (0x01<<4)  /* Sample frequency is 32 Hz */
+} SAMPFREQ_t;
+
+/* BOD Operation in Sleep Mode select */
+typedef enum SLEEP_enum
+{
+    SLEEP_DISABLE_gc = (0x00<<0),  /* Disabled */
+    SLEEP_ENABLE_gc = (0x01<<0),  /* Enabled in continuous mode */
+    SLEEP_SAMPLE_gc = (0x02<<0)  /* Enabled in sampled mode */
+} SLEEP_t;
+
+/* Startup Time select */
+typedef enum SUT_enum
+{
+    SUT_0MS_gc = (0x00<<0),  /* 0 ms */
+    SUT_1MS_gc = (0x01<<0),  /* 1 ms */
+    SUT_2MS_gc = (0x02<<0),  /* 2 ms */
+    SUT_4MS_gc = (0x03<<0),  /* 4 ms */
+    SUT_8MS_gc = (0x04<<0),  /* 8 ms */
+    SUT_16MS_gc = (0x05<<0),  /* 16 ms */
+    SUT_32MS_gc = (0x06<<0),  /* 32 ms */
+    SUT_64MS_gc = (0x07<<0)  /* 64 ms */
+} SUT_t;
+
+/* UPDI Pin Configuration select */
+typedef enum UPDIPINCFG_enum
+{
+    UPDIPINCFG_GPIO_gc = (0x00<<4),  /* PF7 Configured as GPIO pin */
+    UPDIPINCFG_UPDI_gc = (0x01<<4)  /* PF7 Configured as UPDI pin */
+} UPDIPINCFG_t;
+
+/* Watchdog Window Timeout Period select */
+typedef enum WINDOW_enum
+{
+    WINDOW_OFF_gc = (0x00<<4),  /* Window mode off */
+    WINDOW_8CLK_gc = (0x01<<4),  /* 8 cycles (8ms) */
+    WINDOW_16CLK_gc = (0x02<<4),  /* 16 cycles (16ms) */
+    WINDOW_32CLK_gc = (0x03<<4),  /* 32 cycles (32ms) */
+    WINDOW_64CLK_gc = (0x04<<4),  /* 64 cycles (64ms) */
+    WINDOW_128CLK_gc = (0x05<<4),  /* 128 cycles (0.128s) */
+    WINDOW_256CLK_gc = (0x06<<4),  /* 256 cycles (0.256s) */
+    WINDOW_512CLK_gc = (0x07<<4),  /* 512 cycles (0.512s) */
+    WINDOW_1KCLK_gc = (0x08<<4),  /* 1K cycles (1.0s) */
+    WINDOW_2KCLK_gc = (0x09<<4),  /* 2K cycles (2.0s) */
+    WINDOW_4KCLK_gc = (0x0A<<4),  /* 4K cycles (4.0s) */
+    WINDOW_8KCLK_gc = (0x0B<<4)  /* 8K cycles (8.0s) */
+} WINDOW_t;
+
+/*
+--------------------------------------------------------------------------
+GPR - General Purpose Registers
+--------------------------------------------------------------------------
+*/
+
+/* General Purpose Registers */
+typedef struct GPR_struct
+{
+    register8_t GPR0;  /* General Purpose Register 0 */
+    register8_t GPR1;  /* General Purpose Register 1 */
+    register8_t GPR2;  /* General Purpose Register 2 */
+    register8_t GPR3;  /* General Purpose Register 3 */
+} GPR_t;
+
+
+/*
+--------------------------------------------------------------------------
+LOCK - Lockbits
+--------------------------------------------------------------------------
+*/
+
+/* Lockbits */
+typedef struct LOCK_struct
+{
+    _DWORDREGISTER(KEY);  /* Lock Key Bits */
+} LOCK_t;
+
+/* Lock Key select */
+typedef enum LOCK_KEY_enum
+{
+    LOCK_KEY_NOLOCK_gc = (0x5CC5C55C<<0),  /* No locks */
+    LOCK_KEY_RWLOCK_gc = (0xA33A3AA3<<0)  /* Read and write lock */
+} LOCK_KEY_t;
+
+/*
+--------------------------------------------------------------------------
+NVMCTRL - Non-volatile Memory Controller
+--------------------------------------------------------------------------
+*/
+
+/* Non-volatile Memory Controller */
+typedef struct NVMCTRL_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    register8_t reserved_1[1];
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t STATUS;  /* Status */
+    register8_t reserved_2[1];
+    _WORDREGISTER(DATA);  /* Data */
+    register8_t reserved_3[2];
+    _DWORDREGISTER(ADDR);  /* Address */
+    register8_t reserved_4[48];
+} NVMCTRL_t;
+
+/* Command select */
+typedef enum NVMCTRL_CMD_enum
+{
+    NVMCTRL_CMD_NOCMD_gc = (0x00<<0),  /* No Command */
+    NVMCTRL_CMD_NOOP_gc = (0x01<<0),  /* No Operation */
+    NVMCTRL_CMD_FLPW_gc = (0x04<<0),  /* Flash Page Write */
+    NVMCTRL_CMD_FLPERW_gc = (0x05<<0),  /* Flash Page Erase and Write */
+    NVMCTRL_CMD_FLPER_gc = (0x08<<0),  /* Flash Page Erase */
+    NVMCTRL_CMD_FLMPER2_gc = (0x09<<0),  /* Flash 2-page erase enable */
+    NVMCTRL_CMD_FLMPER4_gc = (0x0A<<0),  /* Flash 4-page erase enable */
+    NVMCTRL_CMD_FLMPER8_gc = (0x0B<<0),  /* Flash 8-page erase enable */
+    NVMCTRL_CMD_FLMPER16_gc = (0x0C<<0),  /* Flash 16-page erase enable */
+    NVMCTRL_CMD_FLMPER32_gc = (0x0D<<0),  /* Flash 32-page erase enable */
+    NVMCTRL_CMD_FLPBCLR_gc = (0x0F<<0),  /* Flash Page Buffer Clear */
+    NVMCTRL_CMD_EEPW_gc = (0x14<<0),  /* EEPROM Page Write */
+    NVMCTRL_CMD_EEPERW_gc = (0x15<<0),  /* EEPROM Page Erase and Write */
+    NVMCTRL_CMD_EEPER_gc = (0x17<<0),  /* EEPROM Page Erase */
+    NVMCTRL_CMD_EEPBCLR_gc = (0x1F<<0),  /* EEPROM Page Buffer Clear */
+    NVMCTRL_CMD_CHER_gc = (0x20<<0),  /* Chip Erase Command (UPDI only) */
+    NVMCTRL_CMD_EECHER_gc = (0x30<<0)  /* EEPROM Erase Command (UPDI only) */
+} NVMCTRL_CMD_t;
+
+/* Write error select */
+typedef enum NVMCTRL_ERROR_enum
+{
+    NVMCTRL_ERROR_NOERROR_gc = (0x00<<4),  /* No Error */
+    NVMCTRL_ERROR_WRITEPROTECT_gc = (0x02<<4),  /* Attempt to program write protected area */
+    NVMCTRL_ERROR_CMDCOLLISION_gc = (0x03<<4),  /* Selecting new write command while write command already seleted */
+    NVMCTRL_ERROR_WRONGSECTION_gc = (0x04<<4)  /* Address cannot be written with selected command */
+} NVMCTRL_ERROR_t;
+
+/* Flash Mapping in Data space select */
+typedef enum NVMCTRL_FLMAP_enum
+{
+    NVMCTRL_FLMAP_SECTION0_gc = (0x00<<4),  /* Flash section 0, 0 - 32KB */
+    NVMCTRL_FLMAP_SECTION1_gc = (0x01<<4),  /* Flash section 1, 32 - 64KB */
+    NVMCTRL_FLMAP_SECTION2_gc = (0x02<<4),  /* Flash section 2, 64 - 96KB */
+    NVMCTRL_FLMAP_SECTION3_gc = (0x03<<4)  /* Flash section 3, 96 - 128KB */
+} NVMCTRL_FLMAP_t;
+
+/*
+--------------------------------------------------------------------------
+PORT - I/O Ports
+--------------------------------------------------------------------------
+*/
+
+/* I/O Ports */
+typedef struct PORT_struct
+{
+    register8_t DIR;  /* Data Direction */
+    register8_t DIRSET;  /* Data Direction Set */
+    register8_t DIRCLR;  /* Data Direction Clear */
+    register8_t DIRTGL;  /* Data Direction Toggle */
+    register8_t OUT;  /* Output Value */
+    register8_t OUTSET;  /* Output Value Set */
+    register8_t OUTCLR;  /* Output Value Clear */
+    register8_t OUTTGL;  /* Output Value Toggle */
+    register8_t IN;  /* Input Value */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t PORTCTRL;  /* Port Control */
+    register8_t PINCONFIG;  /* Pin Control Config */
+    register8_t PINCTRLUPD;  /* Pin Control Update */
+    register8_t PINCTRLSET;  /* Pin Control Set */
+    register8_t PINCTRLCLR;  /* Pin Control Clear */
+    register8_t reserved_1[1];
+    register8_t PIN0CTRL;  /* Pin 0 Control */
+    register8_t PIN1CTRL;  /* Pin 1 Control */
+    register8_t PIN2CTRL;  /* Pin 2 Control */
+    register8_t PIN3CTRL;  /* Pin 3 Control */
+    register8_t PIN4CTRL;  /* Pin 4 Control */
+    register8_t PIN5CTRL;  /* Pin 5 Control */
+    register8_t PIN6CTRL;  /* Pin 6 Control */
+    register8_t PIN7CTRL;  /* Pin 7 Control */
+    register8_t EVGENCTRLA;  /* Event Generation Control A */
+    register8_t reserved_2[7];
+} PORT_t;
+
+/* Event Generator 0 Select */
+typedef enum PORT_EVGEN0SEL_enum
+{
+    PORT_EVGEN0SEL_PIN0_gc = (0x00<<0),  /* Pin 0 used as event generator */
+    PORT_EVGEN0SEL_PIN1_gc = (0x01<<0),  /* Pin 1 used as event generator */
+    PORT_EVGEN0SEL_PIN2_gc = (0x02<<0),  /* Pin 2 used as event generator */
+    PORT_EVGEN0SEL_PIN3_gc = (0x03<<0),  /* Pin 3 used as event generator */
+    PORT_EVGEN0SEL_PIN4_gc = (0x04<<0),  /* Pin 4 used as event generator */
+    PORT_EVGEN0SEL_PIN5_gc = (0x05<<0),  /* Pin 5 used as event generator */
+    PORT_EVGEN0SEL_PIN6_gc = (0x06<<0),  /* Pin 6 used as event generator */
+    PORT_EVGEN0SEL_PIN7_gc = (0x07<<0)  /* Pin 7 used as event generator */
+} PORT_EVGEN0SEL_t;
+
+/* Event Generator 1 Select */
+typedef enum PORT_EVGEN1SEL_enum
+{
+    PORT_EVGEN1SEL_PIN0_gc = (0x00<<4),  /* Pin 0 used as event generator */
+    PORT_EVGEN1SEL_PIN1_gc = (0x01<<4),  /* Pin 1 used as event generator */
+    PORT_EVGEN1SEL_PIN2_gc = (0x02<<4),  /* Pin 2 used as event generator */
+    PORT_EVGEN1SEL_PIN3_gc = (0x03<<4),  /* Pin 3 used as event generator */
+    PORT_EVGEN1SEL_PIN4_gc = (0x04<<4),  /* Pin 4 used as event generator */
+    PORT_EVGEN1SEL_PIN5_gc = (0x05<<4),  /* Pin 5 used as event generator */
+    PORT_EVGEN1SEL_PIN6_gc = (0x06<<4),  /* Pin 6 used as event generator */
+    PORT_EVGEN1SEL_PIN7_gc = (0x07<<4)  /* Pin 7 used as event generator */
+} PORT_EVGEN1SEL_t;
+
+/* Input Level Select */
+typedef enum PORT_INLVL_enum
+{
+    PORT_INLVL_ST_gc = (0x00<<6),  /* Schmitt-Trigger input level */
+    PORT_INLVL_TTL_gc = (0x01<<6)  /* TTL Input level */
+} PORT_INLVL_t;
+
+/* Input/Sense Configuration select */
+typedef enum PORT_ISC_enum
+{
+    PORT_ISC_INTDISABLE_gc = (0x00<<0),  /* Interrupt disabled but input buffer enabled */
+    PORT_ISC_BOTHEDGES_gc = (0x01<<0),  /* Sense Both Edges */
+    PORT_ISC_RISING_gc = (0x02<<0),  /* Sense Rising Edge */
+    PORT_ISC_FALLING_gc = (0x03<<0),  /* Sense Falling Edge */
+    PORT_ISC_INPUT_DISABLE_gc = (0x04<<0),  /* Digital Input Buffer disabled */
+    PORT_ISC_LEVEL_gc = (0x05<<0)  /* Sense low Level */
+} PORT_ISC_t;
+
+/*
+--------------------------------------------------------------------------
+PORTMUX - Port Multiplexer
+--------------------------------------------------------------------------
+*/
+
+/* Port Multiplexer */
+typedef struct PORTMUX_struct
+{
+    register8_t EVSYSROUTEA;  /* EVSYS route A */
+    register8_t CCLROUTEA;  /* CCL route A */
+    register8_t USARTROUTEA;  /* USART route A */
+    register8_t reserved_1[2];
+    register8_t SPIROUTEA;  /* SPI route A */
+    register8_t TWIROUTEA;  /* TWI route A */
+    register8_t TCEROUTEA;  /* TCE route A */
+    register8_t TCBROUTEA;  /* TCB route A */
+    register8_t reserved_2[3];
+    register8_t TCFROUTEA;  /* TCF Route A */
+    register8_t reserved_3[19];
+} PORTMUX_t;
+
+/* Event Output A select */
+typedef enum PORTMUX_EVOUTA_enum
+{
+    PORTMUX_EVOUTA_DEFAULT_gc = (0x00<<0),  /* EVOUT on PA2 */
+    PORTMUX_EVOUTA_ALT1_gc = (0x01<<0)  /* EVOUT on PA7 */
+} PORTMUX_EVOUTA_t;
+
+/* Event Output C select */
+typedef enum PORTMUX_EVOUTC_enum
+{
+    PORTMUX_EVOUTC_DEFAULT_gc = (0x00<<2)  /* EVOUT on PC2 */
+} PORTMUX_EVOUTC_t;
+
+/* Event Output D select */
+typedef enum PORTMUX_EVOUTD_enum
+{
+    PORTMUX_EVOUTD_DEFAULT_gc = (0x00<<3),  /* EVOUT on PD2 */
+    PORTMUX_EVOUTD_ALT1_gc = (0x01<<3)  /* EVOUT on PD7 */
+} PORTMUX_EVOUTD_t;
+
+/* Event Output F select */
+typedef enum PORTMUX_EVOUTF_enum
+{
+    PORTMUX_EVOUTF_ALT1_gc = (0x01<<5)  /* EVOUT on PF7 */
+} PORTMUX_EVOUTF_t;
+
+/* CCL Look-Up Table 0 Signals select */
+typedef enum PORTMUX_LUT0_enum
+{
+    PORTMUX_LUT0_DEFAULT_gc = (0x00<<0),  /* Out: PA3 In: PA0, PA1, PA2 */
+    PORTMUX_LUT0_ALT1_gc = (0x01<<0)  /* Out: PA6 In: PA0, PA1, PA2 */
+} PORTMUX_LUT0_t;
+
+/* CCL Look-Up Table 1 Signals select */
+typedef enum PORTMUX_LUT1_enum
+{
+    PORTMUX_LUT1_DEFAULT_gc = (0x00<<1)  /* Out: PC3 In: PC0, PC1, PC2 */
+} PORTMUX_LUT1_t;
+
+/* CCL Look-Up Table 2 Signals select */
+typedef enum PORTMUX_LUT2_enum
+{
+    PORTMUX_LUT2_DEFAULT_gc = (0x00<<2),  /* Out: PD3 In: PD0, PD1, PD2 */
+    PORTMUX_LUT2_ALT1_gc = (0x01<<2)  /* Out: PD6 In: PD0, PD1, PD2 */
+} PORTMUX_LUT2_t;
+
+/* CCL Look-Up Table 3 Signals select */
+typedef enum PORTMUX_LUT3_enum
+{
+    PORTMUX_LUT3_DEFAULT_gc = (0x00<<3)  /* Out: PF3 In: PF0, PF1, PF2 */
+} PORTMUX_LUT3_t;
+
+/* SPI0 Signals select */
+typedef enum PORTMUX_SPI0_enum
+{
+    PORTMUX_SPI0_DEFAULT_gc = (0x00<<0),  /* PA4, PA5, PA6, PA7 */
+    PORTMUX_SPI0_ALT3_gc = (0x03<<0),  /* PA0, PA1, PC0, PC1 */
+    PORTMUX_SPI0_ALT4_gc = (0x04<<0),  /* PD4, PD5, PD6, PD7 */
+    PORTMUX_SPI0_ALT5_gc = (0x05<<0),  /* PC0, PC1, PC2, PC3 */
+    PORTMUX_SPI0_ALT6_gc = (0x06<<0),  /* PC1, PC2, PC3, - */
+    PORTMUX_SPI0_NONE_gc = (0x07<<0)  /* Not connected to any pins, SS set to 1 */
+} PORTMUX_SPI0_t;
+
+/* TCB0 Output select */
+typedef enum PORTMUX_TCB0_enum
+{
+    PORTMUX_TCB0_DEFAULT_gc = (0x00<<0)  /* PA2 */
+} PORTMUX_TCB0_t;
+
+/* TCB1 Output select */
+typedef enum PORTMUX_TCB1_enum
+{
+    PORTMUX_TCB1_DEFAULT_gc = (0x00<<1)  /* PA3 */
+} PORTMUX_TCB1_t;
+
+/* TCE0 Signals select */
+typedef enum PORTMUX_TCE0_enum
+{
+    PORTMUX_TCE0_PORTA_gc = (0x00<<0),  /* PA0, PA1, PA2, PA3, PA4, PA5, PA6, PA7 */
+    PORTMUX_TCE0_PORTC_gc = (0x02<<0),  /* PC0, PC1, PC2, PC3, -, -, -, - */
+    PORTMUX_TCE0_PORTD_gc = (0x03<<0),  /* PD0, PD1, PD2, PD3, PD4, PD5, PD6, PD7 */
+    PORTMUX_TCE0_PORTF_gc = (0x05<<0),  /* PF0, PF1, PF2, PF3, PF4, PF5, -, - */
+    PORTMUX_TCE0_PORTC2_gc = (0x08<<0),  /* PA0, PA1, PC0, PC1, PC2, PC3, -, - */
+    PORTMUX_TCE0_PORTA2_gc = (0x09<<0)  /* PA2, PA3, PA4, PA5, PA6, PA7, -, - */
+} PORTMUX_TCE0_t;
+
+/* TCF0 Output select */
+typedef enum PORTMUX_TCF0_enum
+{
+    PORTMUX_TCF0_DEFAULT_gc = (0x00<<0),  /* PA0, PA1 */
+    PORTMUX_TCF0_ALT1_gc = (0x01<<0)  /* PA6, PA7 */
+} PORTMUX_TCF0_t;
+
+/* TWI0 Signals select */
+typedef enum PORTMUX_TWI0_enum
+{
+    PORTMUX_TWI0_DEFAULT_gc = (0x00<<0),  /* {PA2, PA3}, {PC2, PC3} */
+    PORTMUX_TWI0_ALT2_gc = (0x02<<0),  /* {PC2, PC3}, {-, -} */
+    PORTMUX_TWI0_ALT3_gc = (0x03<<0)  /* {PA0, PA1}, {PC2, PC3} */
+} PORTMUX_TWI0_t;
+
+/* USART0 Routing select */
+typedef enum PORTMUX_USART0_enum
+{
+    PORTMUX_USART0_DEFAULT_gc = (0x00<<0),  /* {PA0, PA1, PA2, PA3} */
+    PORTMUX_USART0_ALT1_gc = (0x01<<0),  /* {PA4, PA5, PA6, PA7} */
+    PORTMUX_USART0_ALT2_gc = (0x02<<0),  /* {PA2,PA3, -, -} */
+    PORTMUX_USART0_ALT3_gc = (0x03<<0),  /* {PD4, PD5, PD6, PD7} */
+    PORTMUX_USART0_ALT4_gc = (0x04<<0),  /* {PC1, PC2, PC3, -} */
+    PORTMUX_USART0_ALT6_gc = (0x06<<0),  /* {PF7, PF6, -, -} */
+    PORTMUX_USART0_NONE_gc = (0x07<<0)  /* Not connected to any pins */
+} PORTMUX_USART0_t;
+
+/*
+--------------------------------------------------------------------------
+RSTCTRL - Reset controller
+--------------------------------------------------------------------------
+*/
+
+/* Reset controller */
+typedef struct RSTCTRL_struct
+{
+    register8_t RSTFR;  /* Reset Flags */
+    register8_t SWRR;  /* Software Reset */
+    register8_t reserved_1[14];
+} RSTCTRL_t;
+
+
+/*
+--------------------------------------------------------------------------
+RTC - Real-Time Counter
+--------------------------------------------------------------------------
+*/
+
+/* Real-Time Counter */
+typedef struct RTC_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t STATUS;  /* Status */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t TEMP;  /* Temporary */
+    register8_t DBGCTRL;  /* Debug control */
+    register8_t CALIB;  /* Calibration */
+    register8_t CLKSEL;  /* Clock Select */
+    _WORDREGISTER(CNT);  /* Counter */
+    _WORDREGISTER(PER);  /* Period */
+    _WORDREGISTER(CMP);  /* Compare */
+    register8_t reserved_1[2];
+    register8_t PITCTRLA;  /* PIT Control A */
+    register8_t PITSTATUS;  /* PIT Status */
+    register8_t PITINTCTRL;  /* PIT Interrupt Control */
+    register8_t PITINTFLAGS;  /* PIT Interrupt Flags */
+    register8_t reserved_2[1];
+    register8_t PITDBGCTRL;  /* PIT Debug control */
+    register8_t PITEVGENCTRLA;  /* PIT Event Generation Control A */
+    register8_t reserved_3[9];
+} RTC_t;
+
+/* Clock Select */
+typedef enum RTC_CLKSEL_enum
+{
+    RTC_CLKSEL_OSC32K_gc = (0x00<<0),  /* Internal 32.768 kHz Oscillator */
+    RTC_CLKSEL_OSC1K_gc = (0x01<<0),  /* Internal 32.768 kHz Oscillator Divided by 32 */
+    RTC_CLKSEL_XOSC32K_gc = (0x02<<0),  /* 32.768 kHz Crystal Oscillator */
+    RTC_CLKSEL_EXTCLK_gc = (0x03<<0)  /* External Clock */
+} RTC_CLKSEL_t;
+
+/* Event Generation 0 Select */
+typedef enum RTC_EVGEN0SEL_enum
+{
+    RTC_EVGEN0SEL_OFF_gc = (0x00<<0),  /* No Event Generated */
+    RTC_EVGEN0SEL_DIV4_gc = (0x01<<0),  /* CLK_RTC divided by 4 */
+    RTC_EVGEN0SEL_DIV8_gc = (0x02<<0),  /* CLK_RTC divided by 8 */
+    RTC_EVGEN0SEL_DIV16_gc = (0x03<<0),  /* CLK_RTC divided by 16 */
+    RTC_EVGEN0SEL_DIV32_gc = (0x04<<0),  /* CLK_RTC divided by 32 */
+    RTC_EVGEN0SEL_DIV64_gc = (0x05<<0),  /* CLK_RTC divided by 64 */
+    RTC_EVGEN0SEL_DIV128_gc = (0x06<<0),  /* CLK_RTC divided by 128 */
+    RTC_EVGEN0SEL_DIV256_gc = (0x07<<0),  /* CLK_RTC divided by 256 */
+    RTC_EVGEN0SEL_DIV512_gc = (0x08<<0),  /* CLK_RTC divided by 512 */
+    RTC_EVGEN0SEL_DIV1024_gc = (0x09<<0),  /* CLK_RTC divided by 1024 */
+    RTC_EVGEN0SEL_DIV2048_gc = (0x0A<<0),  /* CLK_RTC divided by 2048 */
+    RTC_EVGEN0SEL_DIV4096_gc = (0x0B<<0),  /* CLK_RTC divided by 4096 */
+    RTC_EVGEN0SEL_DIV8192_gc = (0x0C<<0),  /* CLK_RTC divided by 8192 */
+    RTC_EVGEN0SEL_DIV16384_gc = (0x0D<<0),  /* CLK_RTC divided by 16384 */
+    RTC_EVGEN0SEL_DIV32768_gc = (0x0E<<0)  /* CLK_RTC divided by 32768 */
+} RTC_EVGEN0SEL_t;
+
+/* Event Generation 1 Select */
+typedef enum RTC_EVGEN1SEL_enum
+{
+    RTC_EVGEN1SEL_OFF_gc = (0x00<<4),  /* No Event Generated */
+    RTC_EVGEN1SEL_DIV4_gc = (0x01<<4),  /* CLK_RTC divided by 4 */
+    RTC_EVGEN1SEL_DIV8_gc = (0x02<<4),  /* CLK_RTC divided by 8 */
+    RTC_EVGEN1SEL_DIV16_gc = (0x03<<4),  /* CLK_RTC divided by 16 */
+    RTC_EVGEN1SEL_DIV32_gc = (0x04<<4),  /* CLK_RTC divided by 32 */
+    RTC_EVGEN1SEL_DIV64_gc = (0x05<<4),  /* CLK_RTC divided by 64 */
+    RTC_EVGEN1SEL_DIV128_gc = (0x06<<4),  /* CLK_RTC divided by 128 */
+    RTC_EVGEN1SEL_DIV256_gc = (0x07<<4),  /* CLK_RTC divided by 256 */
+    RTC_EVGEN1SEL_DIV512_gc = (0x08<<4),  /* CLK_RTC divided by 512 */
+    RTC_EVGEN1SEL_DIV1024_gc = (0x09<<4),  /* CLK_RTC divided by 1024 */
+    RTC_EVGEN1SEL_DIV2048_gc = (0x0A<<4),  /* CLK_RTC divided by 2048 */
+    RTC_EVGEN1SEL_DIV4096_gc = (0x0B<<4),  /* CLK_RTC divided by 4096 */
+    RTC_EVGEN1SEL_DIV8192_gc = (0x0C<<4),  /* CLK_RTC divided by 8192 */
+    RTC_EVGEN1SEL_DIV16384_gc = (0x0D<<4),  /* CLK_RTC divided by 16384 */
+    RTC_EVGEN1SEL_DIV32768_gc = (0x0E<<4)  /* CLK_RTC divided by 32768 */
+} RTC_EVGEN1SEL_t;
+
+/* Period select */
+typedef enum RTC_PERIOD_enum
+{
+    RTC_PERIOD_OFF_gc = (0x00<<3),  /* Off */
+    RTC_PERIOD_CYC4_gc = (0x01<<3),  /* RTC Clock Cycles 4 */
+    RTC_PERIOD_CYC8_gc = (0x02<<3),  /* RTC Clock Cycles 8 */
+    RTC_PERIOD_CYC16_gc = (0x03<<3),  /* RTC Clock Cycles 16 */
+    RTC_PERIOD_CYC32_gc = (0x04<<3),  /* RTC Clock Cycles 32 */
+    RTC_PERIOD_CYC64_gc = (0x05<<3),  /* RTC Clock Cycles 64 */
+    RTC_PERIOD_CYC128_gc = (0x06<<3),  /* RTC Clock Cycles 128 */
+    RTC_PERIOD_CYC256_gc = (0x07<<3),  /* RTC Clock Cycles 256 */
+    RTC_PERIOD_CYC512_gc = (0x08<<3),  /* RTC Clock Cycles 512 */
+    RTC_PERIOD_CYC1024_gc = (0x09<<3),  /* RTC Clock Cycles 1024 */
+    RTC_PERIOD_CYC2048_gc = (0x0A<<3),  /* RTC Clock Cycles 2048 */
+    RTC_PERIOD_CYC4096_gc = (0x0B<<3),  /* RTC Clock Cycles 4096 */
+    RTC_PERIOD_CYC8192_gc = (0x0C<<3),  /* RTC Clock Cycles 8192 */
+    RTC_PERIOD_CYC16384_gc = (0x0D<<3),  /* RTC Clock Cycles 16384 */
+    RTC_PERIOD_CYC32768_gc = (0x0E<<3)  /* RTC Clock Cycles 32768 */
+} RTC_PERIOD_t;
+
+/* Prescaling Factor select */
+typedef enum RTC_PRESCALER_enum
+{
+    RTC_PRESCALER_DIV1_gc = (0x00<<3),  /* RTC Clock / 1 */
+    RTC_PRESCALER_DIV2_gc = (0x01<<3),  /* RTC Clock / 2 */
+    RTC_PRESCALER_DIV4_gc = (0x02<<3),  /* RTC Clock / 4 */
+    RTC_PRESCALER_DIV8_gc = (0x03<<3),  /* RTC Clock / 8 */
+    RTC_PRESCALER_DIV16_gc = (0x04<<3),  /* RTC Clock / 16 */
+    RTC_PRESCALER_DIV32_gc = (0x05<<3),  /* RTC Clock / 32 */
+    RTC_PRESCALER_DIV64_gc = (0x06<<3),  /* RTC Clock / 64 */
+    RTC_PRESCALER_DIV128_gc = (0x07<<3),  /* RTC Clock / 128 */
+    RTC_PRESCALER_DIV256_gc = (0x08<<3),  /* RTC Clock / 256 */
+    RTC_PRESCALER_DIV512_gc = (0x09<<3),  /* RTC Clock / 512 */
+    RTC_PRESCALER_DIV1024_gc = (0x0A<<3),  /* RTC Clock / 1024 */
+    RTC_PRESCALER_DIV2048_gc = (0x0B<<3),  /* RTC Clock / 2048 */
+    RTC_PRESCALER_DIV4096_gc = (0x0C<<3),  /* RTC Clock / 4096 */
+    RTC_PRESCALER_DIV8192_gc = (0x0D<<3),  /* RTC Clock / 8192 */
+    RTC_PRESCALER_DIV16384_gc = (0x0E<<3),  /* RTC Clock / 16384 */
+    RTC_PRESCALER_DIV32768_gc = (0x0F<<3)  /* RTC Clock / 32768 */
+} RTC_PRESCALER_t;
+
+/*
+--------------------------------------------------------------------------
+SIGROW - Signature row
+--------------------------------------------------------------------------
+*/
+
+/* Signature row */
+typedef struct SIGROW_struct
+{
+    register8_t DEVICEID0;  /* Device ID Byte 0 */
+    register8_t DEVICEID1;  /* Device ID Byte 1 */
+    register8_t DEVICEID2;  /* Device ID Byte 2 */
+    register8_t reserved_1[1];
+    _WORDREGISTER(TEMPSENSE0);  /* Temperature Calibration 0 */
+    _WORDREGISTER(TEMPSENSE1);  /* Temperature Calibration 1 */
+    register8_t reserved_2[8];
+    register8_t SERNUM0;  /* Serial Number Byte 0 */
+    register8_t SERNUM1;  /* Serial Number Byte 1 */
+    register8_t SERNUM2;  /* Serial Number Byte 2 */
+    register8_t SERNUM3;  /* Serial Number Byte 3 */
+    register8_t SERNUM4;  /* Serial Number Byte 4 */
+    register8_t SERNUM5;  /* Serial Number Byte 5 */
+    register8_t SERNUM6;  /* Serial Number Byte 6 */
+    register8_t SERNUM7;  /* Serial Number Byte 7 */
+    register8_t SERNUM8;  /* Serial Number Byte 8 */
+    register8_t SERNUM9;  /* Serial Number Byte 9 */
+    register8_t SERNUM10;  /* Serial Number Byte 10 */
+    register8_t SERNUM11;  /* Serial Number Byte 11 */
+    register8_t SERNUM12;  /* Serial Number Byte 12 */
+    register8_t SERNUM13;  /* Serial Number Byte 13 */
+    register8_t SERNUM14;  /* Serial Number Byte 14 */
+    register8_t SERNUM15;  /* Serial Number Byte 15 */
+    register8_t reserved_3[32];
+} SIGROW_t;
+
+
+/*
+--------------------------------------------------------------------------
+SLPCTRL - Sleep Controller
+--------------------------------------------------------------------------
+*/
+
+/* Sleep Controller */
+typedef struct SLPCTRL_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t reserved_1[15];
+} SLPCTRL_t;
+
+/* Sleep mode select */
+typedef enum SLPCTRL_SMODE_enum
+{
+    SLPCTRL_SMODE_IDLE_gc = (0x00<<1),  /* Idle mode */
+    SLPCTRL_SMODE_STDBY_gc = (0x01<<1),  /* Standby Mode */
+    SLPCTRL_SMODE_PDOWN_gc = (0x02<<1)  /* Power-down Mode */
+} SLPCTRL_SMODE_t;
+
+#define SLEEP_MODE_IDLE (0x00<<1)
+#define SLEEP_MODE_STANDBY (0x01<<1)
+#define SLEEP_MODE_PWR_DOWN (0x02<<1)
+/*
+--------------------------------------------------------------------------
+SPI - Serial Peripheral Interface
+--------------------------------------------------------------------------
+*/
+
+/* Serial Peripheral Interface */
+typedef struct SPI_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t DATA;  /* Data */
+    register8_t reserved_1[11];
+} SPI_t;
+
+/* SPI Mode select */
+typedef enum SPI_MODE_enum
+{
+    SPI_MODE_0_gc = (0x00<<0),  /* SPI Mode 0 */
+    SPI_MODE_1_gc = (0x01<<0),  /* SPI Mode 1 */
+    SPI_MODE_2_gc = (0x02<<0),  /* SPI Mode 2 */
+    SPI_MODE_3_gc = (0x03<<0)  /* SPI Mode 3 */
+} SPI_MODE_t;
+
+/* Prescaler select */
+typedef enum SPI_PRESC_enum
+{
+    SPI_PRESC_DIV4_gc = (0x00<<1),  /* CLK_PER / 4 */
+    SPI_PRESC_DIV16_gc = (0x01<<1),  /* CLK_PER / 16 */
+    SPI_PRESC_DIV64_gc = (0x02<<1),  /* CLK_PER / 64 */
+    SPI_PRESC_DIV128_gc = (0x03<<1)  /* CLK_PER / 128 */
+} SPI_PRESC_t;
+
+/*
+--------------------------------------------------------------------------
+SYSCFG - System Configuration Registers
+--------------------------------------------------------------------------
+*/
+
+/* System Configuration Registers */
+typedef struct SYSCFG_struct
+{
+    register8_t reserved_1[1];
+    register8_t REVID;  /* Revision ID */
+    register8_t reserved_2[62];
+} SYSCFG_t;
+
+
+/*
+--------------------------------------------------------------------------
+TCB - 16-bit Timer/Counter Type B
+--------------------------------------------------------------------------
+*/
+
+/* 16-bit Timer/Counter Type B */
+typedef struct TCB_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    register8_t reserved_1[1];
+    register8_t EVCTRL;  /* Event Control */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t STATUS;  /* Status */
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t TEMP;  /* Temporary Value */
+    _WORDREGISTER(CNT);  /* Count */
+    _WORDREGISTER(CCMP);  /* Compare or Capture */
+    register8_t reserved_2[2];
+} TCB_t;
+
+/* Clock Select */
+typedef enum TCB_CLKSEL_enum
+{
+    TCB_CLKSEL_DIV1_gc = (0x00<<1),  /* CLK_PER */
+    TCB_CLKSEL_DIV2_gc = (0x01<<1),  /* CLK_PER/2 */
+    TCB_CLKSEL_TCE0_gc = (0x02<<1),  /* Use CLK_TCE from TCE0 */
+    TCB_CLKSEL_EVENT_gc = (0x07<<1)  /* Count on event edge */
+} TCB_CLKSEL_t;
+
+/* Timer Mode select */
+typedef enum TCB_CNTMODE_enum
+{
+    TCB_CNTMODE_INT_gc = (0x00<<0),  /* Periodic Interrupt */
+    TCB_CNTMODE_TIMEOUT_gc = (0x01<<0),  /* Periodic Timeout */
+    TCB_CNTMODE_CAPT_gc = (0x02<<0),  /* Input Capture Event */
+    TCB_CNTMODE_FRQ_gc = (0x03<<0),  /* Input Capture Frequency measurement */
+    TCB_CNTMODE_PW_gc = (0x04<<0),  /* Input Capture Pulse-Width measurement */
+    TCB_CNTMODE_FRQPW_gc = (0x05<<0),  /* Input Capture Frequency and Pulse-Width measurement */
+    TCB_CNTMODE_SINGLE_gc = (0x06<<0),  /* Single Shot */
+    TCB_CNTMODE_PWM8_gc = (0x07<<0)  /* 8-bit PWM */
+} TCB_CNTMODE_t;
+
+/* Counter Size select */
+typedef enum TCB_CNTSIZE_enum
+{
+    TCB_CNTSIZE_16BITS_gc = (0x00<<0),  /* 16-bit CNT. MAX=16'hFFFF */
+    TCB_CNTSIZE_15BITS_gc = (0x01<<0),  /* 15-bit CNT. MAX=16'h7FFF */
+    TCB_CNTSIZE_14BITS_gc = (0x02<<0),  /* 14-bit CNT. MAX=16'h3FFF */
+    TCB_CNTSIZE_13BITS_gc = (0x03<<0),  /* 13-bit CNT. MAX=16'h1FFF */
+    TCB_CNTSIZE_12BITS_gc = (0x04<<0),  /* 12-bit CNT. MAX=16'h0FFF */
+    TCB_CNTSIZE_11BITS_gc = (0x05<<0),  /* 11-bit CNT. MAX=16'h07FF */
+    TCB_CNTSIZE_10BITS_gc = (0x06<<0),  /* 10-bit CNT. MAX=16'h03FF */
+    TCB_CNTSIZE_9BITS_gc = (0x07<<0)  /* 9-bit CNT. MAX=16'h01FF */
+} TCB_CNTSIZE_t;
+
+/* Event Generation select */
+typedef enum TCB_EVGEN_enum
+{
+    TCB_EVGEN_PULSE_gc = (0x00<<7),  /* Event is generated as pulse at compare match or capture */
+    TCB_EVGEN_WAVEFORM_gc = (0x01<<7)  /* Event is generated as waveform for modes with waveform */
+} TCB_EVGEN_t;
+
+/*
+--------------------------------------------------------------------------
+TCE - 16-bit Timer/Counter Type E
+--------------------------------------------------------------------------
+*/
+
+/* 16-bit Timer/Counter Type E */
+typedef struct TCE_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    register8_t CTRLD;  /* Control D */
+    register8_t CTRLECLR;  /* Control E Clear */
+    register8_t CTRLESET;  /* Control E Set */
+    register8_t CTRLFCLR;  /* Control F Clear */
+    register8_t CTRLFSET;  /* Control F Set */
+    register8_t EVGENCTRL;  /* Event Generation Control */
+    register8_t EVCTRL;  /* Event Control */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t reserved_1[2];
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t TEMP;  /* Temporary data for 16-bit Access */
+    register8_t reserved_2[16];
+    _WORDREGISTER(CNT);  /* Count */
+    _WORDREGISTER(AMP);  /* Amplitude */
+    _WORDREGISTER(OFFSET);  /* Offset */
+    _WORDREGISTER(PER);  /* Period */
+    _WORDREGISTER(CMP0);  /* Compare 0 */
+    _WORDREGISTER(CMP1);  /* Compare 1 */
+    _WORDREGISTER(CMP2);  /* Compare 2 */
+    _WORDREGISTER(CMP3);  /* Compare 3 */
+    register8_t reserved_3[6];
+    _WORDREGISTER(PERBUF);  /* Period Buffer */
+    _WORDREGISTER(CMP0BUF);  /* Compare 0 Buffer */
+    _WORDREGISTER(CMP1BUF);  /* Compare 1 Buffer */
+    _WORDREGISTER(CMP2BUF);  /* Compare 2 Buffer */
+    _WORDREGISTER(CMP3BUF);  /* Compare 3 Buffer */
+} TCE_t;
+
+/* Clock Selection */
+typedef enum TCE_CLKSEL_enum
+{
+    TCE_CLKSEL_DIV1_gc = (0x00<<1),  /* System Clock */
+    TCE_CLKSEL_DIV2_gc = (0x01<<1),  /* System Clock / 2 */
+    TCE_CLKSEL_DIV4_gc = (0x02<<1),  /* System Clock / 4 */
+    TCE_CLKSEL_DIV8_gc = (0x03<<1),  /* System Clock / 8 */
+    TCE_CLKSEL_DIV16_gc = (0x04<<1),  /* System Clock / 16 */
+    TCE_CLKSEL_DIV64_gc = (0x05<<1),  /* System Clock / 64 */
+    TCE_CLKSEL_DIV256_gc = (0x06<<1),  /* System Clock / 256 */
+    TCE_CLKSEL_DIV1024_gc = (0x07<<1)  /* System Clock / 1024 */
+} TCE_CLKSEL_t;
+
+/* Command select */
+typedef enum TCE_CMD_enum
+{
+    TCE_CMD_NONE_gc = (0x00<<2),  /* No Command */
+    TCE_CMD_UPDATE_gc = (0x01<<2),  /* Force Update */
+    TCE_CMD_RESTART_gc = (0x02<<2),  /* Force Restart */
+    TCE_CMD_RESET_gc = (0x03<<2)  /* Force Hard Reset */
+} TCE_CMD_t;
+
+/* Compare # Event select */
+typedef enum TCE_CMP0EV_enum
+{
+    TCE_CMP0EV_PULSE_gc = (0x00<<4),  /* Event output for CMP is a pulse */
+    TCE_CMP0EV_WAVEFORM_gc = (0x01<<4)  /* Event output for CMP is equal to waveform */
+} TCE_CMP0EV_t;
+
+/* Compare # Event select */
+typedef enum TCE_CMP1EV_enum
+{
+    TCE_CMP1EV_PULSE_gc = (0x00<<5),  /* Event output for CMP is a pulse */
+    TCE_CMP1EV_WAVEFORM_gc = (0x01<<5)  /* Event output for CMP is equal to waveform */
+} TCE_CMP1EV_t;
+
+/* Compare # Event select */
+typedef enum TCE_CMP2EV_enum
+{
+    TCE_CMP2EV_PULSE_gc = (0x00<<6),  /* Event output for CMP is a pulse */
+    TCE_CMP2EV_WAVEFORM_gc = (0x01<<6)  /* Event output for CMP is equal to waveform */
+} TCE_CMP2EV_t;
+
+/* Compare # Event select */
+typedef enum TCE_CMP3EV_enum
+{
+    TCE_CMP3EV_PULSE_gc = (0x00<<7),  /* Event output for CMP is a pulse */
+    TCE_CMP3EV_WAVEFORM_gc = (0x01<<7)  /* Event output for CMP is equal to waveform */
+} TCE_CMP3EV_t;
+
+/* Direction select */
+typedef enum TCE_DIR_enum
+{
+    TCE_DIR_UP_gc = (0x00<<0),  /* Count up */
+    TCE_DIR_DOWN_gc = (0x01<<0)  /* Count down */
+} TCE_DIR_t;
+
+/* Event Action A select */
+typedef enum TCE_EVACTA_enum
+{
+    TCE_EVACTA_CNT_POSEDGE_gc = (0x00<<1),  /* Count on positive edge event */
+    TCE_EVACTA_CNT_ANYEDGE_gc = (0x01<<1),  /* Count on any edge event */
+    TCE_EVACTA_CNT_HIGHLVL_gc = (0x02<<1),  /* Count on prescaled clock while event line is 1. */
+    TCE_EVACTA_UPDOWN_gc = (0x03<<1)  /* Count on prescaled clock. Event controls count direction. Up-count when event line is 0, down-count when event line is 1. */
+} TCE_EVACTA_t;
+
+/* Event Action B select */
+typedef enum TCE_EVACTB_enum
+{
+    TCE_EVACTB_NONE_gc = (0x00<<5),  /* No Action */
+    TCE_EVACTB_UPDOWN_gc = (0x03<<5),  /* Count on prescaled clock. Event controls count direction. Up-count when event line is 0, down-count when event line is 1. */
+    TCE_EVACTB_RESTART_POSEDGE_gc = (0x04<<5),  /* Restart counter at positive edge event */
+    TCE_EVACTB_RESTART_ANYEDGE_gc = (0x05<<5),  /* Restart counter on any edge event */
+    TCE_EVACTB_RESTART_HIGHLVL_gc = (0x06<<5)  /* Restart counter while event line is 1. */
+} TCE_EVACTB_t;
+
+/* High Resolution Enable select */
+typedef enum TCE_HREN_enum
+{
+    TCE_HREN_OFF_gc = (0x00<<6),  /* High Resolution Disable */
+    TCE_HREN_4X_gc = (0x01<<6),  /* Resolution increased by 4 (2 bits) */
+    TCE_HREN_8X_gc = (0x02<<6)  /* Resolution increased by 4 (3 bits) */
+} TCE_HREN_t;
+
+/* Scaled Write select */
+typedef enum TCE_SCALE_enum
+{
+    TCE_SCALE_NORMAL_gc = (0x00<<2),  /* Absolute values used when writing to CMPn, CMPnBUF and registers */
+    TCE_SCALE_FRACTIONAL_gc = (0x01<<2)  /* Fractional values used when writing to CMPn, CMPnBUF and registers */
+} TCE_SCALE_t;
+
+/* Scaling Mode select */
+typedef enum TCE_SCALEMODE_enum
+{
+    TCE_SCALEMODE_CENTER_gc = (0x00<<4),  /* CMPn registers scaled vs center (50% duty cycle) */
+    TCE_SCALEMODE_BOTTOM_gc = (0x01<<4),  /* CMPn registers scaled vs BOTTOM (0% duty cycle) */
+    TCE_SCALEMODE_TOP_gc = (0x02<<4),  /* CMPn registers scaled vs TOP (100% duty cycle) */
+    TCE_SCALEMODE_TOPBOTTOM_gc = (0x03<<4)  /* CMPn registers scaled vs TOP or BOTTOM depending on written value. */
+} TCE_SCALEMODE_t;
+
+/* Waveform generation mode select */
+typedef enum TCE_WGMODE_enum
+{
+    TCE_WGMODE_NORMAL_gc = (0x00<<0),  /* Normal Mode */
+    TCE_WGMODE_FRQ_gc = (0x01<<0),  /* Frequency Generation Mode */
+    TCE_WGMODE_SINGLESLOPE_gc = (0x03<<0),  /* Single Slope PWM */
+    TCE_WGMODE_DSTOP_gc = (0x05<<0),  /* Dual Slope PWM, overflow on TOP */
+    TCE_WGMODE_DSBOTH_gc = (0x06<<0),  /* Dual Slope PWM, overflow on TOP and BOTTOM */
+    TCE_WGMODE_DSBOTTOM_gc = (0x07<<0)  /* Dual Slope PWM, overflow on BOTTOM */
+} TCE_WGMODE_t;
+
+/*
+--------------------------------------------------------------------------
+TCF - 24-bit Timer/Counter for frequency generation
+--------------------------------------------------------------------------
+*/
+
+/* 24-bit Timer/Counter for frequency generation */
+typedef struct TCF_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    register8_t CTRLD;  /* Control D */
+    register8_t EVCTRL;  /* Event Control */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t STATUS;  /* Status */
+    register8_t reserved_1[5];
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t reserved_2[2];
+    _DWORDREGISTER(CNT);  /* Count */
+    _DWORDREGISTER(CMP);  /* Compare */
+    register8_t reserved_3[8];
+} TCF_t;
+
+/* Clock Select */
+typedef enum TCF_CLKSEL_enum
+{
+    TCF_CLKSEL_CLKPER_gc = (0x00<<3),  /* Peripheral Clock */
+    TCF_CLKSEL_EVENT_gc = (0x01<<3),  /* Event as clock source */
+    TCF_CLKSEL_OSCHF_gc = (0x02<<3),  /* Internal High Frequency Oscillator */
+    TCF_CLKSEL_OSC32K_gc = (0x03<<3),  /* Internal 32.768 kHz Oscillator */
+    TCF_CLKSEL_PLL_gc = (0x05<<3)  /* PLL */
+} TCF_CLKSEL_t;
+
+/* Command select */
+typedef enum TCF_CMD_enum
+{
+    TCF_CMD_NONE_gc = (0x00<<0),  /* No command */
+    TCF_CMD_UPDATE_gc = (0x01<<0),  /* Force update */
+    TCF_CMD_RESTART_gc = (0x02<<0)  /* Force restart */
+} TCF_CMD_t;
+
+/* Compare # Event Generation select */
+typedef enum TCF_CMP0EV_enum
+{
+    TCF_CMP0EV_PULSE_gc = (0x00<<6),  /* Event is generated as pulse */
+    TCF_CMP0EV_WAVEFORM_gc = (0x01<<6)  /* Waveform is used as event output */
+} TCF_CMP0EV_t;
+
+/* Compare # Event Generation select */
+typedef enum TCF_CMP1EV_enum
+{
+    TCF_CMP1EV_PULSE_gc = (0x00<<7),  /* Event is generated as pulse */
+    TCF_CMP1EV_WAVEFORM_gc = (0x01<<7)  /* Waveform is used as event output */
+} TCF_CMP1EV_t;
+
+/* Event Action A select */
+typedef enum TCF_EVACTA_enum
+{
+    TCF_EVACTA_RESTART_gc = (0x00<<1),  /* Restart Counter */
+    TCF_EVACTA_BLANK_gc = (0x01<<1)  /* Mask waveform output to '0' */
+} TCF_EVACTA_t;
+
+/* Clock Prescaler select */
+typedef enum TCF_PRESC_enum
+{
+    TCF_PRESC_DIV1_gc = (0x00<<1),  /* Runs directly on Clock Source */
+    TCF_PRESC_DIV2_gc = (0x01<<1),  /* Divide clock source by 2 */
+    TCF_PRESC_DIV4_gc = (0x02<<1),  /* Divide clock source by 4 */
+    TCF_PRESC_DIV8_gc = (0x03<<1),  /* Divide clock source by 8 */
+    TCF_PRESC_DIV16_gc = (0x04<<1),  /* Divide clock source by 16 */
+    TCF_PRESC_DIV32_gc = (0x05<<1),  /* Divide clock source by 32 */
+    TCF_PRESC_DIV64_gc = (0x06<<1),  /* Divide clock source by 64 */
+    TCF_PRESC_DIV128_gc = (0x07<<1)  /* Divide clock source by 128 */
+} TCF_PRESC_t;
+
+/* Waveform Generation Mode select */
+typedef enum TCF_WGMODE_enum
+{
+    TCF_WGMODE_FRQ_gc = (0x00<<0),  /* Frequency */
+    TCF_WGMODE_NCOPF_gc = (0x01<<0),  /* Numerically Controlled Oscillator Pulse-Frequency */
+    TCF_WGMODE_NCOFDC_gc = (0x02<<0),  /* Numerically Controlled Oscillator Fixed Duty Cycle */
+    TCF_WGMODE_PWM8_gc = (0x07<<0)  /* 8-bit PWM */
+} TCF_WGMODE_t;
+
+/* Waveform Generation Pulse Length select */
+typedef enum TCF_WGPULSE_enum
+{
+    TCF_WGPULSE_CLK1_gc = (0x00<<4),  /* High pulse duration is 1 clock period */
+    TCF_WGPULSE_CLK2_gc = (0x01<<4),  /* High pulse duration is 2 clock period */
+    TCF_WGPULSE_CLK4_gc = (0x02<<4),  /* High pulse duration is 4 clock period */
+    TCF_WGPULSE_CLK8_gc = (0x03<<4),  /* High pulse duration is 8 clock period */
+    TCF_WGPULSE_CLK16_gc = (0x04<<4),  /* High pulse duration is 16 clock period */
+    TCF_WGPULSE_CLK32_gc = (0x05<<4),  /* High pulse duration is 32 clock period */
+    TCF_WGPULSE_CLK64_gc = (0x06<<4),  /* High pulse duration is 64 clock period */
+    TCF_WGPULSE_CLK128_gc = (0x07<<4)  /* High pulse duration is 128 clock period */
+} TCF_WGPULSE_t;
+
+/* Waveform Output # Polarity select */
+typedef enum TCF_WO0POL_enum
+{
+    TCF_WO0POL_NORMAL_gc = (0x00<<2),  /* Waveform output set on update and cleared on match */
+    TCF_WO0POL_INVERSE_gc = (0x01<<2)  /* Waveform output cleared on update and set on match */
+} TCF_WO0POL_t;
+
+/* Waveform Output # Polarity select */
+typedef enum TCF_WO1POL_enum
+{
+    TCF_WO1POL_NORMAL_gc = (0x00<<3),  /* Waveform output set on update and cleared on match */
+    TCF_WO1POL_INVERSE_gc = (0x01<<3)  /* Waveform output cleared on update and set on match */
+} TCF_WO1POL_t;
+
+/*
+--------------------------------------------------------------------------
+TWI - Two-Wire Interface
+--------------------------------------------------------------------------
+*/
+
+/* Two-Wire Interface */
+typedef struct TWI_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t DUALCTRL;  /* Dual Mode Control */
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t MCTRLA;  /* Host Control A */
+    register8_t MCTRLB;  /* Host Control B */
+    register8_t MSTATUS;  /* Host STATUS */
+    register8_t MBAUD;  /* Host Baud Rate */
+    register8_t MADDR;  /* Host Address */
+    register8_t MDATA;  /* Host Data */
+    register8_t SCTRLA;  /* Client Control A */
+    register8_t SCTRLB;  /* Client Control B */
+    register8_t SSTATUS;  /* Client Status */
+    register8_t SADDR;  /* Client Address */
+    register8_t SDATA;  /* Client Data */
+    register8_t SADDRMASK;  /* Client Address Mask */
+    register8_t reserved_1[1];
+} TWI_t;
+
+/* Acknowledge Action select */
+typedef enum TWI_ACKACT_enum
+{
+    TWI_ACKACT_ACK_gc = (0x00<<2),  /* Send ACK */
+    TWI_ACKACT_NACK_gc = (0x01<<2)  /* Send NACK */
+} TWI_ACKACT_t;
+
+/* Address or Stop select */
+typedef enum TWI_AP_enum
+{
+    TWI_AP_STOP_gc = (0x00<<0),  /* A Stop condition generated the interrupt on APIF flag */
+    TWI_AP_ADR_gc = (0x01<<0)  /* Address detection generated the interrupt on APIF flag */
+} TWI_AP_t;
+
+/* Bus State select */
+typedef enum TWI_BUSSTATE_enum
+{
+    TWI_BUSSTATE_UNKNOWN_gc = (0x00<<0),  /* Unknown bus state */
+    TWI_BUSSTATE_IDLE_gc = (0x01<<0),  /* Bus is idle */
+    TWI_BUSSTATE_OWNER_gc = (0x02<<0),  /* This TWI controls the bus */
+    TWI_BUSSTATE_BUSY_gc = (0x03<<0)  /* The bus is busy */
+} TWI_BUSSTATE_t;
+
+/* Debug Run select */
+typedef enum TWI_DBGRUN_enum
+{
+    TWI_DBGRUN_HALT_gc = (0x00<<0),  /* The peripheral is halted in Break Debug mode and ignores events */
+    TWI_DBGRUN_RUN_gc = (0x01<<0)  /* The peripheral will continue to run in Break Debug mode when the CPU is halted */
+} TWI_DBGRUN_t;
+
+/* Fast-mode Enable select */
+typedef enum TWI_FMEN_enum
+{
+    TWI_FMEN_OFF_gc = (0x00<<0),  /* SCL duty cycle operating according to Sm specification */
+    TWI_FMEN_ON_gc = (0x01<<0)  /* SCL duty cycle operating according to Fm specification */
+} TWI_FMEN_t;
+
+/* Fast-mode Plus Enable select */
+typedef enum TWI_FMPEN_enum
+{
+    TWI_FMPEN_OFF_gc = (0x00<<1),  /* Operating in Standard-mode or Fast-mode */
+    TWI_FMPEN_ON_gc = (0x01<<1)  /* Operating in Fast-mode Plus */
+} TWI_FMPEN_t;
+
+/* Input voltage transition level select */
+typedef enum TWI_INPUTLVL_enum
+{
+    TWI_INPUTLVL_I2C_gc = (0x00<<6),  /* I2C input voltage transition level */
+    TWI_INPUTLVL_SMBUS_gc = (0x01<<6)  /* SMBus 3.0 input voltage transition level */
+} TWI_INPUTLVL_t;
+
+/* Command select */
+typedef enum TWI_MCMD_enum
+{
+    TWI_MCMD_NOACT_gc = (0x00<<0),  /* No action */
+    TWI_MCMD_REPSTART_gc = (0x01<<0),  /* Execute Acknowledge Action followed by repeated Start. */
+    TWI_MCMD_RECVTRANS_gc = (0x02<<0),  /* Execute Acknowledge Action followed by a byte read/write operation. Read/write is defined by DIR. */
+    TWI_MCMD_STOP_gc = (0x03<<0)  /* Execute Acknowledge Action followed by issuing a Stop condition. */
+} TWI_MCMD_t;
+
+/* Command select */
+typedef enum TWI_SCMD_enum
+{
+    TWI_SCMD_NOACT_gc = (0x00<<0),  /* No Action */
+    TWI_SCMD_COMPTRANS_gc = (0x02<<0),  /* Complete transaction */
+    TWI_SCMD_RESPONSE_gc = (0x03<<0)  /* Used in response to an interrupt */
+} TWI_SCMD_t;
+
+/* SDA Hold Time select */
+typedef enum TWI_SDAHOLD_enum
+{
+    TWI_SDAHOLD_OFF_gc = (0x00<<2),  /* No SDA Hold Delay */
+    TWI_SDAHOLD_50NS_gc = (0x01<<2),  /* Short SDA hold time */
+    TWI_SDAHOLD_300NS_gc = (0x02<<2),  /* Meets SMBUS 2.0 specification under typical conditions */
+    TWI_SDAHOLD_500NS_gc = (0x03<<2)  /* Meets SMBUS 2.0 specificaiton across all corners */
+} TWI_SDAHOLD_t;
+
+/* SDA Setup Time select */
+typedef enum TWI_SDASETUP_enum
+{
+    TWI_SDASETUP_4CYC_gc = (0x00<<4),  /* SDA setup time is four clock cycles */
+    TWI_SDASETUP_8CYC_gc = (0x01<<4)  /* SDA setup time is eight clock cycle */
+} TWI_SDASETUP_t;
+
+/* Inactive Bus Time-Out select */
+typedef enum TWI_TIMEOUT_enum
+{
+    TWI_TIMEOUT_DISABLED_gc = (0x00<<2),  /* Bus time-out disabled. I2C. */
+    TWI_TIMEOUT_50US_gc = (0x01<<2),  /* 50us - SMBus */
+    TWI_TIMEOUT_100US_gc = (0x02<<2),  /* 100us */
+    TWI_TIMEOUT_200US_gc = (0x03<<2)  /* 200us */
+} TWI_TIMEOUT_t;
+
+/*
+--------------------------------------------------------------------------
+USART - Universal Synchronous and Asynchronous Receiver and Transmitter
+--------------------------------------------------------------------------
+*/
+
+/* Universal Synchronous and Asynchronous Receiver and Transmitter */
+typedef struct USART_struct
+{
+    register8_t RXDATAL;  /* Receive Data Low Byte */
+    register8_t RXDATAH;  /* Receive Data High Byte */
+    register8_t TXDATAL;  /* Transmit Data Low Byte */
+    register8_t TXDATAH;  /* Transmit Data High Byte */
+    register8_t STATUS;  /* Status */
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    _WORDREGISTER(BAUD);  /* Baud Rate */
+    register8_t CTRLD;  /* Control D */
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t EVCTRL;  /* Event Control */
+    register8_t TXPLCTRL;  /* IRCOM Transmitter Pulse Length Control */
+    register8_t RXPLCTRL;  /* IRCOM Receiver Pulse Length Control */
+    register8_t reserved_1[1];
+} USART_t;
+
+/* Auto Baud Window select */
+typedef enum USART_ABW_enum
+{
+    USART_ABW_WDW0_gc = (0x00<<6),  /* 18% tolerance */
+    USART_ABW_WDW1_gc = (0x01<<6),  /* 15% tolerance */
+    USART_ABW_WDW2_gc = (0x02<<6),  /* 21% tolerance */
+    USART_ABW_WDW3_gc = (0x03<<6)  /* 25% tolerance */
+} USART_ABW_t;
+
+/* Character Size select */
+typedef enum USART_CHSIZE_enum
+{
+    USART_CHSIZE_5BIT_gc = (0x00<<0),  /* Character size: 5 bit */
+    USART_CHSIZE_6BIT_gc = (0x01<<0),  /* Character size: 6 bit */
+    USART_CHSIZE_7BIT_gc = (0x02<<0),  /* Character size: 7 bit */
+    USART_CHSIZE_8BIT_gc = (0x03<<0),  /* Character size: 8 bit */
+    USART_CHSIZE_9BITL_gc = (0x06<<0),  /* Character size: 9 bit read low byte first */
+    USART_CHSIZE_9BITH_gc = (0x07<<0)  /* Character size: 9 bit read high byte first */
+} USART_CHSIZE_t;
+
+/* Communication Mode select */
+typedef enum USART_CMODE_enum
+{
+    USART_CMODE_ASYNCHRONOUS_gc = (0x00<<6),  /* Asynchronous Mode */
+    USART_CMODE_SYNCHRONOUS_gc = (0x01<<6),  /* Synchronous Mode */
+    USART_CMODE_IRCOM_gc = (0x02<<6),  /* Infrared Communication */
+    USART_CMODE_MSPI_gc = (0x03<<6)  /* SPI Host Mode */
+} USART_CMODE_t;
+
+/* Parity Mode select */
+typedef enum USART_PMODE_enum
+{
+    USART_PMODE_DISABLED_gc = (0x00<<4),  /* No Parity */
+    USART_PMODE_EVEN_gc = (0x02<<4),  /* Even Parity */
+    USART_PMODE_ODD_gc = (0x03<<4)  /* Odd Parity */
+} USART_PMODE_t;
+
+/* RS485 Mode internal transmitter select */
+typedef enum USART_RS485_enum
+{
+    USART_RS485_DISABLE_gc = (0x00<<0),  /* RS485 Mode disabled */
+    USART_RS485_ENABLE_gc = (0x01<<0)  /* RS485 Mode enabled */
+} USART_RS485_t;
+
+/* Receiver Mode select */
+typedef enum USART_RXMODE_enum
+{
+    USART_RXMODE_NORMAL_gc = (0x00<<1),  /* Normal mode */
+    USART_RXMODE_CLK2X_gc = (0x01<<1),  /* CLK2x mode */
+    USART_RXMODE_GENAUTO_gc = (0x02<<1),  /* Generic autobaud mode */
+    USART_RXMODE_LINAUTO_gc = (0x03<<1)  /* LIN constrained autobaud mode */
+} USART_RXMODE_t;
+
+/* Stop Bit Mode select */
+typedef enum USART_SBMODE_enum
+{
+    USART_SBMODE_1BIT_gc = (0x00<<3),  /* 1 stop bit */
+    USART_SBMODE_2BIT_gc = (0x01<<3)  /* 2 stop bits */
+} USART_SBMODE_t;
+
+/*
+--------------------------------------------------------------------------
+USERROW - User Row
+--------------------------------------------------------------------------
+*/
+
+/* User Row */
+typedef struct USERROW_struct
+{
+    register8_t USERROW0;  /* User Row Byte 0 */
+    register8_t USERROW1;  /* User Row Byte 1 */
+    register8_t USERROW2;  /* User Row Byte 2 */
+    register8_t USERROW3;  /* User Row Byte 3 */
+    register8_t USERROW4;  /* User Row Byte 4 */
+    register8_t USERROW5;  /* User Row Byte 5 */
+    register8_t USERROW6;  /* User Row Byte 6 */
+    register8_t USERROW7;  /* User Row Byte 7 */
+    register8_t USERROW8;  /* User Row Byte 8 */
+    register8_t USERROW9;  /* User Row Byte 9 */
+    register8_t USERROW10;  /* User Row Byte 10 */
+    register8_t USERROW11;  /* User Row Byte 11 */
+    register8_t USERROW12;  /* User Row Byte 12 */
+    register8_t USERROW13;  /* User Row Byte 13 */
+    register8_t USERROW14;  /* User Row Byte 14 */
+    register8_t USERROW15;  /* User Row Byte 15 */
+    register8_t USERROW16;  /* User Row Byte 16 */
+    register8_t USERROW17;  /* User Row Byte 17 */
+    register8_t USERROW18;  /* User Row Byte 18 */
+    register8_t USERROW19;  /* User Row Byte 19 */
+    register8_t USERROW20;  /* User Row Byte 20 */
+    register8_t USERROW21;  /* User Row Byte 21 */
+    register8_t USERROW22;  /* User Row Byte 22 */
+    register8_t USERROW23;  /* User Row Byte 23 */
+    register8_t USERROW24;  /* User Row Byte 24 */
+    register8_t USERROW25;  /* User Row Byte 25 */
+    register8_t USERROW26;  /* User Row Byte 26 */
+    register8_t USERROW27;  /* User Row Byte 27 */
+    register8_t USERROW28;  /* User Row Byte 28 */
+    register8_t USERROW29;  /* User Row Byte 29 */
+    register8_t USERROW30;  /* User Row Byte 30 */
+    register8_t USERROW31;  /* User Row Byte 31 */
+    register8_t USERROW32;  /* User Row Byte 32 */
+    register8_t USERROW33;  /* User Row Byte 33 */
+    register8_t USERROW34;  /* User Row Byte 34 */
+    register8_t USERROW35;  /* User Row Byte 35 */
+    register8_t USERROW36;  /* User Row Byte 36 */
+    register8_t USERROW37;  /* User Row Byte 37 */
+    register8_t USERROW38;  /* User Row Byte 38 */
+    register8_t USERROW39;  /* User Row Byte 39 */
+    register8_t USERROW40;  /* User Row Byte 40 */
+    register8_t USERROW41;  /* User Row Byte 41 */
+    register8_t USERROW42;  /* User Row Byte 42 */
+    register8_t USERROW43;  /* User Row Byte 43 */
+    register8_t USERROW44;  /* User Row Byte 44 */
+    register8_t USERROW45;  /* User Row Byte 45 */
+    register8_t USERROW46;  /* User Row Byte 46 */
+    register8_t USERROW47;  /* User Row Byte 47 */
+    register8_t USERROW48;  /* User Row Byte 48 */
+    register8_t USERROW49;  /* User Row Byte 49 */
+    register8_t USERROW50;  /* User Row Byte 50 */
+    register8_t USERROW51;  /* User Row Byte 51 */
+    register8_t USERROW52;  /* User Row Byte 52 */
+    register8_t USERROW53;  /* User Row Byte 53 */
+    register8_t USERROW54;  /* User Row Byte 54 */
+    register8_t USERROW55;  /* User Row Byte 55 */
+    register8_t USERROW56;  /* User Row Byte 56 */
+    register8_t USERROW57;  /* User Row Byte 57 */
+    register8_t USERROW58;  /* User Row Byte 58 */
+    register8_t USERROW59;  /* User Row Byte 59 */
+    register8_t USERROW60;  /* User Row Byte 60 */
+    register8_t USERROW61;  /* User Row Byte 61 */
+    register8_t USERROW62;  /* User Row Byte 62 */
+    register8_t USERROW63;  /* User Row Byte 63 */
+} USERROW_t;
+
+
+/*
+--------------------------------------------------------------------------
+VPORT - Virtual Ports
+--------------------------------------------------------------------------
+*/
+
+/* Virtual Ports */
+typedef struct VPORT_struct
+{
+    register8_t DIR;  /* Data Direction */
+    register8_t OUT;  /* Output Value */
+    register8_t IN;  /* Input Value */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+} VPORT_t;
+
+
+/*
+--------------------------------------------------------------------------
+VREF - Voltage reference
+--------------------------------------------------------------------------
+*/
+
+/* Voltage reference */
+typedef struct VREF_struct
+{
+    register8_t reserved_1[2];
+    register8_t DAC0REF;  /* DAC0 Reference */
+    register8_t reserved_2[1];
+    register8_t ACREF;  /* AC Reference */
+    register8_t reserved_3[11];
+} VREF_t;
+
+/* Reference select */
+typedef enum VREF_REFSEL_enum
+{
+    VREF_REFSEL_1V024_gc = (0x00<<0),  /* Internal 1.024V reference */
+    VREF_REFSEL_2V048_gc = (0x01<<0),  /* Internal 2.048V reference */
+    VREF_REFSEL_4V096_gc = (0x02<<0),  /* Internal 4.096V reference */
+    VREF_REFSEL_2V500_gc = (0x03<<0),  /* Internal 2.500V reference */
+    VREF_REFSEL_VDD_gc = (0x05<<0),  /* VDD as reference */
+    VREF_REFSEL_VREFA_gc = (0x06<<0)  /* External reference on VREFA pin */
+} VREF_REFSEL_t;
+
+/*
+--------------------------------------------------------------------------
+WDT - Watch-Dog Timer
+--------------------------------------------------------------------------
+*/
+
+/* Watch-Dog Timer */
+typedef struct WDT_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t STATUS;  /* Status */
+    register8_t reserved_1[14];
+} WDT_t;
+
+/* Period select */
+typedef enum WDT_PERIOD_enum
+{
+    WDT_PERIOD_OFF_gc = (0x00<<0),  /* Off */
+    WDT_PERIOD_8CLK_gc = (0x01<<0),  /* 8 cycles (8ms) */
+    WDT_PERIOD_16CLK_gc = (0x02<<0),  /* 16 cycles (16ms) */
+    WDT_PERIOD_32CLK_gc = (0x03<<0),  /* 32 cycles (32ms) */
+    WDT_PERIOD_64CLK_gc = (0x04<<0),  /* 64 cycles (64ms) */
+    WDT_PERIOD_128CLK_gc = (0x05<<0),  /* 128 cycles (0.128s) */
+    WDT_PERIOD_256CLK_gc = (0x06<<0),  /* 256 cycles (0.256s) */
+    WDT_PERIOD_512CLK_gc = (0x07<<0),  /* 512 cycles (0.512s) */
+    WDT_PERIOD_1KCLK_gc = (0x08<<0),  /* 1K cycles (1.0s) */
+    WDT_PERIOD_2KCLK_gc = (0x09<<0),  /* 2K cycles (2.0s) */
+    WDT_PERIOD_4KCLK_gc = (0x0A<<0),  /* 4K cycles (4.1s) */
+    WDT_PERIOD_8KCLK_gc = (0x0B<<0)  /* 8K cycles (8.2s) */
+} WDT_PERIOD_t;
+
+/* Window select */
+typedef enum WDT_WINDOW_enum
+{
+    WDT_WINDOW_OFF_gc = (0x00<<4),  /* Off */
+    WDT_WINDOW_8CLK_gc = (0x01<<4),  /* 8 cycles (8ms) */
+    WDT_WINDOW_16CLK_gc = (0x02<<4),  /* 16 cycles (16ms) */
+    WDT_WINDOW_32CLK_gc = (0x03<<4),  /* 32 cycles (32ms) */
+    WDT_WINDOW_64CLK_gc = (0x04<<4),  /* 64 cycles (64ms) */
+    WDT_WINDOW_128CLK_gc = (0x05<<4),  /* 128 cycles (0.128s) */
+    WDT_WINDOW_256CLK_gc = (0x06<<4),  /* 256 cycles (0.256s) */
+    WDT_WINDOW_512CLK_gc = (0x07<<4),  /* 512 cycles (0.512s) */
+    WDT_WINDOW_1KCLK_gc = (0x08<<4),  /* 1K cycles (1.0s) */
+    WDT_WINDOW_2KCLK_gc = (0x09<<4),  /* 2K cycles (2.0s) */
+    WDT_WINDOW_4KCLK_gc = (0x0A<<4),  /* 4K cycles (4.1s) */
+    WDT_WINDOW_8KCLK_gc = (0x0B<<4)  /* 8K cycles (8.2s) */
+} WDT_WINDOW_t;
+
+/*
+--------------------------------------------------------------------------
+WEX - Waveform Extension
+--------------------------------------------------------------------------
+*/
+
+/* Waveform Extension */
+typedef struct WEX_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    register8_t reserved_1[1];
+    register8_t EVCTRLA;  /* Event Control A */
+    register8_t EVCTRLB;  /* Event Control B */
+    register8_t EVCTRLC;  /* Event Control C */
+    register8_t BUFCTRL;  /* Buffer Valid Control */
+    register8_t BLANKCTRL;  /* Blanking Control */
+    register8_t BLANKTIME;  /* Blanking Time */
+    register8_t FAULTCTRL;  /* Fault Control */
+    register8_t FAULTDRV;  /* Fault Drive */
+    register8_t FAULTOUT;  /* Fault Output */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t STATUS;  /* Status */
+    register8_t DTLS;  /* Dead-time Low Side */
+    register8_t DTHS;  /* Dead-time High Side */
+    register8_t DTBOTH;  /* Dead-time Both Sides */
+    register8_t SWAP;  /* DTI Swap */
+    register8_t PGMOVR;  /* Pattern Generation Override */
+    register8_t PGMOUT;  /* Pattern Generation Output */
+    register8_t reserved_2[1];
+    register8_t OUTOVEN;  /* Output Override Enable */
+    register8_t DTLSBUF;  /* Dead-time Low Side Buffer */
+    register8_t DTHSBUF;  /* Dead-time High Side Buffer */
+    register8_t DTBOTHBUF;  /* Dead-time Both Sides Buffer */
+    register8_t SWAPBUF;  /* DTI Swap Buffer */
+    register8_t PGMOVRBUF;  /* Pattern Generation Override Buffer */
+    register8_t PGMOUTBUF;  /* Pattern Generation Output Buffer */
+    register8_t reserved_3[2];
+} WEX_t;
+
+/* Blanking Prescaler select */
+typedef enum WEX_BLANKPRESC_enum
+{
+    WEX_BLANKPRESC_DIV1_gc = (0x00<<5),  /* No prescaling */
+    WEX_BLANKPRESC_DIV4_gc = (0x01<<5),  /* Divide CLK_PER by 4 */
+    WEX_BLANKPRESC_DIV16_gc = (0x02<<5),  /* Divide CLK_PER by 16 */
+    WEX_BLANKPRESC_DIV64_gc = (0x03<<5)  /* Divide CLK_PER by 64 */
+} WEX_BLANKPRESC_t;
+
+/* Blanking State select */
+typedef enum WEX_BLANKSTATE_enum
+{
+    WEX_BLANKSTATE_OFF_gc = (0x00<<7),  /* Blanking off */
+    WEX_BLANKSTATE_ON_gc = (0x01<<7)  /* Blanking active */
+} WEX_BLANKSTATE_t;
+
+/* Blanking Trigger select */
+typedef enum WEX_BLANKTRIG_enum
+{
+    WEX_BLANKTRIG_NONE_gc = (0x00<<0),  /* No HW trigger (Software only) */
+    WEX_BLANKTRIG_TCE0UPD_gc = (0x04<<0),  /* TCE0 Update Condition */
+    WEX_BLANKTRIG_TCE0CMP0_gc = (0x08<<0),  /* TCE0 Compare 0 */
+    WEX_BLANKTRIG_TCE0CMP1_gc = (0x0C<<0),  /* TCE0 Compare 1 */
+    WEX_BLANKTRIG_TCE0CMP2_gc = (0x10<<0),  /* TCE0 Compare 2 */
+    WEX_BLANKTRIG_TCE0CMP3_gc = (0x14<<0)  /* TCE0 Compare 3 */
+} WEX_BLANKTRIG_t;
+
+/* Command select */
+typedef enum WEX_CMD_enum
+{
+    WEX_CMD_NONE_gc = (0x00<<0),  /* No Command */
+    WEX_CMD_UPDATE_gc = (0x01<<0),  /* Force update of Dead-time, SWAP and PGM buffer registers. */
+    WEX_CMD_FAULTSET_gc = (0x02<<0),  /* Set Fault Detection */
+    WEX_CMD_FAULTCLR_gc = (0x03<<0),  /* Clear Fault Detection */
+    WEX_CMD_BLANKSET_gc = (0x04<<0),  /* Set SW Blanking */
+    WEX_CMD_BLANKCLR_gc = (0x05<<0)  /* Clear SW Blanking */
+} WEX_CMD_t;
+
+/* Fault Detection Action select */
+typedef enum WEX_FDACT_enum
+{
+    WEX_FDACT_NONE_gc = (0x00<<0),  /* None. Fault Protection Disabled */
+    WEX_FDACT_LOW_gc = (0x01<<0),  /* Drive all pins low */
+    WEX_FDACT_CUSTOM_gc = (0x03<<0)  /* Drive all pins to setting defined by FAULTDRV and FAULTVAL */
+} WEX_FDACT_t;
+
+/* Fault Detection on Debug Break Detection select */
+typedef enum WEX_FDDBD_enum
+{
+    WEX_FDDBD_FAULT_gc = (0x00<<7),  /* OCD Break request is treated as a fault if fault protection is enabled */
+    WEX_FDDBD_IGNORE_gc = (0x01<<7)  /* OCD Breask request will not trigger a fault */
+} WEX_FDDBD_t;
+
+/* Fault Detection Restart Mode select */
+typedef enum WEX_FDMODE_enum
+{
+    WEX_FDMODE_LATCHED_gc = (0x00<<2),  /* Latched Mode. Output will remain in fault state until fault condition is no longer active and FDF is cleared by SW. */
+    WEX_FDMODE_CBC_gc = (0x01<<2)  /* Cycle-by-cycle mode. Waveform output will remain in fault state until fault condition is no longer active. */
+} WEX_FDMODE_t;
+
+/* Fault Detection State select */
+typedef enum WEX_FDSTATE_enum
+{
+    WEX_FDSTATE_NORMAL_gc = (0x00<<0),  /* Normal state */
+    WEX_FDSTATE_FAULT_gc = (0x01<<0)  /* Fault state */
+} WEX_FDSTATE_t;
+
+/* Fault Event Filter Enable select */
+typedef enum WEX_FILTER_enum
+{
+    WEX_FILTER_ZERO_gc = (0x00<<2),  /* No digital filter */
+    WEX_FILTER_SAMPLE1_gc = (0x01<<2),  /* One Sample */
+    WEX_FILTER_SAMPLE2_gc = (0x02<<2),  /* Two Samples */
+    WEX_FILTER_SAMPLE3_gc = (0x03<<2),  /* Three Samples */
+    WEX_FILTER_SAMPLE4_gc = (0x04<<2),  /* Four Samples */
+    WEX_FILTER_SAMPLE5_gc = (0x05<<2),  /* Five Samples */
+    WEX_FILTER_SAMPLE6_gc = (0x06<<2),  /* Six Samples */
+    WEX_FILTER_SAMPLE7_gc = (0x07<<2)  /* Seven Samples */
+} WEX_FILTER_t;
+
+/* Input Matrix select */
+typedef enum WEX_INMX_enum
+{
+    WEX_INMX_DIRECT_gc = (0x00<<4),  /* Direct from TCE0 */
+    WEX_INMX_CWCMA_gc = (0x02<<4),  /* Common Waveform Channel Mode A. Single WO */
+    WEX_INMX_CWCMB_gc = (0x03<<4)  /* Common Waveform Channel Mode B. WO from two PWM channels */
+} WEX_INMX_t;
+
+/* Update Source select */
+typedef enum WEX_UPDSRC_enum
+{
+    WEX_UPDSRC_TCPWM0_gc = (0x00<<0),  /* Timer/Counter for PWM 0 update condition */
+    WEX_UPDSRC_SW_gc = (0x03<<0)  /* Software update only. No hardware update condition */
+} WEX_UPDSRC_t;
+/*
+==========================================================================
+IO Module Instances. Mapped to memory.
+==========================================================================
+*/
+
+#define VPORTA              (*(VPORT_t *) 0x0000) /* Virtual Ports */
+#define VPORTC              (*(VPORT_t *) 0x0008) /* Virtual Ports */
+#define VPORTD              (*(VPORT_t *) 0x000C) /* Virtual Ports */
+#define VPORTF              (*(VPORT_t *) 0x0014) /* Virtual Ports */
+#define GPR                   (*(GPR_t *) 0x001C) /* General Purpose Registers */
+#define RSTCTRL           (*(RSTCTRL_t *) 0x0040) /* Reset controller */
+#define SLPCTRL           (*(SLPCTRL_t *) 0x0050) /* Sleep Controller */
+#define CLKCTRL           (*(CLKCTRL_t *) 0x0060) /* Clock controller */
+#define BOD                   (*(BOD_t *) 0x00A0) /* Bod interface */
+#define VREF                 (*(VREF_t *) 0x00B0) /* Voltage reference */
+#define WDT                   (*(WDT_t *) 0x0100) /* Watch-Dog Timer */
+#define CPUINT             (*(CPUINT_t *) 0x0110) /* Interrupt Controller */
+#define CRCSCAN           (*(CRCSCAN_t *) 0x0120) /* CRCSCAN */
+#define RTC                   (*(RTC_t *) 0x0140) /* Real-Time Counter */
+#define CCL                   (*(CCL_t *) 0x01C0) /* Configurable Custom Logic */
+#define EVSYS               (*(EVSYS_t *) 0x0200) /* Event System */
+#define PORTA                (*(PORT_t *) 0x0400) /* I/O Ports */
+#define PORTC                (*(PORT_t *) 0x0440) /* I/O Ports */
+#define PORTD                (*(PORT_t *) 0x0460) /* I/O Ports */
+#define PORTF                (*(PORT_t *) 0x04A0) /* I/O Ports */
+#define PORTMUX           (*(PORTMUX_t *) 0x05E0) /* Port Multiplexer */
+#define ADC0                  (*(ADC_t *) 0x0600) /* Analog to Digital Converter */
+#define AC0                    (*(AC_t *) 0x0680) /* Analog Comparator */
+#define AC1                    (*(AC_t *) 0x0688) /* Analog Comparator */
+#define USART0              (*(USART_t *) 0x0800) /* Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define TWI0                  (*(TWI_t *) 0x0900) /* Two-Wire Interface */
+#define SPI0                  (*(SPI_t *) 0x0940) /* Serial Peripheral Interface */
+#define TCE0                  (*(TCE_t *) 0x0A00) /* 16-bit Timer/Counter Type E */
+#define TCB0                  (*(TCB_t *) 0x0B00) /* 16-bit Timer/Counter Type B */
+#define TCB1                  (*(TCB_t *) 0x0B10) /* 16-bit Timer/Counter Type B */
+#define TCF0                  (*(TCF_t *) 0x0C00) /* 24-bit Timer/Counter for frequency generation */
+#define WEX0                  (*(WEX_t *) 0x0C80) /* Waveform Extension */
+#define SYSCFG             (*(SYSCFG_t *) 0x0F00) /* System Configuration Registers */
+#define NVMCTRL           (*(NVMCTRL_t *) 0x1000) /* Non-volatile Memory Controller */
+#define LOCK                 (*(LOCK_t *) 0x1040) /* Lockbits */
+#define FUSE                 (*(FUSE_t *) 0x1050) /* Fuses */
+#define SIGROW             (*(SIGROW_t *) 0x1080) /* Signature row */
+#define BOOTROW           (*(BOOTROW_t *) 0x1100) /* Boot Row */
+#define USERROW           (*(USERROW_t *) 0x1200) /* User Row */
+
+#endif /* !defined (__ASSEMBLER__) */
+
+
+/* ========== Flattened fully qualified IO register names ========== */
+
+
+/* VPORT (VPORTA) - Virtual Ports */
+#define VPORTA_DIR  _SFR_MEM8(0x0000)
+#define VPORTA_OUT  _SFR_MEM8(0x0001)
+#define VPORTA_IN  _SFR_MEM8(0x0002)
+#define VPORTA_INTFLAGS  _SFR_MEM8(0x0003)
+
+
+/* VPORT (VPORTC) - Virtual Ports */
+#define VPORTC_DIR  _SFR_MEM8(0x0008)
+#define VPORTC_OUT  _SFR_MEM8(0x0009)
+#define VPORTC_IN  _SFR_MEM8(0x000A)
+#define VPORTC_INTFLAGS  _SFR_MEM8(0x000B)
+
+
+/* VPORT (VPORTD) - Virtual Ports */
+#define VPORTD_DIR  _SFR_MEM8(0x000C)
+#define VPORTD_OUT  _SFR_MEM8(0x000D)
+#define VPORTD_IN  _SFR_MEM8(0x000E)
+#define VPORTD_INTFLAGS  _SFR_MEM8(0x000F)
+
+
+/* VPORT (VPORTF) - Virtual Ports */
+#define VPORTF_DIR  _SFR_MEM8(0x0014)
+#define VPORTF_OUT  _SFR_MEM8(0x0015)
+#define VPORTF_IN  _SFR_MEM8(0x0016)
+#define VPORTF_INTFLAGS  _SFR_MEM8(0x0017)
+
+
+/* GPR - General Purpose Registers */
+#define GPR_GPR0  _SFR_MEM8(0x001C)
+#define GPR_GPR1  _SFR_MEM8(0x001D)
+#define GPR_GPR2  _SFR_MEM8(0x001E)
+#define GPR_GPR3  _SFR_MEM8(0x001F)
+
+
+/* CPU - CPU */
+#define CPU_CCP  _SFR_MEM8(0x0034)
+#define CPU_RAMPZ  _SFR_MEM8(0x003B)
+#define CPU_SP  _SFR_MEM16(0x003D)
+#define CPU_SPL  _SFR_MEM8(0x003D)
+#define CPU_SPH  _SFR_MEM8(0x003E)
+#define CPU_SREG  _SFR_MEM8(0x003F)
+
+
+/* RSTCTRL - Reset controller */
+#define RSTCTRL_RSTFR  _SFR_MEM8(0x0040)
+#define RSTCTRL_SWRR  _SFR_MEM8(0x0041)
+
+
+/* SLPCTRL - Sleep Controller */
+#define SLPCTRL_CTRLA  _SFR_MEM8(0x0050)
+
+
+/* CLKCTRL - Clock controller */
+#define CLKCTRL_MCLKCTRLA  _SFR_MEM8(0x0060)
+#define CLKCTRL_MCLKCTRLB  _SFR_MEM8(0x0061)
+#define CLKCTRL_MCLKSTATUS  _SFR_MEM8(0x0065)
+#define CLKCTRL_MCLKTIMEBASE  _SFR_MEM8(0x0066)
+#define CLKCTRL_OSCHFCTRLA  _SFR_MEM8(0x0068)
+#define CLKCTRL_OSCHFTUNE  _SFR_MEM8(0x0069)
+#define CLKCTRL_PLLCTRLA  _SFR_MEM8(0x0070)
+#define CLKCTRL_PLLCTRLB  _SFR_MEM8(0x0071)
+#define CLKCTRL_OSC32KCTRLA  _SFR_MEM8(0x0078)
+#define CLKCTRL_XOSC32KCTRLA  _SFR_MEM8(0x007C)
+
+
+/* BOD - Bod interface */
+#define BOD_CTRLA  _SFR_MEM8(0x00A0)
+#define BOD_CTRLB  _SFR_MEM8(0x00A1)
+#define BOD_VLMCTRLA  _SFR_MEM8(0x00A8)
+#define BOD_INTCTRL  _SFR_MEM8(0x00A9)
+#define BOD_INTFLAGS  _SFR_MEM8(0x00AA)
+#define BOD_STATUS  _SFR_MEM8(0x00AB)
+
+
+/* VREF - Voltage reference */
+#define VREF_DAC0REF  _SFR_MEM8(0x00B2)
+#define VREF_ACREF  _SFR_MEM8(0x00B4)
+
+
+/* WDT - Watch-Dog Timer */
+#define WDT_CTRLA  _SFR_MEM8(0x0100)
+#define WDT_STATUS  _SFR_MEM8(0x0101)
+
+
+/* CPUINT - Interrupt Controller */
+#define CPUINT_CTRLA  _SFR_MEM8(0x0110)
+#define CPUINT_STATUS  _SFR_MEM8(0x0111)
+#define CPUINT_LVL0PRI  _SFR_MEM8(0x0112)
+#define CPUINT_LVL1VEC  _SFR_MEM8(0x0113)
+
+
+/* CRCSCAN - CRCSCAN */
+#define CRCSCAN_CTRLA  _SFR_MEM8(0x0120)
+#define CRCSCAN_CTRLB  _SFR_MEM8(0x0121)
+#define CRCSCAN_STATUS  _SFR_MEM8(0x0122)
+
+
+/* RTC - Real-Time Counter */
+#define RTC_CTRLA  _SFR_MEM8(0x0140)
+#define RTC_STATUS  _SFR_MEM8(0x0141)
+#define RTC_INTCTRL  _SFR_MEM8(0x0142)
+#define RTC_INTFLAGS  _SFR_MEM8(0x0143)
+#define RTC_TEMP  _SFR_MEM8(0x0144)
+#define RTC_DBGCTRL  _SFR_MEM8(0x0145)
+#define RTC_CALIB  _SFR_MEM8(0x0146)
+#define RTC_CLKSEL  _SFR_MEM8(0x0147)
+#define RTC_CNT  _SFR_MEM16(0x0148)
+#define RTC_CNTL  _SFR_MEM8(0x0148)
+#define RTC_CNTH  _SFR_MEM8(0x0149)
+#define RTC_PER  _SFR_MEM16(0x014A)
+#define RTC_PERL  _SFR_MEM8(0x014A)
+#define RTC_PERH  _SFR_MEM8(0x014B)
+#define RTC_CMP  _SFR_MEM16(0x014C)
+#define RTC_CMPL  _SFR_MEM8(0x014C)
+#define RTC_CMPH  _SFR_MEM8(0x014D)
+#define RTC_PITCTRLA  _SFR_MEM8(0x0150)
+#define RTC_PITSTATUS  _SFR_MEM8(0x0151)
+#define RTC_PITINTCTRL  _SFR_MEM8(0x0152)
+#define RTC_PITINTFLAGS  _SFR_MEM8(0x0153)
+#define RTC_PITDBGCTRL  _SFR_MEM8(0x0155)
+#define RTC_PITEVGENCTRLA  _SFR_MEM8(0x0156)
+
+
+/* CCL - Configurable Custom Logic */
+#define CCL_CTRLA  _SFR_MEM8(0x01C0)
+#define CCL_SEQCTRL0  _SFR_MEM8(0x01C1)
+#define CCL_SEQCTRL1  _SFR_MEM8(0x01C2)
+#define CCL_INTCTRL0  _SFR_MEM8(0x01C5)
+#define CCL_INTFLAGS  _SFR_MEM8(0x01C7)
+#define CCL_LUT0CTRLA  _SFR_MEM8(0x01C8)
+#define CCL_LUT0CTRLB  _SFR_MEM8(0x01C9)
+#define CCL_LUT0CTRLC  _SFR_MEM8(0x01CA)
+#define CCL_TRUTH0  _SFR_MEM8(0x01CB)
+#define CCL_LUT1CTRLA  _SFR_MEM8(0x01CC)
+#define CCL_LUT1CTRLB  _SFR_MEM8(0x01CD)
+#define CCL_LUT1CTRLC  _SFR_MEM8(0x01CE)
+#define CCL_TRUTH1  _SFR_MEM8(0x01CF)
+#define CCL_LUT2CTRLA  _SFR_MEM8(0x01D0)
+#define CCL_LUT2CTRLB  _SFR_MEM8(0x01D1)
+#define CCL_LUT2CTRLC  _SFR_MEM8(0x01D2)
+#define CCL_TRUTH2  _SFR_MEM8(0x01D3)
+#define CCL_LUT3CTRLA  _SFR_MEM8(0x01D4)
+#define CCL_LUT3CTRLB  _SFR_MEM8(0x01D5)
+#define CCL_LUT3CTRLC  _SFR_MEM8(0x01D6)
+#define CCL_TRUTH3  _SFR_MEM8(0x01D7)
+
+
+/* EVSYS - Event System */
+#define EVSYS_SWEVENTA  _SFR_MEM8(0x0200)
+#define EVSYS_CHANNEL0  _SFR_MEM8(0x0210)
+#define EVSYS_CHANNEL1  _SFR_MEM8(0x0211)
+#define EVSYS_CHANNEL2  _SFR_MEM8(0x0212)
+#define EVSYS_CHANNEL3  _SFR_MEM8(0x0213)
+#define EVSYS_CHANNEL4  _SFR_MEM8(0x0214)
+#define EVSYS_CHANNEL5  _SFR_MEM8(0x0215)
+#define EVSYS_USERCCLLUT0A  _SFR_MEM8(0x0220)
+#define EVSYS_USERCCLLUT0B  _SFR_MEM8(0x0221)
+#define EVSYS_USERCCLLUT1A  _SFR_MEM8(0x0222)
+#define EVSYS_USERCCLLUT1B  _SFR_MEM8(0x0223)
+#define EVSYS_USERCCLLUT2A  _SFR_MEM8(0x0224)
+#define EVSYS_USERCCLLUT2B  _SFR_MEM8(0x0225)
+#define EVSYS_USERCCLLUT3A  _SFR_MEM8(0x0226)
+#define EVSYS_USERCCLLUT3B  _SFR_MEM8(0x0227)
+#define EVSYS_USERADC0START  _SFR_MEM8(0x0228)
+#define EVSYS_USEREVSYSEVOUTA  _SFR_MEM8(0x0229)
+#define EVSYS_USEREVSYSEVOUTC  _SFR_MEM8(0x022A)
+#define EVSYS_USEREVSYSEVOUTD  _SFR_MEM8(0x022B)
+#define EVSYS_USEREVSYSEVOUTF  _SFR_MEM8(0x022C)
+#define EVSYS_USERUSART0IRDA  _SFR_MEM8(0x022D)
+#define EVSYS_USERTCE0CNTA  _SFR_MEM8(0x022E)
+#define EVSYS_USERTCE0CNTB  _SFR_MEM8(0x022F)
+#define EVSYS_USERTCB0CAPT  _SFR_MEM8(0x0230)
+#define EVSYS_USERTCB0COUNT  _SFR_MEM8(0x0231)
+#define EVSYS_USERTCB1CAPT  _SFR_MEM8(0x0232)
+#define EVSYS_USERTCB1COUNT  _SFR_MEM8(0x0233)
+#define EVSYS_USERTCF0CNT  _SFR_MEM8(0x0234)
+#define EVSYS_USERTCF0ACT  _SFR_MEM8(0x0235)
+#define EVSYS_USERWEXA  _SFR_MEM8(0x0236)
+#define EVSYS_USERWEXB  _SFR_MEM8(0x0237)
+#define EVSYS_USERWEXC  _SFR_MEM8(0x0238)
+
+
+/* PORT (PORTA) - I/O Ports */
+#define PORTA_DIR  _SFR_MEM8(0x0400)
+#define PORTA_DIRSET  _SFR_MEM8(0x0401)
+#define PORTA_DIRCLR  _SFR_MEM8(0x0402)
+#define PORTA_DIRTGL  _SFR_MEM8(0x0403)
+#define PORTA_OUT  _SFR_MEM8(0x0404)
+#define PORTA_OUTSET  _SFR_MEM8(0x0405)
+#define PORTA_OUTCLR  _SFR_MEM8(0x0406)
+#define PORTA_OUTTGL  _SFR_MEM8(0x0407)
+#define PORTA_IN  _SFR_MEM8(0x0408)
+#define PORTA_INTFLAGS  _SFR_MEM8(0x0409)
+#define PORTA_PORTCTRL  _SFR_MEM8(0x040A)
+#define PORTA_PINCONFIG  _SFR_MEM8(0x040B)
+#define PORTA_PINCTRLUPD  _SFR_MEM8(0x040C)
+#define PORTA_PINCTRLSET  _SFR_MEM8(0x040D)
+#define PORTA_PINCTRLCLR  _SFR_MEM8(0x040E)
+#define PORTA_PIN0CTRL  _SFR_MEM8(0x0410)
+#define PORTA_PIN1CTRL  _SFR_MEM8(0x0411)
+#define PORTA_PIN2CTRL  _SFR_MEM8(0x0412)
+#define PORTA_PIN3CTRL  _SFR_MEM8(0x0413)
+#define PORTA_PIN4CTRL  _SFR_MEM8(0x0414)
+#define PORTA_PIN5CTRL  _SFR_MEM8(0x0415)
+#define PORTA_PIN6CTRL  _SFR_MEM8(0x0416)
+#define PORTA_PIN7CTRL  _SFR_MEM8(0x0417)
+#define PORTA_EVGENCTRLA  _SFR_MEM8(0x0418)
+
+
+/* PORT (PORTC) - I/O Ports */
+#define PORTC_DIR  _SFR_MEM8(0x0440)
+#define PORTC_DIRSET  _SFR_MEM8(0x0441)
+#define PORTC_DIRCLR  _SFR_MEM8(0x0442)
+#define PORTC_DIRTGL  _SFR_MEM8(0x0443)
+#define PORTC_OUT  _SFR_MEM8(0x0444)
+#define PORTC_OUTSET  _SFR_MEM8(0x0445)
+#define PORTC_OUTCLR  _SFR_MEM8(0x0446)
+#define PORTC_OUTTGL  _SFR_MEM8(0x0447)
+#define PORTC_IN  _SFR_MEM8(0x0448)
+#define PORTC_INTFLAGS  _SFR_MEM8(0x0449)
+#define PORTC_PORTCTRL  _SFR_MEM8(0x044A)
+#define PORTC_PINCONFIG  _SFR_MEM8(0x044B)
+#define PORTC_PINCTRLUPD  _SFR_MEM8(0x044C)
+#define PORTC_PINCTRLSET  _SFR_MEM8(0x044D)
+#define PORTC_PINCTRLCLR  _SFR_MEM8(0x044E)
+#define PORTC_PIN0CTRL  _SFR_MEM8(0x0450)
+#define PORTC_PIN1CTRL  _SFR_MEM8(0x0451)
+#define PORTC_PIN2CTRL  _SFR_MEM8(0x0452)
+#define PORTC_PIN3CTRL  _SFR_MEM8(0x0453)
+#define PORTC_PIN4CTRL  _SFR_MEM8(0x0454)
+#define PORTC_PIN5CTRL  _SFR_MEM8(0x0455)
+#define PORTC_PIN6CTRL  _SFR_MEM8(0x0456)
+#define PORTC_PIN7CTRL  _SFR_MEM8(0x0457)
+#define PORTC_EVGENCTRLA  _SFR_MEM8(0x0458)
+
+
+/* PORT (PORTD) - I/O Ports */
+#define PORTD_DIR  _SFR_MEM8(0x0460)
+#define PORTD_DIRSET  _SFR_MEM8(0x0461)
+#define PORTD_DIRCLR  _SFR_MEM8(0x0462)
+#define PORTD_DIRTGL  _SFR_MEM8(0x0463)
+#define PORTD_OUT  _SFR_MEM8(0x0464)
+#define PORTD_OUTSET  _SFR_MEM8(0x0465)
+#define PORTD_OUTCLR  _SFR_MEM8(0x0466)
+#define PORTD_OUTTGL  _SFR_MEM8(0x0467)
+#define PORTD_IN  _SFR_MEM8(0x0468)
+#define PORTD_INTFLAGS  _SFR_MEM8(0x0469)
+#define PORTD_PORTCTRL  _SFR_MEM8(0x046A)
+#define PORTD_PINCONFIG  _SFR_MEM8(0x046B)
+#define PORTD_PINCTRLUPD  _SFR_MEM8(0x046C)
+#define PORTD_PINCTRLSET  _SFR_MEM8(0x046D)
+#define PORTD_PINCTRLCLR  _SFR_MEM8(0x046E)
+#define PORTD_PIN0CTRL  _SFR_MEM8(0x0470)
+#define PORTD_PIN1CTRL  _SFR_MEM8(0x0471)
+#define PORTD_PIN2CTRL  _SFR_MEM8(0x0472)
+#define PORTD_PIN3CTRL  _SFR_MEM8(0x0473)
+#define PORTD_PIN4CTRL  _SFR_MEM8(0x0474)
+#define PORTD_PIN5CTRL  _SFR_MEM8(0x0475)
+#define PORTD_PIN6CTRL  _SFR_MEM8(0x0476)
+#define PORTD_PIN7CTRL  _SFR_MEM8(0x0477)
+#define PORTD_EVGENCTRLA  _SFR_MEM8(0x0478)
+
+
+/* PORT (PORTF) - I/O Ports */
+#define PORTF_DIR  _SFR_MEM8(0x04A0)
+#define PORTF_DIRSET  _SFR_MEM8(0x04A1)
+#define PORTF_DIRCLR  _SFR_MEM8(0x04A2)
+#define PORTF_DIRTGL  _SFR_MEM8(0x04A3)
+#define PORTF_OUT  _SFR_MEM8(0x04A4)
+#define PORTF_OUTSET  _SFR_MEM8(0x04A5)
+#define PORTF_OUTCLR  _SFR_MEM8(0x04A6)
+#define PORTF_OUTTGL  _SFR_MEM8(0x04A7)
+#define PORTF_IN  _SFR_MEM8(0x04A8)
+#define PORTF_INTFLAGS  _SFR_MEM8(0x04A9)
+#define PORTF_PORTCTRL  _SFR_MEM8(0x04AA)
+#define PORTF_PINCONFIG  _SFR_MEM8(0x04AB)
+#define PORTF_PINCTRLUPD  _SFR_MEM8(0x04AC)
+#define PORTF_PINCTRLSET  _SFR_MEM8(0x04AD)
+#define PORTF_PINCTRLCLR  _SFR_MEM8(0x04AE)
+#define PORTF_PIN0CTRL  _SFR_MEM8(0x04B0)
+#define PORTF_PIN1CTRL  _SFR_MEM8(0x04B1)
+#define PORTF_PIN2CTRL  _SFR_MEM8(0x04B2)
+#define PORTF_PIN3CTRL  _SFR_MEM8(0x04B3)
+#define PORTF_PIN4CTRL  _SFR_MEM8(0x04B4)
+#define PORTF_PIN5CTRL  _SFR_MEM8(0x04B5)
+#define PORTF_PIN6CTRL  _SFR_MEM8(0x04B6)
+#define PORTF_PIN7CTRL  _SFR_MEM8(0x04B7)
+#define PORTF_EVGENCTRLA  _SFR_MEM8(0x04B8)
+
+
+/* PORTMUX - Port Multiplexer */
+#define PORTMUX_EVSYSROUTEA  _SFR_MEM8(0x05E0)
+#define PORTMUX_CCLROUTEA  _SFR_MEM8(0x05E1)
+#define PORTMUX_USARTROUTEA  _SFR_MEM8(0x05E2)
+#define PORTMUX_SPIROUTEA  _SFR_MEM8(0x05E5)
+#define PORTMUX_TWIROUTEA  _SFR_MEM8(0x05E6)
+#define PORTMUX_TCEROUTEA  _SFR_MEM8(0x05E7)
+#define PORTMUX_TCBROUTEA  _SFR_MEM8(0x05E8)
+#define PORTMUX_TCFROUTEA  _SFR_MEM8(0x05EC)
+
+
+/* ADC (ADC0) - Analog to Digital Converter */
+#define ADC0_CTRLA  _SFR_MEM8(0x0600)
+#define ADC0_CTRLB  _SFR_MEM8(0x0601)
+#define ADC0_CTRLC  _SFR_MEM8(0x0602)
+#define ADC0_CTRLD  _SFR_MEM8(0x0603)
+#define ADC0_INTCTRL  _SFR_MEM8(0x0604)
+#define ADC0_INTFLAGS  _SFR_MEM8(0x0605)
+#define ADC0_STATUS  _SFR_MEM8(0x0606)
+#define ADC0_DBGCTRL  _SFR_MEM8(0x0607)
+#define ADC0_CTRLE  _SFR_MEM8(0x0608)
+#define ADC0_CTRLF  _SFR_MEM8(0x0609)
+#define ADC0_COMMAND  _SFR_MEM8(0x060A)
+#define ADC0_PGACTRL  _SFR_MEM8(0x060B)
+#define ADC0_MUXPOS  _SFR_MEM8(0x060C)
+#define ADC0_MUXNEG  _SFR_MEM8(0x060D)
+#define ADC0_RESULT  _SFR_MEM32(0x0610)
+#define ADC0_RESULT0  _SFR_MEM8(0x0610)
+#define ADC0_RESULT1  _SFR_MEM8(0x0611)
+#define ADC0_RESULT2  _SFR_MEM8(0x0612)
+#define ADC0_RESULT3  _SFR_MEM8(0x0613)
+#define ADC0_SAMPLE  _SFR_MEM16(0x0614)
+#define ADC0_SAMPLEL  _SFR_MEM8(0x0614)
+#define ADC0_SAMPLEH  _SFR_MEM8(0x0615)
+#define ADC0_TEMP0  _SFR_MEM8(0x0618)
+#define ADC0_TEMP1  _SFR_MEM8(0x0619)
+#define ADC0_TEMP2  _SFR_MEM8(0x061A)
+#define ADC0_WINLT  _SFR_MEM16(0x061C)
+#define ADC0_WINLTL  _SFR_MEM8(0x061C)
+#define ADC0_WINLTH  _SFR_MEM8(0x061D)
+#define ADC0_WINHT  _SFR_MEM16(0x061E)
+#define ADC0_WINHTL  _SFR_MEM8(0x061E)
+#define ADC0_WINHTH  _SFR_MEM8(0x061F)
+
+
+/* AC (AC0) - Analog Comparator */
+#define AC0_CTRLA  _SFR_MEM8(0x0680)
+#define AC0_CTRLB  _SFR_MEM8(0x0681)
+#define AC0_MUXCTRL  _SFR_MEM8(0x0682)
+#define AC0_DACREF  _SFR_MEM8(0x0685)
+#define AC0_INTCTRL  _SFR_MEM8(0x0686)
+#define AC0_STATUS  _SFR_MEM8(0x0687)
+
+
+/* AC (AC1) - Analog Comparator */
+#define AC1_CTRLA  _SFR_MEM8(0x0688)
+#define AC1_CTRLB  _SFR_MEM8(0x0689)
+#define AC1_MUXCTRL  _SFR_MEM8(0x068A)
+#define AC1_DACREF  _SFR_MEM8(0x068D)
+#define AC1_INTCTRL  _SFR_MEM8(0x068E)
+#define AC1_STATUS  _SFR_MEM8(0x068F)
+
+
+/* USART (USART0) - Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define USART0_RXDATAL  _SFR_MEM8(0x0800)
+#define USART0_RXDATAH  _SFR_MEM8(0x0801)
+#define USART0_TXDATAL  _SFR_MEM8(0x0802)
+#define USART0_TXDATAH  _SFR_MEM8(0x0803)
+#define USART0_STATUS  _SFR_MEM8(0x0804)
+#define USART0_CTRLA  _SFR_MEM8(0x0805)
+#define USART0_CTRLB  _SFR_MEM8(0x0806)
+#define USART0_CTRLC  _SFR_MEM8(0x0807)
+#define USART0_BAUD  _SFR_MEM16(0x0808)
+#define USART0_BAUDL  _SFR_MEM8(0x0808)
+#define USART0_BAUDH  _SFR_MEM8(0x0809)
+#define USART0_CTRLD  _SFR_MEM8(0x080A)
+#define USART0_DBGCTRL  _SFR_MEM8(0x080B)
+#define USART0_EVCTRL  _SFR_MEM8(0x080C)
+#define USART0_TXPLCTRL  _SFR_MEM8(0x080D)
+#define USART0_RXPLCTRL  _SFR_MEM8(0x080E)
+
+
+/* TWI (TWI0) - Two-Wire Interface */
+#define TWI0_CTRLA  _SFR_MEM8(0x0900)
+#define TWI0_DUALCTRL  _SFR_MEM8(0x0901)
+#define TWI0_DBGCTRL  _SFR_MEM8(0x0902)
+#define TWI0_MCTRLA  _SFR_MEM8(0x0903)
+#define TWI0_MCTRLB  _SFR_MEM8(0x0904)
+#define TWI0_MSTATUS  _SFR_MEM8(0x0905)
+#define TWI0_MBAUD  _SFR_MEM8(0x0906)
+#define TWI0_MADDR  _SFR_MEM8(0x0907)
+#define TWI0_MDATA  _SFR_MEM8(0x0908)
+#define TWI0_SCTRLA  _SFR_MEM8(0x0909)
+#define TWI0_SCTRLB  _SFR_MEM8(0x090A)
+#define TWI0_SSTATUS  _SFR_MEM8(0x090B)
+#define TWI0_SADDR  _SFR_MEM8(0x090C)
+#define TWI0_SDATA  _SFR_MEM8(0x090D)
+#define TWI0_SADDRMASK  _SFR_MEM8(0x090E)
+
+
+/* SPI (SPI0) - Serial Peripheral Interface */
+#define SPI0_CTRLA  _SFR_MEM8(0x0940)
+#define SPI0_CTRLB  _SFR_MEM8(0x0941)
+#define SPI0_INTCTRL  _SFR_MEM8(0x0942)
+#define SPI0_INTFLAGS  _SFR_MEM8(0x0943)
+#define SPI0_DATA  _SFR_MEM8(0x0944)
+
+
+/* TCE (TCE0) - 16-bit Timer/Counter Type E */
+#define TCE0_CTRLA  _SFR_MEM8(0x0A00)
+#define TCE0_CTRLB  _SFR_MEM8(0x0A01)
+#define TCE0_CTRLC  _SFR_MEM8(0x0A02)
+#define TCE0_CTRLD  _SFR_MEM8(0x0A03)
+#define TCE0_CTRLECLR  _SFR_MEM8(0x0A04)
+#define TCE0_CTRLESET  _SFR_MEM8(0x0A05)
+#define TCE0_CTRLFCLR  _SFR_MEM8(0x0A06)
+#define TCE0_CTRLFSET  _SFR_MEM8(0x0A07)
+#define TCE0_EVGENCTRL  _SFR_MEM8(0x0A08)
+#define TCE0_EVCTRL  _SFR_MEM8(0x0A09)
+#define TCE0_INTCTRL  _SFR_MEM8(0x0A0A)
+#define TCE0_INTFLAGS  _SFR_MEM8(0x0A0B)
+#define TCE0_DBGCTRL  _SFR_MEM8(0x0A0E)
+#define TCE0_TEMP  _SFR_MEM8(0x0A0F)
+#define TCE0_CNT  _SFR_MEM16(0x0A20)
+#define TCE0_CNTL  _SFR_MEM8(0x0A20)
+#define TCE0_CNTH  _SFR_MEM8(0x0A21)
+#define TCE0_AMP  _SFR_MEM16(0x0A22)
+#define TCE0_AMPL  _SFR_MEM8(0x0A22)
+#define TCE0_AMPH  _SFR_MEM8(0x0A23)
+#define TCE0_OFFSET  _SFR_MEM16(0x0A24)
+#define TCE0_OFFSETL  _SFR_MEM8(0x0A24)
+#define TCE0_OFFSETH  _SFR_MEM8(0x0A25)
+#define TCE0_PER  _SFR_MEM16(0x0A26)
+#define TCE0_PERL  _SFR_MEM8(0x0A26)
+#define TCE0_PERH  _SFR_MEM8(0x0A27)
+#define TCE0_CMP0  _SFR_MEM16(0x0A28)
+#define TCE0_CMP0L  _SFR_MEM8(0x0A28)
+#define TCE0_CMP0H  _SFR_MEM8(0x0A29)
+#define TCE0_CMP1  _SFR_MEM16(0x0A2A)
+#define TCE0_CMP1L  _SFR_MEM8(0x0A2A)
+#define TCE0_CMP1H  _SFR_MEM8(0x0A2B)
+#define TCE0_CMP2  _SFR_MEM16(0x0A2C)
+#define TCE0_CMP2L  _SFR_MEM8(0x0A2C)
+#define TCE0_CMP2H  _SFR_MEM8(0x0A2D)
+#define TCE0_CMP3  _SFR_MEM16(0x0A2E)
+#define TCE0_CMP3L  _SFR_MEM8(0x0A2E)
+#define TCE0_CMP3H  _SFR_MEM8(0x0A2F)
+#define TCE0_PERBUF  _SFR_MEM16(0x0A36)
+#define TCE0_PERBUFL  _SFR_MEM8(0x0A36)
+#define TCE0_PERBUFH  _SFR_MEM8(0x0A37)
+#define TCE0_CMP0BUF  _SFR_MEM16(0x0A38)
+#define TCE0_CMP0BUFL  _SFR_MEM8(0x0A38)
+#define TCE0_CMP0BUFH  _SFR_MEM8(0x0A39)
+#define TCE0_CMP1BUF  _SFR_MEM16(0x0A3A)
+#define TCE0_CMP1BUFL  _SFR_MEM8(0x0A3A)
+#define TCE0_CMP1BUFH  _SFR_MEM8(0x0A3B)
+#define TCE0_CMP2BUF  _SFR_MEM16(0x0A3C)
+#define TCE0_CMP2BUFL  _SFR_MEM8(0x0A3C)
+#define TCE0_CMP2BUFH  _SFR_MEM8(0x0A3D)
+#define TCE0_CMP3BUF  _SFR_MEM16(0x0A3E)
+#define TCE0_CMP3BUFL  _SFR_MEM8(0x0A3E)
+#define TCE0_CMP3BUFH  _SFR_MEM8(0x0A3F)
+
+
+/* TCB (TCB0) - 16-bit Timer/Counter Type B */
+#define TCB0_CTRLA  _SFR_MEM8(0x0B00)
+#define TCB0_CTRLB  _SFR_MEM8(0x0B01)
+#define TCB0_CTRLC  _SFR_MEM8(0x0B02)
+#define TCB0_EVCTRL  _SFR_MEM8(0x0B04)
+#define TCB0_INTCTRL  _SFR_MEM8(0x0B05)
+#define TCB0_INTFLAGS  _SFR_MEM8(0x0B06)
+#define TCB0_STATUS  _SFR_MEM8(0x0B07)
+#define TCB0_DBGCTRL  _SFR_MEM8(0x0B08)
+#define TCB0_TEMP  _SFR_MEM8(0x0B09)
+#define TCB0_CNT  _SFR_MEM16(0x0B0A)
+#define TCB0_CNTL  _SFR_MEM8(0x0B0A)
+#define TCB0_CNTH  _SFR_MEM8(0x0B0B)
+#define TCB0_CCMP  _SFR_MEM16(0x0B0C)
+#define TCB0_CCMPL  _SFR_MEM8(0x0B0C)
+#define TCB0_CCMPH  _SFR_MEM8(0x0B0D)
+
+
+/* TCB (TCB1) - 16-bit Timer/Counter Type B */
+#define TCB1_CTRLA  _SFR_MEM8(0x0B10)
+#define TCB1_CTRLB  _SFR_MEM8(0x0B11)
+#define TCB1_CTRLC  _SFR_MEM8(0x0B12)
+#define TCB1_EVCTRL  _SFR_MEM8(0x0B14)
+#define TCB1_INTCTRL  _SFR_MEM8(0x0B15)
+#define TCB1_INTFLAGS  _SFR_MEM8(0x0B16)
+#define TCB1_STATUS  _SFR_MEM8(0x0B17)
+#define TCB1_DBGCTRL  _SFR_MEM8(0x0B18)
+#define TCB1_TEMP  _SFR_MEM8(0x0B19)
+#define TCB1_CNT  _SFR_MEM16(0x0B1A)
+#define TCB1_CNTL  _SFR_MEM8(0x0B1A)
+#define TCB1_CNTH  _SFR_MEM8(0x0B1B)
+#define TCB1_CCMP  _SFR_MEM16(0x0B1C)
+#define TCB1_CCMPL  _SFR_MEM8(0x0B1C)
+#define TCB1_CCMPH  _SFR_MEM8(0x0B1D)
+
+
+/* TCF (TCF0) - 24-bit Timer/Counter for frequency generation */
+#define TCF0_CTRLA  _SFR_MEM8(0x0C00)
+#define TCF0_CTRLB  _SFR_MEM8(0x0C01)
+#define TCF0_CTRLC  _SFR_MEM8(0x0C02)
+#define TCF0_CTRLD  _SFR_MEM8(0x0C03)
+#define TCF0_EVCTRL  _SFR_MEM8(0x0C04)
+#define TCF0_INTCTRL  _SFR_MEM8(0x0C05)
+#define TCF0_INTFLAGS  _SFR_MEM8(0x0C06)
+#define TCF0_STATUS  _SFR_MEM8(0x0C07)
+#define TCF0_DBGCTRL  _SFR_MEM8(0x0C0D)
+#define TCF0_CNT  _SFR_MEM32(0x0C10)
+#define TCF0_CNT0  _SFR_MEM8(0x0C10)
+#define TCF0_CNT1  _SFR_MEM8(0x0C11)
+#define TCF0_CNT2  _SFR_MEM8(0x0C12)
+#define TCF0_CNT3  _SFR_MEM8(0x0C13)
+#define TCF0_CMP  _SFR_MEM32(0x0C14)
+#define TCF0_CMP0  _SFR_MEM8(0x0C14)
+#define TCF0_CMP1  _SFR_MEM8(0x0C15)
+#define TCF0_CMP2  _SFR_MEM8(0x0C16)
+#define TCF0_CMP3  _SFR_MEM8(0x0C17)
+
+
+/* WEX (WEX0) - Waveform Extension */
+#define WEX0_CTRLA  _SFR_MEM8(0x0C80)
+#define WEX0_CTRLB  _SFR_MEM8(0x0C81)
+#define WEX0_CTRLC  _SFR_MEM8(0x0C82)
+#define WEX0_EVCTRLA  _SFR_MEM8(0x0C84)
+#define WEX0_EVCTRLB  _SFR_MEM8(0x0C85)
+#define WEX0_EVCTRLC  _SFR_MEM8(0x0C86)
+#define WEX0_BUFCTRL  _SFR_MEM8(0x0C87)
+#define WEX0_BLANKCTRL  _SFR_MEM8(0x0C88)
+#define WEX0_BLANKTIME  _SFR_MEM8(0x0C89)
+#define WEX0_FAULTCTRL  _SFR_MEM8(0x0C8A)
+#define WEX0_FAULTDRV  _SFR_MEM8(0x0C8B)
+#define WEX0_FAULTOUT  _SFR_MEM8(0x0C8C)
+#define WEX0_INTCTRL  _SFR_MEM8(0x0C8D)
+#define WEX0_INTFLAGS  _SFR_MEM8(0x0C8E)
+#define WEX0_STATUS  _SFR_MEM8(0x0C8F)
+#define WEX0_DTLS  _SFR_MEM8(0x0C90)
+#define WEX0_DTHS  _SFR_MEM8(0x0C91)
+#define WEX0_DTBOTH  _SFR_MEM8(0x0C92)
+#define WEX0_SWAP  _SFR_MEM8(0x0C93)
+#define WEX0_PGMOVR  _SFR_MEM8(0x0C94)
+#define WEX0_PGMOUT  _SFR_MEM8(0x0C95)
+#define WEX0_OUTOVEN  _SFR_MEM8(0x0C97)
+#define WEX0_DTLSBUF  _SFR_MEM8(0x0C98)
+#define WEX0_DTHSBUF  _SFR_MEM8(0x0C99)
+#define WEX0_DTBOTHBUF  _SFR_MEM8(0x0C9A)
+#define WEX0_SWAPBUF  _SFR_MEM8(0x0C9B)
+#define WEX0_PGMOVRBUF  _SFR_MEM8(0x0C9C)
+#define WEX0_PGMOUTBUF  _SFR_MEM8(0x0C9D)
+
+
+/* SYSCFG - System Configuration Registers */
+#define SYSCFG_REVID  _SFR_MEM8(0x0F01)
+
+
+/* NVMCTRL - Non-volatile Memory Controller */
+#define NVMCTRL_CTRLA  _SFR_MEM8(0x1000)
+#define NVMCTRL_CTRLB  _SFR_MEM8(0x1001)
+#define NVMCTRL_CTRLC  _SFR_MEM8(0x1002)
+#define NVMCTRL_INTCTRL  _SFR_MEM8(0x1004)
+#define NVMCTRL_INTFLAGS  _SFR_MEM8(0x1005)
+#define NVMCTRL_STATUS  _SFR_MEM8(0x1006)
+#define NVMCTRL_DATA  _SFR_MEM16(0x1008)
+#define NVMCTRL_DATAL  _SFR_MEM8(0x1008)
+#define NVMCTRL_DATAH  _SFR_MEM8(0x1009)
+#define NVMCTRL_ADDR  _SFR_MEM32(0x100C)
+#define NVMCTRL_ADDR0  _SFR_MEM8(0x100C)
+#define NVMCTRL_ADDR1  _SFR_MEM8(0x100D)
+#define NVMCTRL_ADDR2  _SFR_MEM8(0x100E)
+#define NVMCTRL_ADDR3  _SFR_MEM8(0x100F)
+
+
+/* LOCK - Lockbits */
+#define LOCK_KEY  _SFR_MEM32(0x1040)
+#define LOCK_KEY0  _SFR_MEM8(0x1040)
+#define LOCK_KEY1  _SFR_MEM8(0x1041)
+#define LOCK_KEY2  _SFR_MEM8(0x1042)
+#define LOCK_KEY3  _SFR_MEM8(0x1043)
+
+
+/* FUSE - Fuses */
+#define FUSE_WDTCFG  _SFR_MEM8(0x1050)
+#define FUSE_BODCFG  _SFR_MEM8(0x1051)
+#define FUSE_OSCCFG  _SFR_MEM8(0x1052)
+#define FUSE_SYSCFG0  _SFR_MEM8(0x1055)
+#define FUSE_SYSCFG1  _SFR_MEM8(0x1056)
+#define FUSE_CODESIZE  _SFR_MEM8(0x1057)
+#define FUSE_BOOTSIZE  _SFR_MEM8(0x1058)
+#define FUSE_PDICFG  _SFR_MEM16(0x105A)
+#define FUSE_PDICFGL  _SFR_MEM8(0x105A)
+#define FUSE_PDICFGH  _SFR_MEM8(0x105B)
+
+
+/* SIGROW - Signature row */
+#define SIGROW_DEVICEID0  _SFR_MEM8(0x1080)
+#define SIGROW_DEVICEID1  _SFR_MEM8(0x1081)
+#define SIGROW_DEVICEID2  _SFR_MEM8(0x1082)
+#define SIGROW_TEMPSENSE0  _SFR_MEM16(0x1084)
+#define SIGROW_TEMPSENSE0L  _SFR_MEM8(0x1084)
+#define SIGROW_TEMPSENSE0H  _SFR_MEM8(0x1085)
+#define SIGROW_TEMPSENSE1  _SFR_MEM16(0x1086)
+#define SIGROW_TEMPSENSE1L  _SFR_MEM8(0x1086)
+#define SIGROW_TEMPSENSE1H  _SFR_MEM8(0x1087)
+#define SIGROW_SERNUM0  _SFR_MEM8(0x1090)
+#define SIGROW_SERNUM1  _SFR_MEM8(0x1091)
+#define SIGROW_SERNUM2  _SFR_MEM8(0x1092)
+#define SIGROW_SERNUM3  _SFR_MEM8(0x1093)
+#define SIGROW_SERNUM4  _SFR_MEM8(0x1094)
+#define SIGROW_SERNUM5  _SFR_MEM8(0x1095)
+#define SIGROW_SERNUM6  _SFR_MEM8(0x1096)
+#define SIGROW_SERNUM7  _SFR_MEM8(0x1097)
+#define SIGROW_SERNUM8  _SFR_MEM8(0x1098)
+#define SIGROW_SERNUM9  _SFR_MEM8(0x1099)
+#define SIGROW_SERNUM10  _SFR_MEM8(0x109A)
+#define SIGROW_SERNUM11  _SFR_MEM8(0x109B)
+#define SIGROW_SERNUM12  _SFR_MEM8(0x109C)
+#define SIGROW_SERNUM13  _SFR_MEM8(0x109D)
+#define SIGROW_SERNUM14  _SFR_MEM8(0x109E)
+#define SIGROW_SERNUM15  _SFR_MEM8(0x109F)
+
+
+/* BOOTROW - Boot Row */
+#define BOOTROW_BOOTROW  _SFR_MEM8(0x1100)
+
+
+/* USERROW - User Row */
+#define USERROW_USERROW0  _SFR_MEM8(0x1200)
+#define USERROW_USERROW1  _SFR_MEM8(0x1201)
+#define USERROW_USERROW2  _SFR_MEM8(0x1202)
+#define USERROW_USERROW3  _SFR_MEM8(0x1203)
+#define USERROW_USERROW4  _SFR_MEM8(0x1204)
+#define USERROW_USERROW5  _SFR_MEM8(0x1205)
+#define USERROW_USERROW6  _SFR_MEM8(0x1206)
+#define USERROW_USERROW7  _SFR_MEM8(0x1207)
+#define USERROW_USERROW8  _SFR_MEM8(0x1208)
+#define USERROW_USERROW9  _SFR_MEM8(0x1209)
+#define USERROW_USERROW10  _SFR_MEM8(0x120A)
+#define USERROW_USERROW11  _SFR_MEM8(0x120B)
+#define USERROW_USERROW12  _SFR_MEM8(0x120C)
+#define USERROW_USERROW13  _SFR_MEM8(0x120D)
+#define USERROW_USERROW14  _SFR_MEM8(0x120E)
+#define USERROW_USERROW15  _SFR_MEM8(0x120F)
+#define USERROW_USERROW16  _SFR_MEM8(0x1210)
+#define USERROW_USERROW17  _SFR_MEM8(0x1211)
+#define USERROW_USERROW18  _SFR_MEM8(0x1212)
+#define USERROW_USERROW19  _SFR_MEM8(0x1213)
+#define USERROW_USERROW20  _SFR_MEM8(0x1214)
+#define USERROW_USERROW21  _SFR_MEM8(0x1215)
+#define USERROW_USERROW22  _SFR_MEM8(0x1216)
+#define USERROW_USERROW23  _SFR_MEM8(0x1217)
+#define USERROW_USERROW24  _SFR_MEM8(0x1218)
+#define USERROW_USERROW25  _SFR_MEM8(0x1219)
+#define USERROW_USERROW26  _SFR_MEM8(0x121A)
+#define USERROW_USERROW27  _SFR_MEM8(0x121B)
+#define USERROW_USERROW28  _SFR_MEM8(0x121C)
+#define USERROW_USERROW29  _SFR_MEM8(0x121D)
+#define USERROW_USERROW30  _SFR_MEM8(0x121E)
+#define USERROW_USERROW31  _SFR_MEM8(0x121F)
+#define USERROW_USERROW32  _SFR_MEM8(0x1220)
+#define USERROW_USERROW33  _SFR_MEM8(0x1221)
+#define USERROW_USERROW34  _SFR_MEM8(0x1222)
+#define USERROW_USERROW35  _SFR_MEM8(0x1223)
+#define USERROW_USERROW36  _SFR_MEM8(0x1224)
+#define USERROW_USERROW37  _SFR_MEM8(0x1225)
+#define USERROW_USERROW38  _SFR_MEM8(0x1226)
+#define USERROW_USERROW39  _SFR_MEM8(0x1227)
+#define USERROW_USERROW40  _SFR_MEM8(0x1228)
+#define USERROW_USERROW41  _SFR_MEM8(0x1229)
+#define USERROW_USERROW42  _SFR_MEM8(0x122A)
+#define USERROW_USERROW43  _SFR_MEM8(0x122B)
+#define USERROW_USERROW44  _SFR_MEM8(0x122C)
+#define USERROW_USERROW45  _SFR_MEM8(0x122D)
+#define USERROW_USERROW46  _SFR_MEM8(0x122E)
+#define USERROW_USERROW47  _SFR_MEM8(0x122F)
+#define USERROW_USERROW48  _SFR_MEM8(0x1230)
+#define USERROW_USERROW49  _SFR_MEM8(0x1231)
+#define USERROW_USERROW50  _SFR_MEM8(0x1232)
+#define USERROW_USERROW51  _SFR_MEM8(0x1233)
+#define USERROW_USERROW52  _SFR_MEM8(0x1234)
+#define USERROW_USERROW53  _SFR_MEM8(0x1235)
+#define USERROW_USERROW54  _SFR_MEM8(0x1236)
+#define USERROW_USERROW55  _SFR_MEM8(0x1237)
+#define USERROW_USERROW56  _SFR_MEM8(0x1238)
+#define USERROW_USERROW57  _SFR_MEM8(0x1239)
+#define USERROW_USERROW58  _SFR_MEM8(0x123A)
+#define USERROW_USERROW59  _SFR_MEM8(0x123B)
+#define USERROW_USERROW60  _SFR_MEM8(0x123C)
+#define USERROW_USERROW61  _SFR_MEM8(0x123D)
+#define USERROW_USERROW62  _SFR_MEM8(0x123E)
+#define USERROW_USERROW63  _SFR_MEM8(0x123F)
+
+
+
+/*================== Bitfield Definitions ================== */
+
+/* AC - Analog Comparator */
+/* AC.CTRLA  bit masks and bit positions */
+#define AC_ENABLE_bm  0x01  /* Enable bit mask. */
+#define AC_ENABLE_bp  0  /* Enable bit position. */
+#define AC_HYSMODE_gm  0x06  /* Hysteresis Mode group mask. */
+#define AC_HYSMODE_gp  1  /* Hysteresis Mode group position. */
+#define AC_HYSMODE_0_bm  (1<<1)  /* Hysteresis Mode bit 0 mask. */
+#define AC_HYSMODE_0_bp  1  /* Hysteresis Mode bit 0 position. */
+#define AC_HYSMODE_1_bm  (1<<2)  /* Hysteresis Mode bit 1 mask. */
+#define AC_HYSMODE_1_bp  2  /* Hysteresis Mode bit 1 position. */
+#define AC_POWER_gm  0x18  /* Power profile group mask. */
+#define AC_POWER_gp  3  /* Power profile group position. */
+#define AC_POWER_0_bm  (1<<3)  /* Power profile bit 0 mask. */
+#define AC_POWER_0_bp  3  /* Power profile bit 0 position. */
+#define AC_POWER_1_bm  (1<<4)  /* Power profile bit 1 mask. */
+#define AC_POWER_1_bp  4  /* Power profile bit 1 position. */
+#define AC_OUTEN_bm  0x40  /* Output Pad Enable bit mask. */
+#define AC_OUTEN_bp  6  /* Output Pad Enable bit position. */
+#define AC_RUNSTDBY_bm  0x80  /* Run in Standby Mode bit mask. */
+#define AC_RUNSTDBY_bp  7  /* Run in Standby Mode bit position. */
+
+/* AC.CTRLB  bit masks and bit positions */
+#define AC_WINSEL_gm  0x03  /* Window selection mode group mask. */
+#define AC_WINSEL_gp  0  /* Window selection mode group position. */
+#define AC_WINSEL_0_bm  (1<<0)  /* Window selection mode bit 0 mask. */
+#define AC_WINSEL_0_bp  0  /* Window selection mode bit 0 position. */
+#define AC_WINSEL_1_bm  (1<<1)  /* Window selection mode bit 1 mask. */
+#define AC_WINSEL_1_bp  1  /* Window selection mode bit 1 position. */
+
+/* AC.MUXCTRL  bit masks and bit positions */
+#define AC_MUXNEG_gm  0x07  /* Negative Input MUX Selection group mask. */
+#define AC_MUXNEG_gp  0  /* Negative Input MUX Selection group position. */
+#define AC_MUXNEG_0_bm  (1<<0)  /* Negative Input MUX Selection bit 0 mask. */
+#define AC_MUXNEG_0_bp  0  /* Negative Input MUX Selection bit 0 position. */
+#define AC_MUXNEG_1_bm  (1<<1)  /* Negative Input MUX Selection bit 1 mask. */
+#define AC_MUXNEG_1_bp  1  /* Negative Input MUX Selection bit 1 position. */
+#define AC_MUXNEG_2_bm  (1<<2)  /* Negative Input MUX Selection bit 2 mask. */
+#define AC_MUXNEG_2_bp  2  /* Negative Input MUX Selection bit 2 position. */
+#define AC_MUXPOS_gm  0x38  /* Positive Input MUX Selection group mask. */
+#define AC_MUXPOS_gp  3  /* Positive Input MUX Selection group position. */
+#define AC_MUXPOS_0_bm  (1<<3)  /* Positive Input MUX Selection bit 0 mask. */
+#define AC_MUXPOS_0_bp  3  /* Positive Input MUX Selection bit 0 position. */
+#define AC_MUXPOS_1_bm  (1<<4)  /* Positive Input MUX Selection bit 1 mask. */
+#define AC_MUXPOS_1_bp  4  /* Positive Input MUX Selection bit 1 position. */
+#define AC_MUXPOS_2_bm  (1<<5)  /* Positive Input MUX Selection bit 2 mask. */
+#define AC_MUXPOS_2_bp  5  /* Positive Input MUX Selection bit 2 position. */
+#define AC_INITVAL_bm  0x40  /* AC Output Initial Value bit mask. */
+#define AC_INITVAL_bp  6  /* AC Output Initial Value bit position. */
+#define AC_INVERT_bm  0x80  /* Invert AC Output bit mask. */
+#define AC_INVERT_bp  7  /* Invert AC Output bit position. */
+
+/* AC.DACREF  bit masks and bit positions */
+#define AC_DACREF_gm  0xFF  /* DACREF group mask. */
+#define AC_DACREF_gp  0  /* DACREF group position. */
+#define AC_DACREF_0_bm  (1<<0)  /* DACREF bit 0 mask. */
+#define AC_DACREF_0_bp  0  /* DACREF bit 0 position. */
+#define AC_DACREF_1_bm  (1<<1)  /* DACREF bit 1 mask. */
+#define AC_DACREF_1_bp  1  /* DACREF bit 1 position. */
+#define AC_DACREF_2_bm  (1<<2)  /* DACREF bit 2 mask. */
+#define AC_DACREF_2_bp  2  /* DACREF bit 2 position. */
+#define AC_DACREF_3_bm  (1<<3)  /* DACREF bit 3 mask. */
+#define AC_DACREF_3_bp  3  /* DACREF bit 3 position. */
+#define AC_DACREF_4_bm  (1<<4)  /* DACREF bit 4 mask. */
+#define AC_DACREF_4_bp  4  /* DACREF bit 4 position. */
+#define AC_DACREF_5_bm  (1<<5)  /* DACREF bit 5 mask. */
+#define AC_DACREF_5_bp  5  /* DACREF bit 5 position. */
+#define AC_DACREF_6_bm  (1<<6)  /* DACREF bit 6 mask. */
+#define AC_DACREF_6_bp  6  /* DACREF bit 6 position. */
+#define AC_DACREF_7_bm  (1<<7)  /* DACREF bit 7 mask. */
+#define AC_DACREF_7_bp  7  /* DACREF bit 7 position. */
+
+/* AC.INTCTRL  bit masks and bit positions */
+#define AC_CMP_bm  0x01  /* Interrupt Enable bit mask. */
+#define AC_CMP_bp  0  /* Interrupt Enable bit position. */
+#define AC_INTMODE_NORMAL_gm  0x30  /* Interrupt Mode group mask. */
+#define AC_INTMODE_NORMAL_gp  4  /* Interrupt Mode group position. */
+#define AC_INTMODE_NORMAL_0_bm  (1<<4)  /* Interrupt Mode bit 0 mask. */
+#define AC_INTMODE_NORMAL_0_bp  4  /* Interrupt Mode bit 0 position. */
+#define AC_INTMODE_NORMAL_1_bm  (1<<5)  /* Interrupt Mode bit 1 mask. */
+#define AC_INTMODE_NORMAL_1_bp  5  /* Interrupt Mode bit 1 position. */
+#define AC_INTMODE_WINDOW_gm  0x30  /* Interrupt Mode group mask. */
+#define AC_INTMODE_WINDOW_gp  4  /* Interrupt Mode group position. */
+#define AC_INTMODE_WINDOW_0_bm  (1<<4)  /* Interrupt Mode bit 0 mask. */
+#define AC_INTMODE_WINDOW_0_bp  4  /* Interrupt Mode bit 0 position. */
+#define AC_INTMODE_WINDOW_1_bm  (1<<5)  /* Interrupt Mode bit 1 mask. */
+#define AC_INTMODE_WINDOW_1_bp  5  /* Interrupt Mode bit 1 position. */
+
+/* AC.STATUS  bit masks and bit positions */
+#define AC_CMPIF_bm  0x01  /* Analog Comparator Interrupt Flag bit mask. */
+#define AC_CMPIF_bp  0  /* Analog Comparator Interrupt Flag bit position. */
+#define AC_CMPSTATE_bm  0x10  /* Analog Comparator State bit mask. */
+#define AC_CMPSTATE_bp  4  /* Analog Comparator State bit position. */
+#define AC_WINSTATE_gm  0xC0  /* Analog Comparator Window State group mask. */
+#define AC_WINSTATE_gp  6  /* Analog Comparator Window State group position. */
+#define AC_WINSTATE_0_bm  (1<<6)  /* Analog Comparator Window State bit 0 mask. */
+#define AC_WINSTATE_0_bp  6  /* Analog Comparator Window State bit 0 position. */
+#define AC_WINSTATE_1_bm  (1<<7)  /* Analog Comparator Window State bit 1 mask. */
+#define AC_WINSTATE_1_bp  7  /* Analog Comparator Window State bit 1 position. */
+
+
+/* ADC - Analog to Digital Converter */
+/* ADC.CTRLA  bit masks and bit positions */
+#define ADC_ENABLE_bm  0x01  /* ADC Enable bit mask. */
+#define ADC_ENABLE_bp  0  /* ADC Enable bit position. */
+#define ADC_LOWLAT_bm  0x20  /* Low Latency bit mask. */
+#define ADC_LOWLAT_bp  5  /* Low Latency bit position. */
+#define ADC_RUNSTDBY_bm  0x80  /* Run in Standby bit mask. */
+#define ADC_RUNSTDBY_bp  7  /* Run in Standby bit position. */
+
+/* ADC.CTRLB  bit masks and bit positions */
+#define ADC_PRESC_gm  0x0F  /* Prescaler Value group mask. */
+#define ADC_PRESC_gp  0  /* Prescaler Value group position. */
+#define ADC_PRESC_0_bm  (1<<0)  /* Prescaler Value bit 0 mask. */
+#define ADC_PRESC_0_bp  0  /* Prescaler Value bit 0 position. */
+#define ADC_PRESC_1_bm  (1<<1)  /* Prescaler Value bit 1 mask. */
+#define ADC_PRESC_1_bp  1  /* Prescaler Value bit 1 position. */
+#define ADC_PRESC_2_bm  (1<<2)  /* Prescaler Value bit 2 mask. */
+#define ADC_PRESC_2_bp  2  /* Prescaler Value bit 2 position. */
+#define ADC_PRESC_3_bm  (1<<3)  /* Prescaler Value bit 3 mask. */
+#define ADC_PRESC_3_bp  3  /* Prescaler Value bit 3 position. */
+
+/* ADC.CTRLC  bit masks and bit positions */
+#define ADC_REFSEL_gm  0x07  /* Reference select group mask. */
+#define ADC_REFSEL_gp  0  /* Reference select group position. */
+#define ADC_REFSEL_0_bm  (1<<0)  /* Reference select bit 0 mask. */
+#define ADC_REFSEL_0_bp  0  /* Reference select bit 0 position. */
+#define ADC_REFSEL_1_bm  (1<<1)  /* Reference select bit 1 mask. */
+#define ADC_REFSEL_1_bp  1  /* Reference select bit 1 position. */
+#define ADC_REFSEL_2_bm  (1<<2)  /* Reference select bit 2 mask. */
+#define ADC_REFSEL_2_bp  2  /* Reference select bit 2 position. */
+
+/* ADC.CTRLD  bit masks and bit positions */
+#define ADC_WINCM_gm  0x07  /* Window Comparator Mode group mask. */
+#define ADC_WINCM_gp  0  /* Window Comparator Mode group position. */
+#define ADC_WINCM_0_bm  (1<<0)  /* Window Comparator Mode bit 0 mask. */
+#define ADC_WINCM_0_bp  0  /* Window Comparator Mode bit 0 position. */
+#define ADC_WINCM_1_bm  (1<<1)  /* Window Comparator Mode bit 1 mask. */
+#define ADC_WINCM_1_bp  1  /* Window Comparator Mode bit 1 position. */
+#define ADC_WINCM_2_bm  (1<<2)  /* Window Comparator Mode bit 2 mask. */
+#define ADC_WINCM_2_bp  2  /* Window Comparator Mode bit 2 position. */
+#define ADC_WINSRC_bm  0x08  /* Window Mode Source bit mask. */
+#define ADC_WINSRC_bp  3  /* Window Mode Source bit position. */
+
+/* ADC.INTCTRL  bit masks and bit positions */
+#define ADC_RESRDY_bm  0x01  /* Result Ready Interrupt Enable bit mask. */
+#define ADC_RESRDY_bp  0  /* Result Ready Interrupt Enable bit position. */
+#define ADC_SAMPRDY_bm  0x02  /* Sample Ready Interrupt Enable bit mask. */
+#define ADC_SAMPRDY_bp  1  /* Sample Ready Interrupt Enable bit position. */
+#define ADC_WCMP_bm  0x04  /* Window Comparator Interrupt Enable bit mask. */
+#define ADC_WCMP_bp  2  /* Window Comparator Interrupt Enable bit position. */
+#define ADC_RESOVR_bm  0x08  /* Result Overwrite Interrupt Enable bit mask. */
+#define ADC_RESOVR_bp  3  /* Result Overwrite Interrupt Enable bit position. */
+#define ADC_SAMPOVR_bm  0x10  /* Sample Overwrite Interrupt Enable bit mask. */
+#define ADC_SAMPOVR_bp  4  /* Sample Overwrite Interrupt Enable bit position. */
+#define ADC_TRIGOVR_bm  0x20  /* Trigger Overrun Interrupt Enable bit mask. */
+#define ADC_TRIGOVR_bp  5  /* Trigger Overrun Interrupt Enable bit position. */
+
+/* ADC.INTFLAGS  bit masks and bit positions */
+/* ADC_RESRDY  is already defined. */
+/* ADC_SAMPRDY  is already defined. */
+/* ADC_WCMP  is already defined. */
+/* ADC_RESOVR  is already defined. */
+/* ADC_SAMPOVR  is already defined. */
+/* ADC_TRIGOVR  is already defined. */
+
+/* ADC.STATUS  bit masks and bit positions */
+#define ADC_ADCBUSY_bm  0x01  /* ADC Busy bit mask. */
+#define ADC_ADCBUSY_bp  0  /* ADC Busy bit position. */
+
+/* ADC.DBGCTRL  bit masks and bit positions */
+#define ADC_DBGRUN_bm  0x01  /* Run in Debug Mode bit mask. */
+#define ADC_DBGRUN_bp  0  /* Run in Debug Mode bit position. */
+
+/* ADC.CTRLE  bit masks and bit positions */
+#define ADC_SAMPDUR_gm  0xFF  /* Sample Duration group mask. */
+#define ADC_SAMPDUR_gp  0  /* Sample Duration group position. */
+#define ADC_SAMPDUR_0_bm  (1<<0)  /* Sample Duration bit 0 mask. */
+#define ADC_SAMPDUR_0_bp  0  /* Sample Duration bit 0 position. */
+#define ADC_SAMPDUR_1_bm  (1<<1)  /* Sample Duration bit 1 mask. */
+#define ADC_SAMPDUR_1_bp  1  /* Sample Duration bit 1 position. */
+#define ADC_SAMPDUR_2_bm  (1<<2)  /* Sample Duration bit 2 mask. */
+#define ADC_SAMPDUR_2_bp  2  /* Sample Duration bit 2 position. */
+#define ADC_SAMPDUR_3_bm  (1<<3)  /* Sample Duration bit 3 mask. */
+#define ADC_SAMPDUR_3_bp  3  /* Sample Duration bit 3 position. */
+#define ADC_SAMPDUR_4_bm  (1<<4)  /* Sample Duration bit 4 mask. */
+#define ADC_SAMPDUR_4_bp  4  /* Sample Duration bit 4 position. */
+#define ADC_SAMPDUR_5_bm  (1<<5)  /* Sample Duration bit 5 mask. */
+#define ADC_SAMPDUR_5_bp  5  /* Sample Duration bit 5 position. */
+#define ADC_SAMPDUR_6_bm  (1<<6)  /* Sample Duration bit 6 mask. */
+#define ADC_SAMPDUR_6_bp  6  /* Sample Duration bit 6 position. */
+#define ADC_SAMPDUR_7_bm  (1<<7)  /* Sample Duration bit 7 mask. */
+#define ADC_SAMPDUR_7_bp  7  /* Sample Duration bit 7 position. */
+
+/* ADC.CTRLF  bit masks and bit positions */
+#define ADC_SAMPNUM_gm  0x0F  /* Sample numbers group mask. */
+#define ADC_SAMPNUM_gp  0  /* Sample numbers group position. */
+#define ADC_SAMPNUM_0_bm  (1<<0)  /* Sample numbers bit 0 mask. */
+#define ADC_SAMPNUM_0_bp  0  /* Sample numbers bit 0 position. */
+#define ADC_SAMPNUM_1_bm  (1<<1)  /* Sample numbers bit 1 mask. */
+#define ADC_SAMPNUM_1_bp  1  /* Sample numbers bit 1 position. */
+#define ADC_SAMPNUM_2_bm  (1<<2)  /* Sample numbers bit 2 mask. */
+#define ADC_SAMPNUM_2_bp  2  /* Sample numbers bit 2 position. */
+#define ADC_SAMPNUM_3_bm  (1<<3)  /* Sample numbers bit 3 mask. */
+#define ADC_SAMPNUM_3_bp  3  /* Sample numbers bit 3 position. */
+#define ADC_LEFTADJ_bm  0x10  /* Left Adjust bit mask. */
+#define ADC_LEFTADJ_bp  4  /* Left Adjust bit position. */
+#define ADC_FREERUN_bm  0x20  /* Free-Running mode bit mask. */
+#define ADC_FREERUN_bp  5  /* Free-Running mode bit position. */
+#define ADC_CHOPPING_bm  0x40  /* Sign Chopping bit mask. */
+#define ADC_CHOPPING_bp  6  /* Sign Chopping bit position. */
+
+/* ADC.COMMAND  bit masks and bit positions */
+#define ADC_START_gm  0x07  /* Start command group mask. */
+#define ADC_START_gp  0  /* Start command group position. */
+#define ADC_START_0_bm  (1<<0)  /* Start command bit 0 mask. */
+#define ADC_START_0_bp  0  /* Start command bit 0 position. */
+#define ADC_START_1_bm  (1<<1)  /* Start command bit 1 mask. */
+#define ADC_START_1_bp  1  /* Start command bit 1 position. */
+#define ADC_START_2_bm  (1<<2)  /* Start command bit 2 mask. */
+#define ADC_START_2_bp  2  /* Start command bit 2 position. */
+#define ADC_MODE_gm  0x70  /* Mode group mask. */
+#define ADC_MODE_gp  4  /* Mode group position. */
+#define ADC_MODE_0_bm  (1<<4)  /* Mode bit 0 mask. */
+#define ADC_MODE_0_bp  4  /* Mode bit 0 position. */
+#define ADC_MODE_1_bm  (1<<5)  /* Mode bit 1 mask. */
+#define ADC_MODE_1_bp  5  /* Mode bit 1 position. */
+#define ADC_MODE_2_bm  (1<<6)  /* Mode bit 2 mask. */
+#define ADC_MODE_2_bp  6  /* Mode bit 2 position. */
+#define ADC_DIFF_bm  0x80  /* Differential mode bit mask. */
+#define ADC_DIFF_bp  7  /* Differential mode bit position. */
+
+/* ADC.PGACTRL  bit masks and bit positions */
+#define ADC_PGAEN_bm  0x01  /* PGA Enable bit mask. */
+#define ADC_PGAEN_bp  0  /* PGA Enable bit position. */
+#define ADC_PGABIASSEL_gm  0x18  /* PGA BIAS Select group mask. */
+#define ADC_PGABIASSEL_gp  3  /* PGA BIAS Select group position. */
+#define ADC_PGABIASSEL_0_bm  (1<<3)  /* PGA BIAS Select bit 0 mask. */
+#define ADC_PGABIASSEL_0_bp  3  /* PGA BIAS Select bit 0 position. */
+#define ADC_PGABIASSEL_1_bm  (1<<4)  /* PGA BIAS Select bit 1 mask. */
+#define ADC_PGABIASSEL_1_bp  4  /* PGA BIAS Select bit 1 position. */
+#define ADC_GAIN_gm  0xE0  /* Gain group mask. */
+#define ADC_GAIN_gp  5  /* Gain group position. */
+#define ADC_GAIN_0_bm  (1<<5)  /* Gain bit 0 mask. */
+#define ADC_GAIN_0_bp  5  /* Gain bit 0 position. */
+#define ADC_GAIN_1_bm  (1<<6)  /* Gain bit 1 mask. */
+#define ADC_GAIN_1_bp  6  /* Gain bit 1 position. */
+#define ADC_GAIN_2_bm  (1<<7)  /* Gain bit 2 mask. */
+#define ADC_GAIN_2_bp  7  /* Gain bit 2 position. */
+
+/* ADC.MUXPOS  bit masks and bit positions */
+#define ADC_MUXPOS_gm  0x3F  /* Analog Channel Selection Bits group mask. */
+#define ADC_MUXPOS_gp  0  /* Analog Channel Selection Bits group position. */
+#define ADC_MUXPOS_0_bm  (1<<0)  /* Analog Channel Selection Bits bit 0 mask. */
+#define ADC_MUXPOS_0_bp  0  /* Analog Channel Selection Bits bit 0 position. */
+#define ADC_MUXPOS_1_bm  (1<<1)  /* Analog Channel Selection Bits bit 1 mask. */
+#define ADC_MUXPOS_1_bp  1  /* Analog Channel Selection Bits bit 1 position. */
+#define ADC_MUXPOS_2_bm  (1<<2)  /* Analog Channel Selection Bits bit 2 mask. */
+#define ADC_MUXPOS_2_bp  2  /* Analog Channel Selection Bits bit 2 position. */
+#define ADC_MUXPOS_3_bm  (1<<3)  /* Analog Channel Selection Bits bit 3 mask. */
+#define ADC_MUXPOS_3_bp  3  /* Analog Channel Selection Bits bit 3 position. */
+#define ADC_MUXPOS_4_bm  (1<<4)  /* Analog Channel Selection Bits bit 4 mask. */
+#define ADC_MUXPOS_4_bp  4  /* Analog Channel Selection Bits bit 4 position. */
+#define ADC_MUXPOS_5_bm  (1<<5)  /* Analog Channel Selection Bits bit 5 mask. */
+#define ADC_MUXPOS_5_bp  5  /* Analog Channel Selection Bits bit 5 position. */
+#define ADC_VIA_gm  0xC0  /* VIA group mask. */
+#define ADC_VIA_gp  6  /* VIA group position. */
+#define ADC_VIA_0_bm  (1<<6)  /* VIA bit 0 mask. */
+#define ADC_VIA_0_bp  6  /* VIA bit 0 position. */
+#define ADC_VIA_1_bm  (1<<7)  /* VIA bit 1 mask. */
+#define ADC_VIA_1_bp  7  /* VIA bit 1 position. */
+
+/* ADC.MUXNEG  bit masks and bit positions */
+#define ADC_MUXNEG_gm  0x3F  /* Analog Channel Selection Bits group mask. */
+#define ADC_MUXNEG_gp  0  /* Analog Channel Selection Bits group position. */
+#define ADC_MUXNEG_0_bm  (1<<0)  /* Analog Channel Selection Bits bit 0 mask. */
+#define ADC_MUXNEG_0_bp  0  /* Analog Channel Selection Bits bit 0 position. */
+#define ADC_MUXNEG_1_bm  (1<<1)  /* Analog Channel Selection Bits bit 1 mask. */
+#define ADC_MUXNEG_1_bp  1  /* Analog Channel Selection Bits bit 1 position. */
+#define ADC_MUXNEG_2_bm  (1<<2)  /* Analog Channel Selection Bits bit 2 mask. */
+#define ADC_MUXNEG_2_bp  2  /* Analog Channel Selection Bits bit 2 position. */
+#define ADC_MUXNEG_3_bm  (1<<3)  /* Analog Channel Selection Bits bit 3 mask. */
+#define ADC_MUXNEG_3_bp  3  /* Analog Channel Selection Bits bit 3 position. */
+#define ADC_MUXNEG_4_bm  (1<<4)  /* Analog Channel Selection Bits bit 4 mask. */
+#define ADC_MUXNEG_4_bp  4  /* Analog Channel Selection Bits bit 4 position. */
+#define ADC_MUXNEG_5_bm  (1<<5)  /* Analog Channel Selection Bits bit 5 mask. */
+#define ADC_MUXNEG_5_bp  5  /* Analog Channel Selection Bits bit 5 position. */
+/* ADC_VIA  is already defined. */
+
+
+/* BOD - Bod interface */
+/* BOD.CTRLA  bit masks and bit positions */
+#define BOD_SLEEP_gm  0x03  /* Operation in sleep mode group mask. */
+#define BOD_SLEEP_gp  0  /* Operation in sleep mode group position. */
+#define BOD_SLEEP_0_bm  (1<<0)  /* Operation in sleep mode bit 0 mask. */
+#define BOD_SLEEP_0_bp  0  /* Operation in sleep mode bit 0 position. */
+#define BOD_SLEEP_1_bm  (1<<1)  /* Operation in sleep mode bit 1 mask. */
+#define BOD_SLEEP_1_bp  1  /* Operation in sleep mode bit 1 position. */
+#define BOD_ACTIVE_gm  0x0C  /* Operation in active mode group mask. */
+#define BOD_ACTIVE_gp  2  /* Operation in active mode group position. */
+#define BOD_ACTIVE_0_bm  (1<<2)  /* Operation in active mode bit 0 mask. */
+#define BOD_ACTIVE_0_bp  2  /* Operation in active mode bit 0 position. */
+#define BOD_ACTIVE_1_bm  (1<<3)  /* Operation in active mode bit 1 mask. */
+#define BOD_ACTIVE_1_bp  3  /* Operation in active mode bit 1 position. */
+#define BOD_SAMPFREQ_bm  0x10  /* Sample frequency bit mask. */
+#define BOD_SAMPFREQ_bp  4  /* Sample frequency bit position. */
+
+/* BOD.CTRLB  bit masks and bit positions */
+#define BOD_LVL_gm  0x07  /* Bod level group mask. */
+#define BOD_LVL_gp  0  /* Bod level group position. */
+#define BOD_LVL_0_bm  (1<<0)  /* Bod level bit 0 mask. */
+#define BOD_LVL_0_bp  0  /* Bod level bit 0 position. */
+#define BOD_LVL_1_bm  (1<<1)  /* Bod level bit 1 mask. */
+#define BOD_LVL_1_bp  1  /* Bod level bit 1 position. */
+#define BOD_LVL_2_bm  (1<<2)  /* Bod level bit 2 mask. */
+#define BOD_LVL_2_bp  2  /* Bod level bit 2 position. */
+
+/* BOD.VLMCTRLA  bit masks and bit positions */
+#define BOD_VLMLVL_gm  0x03  /* voltage level monitor level group mask. */
+#define BOD_VLMLVL_gp  0  /* voltage level monitor level group position. */
+#define BOD_VLMLVL_0_bm  (1<<0)  /* voltage level monitor level bit 0 mask. */
+#define BOD_VLMLVL_0_bp  0  /* voltage level monitor level bit 0 position. */
+#define BOD_VLMLVL_1_bm  (1<<1)  /* voltage level monitor level bit 1 mask. */
+#define BOD_VLMLVL_1_bp  1  /* voltage level monitor level bit 1 position. */
+
+/* BOD.INTCTRL  bit masks and bit positions */
+#define BOD_VLMIE_bm  0x01  /* voltage level monitor interrrupt enable bit mask. */
+#define BOD_VLMIE_bp  0  /* voltage level monitor interrrupt enable bit position. */
+#define BOD_VLMCFG_gm  0x06  /* Configuration group mask. */
+#define BOD_VLMCFG_gp  1  /* Configuration group position. */
+#define BOD_VLMCFG_0_bm  (1<<1)  /* Configuration bit 0 mask. */
+#define BOD_VLMCFG_0_bp  1  /* Configuration bit 0 position. */
+#define BOD_VLMCFG_1_bm  (1<<2)  /* Configuration bit 1 mask. */
+#define BOD_VLMCFG_1_bp  2  /* Configuration bit 1 position. */
+
+/* BOD.INTFLAGS  bit masks and bit positions */
+#define BOD_VLMIF_bm  0x01  /* Voltage level monitor interrupt flag bit mask. */
+#define BOD_VLMIF_bp  0  /* Voltage level monitor interrupt flag bit position. */
+
+/* BOD.STATUS  bit masks and bit positions */
+#define BOD_VLMS_bm  0x01  /* Voltage level monitor status bit mask. */
+#define BOD_VLMS_bp  0  /* Voltage level monitor status bit position. */
+
+
+
+/* CCL - Configurable Custom Logic */
+/* CCL.CTRLA  bit masks and bit positions */
+#define CCL_ENABLE_bm  0x01  /* Enable bit mask. */
+#define CCL_ENABLE_bp  0  /* Enable bit position. */
+#define CCL_RUNSTDBY_bm  0x40  /* Run in Standby bit mask. */
+#define CCL_RUNSTDBY_bp  6  /* Run in Standby bit position. */
+
+/* CCL.SEQCTRL0  bit masks and bit positions */
+#define CCL_SEQSEL_gm  0x0F  /* Sequential Selection group mask. */
+#define CCL_SEQSEL_gp  0  /* Sequential Selection group position. */
+#define CCL_SEQSEL_0_bm  (1<<0)  /* Sequential Selection bit 0 mask. */
+#define CCL_SEQSEL_0_bp  0  /* Sequential Selection bit 0 position. */
+#define CCL_SEQSEL_1_bm  (1<<1)  /* Sequential Selection bit 1 mask. */
+#define CCL_SEQSEL_1_bp  1  /* Sequential Selection bit 1 position. */
+#define CCL_SEQSEL_2_bm  (1<<2)  /* Sequential Selection bit 2 mask. */
+#define CCL_SEQSEL_2_bp  2  /* Sequential Selection bit 2 position. */
+#define CCL_SEQSEL_3_bm  (1<<3)  /* Sequential Selection bit 3 mask. */
+#define CCL_SEQSEL_3_bp  3  /* Sequential Selection bit 3 position. */
+
+/* CCL.SEQCTRL1  bit masks and bit positions */
+/* CCL_SEQSEL  is already defined. */
+
+/* CCL.INTCTRL0  bit masks and bit positions */
+#define CCL_INTMODE0_gm  0x03  /* Interrupt Mode for LUT0 group mask. */
+#define CCL_INTMODE0_gp  0  /* Interrupt Mode for LUT0 group position. */
+#define CCL_INTMODE0_0_bm  (1<<0)  /* Interrupt Mode for LUT0 bit 0 mask. */
+#define CCL_INTMODE0_0_bp  0  /* Interrupt Mode for LUT0 bit 0 position. */
+#define CCL_INTMODE0_1_bm  (1<<1)  /* Interrupt Mode for LUT0 bit 1 mask. */
+#define CCL_INTMODE0_1_bp  1  /* Interrupt Mode for LUT0 bit 1 position. */
+#define CCL_INTMODE1_gm  0x0C  /* Interrupt Mode for LUT1 group mask. */
+#define CCL_INTMODE1_gp  2  /* Interrupt Mode for LUT1 group position. */
+#define CCL_INTMODE1_0_bm  (1<<2)  /* Interrupt Mode for LUT1 bit 0 mask. */
+#define CCL_INTMODE1_0_bp  2  /* Interrupt Mode for LUT1 bit 0 position. */
+#define CCL_INTMODE1_1_bm  (1<<3)  /* Interrupt Mode for LUT1 bit 1 mask. */
+#define CCL_INTMODE1_1_bp  3  /* Interrupt Mode for LUT1 bit 1 position. */
+#define CCL_INTMODE2_gm  0x30  /* Interrupt Mode for LUT2 group mask. */
+#define CCL_INTMODE2_gp  4  /* Interrupt Mode for LUT2 group position. */
+#define CCL_INTMODE2_0_bm  (1<<4)  /* Interrupt Mode for LUT2 bit 0 mask. */
+#define CCL_INTMODE2_0_bp  4  /* Interrupt Mode for LUT2 bit 0 position. */
+#define CCL_INTMODE2_1_bm  (1<<5)  /* Interrupt Mode for LUT2 bit 1 mask. */
+#define CCL_INTMODE2_1_bp  5  /* Interrupt Mode for LUT2 bit 1 position. */
+#define CCL_INTMODE3_gm  0xC0  /* Interrupt Mode for LUT3 group mask. */
+#define CCL_INTMODE3_gp  6  /* Interrupt Mode for LUT3 group position. */
+#define CCL_INTMODE3_0_bm  (1<<6)  /* Interrupt Mode for LUT3 bit 0 mask. */
+#define CCL_INTMODE3_0_bp  6  /* Interrupt Mode for LUT3 bit 0 position. */
+#define CCL_INTMODE3_1_bm  (1<<7)  /* Interrupt Mode for LUT3 bit 1 mask. */
+#define CCL_INTMODE3_1_bp  7  /* Interrupt Mode for LUT3 bit 1 position. */
+
+/* CCL.INTFLAGS  bit masks and bit positions */
+#define CCL_INT_gm  0x0F  /* Interrupt Flag group mask. */
+#define CCL_INT_gp  0  /* Interrupt Flag group position. */
+#define CCL_INT_0_bm  (1<<0)  /* Interrupt Flag bit 0 mask. */
+#define CCL_INT_0_bp  0  /* Interrupt Flag bit 0 position. */
+#define CCL_INT0_bm  CCL_INT_0_bm  /* This define is deprecated and should not be used */
+#define CCL_INT0_bp  CCL_INT_0_bp  /* This define is deprecated and should not be used */
+#define CCL_INT_1_bm  (1<<1)  /* Interrupt Flag bit 1 mask. */
+#define CCL_INT_1_bp  1  /* Interrupt Flag bit 1 position. */
+#define CCL_INT1_bm  CCL_INT_1_bm  /* This define is deprecated and should not be used */
+#define CCL_INT1_bp  CCL_INT_1_bp  /* This define is deprecated and should not be used */
+#define CCL_INT_2_bm  (1<<2)  /* Interrupt Flag bit 2 mask. */
+#define CCL_INT_2_bp  2  /* Interrupt Flag bit 2 position. */
+#define CCL_INT2_bm  CCL_INT_2_bm  /* This define is deprecated and should not be used */
+#define CCL_INT2_bp  CCL_INT_2_bp  /* This define is deprecated and should not be used */
+#define CCL_INT_3_bm  (1<<3)  /* Interrupt Flag bit 3 mask. */
+#define CCL_INT_3_bp  3  /* Interrupt Flag bit 3 position. */
+#define CCL_INT3_bm  CCL_INT_3_bm  /* This define is deprecated and should not be used */
+#define CCL_INT3_bp  CCL_INT_3_bp  /* This define is deprecated and should not be used */
+
+/* CCL.LUT0CTRLA  bit masks and bit positions */
+/* CCL_ENABLE  is already defined. */
+#define CCL_CLKSRC_gm  0x0E  /* Clock Source Selection group mask. */
+#define CCL_CLKSRC_gp  1  /* Clock Source Selection group position. */
+#define CCL_CLKSRC_0_bm  (1<<1)  /* Clock Source Selection bit 0 mask. */
+#define CCL_CLKSRC_0_bp  1  /* Clock Source Selection bit 0 position. */
+#define CCL_CLKSRC_1_bm  (1<<2)  /* Clock Source Selection bit 1 mask. */
+#define CCL_CLKSRC_1_bp  2  /* Clock Source Selection bit 1 position. */
+#define CCL_CLKSRC_2_bm  (1<<3)  /* Clock Source Selection bit 2 mask. */
+#define CCL_CLKSRC_2_bp  3  /* Clock Source Selection bit 2 position. */
+#define CCL_FILTSEL_gm  0x30  /* Filter Selection group mask. */
+#define CCL_FILTSEL_gp  4  /* Filter Selection group position. */
+#define CCL_FILTSEL_0_bm  (1<<4)  /* Filter Selection bit 0 mask. */
+#define CCL_FILTSEL_0_bp  4  /* Filter Selection bit 0 position. */
+#define CCL_FILTSEL_1_bm  (1<<5)  /* Filter Selection bit 1 mask. */
+#define CCL_FILTSEL_1_bp  5  /* Filter Selection bit 1 position. */
+#define CCL_OUTEN_bm  0x40  /* Output Enable bit mask. */
+#define CCL_OUTEN_bp  6  /* Output Enable bit position. */
+#define CCL_EDGEDET_bm  0x80  /* Edge Detection Enable bit mask. */
+#define CCL_EDGEDET_bp  7  /* Edge Detection Enable bit position. */
+
+/* CCL.LUT0CTRLB  bit masks and bit positions */
+#define CCL_INSEL0_gm  0x0F  /* LUT Input 0 Source Selection group mask. */
+#define CCL_INSEL0_gp  0  /* LUT Input 0 Source Selection group position. */
+#define CCL_INSEL0_0_bm  (1<<0)  /* LUT Input 0 Source Selection bit 0 mask. */
+#define CCL_INSEL0_0_bp  0  /* LUT Input 0 Source Selection bit 0 position. */
+#define CCL_INSEL0_1_bm  (1<<1)  /* LUT Input 0 Source Selection bit 1 mask. */
+#define CCL_INSEL0_1_bp  1  /* LUT Input 0 Source Selection bit 1 position. */
+#define CCL_INSEL0_2_bm  (1<<2)  /* LUT Input 0 Source Selection bit 2 mask. */
+#define CCL_INSEL0_2_bp  2  /* LUT Input 0 Source Selection bit 2 position. */
+#define CCL_INSEL0_3_bm  (1<<3)  /* LUT Input 0 Source Selection bit 3 mask. */
+#define CCL_INSEL0_3_bp  3  /* LUT Input 0 Source Selection bit 3 position. */
+#define CCL_INSEL1_gm  0xF0  /* LUT Input 1 Source Selection group mask. */
+#define CCL_INSEL1_gp  4  /* LUT Input 1 Source Selection group position. */
+#define CCL_INSEL1_0_bm  (1<<4)  /* LUT Input 1 Source Selection bit 0 mask. */
+#define CCL_INSEL1_0_bp  4  /* LUT Input 1 Source Selection bit 0 position. */
+#define CCL_INSEL1_1_bm  (1<<5)  /* LUT Input 1 Source Selection bit 1 mask. */
+#define CCL_INSEL1_1_bp  5  /* LUT Input 1 Source Selection bit 1 position. */
+#define CCL_INSEL1_2_bm  (1<<6)  /* LUT Input 1 Source Selection bit 2 mask. */
+#define CCL_INSEL1_2_bp  6  /* LUT Input 1 Source Selection bit 2 position. */
+#define CCL_INSEL1_3_bm  (1<<7)  /* LUT Input 1 Source Selection bit 3 mask. */
+#define CCL_INSEL1_3_bp  7  /* LUT Input 1 Source Selection bit 3 position. */
+
+/* CCL.LUT0CTRLC  bit masks and bit positions */
+#define CCL_INSEL2_gm  0x0F  /* LUT Input 2 Source Selection group mask. */
+#define CCL_INSEL2_gp  0  /* LUT Input 2 Source Selection group position. */
+#define CCL_INSEL2_0_bm  (1<<0)  /* LUT Input 2 Source Selection bit 0 mask. */
+#define CCL_INSEL2_0_bp  0  /* LUT Input 2 Source Selection bit 0 position. */
+#define CCL_INSEL2_1_bm  (1<<1)  /* LUT Input 2 Source Selection bit 1 mask. */
+#define CCL_INSEL2_1_bp  1  /* LUT Input 2 Source Selection bit 1 position. */
+#define CCL_INSEL2_2_bm  (1<<2)  /* LUT Input 2 Source Selection bit 2 mask. */
+#define CCL_INSEL2_2_bp  2  /* LUT Input 2 Source Selection bit 2 position. */
+#define CCL_INSEL2_3_bm  (1<<3)  /* LUT Input 2 Source Selection bit 3 mask. */
+#define CCL_INSEL2_3_bp  3  /* LUT Input 2 Source Selection bit 3 position. */
+
+/* CCL.TRUTH0  bit masks and bit positions */
+#define CCL_TRUTH_gm  0xFF  /* Truth Table group mask. */
+#define CCL_TRUTH_gp  0  /* Truth Table group position. */
+#define CCL_TRUTH_0_bm  (1<<0)  /* Truth Table bit 0 mask. */
+#define CCL_TRUTH_0_bp  0  /* Truth Table bit 0 position. */
+#define CCL_TRUTH_1_bm  (1<<1)  /* Truth Table bit 1 mask. */
+#define CCL_TRUTH_1_bp  1  /* Truth Table bit 1 position. */
+#define CCL_TRUTH_2_bm  (1<<2)  /* Truth Table bit 2 mask. */
+#define CCL_TRUTH_2_bp  2  /* Truth Table bit 2 position. */
+#define CCL_TRUTH_3_bm  (1<<3)  /* Truth Table bit 3 mask. */
+#define CCL_TRUTH_3_bp  3  /* Truth Table bit 3 position. */
+#define CCL_TRUTH_4_bm  (1<<4)  /* Truth Table bit 4 mask. */
+#define CCL_TRUTH_4_bp  4  /* Truth Table bit 4 position. */
+#define CCL_TRUTH_5_bm  (1<<5)  /* Truth Table bit 5 mask. */
+#define CCL_TRUTH_5_bp  5  /* Truth Table bit 5 position. */
+#define CCL_TRUTH_6_bm  (1<<6)  /* Truth Table bit 6 mask. */
+#define CCL_TRUTH_6_bp  6  /* Truth Table bit 6 position. */
+#define CCL_TRUTH_7_bm  (1<<7)  /* Truth Table bit 7 mask. */
+#define CCL_TRUTH_7_bp  7  /* Truth Table bit 7 position. */
+
+/* CCL.LUT1CTRLA  bit masks and bit positions */
+/* CCL_ENABLE  is already defined. */
+/* CCL_CLKSRC  is already defined. */
+/* CCL_FILTSEL  is already defined. */
+/* CCL_OUTEN  is already defined. */
+/* CCL_EDGEDET  is already defined. */
+
+/* CCL.LUT1CTRLB  bit masks and bit positions */
+/* CCL_INSEL0  is already defined. */
+/* CCL_INSEL1  is already defined. */
+
+/* CCL.LUT1CTRLC  bit masks and bit positions */
+/* CCL_INSEL2  is already defined. */
+
+/* CCL.TRUTH1  bit masks and bit positions */
+/* CCL_TRUTH  is already defined. */
+
+/* CCL.LUT2CTRLA  bit masks and bit positions */
+/* CCL_ENABLE  is already defined. */
+/* CCL_CLKSRC  is already defined. */
+/* CCL_FILTSEL  is already defined. */
+/* CCL_OUTEN  is already defined. */
+/* CCL_EDGEDET  is already defined. */
+
+/* CCL.LUT2CTRLB  bit masks and bit positions */
+/* CCL_INSEL0  is already defined. */
+/* CCL_INSEL1  is already defined. */
+
+/* CCL.LUT2CTRLC  bit masks and bit positions */
+/* CCL_INSEL2  is already defined. */
+
+/* CCL.TRUTH2  bit masks and bit positions */
+/* CCL_TRUTH  is already defined. */
+
+/* CCL.LUT3CTRLA  bit masks and bit positions */
+/* CCL_ENABLE  is already defined. */
+/* CCL_CLKSRC  is already defined. */
+/* CCL_FILTSEL  is already defined. */
+/* CCL_OUTEN  is already defined. */
+/* CCL_EDGEDET  is already defined. */
+
+/* CCL.LUT3CTRLB  bit masks and bit positions */
+/* CCL_INSEL0  is already defined. */
+/* CCL_INSEL1  is already defined. */
+
+/* CCL.LUT3CTRLC  bit masks and bit positions */
+/* CCL_INSEL2  is already defined. */
+
+/* CCL.TRUTH3  bit masks and bit positions */
+/* CCL_TRUTH  is already defined. */
+
+
+/* CLKCTRL - Clock controller */
+/* CLKCTRL.MCLKCTRLA  bit masks and bit positions */
+#define CLKCTRL_CLKSEL_gm  0x0F  /* Clock select group mask. */
+#define CLKCTRL_CLKSEL_gp  0  /* Clock select group position. */
+#define CLKCTRL_CLKSEL_0_bm  (1<<0)  /* Clock select bit 0 mask. */
+#define CLKCTRL_CLKSEL_0_bp  0  /* Clock select bit 0 position. */
+#define CLKCTRL_CLKSEL_1_bm  (1<<1)  /* Clock select bit 1 mask. */
+#define CLKCTRL_CLKSEL_1_bp  1  /* Clock select bit 1 position. */
+#define CLKCTRL_CLKSEL_2_bm  (1<<2)  /* Clock select bit 2 mask. */
+#define CLKCTRL_CLKSEL_2_bp  2  /* Clock select bit 2 position. */
+#define CLKCTRL_CLKSEL_3_bm  (1<<3)  /* Clock select bit 3 mask. */
+#define CLKCTRL_CLKSEL_3_bp  3  /* Clock select bit 3 position. */
+#define CLKCTRL_CLKOUT_bm  0x80  /* System clock out bit mask. */
+#define CLKCTRL_CLKOUT_bp  7  /* System clock out bit position. */
+
+/* CLKCTRL.MCLKCTRLB  bit masks and bit positions */
+#define CLKCTRL_PEN_bm  0x01  /* Prescaler enable bit mask. */
+#define CLKCTRL_PEN_bp  0  /* Prescaler enable bit position. */
+#define CLKCTRL_PDIV_gm  0x1E  /* Prescaler division group mask. */
+#define CLKCTRL_PDIV_gp  1  /* Prescaler division group position. */
+#define CLKCTRL_PDIV_0_bm  (1<<1)  /* Prescaler division bit 0 mask. */
+#define CLKCTRL_PDIV_0_bp  1  /* Prescaler division bit 0 position. */
+#define CLKCTRL_PDIV_1_bm  (1<<2)  /* Prescaler division bit 1 mask. */
+#define CLKCTRL_PDIV_1_bp  2  /* Prescaler division bit 1 position. */
+#define CLKCTRL_PDIV_2_bm  (1<<3)  /* Prescaler division bit 2 mask. */
+#define CLKCTRL_PDIV_2_bp  3  /* Prescaler division bit 2 position. */
+#define CLKCTRL_PDIV_3_bm  (1<<4)  /* Prescaler division bit 3 mask. */
+#define CLKCTRL_PDIV_3_bp  4  /* Prescaler division bit 3 position. */
+#define CLKCTRL_PBDIV_bm  0x20  /* Prescaler B division bit mask. */
+#define CLKCTRL_PBDIV_bp  5  /* Prescaler B division bit position. */
+
+/* CLKCTRL.MCLKSTATUS  bit masks and bit positions */
+#define CLKCTRL_SOSC_bm  0x01  /* System Oscillator changing bit mask. */
+#define CLKCTRL_SOSC_bp  0  /* System Oscillator changing bit position. */
+#define CLKCTRL_OSCHFS_bm  0x02  /* High frequency oscillator status bit mask. */
+#define CLKCTRL_OSCHFS_bp  1  /* High frequency oscillator status bit position. */
+#define CLKCTRL_OSC32KS_bm  0x04  /* 32KHz oscillator status bit mask. */
+#define CLKCTRL_OSC32KS_bp  2  /* 32KHz oscillator status bit position. */
+#define CLKCTRL_XOSC32KS_bm  0x08  /* 32.768 kHz Crystal Oscillator status bit mask. */
+#define CLKCTRL_XOSC32KS_bp  3  /* 32.768 kHz Crystal Oscillator status bit position. */
+#define CLKCTRL_EXTS_bm  0x10  /* External Clock status bit mask. */
+#define CLKCTRL_EXTS_bp  4  /* External Clock status bit position. */
+#define CLKCTRL_PLLS_bm  0x20  /* PLL status bit mask. */
+#define CLKCTRL_PLLS_bp  5  /* PLL status bit position. */
+
+/* CLKCTRL.MCLKTIMEBASE  bit masks and bit positions */
+#define CLKCTRL_TIMEBASE_gm  0x1F  /* Timebase group mask. */
+#define CLKCTRL_TIMEBASE_gp  0  /* Timebase group position. */
+#define CLKCTRL_TIMEBASE_0_bm  (1<<0)  /* Timebase bit 0 mask. */
+#define CLKCTRL_TIMEBASE_0_bp  0  /* Timebase bit 0 position. */
+#define CLKCTRL_TIMEBASE_1_bm  (1<<1)  /* Timebase bit 1 mask. */
+#define CLKCTRL_TIMEBASE_1_bp  1  /* Timebase bit 1 position. */
+#define CLKCTRL_TIMEBASE_2_bm  (1<<2)  /* Timebase bit 2 mask. */
+#define CLKCTRL_TIMEBASE_2_bp  2  /* Timebase bit 2 position. */
+#define CLKCTRL_TIMEBASE_3_bm  (1<<3)  /* Timebase bit 3 mask. */
+#define CLKCTRL_TIMEBASE_3_bp  3  /* Timebase bit 3 position. */
+#define CLKCTRL_TIMEBASE_4_bm  (1<<4)  /* Timebase bit 4 mask. */
+#define CLKCTRL_TIMEBASE_4_bp  4  /* Timebase bit 4 position. */
+
+/* CLKCTRL.OSCHFCTRLA  bit masks and bit positions */
+#define CLKCTRL_AUTOTUNE_gm  0x03  /* Automatic Oscillator Tune group mask. */
+#define CLKCTRL_AUTOTUNE_gp  0  /* Automatic Oscillator Tune group position. */
+#define CLKCTRL_AUTOTUNE_0_bm  (1<<0)  /* Automatic Oscillator Tune bit 0 mask. */
+#define CLKCTRL_AUTOTUNE_0_bp  0  /* Automatic Oscillator Tune bit 0 position. */
+#define CLKCTRL_AUTOTUNE_1_bm  (1<<1)  /* Automatic Oscillator Tune bit 1 mask. */
+#define CLKCTRL_AUTOTUNE_1_bp  1  /* Automatic Oscillator Tune bit 1 position. */
+#define CLKCTRL_RUNSTDBY_bm  0x80  /* Run in standby bit mask. */
+#define CLKCTRL_RUNSTDBY_bp  7  /* Run in standby bit position. */
+
+/* CLKCTRL.OSCHFTUNE  bit masks and bit positions */
+#define CLKCTRL_TUNE_gm  0xFF  /* Oscillator Tune group mask. */
+#define CLKCTRL_TUNE_gp  0  /* Oscillator Tune group position. */
+#define CLKCTRL_TUNE_0_bm  (1<<0)  /* Oscillator Tune bit 0 mask. */
+#define CLKCTRL_TUNE_0_bp  0  /* Oscillator Tune bit 0 position. */
+#define CLKCTRL_TUNE_1_bm  (1<<1)  /* Oscillator Tune bit 1 mask. */
+#define CLKCTRL_TUNE_1_bp  1  /* Oscillator Tune bit 1 position. */
+#define CLKCTRL_TUNE_2_bm  (1<<2)  /* Oscillator Tune bit 2 mask. */
+#define CLKCTRL_TUNE_2_bp  2  /* Oscillator Tune bit 2 position. */
+#define CLKCTRL_TUNE_3_bm  (1<<3)  /* Oscillator Tune bit 3 mask. */
+#define CLKCTRL_TUNE_3_bp  3  /* Oscillator Tune bit 3 position. */
+#define CLKCTRL_TUNE_4_bm  (1<<4)  /* Oscillator Tune bit 4 mask. */
+#define CLKCTRL_TUNE_4_bp  4  /* Oscillator Tune bit 4 position. */
+#define CLKCTRL_TUNE_5_bm  (1<<5)  /* Oscillator Tune bit 5 mask. */
+#define CLKCTRL_TUNE_5_bp  5  /* Oscillator Tune bit 5 position. */
+#define CLKCTRL_TUNE_6_bm  (1<<6)  /* Oscillator Tune bit 6 mask. */
+#define CLKCTRL_TUNE_6_bp  6  /* Oscillator Tune bit 6 position. */
+#define CLKCTRL_TUNE_7_bm  (1<<7)  /* Oscillator Tune bit 7 mask. */
+#define CLKCTRL_TUNE_7_bp  7  /* Oscillator Tune bit 7 position. */
+
+/* CLKCTRL.PLLCTRLA  bit masks and bit positions */
+#define CLKCTRL_MULFAC_gm  0x03  /* PLL Multiplication Factor group mask. */
+#define CLKCTRL_MULFAC_gp  0  /* PLL Multiplication Factor group position. */
+#define CLKCTRL_MULFAC_0_bm  (1<<0)  /* PLL Multiplication Factor bit 0 mask. */
+#define CLKCTRL_MULFAC_0_bp  0  /* PLL Multiplication Factor bit 0 position. */
+#define CLKCTRL_MULFAC_1_bm  (1<<1)  /* PLL Multiplication Factor bit 1 mask. */
+#define CLKCTRL_MULFAC_1_bp  1  /* PLL Multiplication Factor bit 1 position. */
+#define CLKCTRL_SOURCEDIV_gm  0x18  /* PLL Source Division group mask. */
+#define CLKCTRL_SOURCEDIV_gp  3  /* PLL Source Division group position. */
+#define CLKCTRL_SOURCEDIV_0_bm  (1<<3)  /* PLL Source Division bit 0 mask. */
+#define CLKCTRL_SOURCEDIV_0_bp  3  /* PLL Source Division bit 0 position. */
+#define CLKCTRL_SOURCEDIV_1_bm  (1<<4)  /* PLL Source Division bit 1 mask. */
+#define CLKCTRL_SOURCEDIV_1_bp  4  /* PLL Source Division bit 1 position. */
+#define CLKCTRL_SOURCE_gm  0x60  /* PLL Source group mask. */
+#define CLKCTRL_SOURCE_gp  5  /* PLL Source group position. */
+#define CLKCTRL_SOURCE_0_bm  (1<<5)  /* PLL Source bit 0 mask. */
+#define CLKCTRL_SOURCE_0_bp  5  /* PLL Source bit 0 position. */
+#define CLKCTRL_SOURCE_1_bm  (1<<6)  /* PLL Source bit 1 mask. */
+#define CLKCTRL_SOURCE_1_bp  6  /* PLL Source bit 1 position. */
+/* CLKCTRL_RUNSTDBY  is already defined. */
+
+/* CLKCTRL.PLLCTRLB  bit masks and bit positions */
+#define CLKCTRL_CLKDIV_bm  0x01  /* PLL Output Clock Division bit mask. */
+#define CLKCTRL_CLKDIV_bp  0  /* PLL Output Clock Division bit position. */
+
+/* CLKCTRL.OSC32KCTRLA  bit masks and bit positions */
+/* CLKCTRL_RUNSTDBY  is already defined. */
+
+/* CLKCTRL.XOSC32KCTRLA  bit masks and bit positions */
+#define CLKCTRL_ENABLE_bm  0x01  /* Enable bit mask. */
+#define CLKCTRL_ENABLE_bp  0  /* Enable bit position. */
+#define CLKCTRL_LPMODE_bm  0x02  /* Low power mode bit mask. */
+#define CLKCTRL_LPMODE_bp  1  /* Low power mode bit position. */
+#define CLKCTRL_SEL_bm  0x04  /* Select bit mask. */
+#define CLKCTRL_SEL_bp  2  /* Select bit position. */
+#define CLKCTRL_CSUT_gm  0x30  /* Crystal startup time group mask. */
+#define CLKCTRL_CSUT_gp  4  /* Crystal startup time group position. */
+#define CLKCTRL_CSUT_0_bm  (1<<4)  /* Crystal startup time bit 0 mask. */
+#define CLKCTRL_CSUT_0_bp  4  /* Crystal startup time bit 0 position. */
+#define CLKCTRL_CSUT_1_bm  (1<<5)  /* Crystal startup time bit 1 mask. */
+#define CLKCTRL_CSUT_1_bp  5  /* Crystal startup time bit 1 position. */
+/* CLKCTRL_RUNSTDBY  is already defined. */
+
+
+/* CPU - CPU */
+/* CPU.CCP  bit masks and bit positions */
+#define CPU_CCP_gm  0xFF  /* CCP signature group mask. */
+#define CPU_CCP_gp  0  /* CCP signature group position. */
+#define CPU_CCP_0_bm  (1<<0)  /* CCP signature bit 0 mask. */
+#define CPU_CCP_0_bp  0  /* CCP signature bit 0 position. */
+#define CPU_CCP_1_bm  (1<<1)  /* CCP signature bit 1 mask. */
+#define CPU_CCP_1_bp  1  /* CCP signature bit 1 position. */
+#define CPU_CCP_2_bm  (1<<2)  /* CCP signature bit 2 mask. */
+#define CPU_CCP_2_bp  2  /* CCP signature bit 2 position. */
+#define CPU_CCP_3_bm  (1<<3)  /* CCP signature bit 3 mask. */
+#define CPU_CCP_3_bp  3  /* CCP signature bit 3 position. */
+#define CPU_CCP_4_bm  (1<<4)  /* CCP signature bit 4 mask. */
+#define CPU_CCP_4_bp  4  /* CCP signature bit 4 position. */
+#define CPU_CCP_5_bm  (1<<5)  /* CCP signature bit 5 mask. */
+#define CPU_CCP_5_bp  5  /* CCP signature bit 5 position. */
+#define CPU_CCP_6_bm  (1<<6)  /* CCP signature bit 6 mask. */
+#define CPU_CCP_6_bp  6  /* CCP signature bit 6 position. */
+#define CPU_CCP_7_bm  (1<<7)  /* CCP signature bit 7 mask. */
+#define CPU_CCP_7_bp  7  /* CCP signature bit 7 position. */
+
+/* CPU.SREG  bit masks and bit positions */
+#define CPU_C_bm  0x01  /* Carry Flag bit mask. */
+#define CPU_C_bp  0  /* Carry Flag bit position. */
+#define CPU_Z_bm  0x02  /* Zero Flag bit mask. */
+#define CPU_Z_bp  1  /* Zero Flag bit position. */
+#define CPU_N_bm  0x04  /* Negative Flag bit mask. */
+#define CPU_N_bp  2  /* Negative Flag bit position. */
+#define CPU_V_bm  0x08  /* Two's Complement Overflow Flag bit mask. */
+#define CPU_V_bp  3  /* Two's Complement Overflow Flag bit position. */
+#define CPU_S_bm  0x10  /* N Exclusive Or V Flag bit mask. */
+#define CPU_S_bp  4  /* N Exclusive Or V Flag bit position. */
+#define CPU_H_bm  0x20  /* Half Carry Flag bit mask. */
+#define CPU_H_bp  5  /* Half Carry Flag bit position. */
+#define CPU_T_bm  0x40  /* Transfer Bit bit mask. */
+#define CPU_T_bp  6  /* Transfer Bit bit position. */
+#define CPU_I_bm  0x80  /* Global Interrupt Enable Flag bit mask. */
+#define CPU_I_bp  7  /* Global Interrupt Enable Flag bit position. */
+
+
+/* CPUINT - Interrupt Controller */
+/* CPUINT.CTRLA  bit masks and bit positions */
+#define CPUINT_LVL0RR_bm  0x01  /* Round-robin Scheduling Enable bit mask. */
+#define CPUINT_LVL0RR_bp  0  /* Round-robin Scheduling Enable bit position. */
+#define CPUINT_CVT_bm  0x20  /* Compact Vector Table bit mask. */
+#define CPUINT_CVT_bp  5  /* Compact Vector Table bit position. */
+#define CPUINT_IVSEL_bm  0x40  /* Interrupt Vector Select bit mask. */
+#define CPUINT_IVSEL_bp  6  /* Interrupt Vector Select bit position. */
+
+/* CPUINT.STATUS  bit masks and bit positions */
+#define CPUINT_LVL0EX_bm  0x01  /* Level 0 Interrupt Executing bit mask. */
+#define CPUINT_LVL0EX_bp  0  /* Level 0 Interrupt Executing bit position. */
+#define CPUINT_LVL1EX_bm  0x02  /* Level 1 Interrupt Executing bit mask. */
+#define CPUINT_LVL1EX_bp  1  /* Level 1 Interrupt Executing bit position. */
+#define CPUINT_NMIEX_bm  0x80  /* Non-maskable Interrupt Executing bit mask. */
+#define CPUINT_NMIEX_bp  7  /* Non-maskable Interrupt Executing bit position. */
+
+/* CPUINT.LVL0PRI  bit masks and bit positions */
+#define CPUINT_LVL0PRI_gm  0xFF  /* Interrupt Level Priority group mask. */
+#define CPUINT_LVL0PRI_gp  0  /* Interrupt Level Priority group position. */
+#define CPUINT_LVL0PRI_0_bm  (1<<0)  /* Interrupt Level Priority bit 0 mask. */
+#define CPUINT_LVL0PRI_0_bp  0  /* Interrupt Level Priority bit 0 position. */
+#define CPUINT_LVL0PRI_1_bm  (1<<1)  /* Interrupt Level Priority bit 1 mask. */
+#define CPUINT_LVL0PRI_1_bp  1  /* Interrupt Level Priority bit 1 position. */
+#define CPUINT_LVL0PRI_2_bm  (1<<2)  /* Interrupt Level Priority bit 2 mask. */
+#define CPUINT_LVL0PRI_2_bp  2  /* Interrupt Level Priority bit 2 position. */
+#define CPUINT_LVL0PRI_3_bm  (1<<3)  /* Interrupt Level Priority bit 3 mask. */
+#define CPUINT_LVL0PRI_3_bp  3  /* Interrupt Level Priority bit 3 position. */
+#define CPUINT_LVL0PRI_4_bm  (1<<4)  /* Interrupt Level Priority bit 4 mask. */
+#define CPUINT_LVL0PRI_4_bp  4  /* Interrupt Level Priority bit 4 position. */
+#define CPUINT_LVL0PRI_5_bm  (1<<5)  /* Interrupt Level Priority bit 5 mask. */
+#define CPUINT_LVL0PRI_5_bp  5  /* Interrupt Level Priority bit 5 position. */
+#define CPUINT_LVL0PRI_6_bm  (1<<6)  /* Interrupt Level Priority bit 6 mask. */
+#define CPUINT_LVL0PRI_6_bp  6  /* Interrupt Level Priority bit 6 position. */
+#define CPUINT_LVL0PRI_7_bm  (1<<7)  /* Interrupt Level Priority bit 7 mask. */
+#define CPUINT_LVL0PRI_7_bp  7  /* Interrupt Level Priority bit 7 position. */
+
+/* CPUINT.LVL1VEC  bit masks and bit positions */
+#define CPUINT_LVL1VEC_gm  0xFF  /* Interrupt Vector with High Priority group mask. */
+#define CPUINT_LVL1VEC_gp  0  /* Interrupt Vector with High Priority group position. */
+#define CPUINT_LVL1VEC_0_bm  (1<<0)  /* Interrupt Vector with High Priority bit 0 mask. */
+#define CPUINT_LVL1VEC_0_bp  0  /* Interrupt Vector with High Priority bit 0 position. */
+#define CPUINT_LVL1VEC_1_bm  (1<<1)  /* Interrupt Vector with High Priority bit 1 mask. */
+#define CPUINT_LVL1VEC_1_bp  1  /* Interrupt Vector with High Priority bit 1 position. */
+#define CPUINT_LVL1VEC_2_bm  (1<<2)  /* Interrupt Vector with High Priority bit 2 mask. */
+#define CPUINT_LVL1VEC_2_bp  2  /* Interrupt Vector with High Priority bit 2 position. */
+#define CPUINT_LVL1VEC_3_bm  (1<<3)  /* Interrupt Vector with High Priority bit 3 mask. */
+#define CPUINT_LVL1VEC_3_bp  3  /* Interrupt Vector with High Priority bit 3 position. */
+#define CPUINT_LVL1VEC_4_bm  (1<<4)  /* Interrupt Vector with High Priority bit 4 mask. */
+#define CPUINT_LVL1VEC_4_bp  4  /* Interrupt Vector with High Priority bit 4 position. */
+#define CPUINT_LVL1VEC_5_bm  (1<<5)  /* Interrupt Vector with High Priority bit 5 mask. */
+#define CPUINT_LVL1VEC_5_bp  5  /* Interrupt Vector with High Priority bit 5 position. */
+#define CPUINT_LVL1VEC_6_bm  (1<<6)  /* Interrupt Vector with High Priority bit 6 mask. */
+#define CPUINT_LVL1VEC_6_bp  6  /* Interrupt Vector with High Priority bit 6 position. */
+#define CPUINT_LVL1VEC_7_bm  (1<<7)  /* Interrupt Vector with High Priority bit 7 mask. */
+#define CPUINT_LVL1VEC_7_bp  7  /* Interrupt Vector with High Priority bit 7 position. */
+
+
+/* CRCSCAN - CRCSCAN */
+/* CRCSCAN.CTRLA  bit masks and bit positions */
+#define CRCSCAN_ENABLE_bm  0x01  /* Enable CRC scan bit mask. */
+#define CRCSCAN_ENABLE_bp  0  /* Enable CRC scan bit position. */
+#define CRCSCAN_NMIEN_bm  0x02  /* Enable NMI Trigger bit mask. */
+#define CRCSCAN_NMIEN_bp  1  /* Enable NMI Trigger bit position. */
+#define CRCSCAN_RESET_bm  0x80  /* Reset CRC scan bit mask. */
+#define CRCSCAN_RESET_bp  7  /* Reset CRC scan bit position. */
+
+/* CRCSCAN.CTRLB  bit masks and bit positions */
+#define CRCSCAN_SRC_gm  0x03  /* CRC Source group mask. */
+#define CRCSCAN_SRC_gp  0  /* CRC Source group position. */
+#define CRCSCAN_SRC_0_bm  (1<<0)  /* CRC Source bit 0 mask. */
+#define CRCSCAN_SRC_0_bp  0  /* CRC Source bit 0 position. */
+#define CRCSCAN_SRC_1_bm  (1<<1)  /* CRC Source bit 1 mask. */
+#define CRCSCAN_SRC_1_bp  1  /* CRC Source bit 1 position. */
+
+/* CRCSCAN.STATUS  bit masks and bit positions */
+#define CRCSCAN_BUSY_bm  0x01  /* CRC Busy bit mask. */
+#define CRCSCAN_BUSY_bp  0  /* CRC Busy bit position. */
+#define CRCSCAN_OK_bm  0x02  /* CRC Ok bit mask. */
+#define CRCSCAN_OK_bp  1  /* CRC Ok bit position. */
+
+
+/* EVSYS - Event System */
+/* EVSYS.SWEVENTA  bit masks and bit positions */
+#define EVSYS_SWEVENTA_gm  0xFF  /* Software event on channel select group mask. */
+#define EVSYS_SWEVENTA_gp  0  /* Software event on channel select group position. */
+#define EVSYS_SWEVENTA_0_bm  (1<<0)  /* Software event on channel select bit 0 mask. */
+#define EVSYS_SWEVENTA_0_bp  0  /* Software event on channel select bit 0 position. */
+#define EVSYS_SWEVENTA_1_bm  (1<<1)  /* Software event on channel select bit 1 mask. */
+#define EVSYS_SWEVENTA_1_bp  1  /* Software event on channel select bit 1 position. */
+#define EVSYS_SWEVENTA_2_bm  (1<<2)  /* Software event on channel select bit 2 mask. */
+#define EVSYS_SWEVENTA_2_bp  2  /* Software event on channel select bit 2 position. */
+#define EVSYS_SWEVENTA_3_bm  (1<<3)  /* Software event on channel select bit 3 mask. */
+#define EVSYS_SWEVENTA_3_bp  3  /* Software event on channel select bit 3 position. */
+#define EVSYS_SWEVENTA_4_bm  (1<<4)  /* Software event on channel select bit 4 mask. */
+#define EVSYS_SWEVENTA_4_bp  4  /* Software event on channel select bit 4 position. */
+#define EVSYS_SWEVENTA_5_bm  (1<<5)  /* Software event on channel select bit 5 mask. */
+#define EVSYS_SWEVENTA_5_bp  5  /* Software event on channel select bit 5 position. */
+#define EVSYS_SWEVENTA_6_bm  (1<<6)  /* Software event on channel select bit 6 mask. */
+#define EVSYS_SWEVENTA_6_bp  6  /* Software event on channel select bit 6 position. */
+#define EVSYS_SWEVENTA_7_bm  (1<<7)  /* Software event on channel select bit 7 mask. */
+#define EVSYS_SWEVENTA_7_bp  7  /* Software event on channel select bit 7 position. */
+
+/* EVSYS.CHANNEL0  bit masks and bit positions */
+#define EVSYS_CHANNEL_gm  0xFF  /* Channel generator select group mask. */
+#define EVSYS_CHANNEL_gp  0  /* Channel generator select group position. */
+#define EVSYS_CHANNEL_0_bm  (1<<0)  /* Channel generator select bit 0 mask. */
+#define EVSYS_CHANNEL_0_bp  0  /* Channel generator select bit 0 position. */
+#define EVSYS_CHANNEL_1_bm  (1<<1)  /* Channel generator select bit 1 mask. */
+#define EVSYS_CHANNEL_1_bp  1  /* Channel generator select bit 1 position. */
+#define EVSYS_CHANNEL_2_bm  (1<<2)  /* Channel generator select bit 2 mask. */
+#define EVSYS_CHANNEL_2_bp  2  /* Channel generator select bit 2 position. */
+#define EVSYS_CHANNEL_3_bm  (1<<3)  /* Channel generator select bit 3 mask. */
+#define EVSYS_CHANNEL_3_bp  3  /* Channel generator select bit 3 position. */
+#define EVSYS_CHANNEL_4_bm  (1<<4)  /* Channel generator select bit 4 mask. */
+#define EVSYS_CHANNEL_4_bp  4  /* Channel generator select bit 4 position. */
+#define EVSYS_CHANNEL_5_bm  (1<<5)  /* Channel generator select bit 5 mask. */
+#define EVSYS_CHANNEL_5_bp  5  /* Channel generator select bit 5 position. */
+#define EVSYS_CHANNEL_6_bm  (1<<6)  /* Channel generator select bit 6 mask. */
+#define EVSYS_CHANNEL_6_bp  6  /* Channel generator select bit 6 position. */
+#define EVSYS_CHANNEL_7_bm  (1<<7)  /* Channel generator select bit 7 mask. */
+#define EVSYS_CHANNEL_7_bp  7  /* Channel generator select bit 7 position. */
+
+/* EVSYS.CHANNEL1  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.CHANNEL2  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.CHANNEL3  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.CHANNEL4  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.CHANNEL5  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.USERCCLLUT0A  bit masks and bit positions */
+#define EVSYS_USER_gm  0xFF  /* User channel select group mask. */
+#define EVSYS_USER_gp  0  /* User channel select group position. */
+#define EVSYS_USER_0_bm  (1<<0)  /* User channel select bit 0 mask. */
+#define EVSYS_USER_0_bp  0  /* User channel select bit 0 position. */
+#define EVSYS_USER_1_bm  (1<<1)  /* User channel select bit 1 mask. */
+#define EVSYS_USER_1_bp  1  /* User channel select bit 1 position. */
+#define EVSYS_USER_2_bm  (1<<2)  /* User channel select bit 2 mask. */
+#define EVSYS_USER_2_bp  2  /* User channel select bit 2 position. */
+#define EVSYS_USER_3_bm  (1<<3)  /* User channel select bit 3 mask. */
+#define EVSYS_USER_3_bp  3  /* User channel select bit 3 position. */
+#define EVSYS_USER_4_bm  (1<<4)  /* User channel select bit 4 mask. */
+#define EVSYS_USER_4_bp  4  /* User channel select bit 4 position. */
+#define EVSYS_USER_5_bm  (1<<5)  /* User channel select bit 5 mask. */
+#define EVSYS_USER_5_bp  5  /* User channel select bit 5 position. */
+#define EVSYS_USER_6_bm  (1<<6)  /* User channel select bit 6 mask. */
+#define EVSYS_USER_6_bp  6  /* User channel select bit 6 position. */
+#define EVSYS_USER_7_bm  (1<<7)  /* User channel select bit 7 mask. */
+#define EVSYS_USER_7_bp  7  /* User channel select bit 7 position. */
+
+/* EVSYS.USERCCLLUT0B  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT1A  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT1B  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT2A  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT2B  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT3A  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT3B  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERADC0START  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTC  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTD  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTF  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERUSART0IRDA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCE0CNTA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCE0CNTB  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB0CAPT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB0COUNT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB1CAPT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB1COUNT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCF0CNT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCF0ACT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERWEXA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERWEXB  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERWEXC  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+
+/* FUSE - Fuses */
+/* FUSE.WDTCFG  bit masks and bit positions */
+#define FUSE_PERIOD_gm  0x0F  /* Watchdog Timeout Period group mask. */
+#define FUSE_PERIOD_gp  0  /* Watchdog Timeout Period group position. */
+#define FUSE_PERIOD_0_bm  (1<<0)  /* Watchdog Timeout Period bit 0 mask. */
+#define FUSE_PERIOD_0_bp  0  /* Watchdog Timeout Period bit 0 position. */
+#define FUSE_PERIOD_1_bm  (1<<1)  /* Watchdog Timeout Period bit 1 mask. */
+#define FUSE_PERIOD_1_bp  1  /* Watchdog Timeout Period bit 1 position. */
+#define FUSE_PERIOD_2_bm  (1<<2)  /* Watchdog Timeout Period bit 2 mask. */
+#define FUSE_PERIOD_2_bp  2  /* Watchdog Timeout Period bit 2 position. */
+#define FUSE_PERIOD_3_bm  (1<<3)  /* Watchdog Timeout Period bit 3 mask. */
+#define FUSE_PERIOD_3_bp  3  /* Watchdog Timeout Period bit 3 position. */
+#define FUSE_WINDOW_gm  0xF0  /* Watchdog Window Timeout Period group mask. */
+#define FUSE_WINDOW_gp  4  /* Watchdog Window Timeout Period group position. */
+#define FUSE_WINDOW_0_bm  (1<<4)  /* Watchdog Window Timeout Period bit 0 mask. */
+#define FUSE_WINDOW_0_bp  4  /* Watchdog Window Timeout Period bit 0 position. */
+#define FUSE_WINDOW_1_bm  (1<<5)  /* Watchdog Window Timeout Period bit 1 mask. */
+#define FUSE_WINDOW_1_bp  5  /* Watchdog Window Timeout Period bit 1 position. */
+#define FUSE_WINDOW_2_bm  (1<<6)  /* Watchdog Window Timeout Period bit 2 mask. */
+#define FUSE_WINDOW_2_bp  6  /* Watchdog Window Timeout Period bit 2 position. */
+#define FUSE_WINDOW_3_bm  (1<<7)  /* Watchdog Window Timeout Period bit 3 mask. */
+#define FUSE_WINDOW_3_bp  7  /* Watchdog Window Timeout Period bit 3 position. */
+
+/* FUSE.BODCFG  bit masks and bit positions */
+#define FUSE_SLEEP_gm  0x03  /* BOD Operation in Sleep Mode group mask. */
+#define FUSE_SLEEP_gp  0  /* BOD Operation in Sleep Mode group position. */
+#define FUSE_SLEEP_0_bm  (1<<0)  /* BOD Operation in Sleep Mode bit 0 mask. */
+#define FUSE_SLEEP_0_bp  0  /* BOD Operation in Sleep Mode bit 0 position. */
+#define FUSE_SLEEP_1_bm  (1<<1)  /* BOD Operation in Sleep Mode bit 1 mask. */
+#define FUSE_SLEEP_1_bp  1  /* BOD Operation in Sleep Mode bit 1 position. */
+#define FUSE_ACTIVE_gm  0x0C  /* BOD Operation in Active Mode group mask. */
+#define FUSE_ACTIVE_gp  2  /* BOD Operation in Active Mode group position. */
+#define FUSE_ACTIVE_0_bm  (1<<2)  /* BOD Operation in Active Mode bit 0 mask. */
+#define FUSE_ACTIVE_0_bp  2  /* BOD Operation in Active Mode bit 0 position. */
+#define FUSE_ACTIVE_1_bm  (1<<3)  /* BOD Operation in Active Mode bit 1 mask. */
+#define FUSE_ACTIVE_1_bp  3  /* BOD Operation in Active Mode bit 1 position. */
+#define FUSE_SAMPFREQ_bm  0x10  /* BOD Sample Frequency bit mask. */
+#define FUSE_SAMPFREQ_bp  4  /* BOD Sample Frequency bit position. */
+#define FUSE_LVL_gm  0xE0  /* BOD Level group mask. */
+#define FUSE_LVL_gp  5  /* BOD Level group position. */
+#define FUSE_LVL_0_bm  (1<<5)  /* BOD Level bit 0 mask. */
+#define FUSE_LVL_0_bp  5  /* BOD Level bit 0 position. */
+#define FUSE_LVL_1_bm  (1<<6)  /* BOD Level bit 1 mask. */
+#define FUSE_LVL_1_bp  6  /* BOD Level bit 1 position. */
+#define FUSE_LVL_2_bm  (1<<7)  /* BOD Level bit 2 mask. */
+#define FUSE_LVL_2_bp  7  /* BOD Level bit 2 position. */
+
+/* FUSE.OSCCFG  bit masks and bit positions */
+#define FUSE_OSCHFFRQ_bm  0x08  /* High-frequency Oscillator Frequency bit mask. */
+#define FUSE_OSCHFFRQ_bp  3  /* High-frequency Oscillator Frequency bit position. */
+
+/* FUSE.SYSCFG0  bit masks and bit positions */
+#define FUSE_EESAVE_bm  0x01  /* EEPROM Save bit mask. */
+#define FUSE_EESAVE_bp  0  /* EEPROM Save bit position. */
+#define FUSE_RSTPINCFG_bm  0x08  /* Reset Pin Configuration bit mask. */
+#define FUSE_RSTPINCFG_bp  3  /* Reset Pin Configuration bit position. */
+#define FUSE_UPDIPINCFG_bm  0x10  /* UPDI Pin Configuration bit mask. */
+#define FUSE_UPDIPINCFG_bp  4  /* UPDI Pin Configuration bit position. */
+#define FUSE_CRCSEL_bm  0x20  /* CRC Select bit mask. */
+#define FUSE_CRCSEL_bp  5  /* CRC Select bit position. */
+#define FUSE_CRCSRC_gm  0xC0  /* CRC Source group mask. */
+#define FUSE_CRCSRC_gp  6  /* CRC Source group position. */
+#define FUSE_CRCSRC_0_bm  (1<<6)  /* CRC Source bit 0 mask. */
+#define FUSE_CRCSRC_0_bp  6  /* CRC Source bit 0 position. */
+#define FUSE_CRCSRC_1_bm  (1<<7)  /* CRC Source bit 1 mask. */
+#define FUSE_CRCSRC_1_bp  7  /* CRC Source bit 1 position. */
+
+/* FUSE.SYSCFG1  bit masks and bit positions */
+#define FUSE_SUT_gm  0x07  /* Startup Time group mask. */
+#define FUSE_SUT_gp  0  /* Startup Time group position. */
+#define FUSE_SUT_0_bm  (1<<0)  /* Startup Time bit 0 mask. */
+#define FUSE_SUT_0_bp  0  /* Startup Time bit 0 position. */
+#define FUSE_SUT_1_bm  (1<<1)  /* Startup Time bit 1 mask. */
+#define FUSE_SUT_1_bp  1  /* Startup Time bit 1 position. */
+#define FUSE_SUT_2_bm  (1<<2)  /* Startup Time bit 2 mask. */
+#define FUSE_SUT_2_bp  2  /* Startup Time bit 2 position. */
+
+/* FUSE.PDICFG  bit masks and bit positions */
+#define FUSE_LEVEL_gm  0x03  /* Protection Level group mask. */
+#define FUSE_LEVEL_gp  0  /* Protection Level group position. */
+#define FUSE_LEVEL_0_bm  (1<<0)  /* Protection Level bit 0 mask. */
+#define FUSE_LEVEL_0_bp  0  /* Protection Level bit 0 position. */
+#define FUSE_LEVEL_1_bm  (1<<1)  /* Protection Level bit 1 mask. */
+#define FUSE_LEVEL_1_bp  1  /* Protection Level bit 1 position. */
+#define FUSE_KEY_gm  0xFFF0  /* NVM Protection Activation Key group mask. */
+#define FUSE_KEY_gp  4  /* NVM Protection Activation Key group position. */
+#define FUSE_KEY_0_bm  (1<<4)  /* NVM Protection Activation Key bit 0 mask. */
+#define FUSE_KEY_0_bp  4  /* NVM Protection Activation Key bit 0 position. */
+#define FUSE_KEY_1_bm  (1<<5)  /* NVM Protection Activation Key bit 1 mask. */
+#define FUSE_KEY_1_bp  5  /* NVM Protection Activation Key bit 1 position. */
+#define FUSE_KEY_2_bm  (1<<6)  /* NVM Protection Activation Key bit 2 mask. */
+#define FUSE_KEY_2_bp  6  /* NVM Protection Activation Key bit 2 position. */
+#define FUSE_KEY_3_bm  (1<<7)  /* NVM Protection Activation Key bit 3 mask. */
+#define FUSE_KEY_3_bp  7  /* NVM Protection Activation Key bit 3 position. */
+#define FUSE_KEY_4_bm  (1<<8)  /* NVM Protection Activation Key bit 4 mask. */
+#define FUSE_KEY_4_bp  8  /* NVM Protection Activation Key bit 4 position. */
+#define FUSE_KEY_5_bm  (1<<9)  /* NVM Protection Activation Key bit 5 mask. */
+#define FUSE_KEY_5_bp  9  /* NVM Protection Activation Key bit 5 position. */
+#define FUSE_KEY_6_bm  (1<<10)  /* NVM Protection Activation Key bit 6 mask. */
+#define FUSE_KEY_6_bp  10  /* NVM Protection Activation Key bit 6 position. */
+#define FUSE_KEY_7_bm  (1<<11)  /* NVM Protection Activation Key bit 7 mask. */
+#define FUSE_KEY_7_bp  11  /* NVM Protection Activation Key bit 7 position. */
+#define FUSE_KEY_8_bm  (1<<12)  /* NVM Protection Activation Key bit 8 mask. */
+#define FUSE_KEY_8_bp  12  /* NVM Protection Activation Key bit 8 position. */
+#define FUSE_KEY_9_bm  (1<<13)  /* NVM Protection Activation Key bit 9 mask. */
+#define FUSE_KEY_9_bp  13  /* NVM Protection Activation Key bit 9 position. */
+#define FUSE_KEY_10_bm  (1<<14)  /* NVM Protection Activation Key bit 10 mask. */
+#define FUSE_KEY_10_bp  14  /* NVM Protection Activation Key bit 10 position. */
+#define FUSE_KEY_11_bm  (1<<15)  /* NVM Protection Activation Key bit 11 mask. */
+#define FUSE_KEY_11_bp  15  /* NVM Protection Activation Key bit 11 position. */
+
+
+
+/* LOCK - Lockbits */
+/* LOCK.KEY  bit masks and bit positions */
+#define LOCK_KEY_gm  0xFFFFFFFF  /* Lock Key group mask. */
+#define LOCK_KEY_gp  0  /* Lock Key group position. */
+#define LOCK_KEY_0_bm  (1<<0)  /* Lock Key bit 0 mask. */
+#define LOCK_KEY_0_bp  0  /* Lock Key bit 0 position. */
+#define LOCK_KEY_1_bm  (1<<1)  /* Lock Key bit 1 mask. */
+#define LOCK_KEY_1_bp  1  /* Lock Key bit 1 position. */
+#define LOCK_KEY_2_bm  (1<<2)  /* Lock Key bit 2 mask. */
+#define LOCK_KEY_2_bp  2  /* Lock Key bit 2 position. */
+#define LOCK_KEY_3_bm  (1<<3)  /* Lock Key bit 3 mask. */
+#define LOCK_KEY_3_bp  3  /* Lock Key bit 3 position. */
+#define LOCK_KEY_4_bm  (1<<4)  /* Lock Key bit 4 mask. */
+#define LOCK_KEY_4_bp  4  /* Lock Key bit 4 position. */
+#define LOCK_KEY_5_bm  (1<<5)  /* Lock Key bit 5 mask. */
+#define LOCK_KEY_5_bp  5  /* Lock Key bit 5 position. */
+#define LOCK_KEY_6_bm  (1<<6)  /* Lock Key bit 6 mask. */
+#define LOCK_KEY_6_bp  6  /* Lock Key bit 6 position. */
+#define LOCK_KEY_7_bm  (1<<7)  /* Lock Key bit 7 mask. */
+#define LOCK_KEY_7_bp  7  /* Lock Key bit 7 position. */
+#define LOCK_KEY_8_bm  (1<<8)  /* Lock Key bit 8 mask. */
+#define LOCK_KEY_8_bp  8  /* Lock Key bit 8 position. */
+#define LOCK_KEY_9_bm  (1<<9)  /* Lock Key bit 9 mask. */
+#define LOCK_KEY_9_bp  9  /* Lock Key bit 9 position. */
+#define LOCK_KEY_10_bm  (1<<10)  /* Lock Key bit 10 mask. */
+#define LOCK_KEY_10_bp  10  /* Lock Key bit 10 position. */
+#define LOCK_KEY_11_bm  (1<<11)  /* Lock Key bit 11 mask. */
+#define LOCK_KEY_11_bp  11  /* Lock Key bit 11 position. */
+#define LOCK_KEY_12_bm  (1<<12)  /* Lock Key bit 12 mask. */
+#define LOCK_KEY_12_bp  12  /* Lock Key bit 12 position. */
+#define LOCK_KEY_13_bm  (1<<13)  /* Lock Key bit 13 mask. */
+#define LOCK_KEY_13_bp  13  /* Lock Key bit 13 position. */
+#define LOCK_KEY_14_bm  (1<<14)  /* Lock Key bit 14 mask. */
+#define LOCK_KEY_14_bp  14  /* Lock Key bit 14 position. */
+#define LOCK_KEY_15_bm  (1<<15)  /* Lock Key bit 15 mask. */
+#define LOCK_KEY_15_bp  15  /* Lock Key bit 15 position. */
+#define LOCK_KEY_16_bm  (1<<16)  /* Lock Key bit 16 mask. */
+#define LOCK_KEY_16_bp  16  /* Lock Key bit 16 position. */
+#define LOCK_KEY_17_bm  (1<<17)  /* Lock Key bit 17 mask. */
+#define LOCK_KEY_17_bp  17  /* Lock Key bit 17 position. */
+#define LOCK_KEY_18_bm  (1<<18)  /* Lock Key bit 18 mask. */
+#define LOCK_KEY_18_bp  18  /* Lock Key bit 18 position. */
+#define LOCK_KEY_19_bm  (1<<19)  /* Lock Key bit 19 mask. */
+#define LOCK_KEY_19_bp  19  /* Lock Key bit 19 position. */
+#define LOCK_KEY_20_bm  (1<<20)  /* Lock Key bit 20 mask. */
+#define LOCK_KEY_20_bp  20  /* Lock Key bit 20 position. */
+#define LOCK_KEY_21_bm  (1<<21)  /* Lock Key bit 21 mask. */
+#define LOCK_KEY_21_bp  21  /* Lock Key bit 21 position. */
+#define LOCK_KEY_22_bm  (1<<22)  /* Lock Key bit 22 mask. */
+#define LOCK_KEY_22_bp  22  /* Lock Key bit 22 position. */
+#define LOCK_KEY_23_bm  (1<<23)  /* Lock Key bit 23 mask. */
+#define LOCK_KEY_23_bp  23  /* Lock Key bit 23 position. */
+#define LOCK_KEY_24_bm  (1<<24)  /* Lock Key bit 24 mask. */
+#define LOCK_KEY_24_bp  24  /* Lock Key bit 24 position. */
+#define LOCK_KEY_25_bm  (1<<25)  /* Lock Key bit 25 mask. */
+#define LOCK_KEY_25_bp  25  /* Lock Key bit 25 position. */
+#define LOCK_KEY_26_bm  (1<<26)  /* Lock Key bit 26 mask. */
+#define LOCK_KEY_26_bp  26  /* Lock Key bit 26 position. */
+#define LOCK_KEY_27_bm  (1<<27)  /* Lock Key bit 27 mask. */
+#define LOCK_KEY_27_bp  27  /* Lock Key bit 27 position. */
+#define LOCK_KEY_28_bm  (1<<28)  /* Lock Key bit 28 mask. */
+#define LOCK_KEY_28_bp  28  /* Lock Key bit 28 position. */
+#define LOCK_KEY_29_bm  (1<<29)  /* Lock Key bit 29 mask. */
+#define LOCK_KEY_29_bp  29  /* Lock Key bit 29 position. */
+#define LOCK_KEY_30_bm  (1<<30)  /* Lock Key bit 30 mask. */
+#define LOCK_KEY_30_bp  30  /* Lock Key bit 30 position. */
+#define LOCK_KEY_31_bm  (1<<31)  /* Lock Key bit 31 mask. */
+#define LOCK_KEY_31_bp  31  /* Lock Key bit 31 position. */
+
+
+/* NVMCTRL - Non-volatile Memory Controller */
+/* NVMCTRL.CTRLA  bit masks and bit positions */
+#define NVMCTRL_CMD_gm  0x7F  /* Command group mask. */
+#define NVMCTRL_CMD_gp  0  /* Command group position. */
+#define NVMCTRL_CMD_0_bm  (1<<0)  /* Command bit 0 mask. */
+#define NVMCTRL_CMD_0_bp  0  /* Command bit 0 position. */
+#define NVMCTRL_CMD_1_bm  (1<<1)  /* Command bit 1 mask. */
+#define NVMCTRL_CMD_1_bp  1  /* Command bit 1 position. */
+#define NVMCTRL_CMD_2_bm  (1<<2)  /* Command bit 2 mask. */
+#define NVMCTRL_CMD_2_bp  2  /* Command bit 2 position. */
+#define NVMCTRL_CMD_3_bm  (1<<3)  /* Command bit 3 mask. */
+#define NVMCTRL_CMD_3_bp  3  /* Command bit 3 position. */
+#define NVMCTRL_CMD_4_bm  (1<<4)  /* Command bit 4 mask. */
+#define NVMCTRL_CMD_4_bp  4  /* Command bit 4 position. */
+#define NVMCTRL_CMD_5_bm  (1<<5)  /* Command bit 5 mask. */
+#define NVMCTRL_CMD_5_bp  5  /* Command bit 5 position. */
+#define NVMCTRL_CMD_6_bm  (1<<6)  /* Command bit 6 mask. */
+#define NVMCTRL_CMD_6_bp  6  /* Command bit 6 position. */
+
+/* NVMCTRL.CTRLB  bit masks and bit positions */
+#define NVMCTRL_APPCODEWP_bm  0x01  /* Application Code Write Protect bit mask. */
+#define NVMCTRL_APPCODEWP_bp  0  /* Application Code Write Protect bit position. */
+#define NVMCTRL_BOOTRP_bm  0x02  /* Boot Read Protect bit mask. */
+#define NVMCTRL_BOOTRP_bp  1  /* Boot Read Protect bit position. */
+#define NVMCTRL_APPDATAWP_bm  0x04  /* Application Data Write Protect bit mask. */
+#define NVMCTRL_APPDATAWP_bp  2  /* Application Data Write Protect bit position. */
+#define NVMCTRL_EEWP_bm  0x08  /* EEPROM Write Protect bit mask. */
+#define NVMCTRL_EEWP_bp  3  /* EEPROM Write Protect bit position. */
+#define NVMCTRL_FLMAP_gm  0x30  /* Flash Mapping in Data space group mask. */
+#define NVMCTRL_FLMAP_gp  4  /* Flash Mapping in Data space group position. */
+#define NVMCTRL_FLMAP_0_bm  (1<<4)  /* Flash Mapping in Data space bit 0 mask. */
+#define NVMCTRL_FLMAP_0_bp  4  /* Flash Mapping in Data space bit 0 position. */
+#define NVMCTRL_FLMAP_1_bm  (1<<5)  /* Flash Mapping in Data space bit 1 mask. */
+#define NVMCTRL_FLMAP_1_bp  5  /* Flash Mapping in Data space bit 1 position. */
+#define NVMCTRL_FLMAPLOCK_bm  0x80  /* Flash Mapping Lock bit mask. */
+#define NVMCTRL_FLMAPLOCK_bp  7  /* Flash Mapping Lock bit position. */
+
+/* NVMCTRL.CTRLC  bit masks and bit positions */
+#define NVMCTRL_UROWWP_bm  0x01  /* User Row Write Protect bit mask. */
+#define NVMCTRL_UROWWP_bp  0  /* User Row Write Protect bit position. */
+#define NVMCTRL_BOOTROWWP_bm  0x02  /* Boot Row Write Protect bit mask. */
+#define NVMCTRL_BOOTROWWP_bp  1  /* Boot Row Write Protect bit position. */
+
+/* NVMCTRL.INTCTRL  bit masks and bit positions */
+#define NVMCTRL_EEREADY_bm  0x01  /* EEPROM Ready bit mask. */
+#define NVMCTRL_EEREADY_bp  0  /* EEPROM Ready bit position. */
+#define NVMCTRL_FLREADY_bm  0x02  /* Flash Ready bit mask. */
+#define NVMCTRL_FLREADY_bp  1  /* Flash Ready bit position. */
+
+/* NVMCTRL.INTFLAGS  bit masks and bit positions */
+/* NVMCTRL_EEREADY  is already defined. */
+/* NVMCTRL_FLREADY  is already defined. */
+
+/* NVMCTRL.STATUS  bit masks and bit positions */
+#define NVMCTRL_EEBUSY_bm  0x01  /* EEPROM busy bit mask. */
+#define NVMCTRL_EEBUSY_bp  0  /* EEPROM busy bit position. */
+#define NVMCTRL_FLBUSY_bm  0x02  /* Flash busy bit mask. */
+#define NVMCTRL_FLBUSY_bp  1  /* Flash busy bit position. */
+#define NVMCTRL_ERROR_gm  0x70  /* Write error group mask. */
+#define NVMCTRL_ERROR_gp  4  /* Write error group position. */
+#define NVMCTRL_ERROR_0_bm  (1<<4)  /* Write error bit 0 mask. */
+#define NVMCTRL_ERROR_0_bp  4  /* Write error bit 0 position. */
+#define NVMCTRL_ERROR_1_bm  (1<<5)  /* Write error bit 1 mask. */
+#define NVMCTRL_ERROR_1_bp  5  /* Write error bit 1 position. */
+#define NVMCTRL_ERROR_2_bm  (1<<6)  /* Write error bit 2 mask. */
+#define NVMCTRL_ERROR_2_bp  6  /* Write error bit 2 position. */
+
+/* NVMCTRL.ADDR  bit masks and bit positions */
+#define NVMCTRL_ADDR_gm  0xFFFFFF  /* Address group mask. */
+#define NVMCTRL_ADDR_gp  0  /* Address group position. */
+#define NVMCTRL_ADDR_0_bm  (1<<0)  /* Address bit 0 mask. */
+#define NVMCTRL_ADDR_0_bp  0  /* Address bit 0 position. */
+#define NVMCTRL_ADDR_1_bm  (1<<1)  /* Address bit 1 mask. */
+#define NVMCTRL_ADDR_1_bp  1  /* Address bit 1 position. */
+#define NVMCTRL_ADDR_2_bm  (1<<2)  /* Address bit 2 mask. */
+#define NVMCTRL_ADDR_2_bp  2  /* Address bit 2 position. */
+#define NVMCTRL_ADDR_3_bm  (1<<3)  /* Address bit 3 mask. */
+#define NVMCTRL_ADDR_3_bp  3  /* Address bit 3 position. */
+#define NVMCTRL_ADDR_4_bm  (1<<4)  /* Address bit 4 mask. */
+#define NVMCTRL_ADDR_4_bp  4  /* Address bit 4 position. */
+#define NVMCTRL_ADDR_5_bm  (1<<5)  /* Address bit 5 mask. */
+#define NVMCTRL_ADDR_5_bp  5  /* Address bit 5 position. */
+#define NVMCTRL_ADDR_6_bm  (1<<6)  /* Address bit 6 mask. */
+#define NVMCTRL_ADDR_6_bp  6  /* Address bit 6 position. */
+#define NVMCTRL_ADDR_7_bm  (1<<7)  /* Address bit 7 mask. */
+#define NVMCTRL_ADDR_7_bp  7  /* Address bit 7 position. */
+#define NVMCTRL_ADDR_8_bm  (1<<8)  /* Address bit 8 mask. */
+#define NVMCTRL_ADDR_8_bp  8  /* Address bit 8 position. */
+#define NVMCTRL_ADDR_9_bm  (1<<9)  /* Address bit 9 mask. */
+#define NVMCTRL_ADDR_9_bp  9  /* Address bit 9 position. */
+#define NVMCTRL_ADDR_10_bm  (1<<10)  /* Address bit 10 mask. */
+#define NVMCTRL_ADDR_10_bp  10  /* Address bit 10 position. */
+#define NVMCTRL_ADDR_11_bm  (1<<11)  /* Address bit 11 mask. */
+#define NVMCTRL_ADDR_11_bp  11  /* Address bit 11 position. */
+#define NVMCTRL_ADDR_12_bm  (1<<12)  /* Address bit 12 mask. */
+#define NVMCTRL_ADDR_12_bp  12  /* Address bit 12 position. */
+#define NVMCTRL_ADDR_13_bm  (1<<13)  /* Address bit 13 mask. */
+#define NVMCTRL_ADDR_13_bp  13  /* Address bit 13 position. */
+#define NVMCTRL_ADDR_14_bm  (1<<14)  /* Address bit 14 mask. */
+#define NVMCTRL_ADDR_14_bp  14  /* Address bit 14 position. */
+#define NVMCTRL_ADDR_15_bm  (1<<15)  /* Address bit 15 mask. */
+#define NVMCTRL_ADDR_15_bp  15  /* Address bit 15 position. */
+#define NVMCTRL_ADDR_16_bm  (1<<16)  /* Address bit 16 mask. */
+#define NVMCTRL_ADDR_16_bp  16  /* Address bit 16 position. */
+#define NVMCTRL_ADDR_17_bm  (1<<17)  /* Address bit 17 mask. */
+#define NVMCTRL_ADDR_17_bp  17  /* Address bit 17 position. */
+#define NVMCTRL_ADDR_18_bm  (1<<18)  /* Address bit 18 mask. */
+#define NVMCTRL_ADDR_18_bp  18  /* Address bit 18 position. */
+#define NVMCTRL_ADDR_19_bm  (1<<19)  /* Address bit 19 mask. */
+#define NVMCTRL_ADDR_19_bp  19  /* Address bit 19 position. */
+#define NVMCTRL_ADDR_20_bm  (1<<20)  /* Address bit 20 mask. */
+#define NVMCTRL_ADDR_20_bp  20  /* Address bit 20 position. */
+#define NVMCTRL_ADDR_21_bm  (1<<21)  /* Address bit 21 mask. */
+#define NVMCTRL_ADDR_21_bp  21  /* Address bit 21 position. */
+#define NVMCTRL_ADDR_22_bm  (1<<22)  /* Address bit 22 mask. */
+#define NVMCTRL_ADDR_22_bp  22  /* Address bit 22 position. */
+#define NVMCTRL_ADDR_23_bm  (1<<23)  /* Address bit 23 mask. */
+#define NVMCTRL_ADDR_23_bp  23  /* Address bit 23 position. */
+
+
+/* PORT - I/O Ports */
+/* PORT.INTFLAGS  bit masks and bit positions */
+#define PORT_INT_gm  0xFF  /* Pin Interrupt Flag group mask. */
+#define PORT_INT_gp  0  /* Pin Interrupt Flag group position. */
+#define PORT_INT_0_bm  (1<<0)  /* Pin Interrupt Flag bit 0 mask. */
+#define PORT_INT_0_bp  0  /* Pin Interrupt Flag bit 0 position. */
+#define PORT_INT0_bm  PORT_INT_0_bm  /* This define is deprecated and should not be used */
+#define PORT_INT0_bp  PORT_INT_0_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_1_bm  (1<<1)  /* Pin Interrupt Flag bit 1 mask. */
+#define PORT_INT_1_bp  1  /* Pin Interrupt Flag bit 1 position. */
+#define PORT_INT1_bm  PORT_INT_1_bm  /* This define is deprecated and should not be used */
+#define PORT_INT1_bp  PORT_INT_1_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_2_bm  (1<<2)  /* Pin Interrupt Flag bit 2 mask. */
+#define PORT_INT_2_bp  2  /* Pin Interrupt Flag bit 2 position. */
+#define PORT_INT2_bm  PORT_INT_2_bm  /* This define is deprecated and should not be used */
+#define PORT_INT2_bp  PORT_INT_2_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_3_bm  (1<<3)  /* Pin Interrupt Flag bit 3 mask. */
+#define PORT_INT_3_bp  3  /* Pin Interrupt Flag bit 3 position. */
+#define PORT_INT3_bm  PORT_INT_3_bm  /* This define is deprecated and should not be used */
+#define PORT_INT3_bp  PORT_INT_3_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_4_bm  (1<<4)  /* Pin Interrupt Flag bit 4 mask. */
+#define PORT_INT_4_bp  4  /* Pin Interrupt Flag bit 4 position. */
+#define PORT_INT4_bm  PORT_INT_4_bm  /* This define is deprecated and should not be used */
+#define PORT_INT4_bp  PORT_INT_4_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_5_bm  (1<<5)  /* Pin Interrupt Flag bit 5 mask. */
+#define PORT_INT_5_bp  5  /* Pin Interrupt Flag bit 5 position. */
+#define PORT_INT5_bm  PORT_INT_5_bm  /* This define is deprecated and should not be used */
+#define PORT_INT5_bp  PORT_INT_5_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_6_bm  (1<<6)  /* Pin Interrupt Flag bit 6 mask. */
+#define PORT_INT_6_bp  6  /* Pin Interrupt Flag bit 6 position. */
+#define PORT_INT6_bm  PORT_INT_6_bm  /* This define is deprecated and should not be used */
+#define PORT_INT6_bp  PORT_INT_6_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_7_bm  (1<<7)  /* Pin Interrupt Flag bit 7 mask. */
+#define PORT_INT_7_bp  7  /* Pin Interrupt Flag bit 7 position. */
+#define PORT_INT7_bm  PORT_INT_7_bm  /* This define is deprecated and should not be used */
+#define PORT_INT7_bp  PORT_INT_7_bp  /* This define is deprecated and should not be used */
+
+/* PORT.PORTCTRL  bit masks and bit positions */
+#define PORT_SRL_bm  0x01  /* Slew Rate Limit Enable bit mask. */
+#define PORT_SRL_bp  0  /* Slew Rate Limit Enable bit position. */
+
+/* PORT.PINCONFIG  bit masks and bit positions */
+#define PORT_ISC_gm  0x07  /* Input/Sense Configuration group mask. */
+#define PORT_ISC_gp  0  /* Input/Sense Configuration group position. */
+#define PORT_ISC_0_bm  (1<<0)  /* Input/Sense Configuration bit 0 mask. */
+#define PORT_ISC_0_bp  0  /* Input/Sense Configuration bit 0 position. */
+#define PORT_ISC_1_bm  (1<<1)  /* Input/Sense Configuration bit 1 mask. */
+#define PORT_ISC_1_bp  1  /* Input/Sense Configuration bit 1 position. */
+#define PORT_ISC_2_bm  (1<<2)  /* Input/Sense Configuration bit 2 mask. */
+#define PORT_ISC_2_bp  2  /* Input/Sense Configuration bit 2 position. */
+#define PORT_PULLUPEN_bm  0x08  /* Pullup enable bit mask. */
+#define PORT_PULLUPEN_bp  3  /* Pullup enable bit position. */
+#define PORT_INLVL_bm  0x40  /* Input Level Select bit mask. */
+#define PORT_INLVL_bp  6  /* Input Level Select bit position. */
+#define PORT_INVEN_bm  0x80  /* Inverted I/O Enable bit mask. */
+#define PORT_INVEN_bp  7  /* Inverted I/O Enable bit position. */
+
+/* PORT.PIN0CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN1CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN2CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN3CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN4CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN5CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN6CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN7CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.EVGENCTRLA  bit masks and bit positions */
+#define PORT_EVGEN0SEL_gm  0x07  /* Event Generator 0 Select group mask. */
+#define PORT_EVGEN0SEL_gp  0  /* Event Generator 0 Select group position. */
+#define PORT_EVGEN0SEL_0_bm  (1<<0)  /* Event Generator 0 Select bit 0 mask. */
+#define PORT_EVGEN0SEL_0_bp  0  /* Event Generator 0 Select bit 0 position. */
+#define PORT_EVGEN0SEL_1_bm  (1<<1)  /* Event Generator 0 Select bit 1 mask. */
+#define PORT_EVGEN0SEL_1_bp  1  /* Event Generator 0 Select bit 1 position. */
+#define PORT_EVGEN0SEL_2_bm  (1<<2)  /* Event Generator 0 Select bit 2 mask. */
+#define PORT_EVGEN0SEL_2_bp  2  /* Event Generator 0 Select bit 2 position. */
+#define PORT_EVGEN1SEL_gm  0x70  /* Event Generator 1 Select group mask. */
+#define PORT_EVGEN1SEL_gp  4  /* Event Generator 1 Select group position. */
+#define PORT_EVGEN1SEL_0_bm  (1<<4)  /* Event Generator 1 Select bit 0 mask. */
+#define PORT_EVGEN1SEL_0_bp  4  /* Event Generator 1 Select bit 0 position. */
+#define PORT_EVGEN1SEL_1_bm  (1<<5)  /* Event Generator 1 Select bit 1 mask. */
+#define PORT_EVGEN1SEL_1_bp  5  /* Event Generator 1 Select bit 1 position. */
+#define PORT_EVGEN1SEL_2_bm  (1<<6)  /* Event Generator 1 Select bit 2 mask. */
+#define PORT_EVGEN1SEL_2_bp  6  /* Event Generator 1 Select bit 2 position. */
+
+
+/* PORTMUX - Port Multiplexer */
+/* PORTMUX.EVSYSROUTEA  bit masks and bit positions */
+#define PORTMUX_EVOUTA_bm  0x01  /* Event Output A bit mask. */
+#define PORTMUX_EVOUTA_bp  0  /* Event Output A bit position. */
+#define PORTMUX_EVOUTC_bm  0x04  /* Event Output C bit mask. */
+#define PORTMUX_EVOUTC_bp  2  /* Event Output C bit position. */
+#define PORTMUX_EVOUTD_bm  0x08  /* Event Output D bit mask. */
+#define PORTMUX_EVOUTD_bp  3  /* Event Output D bit position. */
+#define PORTMUX_EVOUTF_bm  0x20  /* Event Output F bit mask. */
+#define PORTMUX_EVOUTF_bp  5  /* Event Output F bit position. */
+
+/* PORTMUX.CCLROUTEA  bit masks and bit positions */
+#define PORTMUX_LUT0_bm  0x01  /* CCL Look-Up Table 0 Signals bit mask. */
+#define PORTMUX_LUT0_bp  0  /* CCL Look-Up Table 0 Signals bit position. */
+#define PORTMUX_LUT1_bm  0x02  /* CCL Look-Up Table 1 Signals bit mask. */
+#define PORTMUX_LUT1_bp  1  /* CCL Look-Up Table 1 Signals bit position. */
+#define PORTMUX_LUT2_bm  0x04  /* CCL Look-Up Table 2 Signals bit mask. */
+#define PORTMUX_LUT2_bp  2  /* CCL Look-Up Table 2 Signals bit position. */
+#define PORTMUX_LUT3_bm  0x08  /* CCL Look-Up Table 3 Signals bit mask. */
+#define PORTMUX_LUT3_bp  3  /* CCL Look-Up Table 3 Signals bit position. */
+
+/* PORTMUX.USARTROUTEA  bit masks and bit positions */
+#define PORTMUX_USART0_gm  0x07  /* USART0 Routing group mask. */
+#define PORTMUX_USART0_gp  0  /* USART0 Routing group position. */
+#define PORTMUX_USART0_0_bm  (1<<0)  /* USART0 Routing bit 0 mask. */
+#define PORTMUX_USART0_0_bp  0  /* USART0 Routing bit 0 position. */
+#define PORTMUX_USART0_1_bm  (1<<1)  /* USART0 Routing bit 1 mask. */
+#define PORTMUX_USART0_1_bp  1  /* USART0 Routing bit 1 position. */
+#define PORTMUX_USART0_2_bm  (1<<2)  /* USART0 Routing bit 2 mask. */
+#define PORTMUX_USART0_2_bp  2  /* USART0 Routing bit 2 position. */
+
+/* PORTMUX.SPIROUTEA  bit masks and bit positions */
+#define PORTMUX_SPI0_gm  0x07  /* SPI0 Signals group mask. */
+#define PORTMUX_SPI0_gp  0  /* SPI0 Signals group position. */
+#define PORTMUX_SPI0_0_bm  (1<<0)  /* SPI0 Signals bit 0 mask. */
+#define PORTMUX_SPI0_0_bp  0  /* SPI0 Signals bit 0 position. */
+#define PORTMUX_SPI0_1_bm  (1<<1)  /* SPI0 Signals bit 1 mask. */
+#define PORTMUX_SPI0_1_bp  1  /* SPI0 Signals bit 1 position. */
+#define PORTMUX_SPI0_2_bm  (1<<2)  /* SPI0 Signals bit 2 mask. */
+#define PORTMUX_SPI0_2_bp  2  /* SPI0 Signals bit 2 position. */
+
+/* PORTMUX.TWIROUTEA  bit masks and bit positions */
+#define PORTMUX_TWI0_gm  0x03  /* TWI0 Signals group mask. */
+#define PORTMUX_TWI0_gp  0  /* TWI0 Signals group position. */
+#define PORTMUX_TWI0_0_bm  (1<<0)  /* TWI0 Signals bit 0 mask. */
+#define PORTMUX_TWI0_0_bp  0  /* TWI0 Signals bit 0 position. */
+#define PORTMUX_TWI0_1_bm  (1<<1)  /* TWI0 Signals bit 1 mask. */
+#define PORTMUX_TWI0_1_bp  1  /* TWI0 Signals bit 1 position. */
+
+/* PORTMUX.TCEROUTEA  bit masks and bit positions */
+#define PORTMUX_TCE0_gm  0x0F  /* TCE0 Signals group mask. */
+#define PORTMUX_TCE0_gp  0  /* TCE0 Signals group position. */
+#define PORTMUX_TCE0_0_bm  (1<<0)  /* TCE0 Signals bit 0 mask. */
+#define PORTMUX_TCE0_0_bp  0  /* TCE0 Signals bit 0 position. */
+#define PORTMUX_TCE0_1_bm  (1<<1)  /* TCE0 Signals bit 1 mask. */
+#define PORTMUX_TCE0_1_bp  1  /* TCE0 Signals bit 1 position. */
+#define PORTMUX_TCE0_2_bm  (1<<2)  /* TCE0 Signals bit 2 mask. */
+#define PORTMUX_TCE0_2_bp  2  /* TCE0 Signals bit 2 position. */
+#define PORTMUX_TCE0_3_bm  (1<<3)  /* TCE0 Signals bit 3 mask. */
+#define PORTMUX_TCE0_3_bp  3  /* TCE0 Signals bit 3 position. */
+
+/* PORTMUX.TCBROUTEA  bit masks and bit positions */
+#define PORTMUX_TCB0_bm  0x01  /* TCB0 Output bit mask. */
+#define PORTMUX_TCB0_bp  0  /* TCB0 Output bit position. */
+#define PORTMUX_TCB1_bm  0x02  /* TCB1 Output bit mask. */
+#define PORTMUX_TCB1_bp  1  /* TCB1 Output bit position. */
+
+/* PORTMUX.TCFROUTEA  bit masks and bit positions */
+#define PORTMUX_TCF0_gm  0x03  /* TCF0 Output group mask. */
+#define PORTMUX_TCF0_gp  0  /* TCF0 Output group position. */
+#define PORTMUX_TCF0_0_bm  (1<<0)  /* TCF0 Output bit 0 mask. */
+#define PORTMUX_TCF0_0_bp  0  /* TCF0 Output bit 0 position. */
+#define PORTMUX_TCF0_1_bm  (1<<1)  /* TCF0 Output bit 1 mask. */
+#define PORTMUX_TCF0_1_bp  1  /* TCF0 Output bit 1 position. */
+
+
+/* RSTCTRL - Reset controller */
+/* RSTCTRL.RSTFR  bit masks and bit positions */
+#define RSTCTRL_PORF_bm  0x01  /* Power on Reset flag bit mask. */
+#define RSTCTRL_PORF_bp  0  /* Power on Reset flag bit position. */
+#define RSTCTRL_BORF_bm  0x02  /* Brown out detector Reset flag bit mask. */
+#define RSTCTRL_BORF_bp  1  /* Brown out detector Reset flag bit position. */
+#define RSTCTRL_EXTRF_bm  0x04  /* External Reset flag bit mask. */
+#define RSTCTRL_EXTRF_bp  2  /* External Reset flag bit position. */
+#define RSTCTRL_WDRF_bm  0x08  /* Watch dog Reset flag bit mask. */
+#define RSTCTRL_WDRF_bp  3  /* Watch dog Reset flag bit position. */
+#define RSTCTRL_SWRF_bm  0x10  /* Software Reset flag bit mask. */
+#define RSTCTRL_SWRF_bp  4  /* Software Reset flag bit position. */
+#define RSTCTRL_UPDIRF_bm  0x20  /* UPDI Reset flag bit mask. */
+#define RSTCTRL_UPDIRF_bp  5  /* UPDI Reset flag bit position. */
+
+/* RSTCTRL.SWRR  bit masks and bit positions */
+#define RSTCTRL_SWRE_bm  0x01  /* Software Reset Enable bit mask. */
+#define RSTCTRL_SWRE_bp  0  /* Software Reset Enable bit position. */
+
+
+/* RTC - Real-Time Counter */
+/* RTC.CTRLA  bit masks and bit positions */
+#define RTC_RTCEN_bm  0x01  /* Enable bit mask. */
+#define RTC_RTCEN_bp  0  /* Enable bit position. */
+#define RTC_CORREN_bm  0x04  /* Correction enable bit mask. */
+#define RTC_CORREN_bp  2  /* Correction enable bit position. */
+#define RTC_PRESCALER_gm  0x78  /* Prescaling Factor group mask. */
+#define RTC_PRESCALER_gp  3  /* Prescaling Factor group position. */
+#define RTC_PRESCALER_0_bm  (1<<3)  /* Prescaling Factor bit 0 mask. */
+#define RTC_PRESCALER_0_bp  3  /* Prescaling Factor bit 0 position. */
+#define RTC_PRESCALER_1_bm  (1<<4)  /* Prescaling Factor bit 1 mask. */
+#define RTC_PRESCALER_1_bp  4  /* Prescaling Factor bit 1 position. */
+#define RTC_PRESCALER_2_bm  (1<<5)  /* Prescaling Factor bit 2 mask. */
+#define RTC_PRESCALER_2_bp  5  /* Prescaling Factor bit 2 position. */
+#define RTC_PRESCALER_3_bm  (1<<6)  /* Prescaling Factor bit 3 mask. */
+#define RTC_PRESCALER_3_bp  6  /* Prescaling Factor bit 3 position. */
+#define RTC_RUNSTDBY_bm  0x80  /* Run In Standby bit mask. */
+#define RTC_RUNSTDBY_bp  7  /* Run In Standby bit position. */
+
+/* RTC.STATUS  bit masks and bit positions */
+#define RTC_CTRLABUSY_bm  0x01  /* CTRLA Synchronization Busy Flag bit mask. */
+#define RTC_CTRLABUSY_bp  0  /* CTRLA Synchronization Busy Flag bit position. */
+#define RTC_CNTBUSY_bm  0x02  /* Count Synchronization Busy Flag bit mask. */
+#define RTC_CNTBUSY_bp  1  /* Count Synchronization Busy Flag bit position. */
+#define RTC_PERBUSY_bm  0x04  /* Period Synchronization Busy Flag bit mask. */
+#define RTC_PERBUSY_bp  2  /* Period Synchronization Busy Flag bit position. */
+#define RTC_CMPBUSY_bm  0x08  /* Comparator Synchronization Busy Flag bit mask. */
+#define RTC_CMPBUSY_bp  3  /* Comparator Synchronization Busy Flag bit position. */
+
+/* RTC.INTCTRL  bit masks and bit positions */
+#define RTC_OVF_bm  0x01  /* Overflow Interrupt enable bit mask. */
+#define RTC_OVF_bp  0  /* Overflow Interrupt enable bit position. */
+#define RTC_CMP_bm  0x02  /* Compare Match Interrupt enable bit mask. */
+#define RTC_CMP_bp  1  /* Compare Match Interrupt enable bit position. */
+
+/* RTC.INTFLAGS  bit masks and bit positions */
+/* RTC_OVF  is already defined. */
+/* RTC_CMP  is already defined. */
+
+/* RTC.DBGCTRL  bit masks and bit positions */
+#define RTC_DBGRUN_bm  0x01  /* Run in debug bit mask. */
+#define RTC_DBGRUN_bp  0  /* Run in debug bit position. */
+
+/* RTC.CALIB  bit masks and bit positions */
+#define RTC_ERROR_gm  0x7F  /* Error Correction Value group mask. */
+#define RTC_ERROR_gp  0  /* Error Correction Value group position. */
+#define RTC_ERROR_0_bm  (1<<0)  /* Error Correction Value bit 0 mask. */
+#define RTC_ERROR_0_bp  0  /* Error Correction Value bit 0 position. */
+#define RTC_ERROR_1_bm  (1<<1)  /* Error Correction Value bit 1 mask. */
+#define RTC_ERROR_1_bp  1  /* Error Correction Value bit 1 position. */
+#define RTC_ERROR_2_bm  (1<<2)  /* Error Correction Value bit 2 mask. */
+#define RTC_ERROR_2_bp  2  /* Error Correction Value bit 2 position. */
+#define RTC_ERROR_3_bm  (1<<3)  /* Error Correction Value bit 3 mask. */
+#define RTC_ERROR_3_bp  3  /* Error Correction Value bit 3 position. */
+#define RTC_ERROR_4_bm  (1<<4)  /* Error Correction Value bit 4 mask. */
+#define RTC_ERROR_4_bp  4  /* Error Correction Value bit 4 position. */
+#define RTC_ERROR_5_bm  (1<<5)  /* Error Correction Value bit 5 mask. */
+#define RTC_ERROR_5_bp  5  /* Error Correction Value bit 5 position. */
+#define RTC_ERROR_6_bm  (1<<6)  /* Error Correction Value bit 6 mask. */
+#define RTC_ERROR_6_bp  6  /* Error Correction Value bit 6 position. */
+#define RTC_SIGN_bm  0x80  /* Error Correction Sign Bit bit mask. */
+#define RTC_SIGN_bp  7  /* Error Correction Sign Bit bit position. */
+
+/* RTC.CLKSEL  bit masks and bit positions */
+#define RTC_CLKSEL_gm  0x03  /* Clock Select group mask. */
+#define RTC_CLKSEL_gp  0  /* Clock Select group position. */
+#define RTC_CLKSEL_0_bm  (1<<0)  /* Clock Select bit 0 mask. */
+#define RTC_CLKSEL_0_bp  0  /* Clock Select bit 0 position. */
+#define RTC_CLKSEL_1_bm  (1<<1)  /* Clock Select bit 1 mask. */
+#define RTC_CLKSEL_1_bp  1  /* Clock Select bit 1 position. */
+
+/* RTC.PITCTRLA  bit masks and bit positions */
+#define RTC_PITEN_bm  0x01  /* Enable bit mask. */
+#define RTC_PITEN_bp  0  /* Enable bit position. */
+#define RTC_PERIOD_gm  0x78  /* Period group mask. */
+#define RTC_PERIOD_gp  3  /* Period group position. */
+#define RTC_PERIOD_0_bm  (1<<3)  /* Period bit 0 mask. */
+#define RTC_PERIOD_0_bp  3  /* Period bit 0 position. */
+#define RTC_PERIOD_1_bm  (1<<4)  /* Period bit 1 mask. */
+#define RTC_PERIOD_1_bp  4  /* Period bit 1 position. */
+#define RTC_PERIOD_2_bm  (1<<5)  /* Period bit 2 mask. */
+#define RTC_PERIOD_2_bp  5  /* Period bit 2 position. */
+#define RTC_PERIOD_3_bm  (1<<6)  /* Period bit 3 mask. */
+#define RTC_PERIOD_3_bp  6  /* Period bit 3 position. */
+
+/* RTC.PITSTATUS  bit masks and bit positions */
+#define RTC_CTRLBUSY_bm  0x01  /* CTRLA Synchronization Busy Flag bit mask. */
+#define RTC_CTRLBUSY_bp  0  /* CTRLA Synchronization Busy Flag bit position. */
+
+/* RTC.PITINTCTRL  bit masks and bit positions */
+#define RTC_PI_bm  0x01  /* Periodic Interrupt bit mask. */
+#define RTC_PI_bp  0  /* Periodic Interrupt bit position. */
+
+/* RTC.PITINTFLAGS  bit masks and bit positions */
+/* RTC_PI  is already defined. */
+
+/* RTC.PITDBGCTRL  bit masks and bit positions */
+/* RTC_DBGRUN  is already defined. */
+
+/* RTC.PITEVGENCTRLA  bit masks and bit positions */
+#define RTC_EVGEN0SEL_gm  0x0F  /* Event Generation 0 Select group mask. */
+#define RTC_EVGEN0SEL_gp  0  /* Event Generation 0 Select group position. */
+#define RTC_EVGEN0SEL_0_bm  (1<<0)  /* Event Generation 0 Select bit 0 mask. */
+#define RTC_EVGEN0SEL_0_bp  0  /* Event Generation 0 Select bit 0 position. */
+#define RTC_EVGEN0SEL_1_bm  (1<<1)  /* Event Generation 0 Select bit 1 mask. */
+#define RTC_EVGEN0SEL_1_bp  1  /* Event Generation 0 Select bit 1 position. */
+#define RTC_EVGEN0SEL_2_bm  (1<<2)  /* Event Generation 0 Select bit 2 mask. */
+#define RTC_EVGEN0SEL_2_bp  2  /* Event Generation 0 Select bit 2 position. */
+#define RTC_EVGEN0SEL_3_bm  (1<<3)  /* Event Generation 0 Select bit 3 mask. */
+#define RTC_EVGEN0SEL_3_bp  3  /* Event Generation 0 Select bit 3 position. */
+#define RTC_EVGEN1SEL_gm  0xF0  /* Event Generation 1 Select group mask. */
+#define RTC_EVGEN1SEL_gp  4  /* Event Generation 1 Select group position. */
+#define RTC_EVGEN1SEL_0_bm  (1<<4)  /* Event Generation 1 Select bit 0 mask. */
+#define RTC_EVGEN1SEL_0_bp  4  /* Event Generation 1 Select bit 0 position. */
+#define RTC_EVGEN1SEL_1_bm  (1<<5)  /* Event Generation 1 Select bit 1 mask. */
+#define RTC_EVGEN1SEL_1_bp  5  /* Event Generation 1 Select bit 1 position. */
+#define RTC_EVGEN1SEL_2_bm  (1<<6)  /* Event Generation 1 Select bit 2 mask. */
+#define RTC_EVGEN1SEL_2_bp  6  /* Event Generation 1 Select bit 2 position. */
+#define RTC_EVGEN1SEL_3_bm  (1<<7)  /* Event Generation 1 Select bit 3 mask. */
+#define RTC_EVGEN1SEL_3_bp  7  /* Event Generation 1 Select bit 3 position. */
+
+
+
+/* SLPCTRL - Sleep Controller */
+/* SLPCTRL.CTRLA  bit masks and bit positions */
+#define SLPCTRL_SEN_bm  0x01  /* Sleep enable bit mask. */
+#define SLPCTRL_SEN_bp  0  /* Sleep enable bit position. */
+#define SLPCTRL_SMODE_gm  0x06  /* Sleep mode group mask. */
+#define SLPCTRL_SMODE_gp  1  /* Sleep mode group position. */
+#define SLPCTRL_SMODE_0_bm  (1<<1)  /* Sleep mode bit 0 mask. */
+#define SLPCTRL_SMODE_0_bp  1  /* Sleep mode bit 0 position. */
+#define SLPCTRL_SMODE_1_bm  (1<<2)  /* Sleep mode bit 1 mask. */
+#define SLPCTRL_SMODE_1_bp  2  /* Sleep mode bit 1 position. */
+
+
+/* SPI - Serial Peripheral Interface */
+/* SPI.CTRLA  bit masks and bit positions */
+#define SPI_ENABLE_bm  0x01  /* Enable Module bit mask. */
+#define SPI_ENABLE_bp  0  /* Enable Module bit position. */
+#define SPI_PRESC_gm  0x06  /* Prescaler group mask. */
+#define SPI_PRESC_gp  1  /* Prescaler group position. */
+#define SPI_PRESC_0_bm  (1<<1)  /* Prescaler bit 0 mask. */
+#define SPI_PRESC_0_bp  1  /* Prescaler bit 0 position. */
+#define SPI_PRESC_1_bm  (1<<2)  /* Prescaler bit 1 mask. */
+#define SPI_PRESC_1_bp  2  /* Prescaler bit 1 position. */
+#define SPI_CLK2X_bm  0x10  /* Enable Double Speed bit mask. */
+#define SPI_CLK2X_bp  4  /* Enable Double Speed bit position. */
+#define SPI_MASTER_bm  0x20  /* Host Operation Enable bit mask. */
+#define SPI_MASTER_bp  5  /* Host Operation Enable bit position. */
+#define SPI_DORD_bm  0x40  /* Data Order Setting bit mask. */
+#define SPI_DORD_bp  6  /* Data Order Setting bit position. */
+
+/* SPI.CTRLB  bit masks and bit positions */
+#define SPI_MODE_gm  0x03  /* SPI Mode group mask. */
+#define SPI_MODE_gp  0  /* SPI Mode group position. */
+#define SPI_MODE_0_bm  (1<<0)  /* SPI Mode bit 0 mask. */
+#define SPI_MODE_0_bp  0  /* SPI Mode bit 0 position. */
+#define SPI_MODE_1_bm  (1<<1)  /* SPI Mode bit 1 mask. */
+#define SPI_MODE_1_bp  1  /* SPI Mode bit 1 position. */
+#define SPI_SSD_bm  0x04  /* SPI Select Disable bit mask. */
+#define SPI_SSD_bp  2  /* SPI Select Disable bit position. */
+#define SPI_BUFWR_bm  0x40  /* Buffer Mode Wait for Receive bit mask. */
+#define SPI_BUFWR_bp  6  /* Buffer Mode Wait for Receive bit position. */
+#define SPI_BUFEN_bm  0x80  /* Buffer Mode Enable bit mask. */
+#define SPI_BUFEN_bp  7  /* Buffer Mode Enable bit position. */
+
+/* SPI.INTCTRL  bit masks and bit positions */
+#define SPI_IE_bm  0x01  /* Interrupt Enable bit mask. */
+#define SPI_IE_bp  0  /* Interrupt Enable bit position. */
+#define SPI_SSIE_bm  0x10  /* SPI Select Trigger Interrupt Enable bit mask. */
+#define SPI_SSIE_bp  4  /* SPI Select Trigger Interrupt Enable bit position. */
+#define SPI_DREIE_bm  0x20  /* Data Register Empty Interrupt Enable bit mask. */
+#define SPI_DREIE_bp  5  /* Data Register Empty Interrupt Enable bit position. */
+#define SPI_TXCIE_bm  0x40  /* Transfer Complete Interrupt Enable bit mask. */
+#define SPI_TXCIE_bp  6  /* Transfer Complete Interrupt Enable bit position. */
+#define SPI_RXCIE_bm  0x80  /* Receive Complete Interrupt Enable bit mask. */
+#define SPI_RXCIE_bp  7  /* Receive Complete Interrupt Enable bit position. */
+
+/* SPI.INTFLAGS  bit masks and bit positions */
+#define SPI_BUFOVF_bm  0x01  /* Buffer Overflow bit mask. */
+#define SPI_BUFOVF_bp  0  /* Buffer Overflow bit position. */
+#define SPI_SSIF_bm  0x10  /* SPI Select Trigger Interrupt Flag bit mask. */
+#define SPI_SSIF_bp  4  /* SPI Select Trigger Interrupt Flag bit position. */
+#define SPI_DREIF_bm  0x20  /* Data Register Empty Interrupt Flag bit mask. */
+#define SPI_DREIF_bp  5  /* Data Register Empty Interrupt Flag bit position. */
+#define SPI_TXCIF_bm  0x40  /* Transfer Complete Interrupt Flag bit mask. */
+#define SPI_TXCIF_bp  6  /* Transfer Complete Interrupt Flag bit position. */
+#define SPI_WRCOL_bm  0x40  /* Write Collision bit mask. */
+#define SPI_WRCOL_bp  6  /* Write Collision bit position. */
+#define SPI_RXCIF_bm  0x80  /* Receive Complete Interrupt Flag bit mask. */
+#define SPI_RXCIF_bp  7  /* Receive Complete Interrupt Flag bit position. */
+#define SPI_IF_bm  0x80  /* Interrupt Flag bit mask. */
+#define SPI_IF_bp  7  /* Interrupt Flag bit position. */
+
+
+/* SYSCFG - System Configuration Registers */
+/* SYSCFG.REVID  bit masks and bit positions */
+#define SYSCFG_MINOR_gm  0x0F  /* Minor Revision group mask. */
+#define SYSCFG_MINOR_gp  0  /* Minor Revision group position. */
+#define SYSCFG_MINOR_0_bm  (1<<0)  /* Minor Revision bit 0 mask. */
+#define SYSCFG_MINOR_0_bp  0  /* Minor Revision bit 0 position. */
+#define SYSCFG_MINOR_1_bm  (1<<1)  /* Minor Revision bit 1 mask. */
+#define SYSCFG_MINOR_1_bp  1  /* Minor Revision bit 1 position. */
+#define SYSCFG_MINOR_2_bm  (1<<2)  /* Minor Revision bit 2 mask. */
+#define SYSCFG_MINOR_2_bp  2  /* Minor Revision bit 2 position. */
+#define SYSCFG_MINOR_3_bm  (1<<3)  /* Minor Revision bit 3 mask. */
+#define SYSCFG_MINOR_3_bp  3  /* Minor Revision bit 3 position. */
+#define SYSCFG_MAJOR_gm  0xF0  /* Major Revision group mask. */
+#define SYSCFG_MAJOR_gp  4  /* Major Revision group position. */
+#define SYSCFG_MAJOR_0_bm  (1<<4)  /* Major Revision bit 0 mask. */
+#define SYSCFG_MAJOR_0_bp  4  /* Major Revision bit 0 position. */
+#define SYSCFG_MAJOR_1_bm  (1<<5)  /* Major Revision bit 1 mask. */
+#define SYSCFG_MAJOR_1_bp  5  /* Major Revision bit 1 position. */
+#define SYSCFG_MAJOR_2_bm  (1<<6)  /* Major Revision bit 2 mask. */
+#define SYSCFG_MAJOR_2_bp  6  /* Major Revision bit 2 position. */
+#define SYSCFG_MAJOR_3_bm  (1<<7)  /* Major Revision bit 3 mask. */
+#define SYSCFG_MAJOR_3_bp  7  /* Major Revision bit 3 position. */
+
+
+/* TCB - 16-bit Timer/Counter Type B */
+/* TCB.CTRLA  bit masks and bit positions */
+#define TCB_ENABLE_bm  0x01  /* Enable bit mask. */
+#define TCB_ENABLE_bp  0  /* Enable bit position. */
+#define TCB_CLKSEL_gm  0x0E  /* Clock Select group mask. */
+#define TCB_CLKSEL_gp  1  /* Clock Select group position. */
+#define TCB_CLKSEL_0_bm  (1<<1)  /* Clock Select bit 0 mask. */
+#define TCB_CLKSEL_0_bp  1  /* Clock Select bit 0 position. */
+#define TCB_CLKSEL_1_bm  (1<<2)  /* Clock Select bit 1 mask. */
+#define TCB_CLKSEL_1_bp  2  /* Clock Select bit 1 position. */
+#define TCB_CLKSEL_2_bm  (1<<3)  /* Clock Select bit 2 mask. */
+#define TCB_CLKSEL_2_bp  3  /* Clock Select bit 2 position. */
+#define TCB_SYNCUPD_bm  0x10  /* Synchronize Update bit mask. */
+#define TCB_SYNCUPD_bp  4  /* Synchronize Update bit position. */
+#define TCB_CASCADE_bm  0x20  /* Cascade two timers bit mask. */
+#define TCB_CASCADE_bp  5  /* Cascade two timers bit position. */
+#define TCB_RUNSTDBY_bm  0x40  /* Run Standby bit mask. */
+#define TCB_RUNSTDBY_bp  6  /* Run Standby bit position. */
+
+/* TCB.CTRLB  bit masks and bit positions */
+#define TCB_CNTMODE_gm  0x07  /* Timer Mode group mask. */
+#define TCB_CNTMODE_gp  0  /* Timer Mode group position. */
+#define TCB_CNTMODE_0_bm  (1<<0)  /* Timer Mode bit 0 mask. */
+#define TCB_CNTMODE_0_bp  0  /* Timer Mode bit 0 position. */
+#define TCB_CNTMODE_1_bm  (1<<1)  /* Timer Mode bit 1 mask. */
+#define TCB_CNTMODE_1_bp  1  /* Timer Mode bit 1 position. */
+#define TCB_CNTMODE_2_bm  (1<<2)  /* Timer Mode bit 2 mask. */
+#define TCB_CNTMODE_2_bp  2  /* Timer Mode bit 2 position. */
+#define TCB_CCMPEN_bm  0x10  /* Pin Output Enable bit mask. */
+#define TCB_CCMPEN_bp  4  /* Pin Output Enable bit position. */
+#define TCB_CCMPINIT_bm  0x20  /* Pin Initial State bit mask. */
+#define TCB_CCMPINIT_bp  5  /* Pin Initial State bit position. */
+#define TCB_ASYNC_bm  0x40  /* Asynchronous Enable bit mask. */
+#define TCB_ASYNC_bp  6  /* Asynchronous Enable bit position. */
+#define TCB_EVGEN_bm  0x80  /* Event Generation bit mask. */
+#define TCB_EVGEN_bp  7  /* Event Generation bit position. */
+
+/* TCB.CTRLC  bit masks and bit positions */
+#define TCB_CNTSIZE_gm  0x07  /* Counter Size group mask. */
+#define TCB_CNTSIZE_gp  0  /* Counter Size group position. */
+#define TCB_CNTSIZE_0_bm  (1<<0)  /* Counter Size bit 0 mask. */
+#define TCB_CNTSIZE_0_bp  0  /* Counter Size bit 0 position. */
+#define TCB_CNTSIZE_1_bm  (1<<1)  /* Counter Size bit 1 mask. */
+#define TCB_CNTSIZE_1_bp  1  /* Counter Size bit 1 position. */
+#define TCB_CNTSIZE_2_bm  (1<<2)  /* Counter Size bit 2 mask. */
+#define TCB_CNTSIZE_2_bp  2  /* Counter Size bit 2 position. */
+
+/* TCB.EVCTRL  bit masks and bit positions */
+#define TCB_CAPTEI_bm  0x01  /* Event Input Enable bit mask. */
+#define TCB_CAPTEI_bp  0  /* Event Input Enable bit position. */
+#define TCB_EDGE_bm  0x10  /* Event Edge bit mask. */
+#define TCB_EDGE_bp  4  /* Event Edge bit position. */
+#define TCB_FILTER_bm  0x40  /* Input Capture Noise Cancellation Filter bit mask. */
+#define TCB_FILTER_bp  6  /* Input Capture Noise Cancellation Filter bit position. */
+
+/* TCB.INTCTRL  bit masks and bit positions */
+#define TCB_CAPT_bm  0x01  /* Capture or Timeout bit mask. */
+#define TCB_CAPT_bp  0  /* Capture or Timeout bit position. */
+#define TCB_OVF_bm  0x02  /* Overflow bit mask. */
+#define TCB_OVF_bp  1  /* Overflow bit position. */
+
+/* TCB.INTFLAGS  bit masks and bit positions */
+/* TCB_CAPT  is already defined. */
+/* TCB_OVF  is already defined. */
+
+/* TCB.STATUS  bit masks and bit positions */
+#define TCB_RUN_bm  0x01  /* Run bit mask. */
+#define TCB_RUN_bp  0  /* Run bit position. */
+
+/* TCB.DBGCTRL  bit masks and bit positions */
+#define TCB_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define TCB_DBGRUN_bp  0  /* Debug Run bit position. */
+
+
+/* TCE - 16-bit Timer/Counter Type E */
+/* TCE.CTRLA  bit masks and bit positions */
+#define TCE_ENABLE_bm  0x01  /* Module Enable bit mask. */
+#define TCE_ENABLE_bp  0  /* Module Enable bit position. */
+#define TCE_CLKSEL_gm  0x0E  /* Clock Selection group mask. */
+#define TCE_CLKSEL_gp  1  /* Clock Selection group position. */
+#define TCE_CLKSEL_0_bm  (1<<1)  /* Clock Selection bit 0 mask. */
+#define TCE_CLKSEL_0_bp  1  /* Clock Selection bit 0 position. */
+#define TCE_CLKSEL_1_bm  (1<<2)  /* Clock Selection bit 1 mask. */
+#define TCE_CLKSEL_1_bp  2  /* Clock Selection bit 1 position. */
+#define TCE_CLKSEL_2_bm  (1<<3)  /* Clock Selection bit 2 mask. */
+#define TCE_CLKSEL_2_bp  3  /* Clock Selection bit 2 position. */
+#define TCE_RUNSTDBY_bm  0x80  /* Run in Standby bit mask. */
+#define TCE_RUNSTDBY_bp  7  /* Run in Standby bit position. */
+
+/* TCE.CTRLB  bit masks and bit positions */
+#define TCE_WGMODE_gm  0x07  /* Waveform generation mode group mask. */
+#define TCE_WGMODE_gp  0  /* Waveform generation mode group position. */
+#define TCE_WGMODE_0_bm  (1<<0)  /* Waveform generation mode bit 0 mask. */
+#define TCE_WGMODE_0_bp  0  /* Waveform generation mode bit 0 position. */
+#define TCE_WGMODE_1_bm  (1<<1)  /* Waveform generation mode bit 1 mask. */
+#define TCE_WGMODE_1_bp  1  /* Waveform generation mode bit 1 position. */
+#define TCE_WGMODE_2_bm  (1<<2)  /* Waveform generation mode bit 2 mask. */
+#define TCE_WGMODE_2_bp  2  /* Waveform generation mode bit 2 position. */
+#define TCE_ALUPD_bm  0x08  /* Auto Lock Update bit mask. */
+#define TCE_ALUPD_bp  3  /* Auto Lock Update bit position. */
+#define TCE_CMP0EN_bm  0x10  /* Compare 0 Enable bit mask. */
+#define TCE_CMP0EN_bp  4  /* Compare 0 Enable bit position. */
+#define TCE_CMP1EN_bm  0x20  /* Compare 1 Enable bit mask. */
+#define TCE_CMP1EN_bp  5  /* Compare 1 Enable bit position. */
+#define TCE_CMP2EN_bm  0x40  /* Compare 2 Enable bit mask. */
+#define TCE_CMP2EN_bp  6  /* Compare 2 Enable bit position. */
+#define TCE_CMP3EN_bm  0x80  /* Compare 3 Enable bit mask. */
+#define TCE_CMP3EN_bp  7  /* Compare 3 Enable bit position. */
+
+/* TCE.CTRLC  bit masks and bit positions */
+#define TCE_CMP0OV_bm  0x01  /* Compare 0 Waveform Output Value bit mask. */
+#define TCE_CMP0OV_bp  0  /* Compare 0 Waveform Output Value bit position. */
+#define TCE_CMP1OV_bm  0x02  /* Compare 1 Waveform Output Value bit mask. */
+#define TCE_CMP1OV_bp  1  /* Compare 1 Waveform Output Value bit position. */
+#define TCE_CMP2OV_bm  0x04  /* Compare 2 Waveform Output Value bit mask. */
+#define TCE_CMP2OV_bp  2  /* Compare 2 Waveform Output Value bit position. */
+#define TCE_CMP3OV_bm  0x08  /* Compare 3 Waveform Output Value bit mask. */
+#define TCE_CMP3OV_bp  3  /* Compare 3 Waveform Output Value bit position. */
+#define TCE_CMP0POL_bm  0x10  /* Compare 0 Polarity bit mask. */
+#define TCE_CMP0POL_bp  4  /* Compare 0 Polarity bit position. */
+#define TCE_CMP1POL_bm  0x20  /* Compare 1 Polarity bit mask. */
+#define TCE_CMP1POL_bp  5  /* Compare 1 Polarity bit position. */
+#define TCE_CMP2POL_bm  0x40  /* Compare 2 Polarity bit mask. */
+#define TCE_CMP2POL_bp  6  /* Compare 2 Polarity bit position. */
+#define TCE_CMP3POL_bm  0x80  /* Compare 3 Polarity bit mask. */
+#define TCE_CMP3POL_bp  7  /* Compare 3 Polarity bit position. */
+
+/* TCE.CTRLD  bit masks and bit positions */
+#define TCE_SCALE_bm  0x04  /* Scaled Write bit mask. */
+#define TCE_SCALE_bp  2  /* Scaled Write bit position. */
+#define TCE_AMPEN_bm  0x08  /* Amplitude Control Enable bit mask. */
+#define TCE_AMPEN_bp  3  /* Amplitude Control Enable bit position. */
+#define TCE_SCALEMODE_gm  0x30  /* Scaling Mode group mask. */
+#define TCE_SCALEMODE_gp  4  /* Scaling Mode group position. */
+#define TCE_SCALEMODE_0_bm  (1<<4)  /* Scaling Mode bit 0 mask. */
+#define TCE_SCALEMODE_0_bp  4  /* Scaling Mode bit 0 position. */
+#define TCE_SCALEMODE_1_bm  (1<<5)  /* Scaling Mode bit 1 mask. */
+#define TCE_SCALEMODE_1_bp  5  /* Scaling Mode bit 1 position. */
+#define TCE_HREN_gm  0xC0  /* High Resolution Enable group mask. */
+#define TCE_HREN_gp  6  /* High Resolution Enable group position. */
+#define TCE_HREN_0_bm  (1<<6)  /* High Resolution Enable bit 0 mask. */
+#define TCE_HREN_0_bp  6  /* High Resolution Enable bit 0 position. */
+#define TCE_HREN_1_bm  (1<<7)  /* High Resolution Enable bit 1 mask. */
+#define TCE_HREN_1_bp  7  /* High Resolution Enable bit 1 position. */
+
+/* TCE.CTRLECLR  bit masks and bit positions */
+#define TCE_DIR_bm  0x01  /* Direction bit mask. */
+#define TCE_DIR_bp  0  /* Direction bit position. */
+#define TCE_LUPD_bm  0x02  /* Lock Update bit mask. */
+#define TCE_LUPD_bp  1  /* Lock Update bit position. */
+#define TCE_CMD_gm  0x0C  /* Command group mask. */
+#define TCE_CMD_gp  2  /* Command group position. */
+#define TCE_CMD_0_bm  (1<<2)  /* Command bit 0 mask. */
+#define TCE_CMD_0_bp  2  /* Command bit 0 position. */
+#define TCE_CMD_1_bm  (1<<3)  /* Command bit 1 mask. */
+#define TCE_CMD_1_bp  3  /* Command bit 1 position. */
+
+/* TCE.CTRLESET  bit masks and bit positions */
+/* TCE_DIR  is already defined. */
+/* TCE_LUPD  is already defined. */
+/* TCE_CMD  is already defined. */
+
+/* TCE.CTRLFCLR  bit masks and bit positions */
+#define TCE_PERBV_bm  0x01  /* Period Buffer Valid bit mask. */
+#define TCE_PERBV_bp  0  /* Period Buffer Valid bit position. */
+#define TCE_CMP0BV_bm  0x02  /* Compare 0 Buffer Valid bit mask. */
+#define TCE_CMP0BV_bp  1  /* Compare 0 Buffer Valid bit position. */
+#define TCE_CMP1BV_bm  0x04  /* Compare 1 Buffer Valid bit mask. */
+#define TCE_CMP1BV_bp  2  /* Compare 1 Buffer Valid bit position. */
+#define TCE_CMP2BV_bm  0x08  /* Compare 2 Buffer Valid bit mask. */
+#define TCE_CMP2BV_bp  3  /* Compare 2 Buffer Valid bit position. */
+#define TCE_CMP3BV_bm  0x10  /* Compare 3 Buffer Valid bit mask. */
+#define TCE_CMP3BV_bp  4  /* Compare 3 Buffer Valid bit position. */
+
+/* TCE.CTRLFSET  bit masks and bit positions */
+/* TCE_PERBV  is already defined. */
+/* TCE_CMP0BV  is already defined. */
+/* TCE_CMP1BV  is already defined. */
+/* TCE_CMP2BV  is already defined. */
+/* TCE_CMP3BV  is already defined. */
+
+/* TCE.EVGENCTRL  bit masks and bit positions */
+#define TCE_CMP0EV_bm  0x10  /* Compare 0 Event bit mask. */
+#define TCE_CMP0EV_bp  4  /* Compare 0 Event bit position. */
+#define TCE_CMP1EV_bm  0x20  /* Compare 1 Event bit mask. */
+#define TCE_CMP1EV_bp  5  /* Compare 1 Event bit position. */
+#define TCE_CMP2EV_bm  0x40  /* Compare 2 Event bit mask. */
+#define TCE_CMP2EV_bp  6  /* Compare 2 Event bit position. */
+#define TCE_CMP3EV_bm  0x80  /* Compare 3 Event bit mask. */
+#define TCE_CMP3EV_bp  7  /* Compare 3 Event bit position. */
+
+/* TCE.EVCTRL  bit masks and bit positions */
+#define TCE_CNTAEI_bm  0x01  /* Count on Event Input A bit mask. */
+#define TCE_CNTAEI_bp  0  /* Count on Event Input A bit position. */
+#define TCE_EVACTA_gm  0x0E  /* Event Action A group mask. */
+#define TCE_EVACTA_gp  1  /* Event Action A group position. */
+#define TCE_EVACTA_0_bm  (1<<1)  /* Event Action A bit 0 mask. */
+#define TCE_EVACTA_0_bp  1  /* Event Action A bit 0 position. */
+#define TCE_EVACTA_1_bm  (1<<2)  /* Event Action A bit 1 mask. */
+#define TCE_EVACTA_1_bp  2  /* Event Action A bit 1 position. */
+#define TCE_EVACTA_2_bm  (1<<3)  /* Event Action A bit 2 mask. */
+#define TCE_EVACTA_2_bp  3  /* Event Action A bit 2 position. */
+#define TCE_CNTBEI_bm  0x10  /* Count on Event Input B bit mask. */
+#define TCE_CNTBEI_bp  4  /* Count on Event Input B bit position. */
+#define TCE_EVACTB_gm  0xE0  /* Event Action B group mask. */
+#define TCE_EVACTB_gp  5  /* Event Action B group position. */
+#define TCE_EVACTB_0_bm  (1<<5)  /* Event Action B bit 0 mask. */
+#define TCE_EVACTB_0_bp  5  /* Event Action B bit 0 position. */
+#define TCE_EVACTB_1_bm  (1<<6)  /* Event Action B bit 1 mask. */
+#define TCE_EVACTB_1_bp  6  /* Event Action B bit 1 position. */
+#define TCE_EVACTB_2_bm  (1<<7)  /* Event Action B bit 2 mask. */
+#define TCE_EVACTB_2_bp  7  /* Event Action B bit 2 position. */
+
+/* TCE.INTCTRL  bit masks and bit positions */
+#define TCE_OVF_bm  0x01  /* Overflow Interrupt Enable bit mask. */
+#define TCE_OVF_bp  0  /* Overflow Interrupt Enable bit position. */
+#define TCE_CMP0_bm  0x10  /* Compare 0 Interrupt Enable bit mask. */
+#define TCE_CMP0_bp  4  /* Compare 0 Interrupt Enable bit position. */
+#define TCE_CMP1_bm  0x20  /* Compare 1 Interrupt Enable bit mask. */
+#define TCE_CMP1_bp  5  /* Compare 1 Interrupt Enable bit position. */
+#define TCE_CMP2_bm  0x40  /* Compare 2 Interrupt Enable bit mask. */
+#define TCE_CMP2_bp  6  /* Compare 2 Interrupt Enable bit position. */
+#define TCE_CMP3_bm  0x80  /* Compare 3 Interrupt Enable bit mask. */
+#define TCE_CMP3_bp  7  /* Compare 3 Interrupt Enable bit position. */
+
+/* TCE.INTFLAGS  bit masks and bit positions */
+/* TCE_OVF  is already defined. */
+/* TCE_CMP0  is already defined. */
+/* TCE_CMP1  is already defined. */
+/* TCE_CMP2  is already defined. */
+/* TCE_CMP3  is already defined. */
+
+/* TCE.DBGCTRL  bit masks and bit positions */
+#define TCE_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define TCE_DBGRUN_bp  0  /* Debug Run bit position. */
+
+
+/* TCF - 24-bit Timer/Counter for frequency generation */
+/* TCF.CTRLA  bit masks and bit positions */
+#define TCF_ENABLE_bm  0x01  /* Enable bit mask. */
+#define TCF_ENABLE_bp  0  /* Enable bit position. */
+#define TCF_PRESC_gm  0x0E  /* Clock Prescaler group mask. */
+#define TCF_PRESC_gp  1  /* Clock Prescaler group position. */
+#define TCF_PRESC_0_bm  (1<<1)  /* Clock Prescaler bit 0 mask. */
+#define TCF_PRESC_0_bp  1  /* Clock Prescaler bit 0 position. */
+#define TCF_PRESC_1_bm  (1<<2)  /* Clock Prescaler bit 1 mask. */
+#define TCF_PRESC_1_bp  2  /* Clock Prescaler bit 1 position. */
+#define TCF_PRESC_2_bm  (1<<3)  /* Clock Prescaler bit 2 mask. */
+#define TCF_PRESC_2_bp  3  /* Clock Prescaler bit 2 position. */
+#define TCF_RUNSTDBY_bm  0x80  /* Run Standby bit mask. */
+#define TCF_RUNSTDBY_bp  7  /* Run Standby bit position. */
+
+/* TCF.CTRLB  bit masks and bit positions */
+#define TCF_WGMODE_gm  0x07  /* Waveform Generation Mode group mask. */
+#define TCF_WGMODE_gp  0  /* Waveform Generation Mode group position. */
+#define TCF_WGMODE_0_bm  (1<<0)  /* Waveform Generation Mode bit 0 mask. */
+#define TCF_WGMODE_0_bp  0  /* Waveform Generation Mode bit 0 position. */
+#define TCF_WGMODE_1_bm  (1<<1)  /* Waveform Generation Mode bit 1 mask. */
+#define TCF_WGMODE_1_bp  1  /* Waveform Generation Mode bit 1 position. */
+#define TCF_WGMODE_2_bm  (1<<2)  /* Waveform Generation Mode bit 2 mask. */
+#define TCF_WGMODE_2_bp  2  /* Waveform Generation Mode bit 2 position. */
+#define TCF_CLKSEL_gm  0x38  /* Clock Select group mask. */
+#define TCF_CLKSEL_gp  3  /* Clock Select group position. */
+#define TCF_CLKSEL_0_bm  (1<<3)  /* Clock Select bit 0 mask. */
+#define TCF_CLKSEL_0_bp  3  /* Clock Select bit 0 position. */
+#define TCF_CLKSEL_1_bm  (1<<4)  /* Clock Select bit 1 mask. */
+#define TCF_CLKSEL_1_bp  4  /* Clock Select bit 1 position. */
+#define TCF_CLKSEL_2_bm  (1<<5)  /* Clock Select bit 2 mask. */
+#define TCF_CLKSEL_2_bp  5  /* Clock Select bit 2 position. */
+#define TCF_CMP0EV_bm  0x40  /* Compare 0 Event Generation bit mask. */
+#define TCF_CMP0EV_bp  6  /* Compare 0 Event Generation bit position. */
+#define TCF_CMP1EV_bm  0x80  /* Compare 1 Event Generation bit mask. */
+#define TCF_CMP1EV_bp  7  /* Compare 1 Event Generation bit position. */
+
+/* TCF.CTRLC  bit masks and bit positions */
+#define TCF_WO0EN_bm  0x01  /* Waveform Output 0 Enable bit mask. */
+#define TCF_WO0EN_bp  0  /* Waveform Output 0 Enable bit position. */
+#define TCF_WO1EN_bm  0x02  /* Waveform Output 1 Enable bit mask. */
+#define TCF_WO1EN_bp  1  /* Waveform Output 1 Enable bit position. */
+#define TCF_WO0POL_bm  0x04  /* Waveform Output 0 Polarity bit mask. */
+#define TCF_WO0POL_bp  2  /* Waveform Output 0 Polarity bit position. */
+#define TCF_WO1POL_bm  0x08  /* Waveform Output 1 Polarity bit mask. */
+#define TCF_WO1POL_bp  3  /* Waveform Output 1 Polarity bit position. */
+#define TCF_WGPULSE_gm  0x70  /* Waveform Generation Pulse Length group mask. */
+#define TCF_WGPULSE_gp  4  /* Waveform Generation Pulse Length group position. */
+#define TCF_WGPULSE_0_bm  (1<<4)  /* Waveform Generation Pulse Length bit 0 mask. */
+#define TCF_WGPULSE_0_bp  4  /* Waveform Generation Pulse Length bit 0 position. */
+#define TCF_WGPULSE_1_bm  (1<<5)  /* Waveform Generation Pulse Length bit 1 mask. */
+#define TCF_WGPULSE_1_bp  5  /* Waveform Generation Pulse Length bit 1 position. */
+#define TCF_WGPULSE_2_bm  (1<<6)  /* Waveform Generation Pulse Length bit 2 mask. */
+#define TCF_WGPULSE_2_bp  6  /* Waveform Generation Pulse Length bit 2 position. */
+
+/* TCF.CTRLD  bit masks and bit positions */
+#define TCF_CMD_gm  0x03  /* Command group mask. */
+#define TCF_CMD_gp  0  /* Command group position. */
+#define TCF_CMD_0_bm  (1<<0)  /* Command bit 0 mask. */
+#define TCF_CMD_0_bp  0  /* Command bit 0 position. */
+#define TCF_CMD_1_bm  (1<<1)  /* Command bit 1 mask. */
+#define TCF_CMD_1_bp  1  /* Command bit 1 position. */
+
+/* TCF.EVCTRL  bit masks and bit positions */
+#define TCF_CNTAEI_bm  0x01  /* Event A Input Enable bit mask. */
+#define TCF_CNTAEI_bp  0  /* Event A Input Enable bit position. */
+#define TCF_EVACTA_gm  0x06  /* Event Action A group mask. */
+#define TCF_EVACTA_gp  1  /* Event Action A group position. */
+#define TCF_EVACTA_0_bm  (1<<1)  /* Event Action A bit 0 mask. */
+#define TCF_EVACTA_0_bp  1  /* Event Action A bit 0 position. */
+#define TCF_EVACTA_1_bm  (1<<2)  /* Event Action A bit 1 mask. */
+#define TCF_EVACTA_1_bp  2  /* Event Action A bit 1 position. */
+#define TCF_FILTERA_bm  0x08  /* Event A Filter bit mask. */
+#define TCF_FILTERA_bp  3  /* Event A Filter bit position. */
+
+/* TCF.INTCTRL  bit masks and bit positions */
+#define TCF_OVF_bm  0x01  /* Overflow bit mask. */
+#define TCF_OVF_bp  0  /* Overflow bit position. */
+#define TCF_CMP0_bm  0x02  /* Compare 0 Interrupt Enable bit mask. */
+#define TCF_CMP0_bp  1  /* Compare 0 Interrupt Enable bit position. */
+#define TCF_CMP1_bm  0x04  /* Compare 1 Interrupt Enable bit mask. */
+#define TCF_CMP1_bp  2  /* Compare 1 Interrupt Enable bit position. */
+
+/* TCF.INTFLAGS  bit masks and bit positions */
+/* TCF_OVF  is already defined. */
+/* TCF_CMP0  is already defined. */
+/* TCF_CMP1  is already defined. */
+
+/* TCF.STATUS  bit masks and bit positions */
+#define TCF_CTRLABUSY_bm  0x02  /* Control A Synchronization Busy bit mask. */
+#define TCF_CTRLABUSY_bp  1  /* Control A Synchronization Busy bit position. */
+#define TCF_CTRLCBUSY_bm  0x04  /* Control B Synchronization Busy bit mask. */
+#define TCF_CTRLCBUSY_bp  2  /* Control B Synchronization Busy bit position. */
+#define TCF_CTRLDBUSY_bm  0x08  /* Control D Synchronization Busy bit mask. */
+#define TCF_CTRLDBUSY_bp  3  /* Control D Synchronization Busy bit position. */
+#define TCF_CNTBUSY_bm  0x10  /* Counter Synchronization Busy bit mask. */
+#define TCF_CNTBUSY_bp  4  /* Counter Synchronization Busy bit position. */
+#define TCF_PERBUSY_bm  0x20  /* Period Synchronization Busy bit mask. */
+#define TCF_PERBUSY_bp  5  /* Period Synchronization Busy bit position. */
+#define TCF_CMP0BUSY_bm  0x40  /* Compare 0 Synchronization Busy bit mask. */
+#define TCF_CMP0BUSY_bp  6  /* Compare 0 Synchronization Busy bit position. */
+#define TCF_CMP1BUSY_bm  0x80  /* Compare 1 Synchronization Busy bit mask. */
+#define TCF_CMP1BUSY_bp  7  /* Compare 1 Synchronization Busy bit position. */
+
+/* TCF.DBGCTRL  bit masks and bit positions */
+#define TCF_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define TCF_DBGRUN_bp  0  /* Debug Run bit position. */
+
+/* TCF.CNT  bit masks and bit positions */
+#define TCF_CNT_gm  0xFFFFFF  /* Counter group mask. */
+#define TCF_CNT_gp  0  /* Counter group position. */
+#define TCF_CNT_0_bm  (1<<0)  /* Counter bit 0 mask. */
+#define TCF_CNT_0_bp  0  /* Counter bit 0 position. */
+#define TCF_CNT_1_bm  (1<<1)  /* Counter bit 1 mask. */
+#define TCF_CNT_1_bp  1  /* Counter bit 1 position. */
+#define TCF_CNT_2_bm  (1<<2)  /* Counter bit 2 mask. */
+#define TCF_CNT_2_bp  2  /* Counter bit 2 position. */
+#define TCF_CNT_3_bm  (1<<3)  /* Counter bit 3 mask. */
+#define TCF_CNT_3_bp  3  /* Counter bit 3 position. */
+#define TCF_CNT_4_bm  (1<<4)  /* Counter bit 4 mask. */
+#define TCF_CNT_4_bp  4  /* Counter bit 4 position. */
+#define TCF_CNT_5_bm  (1<<5)  /* Counter bit 5 mask. */
+#define TCF_CNT_5_bp  5  /* Counter bit 5 position. */
+#define TCF_CNT_6_bm  (1<<6)  /* Counter bit 6 mask. */
+#define TCF_CNT_6_bp  6  /* Counter bit 6 position. */
+#define TCF_CNT_7_bm  (1<<7)  /* Counter bit 7 mask. */
+#define TCF_CNT_7_bp  7  /* Counter bit 7 position. */
+#define TCF_CNT_8_bm  (1<<8)  /* Counter bit 8 mask. */
+#define TCF_CNT_8_bp  8  /* Counter bit 8 position. */
+#define TCF_CNT_9_bm  (1<<9)  /* Counter bit 9 mask. */
+#define TCF_CNT_9_bp  9  /* Counter bit 9 position. */
+#define TCF_CNT_10_bm  (1<<10)  /* Counter bit 10 mask. */
+#define TCF_CNT_10_bp  10  /* Counter bit 10 position. */
+#define TCF_CNT_11_bm  (1<<11)  /* Counter bit 11 mask. */
+#define TCF_CNT_11_bp  11  /* Counter bit 11 position. */
+#define TCF_CNT_12_bm  (1<<12)  /* Counter bit 12 mask. */
+#define TCF_CNT_12_bp  12  /* Counter bit 12 position. */
+#define TCF_CNT_13_bm  (1<<13)  /* Counter bit 13 mask. */
+#define TCF_CNT_13_bp  13  /* Counter bit 13 position. */
+#define TCF_CNT_14_bm  (1<<14)  /* Counter bit 14 mask. */
+#define TCF_CNT_14_bp  14  /* Counter bit 14 position. */
+#define TCF_CNT_15_bm  (1<<15)  /* Counter bit 15 mask. */
+#define TCF_CNT_15_bp  15  /* Counter bit 15 position. */
+#define TCF_CNT_16_bm  (1<<16)  /* Counter bit 16 mask. */
+#define TCF_CNT_16_bp  16  /* Counter bit 16 position. */
+#define TCF_CNT_17_bm  (1<<17)  /* Counter bit 17 mask. */
+#define TCF_CNT_17_bp  17  /* Counter bit 17 position. */
+#define TCF_CNT_18_bm  (1<<18)  /* Counter bit 18 mask. */
+#define TCF_CNT_18_bp  18  /* Counter bit 18 position. */
+#define TCF_CNT_19_bm  (1<<19)  /* Counter bit 19 mask. */
+#define TCF_CNT_19_bp  19  /* Counter bit 19 position. */
+#define TCF_CNT_20_bm  (1<<20)  /* Counter bit 20 mask. */
+#define TCF_CNT_20_bp  20  /* Counter bit 20 position. */
+#define TCF_CNT_21_bm  (1<<21)  /* Counter bit 21 mask. */
+#define TCF_CNT_21_bp  21  /* Counter bit 21 position. */
+#define TCF_CNT_22_bm  (1<<22)  /* Counter bit 22 mask. */
+#define TCF_CNT_22_bp  22  /* Counter bit 22 position. */
+#define TCF_CNT_23_bm  (1<<23)  /* Counter bit 23 mask. */
+#define TCF_CNT_23_bp  23  /* Counter bit 23 position. */
+
+/* TCF.CMP  bit masks and bit positions */
+#define TCF_CMP_gm  0xFFFFFF  /* Compare group mask. */
+#define TCF_CMP_gp  0  /* Compare group position. */
+#define TCF_CMP_0_bm  (1<<0)  /* Compare bit 0 mask. */
+#define TCF_CMP_0_bp  0  /* Compare bit 0 position. */
+#define TCF_CMP_1_bm  (1<<1)  /* Compare bit 1 mask. */
+#define TCF_CMP_1_bp  1  /* Compare bit 1 position. */
+#define TCF_CMP_2_bm  (1<<2)  /* Compare bit 2 mask. */
+#define TCF_CMP_2_bp  2  /* Compare bit 2 position. */
+#define TCF_CMP_3_bm  (1<<3)  /* Compare bit 3 mask. */
+#define TCF_CMP_3_bp  3  /* Compare bit 3 position. */
+#define TCF_CMP_4_bm  (1<<4)  /* Compare bit 4 mask. */
+#define TCF_CMP_4_bp  4  /* Compare bit 4 position. */
+#define TCF_CMP_5_bm  (1<<5)  /* Compare bit 5 mask. */
+#define TCF_CMP_5_bp  5  /* Compare bit 5 position. */
+#define TCF_CMP_6_bm  (1<<6)  /* Compare bit 6 mask. */
+#define TCF_CMP_6_bp  6  /* Compare bit 6 position. */
+#define TCF_CMP_7_bm  (1<<7)  /* Compare bit 7 mask. */
+#define TCF_CMP_7_bp  7  /* Compare bit 7 position. */
+#define TCF_CMP_8_bm  (1<<8)  /* Compare bit 8 mask. */
+#define TCF_CMP_8_bp  8  /* Compare bit 8 position. */
+#define TCF_CMP_9_bm  (1<<9)  /* Compare bit 9 mask. */
+#define TCF_CMP_9_bp  9  /* Compare bit 9 position. */
+#define TCF_CMP_10_bm  (1<<10)  /* Compare bit 10 mask. */
+#define TCF_CMP_10_bp  10  /* Compare bit 10 position. */
+#define TCF_CMP_11_bm  (1<<11)  /* Compare bit 11 mask. */
+#define TCF_CMP_11_bp  11  /* Compare bit 11 position. */
+#define TCF_CMP_12_bm  (1<<12)  /* Compare bit 12 mask. */
+#define TCF_CMP_12_bp  12  /* Compare bit 12 position. */
+#define TCF_CMP_13_bm  (1<<13)  /* Compare bit 13 mask. */
+#define TCF_CMP_13_bp  13  /* Compare bit 13 position. */
+#define TCF_CMP_14_bm  (1<<14)  /* Compare bit 14 mask. */
+#define TCF_CMP_14_bp  14  /* Compare bit 14 position. */
+#define TCF_CMP_15_bm  (1<<15)  /* Compare bit 15 mask. */
+#define TCF_CMP_15_bp  15  /* Compare bit 15 position. */
+#define TCF_CMP_16_bm  (1<<16)  /* Compare bit 16 mask. */
+#define TCF_CMP_16_bp  16  /* Compare bit 16 position. */
+#define TCF_CMP_17_bm  (1<<17)  /* Compare bit 17 mask. */
+#define TCF_CMP_17_bp  17  /* Compare bit 17 position. */
+#define TCF_CMP_18_bm  (1<<18)  /* Compare bit 18 mask. */
+#define TCF_CMP_18_bp  18  /* Compare bit 18 position. */
+#define TCF_CMP_19_bm  (1<<19)  /* Compare bit 19 mask. */
+#define TCF_CMP_19_bp  19  /* Compare bit 19 position. */
+#define TCF_CMP_20_bm  (1<<20)  /* Compare bit 20 mask. */
+#define TCF_CMP_20_bp  20  /* Compare bit 20 position. */
+#define TCF_CMP_21_bm  (1<<21)  /* Compare bit 21 mask. */
+#define TCF_CMP_21_bp  21  /* Compare bit 21 position. */
+#define TCF_CMP_22_bm  (1<<22)  /* Compare bit 22 mask. */
+#define TCF_CMP_22_bp  22  /* Compare bit 22 position. */
+#define TCF_CMP_23_bm  (1<<23)  /* Compare bit 23 mask. */
+#define TCF_CMP_23_bp  23  /* Compare bit 23 position. */
+
+
+/* TWI - Two-Wire Interface */
+/* TWI.CTRLA  bit masks and bit positions */
+#define TWI_FMEN_bm  0x01  /* Fast-mode Enable bit mask. */
+#define TWI_FMEN_bp  0  /* Fast-mode Enable bit position. */
+#define TWI_FMPEN_bm  0x02  /* Fast-mode Plus Enable bit mask. */
+#define TWI_FMPEN_bp  1  /* Fast-mode Plus Enable bit position. */
+#define TWI_SDAHOLD_gm  0x0C  /* SDA Hold Time group mask. */
+#define TWI_SDAHOLD_gp  2  /* SDA Hold Time group position. */
+#define TWI_SDAHOLD_0_bm  (1<<2)  /* SDA Hold Time bit 0 mask. */
+#define TWI_SDAHOLD_0_bp  2  /* SDA Hold Time bit 0 position. */
+#define TWI_SDAHOLD_1_bm  (1<<3)  /* SDA Hold Time bit 1 mask. */
+#define TWI_SDAHOLD_1_bp  3  /* SDA Hold Time bit 1 position. */
+#define TWI_SDASETUP_bm  0x10  /* SDA Setup Time bit mask. */
+#define TWI_SDASETUP_bp  4  /* SDA Setup Time bit position. */
+#define TWI_INPUTLVL_bm  0x40  /* Input voltage transition level bit mask. */
+#define TWI_INPUTLVL_bp  6  /* Input voltage transition level bit position. */
+
+/* TWI.DUALCTRL  bit masks and bit positions */
+#define TWI_ENABLE_bm  0x01  /* Enable bit mask. */
+#define TWI_ENABLE_bp  0  /* Enable bit position. */
+/* TWI_FMPEN  is already defined. */
+/* TWI_SDAHOLD  is already defined. */
+/* TWI_INPUTLVL  is already defined. */
+
+/* TWI.DBGCTRL  bit masks and bit positions */
+#define TWI_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define TWI_DBGRUN_bp  0  /* Debug Run bit position. */
+
+/* TWI.MCTRLA  bit masks and bit positions */
+/* TWI_ENABLE  is already defined. */
+#define TWI_SMEN_bm  0x02  /* Smart Mode Enable bit mask. */
+#define TWI_SMEN_bp  1  /* Smart Mode Enable bit position. */
+#define TWI_TIMEOUT_gm  0x0C  /* Inactive Bus Time-Out group mask. */
+#define TWI_TIMEOUT_gp  2  /* Inactive Bus Time-Out group position. */
+#define TWI_TIMEOUT_0_bm  (1<<2)  /* Inactive Bus Time-Out bit 0 mask. */
+#define TWI_TIMEOUT_0_bp  2  /* Inactive Bus Time-Out bit 0 position. */
+#define TWI_TIMEOUT_1_bm  (1<<3)  /* Inactive Bus Time-Out bit 1 mask. */
+#define TWI_TIMEOUT_1_bp  3  /* Inactive Bus Time-Out bit 1 position. */
+#define TWI_QCEN_bm  0x10  /* Quick Command Enable bit mask. */
+#define TWI_QCEN_bp  4  /* Quick Command Enable bit position. */
+#define TWI_WIEN_bm  0x40  /* Write Interrupt Enable bit mask. */
+#define TWI_WIEN_bp  6  /* Write Interrupt Enable bit position. */
+#define TWI_RIEN_bm  0x80  /* Read Interrupt Enable bit mask. */
+#define TWI_RIEN_bp  7  /* Read Interrupt Enable bit position. */
+
+/* TWI.MCTRLB  bit masks and bit positions */
+#define TWI_MCMD_gm  0x03  /* Command group mask. */
+#define TWI_MCMD_gp  0  /* Command group position. */
+#define TWI_MCMD_0_bm  (1<<0)  /* Command bit 0 mask. */
+#define TWI_MCMD_0_bp  0  /* Command bit 0 position. */
+#define TWI_MCMD_1_bm  (1<<1)  /* Command bit 1 mask. */
+#define TWI_MCMD_1_bp  1  /* Command bit 1 position. */
+#define TWI_ACKACT_bm  0x04  /* Acknowledge Action bit mask. */
+#define TWI_ACKACT_bp  2  /* Acknowledge Action bit position. */
+#define TWI_FLUSH_bm  0x08  /* Flush bit mask. */
+#define TWI_FLUSH_bp  3  /* Flush bit position. */
+
+/* TWI.MSTATUS  bit masks and bit positions */
+#define TWI_BUSSTATE_gm  0x03  /* Bus State group mask. */
+#define TWI_BUSSTATE_gp  0  /* Bus State group position. */
+#define TWI_BUSSTATE_0_bm  (1<<0)  /* Bus State bit 0 mask. */
+#define TWI_BUSSTATE_0_bp  0  /* Bus State bit 0 position. */
+#define TWI_BUSSTATE_1_bm  (1<<1)  /* Bus State bit 1 mask. */
+#define TWI_BUSSTATE_1_bp  1  /* Bus State bit 1 position. */
+#define TWI_BUSERR_bm  0x04  /* Bus Error bit mask. */
+#define TWI_BUSERR_bp  2  /* Bus Error bit position. */
+#define TWI_ARBLOST_bm  0x08  /* Arbitration Lost bit mask. */
+#define TWI_ARBLOST_bp  3  /* Arbitration Lost bit position. */
+#define TWI_RXACK_bm  0x10  /* Received Acknowledge bit mask. */
+#define TWI_RXACK_bp  4  /* Received Acknowledge bit position. */
+#define TWI_CLKHOLD_bm  0x20  /* Clock Hold bit mask. */
+#define TWI_CLKHOLD_bp  5  /* Clock Hold bit position. */
+#define TWI_WIF_bm  0x40  /* Write Interrupt Flag bit mask. */
+#define TWI_WIF_bp  6  /* Write Interrupt Flag bit position. */
+#define TWI_RIF_bm  0x80  /* Read Interrupt Flag bit mask. */
+#define TWI_RIF_bp  7  /* Read Interrupt Flag bit position. */
+
+/* TWI.MBAUD  bit masks and bit positions */
+#define TWI_BAUD_gm  0xFF  /* Baud Rate group mask. */
+#define TWI_BAUD_gp  0  /* Baud Rate group position. */
+#define TWI_BAUD_0_bm  (1<<0)  /* Baud Rate bit 0 mask. */
+#define TWI_BAUD_0_bp  0  /* Baud Rate bit 0 position. */
+#define TWI_BAUD_1_bm  (1<<1)  /* Baud Rate bit 1 mask. */
+#define TWI_BAUD_1_bp  1  /* Baud Rate bit 1 position. */
+#define TWI_BAUD_2_bm  (1<<2)  /* Baud Rate bit 2 mask. */
+#define TWI_BAUD_2_bp  2  /* Baud Rate bit 2 position. */
+#define TWI_BAUD_3_bm  (1<<3)  /* Baud Rate bit 3 mask. */
+#define TWI_BAUD_3_bp  3  /* Baud Rate bit 3 position. */
+#define TWI_BAUD_4_bm  (1<<4)  /* Baud Rate bit 4 mask. */
+#define TWI_BAUD_4_bp  4  /* Baud Rate bit 4 position. */
+#define TWI_BAUD_5_bm  (1<<5)  /* Baud Rate bit 5 mask. */
+#define TWI_BAUD_5_bp  5  /* Baud Rate bit 5 position. */
+#define TWI_BAUD_6_bm  (1<<6)  /* Baud Rate bit 6 mask. */
+#define TWI_BAUD_6_bp  6  /* Baud Rate bit 6 position. */
+#define TWI_BAUD_7_bm  (1<<7)  /* Baud Rate bit 7 mask. */
+#define TWI_BAUD_7_bp  7  /* Baud Rate bit 7 position. */
+
+/* TWI.MADDR  bit masks and bit positions */
+#define TWI_ADDR_gm  0xFF  /* Address group mask. */
+#define TWI_ADDR_gp  0  /* Address group position. */
+#define TWI_ADDR_0_bm  (1<<0)  /* Address bit 0 mask. */
+#define TWI_ADDR_0_bp  0  /* Address bit 0 position. */
+#define TWI_ADDR_1_bm  (1<<1)  /* Address bit 1 mask. */
+#define TWI_ADDR_1_bp  1  /* Address bit 1 position. */
+#define TWI_ADDR_2_bm  (1<<2)  /* Address bit 2 mask. */
+#define TWI_ADDR_2_bp  2  /* Address bit 2 position. */
+#define TWI_ADDR_3_bm  (1<<3)  /* Address bit 3 mask. */
+#define TWI_ADDR_3_bp  3  /* Address bit 3 position. */
+#define TWI_ADDR_4_bm  (1<<4)  /* Address bit 4 mask. */
+#define TWI_ADDR_4_bp  4  /* Address bit 4 position. */
+#define TWI_ADDR_5_bm  (1<<5)  /* Address bit 5 mask. */
+#define TWI_ADDR_5_bp  5  /* Address bit 5 position. */
+#define TWI_ADDR_6_bm  (1<<6)  /* Address bit 6 mask. */
+#define TWI_ADDR_6_bp  6  /* Address bit 6 position. */
+#define TWI_ADDR_7_bm  (1<<7)  /* Address bit 7 mask. */
+#define TWI_ADDR_7_bp  7  /* Address bit 7 position. */
+
+/* TWI.MDATA  bit masks and bit positions */
+#define TWI_DATA_gm  0xFF  /* Data group mask. */
+#define TWI_DATA_gp  0  /* Data group position. */
+#define TWI_DATA_0_bm  (1<<0)  /* Data bit 0 mask. */
+#define TWI_DATA_0_bp  0  /* Data bit 0 position. */
+#define TWI_DATA_1_bm  (1<<1)  /* Data bit 1 mask. */
+#define TWI_DATA_1_bp  1  /* Data bit 1 position. */
+#define TWI_DATA_2_bm  (1<<2)  /* Data bit 2 mask. */
+#define TWI_DATA_2_bp  2  /* Data bit 2 position. */
+#define TWI_DATA_3_bm  (1<<3)  /* Data bit 3 mask. */
+#define TWI_DATA_3_bp  3  /* Data bit 3 position. */
+#define TWI_DATA_4_bm  (1<<4)  /* Data bit 4 mask. */
+#define TWI_DATA_4_bp  4  /* Data bit 4 position. */
+#define TWI_DATA_5_bm  (1<<5)  /* Data bit 5 mask. */
+#define TWI_DATA_5_bp  5  /* Data bit 5 position. */
+#define TWI_DATA_6_bm  (1<<6)  /* Data bit 6 mask. */
+#define TWI_DATA_6_bp  6  /* Data bit 6 position. */
+#define TWI_DATA_7_bm  (1<<7)  /* Data bit 7 mask. */
+#define TWI_DATA_7_bp  7  /* Data bit 7 position. */
+
+/* TWI.SCTRLA  bit masks and bit positions */
+/* TWI_ENABLE  is already defined. */
+/* TWI_SMEN  is already defined. */
+#define TWI_PMEN_bm  0x04  /* Address Recognition Mode bit mask. */
+#define TWI_PMEN_bp  2  /* Address Recognition Mode bit position. */
+#define TWI_PIEN_bm  0x20  /* Stop Interrupt Enable bit mask. */
+#define TWI_PIEN_bp  5  /* Stop Interrupt Enable bit position. */
+#define TWI_APIEN_bm  0x40  /* Address or Stop Interrupt Enable bit mask. */
+#define TWI_APIEN_bp  6  /* Address or Stop Interrupt Enable bit position. */
+#define TWI_DIEN_bm  0x80  /* Data Interrupt Enable bit mask. */
+#define TWI_DIEN_bp  7  /* Data Interrupt Enable bit position. */
+
+/* TWI.SCTRLB  bit masks and bit positions */
+#define TWI_SCMD_gm  0x03  /* Command group mask. */
+#define TWI_SCMD_gp  0  /* Command group position. */
+#define TWI_SCMD_0_bm  (1<<0)  /* Command bit 0 mask. */
+#define TWI_SCMD_0_bp  0  /* Command bit 0 position. */
+#define TWI_SCMD_1_bm  (1<<1)  /* Command bit 1 mask. */
+#define TWI_SCMD_1_bp  1  /* Command bit 1 position. */
+/* TWI_ACKACT  is already defined. */
+
+/* TWI.SSTATUS  bit masks and bit positions */
+#define TWI_AP_bm  0x01  /* Address or Stop bit mask. */
+#define TWI_AP_bp  0  /* Address or Stop bit position. */
+#define TWI_DIR_bm  0x02  /* Read/Write Direction bit mask. */
+#define TWI_DIR_bp  1  /* Read/Write Direction bit position. */
+/* TWI_BUSERR  is already defined. */
+#define TWI_COLL_bm  0x08  /* Collision bit mask. */
+#define TWI_COLL_bp  3  /* Collision bit position. */
+/* TWI_RXACK  is already defined. */
+/* TWI_CLKHOLD  is already defined. */
+#define TWI_APIF_bm  0x40  /* Address or Stop Interrupt Flag bit mask. */
+#define TWI_APIF_bp  6  /* Address or Stop Interrupt Flag bit position. */
+#define TWI_DIF_bm  0x80  /* Data Interrupt Flag bit mask. */
+#define TWI_DIF_bp  7  /* Data Interrupt Flag bit position. */
+
+/* TWI.SADDR  bit masks and bit positions */
+/* TWI_ADDR  is already defined. */
+
+/* TWI.SDATA  bit masks and bit positions */
+/* TWI_DATA  is already defined. */
+
+/* TWI.SADDRMASK  bit masks and bit positions */
+#define TWI_ADDREN_bm  0x01  /* Address Mask Enable bit mask. */
+#define TWI_ADDREN_bp  0  /* Address Mask Enable bit position. */
+#define TWI_ADDRMASK_gm  0xFE  /* Address Mask group mask. */
+#define TWI_ADDRMASK_gp  1  /* Address Mask group position. */
+#define TWI_ADDRMASK_0_bm  (1<<1)  /* Address Mask bit 0 mask. */
+#define TWI_ADDRMASK_0_bp  1  /* Address Mask bit 0 position. */
+#define TWI_ADDRMASK_1_bm  (1<<2)  /* Address Mask bit 1 mask. */
+#define TWI_ADDRMASK_1_bp  2  /* Address Mask bit 1 position. */
+#define TWI_ADDRMASK_2_bm  (1<<3)  /* Address Mask bit 2 mask. */
+#define TWI_ADDRMASK_2_bp  3  /* Address Mask bit 2 position. */
+#define TWI_ADDRMASK_3_bm  (1<<4)  /* Address Mask bit 3 mask. */
+#define TWI_ADDRMASK_3_bp  4  /* Address Mask bit 3 position. */
+#define TWI_ADDRMASK_4_bm  (1<<5)  /* Address Mask bit 4 mask. */
+#define TWI_ADDRMASK_4_bp  5  /* Address Mask bit 4 position. */
+#define TWI_ADDRMASK_5_bm  (1<<6)  /* Address Mask bit 5 mask. */
+#define TWI_ADDRMASK_5_bp  6  /* Address Mask bit 5 position. */
+#define TWI_ADDRMASK_6_bm  (1<<7)  /* Address Mask bit 6 mask. */
+#define TWI_ADDRMASK_6_bp  7  /* Address Mask bit 6 position. */
+
+
+/* USART - Universal Synchronous and Asynchronous Receiver and Transmitter */
+/* USART.RXDATAL  bit masks and bit positions */
+#define USART_DATA_gm  0xFF  /* RX Data group mask. */
+#define USART_DATA_gp  0  /* RX Data group position. */
+#define USART_DATA_0_bm  (1<<0)  /* RX Data bit 0 mask. */
+#define USART_DATA_0_bp  0  /* RX Data bit 0 position. */
+#define USART_DATA_1_bm  (1<<1)  /* RX Data bit 1 mask. */
+#define USART_DATA_1_bp  1  /* RX Data bit 1 position. */
+#define USART_DATA_2_bm  (1<<2)  /* RX Data bit 2 mask. */
+#define USART_DATA_2_bp  2  /* RX Data bit 2 position. */
+#define USART_DATA_3_bm  (1<<3)  /* RX Data bit 3 mask. */
+#define USART_DATA_3_bp  3  /* RX Data bit 3 position. */
+#define USART_DATA_4_bm  (1<<4)  /* RX Data bit 4 mask. */
+#define USART_DATA_4_bp  4  /* RX Data bit 4 position. */
+#define USART_DATA_5_bm  (1<<5)  /* RX Data bit 5 mask. */
+#define USART_DATA_5_bp  5  /* RX Data bit 5 position. */
+#define USART_DATA_6_bm  (1<<6)  /* RX Data bit 6 mask. */
+#define USART_DATA_6_bp  6  /* RX Data bit 6 position. */
+#define USART_DATA_7_bm  (1<<7)  /* RX Data bit 7 mask. */
+#define USART_DATA_7_bp  7  /* RX Data bit 7 position. */
+
+/* USART.RXDATAH  bit masks and bit positions */
+#define USART_DATA8_bm  0x01  /* Receiver Data Register bit mask. */
+#define USART_DATA8_bp  0  /* Receiver Data Register bit position. */
+#define USART_PERR_bm  0x02  /* Parity Error bit mask. */
+#define USART_PERR_bp  1  /* Parity Error bit position. */
+#define USART_FERR_bm  0x04  /* Frame Error bit mask. */
+#define USART_FERR_bp  2  /* Frame Error bit position. */
+#define USART_BUFOVF_bm  0x40  /* Buffer Overflow bit mask. */
+#define USART_BUFOVF_bp  6  /* Buffer Overflow bit position. */
+#define USART_RXCIF_bm  0x80  /* Receive Complete Interrupt Flag bit mask. */
+#define USART_RXCIF_bp  7  /* Receive Complete Interrupt Flag bit position. */
+
+/* USART.TXDATAL  bit masks and bit positions */
+/* USART_DATA  is already defined. */
+
+/* USART.TXDATAH  bit masks and bit positions */
+/* USART_DATA8  is already defined. */
+
+/* USART.STATUS  bit masks and bit positions */
+#define USART_WFB_bm  0x01  /* Wait For Break bit mask. */
+#define USART_WFB_bp  0  /* Wait For Break bit position. */
+#define USART_BDF_bm  0x02  /* Break Detected Flag bit mask. */
+#define USART_BDF_bp  1  /* Break Detected Flag bit position. */
+#define USART_ISFIF_bm  0x08  /* Inconsistent Sync Field Interrupt Flag bit mask. */
+#define USART_ISFIF_bp  3  /* Inconsistent Sync Field Interrupt Flag bit position. */
+#define USART_RXSIF_bm  0x10  /* Receive Start Interrupt bit mask. */
+#define USART_RXSIF_bp  4  /* Receive Start Interrupt bit position. */
+#define USART_DREIF_bm  0x20  /* Data Register Empty Flag bit mask. */
+#define USART_DREIF_bp  5  /* Data Register Empty Flag bit position. */
+#define USART_TXCIF_bm  0x40  /* Transmit Interrupt Flag bit mask. */
+#define USART_TXCIF_bp  6  /* Transmit Interrupt Flag bit position. */
+/* USART_RXCIF  is already defined. */
+
+/* USART.CTRLA  bit masks and bit positions */
+#define USART_RS485_bm  0x01  /* RS485 Mode internal transmitter bit mask. */
+#define USART_RS485_bp  0  /* RS485 Mode internal transmitter bit position. */
+#define USART_ABEIE_bm  0x04  /* Auto-baud Error Interrupt Enable bit mask. */
+#define USART_ABEIE_bp  2  /* Auto-baud Error Interrupt Enable bit position. */
+#define USART_LBME_bm  0x08  /* Loop-back Mode Enable bit mask. */
+#define USART_LBME_bp  3  /* Loop-back Mode Enable bit position. */
+#define USART_RXSIE_bm  0x10  /* Receiver Start Frame Interrupt Enable bit mask. */
+#define USART_RXSIE_bp  4  /* Receiver Start Frame Interrupt Enable bit position. */
+#define USART_DREIE_bm  0x20  /* Data Register Empty Interrupt Enable bit mask. */
+#define USART_DREIE_bp  5  /* Data Register Empty Interrupt Enable bit position. */
+#define USART_TXCIE_bm  0x40  /* Transmit Complete Interrupt Enable bit mask. */
+#define USART_TXCIE_bp  6  /* Transmit Complete Interrupt Enable bit position. */
+#define USART_RXCIE_bm  0x80  /* Receive Complete Interrupt Enable bit mask. */
+#define USART_RXCIE_bp  7  /* Receive Complete Interrupt Enable bit position. */
+
+/* USART.CTRLB  bit masks and bit positions */
+#define USART_MPCM_bm  0x01  /* Multi-processor Communication Mode bit mask. */
+#define USART_MPCM_bp  0  /* Multi-processor Communication Mode bit position. */
+#define USART_RXMODE_gm  0x06  /* Receiver Mode group mask. */
+#define USART_RXMODE_gp  1  /* Receiver Mode group position. */
+#define USART_RXMODE_0_bm  (1<<1)  /* Receiver Mode bit 0 mask. */
+#define USART_RXMODE_0_bp  1  /* Receiver Mode bit 0 position. */
+#define USART_RXMODE_1_bm  (1<<2)  /* Receiver Mode bit 1 mask. */
+#define USART_RXMODE_1_bp  2  /* Receiver Mode bit 1 position. */
+#define USART_ODME_bm  0x08  /* Open Drain Mode Enable bit mask. */
+#define USART_ODME_bp  3  /* Open Drain Mode Enable bit position. */
+#define USART_SFDEN_bm  0x10  /* Start Frame Detection Enable bit mask. */
+#define USART_SFDEN_bp  4  /* Start Frame Detection Enable bit position. */
+#define USART_TXEN_bm  0x40  /* Transmitter Enable bit mask. */
+#define USART_TXEN_bp  6  /* Transmitter Enable bit position. */
+#define USART_RXEN_bm  0x80  /* Reciever enable bit mask. */
+#define USART_RXEN_bp  7  /* Reciever enable bit position. */
+
+/* USART.CTRLC  bit masks and bit positions */
+#define USART_UCPHA_bm  0x02  /* SPI Host Mode, Clock Phase bit mask. */
+#define USART_UCPHA_bp  1  /* SPI Host Mode, Clock Phase bit position. */
+#define USART_UDORD_bm  0x04  /* SPI Host Mode, Data Order bit mask. */
+#define USART_UDORD_bp  2  /* SPI Host Mode, Data Order bit position. */
+#define USART_CHSIZE_gm  0x07  /* Character Size group mask. */
+#define USART_CHSIZE_gp  0  /* Character Size group position. */
+#define USART_CHSIZE_0_bm  (1<<0)  /* Character Size bit 0 mask. */
+#define USART_CHSIZE_0_bp  0  /* Character Size bit 0 position. */
+#define USART_CHSIZE_1_bm  (1<<1)  /* Character Size bit 1 mask. */
+#define USART_CHSIZE_1_bp  1  /* Character Size bit 1 position. */
+#define USART_CHSIZE_2_bm  (1<<2)  /* Character Size bit 2 mask. */
+#define USART_CHSIZE_2_bp  2  /* Character Size bit 2 position. */
+#define USART_SBMODE_bm  0x08  /* Stop Bit Mode bit mask. */
+#define USART_SBMODE_bp  3  /* Stop Bit Mode bit position. */
+#define USART_PMODE_gm  0x30  /* Parity Mode group mask. */
+#define USART_PMODE_gp  4  /* Parity Mode group position. */
+#define USART_PMODE_0_bm  (1<<4)  /* Parity Mode bit 0 mask. */
+#define USART_PMODE_0_bp  4  /* Parity Mode bit 0 position. */
+#define USART_PMODE_1_bm  (1<<5)  /* Parity Mode bit 1 mask. */
+#define USART_PMODE_1_bp  5  /* Parity Mode bit 1 position. */
+#define USART_CMODE_gm  0xC0  /* Communication Mode group mask. */
+#define USART_CMODE_gp  6  /* Communication Mode group position. */
+#define USART_CMODE_0_bm  (1<<6)  /* Communication Mode bit 0 mask. */
+#define USART_CMODE_0_bp  6  /* Communication Mode bit 0 position. */
+#define USART_CMODE_1_bm  (1<<7)  /* Communication Mode bit 1 mask. */
+#define USART_CMODE_1_bp  7  /* Communication Mode bit 1 position. */
+
+/* USART.CTRLD  bit masks and bit positions */
+#define USART_ABW_gm  0xC0  /* Auto Baud Window group mask. */
+#define USART_ABW_gp  6  /* Auto Baud Window group position. */
+#define USART_ABW_0_bm  (1<<6)  /* Auto Baud Window bit 0 mask. */
+#define USART_ABW_0_bp  6  /* Auto Baud Window bit 0 position. */
+#define USART_ABW_1_bm  (1<<7)  /* Auto Baud Window bit 1 mask. */
+#define USART_ABW_1_bp  7  /* Auto Baud Window bit 1 position. */
+
+/* USART.DBGCTRL  bit masks and bit positions */
+#define USART_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define USART_DBGRUN_bp  0  /* Debug Run bit position. */
+
+/* USART.EVCTRL  bit masks and bit positions */
+#define USART_IREI_bm  0x01  /* IrDA Event Input Enable bit mask. */
+#define USART_IREI_bp  0  /* IrDA Event Input Enable bit position. */
+
+/* USART.TXPLCTRL  bit masks and bit positions */
+#define USART_TXPL_gm  0xFF  /* Transmit pulse length group mask. */
+#define USART_TXPL_gp  0  /* Transmit pulse length group position. */
+#define USART_TXPL_0_bm  (1<<0)  /* Transmit pulse length bit 0 mask. */
+#define USART_TXPL_0_bp  0  /* Transmit pulse length bit 0 position. */
+#define USART_TXPL_1_bm  (1<<1)  /* Transmit pulse length bit 1 mask. */
+#define USART_TXPL_1_bp  1  /* Transmit pulse length bit 1 position. */
+#define USART_TXPL_2_bm  (1<<2)  /* Transmit pulse length bit 2 mask. */
+#define USART_TXPL_2_bp  2  /* Transmit pulse length bit 2 position. */
+#define USART_TXPL_3_bm  (1<<3)  /* Transmit pulse length bit 3 mask. */
+#define USART_TXPL_3_bp  3  /* Transmit pulse length bit 3 position. */
+#define USART_TXPL_4_bm  (1<<4)  /* Transmit pulse length bit 4 mask. */
+#define USART_TXPL_4_bp  4  /* Transmit pulse length bit 4 position. */
+#define USART_TXPL_5_bm  (1<<5)  /* Transmit pulse length bit 5 mask. */
+#define USART_TXPL_5_bp  5  /* Transmit pulse length bit 5 position. */
+#define USART_TXPL_6_bm  (1<<6)  /* Transmit pulse length bit 6 mask. */
+#define USART_TXPL_6_bp  6  /* Transmit pulse length bit 6 position. */
+#define USART_TXPL_7_bm  (1<<7)  /* Transmit pulse length bit 7 mask. */
+#define USART_TXPL_7_bp  7  /* Transmit pulse length bit 7 position. */
+
+/* USART.RXPLCTRL  bit masks and bit positions */
+#define USART_RXPL_gm  0x7F  /* Receiver Pulse Lenght group mask. */
+#define USART_RXPL_gp  0  /* Receiver Pulse Lenght group position. */
+#define USART_RXPL_0_bm  (1<<0)  /* Receiver Pulse Lenght bit 0 mask. */
+#define USART_RXPL_0_bp  0  /* Receiver Pulse Lenght bit 0 position. */
+#define USART_RXPL_1_bm  (1<<1)  /* Receiver Pulse Lenght bit 1 mask. */
+#define USART_RXPL_1_bp  1  /* Receiver Pulse Lenght bit 1 position. */
+#define USART_RXPL_2_bm  (1<<2)  /* Receiver Pulse Lenght bit 2 mask. */
+#define USART_RXPL_2_bp  2  /* Receiver Pulse Lenght bit 2 position. */
+#define USART_RXPL_3_bm  (1<<3)  /* Receiver Pulse Lenght bit 3 mask. */
+#define USART_RXPL_3_bp  3  /* Receiver Pulse Lenght bit 3 position. */
+#define USART_RXPL_4_bm  (1<<4)  /* Receiver Pulse Lenght bit 4 mask. */
+#define USART_RXPL_4_bp  4  /* Receiver Pulse Lenght bit 4 position. */
+#define USART_RXPL_5_bm  (1<<5)  /* Receiver Pulse Lenght bit 5 mask. */
+#define USART_RXPL_5_bp  5  /* Receiver Pulse Lenght bit 5 position. */
+#define USART_RXPL_6_bm  (1<<6)  /* Receiver Pulse Lenght bit 6 mask. */
+#define USART_RXPL_6_bp  6  /* Receiver Pulse Lenght bit 6 position. */
+
+
+
+/* VPORT - Virtual Ports */
+/* VPORT.INTFLAGS  bit masks and bit positions */
+#define VPORT_INT_gm  0xFF  /* Pin Interrupt Flag group mask. */
+#define VPORT_INT_gp  0  /* Pin Interrupt Flag group position. */
+#define VPORT_INT_0_bm  (1<<0)  /* Pin Interrupt Flag bit 0 mask. */
+#define VPORT_INT_0_bp  0  /* Pin Interrupt Flag bit 0 position. */
+#define VPORT_INT_1_bm  (1<<1)  /* Pin Interrupt Flag bit 1 mask. */
+#define VPORT_INT_1_bp  1  /* Pin Interrupt Flag bit 1 position. */
+#define VPORT_INT_2_bm  (1<<2)  /* Pin Interrupt Flag bit 2 mask. */
+#define VPORT_INT_2_bp  2  /* Pin Interrupt Flag bit 2 position. */
+#define VPORT_INT_3_bm  (1<<3)  /* Pin Interrupt Flag bit 3 mask. */
+#define VPORT_INT_3_bp  3  /* Pin Interrupt Flag bit 3 position. */
+#define VPORT_INT_4_bm  (1<<4)  /* Pin Interrupt Flag bit 4 mask. */
+#define VPORT_INT_4_bp  4  /* Pin Interrupt Flag bit 4 position. */
+#define VPORT_INT_5_bm  (1<<5)  /* Pin Interrupt Flag bit 5 mask. */
+#define VPORT_INT_5_bp  5  /* Pin Interrupt Flag bit 5 position. */
+#define VPORT_INT_6_bm  (1<<6)  /* Pin Interrupt Flag bit 6 mask. */
+#define VPORT_INT_6_bp  6  /* Pin Interrupt Flag bit 6 position. */
+#define VPORT_INT_7_bm  (1<<7)  /* Pin Interrupt Flag bit 7 mask. */
+#define VPORT_INT_7_bp  7  /* Pin Interrupt Flag bit 7 position. */
+
+
+/* VREF - Voltage reference */
+/* VREF.DAC0REF  bit masks and bit positions */
+#define VREF_REFSEL_gm  0x07  /* Reference select group mask. */
+#define VREF_REFSEL_gp  0  /* Reference select group position. */
+#define VREF_REFSEL_0_bm  (1<<0)  /* Reference select bit 0 mask. */
+#define VREF_REFSEL_0_bp  0  /* Reference select bit 0 position. */
+#define VREF_REFSEL_1_bm  (1<<1)  /* Reference select bit 1 mask. */
+#define VREF_REFSEL_1_bp  1  /* Reference select bit 1 position. */
+#define VREF_REFSEL_2_bm  (1<<2)  /* Reference select bit 2 mask. */
+#define VREF_REFSEL_2_bp  2  /* Reference select bit 2 position. */
+#define VREF_ALWAYSON_bm  0x80  /* Always on bit mask. */
+#define VREF_ALWAYSON_bp  7  /* Always on bit position. */
+
+/* VREF.ACREF  bit masks and bit positions */
+/* VREF_REFSEL  is already defined. */
+/* VREF_ALWAYSON  is already defined. */
+
+
+/* WDT - Watch-Dog Timer */
+/* WDT.CTRLA  bit masks and bit positions */
+#define WDT_PERIOD_gm  0x0F  /* Period group mask. */
+#define WDT_PERIOD_gp  0  /* Period group position. */
+#define WDT_PERIOD_0_bm  (1<<0)  /* Period bit 0 mask. */
+#define WDT_PERIOD_0_bp  0  /* Period bit 0 position. */
+#define WDT_PERIOD_1_bm  (1<<1)  /* Period bit 1 mask. */
+#define WDT_PERIOD_1_bp  1  /* Period bit 1 position. */
+#define WDT_PERIOD_2_bm  (1<<2)  /* Period bit 2 mask. */
+#define WDT_PERIOD_2_bp  2  /* Period bit 2 position. */
+#define WDT_PERIOD_3_bm  (1<<3)  /* Period bit 3 mask. */
+#define WDT_PERIOD_3_bp  3  /* Period bit 3 position. */
+#define WDT_WINDOW_gm  0xF0  /* Window group mask. */
+#define WDT_WINDOW_gp  4  /* Window group position. */
+#define WDT_WINDOW_0_bm  (1<<4)  /* Window bit 0 mask. */
+#define WDT_WINDOW_0_bp  4  /* Window bit 0 position. */
+#define WDT_WINDOW_1_bm  (1<<5)  /* Window bit 1 mask. */
+#define WDT_WINDOW_1_bp  5  /* Window bit 1 position. */
+#define WDT_WINDOW_2_bm  (1<<6)  /* Window bit 2 mask. */
+#define WDT_WINDOW_2_bp  6  /* Window bit 2 position. */
+#define WDT_WINDOW_3_bm  (1<<7)  /* Window bit 3 mask. */
+#define WDT_WINDOW_3_bp  7  /* Window bit 3 position. */
+
+/* WDT.STATUS  bit masks and bit positions */
+#define WDT_SYNCBUSY_bm  0x01  /* Syncronization busy bit mask. */
+#define WDT_SYNCBUSY_bp  0  /* Syncronization busy bit position. */
+#define WDT_LOCK_bm  0x80  /* Lock enable bit mask. */
+#define WDT_LOCK_bp  7  /* Lock enable bit position. */
+
+
+/* WEX - Waveform Extension */
+/* WEX.CTRLA  bit masks and bit positions */
+#define WEX_DTI0EN_bm  0x01  /* Dead-Time Insertion CMP0 Enable bit mask. */
+#define WEX_DTI0EN_bp  0  /* Dead-Time Insertion CMP0 Enable bit position. */
+#define WEX_DTI1EN_bm  0x02  /* Dead-Time Insertion CMP1 Enable bit mask. */
+#define WEX_DTI1EN_bp  1  /* Dead-Time Insertion CMP1 Enable bit position. */
+#define WEX_DTI2EN_bm  0x04  /* Dead-Time Insertion CMP2 Enable bit mask. */
+#define WEX_DTI2EN_bp  2  /* Dead-Time Insertion CMP2 Enable bit position. */
+#define WEX_DTI3EN_bm  0x08  /* Dead-Time Insertion CMP3 Enable bit mask. */
+#define WEX_DTI3EN_bp  3  /* Dead-Time Insertion CMP3 Enable bit position. */
+#define WEX_INMX_gm  0x70  /* Input Matrix group mask. */
+#define WEX_INMX_gp  4  /* Input Matrix group position. */
+#define WEX_INMX_0_bm  (1<<4)  /* Input Matrix bit 0 mask. */
+#define WEX_INMX_0_bp  4  /* Input Matrix bit 0 position. */
+#define WEX_INMX_1_bm  (1<<5)  /* Input Matrix bit 1 mask. */
+#define WEX_INMX_1_bp  5  /* Input Matrix bit 1 position. */
+#define WEX_INMX_2_bm  (1<<6)  /* Input Matrix bit 2 mask. */
+#define WEX_INMX_2_bp  6  /* Input Matrix bit 2 position. */
+#define WEX_PGM_bm  0x80  /* Pattern Generation Mode bit mask. */
+#define WEX_PGM_bp  7  /* Pattern Generation Mode bit position. */
+
+/* WEX.CTRLB  bit masks and bit positions */
+#define WEX_UPDSRC_gm  0x03  /* Update Source group mask. */
+#define WEX_UPDSRC_gp  0  /* Update Source group position. */
+#define WEX_UPDSRC_0_bm  (1<<0)  /* Update Source bit 0 mask. */
+#define WEX_UPDSRC_0_bp  0  /* Update Source bit 0 position. */
+#define WEX_UPDSRC_1_bm  (1<<1)  /* Update Source bit 1 mask. */
+#define WEX_UPDSRC_1_bp  1  /* Update Source bit 1 position. */
+
+/* WEX.CTRLC  bit masks and bit positions */
+#define WEX_CMD_gm  0x07  /* Command group mask. */
+#define WEX_CMD_gp  0  /* Command group position. */
+#define WEX_CMD_0_bm  (1<<0)  /* Command bit 0 mask. */
+#define WEX_CMD_0_bp  0  /* Command bit 0 position. */
+#define WEX_CMD_1_bm  (1<<1)  /* Command bit 1 mask. */
+#define WEX_CMD_1_bp  1  /* Command bit 1 position. */
+#define WEX_CMD_2_bm  (1<<2)  /* Command bit 2 mask. */
+#define WEX_CMD_2_bp  2  /* Command bit 2 position. */
+
+/* WEX.EVCTRLA  bit masks and bit positions */
+#define WEX_FAULTEI_bm  0x01  /* Fault Event Input Enable bit mask. */
+#define WEX_FAULTEI_bp  0  /* Fault Event Input Enable bit position. */
+#define WEX_BLANK_bm  0x02  /* Fault Event Blanking Enable bit mask. */
+#define WEX_BLANK_bp  1  /* Fault Event Blanking Enable bit position. */
+#define WEX_FILTER_gm  0x1C  /* Fault Event Filter Enable group mask. */
+#define WEX_FILTER_gp  2  /* Fault Event Filter Enable group position. */
+#define WEX_FILTER_0_bm  (1<<2)  /* Fault Event Filter Enable bit 0 mask. */
+#define WEX_FILTER_0_bp  2  /* Fault Event Filter Enable bit 0 position. */
+#define WEX_FILTER_1_bm  (1<<3)  /* Fault Event Filter Enable bit 1 mask. */
+#define WEX_FILTER_1_bp  3  /* Fault Event Filter Enable bit 1 position. */
+#define WEX_FILTER_2_bm  (1<<4)  /* Fault Event Filter Enable bit 2 mask. */
+#define WEX_FILTER_2_bp  4  /* Fault Event Filter Enable bit 2 position. */
+
+/* WEX.EVCTRLB  bit masks and bit positions */
+/* WEX_FAULTEI  is already defined. */
+/* WEX_BLANK  is already defined. */
+/* WEX_FILTER  is already defined. */
+
+/* WEX.EVCTRLC  bit masks and bit positions */
+/* WEX_FAULTEI  is already defined. */
+/* WEX_BLANK  is already defined. */
+/* WEX_FILTER  is already defined. */
+
+/* WEX.BUFCTRL  bit masks and bit positions */
+#define WEX_DTLSBV_bm  0x01  /* Dead-time Low Side Buffer Valid bit mask. */
+#define WEX_DTLSBV_bp  0  /* Dead-time Low Side Buffer Valid bit position. */
+#define WEX_DTHSBV_bm  0x02  /* Dead-time High Side Buffer Valid bit mask. */
+#define WEX_DTHSBV_bp  1  /* Dead-time High Side Buffer Valid bit position. */
+#define WEX_SWAPBV_bm  0x04  /* Swap Buffer Valid bit mask. */
+#define WEX_SWAPBV_bp  2  /* Swap Buffer Valid bit position. */
+#define WEX_PGMOVRBV_bm  0x08  /* PGM Override Buffer Valid bit mask. */
+#define WEX_PGMOVRBV_bp  3  /* PGM Override Buffer Valid bit position. */
+#define WEX_PGMOUTBV_bm  0x10  /* PGM Output Value Buffer Valid bit mask. */
+#define WEX_PGMOUTBV_bp  4  /* PGM Output Value Buffer Valid bit position. */
+
+/* WEX.BLANKCTRL  bit masks and bit positions */
+#define WEX_BLANKTRIG_gm  0x1F  /* Blanking Trigger group mask. */
+#define WEX_BLANKTRIG_gp  0  /* Blanking Trigger group position. */
+#define WEX_BLANKTRIG_0_bm  (1<<0)  /* Blanking Trigger bit 0 mask. */
+#define WEX_BLANKTRIG_0_bp  0  /* Blanking Trigger bit 0 position. */
+#define WEX_BLANKTRIG_1_bm  (1<<1)  /* Blanking Trigger bit 1 mask. */
+#define WEX_BLANKTRIG_1_bp  1  /* Blanking Trigger bit 1 position. */
+#define WEX_BLANKTRIG_2_bm  (1<<2)  /* Blanking Trigger bit 2 mask. */
+#define WEX_BLANKTRIG_2_bp  2  /* Blanking Trigger bit 2 position. */
+#define WEX_BLANKTRIG_3_bm  (1<<3)  /* Blanking Trigger bit 3 mask. */
+#define WEX_BLANKTRIG_3_bp  3  /* Blanking Trigger bit 3 position. */
+#define WEX_BLANKTRIG_4_bm  (1<<4)  /* Blanking Trigger bit 4 mask. */
+#define WEX_BLANKTRIG_4_bp  4  /* Blanking Trigger bit 4 position. */
+#define WEX_BLANKPRESC_gm  0x60  /* Blanking Prescaler group mask. */
+#define WEX_BLANKPRESC_gp  5  /* Blanking Prescaler group position. */
+#define WEX_BLANKPRESC_0_bm  (1<<5)  /* Blanking Prescaler bit 0 mask. */
+#define WEX_BLANKPRESC_0_bp  5  /* Blanking Prescaler bit 0 position. */
+#define WEX_BLANKPRESC_1_bm  (1<<6)  /* Blanking Prescaler bit 1 mask. */
+#define WEX_BLANKPRESC_1_bp  6  /* Blanking Prescaler bit 1 position. */
+
+/* WEX.FAULTCTRL  bit masks and bit positions */
+#define WEX_FDACT_gm  0x03  /* Fault Detection Action group mask. */
+#define WEX_FDACT_gp  0  /* Fault Detection Action group position. */
+#define WEX_FDACT_0_bm  (1<<0)  /* Fault Detection Action bit 0 mask. */
+#define WEX_FDACT_0_bp  0  /* Fault Detection Action bit 0 position. */
+#define WEX_FDACT_1_bm  (1<<1)  /* Fault Detection Action bit 1 mask. */
+#define WEX_FDACT_1_bp  1  /* Fault Detection Action bit 1 position. */
+#define WEX_FDMODE_bm  0x04  /* Fault Detection Restart Mode bit mask. */
+#define WEX_FDMODE_bp  2  /* Fault Detection Restart Mode bit position. */
+#define WEX_FDDBD_bm  0x80  /* Fault Detection on Debug Break Detection bit mask. */
+#define WEX_FDDBD_bp  7  /* Fault Detection on Debug Break Detection bit position. */
+
+/* WEX.FAULTDRV  bit masks and bit positions */
+#define WEX_FAULTDRV0_bm  0x01  /* Fault Drive Enable Bit 0 bit mask. */
+#define WEX_FAULTDRV0_bp  0  /* Fault Drive Enable Bit 0 bit position. */
+#define WEX_FAULTDRV1_bm  0x02  /* Fault Drive Enable Bit 1 bit mask. */
+#define WEX_FAULTDRV1_bp  1  /* Fault Drive Enable Bit 1 bit position. */
+#define WEX_FAULTDRV2_bm  0x04  /* Fault Drive Enable Bit 2 bit mask. */
+#define WEX_FAULTDRV2_bp  2  /* Fault Drive Enable Bit 2 bit position. */
+#define WEX_FAULTDRV3_bm  0x08  /* Fault Drive Enable Bit 3 bit mask. */
+#define WEX_FAULTDRV3_bp  3  /* Fault Drive Enable Bit 3 bit position. */
+#define WEX_FAULTDRV4_bm  0x10  /* Fault Drive Enable Bit 4 bit mask. */
+#define WEX_FAULTDRV4_bp  4  /* Fault Drive Enable Bit 4 bit position. */
+#define WEX_FAULTDRV5_bm  0x20  /* Fault Drive Enable Bit 5 bit mask. */
+#define WEX_FAULTDRV5_bp  5  /* Fault Drive Enable Bit 5 bit position. */
+#define WEX_FAULTDRV6_bm  0x40  /* Fault Drive Enable Bit 6 bit mask. */
+#define WEX_FAULTDRV6_bp  6  /* Fault Drive Enable Bit 6 bit position. */
+#define WEX_FAULTDRV7_bm  0x80  /* Fault Drive Enable Bit 7 bit mask. */
+#define WEX_FAULTDRV7_bp  7  /* Fault Drive Enable Bit 7 bit position. */
+
+/* WEX.FAULTOUT  bit masks and bit positions */
+#define WEX_FAULTOUT0_bm  0x01  /* Fault Output Value Bit 0 bit mask. */
+#define WEX_FAULTOUT0_bp  0  /* Fault Output Value Bit 0 bit position. */
+#define WEX_FAULTOUT1_bm  0x02  /* Fault Output Value Bit 1 bit mask. */
+#define WEX_FAULTOUT1_bp  1  /* Fault Output Value Bit 1 bit position. */
+#define WEX_FAULTOUT2_bm  0x04  /* Fault Output Value Bit 2 bit mask. */
+#define WEX_FAULTOUT2_bp  2  /* Fault Output Value Bit 2 bit position. */
+#define WEX_FAULTOUT3_bm  0x08  /* Fault Output Value Bit 3 bit mask. */
+#define WEX_FAULTOUT3_bp  3  /* Fault Output Value Bit 3 bit position. */
+#define WEX_FAULTOUT4_bm  0x10  /* Fault Output Value Bit 4 bit mask. */
+#define WEX_FAULTOUT4_bp  4  /* Fault Output Value Bit 4 bit position. */
+#define WEX_FAULTOUT5_bm  0x20  /* Fault Output Value Bit 5 bit mask. */
+#define WEX_FAULTOUT5_bp  5  /* Fault Output Value Bit 5 bit position. */
+#define WEX_FAULTOUT6_bm  0x40  /* Fault Output Value Bit 6 bit mask. */
+#define WEX_FAULTOUT6_bp  6  /* Fault Output Value Bit 6 bit position. */
+#define WEX_FAULTOUT7_bm  0x80  /* Fault Output Value Bit 7 bit mask. */
+#define WEX_FAULTOUT7_bp  7  /* Fault Output Value Bit 7 bit position. */
+
+/* WEX.INTCTRL  bit masks and bit positions */
+#define WEX_FAULTDET_bm  0x01  /* Fault Detection Interrupt Enable bit mask. */
+#define WEX_FAULTDET_bp  0  /* Fault Detection Interrupt Enable bit position. */
+
+/* WEX.INTFLAGS  bit masks and bit positions */
+/* WEX_FAULTDET  is already defined. */
+#define WEX_FDFEVA_bm  0x04  /* Fault Detection Flag Event Input A bit mask. */
+#define WEX_FDFEVA_bp  2  /* Fault Detection Flag Event Input A bit position. */
+#define WEX_FDFEVB_bm  0x08  /* Fault Detection Flag Event Input B bit mask. */
+#define WEX_FDFEVB_bp  3  /* Fault Detection Flag Event Input B bit position. */
+#define WEX_FDFEVC_bm  0x10  /* Fault Detection Flag Event Input C bit mask. */
+#define WEX_FDFEVC_bp  4  /* Fault Detection Flag Event Input C bit position. */
+
+/* WEX.STATUS  bit masks and bit positions */
+#define WEX_FDSTATE_bm  0x01  /* Fault Detection State bit mask. */
+#define WEX_FDSTATE_bp  0  /* Fault Detection State bit position. */
+#define WEX_FDSEVA_bm  0x04  /* Fault Detection State Event A bit mask. */
+#define WEX_FDSEVA_bp  2  /* Fault Detection State Event A bit position. */
+#define WEX_FDSEVB_bm  0x08  /* Fault Detection State Event B bit mask. */
+#define WEX_FDSEVB_bp  3  /* Fault Detection State Event B bit position. */
+#define WEX_FDSEVC_bm  0x10  /* Fault Detection State Event C bit mask. */
+#define WEX_FDSEVC_bp  4  /* Fault Detection State Event C bit position. */
+#define WEX_BLANKSTATE_bm  0x80  /* Blanking State bit mask. */
+#define WEX_BLANKSTATE_bp  7  /* Blanking State bit position. */
+
+/* WEX.SWAP  bit masks and bit positions */
+#define WEX_SWAP0_bm  0x01  /* Swap DTI Output Pair 0 bit mask. */
+#define WEX_SWAP0_bp  0  /* Swap DTI Output Pair 0 bit position. */
+#define WEX_SWAP1_bm  0x02  /* Swap DTI Output Pair 1 bit mask. */
+#define WEX_SWAP1_bp  1  /* Swap DTI Output Pair 1 bit position. */
+#define WEX_SWAP2_bm  0x04  /* Swap DTI Output Pair 2 bit mask. */
+#define WEX_SWAP2_bp  2  /* Swap DTI Output Pair 2 bit position. */
+#define WEX_SWAP3_bm  0x08  /* Swap DTI Output Pair 3 bit mask. */
+#define WEX_SWAP3_bp  3  /* Swap DTI Output Pair 3 bit position. */
+
+/* WEX.PGMOVR  bit masks and bit positions */
+#define WEX_PGMOVR0_bm  0x01  /* Pattern Generation Override Enable Bit 0 bit mask. */
+#define WEX_PGMOVR0_bp  0  /* Pattern Generation Override Enable Bit 0 bit position. */
+#define WEX_PGMOVR1_bm  0x02  /* Pattern Generation Override Enable Bit 1 bit mask. */
+#define WEX_PGMOVR1_bp  1  /* Pattern Generation Override Enable Bit 1 bit position. */
+#define WEX_PGMOVR2_bm  0x04  /* Pattern Generation Override Enable Bit 2 bit mask. */
+#define WEX_PGMOVR2_bp  2  /* Pattern Generation Override Enable Bit 2 bit position. */
+#define WEX_PGMOVR3_bm  0x08  /* Pattern Generation Override Enable Bit 3 bit mask. */
+#define WEX_PGMOVR3_bp  3  /* Pattern Generation Override Enable Bit 3 bit position. */
+#define WEX_PGMOVR4_bm  0x10  /* Pattern Generation Override Enable Bit 4 bit mask. */
+#define WEX_PGMOVR4_bp  4  /* Pattern Generation Override Enable Bit 4 bit position. */
+#define WEX_PGMOVR5_bm  0x20  /* Pattern Generation Override Enable Bit 5 bit mask. */
+#define WEX_PGMOVR5_bp  5  /* Pattern Generation Override Enable Bit 5 bit position. */
+#define WEX_PGMOVR6_bm  0x40  /* Pattern Generation Override Enable Bit 6 bit mask. */
+#define WEX_PGMOVR6_bp  6  /* Pattern Generation Override Enable Bit 6 bit position. */
+#define WEX_PGMOVR7_bm  0x80  /* Pattern Generation Override Enable Bit 7 bit mask. */
+#define WEX_PGMOVR7_bp  7  /* Pattern Generation Override Enable Bit 7 bit position. */
+
+/* WEX.PGMOUT  bit masks and bit positions */
+#define WEX_PGMOUT0_bm  0x01  /* Pattern Generation Output Value Bit 0 bit mask. */
+#define WEX_PGMOUT0_bp  0  /* Pattern Generation Output Value Bit 0 bit position. */
+#define WEX_PGMOUT1_bm  0x02  /* Pattern Generation Output Value Bit 1 bit mask. */
+#define WEX_PGMOUT1_bp  1  /* Pattern Generation Output Value Bit 1 bit position. */
+#define WEX_PGMOUT2_bm  0x04  /* Pattern Generation Output Value Bit 2 bit mask. */
+#define WEX_PGMOUT2_bp  2  /* Pattern Generation Output Value Bit 2 bit position. */
+#define WEX_PGMOUT3_bm  0x08  /* Pattern Generation Output Value Bit 3 bit mask. */
+#define WEX_PGMOUT3_bp  3  /* Pattern Generation Output Value Bit 3 bit position. */
+#define WEX_PGMOUT4_bm  0x10  /* Pattern Generation Output Value Bit 4 bit mask. */
+#define WEX_PGMOUT4_bp  4  /* Pattern Generation Output Value Bit 4 bit position. */
+#define WEX_PGMOUT5_bm  0x20  /* Pattern Generation Output Value Bit 5 bit mask. */
+#define WEX_PGMOUT5_bp  5  /* Pattern Generation Output Value Bit 5 bit position. */
+#define WEX_PGMOUT6_bm  0x40  /* Pattern Generation Output Value Bit 6 bit mask. */
+#define WEX_PGMOUT6_bp  6  /* Pattern Generation Output Value Bit 6 bit position. */
+#define WEX_PGMOUT7_bm  0x80  /* Pattern Generation Output Value Bit 7 bit mask. */
+#define WEX_PGMOUT7_bp  7  /* Pattern Generation Output Value Bit 7 bit position. */
+
+/* WEX.OUTOVEN  bit masks and bit positions */
+#define WEX_OUTOVEN0_bm  0x01  /* Output Override Enable Bit 0 bit mask. */
+#define WEX_OUTOVEN0_bp  0  /* Output Override Enable Bit 0 bit position. */
+#define WEX_OUTOVEN1_bm  0x02  /* Output Override Enable Bit 1 bit mask. */
+#define WEX_OUTOVEN1_bp  1  /* Output Override Enable Bit 1 bit position. */
+#define WEX_OUTOVEN2_bm  0x04  /* Output Override Enable Bit 2 bit mask. */
+#define WEX_OUTOVEN2_bp  2  /* Output Override Enable Bit 2 bit position. */
+#define WEX_OUTOVEN3_bm  0x08  /* Output Override Enable Bit 3 bit mask. */
+#define WEX_OUTOVEN3_bp  3  /* Output Override Enable Bit 3 bit position. */
+#define WEX_OUTOVEN4_bm  0x10  /* Output Override Enable Bit 4 bit mask. */
+#define WEX_OUTOVEN4_bp  4  /* Output Override Enable Bit 4 bit position. */
+#define WEX_OUTOVEN5_bm  0x20  /* Output Override Enable Bit 5 bit mask. */
+#define WEX_OUTOVEN5_bp  5  /* Output Override Enable Bit 5 bit position. */
+#define WEX_OUTOVEN6_bm  0x40  /* Output Override Enable Bit 6 bit mask. */
+#define WEX_OUTOVEN6_bp  6  /* Output Override Enable Bit 6 bit position. */
+#define WEX_OUTOVEN7_bm  0x80  /* Output Override Enable Bit 7 bit mask. */
+#define WEX_OUTOVEN7_bp  7  /* Output Override Enable Bit 7 bit position. */
+
+/* WEX.SWAPBUF  bit masks and bit positions */
+#define WEX_SWAPBUF0_bm  0x01  /* Swap DTI Output Pair 0 Buffer bit mask. */
+#define WEX_SWAPBUF0_bp  0  /* Swap DTI Output Pair 0 Buffer bit position. */
+#define WEX_SWAPBUF1_bm  0x02  /* Swap DTI Output Pair 1 Buffer bit mask. */
+#define WEX_SWAPBUF1_bp  1  /* Swap DTI Output Pair 1 Buffer bit position. */
+#define WEX_SWAPBUF2_bm  0x04  /* Swap DTI Output Pair 2 Buffer bit mask. */
+#define WEX_SWAPBUF2_bp  2  /* Swap DTI Output Pair 2 Buffer bit position. */
+#define WEX_SWAPBUF3_bm  0x08  /* Swap DTI Output Pair 3 Buffer bit mask. */
+#define WEX_SWAPBUF3_bp  3  /* Swap DTI Output Pair 3 Buffer bit position. */
+
+/* WEX.PGMOVRBUF  bit masks and bit positions */
+#define WEX_PGMOVRBUF0_bm  0x01  /* Pattern Generation Override Enable Buffer Bit 0 bit mask. */
+#define WEX_PGMOVRBUF0_bp  0  /* Pattern Generation Override Enable Buffer Bit 0 bit position. */
+#define WEX_PGMOVRBUF1_bm  0x02  /* Pattern Generation Override Enable Buffer Bit 1 bit mask. */
+#define WEX_PGMOVRBUF1_bp  1  /* Pattern Generation Override Enable Buffer Bit 1 bit position. */
+#define WEX_PGMOVRBUF2_bm  0x04  /* Pattern Generation Override Enable Buffer Bit 2 bit mask. */
+#define WEX_PGMOVRBUF2_bp  2  /* Pattern Generation Override Enable Buffer Bit 2 bit position. */
+#define WEX_PGMOVRBUF3_bm  0x08  /* Pattern Generation Override Enable Buffer Bit 3 bit mask. */
+#define WEX_PGMOVRBUF3_bp  3  /* Pattern Generation Override Enable Buffer Bit 3 bit position. */
+#define WEX_PGMOVRBUF4_bm  0x10  /* Pattern Generation Override Enable Buffer Bit 4 bit mask. */
+#define WEX_PGMOVRBUF4_bp  4  /* Pattern Generation Override Enable Buffer Bit 4 bit position. */
+#define WEX_PGMOVRBUF5_bm  0x20  /* Pattern Generation Override Enable Buffer Bit 5 bit mask. */
+#define WEX_PGMOVRBUF5_bp  5  /* Pattern Generation Override Enable Buffer Bit 5 bit position. */
+#define WEX_PGMOVRBUF6_bm  0x40  /* Pattern Generation Override Enable Buffer Bit 6 bit mask. */
+#define WEX_PGMOVRBUF6_bp  6  /* Pattern Generation Override Enable Buffer Bit 6 bit position. */
+#define WEX_PGMOVRBUF7_bm  0x80  /* Pattern Generation Override Enable Buffer Bit 7 bit mask. */
+#define WEX_PGMOVRBUF7_bp  7  /* Pattern Generation Override Enable Buffer Bit 7 bit position. */
+
+/* WEX.PGMOUTBUF  bit masks and bit positions */
+#define WEX_PGMOUTBUF0_bm  0x01  /* Pattern Generation Output Value Buffer Bit 0 bit mask. */
+#define WEX_PGMOUTBUF0_bp  0  /* Pattern Generation Output Value Buffer Bit 0 bit position. */
+#define WEX_PGMOUTBUF1_bm  0x02  /* Pattern Generation Output Value Buffer Bit 1 bit mask. */
+#define WEX_PGMOUTBUF1_bp  1  /* Pattern Generation Output Value Buffer Bit 1 bit position. */
+#define WEX_PGMOUTBUF2_bm  0x04  /* Pattern Generation Output Value Buffer Bit 2 bit mask. */
+#define WEX_PGMOUTBUF2_bp  2  /* Pattern Generation Output Value Buffer Bit 2 bit position. */
+#define WEX_PGMOUTBUF3_bm  0x08  /* Pattern Generation Output Value Buffer Bit 3 bit mask. */
+#define WEX_PGMOUTBUF3_bp  3  /* Pattern Generation Output Value Buffer Bit 3 bit position. */
+#define WEX_PGMOUTBUF4_bm  0x10  /* Pattern Generation Output Value Buffer Bit 4 bit mask. */
+#define WEX_PGMOUTBUF4_bp  4  /* Pattern Generation Output Value Buffer Bit 4 bit position. */
+#define WEX_PGMOUTBUF5_bm  0x20  /* Pattern Generation Output Value Buffer Bit 5 bit mask. */
+#define WEX_PGMOUTBUF5_bp  5  /* Pattern Generation Output Value Buffer Bit 5 bit position. */
+#define WEX_PGMOUTBUF6_bm  0x40  /* Pattern Generation Output Value Buffer Bit 6 bit mask. */
+#define WEX_PGMOUTBUF6_bp  6  /* Pattern Generation Output Value Buffer Bit 6 bit position. */
+#define WEX_PGMOUTBUF7_bm  0x80  /* Pattern Generation Output Value Buffer Bit 7 bit mask. */
+#define WEX_PGMOUTBUF7_bp  7  /* Pattern Generation Output Value Buffer Bit 7 bit position. */
+
+
+/* ========== Generic Port Pins ========== */
+#define PIN0_bm 0x01
+#define PIN0_bp 0
+#define PIN1_bm 0x02
+#define PIN1_bp 1
+#define PIN2_bm 0x04
+#define PIN2_bp 2
+#define PIN3_bm 0x08
+#define PIN3_bp 3
+#define PIN4_bm 0x10
+#define PIN4_bp 4
+#define PIN5_bm 0x20
+#define PIN5_bp 5
+#define PIN6_bm 0x40
+#define PIN6_bp 6
+#define PIN7_bm 0x80
+#define PIN7_bp 7
+
+/* ========== Interrupt Vector Definitions ========== */
+/* Vector 0 is the reset vector */
+
+/* NMI interrupt vectors */
+#define NMI_vect_num  1
+#define NMI_vect      _VECTOR(1)  /*  */
+
+/* BOD interrupt vectors */
+#define BOD_VLM_vect_num  2
+#define BOD_VLM_vect      _VECTOR(2)  /*  */
+
+/* RTC interrupt vectors */
+#define RTC_CNT_vect_num  3
+#define RTC_CNT_vect      _VECTOR(3)  /*  */
+#define RTC_PIT_vect_num  4
+#define RTC_PIT_vect      _VECTOR(4)  /*  */
+
+/* CCL interrupt vectors */
+#define CCL_CCL_vect_num  5
+#define CCL_CCL_vect      _VECTOR(5)  /*  */
+
+/* PORTA interrupt vectors */
+#define PORTA_PORT_vect_num  6
+#define PORTA_PORT_vect      _VECTOR(6)  /*  */
+
+/* WEX0 interrupt vectors */
+#define WEX0_FDFEVA_vect_num  7
+#define WEX0_FDFEVA_vect      _VECTOR(7)  /*  */
+#define WEX0_FDFEVB_vect_num  7
+#define WEX0_FDFEVB_vect      _VECTOR(7)  /*  */
+#define WEX0_FDFEVC_vect_num  7
+#define WEX0_FDFEVC_vect      _VECTOR(7)  /*  */
+
+/* TCE0 interrupt vectors */
+#define TCE0_OVF_vect_num  8
+#define TCE0_OVF_vect      _VECTOR(8)  /*  */
+#define TCE0_CMP0_vect_num  9
+#define TCE0_CMP0_vect      _VECTOR(9)  /*  */
+#define TCE0_CMP1_vect_num  10
+#define TCE0_CMP1_vect      _VECTOR(10)  /*  */
+#define TCE0_CMP2_vect_num  11
+#define TCE0_CMP2_vect      _VECTOR(11)  /*  */
+#define TCE0_CMP3_vect_num  12
+#define TCE0_CMP3_vect      _VECTOR(12)  /*  */
+
+/* TCB0 interrupt vectors */
+#define TCB0_INT_vect_num  13
+#define TCB0_INT_vect      _VECTOR(13)  /*  */
+
+/* TCB1 interrupt vectors */
+#define TCB1_INT_vect_num  14
+#define TCB1_INT_vect      _VECTOR(14)  /*  */
+
+/* TWI0 interrupt vectors */
+#define TWI0_TWIS_vect_num  15
+#define TWI0_TWIS_vect      _VECTOR(15)  /*  */
+#define TWI0_TWIM_vect_num  16
+#define TWI0_TWIM_vect      _VECTOR(16)  /*  */
+
+/* SPI0 interrupt vectors */
+#define SPI0_INT_vect_num  17
+#define SPI0_INT_vect      _VECTOR(17)  /*  */
+
+/* USART0 interrupt vectors */
+#define USART0_RXC_vect_num  18
+#define USART0_RXC_vect      _VECTOR(18)  /*  */
+#define USART0_DRE_vect_num  19
+#define USART0_DRE_vect      _VECTOR(19)  /*  */
+#define USART0_TXC_vect_num  20
+#define USART0_TXC_vect      _VECTOR(20)  /*  */
+
+/* PORTD interrupt vectors */
+#define PORTD_PORT_vect_num  21
+#define PORTD_PORT_vect      _VECTOR(21)  /*  */
+
+/* TCF0 interrupt vectors */
+#define TCF0_INT_vect_num  22
+#define TCF0_INT_vect      _VECTOR(22)  /*  */
+
+/* AC0 interrupt vectors */
+#define AC0_AC_vect_num  23
+#define AC0_AC_vect      _VECTOR(23)  /*  */
+
+/* ADC0 interrupt vectors */
+#define ADC0_ERROR_vect_num  24
+#define ADC0_ERROR_vect      _VECTOR(24)  /*  */
+#define ADC0_RESRDY_vect_num  25
+#define ADC0_RESRDY_vect      _VECTOR(25)  /*  */
+#define ADC0_SAMPRDY_vect_num  26
+#define ADC0_SAMPRDY_vect      _VECTOR(26)  /*  */
+
+/* AC1 interrupt vectors */
+#define AC1_AC_vect_num  27
+#define AC1_AC_vect      _VECTOR(27)  /*  */
+
+/* PORTC interrupt vectors */
+#define PORTC_PORT_vect_num  28
+#define PORTC_PORT_vect      _VECTOR(28)  /*  */
+
+/* PORTF interrupt vectors */
+#define PORTF_PORT_vect_num  29
+#define PORTF_PORT_vect      _VECTOR(29)  /*  */
+
+/* NVMCTRL interrupt vectors */
+#define NVMCTRL_EEREADY_vect_num  30
+#define NVMCTRL_EEREADY_vect      _VECTOR(30)  /*  */
+#define NVMCTRL_FLREADY_vect_num  30
+#define NVMCTRL_FLREADY_vect      _VECTOR(30)  /*  */
+#define NVMCTRL_NVMREADY_vect_num  30
+#define NVMCTRL_NVMREADY_vect      _VECTOR(30)  /*  */
+
+#define _VECTOR_SIZE 4 /* Size of individual vector. */
+#define _VECTORS_SIZE (31 * _VECTOR_SIZE)
+
+
+/* ========== Constants ========== */
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define DATAMEM_START     (0x0000)
+#  define DATAMEM_SIZE      (65536)
+#else
+#  define DATAMEM_START     (0x0000U)
+#  define DATAMEM_SIZE      (65536U)
+#endif
+#define DATAMEM_END       (DATAMEM_START + DATAMEM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define IO_START     (0x0000)
+#  define IO_SIZE      (4159)
+#  define IO_PAGE_SIZE (0)
+#else
+#  define IO_START     (0x0000U)
+#  define IO_SIZE      (4159U)
+#  define IO_PAGE_SIZE (0U)
+#endif
+#define IO_END       (IO_START + IO_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define LOCKBITS_START     (0x1040)
+#  define LOCKBITS_SIZE      (4)
+#  define LOCKBITS_PAGE_SIZE (4)
+#else
+#  define LOCKBITS_START     (0x1040U)
+#  define LOCKBITS_SIZE      (4U)
+#  define LOCKBITS_PAGE_SIZE (4U)
+#endif
+#define LOCKBITS_END       (LOCKBITS_START + LOCKBITS_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define FUSES_START     (0x1050)
+#  define FUSES_SIZE      (16)
+#  define FUSES_PAGE_SIZE (8)
+#else
+#  define FUSES_START     (0x1050U)
+#  define FUSES_SIZE      (16U)
+#  define FUSES_PAGE_SIZE (8U)
+#endif
+#define FUSES_END       (FUSES_START + FUSES_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define SIGNATURES_START     (0x1080)
+#  define SIGNATURES_SIZE      (3)
+#  define SIGNATURES_PAGE_SIZE (128)
+#else
+#  define SIGNATURES_START     (0x1080U)
+#  define SIGNATURES_SIZE      (3U)
+#  define SIGNATURES_PAGE_SIZE (128U)
+#endif
+#define SIGNATURES_END       (SIGNATURES_START + SIGNATURES_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define PROD_SIGNATURES_START     (0x1083)
+#  define PROD_SIGNATURES_SIZE      (125)
+#  define PROD_SIGNATURES_PAGE_SIZE (128)
+#else
+#  define PROD_SIGNATURES_START     (0x1083U)
+#  define PROD_SIGNATURES_SIZE      (125U)
+#  define PROD_SIGNATURES_PAGE_SIZE (128U)
+#endif
+#define PROD_SIGNATURES_END       (PROD_SIGNATURES_START + PROD_SIGNATURES_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define BOOTROW_START     (0x1100)
+#  define BOOTROW_SIZE      (64)
+#  define BOOTROW_PAGE_SIZE (64)
+#else
+#  define BOOTROW_START     (0x1100U)
+#  define BOOTROW_SIZE      (64U)
+#  define BOOTROW_PAGE_SIZE (64U)
+#endif
+#define BOOTROW_END       (BOOTROW_START + BOOTROW_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define USER_SIGNATURES_START     (0x1200)
+#  define USER_SIGNATURES_SIZE      (64)
+#  define USER_SIGNATURES_PAGE_SIZE (64)
+#else
+#  define USER_SIGNATURES_START     (0x1200U)
+#  define USER_SIGNATURES_SIZE      (64U)
+#  define USER_SIGNATURES_PAGE_SIZE (64U)
+#endif
+#define USER_SIGNATURES_END       (USER_SIGNATURES_START + USER_SIGNATURES_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define EEPROM_START     (0x1400)
+#  define EEPROM_SIZE      (512)
+#  define EEPROM_PAGE_SIZE (8)
+#else
+#  define EEPROM_START     (0x1400U)
+#  define EEPROM_SIZE      (512U)
+#  define EEPROM_PAGE_SIZE (8U)
+#endif
+#define EEPROM_END       (EEPROM_START + EEPROM_SIZE - 1)
+
+/* Added MAPPED_EEPROM segment names for avr-libc */
+#define MAPPED_EEPROM_START     (EEPROM_START)
+#define MAPPED_EEPROM_SIZE      (EEPROM_SIZE)
+#define MAPPED_EEPROM_PAGE_SIZE (EEPROM_PAGE_SIZE)
+#define MAPPED_EEPROM_END       (MAPPED_EEPROM_START + MAPPED_EEPROM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define INTERNAL_SRAM_START     (0x7800)
+#  define INTERNAL_SRAM_SIZE      (2048)
+#  define INTERNAL_SRAM_PAGE_SIZE (0)
+#else
+#  define INTERNAL_SRAM_START     (0x7800U)
+#  define INTERNAL_SRAM_SIZE      (2048U)
+#  define INTERNAL_SRAM_PAGE_SIZE (0U)
+#endif
+#define INTERNAL_SRAM_END       (INTERNAL_SRAM_START + INTERNAL_SRAM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define MAPPED_PROGMEM_START     (0x8000)
+#  define MAPPED_PROGMEM_SIZE      (16384)
+#  define MAPPED_PROGMEM_PAGE_SIZE (64)
+#else
+#  define MAPPED_PROGMEM_START     (0x8000U)
+#  define MAPPED_PROGMEM_SIZE      (16384U)
+#  define MAPPED_PROGMEM_PAGE_SIZE (64U)
+#endif
+#define MAPPED_PROGMEM_END       (MAPPED_PROGMEM_START + MAPPED_PROGMEM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define PROGMEM_START     (0x0000)
+#  define PROGMEM_SIZE      (16384)
+#  define PROGMEM_PAGE_SIZE (64)
+#else
+#  define PROGMEM_START     (0x0000U)
+#  define PROGMEM_SIZE      (16384U)
+#  define PROGMEM_PAGE_SIZE (64U)
+#endif
+#define PROGMEM_END       (PROGMEM_START + PROGMEM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define PROGMEM_NRWW_START     (0x0000)
+#  define PROGMEM_NRWW_SIZE      (4096)
+#  define PROGMEM_NRWW_PAGE_SIZE (64)
+#else
+#  define PROGMEM_NRWW_START     (0x0000U)
+#  define PROGMEM_NRWW_SIZE      (4096U)
+#  define PROGMEM_NRWW_PAGE_SIZE (64U)
+#endif
+#define PROGMEM_NRWW_END       (PROGMEM_NRWW_START + PROGMEM_NRWW_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define PROGMEM_RWW_START     (0x1000)
+#  define PROGMEM_RWW_SIZE      (12288)
+#  define PROGMEM_RWW_PAGE_SIZE (64)
+#else
+#  define PROGMEM_RWW_START     (0x1000U)
+#  define PROGMEM_RWW_SIZE      (12288U)
+#  define PROGMEM_RWW_PAGE_SIZE (64U)
+#endif
+#define PROGMEM_RWW_END       (PROGMEM_RWW_START + PROGMEM_RWW_SIZE - 1)
+
+#define FLASHSTART   PROGMEM_START
+#define FLASHEND     PROGMEM_END
+#define RAMSTART     INTERNAL_SRAM_START
+#define RAMSIZE      INTERNAL_SRAM_SIZE
+#define RAMEND       INTERNAL_SRAM_END
+#define E2END        EEPROM_END
+#define E2PAGESIZE   EEPROM_PAGE_SIZE
+
+/* ========== Fuses ========== */
+#define FUSE_MEMORY_SIZE 16
+
+/* Fuse Byte 0 (WDTCFG) */
+#define FUSE_PERIOD0  (unsigned char)_BV(0)  /* Watchdog Timeout Period Bit 0 */
+#define FUSE_PERIOD1  (unsigned char)_BV(1)  /* Watchdog Timeout Period Bit 1 */
+#define FUSE_PERIOD2  (unsigned char)_BV(2)  /* Watchdog Timeout Period Bit 2 */
+#define FUSE_PERIOD3  (unsigned char)_BV(3)  /* Watchdog Timeout Period Bit 3 */
+#define FUSE_WINDOW0  (unsigned char)_BV(4)  /* Watchdog Window Timeout Period Bit 0 */
+#define FUSE_WINDOW1  (unsigned char)_BV(5)  /* Watchdog Window Timeout Period Bit 1 */
+#define FUSE_WINDOW2  (unsigned char)_BV(6)  /* Watchdog Window Timeout Period Bit 2 */
+#define FUSE_WINDOW3  (unsigned char)_BV(7)  /* Watchdog Window Timeout Period Bit 3 */
+#define FUSE0_DEFAULT  (0x0)
+#define FUSE_WDTCFG_DEFAULT  (0x0)
+
+/* Fuse Byte 1 (BODCFG) */
+#define FUSE_SLEEP0  (unsigned char)_BV(0)  /* BOD Operation in Sleep Mode Bit 0 */
+#define FUSE_SLEEP1  (unsigned char)_BV(1)  /* BOD Operation in Sleep Mode Bit 1 */
+#define FUSE_ACTIVE0  (unsigned char)_BV(2)  /* BOD Operation in Active Mode Bit 0 */
+#define FUSE_ACTIVE1  (unsigned char)_BV(3)  /* BOD Operation in Active Mode Bit 1 */
+#define FUSE_SAMPFREQ  (unsigned char)_BV(4)  /* BOD Sample Frequency */
+#define FUSE_LVL0  (unsigned char)_BV(5)  /* BOD Level Bit 0 */
+#define FUSE_LVL1  (unsigned char)_BV(6)  /* BOD Level Bit 1 */
+#define FUSE_LVL2  (unsigned char)_BV(7)  /* BOD Level Bit 2 */
+#define FUSE1_DEFAULT  (0x0)
+#define FUSE_BODCFG_DEFAULT  (0x0)
+
+/* Fuse Byte 2 (OSCCFG) */
+#define FUSE_OSCHFFRQ  (unsigned char)_BV(3)  /* High-frequency Oscillator Frequency */
+#define FUSE2_DEFAULT  (0x0)
+#define FUSE_OSCCFG_DEFAULT  (0x0)
+
+/* Fuse Byte 3 Reserved */
+
+/* Fuse Byte 4 Reserved */
+
+/* Fuse Byte 5 (SYSCFG0) */
+#define FUSE_EESAVE  (unsigned char)_BV(0)  /* EEPROM Save */
+#define FUSE_RSTPINCFG  (unsigned char)_BV(3)  /* Reset Pin Configuration */
+#define FUSE_UPDIPINCFG  (unsigned char)_BV(4)  /* UPDI Pin Configuration */
+#define FUSE_CRCSEL  (unsigned char)_BV(5)  /* CRC Select */
+#define FUSE_CRCSRC0  (unsigned char)_BV(6)  /* CRC Source Bit 0 */
+#define FUSE_CRCSRC1  (unsigned char)_BV(7)  /* CRC Source Bit 1 */
+#define FUSE5_DEFAULT  (0xD0)
+#define FUSE_SYSCFG0_DEFAULT  (0xD0)
+
+/* Fuse Byte 6 (SYSCFG1) */
+#define FUSE_SUT0  (unsigned char)_BV(0)  /* Startup Time Bit 0 */
+#define FUSE_SUT1  (unsigned char)_BV(1)  /* Startup Time Bit 1 */
+#define FUSE_SUT2  (unsigned char)_BV(2)  /* Startup Time Bit 2 */
+#define FUSE6_DEFAULT  (0x7)
+#define FUSE_SYSCFG1_DEFAULT  (0x7)
+
+/* Fuse Byte 7 (CODESIZE) */
+#define FUSE7_DEFAULT  (0x0)
+#define FUSE_CODESIZE_DEFAULT  (0x0)
+
+/* Fuse Byte 8 (BOOTSIZE) */
+#define FUSE8_DEFAULT  (0x0)
+#define FUSE_BOOTSIZE_DEFAULT  (0x0)
+
+/* Fuse Byte 9 Reserved */
+
+/* Fuse Byte 10 (PDICFG) */
+#define FUSE_LEVEL0  (unsigned char)_BV(0)  /* Protection Level Bit 0 */
+#define FUSE_LEVEL1  (unsigned char)_BV(1)  /* Protection Level Bit 1 */
+#define FUSE_KEY0  (unsigned char)_BV(4)  /* NVM Protection Activation Key Bit 0 */
+#define FUSE_KEY1  (unsigned char)_BV(5)  /* NVM Protection Activation Key Bit 1 */
+#define FUSE_KEY2  (unsigned char)_BV(6)  /* NVM Protection Activation Key Bit 2 */
+#define FUSE_KEY3  (unsigned char)_BV(7)  /* NVM Protection Activation Key Bit 3 */
+#define FUSE_KEY4  (unsigned char)_BV(8)  /* NVM Protection Activation Key Bit 4 */
+#define FUSE_KEY5  (unsigned char)_BV(9)  /* NVM Protection Activation Key Bit 5 */
+#define FUSE_KEY6  (unsigned char)_BV(10)  /* NVM Protection Activation Key Bit 6 */
+#define FUSE_KEY7  (unsigned char)_BV(11)  /* NVM Protection Activation Key Bit 7 */
+#define FUSE_KEY8  (unsigned char)_BV(12)  /* NVM Protection Activation Key Bit 8 */
+#define FUSE_KEY9  (unsigned char)_BV(13)  /* NVM Protection Activation Key Bit 9 */
+#define FUSE_KEY10  (unsigned char)_BV(14)  /* NVM Protection Activation Key Bit 10 */
+#define FUSE_KEY11  (unsigned char)_BV(15)  /* NVM Protection Activation Key Bit 11 */
+#define FUSE10_DEFAULT  (0x3)
+#define FUSE_PDICFG_DEFAULT  (0x3)
+
+/* ========== Lock Bits ========== */
+#define __LOCK_KEY_EXIST
+#ifdef LOCKBITS_DEFAULT
+#undef LOCKBITS_DEFAULT
+#endif //LOCKBITS_DEFAULT
+#define LOCKBITS_DEFAULT  (0x5CC5C55C)
+
+/* ========== Signature ========== */
+#define SIGNATURE_0 0x1E
+#define SIGNATURE_1 0x94
+#define SIGNATURE_2 0x3F
+
+#endif /* #ifdef _AVR_AVR16EB28_H_INCLUDED */
+

--- a/include/avr/ioavr16eb32.h
+++ b/include/avr/ioavr16eb32.h
@@ -1,0 +1,6496 @@
+/*
+ * Copyright (C) 2023, Microchip Technology Inc. and its subsidiaries ("Microchip")
+ * All rights reserved.
+ *
+ * This software is developed by Microchip Technology Inc. and its subsidiaries ("Microchip").
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other
+ *        materials provided with the distribution. Publication is not required when
+ *        this file is used in an embedded application.
+ *
+ *     3. Microchip's name may not be used to endorse or promote products derived from this
+ *        software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY MICROCHIP "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL MICROCHIP BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING BUT NOT LIMITED TO
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWSOEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _AVR_IO_H_
+#  error "Include <avr/io.h> instead of this file."
+#endif
+
+#ifndef _AVR_IOXXX_H_
+#  define _AVR_IOXXX_H_ "ioavr16eb32.h"
+#else
+#  error "Attempt to include more than one <avr/ioXXX.h> file."
+#endif
+
+#ifndef _AVR_AVR16EB32_H_INCLUDED
+#define _AVR_AVR16EB32_H_INCLUDED
+
+/* Ungrouped common registers */
+#define CCP  _SFR_MEM8(0x0034)  /* Configuration Change Protection */
+#define RAMPZ  _SFR_MEM8(0x003B)  /* Extended Z-pointer Register */
+#define SP  _SFR_MEM16(0x003D)  /* Stack Pointer */
+#define SPL  _SFR_MEM8(0x003D)  /* Stack Pointer Low */
+#define SPH  _SFR_MEM8(0x003E)  /* Stack Pointer High */
+#define SREG  _SFR_MEM8(0x003F)  /* Status Register */
+
+/* C Language Only */
+#if !defined (__ASSEMBLER__)
+
+#include <stdint.h>
+
+typedef volatile uint8_t register8_t;
+typedef volatile uint16_t register16_t;
+typedef volatile uint32_t register32_t;
+
+
+#ifdef _WORDREGISTER
+#undef _WORDREGISTER
+#endif
+#define _WORDREGISTER(regname)   \
+    __extension__ union \
+    { \
+        register16_t regname; \
+        struct \
+        { \
+            register8_t regname ## L; \
+            register8_t regname ## H; \
+        }; \
+    }
+
+#ifdef _DWORDREGISTER
+#undef _DWORDREGISTER
+#endif
+#define _DWORDREGISTER(regname)  \
+    __extension__ union \
+    { \
+        register32_t regname; \
+        struct \
+        { \
+            register8_t regname ## 0; \
+            register8_t regname ## 1; \
+            register8_t regname ## 2; \
+            register8_t regname ## 3; \
+        }; \
+    }
+
+
+/*
+==========================================================================
+IO Module Structures
+==========================================================================
+*/
+
+
+/*
+--------------------------------------------------------------------------
+AC - Analog Comparator
+--------------------------------------------------------------------------
+*/
+
+/* Analog Comparator */
+typedef struct AC_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t MUXCTRL;  /* Mux Control A */
+    register8_t reserved_1[2];
+    register8_t DACREF;  /* DAC Voltage Reference */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t STATUS;  /* Status */
+} AC_t;
+
+/* Hysteresis Mode select */
+typedef enum AC_HYSMODE_enum
+{
+    AC_HYSMODE_NONE_gc = (0x00<<1),  /* No hysteresis */
+    AC_HYSMODE_SMALL_gc = (0x01<<1),  /* Small hysteresis */
+    AC_HYSMODE_MEDIUM_gc = (0x02<<1),  /* Medium hysteresis */
+    AC_HYSMODE_LARGE_gc = (0x03<<1)  /* Large hysteresis */
+} AC_HYSMODE_t;
+
+/* AC Output Initial Value select */
+typedef enum AC_INITVAL_enum
+{
+    AC_INITVAL_LOW_gc = (0x00<<6),  /* Output initialized to 0 */
+    AC_INITVAL_HIGH_gc = (0x01<<6)  /* Output initialized to 1 */
+} AC_INITVAL_t;
+
+/* Interrupt Mode select */
+typedef enum AC_INTMODE_NORMAL_enum
+{
+    AC_INTMODE_NORMAL_BOTHEDGE_gc = (0x00<<4),  /* Positive and negative inputs crosses */
+    AC_INTMODE_NORMAL_NEGEDGE_gc = (0x02<<4),  /* Positive input goes below negative input */
+    AC_INTMODE_NORMAL_POSEDGE_gc = (0x03<<4)  /* Positive input goes above negative input */
+} AC_INTMODE_NORMAL_t;
+
+/* Interrupt Mode select */
+typedef enum AC_INTMODE_WINDOW_enum
+{
+    AC_INTMODE_WINDOW_ABOVE_gc = (0x00<<4),  /* Window interrupt when input above both references */
+    AC_INTMODE_WINDOW_INSIDE_gc = (0x01<<4),  /* Window interrupt when input betweeen references */
+    AC_INTMODE_WINDOW_BELOW_gc = (0x02<<4),  /* Window interrupt when input below both references */
+    AC_INTMODE_WINDOW_OUTSIDE_gc = (0x03<<4)  /* Window interrupt when input outside reference */
+} AC_INTMODE_WINDOW_t;
+
+/* Negative Input MUX Selection */
+typedef enum AC_MUXNEG_enum
+{
+    AC_MUXNEG_AINN0_gc = (0x00<<0),  /* Negative Pin 0 */
+    AC_MUXNEG_AINN1_gc = (0x01<<0),  /* Negative Pin 1 */
+    AC_MUXNEG_AINN2_gc = (0x02<<0),  /* Negative Pin 2 */
+    AC_MUXNEG_AINN3_gc = (0x03<<0),  /* Negative Pin 3 */
+    AC_MUXNEG_DACREF_gc = (0x04<<0)  /* DAC Reference */
+} AC_MUXNEG_t;
+
+/* Positive Input MUX Selection */
+typedef enum AC_MUXPOS_enum
+{
+    AC_MUXPOS_AINP0_gc = (0x00<<3),  /* Positive Pin 0 */
+    AC_MUXPOS_AINP1_gc = (0x01<<3),  /* Positive Pin 1 */
+    AC_MUXPOS_AINP2_gc = (0x02<<3),  /* Positive Pin 2 */
+    AC_MUXPOS_AINP3_gc = (0x03<<3),  /* Positive Pin 3 */
+    AC_MUXPOS_AINP4_gc = (0x04<<3),  /* Positive Pin 4 */
+    AC_MUXPOS_AINP5_gc = (0x05<<3),  /* Positive Pin 5 */
+    AC_MUXPOS_AINP6_gc = (0x06<<3)  /* Positive Pin 6 */
+} AC_MUXPOS_t;
+
+/* Power profile select */
+typedef enum AC_POWER_enum
+{
+    AC_POWER_PROFILE0_gc = (0x00<<3),  /* Power profile 0, Fastest response time, highest consumption */
+    AC_POWER_PROFILE1_gc = (0x01<<3)  /* Power profile 1 */
+} AC_POWER_t;
+
+/* Window selection mode */
+typedef enum AC_WINSEL_enum
+{
+    AC_WINSEL_DISABLED_gc = (0x00<<0),  /* Window function disabled */
+    AC_WINSEL_UPSEL1_gc = (0x01<<0)  /* Select ACn+1 as upper limit in window compare */
+} AC_WINSEL_t;
+
+/* Analog Comparator Window State select */
+typedef enum AC_WINSTATE_enum
+{
+    AC_WINSTATE_ABOVE_gc = (0x00<<6),  /* Above window */
+    AC_WINSTATE_INSIDE_gc = (0x01<<6),  /* Inside window */
+    AC_WINSTATE_BELOW_gc = (0x02<<6)  /* Below window */
+} AC_WINSTATE_t;
+
+/*
+--------------------------------------------------------------------------
+ADC - Analog to Digital Converter
+--------------------------------------------------------------------------
+*/
+
+/* Analog to Digital Converter */
+typedef struct ADC_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    register8_t CTRLD;  /* Control D */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t STATUS;  /* Status register */
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t CTRLE;  /* Control E */
+    register8_t CTRLF;  /* Control F */
+    register8_t COMMAND;  /* Command register */
+    register8_t PGACTRL;  /* PGA Control */
+    register8_t MUXPOS;  /* Positive Input Multiplexer */
+    register8_t MUXNEG;  /* Negative Input Multiplexer */
+    register8_t reserved_1[2];
+    _DWORDREGISTER(RESULT);  /* Result */
+    _WORDREGISTER(SAMPLE);  /* Sample */
+    register8_t reserved_2[2];
+    register8_t TEMP0;  /* Temporary Data 0 */
+    register8_t TEMP1;  /* Temporary Data 1 */
+    register8_t TEMP2;  /* Temporary Data 2 */
+    register8_t reserved_3[1];
+    _WORDREGISTER(WINLT);  /* Window Low Threshold */
+    _WORDREGISTER(WINHT);  /* Window High Threshold */
+    register8_t reserved_4[32];
+} ADC_t;
+
+/* Sign Chopping select */
+typedef enum ADC_CHOPPING_enum
+{
+    ADC_CHOPPING_DISABLE_gc = (0x00<<6),  /* Sign Chopping Disabled */
+    ADC_CHOPPING_ENABLE_gc = (0x01<<6)  /* Sign Chopping Enabled */
+} ADC_CHOPPING_t;
+
+/* Gain select */
+typedef enum ADC_GAIN_enum
+{
+    ADC_GAIN_1X_gc = (0x00<<5),  /* 1x gain */
+    ADC_GAIN_2X_gc = (0x01<<5),  /* 2x gain */
+    ADC_GAIN_4X_gc = (0x02<<5),  /* 4x gain */
+    ADC_GAIN_8X_gc = (0x03<<5),  /* 8x gain */
+    ADC_GAIN_16X_gc = (0x04<<5)  /* 16x gain */
+} ADC_GAIN_t;
+
+/* Mode select */
+typedef enum ADC_MODE_enum
+{
+    ADC_MODE_SINGLE_8BIT_gc = (0x00<<4),  /* Single Conversion with 8-bit resolution */
+    ADC_MODE_SINGLE_12BIT_gc = (0x01<<4),  /* Single Conversion with 12-bit resolution */
+    ADC_MODE_SERIES_gc = (0x02<<4),  /* Series with accumulation, separate trigger for every 12-bit conversion */
+    ADC_MODE_SERIES_SCALING_gc = (0x03<<4),  /* Series with accumulation and scaling, separate trigger for every 12-bit conversion */
+    ADC_MODE_BURST_gc = (0x04<<4),  /* Burst with accumulation, one trigger will run SAMPNUM 12-bit conversions */
+    ADC_MODE_BURST_SCALING_gc = (0x05<<4)  /* Burst with accumulation and scaling, one trigger will run SAMPNUM 12-bit conversions */
+} ADC_MODE_t;
+
+/* Analog Channel Selection Bits */
+typedef enum ADC_MUXNEG_enum
+{
+    ADC_MUXNEG_AIN0_gc = (0x00<<0),  /* ADC input pin 0 */
+    ADC_MUXNEG_AIN1_gc = (0x01<<0),  /* ADC input pin 1 */
+    ADC_MUXNEG_AIN2_gc = (0x02<<0),  /* ADC input pin 2 */
+    ADC_MUXNEG_AIN3_gc = (0x03<<0),  /* ADC input pin 3 */
+    ADC_MUXNEG_AIN4_gc = (0x04<<0),  /* ADC input pin 4 */
+    ADC_MUXNEG_AIN5_gc = (0x05<<0),  /* ADC input pin 5 */
+    ADC_MUXNEG_AIN6_gc = (0x06<<0),  /* ADC input pin 6 */
+    ADC_MUXNEG_AIN7_gc = (0x07<<0),  /* ADC input pin 7 */
+    ADC_MUXNEG_AIN16_gc = (0x10<<0),  /* ADC input pin 16 */
+    ADC_MUXNEG_AIN17_gc = (0x11<<0),  /* ADC input pin 17 */
+    ADC_MUXNEG_AIN18_gc = (0x12<<0),  /* ADC input pin 18 */
+    ADC_MUXNEG_AIN19_gc = (0x13<<0),  /* ADC input pin 19 */
+    ADC_MUXNEG_AIN20_gc = (0x14<<0),  /* ADC input pin 20 */
+    ADC_MUXNEG_AIN21_gc = (0x15<<0),  /* ADC input pin 21 */
+    ADC_MUXNEG_AIN22_gc = (0x16<<0),  /* ADC input pin 22 */
+    ADC_MUXNEG_AIN23_gc = (0x17<<0),  /* ADC input pin 23 */
+    ADC_MUXNEG_AIN24_gc = (0x18<<0),  /* ADC input pin 24 */
+    ADC_MUXNEG_AIN25_gc = (0x19<<0),  /* ADC input pin 25 */
+    ADC_MUXNEG_AIN26_gc = (0x1A<<0),  /* ADC input pin 26 */
+    ADC_MUXNEG_AIN27_gc = (0x1B<<0),  /* ADC input pin 27 */
+    ADC_MUXNEG_AIN28_gc = (0x1C<<0),  /* ADC input pin 28 */
+    ADC_MUXNEG_AIN29_gc = (0x1D<<0),  /* ADC input pin 29 */
+    ADC_MUXNEG_AIN30_gc = (0x1E<<0),  /* ADC input pin 30 */
+    ADC_MUXNEG_AIN31_gc = (0x1F<<0),  /* ADC input pin 31 */
+    ADC_MUXNEG_GND_gc = (0x30<<0),  /* Ground */
+    ADC_MUXNEG_DAC0_gc = (0x38<<0),  /* Digital to Analog Converter 0 */
+    ADC_MUXNEG_DACREF0_gc = (0x39<<0),  /* AC0 DAC reference */
+    ADC_MUXNEG_DACREF1_gc = (0x3A<<0)  /* AC1 DAC reference */
+} ADC_MUXNEG_t;
+
+/* Analog Channel Selection Bits */
+typedef enum ADC_MUXPOS_enum
+{
+    ADC_MUXPOS_AIN0_gc = (0x00<<0),  /* ADC input pin 0 */
+    ADC_MUXPOS_AIN1_gc = (0x01<<0),  /* ADC input pin 1 */
+    ADC_MUXPOS_AIN2_gc = (0x02<<0),  /* ADC input pin 2 */
+    ADC_MUXPOS_AIN3_gc = (0x03<<0),  /* ADC input pin 3 */
+    ADC_MUXPOS_AIN4_gc = (0x04<<0),  /* ADC input pin 4 */
+    ADC_MUXPOS_AIN5_gc = (0x05<<0),  /* ADC input pin 5 */
+    ADC_MUXPOS_AIN6_gc = (0x06<<0),  /* ADC input pin 6 */
+    ADC_MUXPOS_AIN7_gc = (0x07<<0),  /* ADC input pin 7 */
+    ADC_MUXPOS_AIN16_gc = (0x10<<0),  /* ADC input pin 16 */
+    ADC_MUXPOS_AIN17_gc = (0x11<<0),  /* ADC input pin 17 */
+    ADC_MUXPOS_AIN18_gc = (0x12<<0),  /* ADC input pin 18 */
+    ADC_MUXPOS_AIN19_gc = (0x13<<0),  /* ADC input pin 19 */
+    ADC_MUXPOS_AIN20_gc = (0x14<<0),  /* ADC input pin 20 */
+    ADC_MUXPOS_AIN21_gc = (0x15<<0),  /* ADC input pin 21 */
+    ADC_MUXPOS_AIN22_gc = (0x16<<0),  /* ADC input pin 22 */
+    ADC_MUXPOS_AIN23_gc = (0x17<<0),  /* ADC input pin 23 */
+    ADC_MUXPOS_AIN24_gc = (0x18<<0),  /* ADC input pin 24 */
+    ADC_MUXPOS_AIN25_gc = (0x19<<0),  /* ADC input pin 25 */
+    ADC_MUXPOS_AIN26_gc = (0x1A<<0),  /* ADC input pin 26 */
+    ADC_MUXPOS_AIN27_gc = (0x1B<<0),  /* ADC input pin 27 */
+    ADC_MUXPOS_AIN28_gc = (0x1C<<0),  /* ADC input pin 28 */
+    ADC_MUXPOS_AIN29_gc = (0x1D<<0),  /* ADC input pin 29 */
+    ADC_MUXPOS_AIN30_gc = (0x1E<<0),  /* ADC input pin 30 */
+    ADC_MUXPOS_AIN31_gc = (0x1F<<0),  /* ADC input pin 31 */
+    ADC_MUXPOS_GND_gc = (0x30<<0),  /* Ground */
+    ADC_MUXPOS_VDD10_gc = (0x31<<0),  /* VDD Divided by 10 */
+    ADC_MUXPOS_TEMPSENSE_gc = (0x32<<0)  /* Temperature Sensor */
+} ADC_MUXPOS_t;
+
+/* PGA BIAS Select */
+typedef enum ADC_PGABIASSEL_enum
+{
+    ADC_PGABIASSEL_100PCT_gc = (0x00<<3),  /* 100% BIAS current. */
+    ADC_PGABIASSEL_75PCT_gc = (0x01<<3),  /* 75% BIAS current. Usable for CLK_ADC<4.5MHz */
+    ADC_PGABIASSEL_50PCT_gc = (0x02<<3),  /* 50% BIAS current. Usable for CLK_ADC<3MHz */
+    ADC_PGABIASSEL_25PCT_gc = (0x03<<3)  /* 25% BIAS current. Usable for CLK_ADC<1.5MHz */
+} ADC_PGABIASSEL_t;
+
+/* Prescaler Value select */
+typedef enum ADC_PRESC_enum
+{
+    ADC_PRESC_DIV2_gc = (0x00<<0),  /* System clock divided by 2 */
+    ADC_PRESC_DIV4_gc = (0x01<<0),  /* System clock divided by 4 */
+    ADC_PRESC_DIV6_gc = (0x02<<0),  /* System clock divided by 6 */
+    ADC_PRESC_DIV8_gc = (0x03<<0),  /* System clock divided by 8 */
+    ADC_PRESC_DIV10_gc = (0x04<<0),  /* System clock divided by 10 */
+    ADC_PRESC_DIV12_gc = (0x05<<0),  /* System clock divided by 12 */
+    ADC_PRESC_DIV14_gc = (0x06<<0),  /* System clock divided by 14 */
+    ADC_PRESC_DIV16_gc = (0x07<<0),  /* System clock divided by 16 */
+    ADC_PRESC_DIV20_gc = (0x08<<0),  /* System clock divided by 20 */
+    ADC_PRESC_DIV24_gc = (0x09<<0),  /* System clock divided by 24 */
+    ADC_PRESC_DIV28_gc = (0x0A<<0),  /* System clock divided by 28 */
+    ADC_PRESC_DIV32_gc = (0x0B<<0),  /* System clock divided by 32 */
+    ADC_PRESC_DIV40_gc = (0x0C<<0),  /* System clock divided by 40 */
+    ADC_PRESC_DIV48_gc = (0x0D<<0),  /* System clock divided by 48 */
+    ADC_PRESC_DIV56_gc = (0x0E<<0),  /* System clock divided by 56 */
+    ADC_PRESC_DIV64_gc = (0x0F<<0)  /* System clock divided by 64 */
+} ADC_PRESC_t;
+
+/* Reference select */
+typedef enum ADC_REFSEL_enum
+{
+    ADC_REFSEL_VDD_gc = (0x00<<0),  /* VDD */
+    ADC_REFSEL_VREFA_gc = (0x02<<0),  /* External Reference */
+    ADC_REFSEL_1V024_gc = (0x04<<0),  /* Internal 1.024V Reference */
+    ADC_REFSEL_2V048_gc = (0x05<<0),  /* Internal 2.048V Reference */
+    ADC_REFSEL_4V096_gc = (0x06<<0),  /* Internal 4.096V Reference */
+    ADC_REFSEL_2V500_gc = (0x07<<0)  /* Internal 2.500V Reference */
+} ADC_REFSEL_t;
+
+/* Sample numbers select */
+typedef enum ADC_SAMPNUM_enum
+{
+    ADC_SAMPNUM_NONE_gc = (0x00<<0),  /* No accumulation */
+    ADC_SAMPNUM_ACC2_gc = (0x01<<0),  /* 2 samples accumulated */
+    ADC_SAMPNUM_ACC4_gc = (0x02<<0),  /* 4 samples accumulated */
+    ADC_SAMPNUM_ACC8_gc = (0x03<<0),  /* 8 samples accumulated */
+    ADC_SAMPNUM_ACC16_gc = (0x04<<0),  /* 16 samples accumulated */
+    ADC_SAMPNUM_ACC32_gc = (0x05<<0),  /* 32 samples accumulated */
+    ADC_SAMPNUM_ACC64_gc = (0x06<<0),  /* 64 samples accumulated */
+    ADC_SAMPNUM_ACC128_gc = (0x07<<0),  /* 128 samples accumulated */
+    ADC_SAMPNUM_ACC256_gc = (0x08<<0),  /* 256 samples accumulated */
+    ADC_SAMPNUM_ACC512_gc = (0x09<<0),  /* 512 samples accumulated */
+    ADC_SAMPNUM_ACC1024_gc = (0x0A<<0)  /* 1024 samples accumulated */
+} ADC_SAMPNUM_t;
+
+/* Start command select */
+typedef enum ADC_START_enum
+{
+    ADC_START_STOP_gc = (0x00<<0),  /* Stop an ongoing conversion */
+    ADC_START_IMMEDIATE_gc = (0x01<<0),  /* Start a conversion immediately. This will be set back to STOP when the first conversion is done, unless Free-Running mode is enabled */
+    ADC_START_MUXPOS_WRITE_gc = (0x02<<0),  /* Start when MUXPOS register is written */
+    ADC_START_MUXNEG_WRITE_gc = (0x03<<0),  /* Start when MUXNEG register is written */
+    ADC_START_EVENT_TRIGGER_gc = (0x04<<0)  /* Start when an event is received */
+} ADC_START_t;
+
+/* VIA select */
+typedef enum ADC_VIA_enum
+{
+    ADC_VIA_DIRECT_gc = (0x00<<6),  /* Inputs connected directly to ADC */
+    ADC_VIA_PGA_gc = (0x01<<6)  /* Inputs connected via PGA */
+} ADC_VIA_t;
+
+/* Window Comparator Mode select */
+typedef enum ADC_WINCM_enum
+{
+    ADC_WINCM_NONE_gc = (0x00<<0),  /* No Window Comparison */
+    ADC_WINCM_BELOW_gc = (0x01<<0),  /* Below Window */
+    ADC_WINCM_ABOVE_gc = (0x02<<0),  /* Above Window */
+    ADC_WINCM_INSIDE_gc = (0x03<<0),  /* Inside Window */
+    ADC_WINCM_OUTSIDE_gc = (0x04<<0)  /* Outside Window */
+} ADC_WINCM_t;
+
+/* Window Mode Source select */
+typedef enum ADC_WINSRC_enum
+{
+    ADC_WINSRC_RESULT_gc = (0x00<<3),  /* Result register used as Window Comparator Source */
+    ADC_WINSRC_SAMPLE_gc = (0x01<<3)  /* Sample register used as Window Comparator Source */
+} ADC_WINSRC_t;
+
+/*
+--------------------------------------------------------------------------
+BOD - Bod interface
+--------------------------------------------------------------------------
+*/
+
+/* Bod interface */
+typedef struct BOD_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t reserved_1[6];
+    register8_t VLMCTRLA;  /* Voltage level monitor Control */
+    register8_t INTCTRL;  /* Voltage level monitor interrupt Control */
+    register8_t INTFLAGS;  /* Voltage level monitor interrupt Flags */
+    register8_t STATUS;  /* Voltage level monitor status */
+    register8_t reserved_2[4];
+} BOD_t;
+
+/* Operation in active mode select */
+typedef enum BOD_ACTIVE_enum
+{
+    BOD_ACTIVE_DISABLE_gc = (0x00<<2),  /* Disabled */
+    BOD_ACTIVE_ENABLED_gc = (0x01<<2),  /* Enabled in continuous mode */
+    BOD_ACTIVE_SAMPLED_gc = (0x02<<2),  /* Enabled in sampled mode */
+    BOD_ACTIVE_ENABLEWAIT_gc = (0x03<<2)  /* Enabled in continuous mode. Execution halted at wake-up until BOD is running */
+} BOD_ACTIVE_t;
+
+/* Bod level select */
+typedef enum BOD_LVL_enum
+{
+    BOD_LVL_BODLEVEL0_gc = (0x00<<0),  /* BOD Disabled during normal operation */
+    BOD_LVL_BODLEVEL1_gc = (0x01<<0),  /* 1.9 V */
+    BOD_LVL_BODLEVEL2_gc = (0x02<<0),  /* 2.7 V */
+    BOD_LVL_BODLEVEL3_gc = (0x03<<0)  /* 4.5 V */
+} BOD_LVL_t;
+
+/* Sample frequency select */
+typedef enum BOD_SAMPFREQ_enum
+{
+    BOD_SAMPFREQ_128HZ_gc = (0x00<<4),  /* Sampling frequency is 128 Hz */
+    BOD_SAMPFREQ_32HZ_gc = (0x01<<4)  /* Sample frequency is 32 Hz */
+} BOD_SAMPFREQ_t;
+
+/* Operation in sleep mode select */
+typedef enum BOD_SLEEP_enum
+{
+    BOD_SLEEP_DISABLE_gc = (0x00<<0),  /* Disabled */
+    BOD_SLEEP_ENABLE_gc = (0x01<<0),  /* Enabled in continuous mode */
+    BOD_SLEEP_SAMPLE_gc = (0x02<<0)  /* Enabled in sampled mode */
+} BOD_SLEEP_t;
+
+/* Configuration select */
+typedef enum BOD_VLMCFG_enum
+{
+    BOD_VLMCFG_FALLING_gc = (0x00<<1),  /* VDD falls below VLM threshold */
+    BOD_VLMCFG_RISING_gc = (0x01<<1),  /* VDD rises above VLM threshold */
+    BOD_VLMCFG_BOTH_gc = (0x02<<1)  /* VDD crosses VLM threshold */
+} BOD_VLMCFG_t;
+
+/* voltage level monitor level select */
+typedef enum BOD_VLMLVL_enum
+{
+    BOD_VLMLVL_OFF_gc = (0x00<<0),  /* VLM Disabled */
+    BOD_VLMLVL_5ABOVE_gc = (0x01<<0),  /* VLM threshold 5% above BOD level */
+    BOD_VLMLVL_15ABOVE_gc = (0x02<<0),  /* VLM threshold 15% above BOD level */
+    BOD_VLMLVL_25ABOVE_gc = (0x03<<0)  /* VLM threshold 25% above BOD level */
+} BOD_VLMLVL_t;
+
+/* Voltage level monitor status select */
+typedef enum BOD_VLMS_enum
+{
+    BOD_VLMS_ABOVE_gc = (0x00<<0),  /* The voltage is above the VLM threshold level */
+    BOD_VLMS_BELOW_gc = (0x01<<0)  /* The voltage is below the VLM threshold level */
+} BOD_VLMS_t;
+
+/*
+--------------------------------------------------------------------------
+BOOTROW - Boot Row
+--------------------------------------------------------------------------
+*/
+
+/* Boot Row */
+typedef struct BOOTROW_struct
+{
+    register8_t BOOTROW[64];  /* Boot Row */
+} BOOTROW_t;
+
+
+/*
+--------------------------------------------------------------------------
+CCL - Configurable Custom Logic
+--------------------------------------------------------------------------
+*/
+
+/* Configurable Custom Logic */
+typedef struct CCL_struct
+{
+    register8_t CTRLA;  /* Control Register A */
+    register8_t SEQCTRL0;  /* Sequential Control 0 */
+    register8_t SEQCTRL1;  /* Sequential Control 1 */
+    register8_t reserved_1[2];
+    register8_t INTCTRL0;  /* Interrupt Control 0 */
+    register8_t reserved_2[1];
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t LUT0CTRLA;  /* LUT 0 Control A */
+    register8_t LUT0CTRLB;  /* LUT 0 Control B */
+    register8_t LUT0CTRLC;  /* LUT 0 Control C */
+    register8_t TRUTH0;  /* Truth 0 */
+    register8_t LUT1CTRLA;  /* LUT 1 Control A */
+    register8_t LUT1CTRLB;  /* LUT 1 Control B */
+    register8_t LUT1CTRLC;  /* LUT 1 Control C */
+    register8_t TRUTH1;  /* Truth 1 */
+    register8_t LUT2CTRLA;  /* LUT 2 Control A */
+    register8_t LUT2CTRLB;  /* LUT 2 Control B */
+    register8_t LUT2CTRLC;  /* LUT 2 Control C */
+    register8_t TRUTH2;  /* Truth 2 */
+    register8_t LUT3CTRLA;  /* LUT 3 Control A */
+    register8_t LUT3CTRLB;  /* LUT 3 Control B */
+    register8_t LUT3CTRLC;  /* LUT 3 Control C */
+    register8_t TRUTH3;  /* Truth 3 */
+    register8_t reserved_3[40];
+} CCL_t;
+
+/* Clock Source Selection */
+typedef enum CCL_CLKSRC_enum
+{
+    CCL_CLKSRC_CLKPER_gc = (0x00<<1),  /* Peripheral Clock */
+    CCL_CLKSRC_IN2_gc = (0x01<<1),  /* INSEL2 selection */
+    CCL_CLKSRC_OSCHF_gc = (0x04<<1),  /* Internal High Frequency oscillator */
+    CCL_CLKSRC_OSC32K_gc = (0x05<<1),  /* Internal 32.768 kHz oscillator */
+    CCL_CLKSRC_OSC1K_gc = (0x06<<1),  /* Internal 32.768 kHz oscillator divided by 32 */
+    CCL_CLKSRC_PLL_gc = (0x07<<1)  /* PLL */
+} CCL_CLKSRC_t;
+
+/* Edge Detection Enable select */
+typedef enum CCL_EDGEDET_enum
+{
+    CCL_EDGEDET_DIS_gc = (0x00<<7),  /* Edge detector is disabled */
+    CCL_EDGEDET_EN_gc = (0x01<<7)  /* Edge detector is enabled */
+} CCL_EDGEDET_t;
+
+/* Filter Selection */
+typedef enum CCL_FILTSEL_enum
+{
+    CCL_FILTSEL_DISABLE_gc = (0x00<<4),  /* Filter disabled */
+    CCL_FILTSEL_SYNCH_gc = (0x01<<4),  /* Synchronizer enabled */
+    CCL_FILTSEL_FILTER_gc = (0x02<<4)  /* Filter enabled */
+} CCL_FILTSEL_t;
+
+/* LUT Input 0 Source Selection */
+typedef enum CCL_INSEL0_enum
+{
+    CCL_INSEL0_MASK_gc = (0x00<<0),  /* Masked input */
+    CCL_INSEL0_FEEDBACK_gc = (0x01<<0),  /* Feedback input */
+    CCL_INSEL0_LINK_gc = (0x02<<0),  /* Output from LUT[n+1] as input source */
+    CCL_INSEL0_EVENTA_gc = (0x03<<0),  /* Event A as input source */
+    CCL_INSEL0_EVENTB_gc = (0x04<<0),  /* Event B as input source */
+    CCL_INSEL0_IN0_gc = (0x05<<0),  /* IN0 input source */
+    CCL_INSEL0_AC0_gc = (0x06<<0),  /* AC0 output input source */
+    CCL_INSEL0_USART0_gc = (0x07<<0),  /* USART0 TxD input source */
+    CCL_INSEL0_SPI0_gc = (0x08<<0),  /* SPI0 MOSI input source */
+    CCL_INSEL0_TCE0_gc = (0x09<<0),  /* TCE0 WO0 input source */
+    CCL_INSEL0_TCB0_gc = (0x0A<<0),  /* TCB0 WO input source */
+    CCL_INSEL0_TCF0_gc = (0x0B<<0),  /* TCF0 WO0 input source */
+    CCL_INSEL0_WEX0_gc = (0x0C<<0)  /* Blanking input source */
+} CCL_INSEL0_t;
+
+/* LUT Input 1 Source Selection */
+typedef enum CCL_INSEL1_enum
+{
+    CCL_INSEL1_MASK_gc = (0x00<<4),  /* Masked input */
+    CCL_INSEL1_FEEDBACK_gc = (0x01<<4),  /* Feedback input */
+    CCL_INSEL1_LINK_gc = (0x02<<4),  /* Output from LUT[n+1] as input source */
+    CCL_INSEL1_EVENTA_gc = (0x03<<4),  /* Event A as input source */
+    CCL_INSEL1_EVENTB_gc = (0x04<<4),  /* Event B as input source */
+    CCL_INSEL1_IN1_gc = (0x05<<4),  /* IN1 input source */
+    CCL_INSEL1_AC1_gc = (0x06<<4),  /* AC1 output input source */
+    CCL_INSEL1_USART0_gc = (0x07<<4),  /* USART0 TxD input source */
+    CCL_INSEL1_SPI0_gc = (0x08<<4),  /* SPI0 MOSI input source */
+    CCL_INSEL1_TCE0_gc = (0x09<<4),  /* TCE0 WO1 input source */
+    CCL_INSEL1_TCB1_gc = (0x0A<<4),  /* TCB1 WO input source */
+    CCL_INSEL1_TCF0_gc = (0x0B<<4),  /* TCF0 WO1 input source */
+    CCL_INSEL1_WEX0_gc = (0x0C<<4)  /* Blanking input source */
+} CCL_INSEL1_t;
+
+/* LUT Input 2 Source Selection */
+typedef enum CCL_INSEL2_enum
+{
+    CCL_INSEL2_MASK_gc = (0x00<<0),  /* Masked input */
+    CCL_INSEL2_FEEDBACK_gc = (0x01<<0),  /* Feedback input */
+    CCL_INSEL2_LINK_gc = (0x02<<0),  /* Output from LUT[n+1] as input source */
+    CCL_INSEL2_EVENTA_gc = (0x03<<0),  /* Event A as input source */
+    CCL_INSEL2_EVENTB_gc = (0x04<<0),  /* Event B as input source */
+    CCL_INSEL2_IN2_gc = (0x05<<0),  /* IN2 input source */
+    CCL_INSEL2_AC1_gc = (0x06<<0),  /* AC1 output input source */
+    CCL_INSEL2_USART0_gc = (0x07<<0),  /* USART0 TxD input source */
+    CCL_INSEL2_SPI0_gc = (0x08<<0),  /* SPI0 SCK input source */
+    CCL_INSEL2_TCE0_gc = (0x09<<0),  /* TCE0 WO2 input source */
+    CCL_INSEL2_TCB1_gc = (0x0A<<0),  /* TCB1 WO input source */
+    CCL_INSEL2_TCF0_gc = (0x0B<<0),  /* TCF0 WO0 input source */
+    CCL_INSEL2_WEX0_gc = (0x0C<<0)  /* Blanking input source */
+} CCL_INSEL2_t;
+
+/* Interrupt Mode for LUT0 select */
+typedef enum CCL_INTMODE0_enum
+{
+    CCL_INTMODE0_INTDISABLE_gc = (0x00<<0),  /* Interrupt disabled */
+    CCL_INTMODE0_RISING_gc = (0x01<<0),  /* Sense rising edge */
+    CCL_INTMODE0_FALLING_gc = (0x02<<0),  /* Sense falling edge */
+    CCL_INTMODE0_BOTH_gc = (0x03<<0)  /* Sense both edges */
+} CCL_INTMODE0_t;
+
+/* Interrupt Mode for LUT1 select */
+typedef enum CCL_INTMODE1_enum
+{
+    CCL_INTMODE1_INTDISABLE_gc = (0x00<<2),  /* Interrupt disabled */
+    CCL_INTMODE1_RISING_gc = (0x01<<2),  /* Sense rising edge */
+    CCL_INTMODE1_FALLING_gc = (0x02<<2),  /* Sense falling edge */
+    CCL_INTMODE1_BOTH_gc = (0x03<<2)  /* Sense both edges */
+} CCL_INTMODE1_t;
+
+/* Interrupt Mode for LUT2 select */
+typedef enum CCL_INTMODE2_enum
+{
+    CCL_INTMODE2_INTDISABLE_gc = (0x00<<4),  /* Interrupt disabled */
+    CCL_INTMODE2_RISING_gc = (0x01<<4),  /* Sense rising edge */
+    CCL_INTMODE2_FALLING_gc = (0x02<<4),  /* Sense falling edge */
+    CCL_INTMODE2_BOTH_gc = (0x03<<4)  /* Sense both edges */
+} CCL_INTMODE2_t;
+
+/* Interrupt Mode for LUT3 select */
+typedef enum CCL_INTMODE3_enum
+{
+    CCL_INTMODE3_INTDISABLE_gc = (0x00<<6),  /* Interrupt disabled */
+    CCL_INTMODE3_RISING_gc = (0x01<<6),  /* Sense rising edge */
+    CCL_INTMODE3_FALLING_gc = (0x02<<6),  /* Sense falling edge */
+    CCL_INTMODE3_BOTH_gc = (0x03<<6)  /* Sense both edges */
+} CCL_INTMODE3_t;
+
+/* Sequential Selection */
+typedef enum CCL_SEQSEL_enum
+{
+    CCL_SEQSEL_DISABLE_gc = (0x00<<0),  /* Sequential logic disabled */
+    CCL_SEQSEL_DFF_gc = (0x01<<0),  /* D FlipFlop */
+    CCL_SEQSEL_JK_gc = (0x02<<0),  /* JK FlipFlop */
+    CCL_SEQSEL_LATCH_gc = (0x03<<0),  /* D Latch */
+    CCL_SEQSEL_RS_gc = (0x04<<0)  /* RS Latch */
+} CCL_SEQSEL_t;
+
+/*
+--------------------------------------------------------------------------
+CLKCTRL - Clock controller
+--------------------------------------------------------------------------
+*/
+
+/* Clock controller */
+typedef struct CLKCTRL_struct
+{
+    register8_t MCLKCTRLA;  /* MCLK Control A */
+    register8_t MCLKCTRLB;  /* MCLK Control B */
+    register8_t reserved_1[3];
+    register8_t MCLKSTATUS;  /* MCLK Status */
+    register8_t MCLKTIMEBASE;  /* MCLK Timebase */
+    register8_t reserved_2[1];
+    register8_t OSCHFCTRLA;  /* OSCHF Control A */
+    register8_t OSCHFTUNE;  /* OSCHF Tune */
+    register8_t reserved_3[6];
+    register8_t PLLCTRLA;  /* PLL Control A */
+    register8_t PLLCTRLB;  /* PLL Control B */
+    register8_t reserved_4[6];
+    register8_t OSC32KCTRLA;  /* OSC32K Control A */
+    register8_t reserved_5[3];
+    register8_t XOSC32KCTRLA;  /* XOSC32K Control A */
+    register8_t reserved_6[35];
+} CLKCTRL_t;
+
+/* Automatic Oscillator Tune select */
+typedef enum CLKCTRL_AUTOTUNE_enum
+{
+    CLKCTRL_AUTOTUNE_OFF_gc = (0x00<<0),  /* Disabled */
+    CLKCTRL_AUTOTUNE_XOSC32K_gc = (0x01<<0)  /* Tune against 32.768 kHz Crystal Oscillator */
+} CLKCTRL_AUTOTUNE_t;
+
+/* PLL Output Clock Division select */
+typedef enum CLKCTRL_CLKDIV_enum
+{
+    CLKCTRL_CLKDIV_NONE_gc = (0x00<<0),  /* PLL output clock undivided */
+    CLKCTRL_CLKDIV_DIV2_gc = (0x01<<0)  /* PLL output clock divided by 2 */
+} CLKCTRL_CLKDIV_t;
+
+/* Clock select */
+typedef enum CLKCTRL_CLKSEL_enum
+{
+    CLKCTRL_CLKSEL_OSCHF_gc = (0x00<<0),  /* Internal high-frequency oscillator */
+    CLKCTRL_CLKSEL_OSC32K_gc = (0x01<<0),  /* Internal 32.768 kHz oscillator */
+    CLKCTRL_CLKSEL_XOSC32K_gc = (0x02<<0),  /* 32.768 kHz crystal oscillator */
+    CLKCTRL_CLKSEL_EXTCLK_gc = (0x03<<0),  /* External clock */
+    CLKCTRL_CLKSEL_PLL_gc = (0x04<<0)  /* PLL Oscillator */
+} CLKCTRL_CLKSEL_t;
+
+/* Crystal startup time select */
+typedef enum CLKCTRL_CSUT_enum
+{
+    CLKCTRL_CSUT_1K_gc = (0x00<<4),  /* 1k cycles */
+    CLKCTRL_CSUT_16K_gc = (0x01<<4),  /* 16k cycles */
+    CLKCTRL_CSUT_32K_gc = (0x02<<4),  /* 32k cycles */
+    CLKCTRL_CSUT_64K_gc = (0x03<<4)  /* 64k cycles */
+} CLKCTRL_CSUT_t;
+
+/* PLL Multiplication Factor select */
+typedef enum CLKCTRL_MULFAC_enum
+{
+    CLKCTRL_MULFAC_OFF_gc = (0x00<<0),  /* PLL Disabled */
+    CLKCTRL_MULFAC_8X_gc = (0x02<<0),  /* Multiply by 8 */
+    CLKCTRL_MULFAC_16X_gc = (0x03<<0)  /* Multiply by 16 */
+} CLKCTRL_MULFAC_t;
+
+/* Prescaler B division select */
+typedef enum CLKCTRL_PBDIV_enum
+{
+    CLKCTRL_PBDIV_NONE_gc = (0x00<<5),  /* No division */
+    CLKCTRL_PBDIV_DIV4_gc = (0x01<<5)  /* Divide by 4 */
+} CLKCTRL_PBDIV_t;
+
+/* Prescaler division select */
+typedef enum CLKCTRL_PDIV_enum
+{
+    CLKCTRL_PDIV_DIV2_gc = (0x00<<1),  /* Divide by 2 */
+    CLKCTRL_PDIV_DIV4_gc = (0x01<<1),  /* Divide by 4 */
+    CLKCTRL_PDIV_DIV8_gc = (0x02<<1),  /* Divide by 8 */
+    CLKCTRL_PDIV_DIV16_gc = (0x03<<1),  /* Divide by 16 */
+    CLKCTRL_PDIV_DIV32_gc = (0x04<<1),  /* Divide by 32 */
+    CLKCTRL_PDIV_DIV64_gc = (0x05<<1),  /* Divide by 64 */
+    CLKCTRL_PDIV_DIV6_gc = (0x08<<1),  /* Divide by 6 */
+    CLKCTRL_PDIV_DIV10_gc = (0x09<<1),  /* Divide by 10 */
+    CLKCTRL_PDIV_DIV12_gc = (0x0A<<1),  /* Divide by 12 */
+    CLKCTRL_PDIV_DIV24_gc = (0x0B<<1),  /* Divide by 24 */
+    CLKCTRL_PDIV_DIV48_gc = (0x0C<<1)  /* Divide by 48 */
+} CLKCTRL_PDIV_t;
+
+/* PLL Source select */
+typedef enum CLKCTRL_SOURCE_enum
+{
+    CLKCTRL_SOURCE_OSCHF_gc = (0x00<<5),  /* Internal High Frequency Oscillator */
+    CLKCTRL_SOURCE_EXTCLK_gc = (0x01<<5)  /* External Clock */
+} CLKCTRL_SOURCE_t;
+
+/* PLL Source Division select */
+typedef enum CLKCTRL_SOURCEDIV_enum
+{
+    CLKCTRL_SOURCEDIV_DIV1_gc = (0x00<<3),  /* Source undivided */
+    CLKCTRL_SOURCEDIV_DIV2_gc = (0x01<<3),  /* Divide source by 2 */
+    CLKCTRL_SOURCEDIV_DIV4_gc = (0x02<<3),  /* Divide source by 4 */
+    CLKCTRL_SOURCEDIV_DIV6_gc = (0x03<<3)  /* Divide source by 6 */
+} CLKCTRL_SOURCEDIV_t;
+
+/*
+--------------------------------------------------------------------------
+CPU - CPU
+--------------------------------------------------------------------------
+*/
+
+#define CORE_VERSION  V4S
+
+/* CCP signature select */
+typedef enum CCP_enum
+{
+    CCP_SPM_gc = (0x9D<<0),  /* SPM Instruction Protection */
+    CCP_IOREG_gc = (0xD8<<0)  /* IO Register Protection */
+} CCP_t;
+
+/*
+--------------------------------------------------------------------------
+CPUINT - Interrupt Controller
+--------------------------------------------------------------------------
+*/
+
+/* Interrupt Controller */
+typedef struct CPUINT_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t STATUS;  /* Status */
+    register8_t LVL0PRI;  /* Interrupt Level 0 Priority */
+    register8_t LVL1VEC;  /* Interrupt Level 1 Priority Vector */
+} CPUINT_t;
+
+
+/*
+--------------------------------------------------------------------------
+CRCSCAN - CRCSCAN
+--------------------------------------------------------------------------
+*/
+
+/* CRCSCAN */
+typedef struct CRCSCAN_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t STATUS;  /* Status */
+    register8_t reserved_1[13];
+} CRCSCAN_t;
+
+/* CRC Source select */
+typedef enum CRCSCAN_SRC_enum
+{
+    CRCSCAN_SRC_FLASH_gc = (0x00<<0),  /* CRC on entire flash */
+    CRCSCAN_SRC_APPLICATION_gc = (0x01<<0),  /* CRC on boot and appl section of flash */
+    CRCSCAN_SRC_BOOT_gc = (0x02<<0)  /* CRC on boot section of flash */
+} CRCSCAN_SRC_t;
+
+/*
+--------------------------------------------------------------------------
+EVSYS - Event System
+--------------------------------------------------------------------------
+*/
+
+/* Event System */
+typedef struct EVSYS_struct
+{
+    register8_t SWEVENTA;  /* Software Event A */
+    register8_t reserved_1[15];
+    register8_t CHANNEL0;  /* Multiplexer Channel 0 */
+    register8_t CHANNEL1;  /* Multiplexer Channel 1 */
+    register8_t CHANNEL2;  /* Multiplexer Channel 2 */
+    register8_t CHANNEL3;  /* Multiplexer Channel 3 */
+    register8_t CHANNEL4;  /* Multiplexer Channel 4 */
+    register8_t CHANNEL5;  /* Multiplexer Channel 5 */
+    register8_t reserved_2[10];
+    register8_t USERCCLLUT0A;  /* CCL0 Event A */
+    register8_t USERCCLLUT0B;  /* CCL0 Event B */
+    register8_t USERCCLLUT1A;  /* CCL1 Event A */
+    register8_t USERCCLLUT1B;  /* CCL1 Event B */
+    register8_t USERCCLLUT2A;  /* CCL2 Event A */
+    register8_t USERCCLLUT2B;  /* CCL2 Event B */
+    register8_t USERCCLLUT3A;  /* CCL3 Event A */
+    register8_t USERCCLLUT3B;  /* CCL3 Event B */
+    register8_t USERADC0START;  /* ADC0 Start */
+    register8_t USEREVSYSEVOUTA;  /* EVOUTA */
+    register8_t USEREVSYSEVOUTC;  /* EVOUTC */
+    register8_t USEREVSYSEVOUTD;  /* EVOUTD */
+    register8_t USEREVSYSEVOUTF;  /* EVOUTF */
+    register8_t USERUSART0IRDA;  /* USART0 IrDA Event */
+    register8_t USERTCE0CNTA;  /* TCE0 Event A */
+    register8_t USERTCE0CNTB;  /* TCE0 Event B */
+    register8_t USERTCB0CAPT;  /* TCB0 Event A */
+    register8_t USERTCB0COUNT;  /* TCB0 Event B */
+    register8_t USERTCB1CAPT;  /* TCB1 Event A */
+    register8_t USERTCB1COUNT;  /* TCB1 Event B */
+    register8_t USERTCF0CNT;  /* TCF0 Clock Event */
+    register8_t USERTCF0ACT;  /* TCF0 Action Event */
+    register8_t USERWEXA;  /* WEX Event A */
+    register8_t USERWEXB;  /* WEX Event B */
+    register8_t USERWEXC;  /* WEX Event C */
+    register8_t reserved_3[7];
+} EVSYS_t;
+
+/* Channel generator select */
+typedef enum EVSYS_CHANNEL_enum
+{
+    EVSYS_CHANNEL_OFF_gc = (0x00<<0),  /* Off */
+    EVSYS_CHANNEL_UPDI_SYNCH_gc = (0x01<<0),  /* UPDI SYNCH character */
+    EVSYS_CHANNEL_RTC_OVF_gc = (0x06<<0),  /* Real Time Counter overflow */
+    EVSYS_CHANNEL_RTC_CMP_gc = (0x07<<0),  /* Real Time Counter compare */
+    EVSYS_CHANNEL_RTC_PITEV0_gc = (0x08<<0),  /* Periodic Interrupt Timer Event 0 */
+    EVSYS_CHANNEL_RTC_PITEV1_gc = (0x09<<0),  /* Periodic Interrupt Timer Event 1 */
+    EVSYS_CHANNEL_CCL_LUT0_gc = (0x10<<0),  /* Configurable Custom Logic LUT0 */
+    EVSYS_CHANNEL_CCL_LUT1_gc = (0x11<<0),  /* Configurable Custom Logic LUT1 */
+    EVSYS_CHANNEL_CCL_LUT2_gc = (0x12<<0),  /* Configurable Custom Logic LUT2 */
+    EVSYS_CHANNEL_CCL_LUT3_gc = (0x13<<0),  /* Configurable Custom Logic LUT3 */
+    EVSYS_CHANNEL_AC0_OUT_gc = (0x20<<0),  /* Analog Comparator 0 out */
+    EVSYS_CHANNEL_AC1_OUT_gc = (0x21<<0),  /* Analog Comparator 1 out */
+    EVSYS_CHANNEL_ADC0_RES_gc = (0x24<<0),  /* ADC 0 Result Ready */
+    EVSYS_CHANNEL_ADC0_SAMP_gc = (0x25<<0),  /* ADC 0 Sample Ready */
+    EVSYS_CHANNEL_ADC0_WCMP_gc = (0x26<<0),  /* ADC 0 Window Compare */
+    EVSYS_CHANNEL_PORTA_EV0_gc = (0x40<<0),  /* Port A Event 0 */
+    EVSYS_CHANNEL_PORTA_EV1_gc = (0x41<<0),  /* Port A Event 1 */
+    EVSYS_CHANNEL_PORTC_EV0_gc = (0x44<<0),  /* Port C Event 0 */
+    EVSYS_CHANNEL_PORTC_EV1_gc = (0x45<<0),  /* Port C Event 1 */
+    EVSYS_CHANNEL_PORTD_EV0_gc = (0x46<<0),  /* Port D Event 0 */
+    EVSYS_CHANNEL_PORTD_EV1_gc = (0x47<<0),  /* Port D Event 1 */
+    EVSYS_CHANNEL_PORTF_EV0_gc = (0x4A<<0),  /* Port F Event 0 */
+    EVSYS_CHANNEL_PORTF_EV1_gc = (0x4B<<0),  /* Port F Event 1 */
+    EVSYS_CHANNEL_USART0_XCK_gc = (0x60<<0),  /* USART 0 XCK */
+    EVSYS_CHANNEL_SPI0_SCK_gc = (0x68<<0),  /* SPI 0 SCK */
+    EVSYS_CHANNEL_TCE0_OVF_gc = (0x80<<0),  /* Timer/Counter E0 overflow */
+    EVSYS_CHANNEL_TCE0_CMP0_gc = (0x84<<0),  /* Timer/Counter E0 compare 0 */
+    EVSYS_CHANNEL_TCE0_CMP1_gc = (0x85<<0),  /* Timer/Counter E0 compare 1 */
+    EVSYS_CHANNEL_TCE0_CMP2_gc = (0x86<<0),  /* Timer/Counter E0 compare 2 */
+    EVSYS_CHANNEL_TCE0_CMP3_gc = (0x87<<0),  /* Timer/Counter E0 compare 3 */
+    EVSYS_CHANNEL_TCB0_CAPT_gc = (0xA0<<0),  /* Timer/Counter B0 capture */
+    EVSYS_CHANNEL_TCB0_OVF_gc = (0xA1<<0),  /* Timer/Counter B0 overflow */
+    EVSYS_CHANNEL_TCB1_CAPT_gc = (0xA2<<0),  /* Timer/Counter B1 capture */
+    EVSYS_CHANNEL_TCB1_OVF_gc = (0xA3<<0),  /* Timer/Counter B1 overflow */
+    EVSYS_CHANNEL_TCF0_OVF_gc = (0xB8<<0),  /* Timer/Counter F0 Overflow */
+    EVSYS_CHANNEL_TCF0_CMP0_gc = (0xB9<<0),  /* Timer/Counter F0 compare 0 */
+    EVSYS_CHANNEL_TCF0_CMP1_gc = (0xBA<<0)  /* Timer/Counter F0 compare 1 */
+} EVSYS_CHANNEL_t;
+
+/* Software event on channel select */
+typedef enum EVSYS_SWEVENTA_enum
+{
+    EVSYS_SWEVENTA_CH0_gc = (0x01<<0),  /* Software event on channel 0 */
+    EVSYS_SWEVENTA_CH1_gc = (0x02<<0),  /* Software event on channel 1 */
+    EVSYS_SWEVENTA_CH2_gc = (0x04<<0),  /* Software event on channel 2 */
+    EVSYS_SWEVENTA_CH3_gc = (0x08<<0),  /* Software event on channel 3 */
+    EVSYS_SWEVENTA_CH4_gc = (0x10<<0),  /* Software event on channel 4 */
+    EVSYS_SWEVENTA_CH5_gc = (0x20<<0),  /* Software event on channel 5 */
+    EVSYS_SWEVENTA_CH6_gc = (0x40<<0),  /* Software event on channel 6 */
+    EVSYS_SWEVENTA_CH7_gc = (0x80<<0)  /* Software event on channel 7 */
+} EVSYS_SWEVENTA_t;
+
+/* User channel select */
+typedef enum EVSYS_USER_enum
+{
+    EVSYS_USER_OFF_gc = (0x00<<0),  /* Off, No Eventsys Channel connected */
+    EVSYS_USER_CHANNEL0_gc = (0x01<<0),  /* Connect user to event channel 0 */
+    EVSYS_USER_CHANNEL1_gc = (0x02<<0),  /* Connect user to event channel 1 */
+    EVSYS_USER_CHANNEL2_gc = (0x03<<0),  /* Connect user to event channel 2 */
+    EVSYS_USER_CHANNEL3_gc = (0x04<<0),  /* Connect user to event channel 3 */
+    EVSYS_USER_CHANNEL4_gc = (0x05<<0),  /* Connect user to event channel 4 */
+    EVSYS_USER_CHANNEL5_gc = (0x06<<0)  /* Connect user to event channel 5 */
+} EVSYS_USER_t;
+
+/*
+--------------------------------------------------------------------------
+FUSE - Fuses
+--------------------------------------------------------------------------
+*/
+
+/* Fuses */
+typedef struct FUSE_struct
+{
+    register8_t WDTCFG;  /* Watchdog Configuration */
+    register8_t BODCFG;  /* BOD Configuration */
+    register8_t OSCCFG;  /* Oscillator Configuration */
+    register8_t reserved_1[2];
+    register8_t SYSCFG0;  /* System Configuration 0 */
+    register8_t SYSCFG1;  /* System Configuration 1 */
+    register8_t CODESIZE;  /* Code Section Size */
+    register8_t BOOTSIZE;  /* Boot Section Size */
+    register8_t reserved_2[1];
+    _WORDREGISTER(PDICFG);  /* Programming and Debugging Interface Configuration */
+} FUSE_t;
+
+/* avr-libc typedef for avr/fuse.h */
+typedef FUSE_t NVM_FUSES_t;
+
+/* BOD Operation in Active Mode select */
+typedef enum ACTIVE_enum
+{
+    ACTIVE_DISABLE_gc = (0x00<<2),  /* Disabled */
+    ACTIVE_ENABLED_gc = (0x01<<2),  /* Enabled in continuous mode */
+    ACTIVE_SAMPLED_gc = (0x02<<2),  /* Enabled in sampled mode */
+    ACTIVE_ENABLEWAIT_gc = (0x03<<2)  /* Enabled in continuous mode. Execution halted at wake-up until BOD is running */
+} ACTIVE_t;
+
+/* CRC Select */
+typedef enum CRCSEL_enum
+{
+    CRCSEL_CRC16_gc = (0x00<<5),  /* Enable CRC16 */
+    CRCSEL_CRC32_gc = (0x01<<5)  /* Enable CRC32 */
+} CRCSEL_t;
+
+/* CRC Source select */
+typedef enum CRCSRC_enum
+{
+    CRCSRC_FLASH_gc = (0x00<<6),  /* CRC of full Flash (boot, application code and application data) */
+    CRCSRC_BOOT_gc = (0x01<<6),  /* CRC of boot section */
+    CRCSRC_BOOTAPP_gc = (0x02<<6),  /* CRC of application code and boot sections */
+    CRCSRC_NOCRC_gc = (0x03<<6)  /* No CRC */
+} CRCSRC_t;
+
+/* EEPROM Save select */
+typedef enum EESAVE_enum
+{
+    EESAVE_DISABLE_gc = (0x00<<0),  /* EEPROM content is erased during chip erase */
+    EESAVE_ENABLE_gc = (0x01<<0)  /* EEPROM content is preserved during chip erase */
+} EESAVE_t;
+
+/* NVM Protection Activation Key select */
+typedef enum KEY_enum
+{
+    KEY_NOTACT_gc = (0x00<<4),  /* Not Active */
+    KEY_NVMACT_gc = (0xB45<<4)  /* NVM Protection Active */
+} KEY_t;
+
+/* Protection Level select */
+typedef enum LEVEL_enum
+{
+    LEVEL_NVMACCDIS_gc = (0x02<<0),  /* NVM Access through UPDI disabled */
+    LEVEL_BASIC_gc = (0x03<<0)  /* UPDI and UPDI pins working normally */
+} LEVEL_t;
+
+/* BOD Level select */
+typedef enum LVL_enum
+{
+    LVL_BODLEVEL0_gc = (0x00<<5),  /* BOD Disabled during normal operation */
+    LVL_BODLEVEL1_gc = (0x01<<5),  /* 1.9 V */
+    LVL_BODLEVEL2_gc = (0x02<<5),  /* 2.7 V */
+    LVL_BODLEVEL3_gc = (0x03<<5)  /* 4.5 V */
+} LVL_t;
+
+/* High-frequency Oscillator Frequency select */
+typedef enum OSCHFFRQ_enum
+{
+    OSCHFFRQ_20M_gc = (0x00<<3),  /* OSCHF running at 20 MHz */
+    OSCHFFRQ_16M_gc = (0x01<<3)  /* OSCHF running at 16 MHz */
+} OSCHFFRQ_t;
+
+/* Watchdog Timeout Period select */
+typedef enum PERIOD_enum
+{
+    PERIOD_OFF_gc = (0x00<<0),  /* Watch-Dog timer Off */
+    PERIOD_8CLK_gc = (0x01<<0),  /* 8 cycles (8ms) */
+    PERIOD_16CLK_gc = (0x02<<0),  /* 16 cycles (16ms) */
+    PERIOD_32CLK_gc = (0x03<<0),  /* 32 cycles (32ms) */
+    PERIOD_64CLK_gc = (0x04<<0),  /* 64 cycles (64ms) */
+    PERIOD_128CLK_gc = (0x05<<0),  /* 128 cycles (0.128s) */
+    PERIOD_256CLK_gc = (0x06<<0),  /* 256 cycles (0.256s) */
+    PERIOD_512CLK_gc = (0x07<<0),  /* 512 cycles (0.512s) */
+    PERIOD_1KCLK_gc = (0x08<<0),  /* 1K cycles (1.0s) */
+    PERIOD_2KCLK_gc = (0x09<<0),  /* 2K cycles (2.0s) */
+    PERIOD_4KCLK_gc = (0x0A<<0),  /* 4K cycles (4.0s) */
+    PERIOD_8KCLK_gc = (0x0B<<0)  /* 8K cycles (8.0s) */
+} PERIOD_t;
+
+/* Reset Pin Configuration select */
+typedef enum RSTPINCFG_enum
+{
+    RSTPINCFG_NONE_gc = (0x00<<3),  /* No External Reset */
+    RSTPINCFG_RESET_gc = (0x01<<3)  /* PF6 configured as RESET pin */
+} RSTPINCFG_t;
+
+/* BOD Sample Frequency select */
+typedef enum SAMPFREQ_enum
+{
+    SAMPFREQ_128HZ_gc = (0x00<<4),  /* Sampling frequency is 128 Hz */
+    SAMPFREQ_32HZ_gc = (0x01<<4)  /* Sample frequency is 32 Hz */
+} SAMPFREQ_t;
+
+/* BOD Operation in Sleep Mode select */
+typedef enum SLEEP_enum
+{
+    SLEEP_DISABLE_gc = (0x00<<0),  /* Disabled */
+    SLEEP_ENABLE_gc = (0x01<<0),  /* Enabled in continuous mode */
+    SLEEP_SAMPLE_gc = (0x02<<0)  /* Enabled in sampled mode */
+} SLEEP_t;
+
+/* Startup Time select */
+typedef enum SUT_enum
+{
+    SUT_0MS_gc = (0x00<<0),  /* 0 ms */
+    SUT_1MS_gc = (0x01<<0),  /* 1 ms */
+    SUT_2MS_gc = (0x02<<0),  /* 2 ms */
+    SUT_4MS_gc = (0x03<<0),  /* 4 ms */
+    SUT_8MS_gc = (0x04<<0),  /* 8 ms */
+    SUT_16MS_gc = (0x05<<0),  /* 16 ms */
+    SUT_32MS_gc = (0x06<<0),  /* 32 ms */
+    SUT_64MS_gc = (0x07<<0)  /* 64 ms */
+} SUT_t;
+
+/* UPDI Pin Configuration select */
+typedef enum UPDIPINCFG_enum
+{
+    UPDIPINCFG_GPIO_gc = (0x00<<4),  /* PF7 Configured as GPIO pin */
+    UPDIPINCFG_UPDI_gc = (0x01<<4)  /* PF7 Configured as UPDI pin */
+} UPDIPINCFG_t;
+
+/* Watchdog Window Timeout Period select */
+typedef enum WINDOW_enum
+{
+    WINDOW_OFF_gc = (0x00<<4),  /* Window mode off */
+    WINDOW_8CLK_gc = (0x01<<4),  /* 8 cycles (8ms) */
+    WINDOW_16CLK_gc = (0x02<<4),  /* 16 cycles (16ms) */
+    WINDOW_32CLK_gc = (0x03<<4),  /* 32 cycles (32ms) */
+    WINDOW_64CLK_gc = (0x04<<4),  /* 64 cycles (64ms) */
+    WINDOW_128CLK_gc = (0x05<<4),  /* 128 cycles (0.128s) */
+    WINDOW_256CLK_gc = (0x06<<4),  /* 256 cycles (0.256s) */
+    WINDOW_512CLK_gc = (0x07<<4),  /* 512 cycles (0.512s) */
+    WINDOW_1KCLK_gc = (0x08<<4),  /* 1K cycles (1.0s) */
+    WINDOW_2KCLK_gc = (0x09<<4),  /* 2K cycles (2.0s) */
+    WINDOW_4KCLK_gc = (0x0A<<4),  /* 4K cycles (4.0s) */
+    WINDOW_8KCLK_gc = (0x0B<<4)  /* 8K cycles (8.0s) */
+} WINDOW_t;
+
+/*
+--------------------------------------------------------------------------
+GPR - General Purpose Registers
+--------------------------------------------------------------------------
+*/
+
+/* General Purpose Registers */
+typedef struct GPR_struct
+{
+    register8_t GPR0;  /* General Purpose Register 0 */
+    register8_t GPR1;  /* General Purpose Register 1 */
+    register8_t GPR2;  /* General Purpose Register 2 */
+    register8_t GPR3;  /* General Purpose Register 3 */
+} GPR_t;
+
+
+/*
+--------------------------------------------------------------------------
+LOCK - Lockbits
+--------------------------------------------------------------------------
+*/
+
+/* Lockbits */
+typedef struct LOCK_struct
+{
+    _DWORDREGISTER(KEY);  /* Lock Key Bits */
+} LOCK_t;
+
+/* Lock Key select */
+typedef enum LOCK_KEY_enum
+{
+    LOCK_KEY_NOLOCK_gc = (0x5CC5C55C<<0),  /* No locks */
+    LOCK_KEY_RWLOCK_gc = (0xA33A3AA3<<0)  /* Read and write lock */
+} LOCK_KEY_t;
+
+/*
+--------------------------------------------------------------------------
+NVMCTRL - Non-volatile Memory Controller
+--------------------------------------------------------------------------
+*/
+
+/* Non-volatile Memory Controller */
+typedef struct NVMCTRL_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    register8_t reserved_1[1];
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t STATUS;  /* Status */
+    register8_t reserved_2[1];
+    _WORDREGISTER(DATA);  /* Data */
+    register8_t reserved_3[2];
+    _DWORDREGISTER(ADDR);  /* Address */
+    register8_t reserved_4[48];
+} NVMCTRL_t;
+
+/* Command select */
+typedef enum NVMCTRL_CMD_enum
+{
+    NVMCTRL_CMD_NOCMD_gc = (0x00<<0),  /* No Command */
+    NVMCTRL_CMD_NOOP_gc = (0x01<<0),  /* No Operation */
+    NVMCTRL_CMD_FLPW_gc = (0x04<<0),  /* Flash Page Write */
+    NVMCTRL_CMD_FLPERW_gc = (0x05<<0),  /* Flash Page Erase and Write */
+    NVMCTRL_CMD_FLPER_gc = (0x08<<0),  /* Flash Page Erase */
+    NVMCTRL_CMD_FLMPER2_gc = (0x09<<0),  /* Flash 2-page erase enable */
+    NVMCTRL_CMD_FLMPER4_gc = (0x0A<<0),  /* Flash 4-page erase enable */
+    NVMCTRL_CMD_FLMPER8_gc = (0x0B<<0),  /* Flash 8-page erase enable */
+    NVMCTRL_CMD_FLMPER16_gc = (0x0C<<0),  /* Flash 16-page erase enable */
+    NVMCTRL_CMD_FLMPER32_gc = (0x0D<<0),  /* Flash 32-page erase enable */
+    NVMCTRL_CMD_FLPBCLR_gc = (0x0F<<0),  /* Flash Page Buffer Clear */
+    NVMCTRL_CMD_EEPW_gc = (0x14<<0),  /* EEPROM Page Write */
+    NVMCTRL_CMD_EEPERW_gc = (0x15<<0),  /* EEPROM Page Erase and Write */
+    NVMCTRL_CMD_EEPER_gc = (0x17<<0),  /* EEPROM Page Erase */
+    NVMCTRL_CMD_EEPBCLR_gc = (0x1F<<0),  /* EEPROM Page Buffer Clear */
+    NVMCTRL_CMD_CHER_gc = (0x20<<0),  /* Chip Erase Command (UPDI only) */
+    NVMCTRL_CMD_EECHER_gc = (0x30<<0)  /* EEPROM Erase Command (UPDI only) */
+} NVMCTRL_CMD_t;
+
+/* Write error select */
+typedef enum NVMCTRL_ERROR_enum
+{
+    NVMCTRL_ERROR_NOERROR_gc = (0x00<<4),  /* No Error */
+    NVMCTRL_ERROR_WRITEPROTECT_gc = (0x02<<4),  /* Attempt to program write protected area */
+    NVMCTRL_ERROR_CMDCOLLISION_gc = (0x03<<4),  /* Selecting new write command while write command already seleted */
+    NVMCTRL_ERROR_WRONGSECTION_gc = (0x04<<4)  /* Address cannot be written with selected command */
+} NVMCTRL_ERROR_t;
+
+/* Flash Mapping in Data space select */
+typedef enum NVMCTRL_FLMAP_enum
+{
+    NVMCTRL_FLMAP_SECTION0_gc = (0x00<<4),  /* Flash section 0, 0 - 32KB */
+    NVMCTRL_FLMAP_SECTION1_gc = (0x01<<4),  /* Flash section 1, 32 - 64KB */
+    NVMCTRL_FLMAP_SECTION2_gc = (0x02<<4),  /* Flash section 2, 64 - 96KB */
+    NVMCTRL_FLMAP_SECTION3_gc = (0x03<<4)  /* Flash section 3, 96 - 128KB */
+} NVMCTRL_FLMAP_t;
+
+/*
+--------------------------------------------------------------------------
+PORT - I/O Ports
+--------------------------------------------------------------------------
+*/
+
+/* I/O Ports */
+typedef struct PORT_struct
+{
+    register8_t DIR;  /* Data Direction */
+    register8_t DIRSET;  /* Data Direction Set */
+    register8_t DIRCLR;  /* Data Direction Clear */
+    register8_t DIRTGL;  /* Data Direction Toggle */
+    register8_t OUT;  /* Output Value */
+    register8_t OUTSET;  /* Output Value Set */
+    register8_t OUTCLR;  /* Output Value Clear */
+    register8_t OUTTGL;  /* Output Value Toggle */
+    register8_t IN;  /* Input Value */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t PORTCTRL;  /* Port Control */
+    register8_t PINCONFIG;  /* Pin Control Config */
+    register8_t PINCTRLUPD;  /* Pin Control Update */
+    register8_t PINCTRLSET;  /* Pin Control Set */
+    register8_t PINCTRLCLR;  /* Pin Control Clear */
+    register8_t reserved_1[1];
+    register8_t PIN0CTRL;  /* Pin 0 Control */
+    register8_t PIN1CTRL;  /* Pin 1 Control */
+    register8_t PIN2CTRL;  /* Pin 2 Control */
+    register8_t PIN3CTRL;  /* Pin 3 Control */
+    register8_t PIN4CTRL;  /* Pin 4 Control */
+    register8_t PIN5CTRL;  /* Pin 5 Control */
+    register8_t PIN6CTRL;  /* Pin 6 Control */
+    register8_t PIN7CTRL;  /* Pin 7 Control */
+    register8_t EVGENCTRLA;  /* Event Generation Control A */
+    register8_t reserved_2[7];
+} PORT_t;
+
+/* Event Generator 0 Select */
+typedef enum PORT_EVGEN0SEL_enum
+{
+    PORT_EVGEN0SEL_PIN0_gc = (0x00<<0),  /* Pin 0 used as event generator */
+    PORT_EVGEN0SEL_PIN1_gc = (0x01<<0),  /* Pin 1 used as event generator */
+    PORT_EVGEN0SEL_PIN2_gc = (0x02<<0),  /* Pin 2 used as event generator */
+    PORT_EVGEN0SEL_PIN3_gc = (0x03<<0),  /* Pin 3 used as event generator */
+    PORT_EVGEN0SEL_PIN4_gc = (0x04<<0),  /* Pin 4 used as event generator */
+    PORT_EVGEN0SEL_PIN5_gc = (0x05<<0),  /* Pin 5 used as event generator */
+    PORT_EVGEN0SEL_PIN6_gc = (0x06<<0),  /* Pin 6 used as event generator */
+    PORT_EVGEN0SEL_PIN7_gc = (0x07<<0)  /* Pin 7 used as event generator */
+} PORT_EVGEN0SEL_t;
+
+/* Event Generator 1 Select */
+typedef enum PORT_EVGEN1SEL_enum
+{
+    PORT_EVGEN1SEL_PIN0_gc = (0x00<<4),  /* Pin 0 used as event generator */
+    PORT_EVGEN1SEL_PIN1_gc = (0x01<<4),  /* Pin 1 used as event generator */
+    PORT_EVGEN1SEL_PIN2_gc = (0x02<<4),  /* Pin 2 used as event generator */
+    PORT_EVGEN1SEL_PIN3_gc = (0x03<<4),  /* Pin 3 used as event generator */
+    PORT_EVGEN1SEL_PIN4_gc = (0x04<<4),  /* Pin 4 used as event generator */
+    PORT_EVGEN1SEL_PIN5_gc = (0x05<<4),  /* Pin 5 used as event generator */
+    PORT_EVGEN1SEL_PIN6_gc = (0x06<<4),  /* Pin 6 used as event generator */
+    PORT_EVGEN1SEL_PIN7_gc = (0x07<<4)  /* Pin 7 used as event generator */
+} PORT_EVGEN1SEL_t;
+
+/* Input Level Select */
+typedef enum PORT_INLVL_enum
+{
+    PORT_INLVL_ST_gc = (0x00<<6),  /* Schmitt-Trigger input level */
+    PORT_INLVL_TTL_gc = (0x01<<6)  /* TTL Input level */
+} PORT_INLVL_t;
+
+/* Input/Sense Configuration select */
+typedef enum PORT_ISC_enum
+{
+    PORT_ISC_INTDISABLE_gc = (0x00<<0),  /* Interrupt disabled but input buffer enabled */
+    PORT_ISC_BOTHEDGES_gc = (0x01<<0),  /* Sense Both Edges */
+    PORT_ISC_RISING_gc = (0x02<<0),  /* Sense Rising Edge */
+    PORT_ISC_FALLING_gc = (0x03<<0),  /* Sense Falling Edge */
+    PORT_ISC_INPUT_DISABLE_gc = (0x04<<0),  /* Digital Input Buffer disabled */
+    PORT_ISC_LEVEL_gc = (0x05<<0)  /* Sense low Level */
+} PORT_ISC_t;
+
+/*
+--------------------------------------------------------------------------
+PORTMUX - Port Multiplexer
+--------------------------------------------------------------------------
+*/
+
+/* Port Multiplexer */
+typedef struct PORTMUX_struct
+{
+    register8_t EVSYSROUTEA;  /* EVSYS route A */
+    register8_t CCLROUTEA;  /* CCL route A */
+    register8_t USARTROUTEA;  /* USART route A */
+    register8_t reserved_1[2];
+    register8_t SPIROUTEA;  /* SPI route A */
+    register8_t TWIROUTEA;  /* TWI route A */
+    register8_t TCEROUTEA;  /* TCE route A */
+    register8_t TCBROUTEA;  /* TCB route A */
+    register8_t reserved_2[3];
+    register8_t TCFROUTEA;  /* TCF Route A */
+    register8_t reserved_3[19];
+} PORTMUX_t;
+
+/* Event Output A select */
+typedef enum PORTMUX_EVOUTA_enum
+{
+    PORTMUX_EVOUTA_DEFAULT_gc = (0x00<<0),  /* EVOUT on PA2 */
+    PORTMUX_EVOUTA_ALT1_gc = (0x01<<0)  /* EVOUT on PA7 */
+} PORTMUX_EVOUTA_t;
+
+/* Event Output C select */
+typedef enum PORTMUX_EVOUTC_enum
+{
+    PORTMUX_EVOUTC_DEFAULT_gc = (0x00<<2)  /* EVOUT on PC2 */
+} PORTMUX_EVOUTC_t;
+
+/* Event Output D select */
+typedef enum PORTMUX_EVOUTD_enum
+{
+    PORTMUX_EVOUTD_DEFAULT_gc = (0x00<<3),  /* EVOUT on PD2 */
+    PORTMUX_EVOUTD_ALT1_gc = (0x01<<3)  /* EVOUT on PD7 */
+} PORTMUX_EVOUTD_t;
+
+/* Event Output F select */
+typedef enum PORTMUX_EVOUTF_enum
+{
+    PORTMUX_EVOUTF_DEFAULT_gc = (0x00<<5),  /* EVOUT on PF2 */
+    PORTMUX_EVOUTF_ALT1_gc = (0x01<<5)  /* EVOUT on PF7 */
+} PORTMUX_EVOUTF_t;
+
+/* CCL Look-Up Table 0 Signals select */
+typedef enum PORTMUX_LUT0_enum
+{
+    PORTMUX_LUT0_DEFAULT_gc = (0x00<<0),  /* Out: PA3 In: PA0, PA1, PA2 */
+    PORTMUX_LUT0_ALT1_gc = (0x01<<0)  /* Out: PA6 In: PA0, PA1, PA2 */
+} PORTMUX_LUT0_t;
+
+/* CCL Look-Up Table 1 Signals select */
+typedef enum PORTMUX_LUT1_enum
+{
+    PORTMUX_LUT1_DEFAULT_gc = (0x00<<1)  /* Out: PC3 In: PC0, PC1, PC2 */
+} PORTMUX_LUT1_t;
+
+/* CCL Look-Up Table 2 Signals select */
+typedef enum PORTMUX_LUT2_enum
+{
+    PORTMUX_LUT2_DEFAULT_gc = (0x00<<2),  /* Out: PD3 In: PD0, PD1, PD2 */
+    PORTMUX_LUT2_ALT1_gc = (0x01<<2)  /* Out: PD6 In: PD0, PD1, PD2 */
+} PORTMUX_LUT2_t;
+
+/* CCL Look-Up Table 3 Signals select */
+typedef enum PORTMUX_LUT3_enum
+{
+    PORTMUX_LUT3_DEFAULT_gc = (0x00<<3)  /* Out: PF3 In: PF0, PF1, PF2 */
+} PORTMUX_LUT3_t;
+
+/* SPI0 Signals select */
+typedef enum PORTMUX_SPI0_enum
+{
+    PORTMUX_SPI0_DEFAULT_gc = (0x00<<0),  /* PA4, PA5, PA6, PA7 */
+    PORTMUX_SPI0_ALT3_gc = (0x03<<0),  /* PA0, PA1, PC0, PC1 */
+    PORTMUX_SPI0_ALT4_gc = (0x04<<0),  /* PD4, PD5, PD6, PD7 */
+    PORTMUX_SPI0_ALT5_gc = (0x05<<0),  /* PC0, PC1, PC2, PC3 */
+    PORTMUX_SPI0_ALT6_gc = (0x06<<0),  /* PC1, PC2, PC3, - */
+    PORTMUX_SPI0_NONE_gc = (0x07<<0)  /* Not connected to any pins, SS set to 1 */
+} PORTMUX_SPI0_t;
+
+/* TCB0 Output select */
+typedef enum PORTMUX_TCB0_enum
+{
+    PORTMUX_TCB0_DEFAULT_gc = (0x00<<0),  /* PA2 */
+    PORTMUX_TCB0_ALT1_gc = (0x01<<0)  /* PF4 */
+} PORTMUX_TCB0_t;
+
+/* TCB1 Output select */
+typedef enum PORTMUX_TCB1_enum
+{
+    PORTMUX_TCB1_DEFAULT_gc = (0x00<<1),  /* PA3 */
+    PORTMUX_TCB1_ALT1_gc = (0x01<<1)  /* PF5 */
+} PORTMUX_TCB1_t;
+
+/* TCE0 Signals select */
+typedef enum PORTMUX_TCE0_enum
+{
+    PORTMUX_TCE0_PORTA_gc = (0x00<<0),  /* PA0, PA1, PA2, PA3, PA4, PA5, PA6, PA7 */
+    PORTMUX_TCE0_PORTC_gc = (0x02<<0),  /* PC0, PC1, PC2, PC3, -, -, -, - */
+    PORTMUX_TCE0_PORTD_gc = (0x03<<0),  /* PD0, PD1, PD2, PD3, PD4, PD5, PD6, PD7 */
+    PORTMUX_TCE0_PORTF_gc = (0x05<<0),  /* PF0, PF1, PF2, PF3, PF4, PF5, -, - */
+    PORTMUX_TCE0_PORTC2_gc = (0x08<<0),  /* PA0, PA1, PC0, PC1, PC2, PC3, -, - */
+    PORTMUX_TCE0_PORTA2_gc = (0x09<<0)  /* PA2, PA3, PA4, PA5, PA6, PA7, -, - */
+} PORTMUX_TCE0_t;
+
+/* TCF0 Output select */
+typedef enum PORTMUX_TCF0_enum
+{
+    PORTMUX_TCF0_DEFAULT_gc = (0x00<<0),  /* PA0, PA1 */
+    PORTMUX_TCF0_ALT1_gc = (0x01<<0),  /* PA6, PA7 */
+    PORTMUX_TCF0_ALT2_gc = (0x02<<0)  /* PF4, PF5 */
+} PORTMUX_TCF0_t;
+
+/* TWI0 Signals select */
+typedef enum PORTMUX_TWI0_enum
+{
+    PORTMUX_TWI0_DEFAULT_gc = (0x00<<0),  /* {PA2, PA3}, {PC2, PC3} */
+    PORTMUX_TWI0_ALT2_gc = (0x02<<0),  /* {PC2, PC3}, {-, -} */
+    PORTMUX_TWI0_ALT3_gc = (0x03<<0)  /* {PA0, PA1}, {PC2, PC3} */
+} PORTMUX_TWI0_t;
+
+/* USART0 Routing select */
+typedef enum PORTMUX_USART0_enum
+{
+    PORTMUX_USART0_DEFAULT_gc = (0x00<<0),  /* {PA0, PA1, PA2, PA3} */
+    PORTMUX_USART0_ALT1_gc = (0x01<<0),  /* {PA4, PA5, PA6, PA7} */
+    PORTMUX_USART0_ALT2_gc = (0x02<<0),  /* {PA2,PA3, -, -} */
+    PORTMUX_USART0_ALT3_gc = (0x03<<0),  /* {PD4, PD5, PD6, PD7} */
+    PORTMUX_USART0_ALT4_gc = (0x04<<0),  /* {PC1, PC2, PC3, -} */
+    PORTMUX_USART0_ALT6_gc = (0x06<<0),  /* {PF7, PF6, -, -} */
+    PORTMUX_USART0_NONE_gc = (0x07<<0)  /* Not connected to any pins */
+} PORTMUX_USART0_t;
+
+/*
+--------------------------------------------------------------------------
+RSTCTRL - Reset controller
+--------------------------------------------------------------------------
+*/
+
+/* Reset controller */
+typedef struct RSTCTRL_struct
+{
+    register8_t RSTFR;  /* Reset Flags */
+    register8_t SWRR;  /* Software Reset */
+    register8_t reserved_1[14];
+} RSTCTRL_t;
+
+
+/*
+--------------------------------------------------------------------------
+RTC - Real-Time Counter
+--------------------------------------------------------------------------
+*/
+
+/* Real-Time Counter */
+typedef struct RTC_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t STATUS;  /* Status */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t TEMP;  /* Temporary */
+    register8_t DBGCTRL;  /* Debug control */
+    register8_t CALIB;  /* Calibration */
+    register8_t CLKSEL;  /* Clock Select */
+    _WORDREGISTER(CNT);  /* Counter */
+    _WORDREGISTER(PER);  /* Period */
+    _WORDREGISTER(CMP);  /* Compare */
+    register8_t reserved_1[2];
+    register8_t PITCTRLA;  /* PIT Control A */
+    register8_t PITSTATUS;  /* PIT Status */
+    register8_t PITINTCTRL;  /* PIT Interrupt Control */
+    register8_t PITINTFLAGS;  /* PIT Interrupt Flags */
+    register8_t reserved_2[1];
+    register8_t PITDBGCTRL;  /* PIT Debug control */
+    register8_t PITEVGENCTRLA;  /* PIT Event Generation Control A */
+    register8_t reserved_3[9];
+} RTC_t;
+
+/* Clock Select */
+typedef enum RTC_CLKSEL_enum
+{
+    RTC_CLKSEL_OSC32K_gc = (0x00<<0),  /* Internal 32.768 kHz Oscillator */
+    RTC_CLKSEL_OSC1K_gc = (0x01<<0),  /* Internal 32.768 kHz Oscillator Divided by 32 */
+    RTC_CLKSEL_XOSC32K_gc = (0x02<<0),  /* 32.768 kHz Crystal Oscillator */
+    RTC_CLKSEL_EXTCLK_gc = (0x03<<0)  /* External Clock */
+} RTC_CLKSEL_t;
+
+/* Event Generation 0 Select */
+typedef enum RTC_EVGEN0SEL_enum
+{
+    RTC_EVGEN0SEL_OFF_gc = (0x00<<0),  /* No Event Generated */
+    RTC_EVGEN0SEL_DIV4_gc = (0x01<<0),  /* CLK_RTC divided by 4 */
+    RTC_EVGEN0SEL_DIV8_gc = (0x02<<0),  /* CLK_RTC divided by 8 */
+    RTC_EVGEN0SEL_DIV16_gc = (0x03<<0),  /* CLK_RTC divided by 16 */
+    RTC_EVGEN0SEL_DIV32_gc = (0x04<<0),  /* CLK_RTC divided by 32 */
+    RTC_EVGEN0SEL_DIV64_gc = (0x05<<0),  /* CLK_RTC divided by 64 */
+    RTC_EVGEN0SEL_DIV128_gc = (0x06<<0),  /* CLK_RTC divided by 128 */
+    RTC_EVGEN0SEL_DIV256_gc = (0x07<<0),  /* CLK_RTC divided by 256 */
+    RTC_EVGEN0SEL_DIV512_gc = (0x08<<0),  /* CLK_RTC divided by 512 */
+    RTC_EVGEN0SEL_DIV1024_gc = (0x09<<0),  /* CLK_RTC divided by 1024 */
+    RTC_EVGEN0SEL_DIV2048_gc = (0x0A<<0),  /* CLK_RTC divided by 2048 */
+    RTC_EVGEN0SEL_DIV4096_gc = (0x0B<<0),  /* CLK_RTC divided by 4096 */
+    RTC_EVGEN0SEL_DIV8192_gc = (0x0C<<0),  /* CLK_RTC divided by 8192 */
+    RTC_EVGEN0SEL_DIV16384_gc = (0x0D<<0),  /* CLK_RTC divided by 16384 */
+    RTC_EVGEN0SEL_DIV32768_gc = (0x0E<<0)  /* CLK_RTC divided by 32768 */
+} RTC_EVGEN0SEL_t;
+
+/* Event Generation 1 Select */
+typedef enum RTC_EVGEN1SEL_enum
+{
+    RTC_EVGEN1SEL_OFF_gc = (0x00<<4),  /* No Event Generated */
+    RTC_EVGEN1SEL_DIV4_gc = (0x01<<4),  /* CLK_RTC divided by 4 */
+    RTC_EVGEN1SEL_DIV8_gc = (0x02<<4),  /* CLK_RTC divided by 8 */
+    RTC_EVGEN1SEL_DIV16_gc = (0x03<<4),  /* CLK_RTC divided by 16 */
+    RTC_EVGEN1SEL_DIV32_gc = (0x04<<4),  /* CLK_RTC divided by 32 */
+    RTC_EVGEN1SEL_DIV64_gc = (0x05<<4),  /* CLK_RTC divided by 64 */
+    RTC_EVGEN1SEL_DIV128_gc = (0x06<<4),  /* CLK_RTC divided by 128 */
+    RTC_EVGEN1SEL_DIV256_gc = (0x07<<4),  /* CLK_RTC divided by 256 */
+    RTC_EVGEN1SEL_DIV512_gc = (0x08<<4),  /* CLK_RTC divided by 512 */
+    RTC_EVGEN1SEL_DIV1024_gc = (0x09<<4),  /* CLK_RTC divided by 1024 */
+    RTC_EVGEN1SEL_DIV2048_gc = (0x0A<<4),  /* CLK_RTC divided by 2048 */
+    RTC_EVGEN1SEL_DIV4096_gc = (0x0B<<4),  /* CLK_RTC divided by 4096 */
+    RTC_EVGEN1SEL_DIV8192_gc = (0x0C<<4),  /* CLK_RTC divided by 8192 */
+    RTC_EVGEN1SEL_DIV16384_gc = (0x0D<<4),  /* CLK_RTC divided by 16384 */
+    RTC_EVGEN1SEL_DIV32768_gc = (0x0E<<4)  /* CLK_RTC divided by 32768 */
+} RTC_EVGEN1SEL_t;
+
+/* Period select */
+typedef enum RTC_PERIOD_enum
+{
+    RTC_PERIOD_OFF_gc = (0x00<<3),  /* Off */
+    RTC_PERIOD_CYC4_gc = (0x01<<3),  /* RTC Clock Cycles 4 */
+    RTC_PERIOD_CYC8_gc = (0x02<<3),  /* RTC Clock Cycles 8 */
+    RTC_PERIOD_CYC16_gc = (0x03<<3),  /* RTC Clock Cycles 16 */
+    RTC_PERIOD_CYC32_gc = (0x04<<3),  /* RTC Clock Cycles 32 */
+    RTC_PERIOD_CYC64_gc = (0x05<<3),  /* RTC Clock Cycles 64 */
+    RTC_PERIOD_CYC128_gc = (0x06<<3),  /* RTC Clock Cycles 128 */
+    RTC_PERIOD_CYC256_gc = (0x07<<3),  /* RTC Clock Cycles 256 */
+    RTC_PERIOD_CYC512_gc = (0x08<<3),  /* RTC Clock Cycles 512 */
+    RTC_PERIOD_CYC1024_gc = (0x09<<3),  /* RTC Clock Cycles 1024 */
+    RTC_PERIOD_CYC2048_gc = (0x0A<<3),  /* RTC Clock Cycles 2048 */
+    RTC_PERIOD_CYC4096_gc = (0x0B<<3),  /* RTC Clock Cycles 4096 */
+    RTC_PERIOD_CYC8192_gc = (0x0C<<3),  /* RTC Clock Cycles 8192 */
+    RTC_PERIOD_CYC16384_gc = (0x0D<<3),  /* RTC Clock Cycles 16384 */
+    RTC_PERIOD_CYC32768_gc = (0x0E<<3)  /* RTC Clock Cycles 32768 */
+} RTC_PERIOD_t;
+
+/* Prescaling Factor select */
+typedef enum RTC_PRESCALER_enum
+{
+    RTC_PRESCALER_DIV1_gc = (0x00<<3),  /* RTC Clock / 1 */
+    RTC_PRESCALER_DIV2_gc = (0x01<<3),  /* RTC Clock / 2 */
+    RTC_PRESCALER_DIV4_gc = (0x02<<3),  /* RTC Clock / 4 */
+    RTC_PRESCALER_DIV8_gc = (0x03<<3),  /* RTC Clock / 8 */
+    RTC_PRESCALER_DIV16_gc = (0x04<<3),  /* RTC Clock / 16 */
+    RTC_PRESCALER_DIV32_gc = (0x05<<3),  /* RTC Clock / 32 */
+    RTC_PRESCALER_DIV64_gc = (0x06<<3),  /* RTC Clock / 64 */
+    RTC_PRESCALER_DIV128_gc = (0x07<<3),  /* RTC Clock / 128 */
+    RTC_PRESCALER_DIV256_gc = (0x08<<3),  /* RTC Clock / 256 */
+    RTC_PRESCALER_DIV512_gc = (0x09<<3),  /* RTC Clock / 512 */
+    RTC_PRESCALER_DIV1024_gc = (0x0A<<3),  /* RTC Clock / 1024 */
+    RTC_PRESCALER_DIV2048_gc = (0x0B<<3),  /* RTC Clock / 2048 */
+    RTC_PRESCALER_DIV4096_gc = (0x0C<<3),  /* RTC Clock / 4096 */
+    RTC_PRESCALER_DIV8192_gc = (0x0D<<3),  /* RTC Clock / 8192 */
+    RTC_PRESCALER_DIV16384_gc = (0x0E<<3),  /* RTC Clock / 16384 */
+    RTC_PRESCALER_DIV32768_gc = (0x0F<<3)  /* RTC Clock / 32768 */
+} RTC_PRESCALER_t;
+
+/*
+--------------------------------------------------------------------------
+SIGROW - Signature row
+--------------------------------------------------------------------------
+*/
+
+/* Signature row */
+typedef struct SIGROW_struct
+{
+    register8_t DEVICEID0;  /* Device ID Byte 0 */
+    register8_t DEVICEID1;  /* Device ID Byte 1 */
+    register8_t DEVICEID2;  /* Device ID Byte 2 */
+    register8_t reserved_1[1];
+    _WORDREGISTER(TEMPSENSE0);  /* Temperature Calibration 0 */
+    _WORDREGISTER(TEMPSENSE1);  /* Temperature Calibration 1 */
+    register8_t reserved_2[8];
+    register8_t SERNUM0;  /* Serial Number Byte 0 */
+    register8_t SERNUM1;  /* Serial Number Byte 1 */
+    register8_t SERNUM2;  /* Serial Number Byte 2 */
+    register8_t SERNUM3;  /* Serial Number Byte 3 */
+    register8_t SERNUM4;  /* Serial Number Byte 4 */
+    register8_t SERNUM5;  /* Serial Number Byte 5 */
+    register8_t SERNUM6;  /* Serial Number Byte 6 */
+    register8_t SERNUM7;  /* Serial Number Byte 7 */
+    register8_t SERNUM8;  /* Serial Number Byte 8 */
+    register8_t SERNUM9;  /* Serial Number Byte 9 */
+    register8_t SERNUM10;  /* Serial Number Byte 10 */
+    register8_t SERNUM11;  /* Serial Number Byte 11 */
+    register8_t SERNUM12;  /* Serial Number Byte 12 */
+    register8_t SERNUM13;  /* Serial Number Byte 13 */
+    register8_t SERNUM14;  /* Serial Number Byte 14 */
+    register8_t SERNUM15;  /* Serial Number Byte 15 */
+    register8_t reserved_3[32];
+} SIGROW_t;
+
+
+/*
+--------------------------------------------------------------------------
+SLPCTRL - Sleep Controller
+--------------------------------------------------------------------------
+*/
+
+/* Sleep Controller */
+typedef struct SLPCTRL_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t reserved_1[15];
+} SLPCTRL_t;
+
+/* Sleep mode select */
+typedef enum SLPCTRL_SMODE_enum
+{
+    SLPCTRL_SMODE_IDLE_gc = (0x00<<1),  /* Idle mode */
+    SLPCTRL_SMODE_STDBY_gc = (0x01<<1),  /* Standby Mode */
+    SLPCTRL_SMODE_PDOWN_gc = (0x02<<1)  /* Power-down Mode */
+} SLPCTRL_SMODE_t;
+
+#define SLEEP_MODE_IDLE (0x00<<1)
+#define SLEEP_MODE_STANDBY (0x01<<1)
+#define SLEEP_MODE_PWR_DOWN (0x02<<1)
+/*
+--------------------------------------------------------------------------
+SPI - Serial Peripheral Interface
+--------------------------------------------------------------------------
+*/
+
+/* Serial Peripheral Interface */
+typedef struct SPI_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t DATA;  /* Data */
+    register8_t reserved_1[11];
+} SPI_t;
+
+/* SPI Mode select */
+typedef enum SPI_MODE_enum
+{
+    SPI_MODE_0_gc = (0x00<<0),  /* SPI Mode 0 */
+    SPI_MODE_1_gc = (0x01<<0),  /* SPI Mode 1 */
+    SPI_MODE_2_gc = (0x02<<0),  /* SPI Mode 2 */
+    SPI_MODE_3_gc = (0x03<<0)  /* SPI Mode 3 */
+} SPI_MODE_t;
+
+/* Prescaler select */
+typedef enum SPI_PRESC_enum
+{
+    SPI_PRESC_DIV4_gc = (0x00<<1),  /* CLK_PER / 4 */
+    SPI_PRESC_DIV16_gc = (0x01<<1),  /* CLK_PER / 16 */
+    SPI_PRESC_DIV64_gc = (0x02<<1),  /* CLK_PER / 64 */
+    SPI_PRESC_DIV128_gc = (0x03<<1)  /* CLK_PER / 128 */
+} SPI_PRESC_t;
+
+/*
+--------------------------------------------------------------------------
+SYSCFG - System Configuration Registers
+--------------------------------------------------------------------------
+*/
+
+/* System Configuration Registers */
+typedef struct SYSCFG_struct
+{
+    register8_t reserved_1[1];
+    register8_t REVID;  /* Revision ID */
+    register8_t reserved_2[62];
+} SYSCFG_t;
+
+
+/*
+--------------------------------------------------------------------------
+TCB - 16-bit Timer/Counter Type B
+--------------------------------------------------------------------------
+*/
+
+/* 16-bit Timer/Counter Type B */
+typedef struct TCB_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    register8_t reserved_1[1];
+    register8_t EVCTRL;  /* Event Control */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t STATUS;  /* Status */
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t TEMP;  /* Temporary Value */
+    _WORDREGISTER(CNT);  /* Count */
+    _WORDREGISTER(CCMP);  /* Compare or Capture */
+    register8_t reserved_2[2];
+} TCB_t;
+
+/* Clock Select */
+typedef enum TCB_CLKSEL_enum
+{
+    TCB_CLKSEL_DIV1_gc = (0x00<<1),  /* CLK_PER */
+    TCB_CLKSEL_DIV2_gc = (0x01<<1),  /* CLK_PER/2 */
+    TCB_CLKSEL_TCE0_gc = (0x02<<1),  /* Use CLK_TCE from TCE0 */
+    TCB_CLKSEL_EVENT_gc = (0x07<<1)  /* Count on event edge */
+} TCB_CLKSEL_t;
+
+/* Timer Mode select */
+typedef enum TCB_CNTMODE_enum
+{
+    TCB_CNTMODE_INT_gc = (0x00<<0),  /* Periodic Interrupt */
+    TCB_CNTMODE_TIMEOUT_gc = (0x01<<0),  /* Periodic Timeout */
+    TCB_CNTMODE_CAPT_gc = (0x02<<0),  /* Input Capture Event */
+    TCB_CNTMODE_FRQ_gc = (0x03<<0),  /* Input Capture Frequency measurement */
+    TCB_CNTMODE_PW_gc = (0x04<<0),  /* Input Capture Pulse-Width measurement */
+    TCB_CNTMODE_FRQPW_gc = (0x05<<0),  /* Input Capture Frequency and Pulse-Width measurement */
+    TCB_CNTMODE_SINGLE_gc = (0x06<<0),  /* Single Shot */
+    TCB_CNTMODE_PWM8_gc = (0x07<<0)  /* 8-bit PWM */
+} TCB_CNTMODE_t;
+
+/* Counter Size select */
+typedef enum TCB_CNTSIZE_enum
+{
+    TCB_CNTSIZE_16BITS_gc = (0x00<<0),  /* 16-bit CNT. MAX=16'hFFFF */
+    TCB_CNTSIZE_15BITS_gc = (0x01<<0),  /* 15-bit CNT. MAX=16'h7FFF */
+    TCB_CNTSIZE_14BITS_gc = (0x02<<0),  /* 14-bit CNT. MAX=16'h3FFF */
+    TCB_CNTSIZE_13BITS_gc = (0x03<<0),  /* 13-bit CNT. MAX=16'h1FFF */
+    TCB_CNTSIZE_12BITS_gc = (0x04<<0),  /* 12-bit CNT. MAX=16'h0FFF */
+    TCB_CNTSIZE_11BITS_gc = (0x05<<0),  /* 11-bit CNT. MAX=16'h07FF */
+    TCB_CNTSIZE_10BITS_gc = (0x06<<0),  /* 10-bit CNT. MAX=16'h03FF */
+    TCB_CNTSIZE_9BITS_gc = (0x07<<0)  /* 9-bit CNT. MAX=16'h01FF */
+} TCB_CNTSIZE_t;
+
+/* Event Generation select */
+typedef enum TCB_EVGEN_enum
+{
+    TCB_EVGEN_PULSE_gc = (0x00<<7),  /* Event is generated as pulse at compare match or capture */
+    TCB_EVGEN_WAVEFORM_gc = (0x01<<7)  /* Event is generated as waveform for modes with waveform */
+} TCB_EVGEN_t;
+
+/*
+--------------------------------------------------------------------------
+TCE - 16-bit Timer/Counter Type E
+--------------------------------------------------------------------------
+*/
+
+/* 16-bit Timer/Counter Type E */
+typedef struct TCE_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    register8_t CTRLD;  /* Control D */
+    register8_t CTRLECLR;  /* Control E Clear */
+    register8_t CTRLESET;  /* Control E Set */
+    register8_t CTRLFCLR;  /* Control F Clear */
+    register8_t CTRLFSET;  /* Control F Set */
+    register8_t EVGENCTRL;  /* Event Generation Control */
+    register8_t EVCTRL;  /* Event Control */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t reserved_1[2];
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t TEMP;  /* Temporary data for 16-bit Access */
+    register8_t reserved_2[16];
+    _WORDREGISTER(CNT);  /* Count */
+    _WORDREGISTER(AMP);  /* Amplitude */
+    _WORDREGISTER(OFFSET);  /* Offset */
+    _WORDREGISTER(PER);  /* Period */
+    _WORDREGISTER(CMP0);  /* Compare 0 */
+    _WORDREGISTER(CMP1);  /* Compare 1 */
+    _WORDREGISTER(CMP2);  /* Compare 2 */
+    _WORDREGISTER(CMP3);  /* Compare 3 */
+    register8_t reserved_3[6];
+    _WORDREGISTER(PERBUF);  /* Period Buffer */
+    _WORDREGISTER(CMP0BUF);  /* Compare 0 Buffer */
+    _WORDREGISTER(CMP1BUF);  /* Compare 1 Buffer */
+    _WORDREGISTER(CMP2BUF);  /* Compare 2 Buffer */
+    _WORDREGISTER(CMP3BUF);  /* Compare 3 Buffer */
+} TCE_t;
+
+/* Clock Selection */
+typedef enum TCE_CLKSEL_enum
+{
+    TCE_CLKSEL_DIV1_gc = (0x00<<1),  /* System Clock */
+    TCE_CLKSEL_DIV2_gc = (0x01<<1),  /* System Clock / 2 */
+    TCE_CLKSEL_DIV4_gc = (0x02<<1),  /* System Clock / 4 */
+    TCE_CLKSEL_DIV8_gc = (0x03<<1),  /* System Clock / 8 */
+    TCE_CLKSEL_DIV16_gc = (0x04<<1),  /* System Clock / 16 */
+    TCE_CLKSEL_DIV64_gc = (0x05<<1),  /* System Clock / 64 */
+    TCE_CLKSEL_DIV256_gc = (0x06<<1),  /* System Clock / 256 */
+    TCE_CLKSEL_DIV1024_gc = (0x07<<1)  /* System Clock / 1024 */
+} TCE_CLKSEL_t;
+
+/* Command select */
+typedef enum TCE_CMD_enum
+{
+    TCE_CMD_NONE_gc = (0x00<<2),  /* No Command */
+    TCE_CMD_UPDATE_gc = (0x01<<2),  /* Force Update */
+    TCE_CMD_RESTART_gc = (0x02<<2),  /* Force Restart */
+    TCE_CMD_RESET_gc = (0x03<<2)  /* Force Hard Reset */
+} TCE_CMD_t;
+
+/* Compare # Event select */
+typedef enum TCE_CMP0EV_enum
+{
+    TCE_CMP0EV_PULSE_gc = (0x00<<4),  /* Event output for CMP is a pulse */
+    TCE_CMP0EV_WAVEFORM_gc = (0x01<<4)  /* Event output for CMP is equal to waveform */
+} TCE_CMP0EV_t;
+
+/* Compare # Event select */
+typedef enum TCE_CMP1EV_enum
+{
+    TCE_CMP1EV_PULSE_gc = (0x00<<5),  /* Event output for CMP is a pulse */
+    TCE_CMP1EV_WAVEFORM_gc = (0x01<<5)  /* Event output for CMP is equal to waveform */
+} TCE_CMP1EV_t;
+
+/* Compare # Event select */
+typedef enum TCE_CMP2EV_enum
+{
+    TCE_CMP2EV_PULSE_gc = (0x00<<6),  /* Event output for CMP is a pulse */
+    TCE_CMP2EV_WAVEFORM_gc = (0x01<<6)  /* Event output for CMP is equal to waveform */
+} TCE_CMP2EV_t;
+
+/* Compare # Event select */
+typedef enum TCE_CMP3EV_enum
+{
+    TCE_CMP3EV_PULSE_gc = (0x00<<7),  /* Event output for CMP is a pulse */
+    TCE_CMP3EV_WAVEFORM_gc = (0x01<<7)  /* Event output for CMP is equal to waveform */
+} TCE_CMP3EV_t;
+
+/* Direction select */
+typedef enum TCE_DIR_enum
+{
+    TCE_DIR_UP_gc = (0x00<<0),  /* Count up */
+    TCE_DIR_DOWN_gc = (0x01<<0)  /* Count down */
+} TCE_DIR_t;
+
+/* Event Action A select */
+typedef enum TCE_EVACTA_enum
+{
+    TCE_EVACTA_CNT_POSEDGE_gc = (0x00<<1),  /* Count on positive edge event */
+    TCE_EVACTA_CNT_ANYEDGE_gc = (0x01<<1),  /* Count on any edge event */
+    TCE_EVACTA_CNT_HIGHLVL_gc = (0x02<<1),  /* Count on prescaled clock while event line is 1. */
+    TCE_EVACTA_UPDOWN_gc = (0x03<<1)  /* Count on prescaled clock. Event controls count direction. Up-count when event line is 0, down-count when event line is 1. */
+} TCE_EVACTA_t;
+
+/* Event Action B select */
+typedef enum TCE_EVACTB_enum
+{
+    TCE_EVACTB_NONE_gc = (0x00<<5),  /* No Action */
+    TCE_EVACTB_UPDOWN_gc = (0x03<<5),  /* Count on prescaled clock. Event controls count direction. Up-count when event line is 0, down-count when event line is 1. */
+    TCE_EVACTB_RESTART_POSEDGE_gc = (0x04<<5),  /* Restart counter at positive edge event */
+    TCE_EVACTB_RESTART_ANYEDGE_gc = (0x05<<5),  /* Restart counter on any edge event */
+    TCE_EVACTB_RESTART_HIGHLVL_gc = (0x06<<5)  /* Restart counter while event line is 1. */
+} TCE_EVACTB_t;
+
+/* High Resolution Enable select */
+typedef enum TCE_HREN_enum
+{
+    TCE_HREN_OFF_gc = (0x00<<6),  /* High Resolution Disable */
+    TCE_HREN_4X_gc = (0x01<<6),  /* Resolution increased by 4 (2 bits) */
+    TCE_HREN_8X_gc = (0x02<<6)  /* Resolution increased by 4 (3 bits) */
+} TCE_HREN_t;
+
+/* Scaled Write select */
+typedef enum TCE_SCALE_enum
+{
+    TCE_SCALE_NORMAL_gc = (0x00<<2),  /* Absolute values used when writing to CMPn, CMPnBUF and registers */
+    TCE_SCALE_FRACTIONAL_gc = (0x01<<2)  /* Fractional values used when writing to CMPn, CMPnBUF and registers */
+} TCE_SCALE_t;
+
+/* Scaling Mode select */
+typedef enum TCE_SCALEMODE_enum
+{
+    TCE_SCALEMODE_CENTER_gc = (0x00<<4),  /* CMPn registers scaled vs center (50% duty cycle) */
+    TCE_SCALEMODE_BOTTOM_gc = (0x01<<4),  /* CMPn registers scaled vs BOTTOM (0% duty cycle) */
+    TCE_SCALEMODE_TOP_gc = (0x02<<4),  /* CMPn registers scaled vs TOP (100% duty cycle) */
+    TCE_SCALEMODE_TOPBOTTOM_gc = (0x03<<4)  /* CMPn registers scaled vs TOP or BOTTOM depending on written value. */
+} TCE_SCALEMODE_t;
+
+/* Waveform generation mode select */
+typedef enum TCE_WGMODE_enum
+{
+    TCE_WGMODE_NORMAL_gc = (0x00<<0),  /* Normal Mode */
+    TCE_WGMODE_FRQ_gc = (0x01<<0),  /* Frequency Generation Mode */
+    TCE_WGMODE_SINGLESLOPE_gc = (0x03<<0),  /* Single Slope PWM */
+    TCE_WGMODE_DSTOP_gc = (0x05<<0),  /* Dual Slope PWM, overflow on TOP */
+    TCE_WGMODE_DSBOTH_gc = (0x06<<0),  /* Dual Slope PWM, overflow on TOP and BOTTOM */
+    TCE_WGMODE_DSBOTTOM_gc = (0x07<<0)  /* Dual Slope PWM, overflow on BOTTOM */
+} TCE_WGMODE_t;
+
+/*
+--------------------------------------------------------------------------
+TCF - 24-bit Timer/Counter for frequency generation
+--------------------------------------------------------------------------
+*/
+
+/* 24-bit Timer/Counter for frequency generation */
+typedef struct TCF_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    register8_t CTRLD;  /* Control D */
+    register8_t EVCTRL;  /* Event Control */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t STATUS;  /* Status */
+    register8_t reserved_1[5];
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t reserved_2[2];
+    _DWORDREGISTER(CNT);  /* Count */
+    _DWORDREGISTER(CMP);  /* Compare */
+    register8_t reserved_3[8];
+} TCF_t;
+
+/* Clock Select */
+typedef enum TCF_CLKSEL_enum
+{
+    TCF_CLKSEL_CLKPER_gc = (0x00<<3),  /* Peripheral Clock */
+    TCF_CLKSEL_EVENT_gc = (0x01<<3),  /* Event as clock source */
+    TCF_CLKSEL_OSCHF_gc = (0x02<<3),  /* Internal High Frequency Oscillator */
+    TCF_CLKSEL_OSC32K_gc = (0x03<<3),  /* Internal 32.768 kHz Oscillator */
+    TCF_CLKSEL_PLL_gc = (0x05<<3)  /* PLL */
+} TCF_CLKSEL_t;
+
+/* Command select */
+typedef enum TCF_CMD_enum
+{
+    TCF_CMD_NONE_gc = (0x00<<0),  /* No command */
+    TCF_CMD_UPDATE_gc = (0x01<<0),  /* Force update */
+    TCF_CMD_RESTART_gc = (0x02<<0)  /* Force restart */
+} TCF_CMD_t;
+
+/* Compare # Event Generation select */
+typedef enum TCF_CMP0EV_enum
+{
+    TCF_CMP0EV_PULSE_gc = (0x00<<6),  /* Event is generated as pulse */
+    TCF_CMP0EV_WAVEFORM_gc = (0x01<<6)  /* Waveform is used as event output */
+} TCF_CMP0EV_t;
+
+/* Compare # Event Generation select */
+typedef enum TCF_CMP1EV_enum
+{
+    TCF_CMP1EV_PULSE_gc = (0x00<<7),  /* Event is generated as pulse */
+    TCF_CMP1EV_WAVEFORM_gc = (0x01<<7)  /* Waveform is used as event output */
+} TCF_CMP1EV_t;
+
+/* Event Action A select */
+typedef enum TCF_EVACTA_enum
+{
+    TCF_EVACTA_RESTART_gc = (0x00<<1),  /* Restart Counter */
+    TCF_EVACTA_BLANK_gc = (0x01<<1)  /* Mask waveform output to '0' */
+} TCF_EVACTA_t;
+
+/* Clock Prescaler select */
+typedef enum TCF_PRESC_enum
+{
+    TCF_PRESC_DIV1_gc = (0x00<<1),  /* Runs directly on Clock Source */
+    TCF_PRESC_DIV2_gc = (0x01<<1),  /* Divide clock source by 2 */
+    TCF_PRESC_DIV4_gc = (0x02<<1),  /* Divide clock source by 4 */
+    TCF_PRESC_DIV8_gc = (0x03<<1),  /* Divide clock source by 8 */
+    TCF_PRESC_DIV16_gc = (0x04<<1),  /* Divide clock source by 16 */
+    TCF_PRESC_DIV32_gc = (0x05<<1),  /* Divide clock source by 32 */
+    TCF_PRESC_DIV64_gc = (0x06<<1),  /* Divide clock source by 64 */
+    TCF_PRESC_DIV128_gc = (0x07<<1)  /* Divide clock source by 128 */
+} TCF_PRESC_t;
+
+/* Waveform Generation Mode select */
+typedef enum TCF_WGMODE_enum
+{
+    TCF_WGMODE_FRQ_gc = (0x00<<0),  /* Frequency */
+    TCF_WGMODE_NCOPF_gc = (0x01<<0),  /* Numerically Controlled Oscillator Pulse-Frequency */
+    TCF_WGMODE_NCOFDC_gc = (0x02<<0),  /* Numerically Controlled Oscillator Fixed Duty Cycle */
+    TCF_WGMODE_PWM8_gc = (0x07<<0)  /* 8-bit PWM */
+} TCF_WGMODE_t;
+
+/* Waveform Generation Pulse Length select */
+typedef enum TCF_WGPULSE_enum
+{
+    TCF_WGPULSE_CLK1_gc = (0x00<<4),  /* High pulse duration is 1 clock period */
+    TCF_WGPULSE_CLK2_gc = (0x01<<4),  /* High pulse duration is 2 clock period */
+    TCF_WGPULSE_CLK4_gc = (0x02<<4),  /* High pulse duration is 4 clock period */
+    TCF_WGPULSE_CLK8_gc = (0x03<<4),  /* High pulse duration is 8 clock period */
+    TCF_WGPULSE_CLK16_gc = (0x04<<4),  /* High pulse duration is 16 clock period */
+    TCF_WGPULSE_CLK32_gc = (0x05<<4),  /* High pulse duration is 32 clock period */
+    TCF_WGPULSE_CLK64_gc = (0x06<<4),  /* High pulse duration is 64 clock period */
+    TCF_WGPULSE_CLK128_gc = (0x07<<4)  /* High pulse duration is 128 clock period */
+} TCF_WGPULSE_t;
+
+/* Waveform Output # Polarity select */
+typedef enum TCF_WO0POL_enum
+{
+    TCF_WO0POL_NORMAL_gc = (0x00<<2),  /* Waveform output set on update and cleared on match */
+    TCF_WO0POL_INVERSE_gc = (0x01<<2)  /* Waveform output cleared on update and set on match */
+} TCF_WO0POL_t;
+
+/* Waveform Output # Polarity select */
+typedef enum TCF_WO1POL_enum
+{
+    TCF_WO1POL_NORMAL_gc = (0x00<<3),  /* Waveform output set on update and cleared on match */
+    TCF_WO1POL_INVERSE_gc = (0x01<<3)  /* Waveform output cleared on update and set on match */
+} TCF_WO1POL_t;
+
+/*
+--------------------------------------------------------------------------
+TWI - Two-Wire Interface
+--------------------------------------------------------------------------
+*/
+
+/* Two-Wire Interface */
+typedef struct TWI_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t DUALCTRL;  /* Dual Mode Control */
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t MCTRLA;  /* Host Control A */
+    register8_t MCTRLB;  /* Host Control B */
+    register8_t MSTATUS;  /* Host STATUS */
+    register8_t MBAUD;  /* Host Baud Rate */
+    register8_t MADDR;  /* Host Address */
+    register8_t MDATA;  /* Host Data */
+    register8_t SCTRLA;  /* Client Control A */
+    register8_t SCTRLB;  /* Client Control B */
+    register8_t SSTATUS;  /* Client Status */
+    register8_t SADDR;  /* Client Address */
+    register8_t SDATA;  /* Client Data */
+    register8_t SADDRMASK;  /* Client Address Mask */
+    register8_t reserved_1[1];
+} TWI_t;
+
+/* Acknowledge Action select */
+typedef enum TWI_ACKACT_enum
+{
+    TWI_ACKACT_ACK_gc = (0x00<<2),  /* Send ACK */
+    TWI_ACKACT_NACK_gc = (0x01<<2)  /* Send NACK */
+} TWI_ACKACT_t;
+
+/* Address or Stop select */
+typedef enum TWI_AP_enum
+{
+    TWI_AP_STOP_gc = (0x00<<0),  /* A Stop condition generated the interrupt on APIF flag */
+    TWI_AP_ADR_gc = (0x01<<0)  /* Address detection generated the interrupt on APIF flag */
+} TWI_AP_t;
+
+/* Bus State select */
+typedef enum TWI_BUSSTATE_enum
+{
+    TWI_BUSSTATE_UNKNOWN_gc = (0x00<<0),  /* Unknown bus state */
+    TWI_BUSSTATE_IDLE_gc = (0x01<<0),  /* Bus is idle */
+    TWI_BUSSTATE_OWNER_gc = (0x02<<0),  /* This TWI controls the bus */
+    TWI_BUSSTATE_BUSY_gc = (0x03<<0)  /* The bus is busy */
+} TWI_BUSSTATE_t;
+
+/* Debug Run select */
+typedef enum TWI_DBGRUN_enum
+{
+    TWI_DBGRUN_HALT_gc = (0x00<<0),  /* The peripheral is halted in Break Debug mode and ignores events */
+    TWI_DBGRUN_RUN_gc = (0x01<<0)  /* The peripheral will continue to run in Break Debug mode when the CPU is halted */
+} TWI_DBGRUN_t;
+
+/* Fast-mode Enable select */
+typedef enum TWI_FMEN_enum
+{
+    TWI_FMEN_OFF_gc = (0x00<<0),  /* SCL duty cycle operating according to Sm specification */
+    TWI_FMEN_ON_gc = (0x01<<0)  /* SCL duty cycle operating according to Fm specification */
+} TWI_FMEN_t;
+
+/* Fast-mode Plus Enable select */
+typedef enum TWI_FMPEN_enum
+{
+    TWI_FMPEN_OFF_gc = (0x00<<1),  /* Operating in Standard-mode or Fast-mode */
+    TWI_FMPEN_ON_gc = (0x01<<1)  /* Operating in Fast-mode Plus */
+} TWI_FMPEN_t;
+
+/* Input voltage transition level select */
+typedef enum TWI_INPUTLVL_enum
+{
+    TWI_INPUTLVL_I2C_gc = (0x00<<6),  /* I2C input voltage transition level */
+    TWI_INPUTLVL_SMBUS_gc = (0x01<<6)  /* SMBus 3.0 input voltage transition level */
+} TWI_INPUTLVL_t;
+
+/* Command select */
+typedef enum TWI_MCMD_enum
+{
+    TWI_MCMD_NOACT_gc = (0x00<<0),  /* No action */
+    TWI_MCMD_REPSTART_gc = (0x01<<0),  /* Execute Acknowledge Action followed by repeated Start. */
+    TWI_MCMD_RECVTRANS_gc = (0x02<<0),  /* Execute Acknowledge Action followed by a byte read/write operation. Read/write is defined by DIR. */
+    TWI_MCMD_STOP_gc = (0x03<<0)  /* Execute Acknowledge Action followed by issuing a Stop condition. */
+} TWI_MCMD_t;
+
+/* Command select */
+typedef enum TWI_SCMD_enum
+{
+    TWI_SCMD_NOACT_gc = (0x00<<0),  /* No Action */
+    TWI_SCMD_COMPTRANS_gc = (0x02<<0),  /* Complete transaction */
+    TWI_SCMD_RESPONSE_gc = (0x03<<0)  /* Used in response to an interrupt */
+} TWI_SCMD_t;
+
+/* SDA Hold Time select */
+typedef enum TWI_SDAHOLD_enum
+{
+    TWI_SDAHOLD_OFF_gc = (0x00<<2),  /* No SDA Hold Delay */
+    TWI_SDAHOLD_50NS_gc = (0x01<<2),  /* Short SDA hold time */
+    TWI_SDAHOLD_300NS_gc = (0x02<<2),  /* Meets SMBUS 2.0 specification under typical conditions */
+    TWI_SDAHOLD_500NS_gc = (0x03<<2)  /* Meets SMBUS 2.0 specificaiton across all corners */
+} TWI_SDAHOLD_t;
+
+/* SDA Setup Time select */
+typedef enum TWI_SDASETUP_enum
+{
+    TWI_SDASETUP_4CYC_gc = (0x00<<4),  /* SDA setup time is four clock cycles */
+    TWI_SDASETUP_8CYC_gc = (0x01<<4)  /* SDA setup time is eight clock cycle */
+} TWI_SDASETUP_t;
+
+/* Inactive Bus Time-Out select */
+typedef enum TWI_TIMEOUT_enum
+{
+    TWI_TIMEOUT_DISABLED_gc = (0x00<<2),  /* Bus time-out disabled. I2C. */
+    TWI_TIMEOUT_50US_gc = (0x01<<2),  /* 50us - SMBus */
+    TWI_TIMEOUT_100US_gc = (0x02<<2),  /* 100us */
+    TWI_TIMEOUT_200US_gc = (0x03<<2)  /* 200us */
+} TWI_TIMEOUT_t;
+
+/*
+--------------------------------------------------------------------------
+USART - Universal Synchronous and Asynchronous Receiver and Transmitter
+--------------------------------------------------------------------------
+*/
+
+/* Universal Synchronous and Asynchronous Receiver and Transmitter */
+typedef struct USART_struct
+{
+    register8_t RXDATAL;  /* Receive Data Low Byte */
+    register8_t RXDATAH;  /* Receive Data High Byte */
+    register8_t TXDATAL;  /* Transmit Data Low Byte */
+    register8_t TXDATAH;  /* Transmit Data High Byte */
+    register8_t STATUS;  /* Status */
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    _WORDREGISTER(BAUD);  /* Baud Rate */
+    register8_t CTRLD;  /* Control D */
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t EVCTRL;  /* Event Control */
+    register8_t TXPLCTRL;  /* IRCOM Transmitter Pulse Length Control */
+    register8_t RXPLCTRL;  /* IRCOM Receiver Pulse Length Control */
+    register8_t reserved_1[1];
+} USART_t;
+
+/* Auto Baud Window select */
+typedef enum USART_ABW_enum
+{
+    USART_ABW_WDW0_gc = (0x00<<6),  /* 18% tolerance */
+    USART_ABW_WDW1_gc = (0x01<<6),  /* 15% tolerance */
+    USART_ABW_WDW2_gc = (0x02<<6),  /* 21% tolerance */
+    USART_ABW_WDW3_gc = (0x03<<6)  /* 25% tolerance */
+} USART_ABW_t;
+
+/* Character Size select */
+typedef enum USART_CHSIZE_enum
+{
+    USART_CHSIZE_5BIT_gc = (0x00<<0),  /* Character size: 5 bit */
+    USART_CHSIZE_6BIT_gc = (0x01<<0),  /* Character size: 6 bit */
+    USART_CHSIZE_7BIT_gc = (0x02<<0),  /* Character size: 7 bit */
+    USART_CHSIZE_8BIT_gc = (0x03<<0),  /* Character size: 8 bit */
+    USART_CHSIZE_9BITL_gc = (0x06<<0),  /* Character size: 9 bit read low byte first */
+    USART_CHSIZE_9BITH_gc = (0x07<<0)  /* Character size: 9 bit read high byte first */
+} USART_CHSIZE_t;
+
+/* Communication Mode select */
+typedef enum USART_CMODE_enum
+{
+    USART_CMODE_ASYNCHRONOUS_gc = (0x00<<6),  /* Asynchronous Mode */
+    USART_CMODE_SYNCHRONOUS_gc = (0x01<<6),  /* Synchronous Mode */
+    USART_CMODE_IRCOM_gc = (0x02<<6),  /* Infrared Communication */
+    USART_CMODE_MSPI_gc = (0x03<<6)  /* SPI Host Mode */
+} USART_CMODE_t;
+
+/* Parity Mode select */
+typedef enum USART_PMODE_enum
+{
+    USART_PMODE_DISABLED_gc = (0x00<<4),  /* No Parity */
+    USART_PMODE_EVEN_gc = (0x02<<4),  /* Even Parity */
+    USART_PMODE_ODD_gc = (0x03<<4)  /* Odd Parity */
+} USART_PMODE_t;
+
+/* RS485 Mode internal transmitter select */
+typedef enum USART_RS485_enum
+{
+    USART_RS485_DISABLE_gc = (0x00<<0),  /* RS485 Mode disabled */
+    USART_RS485_ENABLE_gc = (0x01<<0)  /* RS485 Mode enabled */
+} USART_RS485_t;
+
+/* Receiver Mode select */
+typedef enum USART_RXMODE_enum
+{
+    USART_RXMODE_NORMAL_gc = (0x00<<1),  /* Normal mode */
+    USART_RXMODE_CLK2X_gc = (0x01<<1),  /* CLK2x mode */
+    USART_RXMODE_GENAUTO_gc = (0x02<<1),  /* Generic autobaud mode */
+    USART_RXMODE_LINAUTO_gc = (0x03<<1)  /* LIN constrained autobaud mode */
+} USART_RXMODE_t;
+
+/* Stop Bit Mode select */
+typedef enum USART_SBMODE_enum
+{
+    USART_SBMODE_1BIT_gc = (0x00<<3),  /* 1 stop bit */
+    USART_SBMODE_2BIT_gc = (0x01<<3)  /* 2 stop bits */
+} USART_SBMODE_t;
+
+/*
+--------------------------------------------------------------------------
+USERROW - User Row
+--------------------------------------------------------------------------
+*/
+
+/* User Row */
+typedef struct USERROW_struct
+{
+    register8_t USERROW0;  /* User Row Byte 0 */
+    register8_t USERROW1;  /* User Row Byte 1 */
+    register8_t USERROW2;  /* User Row Byte 2 */
+    register8_t USERROW3;  /* User Row Byte 3 */
+    register8_t USERROW4;  /* User Row Byte 4 */
+    register8_t USERROW5;  /* User Row Byte 5 */
+    register8_t USERROW6;  /* User Row Byte 6 */
+    register8_t USERROW7;  /* User Row Byte 7 */
+    register8_t USERROW8;  /* User Row Byte 8 */
+    register8_t USERROW9;  /* User Row Byte 9 */
+    register8_t USERROW10;  /* User Row Byte 10 */
+    register8_t USERROW11;  /* User Row Byte 11 */
+    register8_t USERROW12;  /* User Row Byte 12 */
+    register8_t USERROW13;  /* User Row Byte 13 */
+    register8_t USERROW14;  /* User Row Byte 14 */
+    register8_t USERROW15;  /* User Row Byte 15 */
+    register8_t USERROW16;  /* User Row Byte 16 */
+    register8_t USERROW17;  /* User Row Byte 17 */
+    register8_t USERROW18;  /* User Row Byte 18 */
+    register8_t USERROW19;  /* User Row Byte 19 */
+    register8_t USERROW20;  /* User Row Byte 20 */
+    register8_t USERROW21;  /* User Row Byte 21 */
+    register8_t USERROW22;  /* User Row Byte 22 */
+    register8_t USERROW23;  /* User Row Byte 23 */
+    register8_t USERROW24;  /* User Row Byte 24 */
+    register8_t USERROW25;  /* User Row Byte 25 */
+    register8_t USERROW26;  /* User Row Byte 26 */
+    register8_t USERROW27;  /* User Row Byte 27 */
+    register8_t USERROW28;  /* User Row Byte 28 */
+    register8_t USERROW29;  /* User Row Byte 29 */
+    register8_t USERROW30;  /* User Row Byte 30 */
+    register8_t USERROW31;  /* User Row Byte 31 */
+    register8_t USERROW32;  /* User Row Byte 32 */
+    register8_t USERROW33;  /* User Row Byte 33 */
+    register8_t USERROW34;  /* User Row Byte 34 */
+    register8_t USERROW35;  /* User Row Byte 35 */
+    register8_t USERROW36;  /* User Row Byte 36 */
+    register8_t USERROW37;  /* User Row Byte 37 */
+    register8_t USERROW38;  /* User Row Byte 38 */
+    register8_t USERROW39;  /* User Row Byte 39 */
+    register8_t USERROW40;  /* User Row Byte 40 */
+    register8_t USERROW41;  /* User Row Byte 41 */
+    register8_t USERROW42;  /* User Row Byte 42 */
+    register8_t USERROW43;  /* User Row Byte 43 */
+    register8_t USERROW44;  /* User Row Byte 44 */
+    register8_t USERROW45;  /* User Row Byte 45 */
+    register8_t USERROW46;  /* User Row Byte 46 */
+    register8_t USERROW47;  /* User Row Byte 47 */
+    register8_t USERROW48;  /* User Row Byte 48 */
+    register8_t USERROW49;  /* User Row Byte 49 */
+    register8_t USERROW50;  /* User Row Byte 50 */
+    register8_t USERROW51;  /* User Row Byte 51 */
+    register8_t USERROW52;  /* User Row Byte 52 */
+    register8_t USERROW53;  /* User Row Byte 53 */
+    register8_t USERROW54;  /* User Row Byte 54 */
+    register8_t USERROW55;  /* User Row Byte 55 */
+    register8_t USERROW56;  /* User Row Byte 56 */
+    register8_t USERROW57;  /* User Row Byte 57 */
+    register8_t USERROW58;  /* User Row Byte 58 */
+    register8_t USERROW59;  /* User Row Byte 59 */
+    register8_t USERROW60;  /* User Row Byte 60 */
+    register8_t USERROW61;  /* User Row Byte 61 */
+    register8_t USERROW62;  /* User Row Byte 62 */
+    register8_t USERROW63;  /* User Row Byte 63 */
+} USERROW_t;
+
+
+/*
+--------------------------------------------------------------------------
+VPORT - Virtual Ports
+--------------------------------------------------------------------------
+*/
+
+/* Virtual Ports */
+typedef struct VPORT_struct
+{
+    register8_t DIR;  /* Data Direction */
+    register8_t OUT;  /* Output Value */
+    register8_t IN;  /* Input Value */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+} VPORT_t;
+
+
+/*
+--------------------------------------------------------------------------
+VREF - Voltage reference
+--------------------------------------------------------------------------
+*/
+
+/* Voltage reference */
+typedef struct VREF_struct
+{
+    register8_t reserved_1[2];
+    register8_t DAC0REF;  /* DAC0 Reference */
+    register8_t reserved_2[1];
+    register8_t ACREF;  /* AC Reference */
+    register8_t reserved_3[11];
+} VREF_t;
+
+/* Reference select */
+typedef enum VREF_REFSEL_enum
+{
+    VREF_REFSEL_1V024_gc = (0x00<<0),  /* Internal 1.024V reference */
+    VREF_REFSEL_2V048_gc = (0x01<<0),  /* Internal 2.048V reference */
+    VREF_REFSEL_4V096_gc = (0x02<<0),  /* Internal 4.096V reference */
+    VREF_REFSEL_2V500_gc = (0x03<<0),  /* Internal 2.500V reference */
+    VREF_REFSEL_VDD_gc = (0x05<<0),  /* VDD as reference */
+    VREF_REFSEL_VREFA_gc = (0x06<<0)  /* External reference on VREFA pin */
+} VREF_REFSEL_t;
+
+/*
+--------------------------------------------------------------------------
+WDT - Watch-Dog Timer
+--------------------------------------------------------------------------
+*/
+
+/* Watch-Dog Timer */
+typedef struct WDT_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t STATUS;  /* Status */
+    register8_t reserved_1[14];
+} WDT_t;
+
+/* Period select */
+typedef enum WDT_PERIOD_enum
+{
+    WDT_PERIOD_OFF_gc = (0x00<<0),  /* Off */
+    WDT_PERIOD_8CLK_gc = (0x01<<0),  /* 8 cycles (8ms) */
+    WDT_PERIOD_16CLK_gc = (0x02<<0),  /* 16 cycles (16ms) */
+    WDT_PERIOD_32CLK_gc = (0x03<<0),  /* 32 cycles (32ms) */
+    WDT_PERIOD_64CLK_gc = (0x04<<0),  /* 64 cycles (64ms) */
+    WDT_PERIOD_128CLK_gc = (0x05<<0),  /* 128 cycles (0.128s) */
+    WDT_PERIOD_256CLK_gc = (0x06<<0),  /* 256 cycles (0.256s) */
+    WDT_PERIOD_512CLK_gc = (0x07<<0),  /* 512 cycles (0.512s) */
+    WDT_PERIOD_1KCLK_gc = (0x08<<0),  /* 1K cycles (1.0s) */
+    WDT_PERIOD_2KCLK_gc = (0x09<<0),  /* 2K cycles (2.0s) */
+    WDT_PERIOD_4KCLK_gc = (0x0A<<0),  /* 4K cycles (4.1s) */
+    WDT_PERIOD_8KCLK_gc = (0x0B<<0)  /* 8K cycles (8.2s) */
+} WDT_PERIOD_t;
+
+/* Window select */
+typedef enum WDT_WINDOW_enum
+{
+    WDT_WINDOW_OFF_gc = (0x00<<4),  /* Off */
+    WDT_WINDOW_8CLK_gc = (0x01<<4),  /* 8 cycles (8ms) */
+    WDT_WINDOW_16CLK_gc = (0x02<<4),  /* 16 cycles (16ms) */
+    WDT_WINDOW_32CLK_gc = (0x03<<4),  /* 32 cycles (32ms) */
+    WDT_WINDOW_64CLK_gc = (0x04<<4),  /* 64 cycles (64ms) */
+    WDT_WINDOW_128CLK_gc = (0x05<<4),  /* 128 cycles (0.128s) */
+    WDT_WINDOW_256CLK_gc = (0x06<<4),  /* 256 cycles (0.256s) */
+    WDT_WINDOW_512CLK_gc = (0x07<<4),  /* 512 cycles (0.512s) */
+    WDT_WINDOW_1KCLK_gc = (0x08<<4),  /* 1K cycles (1.0s) */
+    WDT_WINDOW_2KCLK_gc = (0x09<<4),  /* 2K cycles (2.0s) */
+    WDT_WINDOW_4KCLK_gc = (0x0A<<4),  /* 4K cycles (4.1s) */
+    WDT_WINDOW_8KCLK_gc = (0x0B<<4)  /* 8K cycles (8.2s) */
+} WDT_WINDOW_t;
+
+/*
+--------------------------------------------------------------------------
+WEX - Waveform Extension
+--------------------------------------------------------------------------
+*/
+
+/* Waveform Extension */
+typedef struct WEX_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    register8_t reserved_1[1];
+    register8_t EVCTRLA;  /* Event Control A */
+    register8_t EVCTRLB;  /* Event Control B */
+    register8_t EVCTRLC;  /* Event Control C */
+    register8_t BUFCTRL;  /* Buffer Valid Control */
+    register8_t BLANKCTRL;  /* Blanking Control */
+    register8_t BLANKTIME;  /* Blanking Time */
+    register8_t FAULTCTRL;  /* Fault Control */
+    register8_t FAULTDRV;  /* Fault Drive */
+    register8_t FAULTOUT;  /* Fault Output */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t STATUS;  /* Status */
+    register8_t DTLS;  /* Dead-time Low Side */
+    register8_t DTHS;  /* Dead-time High Side */
+    register8_t DTBOTH;  /* Dead-time Both Sides */
+    register8_t SWAP;  /* DTI Swap */
+    register8_t PGMOVR;  /* Pattern Generation Override */
+    register8_t PGMOUT;  /* Pattern Generation Output */
+    register8_t reserved_2[1];
+    register8_t OUTOVEN;  /* Output Override Enable */
+    register8_t DTLSBUF;  /* Dead-time Low Side Buffer */
+    register8_t DTHSBUF;  /* Dead-time High Side Buffer */
+    register8_t DTBOTHBUF;  /* Dead-time Both Sides Buffer */
+    register8_t SWAPBUF;  /* DTI Swap Buffer */
+    register8_t PGMOVRBUF;  /* Pattern Generation Override Buffer */
+    register8_t PGMOUTBUF;  /* Pattern Generation Output Buffer */
+    register8_t reserved_3[2];
+} WEX_t;
+
+/* Blanking Prescaler select */
+typedef enum WEX_BLANKPRESC_enum
+{
+    WEX_BLANKPRESC_DIV1_gc = (0x00<<5),  /* No prescaling */
+    WEX_BLANKPRESC_DIV4_gc = (0x01<<5),  /* Divide CLK_PER by 4 */
+    WEX_BLANKPRESC_DIV16_gc = (0x02<<5),  /* Divide CLK_PER by 16 */
+    WEX_BLANKPRESC_DIV64_gc = (0x03<<5)  /* Divide CLK_PER by 64 */
+} WEX_BLANKPRESC_t;
+
+/* Blanking State select */
+typedef enum WEX_BLANKSTATE_enum
+{
+    WEX_BLANKSTATE_OFF_gc = (0x00<<7),  /* Blanking off */
+    WEX_BLANKSTATE_ON_gc = (0x01<<7)  /* Blanking active */
+} WEX_BLANKSTATE_t;
+
+/* Blanking Trigger select */
+typedef enum WEX_BLANKTRIG_enum
+{
+    WEX_BLANKTRIG_NONE_gc = (0x00<<0),  /* No HW trigger (Software only) */
+    WEX_BLANKTRIG_TCE0UPD_gc = (0x04<<0),  /* TCE0 Update Condition */
+    WEX_BLANKTRIG_TCE0CMP0_gc = (0x08<<0),  /* TCE0 Compare 0 */
+    WEX_BLANKTRIG_TCE0CMP1_gc = (0x0C<<0),  /* TCE0 Compare 1 */
+    WEX_BLANKTRIG_TCE0CMP2_gc = (0x10<<0),  /* TCE0 Compare 2 */
+    WEX_BLANKTRIG_TCE0CMP3_gc = (0x14<<0)  /* TCE0 Compare 3 */
+} WEX_BLANKTRIG_t;
+
+/* Command select */
+typedef enum WEX_CMD_enum
+{
+    WEX_CMD_NONE_gc = (0x00<<0),  /* No Command */
+    WEX_CMD_UPDATE_gc = (0x01<<0),  /* Force update of Dead-time, SWAP and PGM buffer registers. */
+    WEX_CMD_FAULTSET_gc = (0x02<<0),  /* Set Fault Detection */
+    WEX_CMD_FAULTCLR_gc = (0x03<<0),  /* Clear Fault Detection */
+    WEX_CMD_BLANKSET_gc = (0x04<<0),  /* Set SW Blanking */
+    WEX_CMD_BLANKCLR_gc = (0x05<<0)  /* Clear SW Blanking */
+} WEX_CMD_t;
+
+/* Fault Detection Action select */
+typedef enum WEX_FDACT_enum
+{
+    WEX_FDACT_NONE_gc = (0x00<<0),  /* None. Fault Protection Disabled */
+    WEX_FDACT_LOW_gc = (0x01<<0),  /* Drive all pins low */
+    WEX_FDACT_CUSTOM_gc = (0x03<<0)  /* Drive all pins to setting defined by FAULTDRV and FAULTVAL */
+} WEX_FDACT_t;
+
+/* Fault Detection on Debug Break Detection select */
+typedef enum WEX_FDDBD_enum
+{
+    WEX_FDDBD_FAULT_gc = (0x00<<7),  /* OCD Break request is treated as a fault if fault protection is enabled */
+    WEX_FDDBD_IGNORE_gc = (0x01<<7)  /* OCD Breask request will not trigger a fault */
+} WEX_FDDBD_t;
+
+/* Fault Detection Restart Mode select */
+typedef enum WEX_FDMODE_enum
+{
+    WEX_FDMODE_LATCHED_gc = (0x00<<2),  /* Latched Mode. Output will remain in fault state until fault condition is no longer active and FDF is cleared by SW. */
+    WEX_FDMODE_CBC_gc = (0x01<<2)  /* Cycle-by-cycle mode. Waveform output will remain in fault state until fault condition is no longer active. */
+} WEX_FDMODE_t;
+
+/* Fault Detection State select */
+typedef enum WEX_FDSTATE_enum
+{
+    WEX_FDSTATE_NORMAL_gc = (0x00<<0),  /* Normal state */
+    WEX_FDSTATE_FAULT_gc = (0x01<<0)  /* Fault state */
+} WEX_FDSTATE_t;
+
+/* Fault Event Filter Enable select */
+typedef enum WEX_FILTER_enum
+{
+    WEX_FILTER_ZERO_gc = (0x00<<2),  /* No digital filter */
+    WEX_FILTER_SAMPLE1_gc = (0x01<<2),  /* One Sample */
+    WEX_FILTER_SAMPLE2_gc = (0x02<<2),  /* Two Samples */
+    WEX_FILTER_SAMPLE3_gc = (0x03<<2),  /* Three Samples */
+    WEX_FILTER_SAMPLE4_gc = (0x04<<2),  /* Four Samples */
+    WEX_FILTER_SAMPLE5_gc = (0x05<<2),  /* Five Samples */
+    WEX_FILTER_SAMPLE6_gc = (0x06<<2),  /* Six Samples */
+    WEX_FILTER_SAMPLE7_gc = (0x07<<2)  /* Seven Samples */
+} WEX_FILTER_t;
+
+/* Input Matrix select */
+typedef enum WEX_INMX_enum
+{
+    WEX_INMX_DIRECT_gc = (0x00<<4),  /* Direct from TCE0 */
+    WEX_INMX_CWCMA_gc = (0x02<<4),  /* Common Waveform Channel Mode A. Single WO */
+    WEX_INMX_CWCMB_gc = (0x03<<4)  /* Common Waveform Channel Mode B. WO from two PWM channels */
+} WEX_INMX_t;
+
+/* Update Source select */
+typedef enum WEX_UPDSRC_enum
+{
+    WEX_UPDSRC_TCPWM0_gc = (0x00<<0),  /* Timer/Counter for PWM 0 update condition */
+    WEX_UPDSRC_SW_gc = (0x03<<0)  /* Software update only. No hardware update condition */
+} WEX_UPDSRC_t;
+/*
+==========================================================================
+IO Module Instances. Mapped to memory.
+==========================================================================
+*/
+
+#define VPORTA              (*(VPORT_t *) 0x0000) /* Virtual Ports */
+#define VPORTC              (*(VPORT_t *) 0x0008) /* Virtual Ports */
+#define VPORTD              (*(VPORT_t *) 0x000C) /* Virtual Ports */
+#define VPORTF              (*(VPORT_t *) 0x0014) /* Virtual Ports */
+#define GPR                   (*(GPR_t *) 0x001C) /* General Purpose Registers */
+#define RSTCTRL           (*(RSTCTRL_t *) 0x0040) /* Reset controller */
+#define SLPCTRL           (*(SLPCTRL_t *) 0x0050) /* Sleep Controller */
+#define CLKCTRL           (*(CLKCTRL_t *) 0x0060) /* Clock controller */
+#define BOD                   (*(BOD_t *) 0x00A0) /* Bod interface */
+#define VREF                 (*(VREF_t *) 0x00B0) /* Voltage reference */
+#define WDT                   (*(WDT_t *) 0x0100) /* Watch-Dog Timer */
+#define CPUINT             (*(CPUINT_t *) 0x0110) /* Interrupt Controller */
+#define CRCSCAN           (*(CRCSCAN_t *) 0x0120) /* CRCSCAN */
+#define RTC                   (*(RTC_t *) 0x0140) /* Real-Time Counter */
+#define CCL                   (*(CCL_t *) 0x01C0) /* Configurable Custom Logic */
+#define EVSYS               (*(EVSYS_t *) 0x0200) /* Event System */
+#define PORTA                (*(PORT_t *) 0x0400) /* I/O Ports */
+#define PORTC                (*(PORT_t *) 0x0440) /* I/O Ports */
+#define PORTD                (*(PORT_t *) 0x0460) /* I/O Ports */
+#define PORTF                (*(PORT_t *) 0x04A0) /* I/O Ports */
+#define PORTMUX           (*(PORTMUX_t *) 0x05E0) /* Port Multiplexer */
+#define ADC0                  (*(ADC_t *) 0x0600) /* Analog to Digital Converter */
+#define AC0                    (*(AC_t *) 0x0680) /* Analog Comparator */
+#define AC1                    (*(AC_t *) 0x0688) /* Analog Comparator */
+#define USART0              (*(USART_t *) 0x0800) /* Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define TWI0                  (*(TWI_t *) 0x0900) /* Two-Wire Interface */
+#define SPI0                  (*(SPI_t *) 0x0940) /* Serial Peripheral Interface */
+#define TCE0                  (*(TCE_t *) 0x0A00) /* 16-bit Timer/Counter Type E */
+#define TCB0                  (*(TCB_t *) 0x0B00) /* 16-bit Timer/Counter Type B */
+#define TCB1                  (*(TCB_t *) 0x0B10) /* 16-bit Timer/Counter Type B */
+#define TCF0                  (*(TCF_t *) 0x0C00) /* 24-bit Timer/Counter for frequency generation */
+#define WEX0                  (*(WEX_t *) 0x0C80) /* Waveform Extension */
+#define SYSCFG             (*(SYSCFG_t *) 0x0F00) /* System Configuration Registers */
+#define NVMCTRL           (*(NVMCTRL_t *) 0x1000) /* Non-volatile Memory Controller */
+#define LOCK                 (*(LOCK_t *) 0x1040) /* Lockbits */
+#define FUSE                 (*(FUSE_t *) 0x1050) /* Fuses */
+#define SIGROW             (*(SIGROW_t *) 0x1080) /* Signature row */
+#define BOOTROW           (*(BOOTROW_t *) 0x1100) /* Boot Row */
+#define USERROW           (*(USERROW_t *) 0x1200) /* User Row */
+
+#endif /* !defined (__ASSEMBLER__) */
+
+
+/* ========== Flattened fully qualified IO register names ========== */
+
+
+/* VPORT (VPORTA) - Virtual Ports */
+#define VPORTA_DIR  _SFR_MEM8(0x0000)
+#define VPORTA_OUT  _SFR_MEM8(0x0001)
+#define VPORTA_IN  _SFR_MEM8(0x0002)
+#define VPORTA_INTFLAGS  _SFR_MEM8(0x0003)
+
+
+/* VPORT (VPORTC) - Virtual Ports */
+#define VPORTC_DIR  _SFR_MEM8(0x0008)
+#define VPORTC_OUT  _SFR_MEM8(0x0009)
+#define VPORTC_IN  _SFR_MEM8(0x000A)
+#define VPORTC_INTFLAGS  _SFR_MEM8(0x000B)
+
+
+/* VPORT (VPORTD) - Virtual Ports */
+#define VPORTD_DIR  _SFR_MEM8(0x000C)
+#define VPORTD_OUT  _SFR_MEM8(0x000D)
+#define VPORTD_IN  _SFR_MEM8(0x000E)
+#define VPORTD_INTFLAGS  _SFR_MEM8(0x000F)
+
+
+/* VPORT (VPORTF) - Virtual Ports */
+#define VPORTF_DIR  _SFR_MEM8(0x0014)
+#define VPORTF_OUT  _SFR_MEM8(0x0015)
+#define VPORTF_IN  _SFR_MEM8(0x0016)
+#define VPORTF_INTFLAGS  _SFR_MEM8(0x0017)
+
+
+/* GPR - General Purpose Registers */
+#define GPR_GPR0  _SFR_MEM8(0x001C)
+#define GPR_GPR1  _SFR_MEM8(0x001D)
+#define GPR_GPR2  _SFR_MEM8(0x001E)
+#define GPR_GPR3  _SFR_MEM8(0x001F)
+
+
+/* CPU - CPU */
+#define CPU_CCP  _SFR_MEM8(0x0034)
+#define CPU_RAMPZ  _SFR_MEM8(0x003B)
+#define CPU_SP  _SFR_MEM16(0x003D)
+#define CPU_SPL  _SFR_MEM8(0x003D)
+#define CPU_SPH  _SFR_MEM8(0x003E)
+#define CPU_SREG  _SFR_MEM8(0x003F)
+
+
+/* RSTCTRL - Reset controller */
+#define RSTCTRL_RSTFR  _SFR_MEM8(0x0040)
+#define RSTCTRL_SWRR  _SFR_MEM8(0x0041)
+
+
+/* SLPCTRL - Sleep Controller */
+#define SLPCTRL_CTRLA  _SFR_MEM8(0x0050)
+
+
+/* CLKCTRL - Clock controller */
+#define CLKCTRL_MCLKCTRLA  _SFR_MEM8(0x0060)
+#define CLKCTRL_MCLKCTRLB  _SFR_MEM8(0x0061)
+#define CLKCTRL_MCLKSTATUS  _SFR_MEM8(0x0065)
+#define CLKCTRL_MCLKTIMEBASE  _SFR_MEM8(0x0066)
+#define CLKCTRL_OSCHFCTRLA  _SFR_MEM8(0x0068)
+#define CLKCTRL_OSCHFTUNE  _SFR_MEM8(0x0069)
+#define CLKCTRL_PLLCTRLA  _SFR_MEM8(0x0070)
+#define CLKCTRL_PLLCTRLB  _SFR_MEM8(0x0071)
+#define CLKCTRL_OSC32KCTRLA  _SFR_MEM8(0x0078)
+#define CLKCTRL_XOSC32KCTRLA  _SFR_MEM8(0x007C)
+
+
+/* BOD - Bod interface */
+#define BOD_CTRLA  _SFR_MEM8(0x00A0)
+#define BOD_CTRLB  _SFR_MEM8(0x00A1)
+#define BOD_VLMCTRLA  _SFR_MEM8(0x00A8)
+#define BOD_INTCTRL  _SFR_MEM8(0x00A9)
+#define BOD_INTFLAGS  _SFR_MEM8(0x00AA)
+#define BOD_STATUS  _SFR_MEM8(0x00AB)
+
+
+/* VREF - Voltage reference */
+#define VREF_DAC0REF  _SFR_MEM8(0x00B2)
+#define VREF_ACREF  _SFR_MEM8(0x00B4)
+
+
+/* WDT - Watch-Dog Timer */
+#define WDT_CTRLA  _SFR_MEM8(0x0100)
+#define WDT_STATUS  _SFR_MEM8(0x0101)
+
+
+/* CPUINT - Interrupt Controller */
+#define CPUINT_CTRLA  _SFR_MEM8(0x0110)
+#define CPUINT_STATUS  _SFR_MEM8(0x0111)
+#define CPUINT_LVL0PRI  _SFR_MEM8(0x0112)
+#define CPUINT_LVL1VEC  _SFR_MEM8(0x0113)
+
+
+/* CRCSCAN - CRCSCAN */
+#define CRCSCAN_CTRLA  _SFR_MEM8(0x0120)
+#define CRCSCAN_CTRLB  _SFR_MEM8(0x0121)
+#define CRCSCAN_STATUS  _SFR_MEM8(0x0122)
+
+
+/* RTC - Real-Time Counter */
+#define RTC_CTRLA  _SFR_MEM8(0x0140)
+#define RTC_STATUS  _SFR_MEM8(0x0141)
+#define RTC_INTCTRL  _SFR_MEM8(0x0142)
+#define RTC_INTFLAGS  _SFR_MEM8(0x0143)
+#define RTC_TEMP  _SFR_MEM8(0x0144)
+#define RTC_DBGCTRL  _SFR_MEM8(0x0145)
+#define RTC_CALIB  _SFR_MEM8(0x0146)
+#define RTC_CLKSEL  _SFR_MEM8(0x0147)
+#define RTC_CNT  _SFR_MEM16(0x0148)
+#define RTC_CNTL  _SFR_MEM8(0x0148)
+#define RTC_CNTH  _SFR_MEM8(0x0149)
+#define RTC_PER  _SFR_MEM16(0x014A)
+#define RTC_PERL  _SFR_MEM8(0x014A)
+#define RTC_PERH  _SFR_MEM8(0x014B)
+#define RTC_CMP  _SFR_MEM16(0x014C)
+#define RTC_CMPL  _SFR_MEM8(0x014C)
+#define RTC_CMPH  _SFR_MEM8(0x014D)
+#define RTC_PITCTRLA  _SFR_MEM8(0x0150)
+#define RTC_PITSTATUS  _SFR_MEM8(0x0151)
+#define RTC_PITINTCTRL  _SFR_MEM8(0x0152)
+#define RTC_PITINTFLAGS  _SFR_MEM8(0x0153)
+#define RTC_PITDBGCTRL  _SFR_MEM8(0x0155)
+#define RTC_PITEVGENCTRLA  _SFR_MEM8(0x0156)
+
+
+/* CCL - Configurable Custom Logic */
+#define CCL_CTRLA  _SFR_MEM8(0x01C0)
+#define CCL_SEQCTRL0  _SFR_MEM8(0x01C1)
+#define CCL_SEQCTRL1  _SFR_MEM8(0x01C2)
+#define CCL_INTCTRL0  _SFR_MEM8(0x01C5)
+#define CCL_INTFLAGS  _SFR_MEM8(0x01C7)
+#define CCL_LUT0CTRLA  _SFR_MEM8(0x01C8)
+#define CCL_LUT0CTRLB  _SFR_MEM8(0x01C9)
+#define CCL_LUT0CTRLC  _SFR_MEM8(0x01CA)
+#define CCL_TRUTH0  _SFR_MEM8(0x01CB)
+#define CCL_LUT1CTRLA  _SFR_MEM8(0x01CC)
+#define CCL_LUT1CTRLB  _SFR_MEM8(0x01CD)
+#define CCL_LUT1CTRLC  _SFR_MEM8(0x01CE)
+#define CCL_TRUTH1  _SFR_MEM8(0x01CF)
+#define CCL_LUT2CTRLA  _SFR_MEM8(0x01D0)
+#define CCL_LUT2CTRLB  _SFR_MEM8(0x01D1)
+#define CCL_LUT2CTRLC  _SFR_MEM8(0x01D2)
+#define CCL_TRUTH2  _SFR_MEM8(0x01D3)
+#define CCL_LUT3CTRLA  _SFR_MEM8(0x01D4)
+#define CCL_LUT3CTRLB  _SFR_MEM8(0x01D5)
+#define CCL_LUT3CTRLC  _SFR_MEM8(0x01D6)
+#define CCL_TRUTH3  _SFR_MEM8(0x01D7)
+
+
+/* EVSYS - Event System */
+#define EVSYS_SWEVENTA  _SFR_MEM8(0x0200)
+#define EVSYS_CHANNEL0  _SFR_MEM8(0x0210)
+#define EVSYS_CHANNEL1  _SFR_MEM8(0x0211)
+#define EVSYS_CHANNEL2  _SFR_MEM8(0x0212)
+#define EVSYS_CHANNEL3  _SFR_MEM8(0x0213)
+#define EVSYS_CHANNEL4  _SFR_MEM8(0x0214)
+#define EVSYS_CHANNEL5  _SFR_MEM8(0x0215)
+#define EVSYS_USERCCLLUT0A  _SFR_MEM8(0x0220)
+#define EVSYS_USERCCLLUT0B  _SFR_MEM8(0x0221)
+#define EVSYS_USERCCLLUT1A  _SFR_MEM8(0x0222)
+#define EVSYS_USERCCLLUT1B  _SFR_MEM8(0x0223)
+#define EVSYS_USERCCLLUT2A  _SFR_MEM8(0x0224)
+#define EVSYS_USERCCLLUT2B  _SFR_MEM8(0x0225)
+#define EVSYS_USERCCLLUT3A  _SFR_MEM8(0x0226)
+#define EVSYS_USERCCLLUT3B  _SFR_MEM8(0x0227)
+#define EVSYS_USERADC0START  _SFR_MEM8(0x0228)
+#define EVSYS_USEREVSYSEVOUTA  _SFR_MEM8(0x0229)
+#define EVSYS_USEREVSYSEVOUTC  _SFR_MEM8(0x022A)
+#define EVSYS_USEREVSYSEVOUTD  _SFR_MEM8(0x022B)
+#define EVSYS_USEREVSYSEVOUTF  _SFR_MEM8(0x022C)
+#define EVSYS_USERUSART0IRDA  _SFR_MEM8(0x022D)
+#define EVSYS_USERTCE0CNTA  _SFR_MEM8(0x022E)
+#define EVSYS_USERTCE0CNTB  _SFR_MEM8(0x022F)
+#define EVSYS_USERTCB0CAPT  _SFR_MEM8(0x0230)
+#define EVSYS_USERTCB0COUNT  _SFR_MEM8(0x0231)
+#define EVSYS_USERTCB1CAPT  _SFR_MEM8(0x0232)
+#define EVSYS_USERTCB1COUNT  _SFR_MEM8(0x0233)
+#define EVSYS_USERTCF0CNT  _SFR_MEM8(0x0234)
+#define EVSYS_USERTCF0ACT  _SFR_MEM8(0x0235)
+#define EVSYS_USERWEXA  _SFR_MEM8(0x0236)
+#define EVSYS_USERWEXB  _SFR_MEM8(0x0237)
+#define EVSYS_USERWEXC  _SFR_MEM8(0x0238)
+
+
+/* PORT (PORTA) - I/O Ports */
+#define PORTA_DIR  _SFR_MEM8(0x0400)
+#define PORTA_DIRSET  _SFR_MEM8(0x0401)
+#define PORTA_DIRCLR  _SFR_MEM8(0x0402)
+#define PORTA_DIRTGL  _SFR_MEM8(0x0403)
+#define PORTA_OUT  _SFR_MEM8(0x0404)
+#define PORTA_OUTSET  _SFR_MEM8(0x0405)
+#define PORTA_OUTCLR  _SFR_MEM8(0x0406)
+#define PORTA_OUTTGL  _SFR_MEM8(0x0407)
+#define PORTA_IN  _SFR_MEM8(0x0408)
+#define PORTA_INTFLAGS  _SFR_MEM8(0x0409)
+#define PORTA_PORTCTRL  _SFR_MEM8(0x040A)
+#define PORTA_PINCONFIG  _SFR_MEM8(0x040B)
+#define PORTA_PINCTRLUPD  _SFR_MEM8(0x040C)
+#define PORTA_PINCTRLSET  _SFR_MEM8(0x040D)
+#define PORTA_PINCTRLCLR  _SFR_MEM8(0x040E)
+#define PORTA_PIN0CTRL  _SFR_MEM8(0x0410)
+#define PORTA_PIN1CTRL  _SFR_MEM8(0x0411)
+#define PORTA_PIN2CTRL  _SFR_MEM8(0x0412)
+#define PORTA_PIN3CTRL  _SFR_MEM8(0x0413)
+#define PORTA_PIN4CTRL  _SFR_MEM8(0x0414)
+#define PORTA_PIN5CTRL  _SFR_MEM8(0x0415)
+#define PORTA_PIN6CTRL  _SFR_MEM8(0x0416)
+#define PORTA_PIN7CTRL  _SFR_MEM8(0x0417)
+#define PORTA_EVGENCTRLA  _SFR_MEM8(0x0418)
+
+
+/* PORT (PORTC) - I/O Ports */
+#define PORTC_DIR  _SFR_MEM8(0x0440)
+#define PORTC_DIRSET  _SFR_MEM8(0x0441)
+#define PORTC_DIRCLR  _SFR_MEM8(0x0442)
+#define PORTC_DIRTGL  _SFR_MEM8(0x0443)
+#define PORTC_OUT  _SFR_MEM8(0x0444)
+#define PORTC_OUTSET  _SFR_MEM8(0x0445)
+#define PORTC_OUTCLR  _SFR_MEM8(0x0446)
+#define PORTC_OUTTGL  _SFR_MEM8(0x0447)
+#define PORTC_IN  _SFR_MEM8(0x0448)
+#define PORTC_INTFLAGS  _SFR_MEM8(0x0449)
+#define PORTC_PORTCTRL  _SFR_MEM8(0x044A)
+#define PORTC_PINCONFIG  _SFR_MEM8(0x044B)
+#define PORTC_PINCTRLUPD  _SFR_MEM8(0x044C)
+#define PORTC_PINCTRLSET  _SFR_MEM8(0x044D)
+#define PORTC_PINCTRLCLR  _SFR_MEM8(0x044E)
+#define PORTC_PIN0CTRL  _SFR_MEM8(0x0450)
+#define PORTC_PIN1CTRL  _SFR_MEM8(0x0451)
+#define PORTC_PIN2CTRL  _SFR_MEM8(0x0452)
+#define PORTC_PIN3CTRL  _SFR_MEM8(0x0453)
+#define PORTC_PIN4CTRL  _SFR_MEM8(0x0454)
+#define PORTC_PIN5CTRL  _SFR_MEM8(0x0455)
+#define PORTC_PIN6CTRL  _SFR_MEM8(0x0456)
+#define PORTC_PIN7CTRL  _SFR_MEM8(0x0457)
+#define PORTC_EVGENCTRLA  _SFR_MEM8(0x0458)
+
+
+/* PORT (PORTD) - I/O Ports */
+#define PORTD_DIR  _SFR_MEM8(0x0460)
+#define PORTD_DIRSET  _SFR_MEM8(0x0461)
+#define PORTD_DIRCLR  _SFR_MEM8(0x0462)
+#define PORTD_DIRTGL  _SFR_MEM8(0x0463)
+#define PORTD_OUT  _SFR_MEM8(0x0464)
+#define PORTD_OUTSET  _SFR_MEM8(0x0465)
+#define PORTD_OUTCLR  _SFR_MEM8(0x0466)
+#define PORTD_OUTTGL  _SFR_MEM8(0x0467)
+#define PORTD_IN  _SFR_MEM8(0x0468)
+#define PORTD_INTFLAGS  _SFR_MEM8(0x0469)
+#define PORTD_PORTCTRL  _SFR_MEM8(0x046A)
+#define PORTD_PINCONFIG  _SFR_MEM8(0x046B)
+#define PORTD_PINCTRLUPD  _SFR_MEM8(0x046C)
+#define PORTD_PINCTRLSET  _SFR_MEM8(0x046D)
+#define PORTD_PINCTRLCLR  _SFR_MEM8(0x046E)
+#define PORTD_PIN0CTRL  _SFR_MEM8(0x0470)
+#define PORTD_PIN1CTRL  _SFR_MEM8(0x0471)
+#define PORTD_PIN2CTRL  _SFR_MEM8(0x0472)
+#define PORTD_PIN3CTRL  _SFR_MEM8(0x0473)
+#define PORTD_PIN4CTRL  _SFR_MEM8(0x0474)
+#define PORTD_PIN5CTRL  _SFR_MEM8(0x0475)
+#define PORTD_PIN6CTRL  _SFR_MEM8(0x0476)
+#define PORTD_PIN7CTRL  _SFR_MEM8(0x0477)
+#define PORTD_EVGENCTRLA  _SFR_MEM8(0x0478)
+
+
+/* PORT (PORTF) - I/O Ports */
+#define PORTF_DIR  _SFR_MEM8(0x04A0)
+#define PORTF_DIRSET  _SFR_MEM8(0x04A1)
+#define PORTF_DIRCLR  _SFR_MEM8(0x04A2)
+#define PORTF_DIRTGL  _SFR_MEM8(0x04A3)
+#define PORTF_OUT  _SFR_MEM8(0x04A4)
+#define PORTF_OUTSET  _SFR_MEM8(0x04A5)
+#define PORTF_OUTCLR  _SFR_MEM8(0x04A6)
+#define PORTF_OUTTGL  _SFR_MEM8(0x04A7)
+#define PORTF_IN  _SFR_MEM8(0x04A8)
+#define PORTF_INTFLAGS  _SFR_MEM8(0x04A9)
+#define PORTF_PORTCTRL  _SFR_MEM8(0x04AA)
+#define PORTF_PINCONFIG  _SFR_MEM8(0x04AB)
+#define PORTF_PINCTRLUPD  _SFR_MEM8(0x04AC)
+#define PORTF_PINCTRLSET  _SFR_MEM8(0x04AD)
+#define PORTF_PINCTRLCLR  _SFR_MEM8(0x04AE)
+#define PORTF_PIN0CTRL  _SFR_MEM8(0x04B0)
+#define PORTF_PIN1CTRL  _SFR_MEM8(0x04B1)
+#define PORTF_PIN2CTRL  _SFR_MEM8(0x04B2)
+#define PORTF_PIN3CTRL  _SFR_MEM8(0x04B3)
+#define PORTF_PIN4CTRL  _SFR_MEM8(0x04B4)
+#define PORTF_PIN5CTRL  _SFR_MEM8(0x04B5)
+#define PORTF_PIN6CTRL  _SFR_MEM8(0x04B6)
+#define PORTF_PIN7CTRL  _SFR_MEM8(0x04B7)
+#define PORTF_EVGENCTRLA  _SFR_MEM8(0x04B8)
+
+
+/* PORTMUX - Port Multiplexer */
+#define PORTMUX_EVSYSROUTEA  _SFR_MEM8(0x05E0)
+#define PORTMUX_CCLROUTEA  _SFR_MEM8(0x05E1)
+#define PORTMUX_USARTROUTEA  _SFR_MEM8(0x05E2)
+#define PORTMUX_SPIROUTEA  _SFR_MEM8(0x05E5)
+#define PORTMUX_TWIROUTEA  _SFR_MEM8(0x05E6)
+#define PORTMUX_TCEROUTEA  _SFR_MEM8(0x05E7)
+#define PORTMUX_TCBROUTEA  _SFR_MEM8(0x05E8)
+#define PORTMUX_TCFROUTEA  _SFR_MEM8(0x05EC)
+
+
+/* ADC (ADC0) - Analog to Digital Converter */
+#define ADC0_CTRLA  _SFR_MEM8(0x0600)
+#define ADC0_CTRLB  _SFR_MEM8(0x0601)
+#define ADC0_CTRLC  _SFR_MEM8(0x0602)
+#define ADC0_CTRLD  _SFR_MEM8(0x0603)
+#define ADC0_INTCTRL  _SFR_MEM8(0x0604)
+#define ADC0_INTFLAGS  _SFR_MEM8(0x0605)
+#define ADC0_STATUS  _SFR_MEM8(0x0606)
+#define ADC0_DBGCTRL  _SFR_MEM8(0x0607)
+#define ADC0_CTRLE  _SFR_MEM8(0x0608)
+#define ADC0_CTRLF  _SFR_MEM8(0x0609)
+#define ADC0_COMMAND  _SFR_MEM8(0x060A)
+#define ADC0_PGACTRL  _SFR_MEM8(0x060B)
+#define ADC0_MUXPOS  _SFR_MEM8(0x060C)
+#define ADC0_MUXNEG  _SFR_MEM8(0x060D)
+#define ADC0_RESULT  _SFR_MEM32(0x0610)
+#define ADC0_RESULT0  _SFR_MEM8(0x0610)
+#define ADC0_RESULT1  _SFR_MEM8(0x0611)
+#define ADC0_RESULT2  _SFR_MEM8(0x0612)
+#define ADC0_RESULT3  _SFR_MEM8(0x0613)
+#define ADC0_SAMPLE  _SFR_MEM16(0x0614)
+#define ADC0_SAMPLEL  _SFR_MEM8(0x0614)
+#define ADC0_SAMPLEH  _SFR_MEM8(0x0615)
+#define ADC0_TEMP0  _SFR_MEM8(0x0618)
+#define ADC0_TEMP1  _SFR_MEM8(0x0619)
+#define ADC0_TEMP2  _SFR_MEM8(0x061A)
+#define ADC0_WINLT  _SFR_MEM16(0x061C)
+#define ADC0_WINLTL  _SFR_MEM8(0x061C)
+#define ADC0_WINLTH  _SFR_MEM8(0x061D)
+#define ADC0_WINHT  _SFR_MEM16(0x061E)
+#define ADC0_WINHTL  _SFR_MEM8(0x061E)
+#define ADC0_WINHTH  _SFR_MEM8(0x061F)
+
+
+/* AC (AC0) - Analog Comparator */
+#define AC0_CTRLA  _SFR_MEM8(0x0680)
+#define AC0_CTRLB  _SFR_MEM8(0x0681)
+#define AC0_MUXCTRL  _SFR_MEM8(0x0682)
+#define AC0_DACREF  _SFR_MEM8(0x0685)
+#define AC0_INTCTRL  _SFR_MEM8(0x0686)
+#define AC0_STATUS  _SFR_MEM8(0x0687)
+
+
+/* AC (AC1) - Analog Comparator */
+#define AC1_CTRLA  _SFR_MEM8(0x0688)
+#define AC1_CTRLB  _SFR_MEM8(0x0689)
+#define AC1_MUXCTRL  _SFR_MEM8(0x068A)
+#define AC1_DACREF  _SFR_MEM8(0x068D)
+#define AC1_INTCTRL  _SFR_MEM8(0x068E)
+#define AC1_STATUS  _SFR_MEM8(0x068F)
+
+
+/* USART (USART0) - Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define USART0_RXDATAL  _SFR_MEM8(0x0800)
+#define USART0_RXDATAH  _SFR_MEM8(0x0801)
+#define USART0_TXDATAL  _SFR_MEM8(0x0802)
+#define USART0_TXDATAH  _SFR_MEM8(0x0803)
+#define USART0_STATUS  _SFR_MEM8(0x0804)
+#define USART0_CTRLA  _SFR_MEM8(0x0805)
+#define USART0_CTRLB  _SFR_MEM8(0x0806)
+#define USART0_CTRLC  _SFR_MEM8(0x0807)
+#define USART0_BAUD  _SFR_MEM16(0x0808)
+#define USART0_BAUDL  _SFR_MEM8(0x0808)
+#define USART0_BAUDH  _SFR_MEM8(0x0809)
+#define USART0_CTRLD  _SFR_MEM8(0x080A)
+#define USART0_DBGCTRL  _SFR_MEM8(0x080B)
+#define USART0_EVCTRL  _SFR_MEM8(0x080C)
+#define USART0_TXPLCTRL  _SFR_MEM8(0x080D)
+#define USART0_RXPLCTRL  _SFR_MEM8(0x080E)
+
+
+/* TWI (TWI0) - Two-Wire Interface */
+#define TWI0_CTRLA  _SFR_MEM8(0x0900)
+#define TWI0_DUALCTRL  _SFR_MEM8(0x0901)
+#define TWI0_DBGCTRL  _SFR_MEM8(0x0902)
+#define TWI0_MCTRLA  _SFR_MEM8(0x0903)
+#define TWI0_MCTRLB  _SFR_MEM8(0x0904)
+#define TWI0_MSTATUS  _SFR_MEM8(0x0905)
+#define TWI0_MBAUD  _SFR_MEM8(0x0906)
+#define TWI0_MADDR  _SFR_MEM8(0x0907)
+#define TWI0_MDATA  _SFR_MEM8(0x0908)
+#define TWI0_SCTRLA  _SFR_MEM8(0x0909)
+#define TWI0_SCTRLB  _SFR_MEM8(0x090A)
+#define TWI0_SSTATUS  _SFR_MEM8(0x090B)
+#define TWI0_SADDR  _SFR_MEM8(0x090C)
+#define TWI0_SDATA  _SFR_MEM8(0x090D)
+#define TWI0_SADDRMASK  _SFR_MEM8(0x090E)
+
+
+/* SPI (SPI0) - Serial Peripheral Interface */
+#define SPI0_CTRLA  _SFR_MEM8(0x0940)
+#define SPI0_CTRLB  _SFR_MEM8(0x0941)
+#define SPI0_INTCTRL  _SFR_MEM8(0x0942)
+#define SPI0_INTFLAGS  _SFR_MEM8(0x0943)
+#define SPI0_DATA  _SFR_MEM8(0x0944)
+
+
+/* TCE (TCE0) - 16-bit Timer/Counter Type E */
+#define TCE0_CTRLA  _SFR_MEM8(0x0A00)
+#define TCE0_CTRLB  _SFR_MEM8(0x0A01)
+#define TCE0_CTRLC  _SFR_MEM8(0x0A02)
+#define TCE0_CTRLD  _SFR_MEM8(0x0A03)
+#define TCE0_CTRLECLR  _SFR_MEM8(0x0A04)
+#define TCE0_CTRLESET  _SFR_MEM8(0x0A05)
+#define TCE0_CTRLFCLR  _SFR_MEM8(0x0A06)
+#define TCE0_CTRLFSET  _SFR_MEM8(0x0A07)
+#define TCE0_EVGENCTRL  _SFR_MEM8(0x0A08)
+#define TCE0_EVCTRL  _SFR_MEM8(0x0A09)
+#define TCE0_INTCTRL  _SFR_MEM8(0x0A0A)
+#define TCE0_INTFLAGS  _SFR_MEM8(0x0A0B)
+#define TCE0_DBGCTRL  _SFR_MEM8(0x0A0E)
+#define TCE0_TEMP  _SFR_MEM8(0x0A0F)
+#define TCE0_CNT  _SFR_MEM16(0x0A20)
+#define TCE0_CNTL  _SFR_MEM8(0x0A20)
+#define TCE0_CNTH  _SFR_MEM8(0x0A21)
+#define TCE0_AMP  _SFR_MEM16(0x0A22)
+#define TCE0_AMPL  _SFR_MEM8(0x0A22)
+#define TCE0_AMPH  _SFR_MEM8(0x0A23)
+#define TCE0_OFFSET  _SFR_MEM16(0x0A24)
+#define TCE0_OFFSETL  _SFR_MEM8(0x0A24)
+#define TCE0_OFFSETH  _SFR_MEM8(0x0A25)
+#define TCE0_PER  _SFR_MEM16(0x0A26)
+#define TCE0_PERL  _SFR_MEM8(0x0A26)
+#define TCE0_PERH  _SFR_MEM8(0x0A27)
+#define TCE0_CMP0  _SFR_MEM16(0x0A28)
+#define TCE0_CMP0L  _SFR_MEM8(0x0A28)
+#define TCE0_CMP0H  _SFR_MEM8(0x0A29)
+#define TCE0_CMP1  _SFR_MEM16(0x0A2A)
+#define TCE0_CMP1L  _SFR_MEM8(0x0A2A)
+#define TCE0_CMP1H  _SFR_MEM8(0x0A2B)
+#define TCE0_CMP2  _SFR_MEM16(0x0A2C)
+#define TCE0_CMP2L  _SFR_MEM8(0x0A2C)
+#define TCE0_CMP2H  _SFR_MEM8(0x0A2D)
+#define TCE0_CMP3  _SFR_MEM16(0x0A2E)
+#define TCE0_CMP3L  _SFR_MEM8(0x0A2E)
+#define TCE0_CMP3H  _SFR_MEM8(0x0A2F)
+#define TCE0_PERBUF  _SFR_MEM16(0x0A36)
+#define TCE0_PERBUFL  _SFR_MEM8(0x0A36)
+#define TCE0_PERBUFH  _SFR_MEM8(0x0A37)
+#define TCE0_CMP0BUF  _SFR_MEM16(0x0A38)
+#define TCE0_CMP0BUFL  _SFR_MEM8(0x0A38)
+#define TCE0_CMP0BUFH  _SFR_MEM8(0x0A39)
+#define TCE0_CMP1BUF  _SFR_MEM16(0x0A3A)
+#define TCE0_CMP1BUFL  _SFR_MEM8(0x0A3A)
+#define TCE0_CMP1BUFH  _SFR_MEM8(0x0A3B)
+#define TCE0_CMP2BUF  _SFR_MEM16(0x0A3C)
+#define TCE0_CMP2BUFL  _SFR_MEM8(0x0A3C)
+#define TCE0_CMP2BUFH  _SFR_MEM8(0x0A3D)
+#define TCE0_CMP3BUF  _SFR_MEM16(0x0A3E)
+#define TCE0_CMP3BUFL  _SFR_MEM8(0x0A3E)
+#define TCE0_CMP3BUFH  _SFR_MEM8(0x0A3F)
+
+
+/* TCB (TCB0) - 16-bit Timer/Counter Type B */
+#define TCB0_CTRLA  _SFR_MEM8(0x0B00)
+#define TCB0_CTRLB  _SFR_MEM8(0x0B01)
+#define TCB0_CTRLC  _SFR_MEM8(0x0B02)
+#define TCB0_EVCTRL  _SFR_MEM8(0x0B04)
+#define TCB0_INTCTRL  _SFR_MEM8(0x0B05)
+#define TCB0_INTFLAGS  _SFR_MEM8(0x0B06)
+#define TCB0_STATUS  _SFR_MEM8(0x0B07)
+#define TCB0_DBGCTRL  _SFR_MEM8(0x0B08)
+#define TCB0_TEMP  _SFR_MEM8(0x0B09)
+#define TCB0_CNT  _SFR_MEM16(0x0B0A)
+#define TCB0_CNTL  _SFR_MEM8(0x0B0A)
+#define TCB0_CNTH  _SFR_MEM8(0x0B0B)
+#define TCB0_CCMP  _SFR_MEM16(0x0B0C)
+#define TCB0_CCMPL  _SFR_MEM8(0x0B0C)
+#define TCB0_CCMPH  _SFR_MEM8(0x0B0D)
+
+
+/* TCB (TCB1) - 16-bit Timer/Counter Type B */
+#define TCB1_CTRLA  _SFR_MEM8(0x0B10)
+#define TCB1_CTRLB  _SFR_MEM8(0x0B11)
+#define TCB1_CTRLC  _SFR_MEM8(0x0B12)
+#define TCB1_EVCTRL  _SFR_MEM8(0x0B14)
+#define TCB1_INTCTRL  _SFR_MEM8(0x0B15)
+#define TCB1_INTFLAGS  _SFR_MEM8(0x0B16)
+#define TCB1_STATUS  _SFR_MEM8(0x0B17)
+#define TCB1_DBGCTRL  _SFR_MEM8(0x0B18)
+#define TCB1_TEMP  _SFR_MEM8(0x0B19)
+#define TCB1_CNT  _SFR_MEM16(0x0B1A)
+#define TCB1_CNTL  _SFR_MEM8(0x0B1A)
+#define TCB1_CNTH  _SFR_MEM8(0x0B1B)
+#define TCB1_CCMP  _SFR_MEM16(0x0B1C)
+#define TCB1_CCMPL  _SFR_MEM8(0x0B1C)
+#define TCB1_CCMPH  _SFR_MEM8(0x0B1D)
+
+
+/* TCF (TCF0) - 24-bit Timer/Counter for frequency generation */
+#define TCF0_CTRLA  _SFR_MEM8(0x0C00)
+#define TCF0_CTRLB  _SFR_MEM8(0x0C01)
+#define TCF0_CTRLC  _SFR_MEM8(0x0C02)
+#define TCF0_CTRLD  _SFR_MEM8(0x0C03)
+#define TCF0_EVCTRL  _SFR_MEM8(0x0C04)
+#define TCF0_INTCTRL  _SFR_MEM8(0x0C05)
+#define TCF0_INTFLAGS  _SFR_MEM8(0x0C06)
+#define TCF0_STATUS  _SFR_MEM8(0x0C07)
+#define TCF0_DBGCTRL  _SFR_MEM8(0x0C0D)
+#define TCF0_CNT  _SFR_MEM32(0x0C10)
+#define TCF0_CNT0  _SFR_MEM8(0x0C10)
+#define TCF0_CNT1  _SFR_MEM8(0x0C11)
+#define TCF0_CNT2  _SFR_MEM8(0x0C12)
+#define TCF0_CNT3  _SFR_MEM8(0x0C13)
+#define TCF0_CMP  _SFR_MEM32(0x0C14)
+#define TCF0_CMP0  _SFR_MEM8(0x0C14)
+#define TCF0_CMP1  _SFR_MEM8(0x0C15)
+#define TCF0_CMP2  _SFR_MEM8(0x0C16)
+#define TCF0_CMP3  _SFR_MEM8(0x0C17)
+
+
+/* WEX (WEX0) - Waveform Extension */
+#define WEX0_CTRLA  _SFR_MEM8(0x0C80)
+#define WEX0_CTRLB  _SFR_MEM8(0x0C81)
+#define WEX0_CTRLC  _SFR_MEM8(0x0C82)
+#define WEX0_EVCTRLA  _SFR_MEM8(0x0C84)
+#define WEX0_EVCTRLB  _SFR_MEM8(0x0C85)
+#define WEX0_EVCTRLC  _SFR_MEM8(0x0C86)
+#define WEX0_BUFCTRL  _SFR_MEM8(0x0C87)
+#define WEX0_BLANKCTRL  _SFR_MEM8(0x0C88)
+#define WEX0_BLANKTIME  _SFR_MEM8(0x0C89)
+#define WEX0_FAULTCTRL  _SFR_MEM8(0x0C8A)
+#define WEX0_FAULTDRV  _SFR_MEM8(0x0C8B)
+#define WEX0_FAULTOUT  _SFR_MEM8(0x0C8C)
+#define WEX0_INTCTRL  _SFR_MEM8(0x0C8D)
+#define WEX0_INTFLAGS  _SFR_MEM8(0x0C8E)
+#define WEX0_STATUS  _SFR_MEM8(0x0C8F)
+#define WEX0_DTLS  _SFR_MEM8(0x0C90)
+#define WEX0_DTHS  _SFR_MEM8(0x0C91)
+#define WEX0_DTBOTH  _SFR_MEM8(0x0C92)
+#define WEX0_SWAP  _SFR_MEM8(0x0C93)
+#define WEX0_PGMOVR  _SFR_MEM8(0x0C94)
+#define WEX0_PGMOUT  _SFR_MEM8(0x0C95)
+#define WEX0_OUTOVEN  _SFR_MEM8(0x0C97)
+#define WEX0_DTLSBUF  _SFR_MEM8(0x0C98)
+#define WEX0_DTHSBUF  _SFR_MEM8(0x0C99)
+#define WEX0_DTBOTHBUF  _SFR_MEM8(0x0C9A)
+#define WEX0_SWAPBUF  _SFR_MEM8(0x0C9B)
+#define WEX0_PGMOVRBUF  _SFR_MEM8(0x0C9C)
+#define WEX0_PGMOUTBUF  _SFR_MEM8(0x0C9D)
+
+
+/* SYSCFG - System Configuration Registers */
+#define SYSCFG_REVID  _SFR_MEM8(0x0F01)
+
+
+/* NVMCTRL - Non-volatile Memory Controller */
+#define NVMCTRL_CTRLA  _SFR_MEM8(0x1000)
+#define NVMCTRL_CTRLB  _SFR_MEM8(0x1001)
+#define NVMCTRL_CTRLC  _SFR_MEM8(0x1002)
+#define NVMCTRL_INTCTRL  _SFR_MEM8(0x1004)
+#define NVMCTRL_INTFLAGS  _SFR_MEM8(0x1005)
+#define NVMCTRL_STATUS  _SFR_MEM8(0x1006)
+#define NVMCTRL_DATA  _SFR_MEM16(0x1008)
+#define NVMCTRL_DATAL  _SFR_MEM8(0x1008)
+#define NVMCTRL_DATAH  _SFR_MEM8(0x1009)
+#define NVMCTRL_ADDR  _SFR_MEM32(0x100C)
+#define NVMCTRL_ADDR0  _SFR_MEM8(0x100C)
+#define NVMCTRL_ADDR1  _SFR_MEM8(0x100D)
+#define NVMCTRL_ADDR2  _SFR_MEM8(0x100E)
+#define NVMCTRL_ADDR3  _SFR_MEM8(0x100F)
+
+
+/* LOCK - Lockbits */
+#define LOCK_KEY  _SFR_MEM32(0x1040)
+#define LOCK_KEY0  _SFR_MEM8(0x1040)
+#define LOCK_KEY1  _SFR_MEM8(0x1041)
+#define LOCK_KEY2  _SFR_MEM8(0x1042)
+#define LOCK_KEY3  _SFR_MEM8(0x1043)
+
+
+/* FUSE - Fuses */
+#define FUSE_WDTCFG  _SFR_MEM8(0x1050)
+#define FUSE_BODCFG  _SFR_MEM8(0x1051)
+#define FUSE_OSCCFG  _SFR_MEM8(0x1052)
+#define FUSE_SYSCFG0  _SFR_MEM8(0x1055)
+#define FUSE_SYSCFG1  _SFR_MEM8(0x1056)
+#define FUSE_CODESIZE  _SFR_MEM8(0x1057)
+#define FUSE_BOOTSIZE  _SFR_MEM8(0x1058)
+#define FUSE_PDICFG  _SFR_MEM16(0x105A)
+#define FUSE_PDICFGL  _SFR_MEM8(0x105A)
+#define FUSE_PDICFGH  _SFR_MEM8(0x105B)
+
+
+/* SIGROW - Signature row */
+#define SIGROW_DEVICEID0  _SFR_MEM8(0x1080)
+#define SIGROW_DEVICEID1  _SFR_MEM8(0x1081)
+#define SIGROW_DEVICEID2  _SFR_MEM8(0x1082)
+#define SIGROW_TEMPSENSE0  _SFR_MEM16(0x1084)
+#define SIGROW_TEMPSENSE0L  _SFR_MEM8(0x1084)
+#define SIGROW_TEMPSENSE0H  _SFR_MEM8(0x1085)
+#define SIGROW_TEMPSENSE1  _SFR_MEM16(0x1086)
+#define SIGROW_TEMPSENSE1L  _SFR_MEM8(0x1086)
+#define SIGROW_TEMPSENSE1H  _SFR_MEM8(0x1087)
+#define SIGROW_SERNUM0  _SFR_MEM8(0x1090)
+#define SIGROW_SERNUM1  _SFR_MEM8(0x1091)
+#define SIGROW_SERNUM2  _SFR_MEM8(0x1092)
+#define SIGROW_SERNUM3  _SFR_MEM8(0x1093)
+#define SIGROW_SERNUM4  _SFR_MEM8(0x1094)
+#define SIGROW_SERNUM5  _SFR_MEM8(0x1095)
+#define SIGROW_SERNUM6  _SFR_MEM8(0x1096)
+#define SIGROW_SERNUM7  _SFR_MEM8(0x1097)
+#define SIGROW_SERNUM8  _SFR_MEM8(0x1098)
+#define SIGROW_SERNUM9  _SFR_MEM8(0x1099)
+#define SIGROW_SERNUM10  _SFR_MEM8(0x109A)
+#define SIGROW_SERNUM11  _SFR_MEM8(0x109B)
+#define SIGROW_SERNUM12  _SFR_MEM8(0x109C)
+#define SIGROW_SERNUM13  _SFR_MEM8(0x109D)
+#define SIGROW_SERNUM14  _SFR_MEM8(0x109E)
+#define SIGROW_SERNUM15  _SFR_MEM8(0x109F)
+
+
+/* BOOTROW - Boot Row */
+#define BOOTROW_BOOTROW  _SFR_MEM8(0x1100)
+
+
+/* USERROW - User Row */
+#define USERROW_USERROW0  _SFR_MEM8(0x1200)
+#define USERROW_USERROW1  _SFR_MEM8(0x1201)
+#define USERROW_USERROW2  _SFR_MEM8(0x1202)
+#define USERROW_USERROW3  _SFR_MEM8(0x1203)
+#define USERROW_USERROW4  _SFR_MEM8(0x1204)
+#define USERROW_USERROW5  _SFR_MEM8(0x1205)
+#define USERROW_USERROW6  _SFR_MEM8(0x1206)
+#define USERROW_USERROW7  _SFR_MEM8(0x1207)
+#define USERROW_USERROW8  _SFR_MEM8(0x1208)
+#define USERROW_USERROW9  _SFR_MEM8(0x1209)
+#define USERROW_USERROW10  _SFR_MEM8(0x120A)
+#define USERROW_USERROW11  _SFR_MEM8(0x120B)
+#define USERROW_USERROW12  _SFR_MEM8(0x120C)
+#define USERROW_USERROW13  _SFR_MEM8(0x120D)
+#define USERROW_USERROW14  _SFR_MEM8(0x120E)
+#define USERROW_USERROW15  _SFR_MEM8(0x120F)
+#define USERROW_USERROW16  _SFR_MEM8(0x1210)
+#define USERROW_USERROW17  _SFR_MEM8(0x1211)
+#define USERROW_USERROW18  _SFR_MEM8(0x1212)
+#define USERROW_USERROW19  _SFR_MEM8(0x1213)
+#define USERROW_USERROW20  _SFR_MEM8(0x1214)
+#define USERROW_USERROW21  _SFR_MEM8(0x1215)
+#define USERROW_USERROW22  _SFR_MEM8(0x1216)
+#define USERROW_USERROW23  _SFR_MEM8(0x1217)
+#define USERROW_USERROW24  _SFR_MEM8(0x1218)
+#define USERROW_USERROW25  _SFR_MEM8(0x1219)
+#define USERROW_USERROW26  _SFR_MEM8(0x121A)
+#define USERROW_USERROW27  _SFR_MEM8(0x121B)
+#define USERROW_USERROW28  _SFR_MEM8(0x121C)
+#define USERROW_USERROW29  _SFR_MEM8(0x121D)
+#define USERROW_USERROW30  _SFR_MEM8(0x121E)
+#define USERROW_USERROW31  _SFR_MEM8(0x121F)
+#define USERROW_USERROW32  _SFR_MEM8(0x1220)
+#define USERROW_USERROW33  _SFR_MEM8(0x1221)
+#define USERROW_USERROW34  _SFR_MEM8(0x1222)
+#define USERROW_USERROW35  _SFR_MEM8(0x1223)
+#define USERROW_USERROW36  _SFR_MEM8(0x1224)
+#define USERROW_USERROW37  _SFR_MEM8(0x1225)
+#define USERROW_USERROW38  _SFR_MEM8(0x1226)
+#define USERROW_USERROW39  _SFR_MEM8(0x1227)
+#define USERROW_USERROW40  _SFR_MEM8(0x1228)
+#define USERROW_USERROW41  _SFR_MEM8(0x1229)
+#define USERROW_USERROW42  _SFR_MEM8(0x122A)
+#define USERROW_USERROW43  _SFR_MEM8(0x122B)
+#define USERROW_USERROW44  _SFR_MEM8(0x122C)
+#define USERROW_USERROW45  _SFR_MEM8(0x122D)
+#define USERROW_USERROW46  _SFR_MEM8(0x122E)
+#define USERROW_USERROW47  _SFR_MEM8(0x122F)
+#define USERROW_USERROW48  _SFR_MEM8(0x1230)
+#define USERROW_USERROW49  _SFR_MEM8(0x1231)
+#define USERROW_USERROW50  _SFR_MEM8(0x1232)
+#define USERROW_USERROW51  _SFR_MEM8(0x1233)
+#define USERROW_USERROW52  _SFR_MEM8(0x1234)
+#define USERROW_USERROW53  _SFR_MEM8(0x1235)
+#define USERROW_USERROW54  _SFR_MEM8(0x1236)
+#define USERROW_USERROW55  _SFR_MEM8(0x1237)
+#define USERROW_USERROW56  _SFR_MEM8(0x1238)
+#define USERROW_USERROW57  _SFR_MEM8(0x1239)
+#define USERROW_USERROW58  _SFR_MEM8(0x123A)
+#define USERROW_USERROW59  _SFR_MEM8(0x123B)
+#define USERROW_USERROW60  _SFR_MEM8(0x123C)
+#define USERROW_USERROW61  _SFR_MEM8(0x123D)
+#define USERROW_USERROW62  _SFR_MEM8(0x123E)
+#define USERROW_USERROW63  _SFR_MEM8(0x123F)
+
+
+
+/*================== Bitfield Definitions ================== */
+
+/* AC - Analog Comparator */
+/* AC.CTRLA  bit masks and bit positions */
+#define AC_ENABLE_bm  0x01  /* Enable bit mask. */
+#define AC_ENABLE_bp  0  /* Enable bit position. */
+#define AC_HYSMODE_gm  0x06  /* Hysteresis Mode group mask. */
+#define AC_HYSMODE_gp  1  /* Hysteresis Mode group position. */
+#define AC_HYSMODE_0_bm  (1<<1)  /* Hysteresis Mode bit 0 mask. */
+#define AC_HYSMODE_0_bp  1  /* Hysteresis Mode bit 0 position. */
+#define AC_HYSMODE_1_bm  (1<<2)  /* Hysteresis Mode bit 1 mask. */
+#define AC_HYSMODE_1_bp  2  /* Hysteresis Mode bit 1 position. */
+#define AC_POWER_gm  0x18  /* Power profile group mask. */
+#define AC_POWER_gp  3  /* Power profile group position. */
+#define AC_POWER_0_bm  (1<<3)  /* Power profile bit 0 mask. */
+#define AC_POWER_0_bp  3  /* Power profile bit 0 position. */
+#define AC_POWER_1_bm  (1<<4)  /* Power profile bit 1 mask. */
+#define AC_POWER_1_bp  4  /* Power profile bit 1 position. */
+#define AC_OUTEN_bm  0x40  /* Output Pad Enable bit mask. */
+#define AC_OUTEN_bp  6  /* Output Pad Enable bit position. */
+#define AC_RUNSTDBY_bm  0x80  /* Run in Standby Mode bit mask. */
+#define AC_RUNSTDBY_bp  7  /* Run in Standby Mode bit position. */
+
+/* AC.CTRLB  bit masks and bit positions */
+#define AC_WINSEL_gm  0x03  /* Window selection mode group mask. */
+#define AC_WINSEL_gp  0  /* Window selection mode group position. */
+#define AC_WINSEL_0_bm  (1<<0)  /* Window selection mode bit 0 mask. */
+#define AC_WINSEL_0_bp  0  /* Window selection mode bit 0 position. */
+#define AC_WINSEL_1_bm  (1<<1)  /* Window selection mode bit 1 mask. */
+#define AC_WINSEL_1_bp  1  /* Window selection mode bit 1 position. */
+
+/* AC.MUXCTRL  bit masks and bit positions */
+#define AC_MUXNEG_gm  0x07  /* Negative Input MUX Selection group mask. */
+#define AC_MUXNEG_gp  0  /* Negative Input MUX Selection group position. */
+#define AC_MUXNEG_0_bm  (1<<0)  /* Negative Input MUX Selection bit 0 mask. */
+#define AC_MUXNEG_0_bp  0  /* Negative Input MUX Selection bit 0 position. */
+#define AC_MUXNEG_1_bm  (1<<1)  /* Negative Input MUX Selection bit 1 mask. */
+#define AC_MUXNEG_1_bp  1  /* Negative Input MUX Selection bit 1 position. */
+#define AC_MUXNEG_2_bm  (1<<2)  /* Negative Input MUX Selection bit 2 mask. */
+#define AC_MUXNEG_2_bp  2  /* Negative Input MUX Selection bit 2 position. */
+#define AC_MUXPOS_gm  0x38  /* Positive Input MUX Selection group mask. */
+#define AC_MUXPOS_gp  3  /* Positive Input MUX Selection group position. */
+#define AC_MUXPOS_0_bm  (1<<3)  /* Positive Input MUX Selection bit 0 mask. */
+#define AC_MUXPOS_0_bp  3  /* Positive Input MUX Selection bit 0 position. */
+#define AC_MUXPOS_1_bm  (1<<4)  /* Positive Input MUX Selection bit 1 mask. */
+#define AC_MUXPOS_1_bp  4  /* Positive Input MUX Selection bit 1 position. */
+#define AC_MUXPOS_2_bm  (1<<5)  /* Positive Input MUX Selection bit 2 mask. */
+#define AC_MUXPOS_2_bp  5  /* Positive Input MUX Selection bit 2 position. */
+#define AC_INITVAL_bm  0x40  /* AC Output Initial Value bit mask. */
+#define AC_INITVAL_bp  6  /* AC Output Initial Value bit position. */
+#define AC_INVERT_bm  0x80  /* Invert AC Output bit mask. */
+#define AC_INVERT_bp  7  /* Invert AC Output bit position. */
+
+/* AC.DACREF  bit masks and bit positions */
+#define AC_DACREF_gm  0xFF  /* DACREF group mask. */
+#define AC_DACREF_gp  0  /* DACREF group position. */
+#define AC_DACREF_0_bm  (1<<0)  /* DACREF bit 0 mask. */
+#define AC_DACREF_0_bp  0  /* DACREF bit 0 position. */
+#define AC_DACREF_1_bm  (1<<1)  /* DACREF bit 1 mask. */
+#define AC_DACREF_1_bp  1  /* DACREF bit 1 position. */
+#define AC_DACREF_2_bm  (1<<2)  /* DACREF bit 2 mask. */
+#define AC_DACREF_2_bp  2  /* DACREF bit 2 position. */
+#define AC_DACREF_3_bm  (1<<3)  /* DACREF bit 3 mask. */
+#define AC_DACREF_3_bp  3  /* DACREF bit 3 position. */
+#define AC_DACREF_4_bm  (1<<4)  /* DACREF bit 4 mask. */
+#define AC_DACREF_4_bp  4  /* DACREF bit 4 position. */
+#define AC_DACREF_5_bm  (1<<5)  /* DACREF bit 5 mask. */
+#define AC_DACREF_5_bp  5  /* DACREF bit 5 position. */
+#define AC_DACREF_6_bm  (1<<6)  /* DACREF bit 6 mask. */
+#define AC_DACREF_6_bp  6  /* DACREF bit 6 position. */
+#define AC_DACREF_7_bm  (1<<7)  /* DACREF bit 7 mask. */
+#define AC_DACREF_7_bp  7  /* DACREF bit 7 position. */
+
+/* AC.INTCTRL  bit masks and bit positions */
+#define AC_CMP_bm  0x01  /* Interrupt Enable bit mask. */
+#define AC_CMP_bp  0  /* Interrupt Enable bit position. */
+#define AC_INTMODE_NORMAL_gm  0x30  /* Interrupt Mode group mask. */
+#define AC_INTMODE_NORMAL_gp  4  /* Interrupt Mode group position. */
+#define AC_INTMODE_NORMAL_0_bm  (1<<4)  /* Interrupt Mode bit 0 mask. */
+#define AC_INTMODE_NORMAL_0_bp  4  /* Interrupt Mode bit 0 position. */
+#define AC_INTMODE_NORMAL_1_bm  (1<<5)  /* Interrupt Mode bit 1 mask. */
+#define AC_INTMODE_NORMAL_1_bp  5  /* Interrupt Mode bit 1 position. */
+#define AC_INTMODE_WINDOW_gm  0x30  /* Interrupt Mode group mask. */
+#define AC_INTMODE_WINDOW_gp  4  /* Interrupt Mode group position. */
+#define AC_INTMODE_WINDOW_0_bm  (1<<4)  /* Interrupt Mode bit 0 mask. */
+#define AC_INTMODE_WINDOW_0_bp  4  /* Interrupt Mode bit 0 position. */
+#define AC_INTMODE_WINDOW_1_bm  (1<<5)  /* Interrupt Mode bit 1 mask. */
+#define AC_INTMODE_WINDOW_1_bp  5  /* Interrupt Mode bit 1 position. */
+
+/* AC.STATUS  bit masks and bit positions */
+#define AC_CMPIF_bm  0x01  /* Analog Comparator Interrupt Flag bit mask. */
+#define AC_CMPIF_bp  0  /* Analog Comparator Interrupt Flag bit position. */
+#define AC_CMPSTATE_bm  0x10  /* Analog Comparator State bit mask. */
+#define AC_CMPSTATE_bp  4  /* Analog Comparator State bit position. */
+#define AC_WINSTATE_gm  0xC0  /* Analog Comparator Window State group mask. */
+#define AC_WINSTATE_gp  6  /* Analog Comparator Window State group position. */
+#define AC_WINSTATE_0_bm  (1<<6)  /* Analog Comparator Window State bit 0 mask. */
+#define AC_WINSTATE_0_bp  6  /* Analog Comparator Window State bit 0 position. */
+#define AC_WINSTATE_1_bm  (1<<7)  /* Analog Comparator Window State bit 1 mask. */
+#define AC_WINSTATE_1_bp  7  /* Analog Comparator Window State bit 1 position. */
+
+
+/* ADC - Analog to Digital Converter */
+/* ADC.CTRLA  bit masks and bit positions */
+#define ADC_ENABLE_bm  0x01  /* ADC Enable bit mask. */
+#define ADC_ENABLE_bp  0  /* ADC Enable bit position. */
+#define ADC_LOWLAT_bm  0x20  /* Low Latency bit mask. */
+#define ADC_LOWLAT_bp  5  /* Low Latency bit position. */
+#define ADC_RUNSTDBY_bm  0x80  /* Run in Standby bit mask. */
+#define ADC_RUNSTDBY_bp  7  /* Run in Standby bit position. */
+
+/* ADC.CTRLB  bit masks and bit positions */
+#define ADC_PRESC_gm  0x0F  /* Prescaler Value group mask. */
+#define ADC_PRESC_gp  0  /* Prescaler Value group position. */
+#define ADC_PRESC_0_bm  (1<<0)  /* Prescaler Value bit 0 mask. */
+#define ADC_PRESC_0_bp  0  /* Prescaler Value bit 0 position. */
+#define ADC_PRESC_1_bm  (1<<1)  /* Prescaler Value bit 1 mask. */
+#define ADC_PRESC_1_bp  1  /* Prescaler Value bit 1 position. */
+#define ADC_PRESC_2_bm  (1<<2)  /* Prescaler Value bit 2 mask. */
+#define ADC_PRESC_2_bp  2  /* Prescaler Value bit 2 position. */
+#define ADC_PRESC_3_bm  (1<<3)  /* Prescaler Value bit 3 mask. */
+#define ADC_PRESC_3_bp  3  /* Prescaler Value bit 3 position. */
+
+/* ADC.CTRLC  bit masks and bit positions */
+#define ADC_REFSEL_gm  0x07  /* Reference select group mask. */
+#define ADC_REFSEL_gp  0  /* Reference select group position. */
+#define ADC_REFSEL_0_bm  (1<<0)  /* Reference select bit 0 mask. */
+#define ADC_REFSEL_0_bp  0  /* Reference select bit 0 position. */
+#define ADC_REFSEL_1_bm  (1<<1)  /* Reference select bit 1 mask. */
+#define ADC_REFSEL_1_bp  1  /* Reference select bit 1 position. */
+#define ADC_REFSEL_2_bm  (1<<2)  /* Reference select bit 2 mask. */
+#define ADC_REFSEL_2_bp  2  /* Reference select bit 2 position. */
+
+/* ADC.CTRLD  bit masks and bit positions */
+#define ADC_WINCM_gm  0x07  /* Window Comparator Mode group mask. */
+#define ADC_WINCM_gp  0  /* Window Comparator Mode group position. */
+#define ADC_WINCM_0_bm  (1<<0)  /* Window Comparator Mode bit 0 mask. */
+#define ADC_WINCM_0_bp  0  /* Window Comparator Mode bit 0 position. */
+#define ADC_WINCM_1_bm  (1<<1)  /* Window Comparator Mode bit 1 mask. */
+#define ADC_WINCM_1_bp  1  /* Window Comparator Mode bit 1 position. */
+#define ADC_WINCM_2_bm  (1<<2)  /* Window Comparator Mode bit 2 mask. */
+#define ADC_WINCM_2_bp  2  /* Window Comparator Mode bit 2 position. */
+#define ADC_WINSRC_bm  0x08  /* Window Mode Source bit mask. */
+#define ADC_WINSRC_bp  3  /* Window Mode Source bit position. */
+
+/* ADC.INTCTRL  bit masks and bit positions */
+#define ADC_RESRDY_bm  0x01  /* Result Ready Interrupt Enable bit mask. */
+#define ADC_RESRDY_bp  0  /* Result Ready Interrupt Enable bit position. */
+#define ADC_SAMPRDY_bm  0x02  /* Sample Ready Interrupt Enable bit mask. */
+#define ADC_SAMPRDY_bp  1  /* Sample Ready Interrupt Enable bit position. */
+#define ADC_WCMP_bm  0x04  /* Window Comparator Interrupt Enable bit mask. */
+#define ADC_WCMP_bp  2  /* Window Comparator Interrupt Enable bit position. */
+#define ADC_RESOVR_bm  0x08  /* Result Overwrite Interrupt Enable bit mask. */
+#define ADC_RESOVR_bp  3  /* Result Overwrite Interrupt Enable bit position. */
+#define ADC_SAMPOVR_bm  0x10  /* Sample Overwrite Interrupt Enable bit mask. */
+#define ADC_SAMPOVR_bp  4  /* Sample Overwrite Interrupt Enable bit position. */
+#define ADC_TRIGOVR_bm  0x20  /* Trigger Overrun Interrupt Enable bit mask. */
+#define ADC_TRIGOVR_bp  5  /* Trigger Overrun Interrupt Enable bit position. */
+
+/* ADC.INTFLAGS  bit masks and bit positions */
+/* ADC_RESRDY  is already defined. */
+/* ADC_SAMPRDY  is already defined. */
+/* ADC_WCMP  is already defined. */
+/* ADC_RESOVR  is already defined. */
+/* ADC_SAMPOVR  is already defined. */
+/* ADC_TRIGOVR  is already defined. */
+
+/* ADC.STATUS  bit masks and bit positions */
+#define ADC_ADCBUSY_bm  0x01  /* ADC Busy bit mask. */
+#define ADC_ADCBUSY_bp  0  /* ADC Busy bit position. */
+
+/* ADC.DBGCTRL  bit masks and bit positions */
+#define ADC_DBGRUN_bm  0x01  /* Run in Debug Mode bit mask. */
+#define ADC_DBGRUN_bp  0  /* Run in Debug Mode bit position. */
+
+/* ADC.CTRLE  bit masks and bit positions */
+#define ADC_SAMPDUR_gm  0xFF  /* Sample Duration group mask. */
+#define ADC_SAMPDUR_gp  0  /* Sample Duration group position. */
+#define ADC_SAMPDUR_0_bm  (1<<0)  /* Sample Duration bit 0 mask. */
+#define ADC_SAMPDUR_0_bp  0  /* Sample Duration bit 0 position. */
+#define ADC_SAMPDUR_1_bm  (1<<1)  /* Sample Duration bit 1 mask. */
+#define ADC_SAMPDUR_1_bp  1  /* Sample Duration bit 1 position. */
+#define ADC_SAMPDUR_2_bm  (1<<2)  /* Sample Duration bit 2 mask. */
+#define ADC_SAMPDUR_2_bp  2  /* Sample Duration bit 2 position. */
+#define ADC_SAMPDUR_3_bm  (1<<3)  /* Sample Duration bit 3 mask. */
+#define ADC_SAMPDUR_3_bp  3  /* Sample Duration bit 3 position. */
+#define ADC_SAMPDUR_4_bm  (1<<4)  /* Sample Duration bit 4 mask. */
+#define ADC_SAMPDUR_4_bp  4  /* Sample Duration bit 4 position. */
+#define ADC_SAMPDUR_5_bm  (1<<5)  /* Sample Duration bit 5 mask. */
+#define ADC_SAMPDUR_5_bp  5  /* Sample Duration bit 5 position. */
+#define ADC_SAMPDUR_6_bm  (1<<6)  /* Sample Duration bit 6 mask. */
+#define ADC_SAMPDUR_6_bp  6  /* Sample Duration bit 6 position. */
+#define ADC_SAMPDUR_7_bm  (1<<7)  /* Sample Duration bit 7 mask. */
+#define ADC_SAMPDUR_7_bp  7  /* Sample Duration bit 7 position. */
+
+/* ADC.CTRLF  bit masks and bit positions */
+#define ADC_SAMPNUM_gm  0x0F  /* Sample numbers group mask. */
+#define ADC_SAMPNUM_gp  0  /* Sample numbers group position. */
+#define ADC_SAMPNUM_0_bm  (1<<0)  /* Sample numbers bit 0 mask. */
+#define ADC_SAMPNUM_0_bp  0  /* Sample numbers bit 0 position. */
+#define ADC_SAMPNUM_1_bm  (1<<1)  /* Sample numbers bit 1 mask. */
+#define ADC_SAMPNUM_1_bp  1  /* Sample numbers bit 1 position. */
+#define ADC_SAMPNUM_2_bm  (1<<2)  /* Sample numbers bit 2 mask. */
+#define ADC_SAMPNUM_2_bp  2  /* Sample numbers bit 2 position. */
+#define ADC_SAMPNUM_3_bm  (1<<3)  /* Sample numbers bit 3 mask. */
+#define ADC_SAMPNUM_3_bp  3  /* Sample numbers bit 3 position. */
+#define ADC_LEFTADJ_bm  0x10  /* Left Adjust bit mask. */
+#define ADC_LEFTADJ_bp  4  /* Left Adjust bit position. */
+#define ADC_FREERUN_bm  0x20  /* Free-Running mode bit mask. */
+#define ADC_FREERUN_bp  5  /* Free-Running mode bit position. */
+#define ADC_CHOPPING_bm  0x40  /* Sign Chopping bit mask. */
+#define ADC_CHOPPING_bp  6  /* Sign Chopping bit position. */
+
+/* ADC.COMMAND  bit masks and bit positions */
+#define ADC_START_gm  0x07  /* Start command group mask. */
+#define ADC_START_gp  0  /* Start command group position. */
+#define ADC_START_0_bm  (1<<0)  /* Start command bit 0 mask. */
+#define ADC_START_0_bp  0  /* Start command bit 0 position. */
+#define ADC_START_1_bm  (1<<1)  /* Start command bit 1 mask. */
+#define ADC_START_1_bp  1  /* Start command bit 1 position. */
+#define ADC_START_2_bm  (1<<2)  /* Start command bit 2 mask. */
+#define ADC_START_2_bp  2  /* Start command bit 2 position. */
+#define ADC_MODE_gm  0x70  /* Mode group mask. */
+#define ADC_MODE_gp  4  /* Mode group position. */
+#define ADC_MODE_0_bm  (1<<4)  /* Mode bit 0 mask. */
+#define ADC_MODE_0_bp  4  /* Mode bit 0 position. */
+#define ADC_MODE_1_bm  (1<<5)  /* Mode bit 1 mask. */
+#define ADC_MODE_1_bp  5  /* Mode bit 1 position. */
+#define ADC_MODE_2_bm  (1<<6)  /* Mode bit 2 mask. */
+#define ADC_MODE_2_bp  6  /* Mode bit 2 position. */
+#define ADC_DIFF_bm  0x80  /* Differential mode bit mask. */
+#define ADC_DIFF_bp  7  /* Differential mode bit position. */
+
+/* ADC.PGACTRL  bit masks and bit positions */
+#define ADC_PGAEN_bm  0x01  /* PGA Enable bit mask. */
+#define ADC_PGAEN_bp  0  /* PGA Enable bit position. */
+#define ADC_PGABIASSEL_gm  0x18  /* PGA BIAS Select group mask. */
+#define ADC_PGABIASSEL_gp  3  /* PGA BIAS Select group position. */
+#define ADC_PGABIASSEL_0_bm  (1<<3)  /* PGA BIAS Select bit 0 mask. */
+#define ADC_PGABIASSEL_0_bp  3  /* PGA BIAS Select bit 0 position. */
+#define ADC_PGABIASSEL_1_bm  (1<<4)  /* PGA BIAS Select bit 1 mask. */
+#define ADC_PGABIASSEL_1_bp  4  /* PGA BIAS Select bit 1 position. */
+#define ADC_GAIN_gm  0xE0  /* Gain group mask. */
+#define ADC_GAIN_gp  5  /* Gain group position. */
+#define ADC_GAIN_0_bm  (1<<5)  /* Gain bit 0 mask. */
+#define ADC_GAIN_0_bp  5  /* Gain bit 0 position. */
+#define ADC_GAIN_1_bm  (1<<6)  /* Gain bit 1 mask. */
+#define ADC_GAIN_1_bp  6  /* Gain bit 1 position. */
+#define ADC_GAIN_2_bm  (1<<7)  /* Gain bit 2 mask. */
+#define ADC_GAIN_2_bp  7  /* Gain bit 2 position. */
+
+/* ADC.MUXPOS  bit masks and bit positions */
+#define ADC_MUXPOS_gm  0x3F  /* Analog Channel Selection Bits group mask. */
+#define ADC_MUXPOS_gp  0  /* Analog Channel Selection Bits group position. */
+#define ADC_MUXPOS_0_bm  (1<<0)  /* Analog Channel Selection Bits bit 0 mask. */
+#define ADC_MUXPOS_0_bp  0  /* Analog Channel Selection Bits bit 0 position. */
+#define ADC_MUXPOS_1_bm  (1<<1)  /* Analog Channel Selection Bits bit 1 mask. */
+#define ADC_MUXPOS_1_bp  1  /* Analog Channel Selection Bits bit 1 position. */
+#define ADC_MUXPOS_2_bm  (1<<2)  /* Analog Channel Selection Bits bit 2 mask. */
+#define ADC_MUXPOS_2_bp  2  /* Analog Channel Selection Bits bit 2 position. */
+#define ADC_MUXPOS_3_bm  (1<<3)  /* Analog Channel Selection Bits bit 3 mask. */
+#define ADC_MUXPOS_3_bp  3  /* Analog Channel Selection Bits bit 3 position. */
+#define ADC_MUXPOS_4_bm  (1<<4)  /* Analog Channel Selection Bits bit 4 mask. */
+#define ADC_MUXPOS_4_bp  4  /* Analog Channel Selection Bits bit 4 position. */
+#define ADC_MUXPOS_5_bm  (1<<5)  /* Analog Channel Selection Bits bit 5 mask. */
+#define ADC_MUXPOS_5_bp  5  /* Analog Channel Selection Bits bit 5 position. */
+#define ADC_VIA_gm  0xC0  /* VIA group mask. */
+#define ADC_VIA_gp  6  /* VIA group position. */
+#define ADC_VIA_0_bm  (1<<6)  /* VIA bit 0 mask. */
+#define ADC_VIA_0_bp  6  /* VIA bit 0 position. */
+#define ADC_VIA_1_bm  (1<<7)  /* VIA bit 1 mask. */
+#define ADC_VIA_1_bp  7  /* VIA bit 1 position. */
+
+/* ADC.MUXNEG  bit masks and bit positions */
+#define ADC_MUXNEG_gm  0x3F  /* Analog Channel Selection Bits group mask. */
+#define ADC_MUXNEG_gp  0  /* Analog Channel Selection Bits group position. */
+#define ADC_MUXNEG_0_bm  (1<<0)  /* Analog Channel Selection Bits bit 0 mask. */
+#define ADC_MUXNEG_0_bp  0  /* Analog Channel Selection Bits bit 0 position. */
+#define ADC_MUXNEG_1_bm  (1<<1)  /* Analog Channel Selection Bits bit 1 mask. */
+#define ADC_MUXNEG_1_bp  1  /* Analog Channel Selection Bits bit 1 position. */
+#define ADC_MUXNEG_2_bm  (1<<2)  /* Analog Channel Selection Bits bit 2 mask. */
+#define ADC_MUXNEG_2_bp  2  /* Analog Channel Selection Bits bit 2 position. */
+#define ADC_MUXNEG_3_bm  (1<<3)  /* Analog Channel Selection Bits bit 3 mask. */
+#define ADC_MUXNEG_3_bp  3  /* Analog Channel Selection Bits bit 3 position. */
+#define ADC_MUXNEG_4_bm  (1<<4)  /* Analog Channel Selection Bits bit 4 mask. */
+#define ADC_MUXNEG_4_bp  4  /* Analog Channel Selection Bits bit 4 position. */
+#define ADC_MUXNEG_5_bm  (1<<5)  /* Analog Channel Selection Bits bit 5 mask. */
+#define ADC_MUXNEG_5_bp  5  /* Analog Channel Selection Bits bit 5 position. */
+/* ADC_VIA  is already defined. */
+
+
+/* BOD - Bod interface */
+/* BOD.CTRLA  bit masks and bit positions */
+#define BOD_SLEEP_gm  0x03  /* Operation in sleep mode group mask. */
+#define BOD_SLEEP_gp  0  /* Operation in sleep mode group position. */
+#define BOD_SLEEP_0_bm  (1<<0)  /* Operation in sleep mode bit 0 mask. */
+#define BOD_SLEEP_0_bp  0  /* Operation in sleep mode bit 0 position. */
+#define BOD_SLEEP_1_bm  (1<<1)  /* Operation in sleep mode bit 1 mask. */
+#define BOD_SLEEP_1_bp  1  /* Operation in sleep mode bit 1 position. */
+#define BOD_ACTIVE_gm  0x0C  /* Operation in active mode group mask. */
+#define BOD_ACTIVE_gp  2  /* Operation in active mode group position. */
+#define BOD_ACTIVE_0_bm  (1<<2)  /* Operation in active mode bit 0 mask. */
+#define BOD_ACTIVE_0_bp  2  /* Operation in active mode bit 0 position. */
+#define BOD_ACTIVE_1_bm  (1<<3)  /* Operation in active mode bit 1 mask. */
+#define BOD_ACTIVE_1_bp  3  /* Operation in active mode bit 1 position. */
+#define BOD_SAMPFREQ_bm  0x10  /* Sample frequency bit mask. */
+#define BOD_SAMPFREQ_bp  4  /* Sample frequency bit position. */
+
+/* BOD.CTRLB  bit masks and bit positions */
+#define BOD_LVL_gm  0x07  /* Bod level group mask. */
+#define BOD_LVL_gp  0  /* Bod level group position. */
+#define BOD_LVL_0_bm  (1<<0)  /* Bod level bit 0 mask. */
+#define BOD_LVL_0_bp  0  /* Bod level bit 0 position. */
+#define BOD_LVL_1_bm  (1<<1)  /* Bod level bit 1 mask. */
+#define BOD_LVL_1_bp  1  /* Bod level bit 1 position. */
+#define BOD_LVL_2_bm  (1<<2)  /* Bod level bit 2 mask. */
+#define BOD_LVL_2_bp  2  /* Bod level bit 2 position. */
+
+/* BOD.VLMCTRLA  bit masks and bit positions */
+#define BOD_VLMLVL_gm  0x03  /* voltage level monitor level group mask. */
+#define BOD_VLMLVL_gp  0  /* voltage level monitor level group position. */
+#define BOD_VLMLVL_0_bm  (1<<0)  /* voltage level monitor level bit 0 mask. */
+#define BOD_VLMLVL_0_bp  0  /* voltage level monitor level bit 0 position. */
+#define BOD_VLMLVL_1_bm  (1<<1)  /* voltage level monitor level bit 1 mask. */
+#define BOD_VLMLVL_1_bp  1  /* voltage level monitor level bit 1 position. */
+
+/* BOD.INTCTRL  bit masks and bit positions */
+#define BOD_VLMIE_bm  0x01  /* voltage level monitor interrrupt enable bit mask. */
+#define BOD_VLMIE_bp  0  /* voltage level monitor interrrupt enable bit position. */
+#define BOD_VLMCFG_gm  0x06  /* Configuration group mask. */
+#define BOD_VLMCFG_gp  1  /* Configuration group position. */
+#define BOD_VLMCFG_0_bm  (1<<1)  /* Configuration bit 0 mask. */
+#define BOD_VLMCFG_0_bp  1  /* Configuration bit 0 position. */
+#define BOD_VLMCFG_1_bm  (1<<2)  /* Configuration bit 1 mask. */
+#define BOD_VLMCFG_1_bp  2  /* Configuration bit 1 position. */
+
+/* BOD.INTFLAGS  bit masks and bit positions */
+#define BOD_VLMIF_bm  0x01  /* Voltage level monitor interrupt flag bit mask. */
+#define BOD_VLMIF_bp  0  /* Voltage level monitor interrupt flag bit position. */
+
+/* BOD.STATUS  bit masks and bit positions */
+#define BOD_VLMS_bm  0x01  /* Voltage level monitor status bit mask. */
+#define BOD_VLMS_bp  0  /* Voltage level monitor status bit position. */
+
+
+
+/* CCL - Configurable Custom Logic */
+/* CCL.CTRLA  bit masks and bit positions */
+#define CCL_ENABLE_bm  0x01  /* Enable bit mask. */
+#define CCL_ENABLE_bp  0  /* Enable bit position. */
+#define CCL_RUNSTDBY_bm  0x40  /* Run in Standby bit mask. */
+#define CCL_RUNSTDBY_bp  6  /* Run in Standby bit position. */
+
+/* CCL.SEQCTRL0  bit masks and bit positions */
+#define CCL_SEQSEL_gm  0x0F  /* Sequential Selection group mask. */
+#define CCL_SEQSEL_gp  0  /* Sequential Selection group position. */
+#define CCL_SEQSEL_0_bm  (1<<0)  /* Sequential Selection bit 0 mask. */
+#define CCL_SEQSEL_0_bp  0  /* Sequential Selection bit 0 position. */
+#define CCL_SEQSEL_1_bm  (1<<1)  /* Sequential Selection bit 1 mask. */
+#define CCL_SEQSEL_1_bp  1  /* Sequential Selection bit 1 position. */
+#define CCL_SEQSEL_2_bm  (1<<2)  /* Sequential Selection bit 2 mask. */
+#define CCL_SEQSEL_2_bp  2  /* Sequential Selection bit 2 position. */
+#define CCL_SEQSEL_3_bm  (1<<3)  /* Sequential Selection bit 3 mask. */
+#define CCL_SEQSEL_3_bp  3  /* Sequential Selection bit 3 position. */
+
+/* CCL.SEQCTRL1  bit masks and bit positions */
+/* CCL_SEQSEL  is already defined. */
+
+/* CCL.INTCTRL0  bit masks and bit positions */
+#define CCL_INTMODE0_gm  0x03  /* Interrupt Mode for LUT0 group mask. */
+#define CCL_INTMODE0_gp  0  /* Interrupt Mode for LUT0 group position. */
+#define CCL_INTMODE0_0_bm  (1<<0)  /* Interrupt Mode for LUT0 bit 0 mask. */
+#define CCL_INTMODE0_0_bp  0  /* Interrupt Mode for LUT0 bit 0 position. */
+#define CCL_INTMODE0_1_bm  (1<<1)  /* Interrupt Mode for LUT0 bit 1 mask. */
+#define CCL_INTMODE0_1_bp  1  /* Interrupt Mode for LUT0 bit 1 position. */
+#define CCL_INTMODE1_gm  0x0C  /* Interrupt Mode for LUT1 group mask. */
+#define CCL_INTMODE1_gp  2  /* Interrupt Mode for LUT1 group position. */
+#define CCL_INTMODE1_0_bm  (1<<2)  /* Interrupt Mode for LUT1 bit 0 mask. */
+#define CCL_INTMODE1_0_bp  2  /* Interrupt Mode for LUT1 bit 0 position. */
+#define CCL_INTMODE1_1_bm  (1<<3)  /* Interrupt Mode for LUT1 bit 1 mask. */
+#define CCL_INTMODE1_1_bp  3  /* Interrupt Mode for LUT1 bit 1 position. */
+#define CCL_INTMODE2_gm  0x30  /* Interrupt Mode for LUT2 group mask. */
+#define CCL_INTMODE2_gp  4  /* Interrupt Mode for LUT2 group position. */
+#define CCL_INTMODE2_0_bm  (1<<4)  /* Interrupt Mode for LUT2 bit 0 mask. */
+#define CCL_INTMODE2_0_bp  4  /* Interrupt Mode for LUT2 bit 0 position. */
+#define CCL_INTMODE2_1_bm  (1<<5)  /* Interrupt Mode for LUT2 bit 1 mask. */
+#define CCL_INTMODE2_1_bp  5  /* Interrupt Mode for LUT2 bit 1 position. */
+#define CCL_INTMODE3_gm  0xC0  /* Interrupt Mode for LUT3 group mask. */
+#define CCL_INTMODE3_gp  6  /* Interrupt Mode for LUT3 group position. */
+#define CCL_INTMODE3_0_bm  (1<<6)  /* Interrupt Mode for LUT3 bit 0 mask. */
+#define CCL_INTMODE3_0_bp  6  /* Interrupt Mode for LUT3 bit 0 position. */
+#define CCL_INTMODE3_1_bm  (1<<7)  /* Interrupt Mode for LUT3 bit 1 mask. */
+#define CCL_INTMODE3_1_bp  7  /* Interrupt Mode for LUT3 bit 1 position. */
+
+/* CCL.INTFLAGS  bit masks and bit positions */
+#define CCL_INT_gm  0x0F  /* Interrupt Flag group mask. */
+#define CCL_INT_gp  0  /* Interrupt Flag group position. */
+#define CCL_INT_0_bm  (1<<0)  /* Interrupt Flag bit 0 mask. */
+#define CCL_INT_0_bp  0  /* Interrupt Flag bit 0 position. */
+#define CCL_INT0_bm  CCL_INT_0_bm  /* This define is deprecated and should not be used */
+#define CCL_INT0_bp  CCL_INT_0_bp  /* This define is deprecated and should not be used */
+#define CCL_INT_1_bm  (1<<1)  /* Interrupt Flag bit 1 mask. */
+#define CCL_INT_1_bp  1  /* Interrupt Flag bit 1 position. */
+#define CCL_INT1_bm  CCL_INT_1_bm  /* This define is deprecated and should not be used */
+#define CCL_INT1_bp  CCL_INT_1_bp  /* This define is deprecated and should not be used */
+#define CCL_INT_2_bm  (1<<2)  /* Interrupt Flag bit 2 mask. */
+#define CCL_INT_2_bp  2  /* Interrupt Flag bit 2 position. */
+#define CCL_INT2_bm  CCL_INT_2_bm  /* This define is deprecated and should not be used */
+#define CCL_INT2_bp  CCL_INT_2_bp  /* This define is deprecated and should not be used */
+#define CCL_INT_3_bm  (1<<3)  /* Interrupt Flag bit 3 mask. */
+#define CCL_INT_3_bp  3  /* Interrupt Flag bit 3 position. */
+#define CCL_INT3_bm  CCL_INT_3_bm  /* This define is deprecated and should not be used */
+#define CCL_INT3_bp  CCL_INT_3_bp  /* This define is deprecated and should not be used */
+
+/* CCL.LUT0CTRLA  bit masks and bit positions */
+/* CCL_ENABLE  is already defined. */
+#define CCL_CLKSRC_gm  0x0E  /* Clock Source Selection group mask. */
+#define CCL_CLKSRC_gp  1  /* Clock Source Selection group position. */
+#define CCL_CLKSRC_0_bm  (1<<1)  /* Clock Source Selection bit 0 mask. */
+#define CCL_CLKSRC_0_bp  1  /* Clock Source Selection bit 0 position. */
+#define CCL_CLKSRC_1_bm  (1<<2)  /* Clock Source Selection bit 1 mask. */
+#define CCL_CLKSRC_1_bp  2  /* Clock Source Selection bit 1 position. */
+#define CCL_CLKSRC_2_bm  (1<<3)  /* Clock Source Selection bit 2 mask. */
+#define CCL_CLKSRC_2_bp  3  /* Clock Source Selection bit 2 position. */
+#define CCL_FILTSEL_gm  0x30  /* Filter Selection group mask. */
+#define CCL_FILTSEL_gp  4  /* Filter Selection group position. */
+#define CCL_FILTSEL_0_bm  (1<<4)  /* Filter Selection bit 0 mask. */
+#define CCL_FILTSEL_0_bp  4  /* Filter Selection bit 0 position. */
+#define CCL_FILTSEL_1_bm  (1<<5)  /* Filter Selection bit 1 mask. */
+#define CCL_FILTSEL_1_bp  5  /* Filter Selection bit 1 position. */
+#define CCL_OUTEN_bm  0x40  /* Output Enable bit mask. */
+#define CCL_OUTEN_bp  6  /* Output Enable bit position. */
+#define CCL_EDGEDET_bm  0x80  /* Edge Detection Enable bit mask. */
+#define CCL_EDGEDET_bp  7  /* Edge Detection Enable bit position. */
+
+/* CCL.LUT0CTRLB  bit masks and bit positions */
+#define CCL_INSEL0_gm  0x0F  /* LUT Input 0 Source Selection group mask. */
+#define CCL_INSEL0_gp  0  /* LUT Input 0 Source Selection group position. */
+#define CCL_INSEL0_0_bm  (1<<0)  /* LUT Input 0 Source Selection bit 0 mask. */
+#define CCL_INSEL0_0_bp  0  /* LUT Input 0 Source Selection bit 0 position. */
+#define CCL_INSEL0_1_bm  (1<<1)  /* LUT Input 0 Source Selection bit 1 mask. */
+#define CCL_INSEL0_1_bp  1  /* LUT Input 0 Source Selection bit 1 position. */
+#define CCL_INSEL0_2_bm  (1<<2)  /* LUT Input 0 Source Selection bit 2 mask. */
+#define CCL_INSEL0_2_bp  2  /* LUT Input 0 Source Selection bit 2 position. */
+#define CCL_INSEL0_3_bm  (1<<3)  /* LUT Input 0 Source Selection bit 3 mask. */
+#define CCL_INSEL0_3_bp  3  /* LUT Input 0 Source Selection bit 3 position. */
+#define CCL_INSEL1_gm  0xF0  /* LUT Input 1 Source Selection group mask. */
+#define CCL_INSEL1_gp  4  /* LUT Input 1 Source Selection group position. */
+#define CCL_INSEL1_0_bm  (1<<4)  /* LUT Input 1 Source Selection bit 0 mask. */
+#define CCL_INSEL1_0_bp  4  /* LUT Input 1 Source Selection bit 0 position. */
+#define CCL_INSEL1_1_bm  (1<<5)  /* LUT Input 1 Source Selection bit 1 mask. */
+#define CCL_INSEL1_1_bp  5  /* LUT Input 1 Source Selection bit 1 position. */
+#define CCL_INSEL1_2_bm  (1<<6)  /* LUT Input 1 Source Selection bit 2 mask. */
+#define CCL_INSEL1_2_bp  6  /* LUT Input 1 Source Selection bit 2 position. */
+#define CCL_INSEL1_3_bm  (1<<7)  /* LUT Input 1 Source Selection bit 3 mask. */
+#define CCL_INSEL1_3_bp  7  /* LUT Input 1 Source Selection bit 3 position. */
+
+/* CCL.LUT0CTRLC  bit masks and bit positions */
+#define CCL_INSEL2_gm  0x0F  /* LUT Input 2 Source Selection group mask. */
+#define CCL_INSEL2_gp  0  /* LUT Input 2 Source Selection group position. */
+#define CCL_INSEL2_0_bm  (1<<0)  /* LUT Input 2 Source Selection bit 0 mask. */
+#define CCL_INSEL2_0_bp  0  /* LUT Input 2 Source Selection bit 0 position. */
+#define CCL_INSEL2_1_bm  (1<<1)  /* LUT Input 2 Source Selection bit 1 mask. */
+#define CCL_INSEL2_1_bp  1  /* LUT Input 2 Source Selection bit 1 position. */
+#define CCL_INSEL2_2_bm  (1<<2)  /* LUT Input 2 Source Selection bit 2 mask. */
+#define CCL_INSEL2_2_bp  2  /* LUT Input 2 Source Selection bit 2 position. */
+#define CCL_INSEL2_3_bm  (1<<3)  /* LUT Input 2 Source Selection bit 3 mask. */
+#define CCL_INSEL2_3_bp  3  /* LUT Input 2 Source Selection bit 3 position. */
+
+/* CCL.TRUTH0  bit masks and bit positions */
+#define CCL_TRUTH_gm  0xFF  /* Truth Table group mask. */
+#define CCL_TRUTH_gp  0  /* Truth Table group position. */
+#define CCL_TRUTH_0_bm  (1<<0)  /* Truth Table bit 0 mask. */
+#define CCL_TRUTH_0_bp  0  /* Truth Table bit 0 position. */
+#define CCL_TRUTH_1_bm  (1<<1)  /* Truth Table bit 1 mask. */
+#define CCL_TRUTH_1_bp  1  /* Truth Table bit 1 position. */
+#define CCL_TRUTH_2_bm  (1<<2)  /* Truth Table bit 2 mask. */
+#define CCL_TRUTH_2_bp  2  /* Truth Table bit 2 position. */
+#define CCL_TRUTH_3_bm  (1<<3)  /* Truth Table bit 3 mask. */
+#define CCL_TRUTH_3_bp  3  /* Truth Table bit 3 position. */
+#define CCL_TRUTH_4_bm  (1<<4)  /* Truth Table bit 4 mask. */
+#define CCL_TRUTH_4_bp  4  /* Truth Table bit 4 position. */
+#define CCL_TRUTH_5_bm  (1<<5)  /* Truth Table bit 5 mask. */
+#define CCL_TRUTH_5_bp  5  /* Truth Table bit 5 position. */
+#define CCL_TRUTH_6_bm  (1<<6)  /* Truth Table bit 6 mask. */
+#define CCL_TRUTH_6_bp  6  /* Truth Table bit 6 position. */
+#define CCL_TRUTH_7_bm  (1<<7)  /* Truth Table bit 7 mask. */
+#define CCL_TRUTH_7_bp  7  /* Truth Table bit 7 position. */
+
+/* CCL.LUT1CTRLA  bit masks and bit positions */
+/* CCL_ENABLE  is already defined. */
+/* CCL_CLKSRC  is already defined. */
+/* CCL_FILTSEL  is already defined. */
+/* CCL_OUTEN  is already defined. */
+/* CCL_EDGEDET  is already defined. */
+
+/* CCL.LUT1CTRLB  bit masks and bit positions */
+/* CCL_INSEL0  is already defined. */
+/* CCL_INSEL1  is already defined. */
+
+/* CCL.LUT1CTRLC  bit masks and bit positions */
+/* CCL_INSEL2  is already defined. */
+
+/* CCL.TRUTH1  bit masks and bit positions */
+/* CCL_TRUTH  is already defined. */
+
+/* CCL.LUT2CTRLA  bit masks and bit positions */
+/* CCL_ENABLE  is already defined. */
+/* CCL_CLKSRC  is already defined. */
+/* CCL_FILTSEL  is already defined. */
+/* CCL_OUTEN  is already defined. */
+/* CCL_EDGEDET  is already defined. */
+
+/* CCL.LUT2CTRLB  bit masks and bit positions */
+/* CCL_INSEL0  is already defined. */
+/* CCL_INSEL1  is already defined. */
+
+/* CCL.LUT2CTRLC  bit masks and bit positions */
+/* CCL_INSEL2  is already defined. */
+
+/* CCL.TRUTH2  bit masks and bit positions */
+/* CCL_TRUTH  is already defined. */
+
+/* CCL.LUT3CTRLA  bit masks and bit positions */
+/* CCL_ENABLE  is already defined. */
+/* CCL_CLKSRC  is already defined. */
+/* CCL_FILTSEL  is already defined. */
+/* CCL_OUTEN  is already defined. */
+/* CCL_EDGEDET  is already defined. */
+
+/* CCL.LUT3CTRLB  bit masks and bit positions */
+/* CCL_INSEL0  is already defined. */
+/* CCL_INSEL1  is already defined. */
+
+/* CCL.LUT3CTRLC  bit masks and bit positions */
+/* CCL_INSEL2  is already defined. */
+
+/* CCL.TRUTH3  bit masks and bit positions */
+/* CCL_TRUTH  is already defined. */
+
+
+/* CLKCTRL - Clock controller */
+/* CLKCTRL.MCLKCTRLA  bit masks and bit positions */
+#define CLKCTRL_CLKSEL_gm  0x0F  /* Clock select group mask. */
+#define CLKCTRL_CLKSEL_gp  0  /* Clock select group position. */
+#define CLKCTRL_CLKSEL_0_bm  (1<<0)  /* Clock select bit 0 mask. */
+#define CLKCTRL_CLKSEL_0_bp  0  /* Clock select bit 0 position. */
+#define CLKCTRL_CLKSEL_1_bm  (1<<1)  /* Clock select bit 1 mask. */
+#define CLKCTRL_CLKSEL_1_bp  1  /* Clock select bit 1 position. */
+#define CLKCTRL_CLKSEL_2_bm  (1<<2)  /* Clock select bit 2 mask. */
+#define CLKCTRL_CLKSEL_2_bp  2  /* Clock select bit 2 position. */
+#define CLKCTRL_CLKSEL_3_bm  (1<<3)  /* Clock select bit 3 mask. */
+#define CLKCTRL_CLKSEL_3_bp  3  /* Clock select bit 3 position. */
+#define CLKCTRL_CLKOUT_bm  0x80  /* System clock out bit mask. */
+#define CLKCTRL_CLKOUT_bp  7  /* System clock out bit position. */
+
+/* CLKCTRL.MCLKCTRLB  bit masks and bit positions */
+#define CLKCTRL_PEN_bm  0x01  /* Prescaler enable bit mask. */
+#define CLKCTRL_PEN_bp  0  /* Prescaler enable bit position. */
+#define CLKCTRL_PDIV_gm  0x1E  /* Prescaler division group mask. */
+#define CLKCTRL_PDIV_gp  1  /* Prescaler division group position. */
+#define CLKCTRL_PDIV_0_bm  (1<<1)  /* Prescaler division bit 0 mask. */
+#define CLKCTRL_PDIV_0_bp  1  /* Prescaler division bit 0 position. */
+#define CLKCTRL_PDIV_1_bm  (1<<2)  /* Prescaler division bit 1 mask. */
+#define CLKCTRL_PDIV_1_bp  2  /* Prescaler division bit 1 position. */
+#define CLKCTRL_PDIV_2_bm  (1<<3)  /* Prescaler division bit 2 mask. */
+#define CLKCTRL_PDIV_2_bp  3  /* Prescaler division bit 2 position. */
+#define CLKCTRL_PDIV_3_bm  (1<<4)  /* Prescaler division bit 3 mask. */
+#define CLKCTRL_PDIV_3_bp  4  /* Prescaler division bit 3 position. */
+#define CLKCTRL_PBDIV_bm  0x20  /* Prescaler B division bit mask. */
+#define CLKCTRL_PBDIV_bp  5  /* Prescaler B division bit position. */
+
+/* CLKCTRL.MCLKSTATUS  bit masks and bit positions */
+#define CLKCTRL_SOSC_bm  0x01  /* System Oscillator changing bit mask. */
+#define CLKCTRL_SOSC_bp  0  /* System Oscillator changing bit position. */
+#define CLKCTRL_OSCHFS_bm  0x02  /* High frequency oscillator status bit mask. */
+#define CLKCTRL_OSCHFS_bp  1  /* High frequency oscillator status bit position. */
+#define CLKCTRL_OSC32KS_bm  0x04  /* 32KHz oscillator status bit mask. */
+#define CLKCTRL_OSC32KS_bp  2  /* 32KHz oscillator status bit position. */
+#define CLKCTRL_XOSC32KS_bm  0x08  /* 32.768 kHz Crystal Oscillator status bit mask. */
+#define CLKCTRL_XOSC32KS_bp  3  /* 32.768 kHz Crystal Oscillator status bit position. */
+#define CLKCTRL_EXTS_bm  0x10  /* External Clock status bit mask. */
+#define CLKCTRL_EXTS_bp  4  /* External Clock status bit position. */
+#define CLKCTRL_PLLS_bm  0x20  /* PLL status bit mask. */
+#define CLKCTRL_PLLS_bp  5  /* PLL status bit position. */
+
+/* CLKCTRL.MCLKTIMEBASE  bit masks and bit positions */
+#define CLKCTRL_TIMEBASE_gm  0x1F  /* Timebase group mask. */
+#define CLKCTRL_TIMEBASE_gp  0  /* Timebase group position. */
+#define CLKCTRL_TIMEBASE_0_bm  (1<<0)  /* Timebase bit 0 mask. */
+#define CLKCTRL_TIMEBASE_0_bp  0  /* Timebase bit 0 position. */
+#define CLKCTRL_TIMEBASE_1_bm  (1<<1)  /* Timebase bit 1 mask. */
+#define CLKCTRL_TIMEBASE_1_bp  1  /* Timebase bit 1 position. */
+#define CLKCTRL_TIMEBASE_2_bm  (1<<2)  /* Timebase bit 2 mask. */
+#define CLKCTRL_TIMEBASE_2_bp  2  /* Timebase bit 2 position. */
+#define CLKCTRL_TIMEBASE_3_bm  (1<<3)  /* Timebase bit 3 mask. */
+#define CLKCTRL_TIMEBASE_3_bp  3  /* Timebase bit 3 position. */
+#define CLKCTRL_TIMEBASE_4_bm  (1<<4)  /* Timebase bit 4 mask. */
+#define CLKCTRL_TIMEBASE_4_bp  4  /* Timebase bit 4 position. */
+
+/* CLKCTRL.OSCHFCTRLA  bit masks and bit positions */
+#define CLKCTRL_AUTOTUNE_gm  0x03  /* Automatic Oscillator Tune group mask. */
+#define CLKCTRL_AUTOTUNE_gp  0  /* Automatic Oscillator Tune group position. */
+#define CLKCTRL_AUTOTUNE_0_bm  (1<<0)  /* Automatic Oscillator Tune bit 0 mask. */
+#define CLKCTRL_AUTOTUNE_0_bp  0  /* Automatic Oscillator Tune bit 0 position. */
+#define CLKCTRL_AUTOTUNE_1_bm  (1<<1)  /* Automatic Oscillator Tune bit 1 mask. */
+#define CLKCTRL_AUTOTUNE_1_bp  1  /* Automatic Oscillator Tune bit 1 position. */
+#define CLKCTRL_RUNSTDBY_bm  0x80  /* Run in standby bit mask. */
+#define CLKCTRL_RUNSTDBY_bp  7  /* Run in standby bit position. */
+
+/* CLKCTRL.OSCHFTUNE  bit masks and bit positions */
+#define CLKCTRL_TUNE_gm  0xFF  /* Oscillator Tune group mask. */
+#define CLKCTRL_TUNE_gp  0  /* Oscillator Tune group position. */
+#define CLKCTRL_TUNE_0_bm  (1<<0)  /* Oscillator Tune bit 0 mask. */
+#define CLKCTRL_TUNE_0_bp  0  /* Oscillator Tune bit 0 position. */
+#define CLKCTRL_TUNE_1_bm  (1<<1)  /* Oscillator Tune bit 1 mask. */
+#define CLKCTRL_TUNE_1_bp  1  /* Oscillator Tune bit 1 position. */
+#define CLKCTRL_TUNE_2_bm  (1<<2)  /* Oscillator Tune bit 2 mask. */
+#define CLKCTRL_TUNE_2_bp  2  /* Oscillator Tune bit 2 position. */
+#define CLKCTRL_TUNE_3_bm  (1<<3)  /* Oscillator Tune bit 3 mask. */
+#define CLKCTRL_TUNE_3_bp  3  /* Oscillator Tune bit 3 position. */
+#define CLKCTRL_TUNE_4_bm  (1<<4)  /* Oscillator Tune bit 4 mask. */
+#define CLKCTRL_TUNE_4_bp  4  /* Oscillator Tune bit 4 position. */
+#define CLKCTRL_TUNE_5_bm  (1<<5)  /* Oscillator Tune bit 5 mask. */
+#define CLKCTRL_TUNE_5_bp  5  /* Oscillator Tune bit 5 position. */
+#define CLKCTRL_TUNE_6_bm  (1<<6)  /* Oscillator Tune bit 6 mask. */
+#define CLKCTRL_TUNE_6_bp  6  /* Oscillator Tune bit 6 position. */
+#define CLKCTRL_TUNE_7_bm  (1<<7)  /* Oscillator Tune bit 7 mask. */
+#define CLKCTRL_TUNE_7_bp  7  /* Oscillator Tune bit 7 position. */
+
+/* CLKCTRL.PLLCTRLA  bit masks and bit positions */
+#define CLKCTRL_MULFAC_gm  0x03  /* PLL Multiplication Factor group mask. */
+#define CLKCTRL_MULFAC_gp  0  /* PLL Multiplication Factor group position. */
+#define CLKCTRL_MULFAC_0_bm  (1<<0)  /* PLL Multiplication Factor bit 0 mask. */
+#define CLKCTRL_MULFAC_0_bp  0  /* PLL Multiplication Factor bit 0 position. */
+#define CLKCTRL_MULFAC_1_bm  (1<<1)  /* PLL Multiplication Factor bit 1 mask. */
+#define CLKCTRL_MULFAC_1_bp  1  /* PLL Multiplication Factor bit 1 position. */
+#define CLKCTRL_SOURCEDIV_gm  0x18  /* PLL Source Division group mask. */
+#define CLKCTRL_SOURCEDIV_gp  3  /* PLL Source Division group position. */
+#define CLKCTRL_SOURCEDIV_0_bm  (1<<3)  /* PLL Source Division bit 0 mask. */
+#define CLKCTRL_SOURCEDIV_0_bp  3  /* PLL Source Division bit 0 position. */
+#define CLKCTRL_SOURCEDIV_1_bm  (1<<4)  /* PLL Source Division bit 1 mask. */
+#define CLKCTRL_SOURCEDIV_1_bp  4  /* PLL Source Division bit 1 position. */
+#define CLKCTRL_SOURCE_gm  0x60  /* PLL Source group mask. */
+#define CLKCTRL_SOURCE_gp  5  /* PLL Source group position. */
+#define CLKCTRL_SOURCE_0_bm  (1<<5)  /* PLL Source bit 0 mask. */
+#define CLKCTRL_SOURCE_0_bp  5  /* PLL Source bit 0 position. */
+#define CLKCTRL_SOURCE_1_bm  (1<<6)  /* PLL Source bit 1 mask. */
+#define CLKCTRL_SOURCE_1_bp  6  /* PLL Source bit 1 position. */
+/* CLKCTRL_RUNSTDBY  is already defined. */
+
+/* CLKCTRL.PLLCTRLB  bit masks and bit positions */
+#define CLKCTRL_CLKDIV_bm  0x01  /* PLL Output Clock Division bit mask. */
+#define CLKCTRL_CLKDIV_bp  0  /* PLL Output Clock Division bit position. */
+
+/* CLKCTRL.OSC32KCTRLA  bit masks and bit positions */
+/* CLKCTRL_RUNSTDBY  is already defined. */
+
+/* CLKCTRL.XOSC32KCTRLA  bit masks and bit positions */
+#define CLKCTRL_ENABLE_bm  0x01  /* Enable bit mask. */
+#define CLKCTRL_ENABLE_bp  0  /* Enable bit position. */
+#define CLKCTRL_LPMODE_bm  0x02  /* Low power mode bit mask. */
+#define CLKCTRL_LPMODE_bp  1  /* Low power mode bit position. */
+#define CLKCTRL_SEL_bm  0x04  /* Select bit mask. */
+#define CLKCTRL_SEL_bp  2  /* Select bit position. */
+#define CLKCTRL_CSUT_gm  0x30  /* Crystal startup time group mask. */
+#define CLKCTRL_CSUT_gp  4  /* Crystal startup time group position. */
+#define CLKCTRL_CSUT_0_bm  (1<<4)  /* Crystal startup time bit 0 mask. */
+#define CLKCTRL_CSUT_0_bp  4  /* Crystal startup time bit 0 position. */
+#define CLKCTRL_CSUT_1_bm  (1<<5)  /* Crystal startup time bit 1 mask. */
+#define CLKCTRL_CSUT_1_bp  5  /* Crystal startup time bit 1 position. */
+/* CLKCTRL_RUNSTDBY  is already defined. */
+
+
+/* CPU - CPU */
+/* CPU.CCP  bit masks and bit positions */
+#define CPU_CCP_gm  0xFF  /* CCP signature group mask. */
+#define CPU_CCP_gp  0  /* CCP signature group position. */
+#define CPU_CCP_0_bm  (1<<0)  /* CCP signature bit 0 mask. */
+#define CPU_CCP_0_bp  0  /* CCP signature bit 0 position. */
+#define CPU_CCP_1_bm  (1<<1)  /* CCP signature bit 1 mask. */
+#define CPU_CCP_1_bp  1  /* CCP signature bit 1 position. */
+#define CPU_CCP_2_bm  (1<<2)  /* CCP signature bit 2 mask. */
+#define CPU_CCP_2_bp  2  /* CCP signature bit 2 position. */
+#define CPU_CCP_3_bm  (1<<3)  /* CCP signature bit 3 mask. */
+#define CPU_CCP_3_bp  3  /* CCP signature bit 3 position. */
+#define CPU_CCP_4_bm  (1<<4)  /* CCP signature bit 4 mask. */
+#define CPU_CCP_4_bp  4  /* CCP signature bit 4 position. */
+#define CPU_CCP_5_bm  (1<<5)  /* CCP signature bit 5 mask. */
+#define CPU_CCP_5_bp  5  /* CCP signature bit 5 position. */
+#define CPU_CCP_6_bm  (1<<6)  /* CCP signature bit 6 mask. */
+#define CPU_CCP_6_bp  6  /* CCP signature bit 6 position. */
+#define CPU_CCP_7_bm  (1<<7)  /* CCP signature bit 7 mask. */
+#define CPU_CCP_7_bp  7  /* CCP signature bit 7 position. */
+
+/* CPU.SREG  bit masks and bit positions */
+#define CPU_C_bm  0x01  /* Carry Flag bit mask. */
+#define CPU_C_bp  0  /* Carry Flag bit position. */
+#define CPU_Z_bm  0x02  /* Zero Flag bit mask. */
+#define CPU_Z_bp  1  /* Zero Flag bit position. */
+#define CPU_N_bm  0x04  /* Negative Flag bit mask. */
+#define CPU_N_bp  2  /* Negative Flag bit position. */
+#define CPU_V_bm  0x08  /* Two's Complement Overflow Flag bit mask. */
+#define CPU_V_bp  3  /* Two's Complement Overflow Flag bit position. */
+#define CPU_S_bm  0x10  /* N Exclusive Or V Flag bit mask. */
+#define CPU_S_bp  4  /* N Exclusive Or V Flag bit position. */
+#define CPU_H_bm  0x20  /* Half Carry Flag bit mask. */
+#define CPU_H_bp  5  /* Half Carry Flag bit position. */
+#define CPU_T_bm  0x40  /* Transfer Bit bit mask. */
+#define CPU_T_bp  6  /* Transfer Bit bit position. */
+#define CPU_I_bm  0x80  /* Global Interrupt Enable Flag bit mask. */
+#define CPU_I_bp  7  /* Global Interrupt Enable Flag bit position. */
+
+
+/* CPUINT - Interrupt Controller */
+/* CPUINT.CTRLA  bit masks and bit positions */
+#define CPUINT_LVL0RR_bm  0x01  /* Round-robin Scheduling Enable bit mask. */
+#define CPUINT_LVL0RR_bp  0  /* Round-robin Scheduling Enable bit position. */
+#define CPUINT_CVT_bm  0x20  /* Compact Vector Table bit mask. */
+#define CPUINT_CVT_bp  5  /* Compact Vector Table bit position. */
+#define CPUINT_IVSEL_bm  0x40  /* Interrupt Vector Select bit mask. */
+#define CPUINT_IVSEL_bp  6  /* Interrupt Vector Select bit position. */
+
+/* CPUINT.STATUS  bit masks and bit positions */
+#define CPUINT_LVL0EX_bm  0x01  /* Level 0 Interrupt Executing bit mask. */
+#define CPUINT_LVL0EX_bp  0  /* Level 0 Interrupt Executing bit position. */
+#define CPUINT_LVL1EX_bm  0x02  /* Level 1 Interrupt Executing bit mask. */
+#define CPUINT_LVL1EX_bp  1  /* Level 1 Interrupt Executing bit position. */
+#define CPUINT_NMIEX_bm  0x80  /* Non-maskable Interrupt Executing bit mask. */
+#define CPUINT_NMIEX_bp  7  /* Non-maskable Interrupt Executing bit position. */
+
+/* CPUINT.LVL0PRI  bit masks and bit positions */
+#define CPUINT_LVL0PRI_gm  0xFF  /* Interrupt Level Priority group mask. */
+#define CPUINT_LVL0PRI_gp  0  /* Interrupt Level Priority group position. */
+#define CPUINT_LVL0PRI_0_bm  (1<<0)  /* Interrupt Level Priority bit 0 mask. */
+#define CPUINT_LVL0PRI_0_bp  0  /* Interrupt Level Priority bit 0 position. */
+#define CPUINT_LVL0PRI_1_bm  (1<<1)  /* Interrupt Level Priority bit 1 mask. */
+#define CPUINT_LVL0PRI_1_bp  1  /* Interrupt Level Priority bit 1 position. */
+#define CPUINT_LVL0PRI_2_bm  (1<<2)  /* Interrupt Level Priority bit 2 mask. */
+#define CPUINT_LVL0PRI_2_bp  2  /* Interrupt Level Priority bit 2 position. */
+#define CPUINT_LVL0PRI_3_bm  (1<<3)  /* Interrupt Level Priority bit 3 mask. */
+#define CPUINT_LVL0PRI_3_bp  3  /* Interrupt Level Priority bit 3 position. */
+#define CPUINT_LVL0PRI_4_bm  (1<<4)  /* Interrupt Level Priority bit 4 mask. */
+#define CPUINT_LVL0PRI_4_bp  4  /* Interrupt Level Priority bit 4 position. */
+#define CPUINT_LVL0PRI_5_bm  (1<<5)  /* Interrupt Level Priority bit 5 mask. */
+#define CPUINT_LVL0PRI_5_bp  5  /* Interrupt Level Priority bit 5 position. */
+#define CPUINT_LVL0PRI_6_bm  (1<<6)  /* Interrupt Level Priority bit 6 mask. */
+#define CPUINT_LVL0PRI_6_bp  6  /* Interrupt Level Priority bit 6 position. */
+#define CPUINT_LVL0PRI_7_bm  (1<<7)  /* Interrupt Level Priority bit 7 mask. */
+#define CPUINT_LVL0PRI_7_bp  7  /* Interrupt Level Priority bit 7 position. */
+
+/* CPUINT.LVL1VEC  bit masks and bit positions */
+#define CPUINT_LVL1VEC_gm  0xFF  /* Interrupt Vector with High Priority group mask. */
+#define CPUINT_LVL1VEC_gp  0  /* Interrupt Vector with High Priority group position. */
+#define CPUINT_LVL1VEC_0_bm  (1<<0)  /* Interrupt Vector with High Priority bit 0 mask. */
+#define CPUINT_LVL1VEC_0_bp  0  /* Interrupt Vector with High Priority bit 0 position. */
+#define CPUINT_LVL1VEC_1_bm  (1<<1)  /* Interrupt Vector with High Priority bit 1 mask. */
+#define CPUINT_LVL1VEC_1_bp  1  /* Interrupt Vector with High Priority bit 1 position. */
+#define CPUINT_LVL1VEC_2_bm  (1<<2)  /* Interrupt Vector with High Priority bit 2 mask. */
+#define CPUINT_LVL1VEC_2_bp  2  /* Interrupt Vector with High Priority bit 2 position. */
+#define CPUINT_LVL1VEC_3_bm  (1<<3)  /* Interrupt Vector with High Priority bit 3 mask. */
+#define CPUINT_LVL1VEC_3_bp  3  /* Interrupt Vector with High Priority bit 3 position. */
+#define CPUINT_LVL1VEC_4_bm  (1<<4)  /* Interrupt Vector with High Priority bit 4 mask. */
+#define CPUINT_LVL1VEC_4_bp  4  /* Interrupt Vector with High Priority bit 4 position. */
+#define CPUINT_LVL1VEC_5_bm  (1<<5)  /* Interrupt Vector with High Priority bit 5 mask. */
+#define CPUINT_LVL1VEC_5_bp  5  /* Interrupt Vector with High Priority bit 5 position. */
+#define CPUINT_LVL1VEC_6_bm  (1<<6)  /* Interrupt Vector with High Priority bit 6 mask. */
+#define CPUINT_LVL1VEC_6_bp  6  /* Interrupt Vector with High Priority bit 6 position. */
+#define CPUINT_LVL1VEC_7_bm  (1<<7)  /* Interrupt Vector with High Priority bit 7 mask. */
+#define CPUINT_LVL1VEC_7_bp  7  /* Interrupt Vector with High Priority bit 7 position. */
+
+
+/* CRCSCAN - CRCSCAN */
+/* CRCSCAN.CTRLA  bit masks and bit positions */
+#define CRCSCAN_ENABLE_bm  0x01  /* Enable CRC scan bit mask. */
+#define CRCSCAN_ENABLE_bp  0  /* Enable CRC scan bit position. */
+#define CRCSCAN_NMIEN_bm  0x02  /* Enable NMI Trigger bit mask. */
+#define CRCSCAN_NMIEN_bp  1  /* Enable NMI Trigger bit position. */
+#define CRCSCAN_RESET_bm  0x80  /* Reset CRC scan bit mask. */
+#define CRCSCAN_RESET_bp  7  /* Reset CRC scan bit position. */
+
+/* CRCSCAN.CTRLB  bit masks and bit positions */
+#define CRCSCAN_SRC_gm  0x03  /* CRC Source group mask. */
+#define CRCSCAN_SRC_gp  0  /* CRC Source group position. */
+#define CRCSCAN_SRC_0_bm  (1<<0)  /* CRC Source bit 0 mask. */
+#define CRCSCAN_SRC_0_bp  0  /* CRC Source bit 0 position. */
+#define CRCSCAN_SRC_1_bm  (1<<1)  /* CRC Source bit 1 mask. */
+#define CRCSCAN_SRC_1_bp  1  /* CRC Source bit 1 position. */
+
+/* CRCSCAN.STATUS  bit masks and bit positions */
+#define CRCSCAN_BUSY_bm  0x01  /* CRC Busy bit mask. */
+#define CRCSCAN_BUSY_bp  0  /* CRC Busy bit position. */
+#define CRCSCAN_OK_bm  0x02  /* CRC Ok bit mask. */
+#define CRCSCAN_OK_bp  1  /* CRC Ok bit position. */
+
+
+/* EVSYS - Event System */
+/* EVSYS.SWEVENTA  bit masks and bit positions */
+#define EVSYS_SWEVENTA_gm  0xFF  /* Software event on channel select group mask. */
+#define EVSYS_SWEVENTA_gp  0  /* Software event on channel select group position. */
+#define EVSYS_SWEVENTA_0_bm  (1<<0)  /* Software event on channel select bit 0 mask. */
+#define EVSYS_SWEVENTA_0_bp  0  /* Software event on channel select bit 0 position. */
+#define EVSYS_SWEVENTA_1_bm  (1<<1)  /* Software event on channel select bit 1 mask. */
+#define EVSYS_SWEVENTA_1_bp  1  /* Software event on channel select bit 1 position. */
+#define EVSYS_SWEVENTA_2_bm  (1<<2)  /* Software event on channel select bit 2 mask. */
+#define EVSYS_SWEVENTA_2_bp  2  /* Software event on channel select bit 2 position. */
+#define EVSYS_SWEVENTA_3_bm  (1<<3)  /* Software event on channel select bit 3 mask. */
+#define EVSYS_SWEVENTA_3_bp  3  /* Software event on channel select bit 3 position. */
+#define EVSYS_SWEVENTA_4_bm  (1<<4)  /* Software event on channel select bit 4 mask. */
+#define EVSYS_SWEVENTA_4_bp  4  /* Software event on channel select bit 4 position. */
+#define EVSYS_SWEVENTA_5_bm  (1<<5)  /* Software event on channel select bit 5 mask. */
+#define EVSYS_SWEVENTA_5_bp  5  /* Software event on channel select bit 5 position. */
+#define EVSYS_SWEVENTA_6_bm  (1<<6)  /* Software event on channel select bit 6 mask. */
+#define EVSYS_SWEVENTA_6_bp  6  /* Software event on channel select bit 6 position. */
+#define EVSYS_SWEVENTA_7_bm  (1<<7)  /* Software event on channel select bit 7 mask. */
+#define EVSYS_SWEVENTA_7_bp  7  /* Software event on channel select bit 7 position. */
+
+/* EVSYS.CHANNEL0  bit masks and bit positions */
+#define EVSYS_CHANNEL_gm  0xFF  /* Channel generator select group mask. */
+#define EVSYS_CHANNEL_gp  0  /* Channel generator select group position. */
+#define EVSYS_CHANNEL_0_bm  (1<<0)  /* Channel generator select bit 0 mask. */
+#define EVSYS_CHANNEL_0_bp  0  /* Channel generator select bit 0 position. */
+#define EVSYS_CHANNEL_1_bm  (1<<1)  /* Channel generator select bit 1 mask. */
+#define EVSYS_CHANNEL_1_bp  1  /* Channel generator select bit 1 position. */
+#define EVSYS_CHANNEL_2_bm  (1<<2)  /* Channel generator select bit 2 mask. */
+#define EVSYS_CHANNEL_2_bp  2  /* Channel generator select bit 2 position. */
+#define EVSYS_CHANNEL_3_bm  (1<<3)  /* Channel generator select bit 3 mask. */
+#define EVSYS_CHANNEL_3_bp  3  /* Channel generator select bit 3 position. */
+#define EVSYS_CHANNEL_4_bm  (1<<4)  /* Channel generator select bit 4 mask. */
+#define EVSYS_CHANNEL_4_bp  4  /* Channel generator select bit 4 position. */
+#define EVSYS_CHANNEL_5_bm  (1<<5)  /* Channel generator select bit 5 mask. */
+#define EVSYS_CHANNEL_5_bp  5  /* Channel generator select bit 5 position. */
+#define EVSYS_CHANNEL_6_bm  (1<<6)  /* Channel generator select bit 6 mask. */
+#define EVSYS_CHANNEL_6_bp  6  /* Channel generator select bit 6 position. */
+#define EVSYS_CHANNEL_7_bm  (1<<7)  /* Channel generator select bit 7 mask. */
+#define EVSYS_CHANNEL_7_bp  7  /* Channel generator select bit 7 position. */
+
+/* EVSYS.CHANNEL1  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.CHANNEL2  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.CHANNEL3  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.CHANNEL4  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.CHANNEL5  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.USERCCLLUT0A  bit masks and bit positions */
+#define EVSYS_USER_gm  0xFF  /* User channel select group mask. */
+#define EVSYS_USER_gp  0  /* User channel select group position. */
+#define EVSYS_USER_0_bm  (1<<0)  /* User channel select bit 0 mask. */
+#define EVSYS_USER_0_bp  0  /* User channel select bit 0 position. */
+#define EVSYS_USER_1_bm  (1<<1)  /* User channel select bit 1 mask. */
+#define EVSYS_USER_1_bp  1  /* User channel select bit 1 position. */
+#define EVSYS_USER_2_bm  (1<<2)  /* User channel select bit 2 mask. */
+#define EVSYS_USER_2_bp  2  /* User channel select bit 2 position. */
+#define EVSYS_USER_3_bm  (1<<3)  /* User channel select bit 3 mask. */
+#define EVSYS_USER_3_bp  3  /* User channel select bit 3 position. */
+#define EVSYS_USER_4_bm  (1<<4)  /* User channel select bit 4 mask. */
+#define EVSYS_USER_4_bp  4  /* User channel select bit 4 position. */
+#define EVSYS_USER_5_bm  (1<<5)  /* User channel select bit 5 mask. */
+#define EVSYS_USER_5_bp  5  /* User channel select bit 5 position. */
+#define EVSYS_USER_6_bm  (1<<6)  /* User channel select bit 6 mask. */
+#define EVSYS_USER_6_bp  6  /* User channel select bit 6 position. */
+#define EVSYS_USER_7_bm  (1<<7)  /* User channel select bit 7 mask. */
+#define EVSYS_USER_7_bp  7  /* User channel select bit 7 position. */
+
+/* EVSYS.USERCCLLUT0B  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT1A  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT1B  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT2A  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT2B  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT3A  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT3B  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERADC0START  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTC  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTD  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTF  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERUSART0IRDA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCE0CNTA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCE0CNTB  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB0CAPT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB0COUNT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB1CAPT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB1COUNT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCF0CNT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCF0ACT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERWEXA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERWEXB  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERWEXC  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+
+/* FUSE - Fuses */
+/* FUSE.WDTCFG  bit masks and bit positions */
+#define FUSE_PERIOD_gm  0x0F  /* Watchdog Timeout Period group mask. */
+#define FUSE_PERIOD_gp  0  /* Watchdog Timeout Period group position. */
+#define FUSE_PERIOD_0_bm  (1<<0)  /* Watchdog Timeout Period bit 0 mask. */
+#define FUSE_PERIOD_0_bp  0  /* Watchdog Timeout Period bit 0 position. */
+#define FUSE_PERIOD_1_bm  (1<<1)  /* Watchdog Timeout Period bit 1 mask. */
+#define FUSE_PERIOD_1_bp  1  /* Watchdog Timeout Period bit 1 position. */
+#define FUSE_PERIOD_2_bm  (1<<2)  /* Watchdog Timeout Period bit 2 mask. */
+#define FUSE_PERIOD_2_bp  2  /* Watchdog Timeout Period bit 2 position. */
+#define FUSE_PERIOD_3_bm  (1<<3)  /* Watchdog Timeout Period bit 3 mask. */
+#define FUSE_PERIOD_3_bp  3  /* Watchdog Timeout Period bit 3 position. */
+#define FUSE_WINDOW_gm  0xF0  /* Watchdog Window Timeout Period group mask. */
+#define FUSE_WINDOW_gp  4  /* Watchdog Window Timeout Period group position. */
+#define FUSE_WINDOW_0_bm  (1<<4)  /* Watchdog Window Timeout Period bit 0 mask. */
+#define FUSE_WINDOW_0_bp  4  /* Watchdog Window Timeout Period bit 0 position. */
+#define FUSE_WINDOW_1_bm  (1<<5)  /* Watchdog Window Timeout Period bit 1 mask. */
+#define FUSE_WINDOW_1_bp  5  /* Watchdog Window Timeout Period bit 1 position. */
+#define FUSE_WINDOW_2_bm  (1<<6)  /* Watchdog Window Timeout Period bit 2 mask. */
+#define FUSE_WINDOW_2_bp  6  /* Watchdog Window Timeout Period bit 2 position. */
+#define FUSE_WINDOW_3_bm  (1<<7)  /* Watchdog Window Timeout Period bit 3 mask. */
+#define FUSE_WINDOW_3_bp  7  /* Watchdog Window Timeout Period bit 3 position. */
+
+/* FUSE.BODCFG  bit masks and bit positions */
+#define FUSE_SLEEP_gm  0x03  /* BOD Operation in Sleep Mode group mask. */
+#define FUSE_SLEEP_gp  0  /* BOD Operation in Sleep Mode group position. */
+#define FUSE_SLEEP_0_bm  (1<<0)  /* BOD Operation in Sleep Mode bit 0 mask. */
+#define FUSE_SLEEP_0_bp  0  /* BOD Operation in Sleep Mode bit 0 position. */
+#define FUSE_SLEEP_1_bm  (1<<1)  /* BOD Operation in Sleep Mode bit 1 mask. */
+#define FUSE_SLEEP_1_bp  1  /* BOD Operation in Sleep Mode bit 1 position. */
+#define FUSE_ACTIVE_gm  0x0C  /* BOD Operation in Active Mode group mask. */
+#define FUSE_ACTIVE_gp  2  /* BOD Operation in Active Mode group position. */
+#define FUSE_ACTIVE_0_bm  (1<<2)  /* BOD Operation in Active Mode bit 0 mask. */
+#define FUSE_ACTIVE_0_bp  2  /* BOD Operation in Active Mode bit 0 position. */
+#define FUSE_ACTIVE_1_bm  (1<<3)  /* BOD Operation in Active Mode bit 1 mask. */
+#define FUSE_ACTIVE_1_bp  3  /* BOD Operation in Active Mode bit 1 position. */
+#define FUSE_SAMPFREQ_bm  0x10  /* BOD Sample Frequency bit mask. */
+#define FUSE_SAMPFREQ_bp  4  /* BOD Sample Frequency bit position. */
+#define FUSE_LVL_gm  0xE0  /* BOD Level group mask. */
+#define FUSE_LVL_gp  5  /* BOD Level group position. */
+#define FUSE_LVL_0_bm  (1<<5)  /* BOD Level bit 0 mask. */
+#define FUSE_LVL_0_bp  5  /* BOD Level bit 0 position. */
+#define FUSE_LVL_1_bm  (1<<6)  /* BOD Level bit 1 mask. */
+#define FUSE_LVL_1_bp  6  /* BOD Level bit 1 position. */
+#define FUSE_LVL_2_bm  (1<<7)  /* BOD Level bit 2 mask. */
+#define FUSE_LVL_2_bp  7  /* BOD Level bit 2 position. */
+
+/* FUSE.OSCCFG  bit masks and bit positions */
+#define FUSE_OSCHFFRQ_bm  0x08  /* High-frequency Oscillator Frequency bit mask. */
+#define FUSE_OSCHFFRQ_bp  3  /* High-frequency Oscillator Frequency bit position. */
+
+/* FUSE.SYSCFG0  bit masks and bit positions */
+#define FUSE_EESAVE_bm  0x01  /* EEPROM Save bit mask. */
+#define FUSE_EESAVE_bp  0  /* EEPROM Save bit position. */
+#define FUSE_RSTPINCFG_bm  0x08  /* Reset Pin Configuration bit mask. */
+#define FUSE_RSTPINCFG_bp  3  /* Reset Pin Configuration bit position. */
+#define FUSE_UPDIPINCFG_bm  0x10  /* UPDI Pin Configuration bit mask. */
+#define FUSE_UPDIPINCFG_bp  4  /* UPDI Pin Configuration bit position. */
+#define FUSE_CRCSEL_bm  0x20  /* CRC Select bit mask. */
+#define FUSE_CRCSEL_bp  5  /* CRC Select bit position. */
+#define FUSE_CRCSRC_gm  0xC0  /* CRC Source group mask. */
+#define FUSE_CRCSRC_gp  6  /* CRC Source group position. */
+#define FUSE_CRCSRC_0_bm  (1<<6)  /* CRC Source bit 0 mask. */
+#define FUSE_CRCSRC_0_bp  6  /* CRC Source bit 0 position. */
+#define FUSE_CRCSRC_1_bm  (1<<7)  /* CRC Source bit 1 mask. */
+#define FUSE_CRCSRC_1_bp  7  /* CRC Source bit 1 position. */
+
+/* FUSE.SYSCFG1  bit masks and bit positions */
+#define FUSE_SUT_gm  0x07  /* Startup Time group mask. */
+#define FUSE_SUT_gp  0  /* Startup Time group position. */
+#define FUSE_SUT_0_bm  (1<<0)  /* Startup Time bit 0 mask. */
+#define FUSE_SUT_0_bp  0  /* Startup Time bit 0 position. */
+#define FUSE_SUT_1_bm  (1<<1)  /* Startup Time bit 1 mask. */
+#define FUSE_SUT_1_bp  1  /* Startup Time bit 1 position. */
+#define FUSE_SUT_2_bm  (1<<2)  /* Startup Time bit 2 mask. */
+#define FUSE_SUT_2_bp  2  /* Startup Time bit 2 position. */
+
+/* FUSE.PDICFG  bit masks and bit positions */
+#define FUSE_LEVEL_gm  0x03  /* Protection Level group mask. */
+#define FUSE_LEVEL_gp  0  /* Protection Level group position. */
+#define FUSE_LEVEL_0_bm  (1<<0)  /* Protection Level bit 0 mask. */
+#define FUSE_LEVEL_0_bp  0  /* Protection Level bit 0 position. */
+#define FUSE_LEVEL_1_bm  (1<<1)  /* Protection Level bit 1 mask. */
+#define FUSE_LEVEL_1_bp  1  /* Protection Level bit 1 position. */
+#define FUSE_KEY_gm  0xFFF0  /* NVM Protection Activation Key group mask. */
+#define FUSE_KEY_gp  4  /* NVM Protection Activation Key group position. */
+#define FUSE_KEY_0_bm  (1<<4)  /* NVM Protection Activation Key bit 0 mask. */
+#define FUSE_KEY_0_bp  4  /* NVM Protection Activation Key bit 0 position. */
+#define FUSE_KEY_1_bm  (1<<5)  /* NVM Protection Activation Key bit 1 mask. */
+#define FUSE_KEY_1_bp  5  /* NVM Protection Activation Key bit 1 position. */
+#define FUSE_KEY_2_bm  (1<<6)  /* NVM Protection Activation Key bit 2 mask. */
+#define FUSE_KEY_2_bp  6  /* NVM Protection Activation Key bit 2 position. */
+#define FUSE_KEY_3_bm  (1<<7)  /* NVM Protection Activation Key bit 3 mask. */
+#define FUSE_KEY_3_bp  7  /* NVM Protection Activation Key bit 3 position. */
+#define FUSE_KEY_4_bm  (1<<8)  /* NVM Protection Activation Key bit 4 mask. */
+#define FUSE_KEY_4_bp  8  /* NVM Protection Activation Key bit 4 position. */
+#define FUSE_KEY_5_bm  (1<<9)  /* NVM Protection Activation Key bit 5 mask. */
+#define FUSE_KEY_5_bp  9  /* NVM Protection Activation Key bit 5 position. */
+#define FUSE_KEY_6_bm  (1<<10)  /* NVM Protection Activation Key bit 6 mask. */
+#define FUSE_KEY_6_bp  10  /* NVM Protection Activation Key bit 6 position. */
+#define FUSE_KEY_7_bm  (1<<11)  /* NVM Protection Activation Key bit 7 mask. */
+#define FUSE_KEY_7_bp  11  /* NVM Protection Activation Key bit 7 position. */
+#define FUSE_KEY_8_bm  (1<<12)  /* NVM Protection Activation Key bit 8 mask. */
+#define FUSE_KEY_8_bp  12  /* NVM Protection Activation Key bit 8 position. */
+#define FUSE_KEY_9_bm  (1<<13)  /* NVM Protection Activation Key bit 9 mask. */
+#define FUSE_KEY_9_bp  13  /* NVM Protection Activation Key bit 9 position. */
+#define FUSE_KEY_10_bm  (1<<14)  /* NVM Protection Activation Key bit 10 mask. */
+#define FUSE_KEY_10_bp  14  /* NVM Protection Activation Key bit 10 position. */
+#define FUSE_KEY_11_bm  (1<<15)  /* NVM Protection Activation Key bit 11 mask. */
+#define FUSE_KEY_11_bp  15  /* NVM Protection Activation Key bit 11 position. */
+
+
+
+/* LOCK - Lockbits */
+/* LOCK.KEY  bit masks and bit positions */
+#define LOCK_KEY_gm  0xFFFFFFFF  /* Lock Key group mask. */
+#define LOCK_KEY_gp  0  /* Lock Key group position. */
+#define LOCK_KEY_0_bm  (1<<0)  /* Lock Key bit 0 mask. */
+#define LOCK_KEY_0_bp  0  /* Lock Key bit 0 position. */
+#define LOCK_KEY_1_bm  (1<<1)  /* Lock Key bit 1 mask. */
+#define LOCK_KEY_1_bp  1  /* Lock Key bit 1 position. */
+#define LOCK_KEY_2_bm  (1<<2)  /* Lock Key bit 2 mask. */
+#define LOCK_KEY_2_bp  2  /* Lock Key bit 2 position. */
+#define LOCK_KEY_3_bm  (1<<3)  /* Lock Key bit 3 mask. */
+#define LOCK_KEY_3_bp  3  /* Lock Key bit 3 position. */
+#define LOCK_KEY_4_bm  (1<<4)  /* Lock Key bit 4 mask. */
+#define LOCK_KEY_4_bp  4  /* Lock Key bit 4 position. */
+#define LOCK_KEY_5_bm  (1<<5)  /* Lock Key bit 5 mask. */
+#define LOCK_KEY_5_bp  5  /* Lock Key bit 5 position. */
+#define LOCK_KEY_6_bm  (1<<6)  /* Lock Key bit 6 mask. */
+#define LOCK_KEY_6_bp  6  /* Lock Key bit 6 position. */
+#define LOCK_KEY_7_bm  (1<<7)  /* Lock Key bit 7 mask. */
+#define LOCK_KEY_7_bp  7  /* Lock Key bit 7 position. */
+#define LOCK_KEY_8_bm  (1<<8)  /* Lock Key bit 8 mask. */
+#define LOCK_KEY_8_bp  8  /* Lock Key bit 8 position. */
+#define LOCK_KEY_9_bm  (1<<9)  /* Lock Key bit 9 mask. */
+#define LOCK_KEY_9_bp  9  /* Lock Key bit 9 position. */
+#define LOCK_KEY_10_bm  (1<<10)  /* Lock Key bit 10 mask. */
+#define LOCK_KEY_10_bp  10  /* Lock Key bit 10 position. */
+#define LOCK_KEY_11_bm  (1<<11)  /* Lock Key bit 11 mask. */
+#define LOCK_KEY_11_bp  11  /* Lock Key bit 11 position. */
+#define LOCK_KEY_12_bm  (1<<12)  /* Lock Key bit 12 mask. */
+#define LOCK_KEY_12_bp  12  /* Lock Key bit 12 position. */
+#define LOCK_KEY_13_bm  (1<<13)  /* Lock Key bit 13 mask. */
+#define LOCK_KEY_13_bp  13  /* Lock Key bit 13 position. */
+#define LOCK_KEY_14_bm  (1<<14)  /* Lock Key bit 14 mask. */
+#define LOCK_KEY_14_bp  14  /* Lock Key bit 14 position. */
+#define LOCK_KEY_15_bm  (1<<15)  /* Lock Key bit 15 mask. */
+#define LOCK_KEY_15_bp  15  /* Lock Key bit 15 position. */
+#define LOCK_KEY_16_bm  (1<<16)  /* Lock Key bit 16 mask. */
+#define LOCK_KEY_16_bp  16  /* Lock Key bit 16 position. */
+#define LOCK_KEY_17_bm  (1<<17)  /* Lock Key bit 17 mask. */
+#define LOCK_KEY_17_bp  17  /* Lock Key bit 17 position. */
+#define LOCK_KEY_18_bm  (1<<18)  /* Lock Key bit 18 mask. */
+#define LOCK_KEY_18_bp  18  /* Lock Key bit 18 position. */
+#define LOCK_KEY_19_bm  (1<<19)  /* Lock Key bit 19 mask. */
+#define LOCK_KEY_19_bp  19  /* Lock Key bit 19 position. */
+#define LOCK_KEY_20_bm  (1<<20)  /* Lock Key bit 20 mask. */
+#define LOCK_KEY_20_bp  20  /* Lock Key bit 20 position. */
+#define LOCK_KEY_21_bm  (1<<21)  /* Lock Key bit 21 mask. */
+#define LOCK_KEY_21_bp  21  /* Lock Key bit 21 position. */
+#define LOCK_KEY_22_bm  (1<<22)  /* Lock Key bit 22 mask. */
+#define LOCK_KEY_22_bp  22  /* Lock Key bit 22 position. */
+#define LOCK_KEY_23_bm  (1<<23)  /* Lock Key bit 23 mask. */
+#define LOCK_KEY_23_bp  23  /* Lock Key bit 23 position. */
+#define LOCK_KEY_24_bm  (1<<24)  /* Lock Key bit 24 mask. */
+#define LOCK_KEY_24_bp  24  /* Lock Key bit 24 position. */
+#define LOCK_KEY_25_bm  (1<<25)  /* Lock Key bit 25 mask. */
+#define LOCK_KEY_25_bp  25  /* Lock Key bit 25 position. */
+#define LOCK_KEY_26_bm  (1<<26)  /* Lock Key bit 26 mask. */
+#define LOCK_KEY_26_bp  26  /* Lock Key bit 26 position. */
+#define LOCK_KEY_27_bm  (1<<27)  /* Lock Key bit 27 mask. */
+#define LOCK_KEY_27_bp  27  /* Lock Key bit 27 position. */
+#define LOCK_KEY_28_bm  (1<<28)  /* Lock Key bit 28 mask. */
+#define LOCK_KEY_28_bp  28  /* Lock Key bit 28 position. */
+#define LOCK_KEY_29_bm  (1<<29)  /* Lock Key bit 29 mask. */
+#define LOCK_KEY_29_bp  29  /* Lock Key bit 29 position. */
+#define LOCK_KEY_30_bm  (1<<30)  /* Lock Key bit 30 mask. */
+#define LOCK_KEY_30_bp  30  /* Lock Key bit 30 position. */
+#define LOCK_KEY_31_bm  (1<<31)  /* Lock Key bit 31 mask. */
+#define LOCK_KEY_31_bp  31  /* Lock Key bit 31 position. */
+
+
+/* NVMCTRL - Non-volatile Memory Controller */
+/* NVMCTRL.CTRLA  bit masks and bit positions */
+#define NVMCTRL_CMD_gm  0x7F  /* Command group mask. */
+#define NVMCTRL_CMD_gp  0  /* Command group position. */
+#define NVMCTRL_CMD_0_bm  (1<<0)  /* Command bit 0 mask. */
+#define NVMCTRL_CMD_0_bp  0  /* Command bit 0 position. */
+#define NVMCTRL_CMD_1_bm  (1<<1)  /* Command bit 1 mask. */
+#define NVMCTRL_CMD_1_bp  1  /* Command bit 1 position. */
+#define NVMCTRL_CMD_2_bm  (1<<2)  /* Command bit 2 mask. */
+#define NVMCTRL_CMD_2_bp  2  /* Command bit 2 position. */
+#define NVMCTRL_CMD_3_bm  (1<<3)  /* Command bit 3 mask. */
+#define NVMCTRL_CMD_3_bp  3  /* Command bit 3 position. */
+#define NVMCTRL_CMD_4_bm  (1<<4)  /* Command bit 4 mask. */
+#define NVMCTRL_CMD_4_bp  4  /* Command bit 4 position. */
+#define NVMCTRL_CMD_5_bm  (1<<5)  /* Command bit 5 mask. */
+#define NVMCTRL_CMD_5_bp  5  /* Command bit 5 position. */
+#define NVMCTRL_CMD_6_bm  (1<<6)  /* Command bit 6 mask. */
+#define NVMCTRL_CMD_6_bp  6  /* Command bit 6 position. */
+
+/* NVMCTRL.CTRLB  bit masks and bit positions */
+#define NVMCTRL_APPCODEWP_bm  0x01  /* Application Code Write Protect bit mask. */
+#define NVMCTRL_APPCODEWP_bp  0  /* Application Code Write Protect bit position. */
+#define NVMCTRL_BOOTRP_bm  0x02  /* Boot Read Protect bit mask. */
+#define NVMCTRL_BOOTRP_bp  1  /* Boot Read Protect bit position. */
+#define NVMCTRL_APPDATAWP_bm  0x04  /* Application Data Write Protect bit mask. */
+#define NVMCTRL_APPDATAWP_bp  2  /* Application Data Write Protect bit position. */
+#define NVMCTRL_EEWP_bm  0x08  /* EEPROM Write Protect bit mask. */
+#define NVMCTRL_EEWP_bp  3  /* EEPROM Write Protect bit position. */
+#define NVMCTRL_FLMAP_gm  0x30  /* Flash Mapping in Data space group mask. */
+#define NVMCTRL_FLMAP_gp  4  /* Flash Mapping in Data space group position. */
+#define NVMCTRL_FLMAP_0_bm  (1<<4)  /* Flash Mapping in Data space bit 0 mask. */
+#define NVMCTRL_FLMAP_0_bp  4  /* Flash Mapping in Data space bit 0 position. */
+#define NVMCTRL_FLMAP_1_bm  (1<<5)  /* Flash Mapping in Data space bit 1 mask. */
+#define NVMCTRL_FLMAP_1_bp  5  /* Flash Mapping in Data space bit 1 position. */
+#define NVMCTRL_FLMAPLOCK_bm  0x80  /* Flash Mapping Lock bit mask. */
+#define NVMCTRL_FLMAPLOCK_bp  7  /* Flash Mapping Lock bit position. */
+
+/* NVMCTRL.CTRLC  bit masks and bit positions */
+#define NVMCTRL_UROWWP_bm  0x01  /* User Row Write Protect bit mask. */
+#define NVMCTRL_UROWWP_bp  0  /* User Row Write Protect bit position. */
+#define NVMCTRL_BOOTROWWP_bm  0x02  /* Boot Row Write Protect bit mask. */
+#define NVMCTRL_BOOTROWWP_bp  1  /* Boot Row Write Protect bit position. */
+
+/* NVMCTRL.INTCTRL  bit masks and bit positions */
+#define NVMCTRL_EEREADY_bm  0x01  /* EEPROM Ready bit mask. */
+#define NVMCTRL_EEREADY_bp  0  /* EEPROM Ready bit position. */
+#define NVMCTRL_FLREADY_bm  0x02  /* Flash Ready bit mask. */
+#define NVMCTRL_FLREADY_bp  1  /* Flash Ready bit position. */
+
+/* NVMCTRL.INTFLAGS  bit masks and bit positions */
+/* NVMCTRL_EEREADY  is already defined. */
+/* NVMCTRL_FLREADY  is already defined. */
+
+/* NVMCTRL.STATUS  bit masks and bit positions */
+#define NVMCTRL_EEBUSY_bm  0x01  /* EEPROM busy bit mask. */
+#define NVMCTRL_EEBUSY_bp  0  /* EEPROM busy bit position. */
+#define NVMCTRL_FLBUSY_bm  0x02  /* Flash busy bit mask. */
+#define NVMCTRL_FLBUSY_bp  1  /* Flash busy bit position. */
+#define NVMCTRL_ERROR_gm  0x70  /* Write error group mask. */
+#define NVMCTRL_ERROR_gp  4  /* Write error group position. */
+#define NVMCTRL_ERROR_0_bm  (1<<4)  /* Write error bit 0 mask. */
+#define NVMCTRL_ERROR_0_bp  4  /* Write error bit 0 position. */
+#define NVMCTRL_ERROR_1_bm  (1<<5)  /* Write error bit 1 mask. */
+#define NVMCTRL_ERROR_1_bp  5  /* Write error bit 1 position. */
+#define NVMCTRL_ERROR_2_bm  (1<<6)  /* Write error bit 2 mask. */
+#define NVMCTRL_ERROR_2_bp  6  /* Write error bit 2 position. */
+
+/* NVMCTRL.ADDR  bit masks and bit positions */
+#define NVMCTRL_ADDR_gm  0xFFFFFF  /* Address group mask. */
+#define NVMCTRL_ADDR_gp  0  /* Address group position. */
+#define NVMCTRL_ADDR_0_bm  (1<<0)  /* Address bit 0 mask. */
+#define NVMCTRL_ADDR_0_bp  0  /* Address bit 0 position. */
+#define NVMCTRL_ADDR_1_bm  (1<<1)  /* Address bit 1 mask. */
+#define NVMCTRL_ADDR_1_bp  1  /* Address bit 1 position. */
+#define NVMCTRL_ADDR_2_bm  (1<<2)  /* Address bit 2 mask. */
+#define NVMCTRL_ADDR_2_bp  2  /* Address bit 2 position. */
+#define NVMCTRL_ADDR_3_bm  (1<<3)  /* Address bit 3 mask. */
+#define NVMCTRL_ADDR_3_bp  3  /* Address bit 3 position. */
+#define NVMCTRL_ADDR_4_bm  (1<<4)  /* Address bit 4 mask. */
+#define NVMCTRL_ADDR_4_bp  4  /* Address bit 4 position. */
+#define NVMCTRL_ADDR_5_bm  (1<<5)  /* Address bit 5 mask. */
+#define NVMCTRL_ADDR_5_bp  5  /* Address bit 5 position. */
+#define NVMCTRL_ADDR_6_bm  (1<<6)  /* Address bit 6 mask. */
+#define NVMCTRL_ADDR_6_bp  6  /* Address bit 6 position. */
+#define NVMCTRL_ADDR_7_bm  (1<<7)  /* Address bit 7 mask. */
+#define NVMCTRL_ADDR_7_bp  7  /* Address bit 7 position. */
+#define NVMCTRL_ADDR_8_bm  (1<<8)  /* Address bit 8 mask. */
+#define NVMCTRL_ADDR_8_bp  8  /* Address bit 8 position. */
+#define NVMCTRL_ADDR_9_bm  (1<<9)  /* Address bit 9 mask. */
+#define NVMCTRL_ADDR_9_bp  9  /* Address bit 9 position. */
+#define NVMCTRL_ADDR_10_bm  (1<<10)  /* Address bit 10 mask. */
+#define NVMCTRL_ADDR_10_bp  10  /* Address bit 10 position. */
+#define NVMCTRL_ADDR_11_bm  (1<<11)  /* Address bit 11 mask. */
+#define NVMCTRL_ADDR_11_bp  11  /* Address bit 11 position. */
+#define NVMCTRL_ADDR_12_bm  (1<<12)  /* Address bit 12 mask. */
+#define NVMCTRL_ADDR_12_bp  12  /* Address bit 12 position. */
+#define NVMCTRL_ADDR_13_bm  (1<<13)  /* Address bit 13 mask. */
+#define NVMCTRL_ADDR_13_bp  13  /* Address bit 13 position. */
+#define NVMCTRL_ADDR_14_bm  (1<<14)  /* Address bit 14 mask. */
+#define NVMCTRL_ADDR_14_bp  14  /* Address bit 14 position. */
+#define NVMCTRL_ADDR_15_bm  (1<<15)  /* Address bit 15 mask. */
+#define NVMCTRL_ADDR_15_bp  15  /* Address bit 15 position. */
+#define NVMCTRL_ADDR_16_bm  (1<<16)  /* Address bit 16 mask. */
+#define NVMCTRL_ADDR_16_bp  16  /* Address bit 16 position. */
+#define NVMCTRL_ADDR_17_bm  (1<<17)  /* Address bit 17 mask. */
+#define NVMCTRL_ADDR_17_bp  17  /* Address bit 17 position. */
+#define NVMCTRL_ADDR_18_bm  (1<<18)  /* Address bit 18 mask. */
+#define NVMCTRL_ADDR_18_bp  18  /* Address bit 18 position. */
+#define NVMCTRL_ADDR_19_bm  (1<<19)  /* Address bit 19 mask. */
+#define NVMCTRL_ADDR_19_bp  19  /* Address bit 19 position. */
+#define NVMCTRL_ADDR_20_bm  (1<<20)  /* Address bit 20 mask. */
+#define NVMCTRL_ADDR_20_bp  20  /* Address bit 20 position. */
+#define NVMCTRL_ADDR_21_bm  (1<<21)  /* Address bit 21 mask. */
+#define NVMCTRL_ADDR_21_bp  21  /* Address bit 21 position. */
+#define NVMCTRL_ADDR_22_bm  (1<<22)  /* Address bit 22 mask. */
+#define NVMCTRL_ADDR_22_bp  22  /* Address bit 22 position. */
+#define NVMCTRL_ADDR_23_bm  (1<<23)  /* Address bit 23 mask. */
+#define NVMCTRL_ADDR_23_bp  23  /* Address bit 23 position. */
+
+
+/* PORT - I/O Ports */
+/* PORT.INTFLAGS  bit masks and bit positions */
+#define PORT_INT_gm  0xFF  /* Pin Interrupt Flag group mask. */
+#define PORT_INT_gp  0  /* Pin Interrupt Flag group position. */
+#define PORT_INT_0_bm  (1<<0)  /* Pin Interrupt Flag bit 0 mask. */
+#define PORT_INT_0_bp  0  /* Pin Interrupt Flag bit 0 position. */
+#define PORT_INT0_bm  PORT_INT_0_bm  /* This define is deprecated and should not be used */
+#define PORT_INT0_bp  PORT_INT_0_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_1_bm  (1<<1)  /* Pin Interrupt Flag bit 1 mask. */
+#define PORT_INT_1_bp  1  /* Pin Interrupt Flag bit 1 position. */
+#define PORT_INT1_bm  PORT_INT_1_bm  /* This define is deprecated and should not be used */
+#define PORT_INT1_bp  PORT_INT_1_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_2_bm  (1<<2)  /* Pin Interrupt Flag bit 2 mask. */
+#define PORT_INT_2_bp  2  /* Pin Interrupt Flag bit 2 position. */
+#define PORT_INT2_bm  PORT_INT_2_bm  /* This define is deprecated and should not be used */
+#define PORT_INT2_bp  PORT_INT_2_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_3_bm  (1<<3)  /* Pin Interrupt Flag bit 3 mask. */
+#define PORT_INT_3_bp  3  /* Pin Interrupt Flag bit 3 position. */
+#define PORT_INT3_bm  PORT_INT_3_bm  /* This define is deprecated and should not be used */
+#define PORT_INT3_bp  PORT_INT_3_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_4_bm  (1<<4)  /* Pin Interrupt Flag bit 4 mask. */
+#define PORT_INT_4_bp  4  /* Pin Interrupt Flag bit 4 position. */
+#define PORT_INT4_bm  PORT_INT_4_bm  /* This define is deprecated and should not be used */
+#define PORT_INT4_bp  PORT_INT_4_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_5_bm  (1<<5)  /* Pin Interrupt Flag bit 5 mask. */
+#define PORT_INT_5_bp  5  /* Pin Interrupt Flag bit 5 position. */
+#define PORT_INT5_bm  PORT_INT_5_bm  /* This define is deprecated and should not be used */
+#define PORT_INT5_bp  PORT_INT_5_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_6_bm  (1<<6)  /* Pin Interrupt Flag bit 6 mask. */
+#define PORT_INT_6_bp  6  /* Pin Interrupt Flag bit 6 position. */
+#define PORT_INT6_bm  PORT_INT_6_bm  /* This define is deprecated and should not be used */
+#define PORT_INT6_bp  PORT_INT_6_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_7_bm  (1<<7)  /* Pin Interrupt Flag bit 7 mask. */
+#define PORT_INT_7_bp  7  /* Pin Interrupt Flag bit 7 position. */
+#define PORT_INT7_bm  PORT_INT_7_bm  /* This define is deprecated and should not be used */
+#define PORT_INT7_bp  PORT_INT_7_bp  /* This define is deprecated and should not be used */
+
+/* PORT.PORTCTRL  bit masks and bit positions */
+#define PORT_SRL_bm  0x01  /* Slew Rate Limit Enable bit mask. */
+#define PORT_SRL_bp  0  /* Slew Rate Limit Enable bit position. */
+
+/* PORT.PINCONFIG  bit masks and bit positions */
+#define PORT_ISC_gm  0x07  /* Input/Sense Configuration group mask. */
+#define PORT_ISC_gp  0  /* Input/Sense Configuration group position. */
+#define PORT_ISC_0_bm  (1<<0)  /* Input/Sense Configuration bit 0 mask. */
+#define PORT_ISC_0_bp  0  /* Input/Sense Configuration bit 0 position. */
+#define PORT_ISC_1_bm  (1<<1)  /* Input/Sense Configuration bit 1 mask. */
+#define PORT_ISC_1_bp  1  /* Input/Sense Configuration bit 1 position. */
+#define PORT_ISC_2_bm  (1<<2)  /* Input/Sense Configuration bit 2 mask. */
+#define PORT_ISC_2_bp  2  /* Input/Sense Configuration bit 2 position. */
+#define PORT_PULLUPEN_bm  0x08  /* Pullup enable bit mask. */
+#define PORT_PULLUPEN_bp  3  /* Pullup enable bit position. */
+#define PORT_INLVL_bm  0x40  /* Input Level Select bit mask. */
+#define PORT_INLVL_bp  6  /* Input Level Select bit position. */
+#define PORT_INVEN_bm  0x80  /* Inverted I/O Enable bit mask. */
+#define PORT_INVEN_bp  7  /* Inverted I/O Enable bit position. */
+
+/* PORT.PIN0CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN1CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN2CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN3CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN4CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN5CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN6CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN7CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.EVGENCTRLA  bit masks and bit positions */
+#define PORT_EVGEN0SEL_gm  0x07  /* Event Generator 0 Select group mask. */
+#define PORT_EVGEN0SEL_gp  0  /* Event Generator 0 Select group position. */
+#define PORT_EVGEN0SEL_0_bm  (1<<0)  /* Event Generator 0 Select bit 0 mask. */
+#define PORT_EVGEN0SEL_0_bp  0  /* Event Generator 0 Select bit 0 position. */
+#define PORT_EVGEN0SEL_1_bm  (1<<1)  /* Event Generator 0 Select bit 1 mask. */
+#define PORT_EVGEN0SEL_1_bp  1  /* Event Generator 0 Select bit 1 position. */
+#define PORT_EVGEN0SEL_2_bm  (1<<2)  /* Event Generator 0 Select bit 2 mask. */
+#define PORT_EVGEN0SEL_2_bp  2  /* Event Generator 0 Select bit 2 position. */
+#define PORT_EVGEN1SEL_gm  0x70  /* Event Generator 1 Select group mask. */
+#define PORT_EVGEN1SEL_gp  4  /* Event Generator 1 Select group position. */
+#define PORT_EVGEN1SEL_0_bm  (1<<4)  /* Event Generator 1 Select bit 0 mask. */
+#define PORT_EVGEN1SEL_0_bp  4  /* Event Generator 1 Select bit 0 position. */
+#define PORT_EVGEN1SEL_1_bm  (1<<5)  /* Event Generator 1 Select bit 1 mask. */
+#define PORT_EVGEN1SEL_1_bp  5  /* Event Generator 1 Select bit 1 position. */
+#define PORT_EVGEN1SEL_2_bm  (1<<6)  /* Event Generator 1 Select bit 2 mask. */
+#define PORT_EVGEN1SEL_2_bp  6  /* Event Generator 1 Select bit 2 position. */
+
+
+/* PORTMUX - Port Multiplexer */
+/* PORTMUX.EVSYSROUTEA  bit masks and bit positions */
+#define PORTMUX_EVOUTA_bm  0x01  /* Event Output A bit mask. */
+#define PORTMUX_EVOUTA_bp  0  /* Event Output A bit position. */
+#define PORTMUX_EVOUTC_bm  0x04  /* Event Output C bit mask. */
+#define PORTMUX_EVOUTC_bp  2  /* Event Output C bit position. */
+#define PORTMUX_EVOUTD_bm  0x08  /* Event Output D bit mask. */
+#define PORTMUX_EVOUTD_bp  3  /* Event Output D bit position. */
+#define PORTMUX_EVOUTF_bm  0x20  /* Event Output F bit mask. */
+#define PORTMUX_EVOUTF_bp  5  /* Event Output F bit position. */
+
+/* PORTMUX.CCLROUTEA  bit masks and bit positions */
+#define PORTMUX_LUT0_bm  0x01  /* CCL Look-Up Table 0 Signals bit mask. */
+#define PORTMUX_LUT0_bp  0  /* CCL Look-Up Table 0 Signals bit position. */
+#define PORTMUX_LUT1_bm  0x02  /* CCL Look-Up Table 1 Signals bit mask. */
+#define PORTMUX_LUT1_bp  1  /* CCL Look-Up Table 1 Signals bit position. */
+#define PORTMUX_LUT2_bm  0x04  /* CCL Look-Up Table 2 Signals bit mask. */
+#define PORTMUX_LUT2_bp  2  /* CCL Look-Up Table 2 Signals bit position. */
+#define PORTMUX_LUT3_bm  0x08  /* CCL Look-Up Table 3 Signals bit mask. */
+#define PORTMUX_LUT3_bp  3  /* CCL Look-Up Table 3 Signals bit position. */
+
+/* PORTMUX.USARTROUTEA  bit masks and bit positions */
+#define PORTMUX_USART0_gm  0x07  /* USART0 Routing group mask. */
+#define PORTMUX_USART0_gp  0  /* USART0 Routing group position. */
+#define PORTMUX_USART0_0_bm  (1<<0)  /* USART0 Routing bit 0 mask. */
+#define PORTMUX_USART0_0_bp  0  /* USART0 Routing bit 0 position. */
+#define PORTMUX_USART0_1_bm  (1<<1)  /* USART0 Routing bit 1 mask. */
+#define PORTMUX_USART0_1_bp  1  /* USART0 Routing bit 1 position. */
+#define PORTMUX_USART0_2_bm  (1<<2)  /* USART0 Routing bit 2 mask. */
+#define PORTMUX_USART0_2_bp  2  /* USART0 Routing bit 2 position. */
+
+/* PORTMUX.SPIROUTEA  bit masks and bit positions */
+#define PORTMUX_SPI0_gm  0x07  /* SPI0 Signals group mask. */
+#define PORTMUX_SPI0_gp  0  /* SPI0 Signals group position. */
+#define PORTMUX_SPI0_0_bm  (1<<0)  /* SPI0 Signals bit 0 mask. */
+#define PORTMUX_SPI0_0_bp  0  /* SPI0 Signals bit 0 position. */
+#define PORTMUX_SPI0_1_bm  (1<<1)  /* SPI0 Signals bit 1 mask. */
+#define PORTMUX_SPI0_1_bp  1  /* SPI0 Signals bit 1 position. */
+#define PORTMUX_SPI0_2_bm  (1<<2)  /* SPI0 Signals bit 2 mask. */
+#define PORTMUX_SPI0_2_bp  2  /* SPI0 Signals bit 2 position. */
+
+/* PORTMUX.TWIROUTEA  bit masks and bit positions */
+#define PORTMUX_TWI0_gm  0x03  /* TWI0 Signals group mask. */
+#define PORTMUX_TWI0_gp  0  /* TWI0 Signals group position. */
+#define PORTMUX_TWI0_0_bm  (1<<0)  /* TWI0 Signals bit 0 mask. */
+#define PORTMUX_TWI0_0_bp  0  /* TWI0 Signals bit 0 position. */
+#define PORTMUX_TWI0_1_bm  (1<<1)  /* TWI0 Signals bit 1 mask. */
+#define PORTMUX_TWI0_1_bp  1  /* TWI0 Signals bit 1 position. */
+
+/* PORTMUX.TCEROUTEA  bit masks and bit positions */
+#define PORTMUX_TCE0_gm  0x0F  /* TCE0 Signals group mask. */
+#define PORTMUX_TCE0_gp  0  /* TCE0 Signals group position. */
+#define PORTMUX_TCE0_0_bm  (1<<0)  /* TCE0 Signals bit 0 mask. */
+#define PORTMUX_TCE0_0_bp  0  /* TCE0 Signals bit 0 position. */
+#define PORTMUX_TCE0_1_bm  (1<<1)  /* TCE0 Signals bit 1 mask. */
+#define PORTMUX_TCE0_1_bp  1  /* TCE0 Signals bit 1 position. */
+#define PORTMUX_TCE0_2_bm  (1<<2)  /* TCE0 Signals bit 2 mask. */
+#define PORTMUX_TCE0_2_bp  2  /* TCE0 Signals bit 2 position. */
+#define PORTMUX_TCE0_3_bm  (1<<3)  /* TCE0 Signals bit 3 mask. */
+#define PORTMUX_TCE0_3_bp  3  /* TCE0 Signals bit 3 position. */
+
+/* PORTMUX.TCBROUTEA  bit masks and bit positions */
+#define PORTMUX_TCB0_bm  0x01  /* TCB0 Output bit mask. */
+#define PORTMUX_TCB0_bp  0  /* TCB0 Output bit position. */
+#define PORTMUX_TCB1_bm  0x02  /* TCB1 Output bit mask. */
+#define PORTMUX_TCB1_bp  1  /* TCB1 Output bit position. */
+
+/* PORTMUX.TCFROUTEA  bit masks and bit positions */
+#define PORTMUX_TCF0_gm  0x03  /* TCF0 Output group mask. */
+#define PORTMUX_TCF0_gp  0  /* TCF0 Output group position. */
+#define PORTMUX_TCF0_0_bm  (1<<0)  /* TCF0 Output bit 0 mask. */
+#define PORTMUX_TCF0_0_bp  0  /* TCF0 Output bit 0 position. */
+#define PORTMUX_TCF0_1_bm  (1<<1)  /* TCF0 Output bit 1 mask. */
+#define PORTMUX_TCF0_1_bp  1  /* TCF0 Output bit 1 position. */
+
+
+/* RSTCTRL - Reset controller */
+/* RSTCTRL.RSTFR  bit masks and bit positions */
+#define RSTCTRL_PORF_bm  0x01  /* Power on Reset flag bit mask. */
+#define RSTCTRL_PORF_bp  0  /* Power on Reset flag bit position. */
+#define RSTCTRL_BORF_bm  0x02  /* Brown out detector Reset flag bit mask. */
+#define RSTCTRL_BORF_bp  1  /* Brown out detector Reset flag bit position. */
+#define RSTCTRL_EXTRF_bm  0x04  /* External Reset flag bit mask. */
+#define RSTCTRL_EXTRF_bp  2  /* External Reset flag bit position. */
+#define RSTCTRL_WDRF_bm  0x08  /* Watch dog Reset flag bit mask. */
+#define RSTCTRL_WDRF_bp  3  /* Watch dog Reset flag bit position. */
+#define RSTCTRL_SWRF_bm  0x10  /* Software Reset flag bit mask. */
+#define RSTCTRL_SWRF_bp  4  /* Software Reset flag bit position. */
+#define RSTCTRL_UPDIRF_bm  0x20  /* UPDI Reset flag bit mask. */
+#define RSTCTRL_UPDIRF_bp  5  /* UPDI Reset flag bit position. */
+
+/* RSTCTRL.SWRR  bit masks and bit positions */
+#define RSTCTRL_SWRE_bm  0x01  /* Software Reset Enable bit mask. */
+#define RSTCTRL_SWRE_bp  0  /* Software Reset Enable bit position. */
+
+
+/* RTC - Real-Time Counter */
+/* RTC.CTRLA  bit masks and bit positions */
+#define RTC_RTCEN_bm  0x01  /* Enable bit mask. */
+#define RTC_RTCEN_bp  0  /* Enable bit position. */
+#define RTC_CORREN_bm  0x04  /* Correction enable bit mask. */
+#define RTC_CORREN_bp  2  /* Correction enable bit position. */
+#define RTC_PRESCALER_gm  0x78  /* Prescaling Factor group mask. */
+#define RTC_PRESCALER_gp  3  /* Prescaling Factor group position. */
+#define RTC_PRESCALER_0_bm  (1<<3)  /* Prescaling Factor bit 0 mask. */
+#define RTC_PRESCALER_0_bp  3  /* Prescaling Factor bit 0 position. */
+#define RTC_PRESCALER_1_bm  (1<<4)  /* Prescaling Factor bit 1 mask. */
+#define RTC_PRESCALER_1_bp  4  /* Prescaling Factor bit 1 position. */
+#define RTC_PRESCALER_2_bm  (1<<5)  /* Prescaling Factor bit 2 mask. */
+#define RTC_PRESCALER_2_bp  5  /* Prescaling Factor bit 2 position. */
+#define RTC_PRESCALER_3_bm  (1<<6)  /* Prescaling Factor bit 3 mask. */
+#define RTC_PRESCALER_3_bp  6  /* Prescaling Factor bit 3 position. */
+#define RTC_RUNSTDBY_bm  0x80  /* Run In Standby bit mask. */
+#define RTC_RUNSTDBY_bp  7  /* Run In Standby bit position. */
+
+/* RTC.STATUS  bit masks and bit positions */
+#define RTC_CTRLABUSY_bm  0x01  /* CTRLA Synchronization Busy Flag bit mask. */
+#define RTC_CTRLABUSY_bp  0  /* CTRLA Synchronization Busy Flag bit position. */
+#define RTC_CNTBUSY_bm  0x02  /* Count Synchronization Busy Flag bit mask. */
+#define RTC_CNTBUSY_bp  1  /* Count Synchronization Busy Flag bit position. */
+#define RTC_PERBUSY_bm  0x04  /* Period Synchronization Busy Flag bit mask. */
+#define RTC_PERBUSY_bp  2  /* Period Synchronization Busy Flag bit position. */
+#define RTC_CMPBUSY_bm  0x08  /* Comparator Synchronization Busy Flag bit mask. */
+#define RTC_CMPBUSY_bp  3  /* Comparator Synchronization Busy Flag bit position. */
+
+/* RTC.INTCTRL  bit masks and bit positions */
+#define RTC_OVF_bm  0x01  /* Overflow Interrupt enable bit mask. */
+#define RTC_OVF_bp  0  /* Overflow Interrupt enable bit position. */
+#define RTC_CMP_bm  0x02  /* Compare Match Interrupt enable bit mask. */
+#define RTC_CMP_bp  1  /* Compare Match Interrupt enable bit position. */
+
+/* RTC.INTFLAGS  bit masks and bit positions */
+/* RTC_OVF  is already defined. */
+/* RTC_CMP  is already defined. */
+
+/* RTC.DBGCTRL  bit masks and bit positions */
+#define RTC_DBGRUN_bm  0x01  /* Run in debug bit mask. */
+#define RTC_DBGRUN_bp  0  /* Run in debug bit position. */
+
+/* RTC.CALIB  bit masks and bit positions */
+#define RTC_ERROR_gm  0x7F  /* Error Correction Value group mask. */
+#define RTC_ERROR_gp  0  /* Error Correction Value group position. */
+#define RTC_ERROR_0_bm  (1<<0)  /* Error Correction Value bit 0 mask. */
+#define RTC_ERROR_0_bp  0  /* Error Correction Value bit 0 position. */
+#define RTC_ERROR_1_bm  (1<<1)  /* Error Correction Value bit 1 mask. */
+#define RTC_ERROR_1_bp  1  /* Error Correction Value bit 1 position. */
+#define RTC_ERROR_2_bm  (1<<2)  /* Error Correction Value bit 2 mask. */
+#define RTC_ERROR_2_bp  2  /* Error Correction Value bit 2 position. */
+#define RTC_ERROR_3_bm  (1<<3)  /* Error Correction Value bit 3 mask. */
+#define RTC_ERROR_3_bp  3  /* Error Correction Value bit 3 position. */
+#define RTC_ERROR_4_bm  (1<<4)  /* Error Correction Value bit 4 mask. */
+#define RTC_ERROR_4_bp  4  /* Error Correction Value bit 4 position. */
+#define RTC_ERROR_5_bm  (1<<5)  /* Error Correction Value bit 5 mask. */
+#define RTC_ERROR_5_bp  5  /* Error Correction Value bit 5 position. */
+#define RTC_ERROR_6_bm  (1<<6)  /* Error Correction Value bit 6 mask. */
+#define RTC_ERROR_6_bp  6  /* Error Correction Value bit 6 position. */
+#define RTC_SIGN_bm  0x80  /* Error Correction Sign Bit bit mask. */
+#define RTC_SIGN_bp  7  /* Error Correction Sign Bit bit position. */
+
+/* RTC.CLKSEL  bit masks and bit positions */
+#define RTC_CLKSEL_gm  0x03  /* Clock Select group mask. */
+#define RTC_CLKSEL_gp  0  /* Clock Select group position. */
+#define RTC_CLKSEL_0_bm  (1<<0)  /* Clock Select bit 0 mask. */
+#define RTC_CLKSEL_0_bp  0  /* Clock Select bit 0 position. */
+#define RTC_CLKSEL_1_bm  (1<<1)  /* Clock Select bit 1 mask. */
+#define RTC_CLKSEL_1_bp  1  /* Clock Select bit 1 position. */
+
+/* RTC.PITCTRLA  bit masks and bit positions */
+#define RTC_PITEN_bm  0x01  /* Enable bit mask. */
+#define RTC_PITEN_bp  0  /* Enable bit position. */
+#define RTC_PERIOD_gm  0x78  /* Period group mask. */
+#define RTC_PERIOD_gp  3  /* Period group position. */
+#define RTC_PERIOD_0_bm  (1<<3)  /* Period bit 0 mask. */
+#define RTC_PERIOD_0_bp  3  /* Period bit 0 position. */
+#define RTC_PERIOD_1_bm  (1<<4)  /* Period bit 1 mask. */
+#define RTC_PERIOD_1_bp  4  /* Period bit 1 position. */
+#define RTC_PERIOD_2_bm  (1<<5)  /* Period bit 2 mask. */
+#define RTC_PERIOD_2_bp  5  /* Period bit 2 position. */
+#define RTC_PERIOD_3_bm  (1<<6)  /* Period bit 3 mask. */
+#define RTC_PERIOD_3_bp  6  /* Period bit 3 position. */
+
+/* RTC.PITSTATUS  bit masks and bit positions */
+#define RTC_CTRLBUSY_bm  0x01  /* CTRLA Synchronization Busy Flag bit mask. */
+#define RTC_CTRLBUSY_bp  0  /* CTRLA Synchronization Busy Flag bit position. */
+
+/* RTC.PITINTCTRL  bit masks and bit positions */
+#define RTC_PI_bm  0x01  /* Periodic Interrupt bit mask. */
+#define RTC_PI_bp  0  /* Periodic Interrupt bit position. */
+
+/* RTC.PITINTFLAGS  bit masks and bit positions */
+/* RTC_PI  is already defined. */
+
+/* RTC.PITDBGCTRL  bit masks and bit positions */
+/* RTC_DBGRUN  is already defined. */
+
+/* RTC.PITEVGENCTRLA  bit masks and bit positions */
+#define RTC_EVGEN0SEL_gm  0x0F  /* Event Generation 0 Select group mask. */
+#define RTC_EVGEN0SEL_gp  0  /* Event Generation 0 Select group position. */
+#define RTC_EVGEN0SEL_0_bm  (1<<0)  /* Event Generation 0 Select bit 0 mask. */
+#define RTC_EVGEN0SEL_0_bp  0  /* Event Generation 0 Select bit 0 position. */
+#define RTC_EVGEN0SEL_1_bm  (1<<1)  /* Event Generation 0 Select bit 1 mask. */
+#define RTC_EVGEN0SEL_1_bp  1  /* Event Generation 0 Select bit 1 position. */
+#define RTC_EVGEN0SEL_2_bm  (1<<2)  /* Event Generation 0 Select bit 2 mask. */
+#define RTC_EVGEN0SEL_2_bp  2  /* Event Generation 0 Select bit 2 position. */
+#define RTC_EVGEN0SEL_3_bm  (1<<3)  /* Event Generation 0 Select bit 3 mask. */
+#define RTC_EVGEN0SEL_3_bp  3  /* Event Generation 0 Select bit 3 position. */
+#define RTC_EVGEN1SEL_gm  0xF0  /* Event Generation 1 Select group mask. */
+#define RTC_EVGEN1SEL_gp  4  /* Event Generation 1 Select group position. */
+#define RTC_EVGEN1SEL_0_bm  (1<<4)  /* Event Generation 1 Select bit 0 mask. */
+#define RTC_EVGEN1SEL_0_bp  4  /* Event Generation 1 Select bit 0 position. */
+#define RTC_EVGEN1SEL_1_bm  (1<<5)  /* Event Generation 1 Select bit 1 mask. */
+#define RTC_EVGEN1SEL_1_bp  5  /* Event Generation 1 Select bit 1 position. */
+#define RTC_EVGEN1SEL_2_bm  (1<<6)  /* Event Generation 1 Select bit 2 mask. */
+#define RTC_EVGEN1SEL_2_bp  6  /* Event Generation 1 Select bit 2 position. */
+#define RTC_EVGEN1SEL_3_bm  (1<<7)  /* Event Generation 1 Select bit 3 mask. */
+#define RTC_EVGEN1SEL_3_bp  7  /* Event Generation 1 Select bit 3 position. */
+
+
+
+/* SLPCTRL - Sleep Controller */
+/* SLPCTRL.CTRLA  bit masks and bit positions */
+#define SLPCTRL_SEN_bm  0x01  /* Sleep enable bit mask. */
+#define SLPCTRL_SEN_bp  0  /* Sleep enable bit position. */
+#define SLPCTRL_SMODE_gm  0x06  /* Sleep mode group mask. */
+#define SLPCTRL_SMODE_gp  1  /* Sleep mode group position. */
+#define SLPCTRL_SMODE_0_bm  (1<<1)  /* Sleep mode bit 0 mask. */
+#define SLPCTRL_SMODE_0_bp  1  /* Sleep mode bit 0 position. */
+#define SLPCTRL_SMODE_1_bm  (1<<2)  /* Sleep mode bit 1 mask. */
+#define SLPCTRL_SMODE_1_bp  2  /* Sleep mode bit 1 position. */
+
+
+/* SPI - Serial Peripheral Interface */
+/* SPI.CTRLA  bit masks and bit positions */
+#define SPI_ENABLE_bm  0x01  /* Enable Module bit mask. */
+#define SPI_ENABLE_bp  0  /* Enable Module bit position. */
+#define SPI_PRESC_gm  0x06  /* Prescaler group mask. */
+#define SPI_PRESC_gp  1  /* Prescaler group position. */
+#define SPI_PRESC_0_bm  (1<<1)  /* Prescaler bit 0 mask. */
+#define SPI_PRESC_0_bp  1  /* Prescaler bit 0 position. */
+#define SPI_PRESC_1_bm  (1<<2)  /* Prescaler bit 1 mask. */
+#define SPI_PRESC_1_bp  2  /* Prescaler bit 1 position. */
+#define SPI_CLK2X_bm  0x10  /* Enable Double Speed bit mask. */
+#define SPI_CLK2X_bp  4  /* Enable Double Speed bit position. */
+#define SPI_MASTER_bm  0x20  /* Host Operation Enable bit mask. */
+#define SPI_MASTER_bp  5  /* Host Operation Enable bit position. */
+#define SPI_DORD_bm  0x40  /* Data Order Setting bit mask. */
+#define SPI_DORD_bp  6  /* Data Order Setting bit position. */
+
+/* SPI.CTRLB  bit masks and bit positions */
+#define SPI_MODE_gm  0x03  /* SPI Mode group mask. */
+#define SPI_MODE_gp  0  /* SPI Mode group position. */
+#define SPI_MODE_0_bm  (1<<0)  /* SPI Mode bit 0 mask. */
+#define SPI_MODE_0_bp  0  /* SPI Mode bit 0 position. */
+#define SPI_MODE_1_bm  (1<<1)  /* SPI Mode bit 1 mask. */
+#define SPI_MODE_1_bp  1  /* SPI Mode bit 1 position. */
+#define SPI_SSD_bm  0x04  /* SPI Select Disable bit mask. */
+#define SPI_SSD_bp  2  /* SPI Select Disable bit position. */
+#define SPI_BUFWR_bm  0x40  /* Buffer Mode Wait for Receive bit mask. */
+#define SPI_BUFWR_bp  6  /* Buffer Mode Wait for Receive bit position. */
+#define SPI_BUFEN_bm  0x80  /* Buffer Mode Enable bit mask. */
+#define SPI_BUFEN_bp  7  /* Buffer Mode Enable bit position. */
+
+/* SPI.INTCTRL  bit masks and bit positions */
+#define SPI_IE_bm  0x01  /* Interrupt Enable bit mask. */
+#define SPI_IE_bp  0  /* Interrupt Enable bit position. */
+#define SPI_SSIE_bm  0x10  /* SPI Select Trigger Interrupt Enable bit mask. */
+#define SPI_SSIE_bp  4  /* SPI Select Trigger Interrupt Enable bit position. */
+#define SPI_DREIE_bm  0x20  /* Data Register Empty Interrupt Enable bit mask. */
+#define SPI_DREIE_bp  5  /* Data Register Empty Interrupt Enable bit position. */
+#define SPI_TXCIE_bm  0x40  /* Transfer Complete Interrupt Enable bit mask. */
+#define SPI_TXCIE_bp  6  /* Transfer Complete Interrupt Enable bit position. */
+#define SPI_RXCIE_bm  0x80  /* Receive Complete Interrupt Enable bit mask. */
+#define SPI_RXCIE_bp  7  /* Receive Complete Interrupt Enable bit position. */
+
+/* SPI.INTFLAGS  bit masks and bit positions */
+#define SPI_BUFOVF_bm  0x01  /* Buffer Overflow bit mask. */
+#define SPI_BUFOVF_bp  0  /* Buffer Overflow bit position. */
+#define SPI_SSIF_bm  0x10  /* SPI Select Trigger Interrupt Flag bit mask. */
+#define SPI_SSIF_bp  4  /* SPI Select Trigger Interrupt Flag bit position. */
+#define SPI_DREIF_bm  0x20  /* Data Register Empty Interrupt Flag bit mask. */
+#define SPI_DREIF_bp  5  /* Data Register Empty Interrupt Flag bit position. */
+#define SPI_TXCIF_bm  0x40  /* Transfer Complete Interrupt Flag bit mask. */
+#define SPI_TXCIF_bp  6  /* Transfer Complete Interrupt Flag bit position. */
+#define SPI_WRCOL_bm  0x40  /* Write Collision bit mask. */
+#define SPI_WRCOL_bp  6  /* Write Collision bit position. */
+#define SPI_RXCIF_bm  0x80  /* Receive Complete Interrupt Flag bit mask. */
+#define SPI_RXCIF_bp  7  /* Receive Complete Interrupt Flag bit position. */
+#define SPI_IF_bm  0x80  /* Interrupt Flag bit mask. */
+#define SPI_IF_bp  7  /* Interrupt Flag bit position. */
+
+
+/* SYSCFG - System Configuration Registers */
+/* SYSCFG.REVID  bit masks and bit positions */
+#define SYSCFG_MINOR_gm  0x0F  /* Minor Revision group mask. */
+#define SYSCFG_MINOR_gp  0  /* Minor Revision group position. */
+#define SYSCFG_MINOR_0_bm  (1<<0)  /* Minor Revision bit 0 mask. */
+#define SYSCFG_MINOR_0_bp  0  /* Minor Revision bit 0 position. */
+#define SYSCFG_MINOR_1_bm  (1<<1)  /* Minor Revision bit 1 mask. */
+#define SYSCFG_MINOR_1_bp  1  /* Minor Revision bit 1 position. */
+#define SYSCFG_MINOR_2_bm  (1<<2)  /* Minor Revision bit 2 mask. */
+#define SYSCFG_MINOR_2_bp  2  /* Minor Revision bit 2 position. */
+#define SYSCFG_MINOR_3_bm  (1<<3)  /* Minor Revision bit 3 mask. */
+#define SYSCFG_MINOR_3_bp  3  /* Minor Revision bit 3 position. */
+#define SYSCFG_MAJOR_gm  0xF0  /* Major Revision group mask. */
+#define SYSCFG_MAJOR_gp  4  /* Major Revision group position. */
+#define SYSCFG_MAJOR_0_bm  (1<<4)  /* Major Revision bit 0 mask. */
+#define SYSCFG_MAJOR_0_bp  4  /* Major Revision bit 0 position. */
+#define SYSCFG_MAJOR_1_bm  (1<<5)  /* Major Revision bit 1 mask. */
+#define SYSCFG_MAJOR_1_bp  5  /* Major Revision bit 1 position. */
+#define SYSCFG_MAJOR_2_bm  (1<<6)  /* Major Revision bit 2 mask. */
+#define SYSCFG_MAJOR_2_bp  6  /* Major Revision bit 2 position. */
+#define SYSCFG_MAJOR_3_bm  (1<<7)  /* Major Revision bit 3 mask. */
+#define SYSCFG_MAJOR_3_bp  7  /* Major Revision bit 3 position. */
+
+
+/* TCB - 16-bit Timer/Counter Type B */
+/* TCB.CTRLA  bit masks and bit positions */
+#define TCB_ENABLE_bm  0x01  /* Enable bit mask. */
+#define TCB_ENABLE_bp  0  /* Enable bit position. */
+#define TCB_CLKSEL_gm  0x0E  /* Clock Select group mask. */
+#define TCB_CLKSEL_gp  1  /* Clock Select group position. */
+#define TCB_CLKSEL_0_bm  (1<<1)  /* Clock Select bit 0 mask. */
+#define TCB_CLKSEL_0_bp  1  /* Clock Select bit 0 position. */
+#define TCB_CLKSEL_1_bm  (1<<2)  /* Clock Select bit 1 mask. */
+#define TCB_CLKSEL_1_bp  2  /* Clock Select bit 1 position. */
+#define TCB_CLKSEL_2_bm  (1<<3)  /* Clock Select bit 2 mask. */
+#define TCB_CLKSEL_2_bp  3  /* Clock Select bit 2 position. */
+#define TCB_SYNCUPD_bm  0x10  /* Synchronize Update bit mask. */
+#define TCB_SYNCUPD_bp  4  /* Synchronize Update bit position. */
+#define TCB_CASCADE_bm  0x20  /* Cascade two timers bit mask. */
+#define TCB_CASCADE_bp  5  /* Cascade two timers bit position. */
+#define TCB_RUNSTDBY_bm  0x40  /* Run Standby bit mask. */
+#define TCB_RUNSTDBY_bp  6  /* Run Standby bit position. */
+
+/* TCB.CTRLB  bit masks and bit positions */
+#define TCB_CNTMODE_gm  0x07  /* Timer Mode group mask. */
+#define TCB_CNTMODE_gp  0  /* Timer Mode group position. */
+#define TCB_CNTMODE_0_bm  (1<<0)  /* Timer Mode bit 0 mask. */
+#define TCB_CNTMODE_0_bp  0  /* Timer Mode bit 0 position. */
+#define TCB_CNTMODE_1_bm  (1<<1)  /* Timer Mode bit 1 mask. */
+#define TCB_CNTMODE_1_bp  1  /* Timer Mode bit 1 position. */
+#define TCB_CNTMODE_2_bm  (1<<2)  /* Timer Mode bit 2 mask. */
+#define TCB_CNTMODE_2_bp  2  /* Timer Mode bit 2 position. */
+#define TCB_CCMPEN_bm  0x10  /* Pin Output Enable bit mask. */
+#define TCB_CCMPEN_bp  4  /* Pin Output Enable bit position. */
+#define TCB_CCMPINIT_bm  0x20  /* Pin Initial State bit mask. */
+#define TCB_CCMPINIT_bp  5  /* Pin Initial State bit position. */
+#define TCB_ASYNC_bm  0x40  /* Asynchronous Enable bit mask. */
+#define TCB_ASYNC_bp  6  /* Asynchronous Enable bit position. */
+#define TCB_EVGEN_bm  0x80  /* Event Generation bit mask. */
+#define TCB_EVGEN_bp  7  /* Event Generation bit position. */
+
+/* TCB.CTRLC  bit masks and bit positions */
+#define TCB_CNTSIZE_gm  0x07  /* Counter Size group mask. */
+#define TCB_CNTSIZE_gp  0  /* Counter Size group position. */
+#define TCB_CNTSIZE_0_bm  (1<<0)  /* Counter Size bit 0 mask. */
+#define TCB_CNTSIZE_0_bp  0  /* Counter Size bit 0 position. */
+#define TCB_CNTSIZE_1_bm  (1<<1)  /* Counter Size bit 1 mask. */
+#define TCB_CNTSIZE_1_bp  1  /* Counter Size bit 1 position. */
+#define TCB_CNTSIZE_2_bm  (1<<2)  /* Counter Size bit 2 mask. */
+#define TCB_CNTSIZE_2_bp  2  /* Counter Size bit 2 position. */
+
+/* TCB.EVCTRL  bit masks and bit positions */
+#define TCB_CAPTEI_bm  0x01  /* Event Input Enable bit mask. */
+#define TCB_CAPTEI_bp  0  /* Event Input Enable bit position. */
+#define TCB_EDGE_bm  0x10  /* Event Edge bit mask. */
+#define TCB_EDGE_bp  4  /* Event Edge bit position. */
+#define TCB_FILTER_bm  0x40  /* Input Capture Noise Cancellation Filter bit mask. */
+#define TCB_FILTER_bp  6  /* Input Capture Noise Cancellation Filter bit position. */
+
+/* TCB.INTCTRL  bit masks and bit positions */
+#define TCB_CAPT_bm  0x01  /* Capture or Timeout bit mask. */
+#define TCB_CAPT_bp  0  /* Capture or Timeout bit position. */
+#define TCB_OVF_bm  0x02  /* Overflow bit mask. */
+#define TCB_OVF_bp  1  /* Overflow bit position. */
+
+/* TCB.INTFLAGS  bit masks and bit positions */
+/* TCB_CAPT  is already defined. */
+/* TCB_OVF  is already defined. */
+
+/* TCB.STATUS  bit masks and bit positions */
+#define TCB_RUN_bm  0x01  /* Run bit mask. */
+#define TCB_RUN_bp  0  /* Run bit position. */
+
+/* TCB.DBGCTRL  bit masks and bit positions */
+#define TCB_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define TCB_DBGRUN_bp  0  /* Debug Run bit position. */
+
+
+/* TCE - 16-bit Timer/Counter Type E */
+/* TCE.CTRLA  bit masks and bit positions */
+#define TCE_ENABLE_bm  0x01  /* Module Enable bit mask. */
+#define TCE_ENABLE_bp  0  /* Module Enable bit position. */
+#define TCE_CLKSEL_gm  0x0E  /* Clock Selection group mask. */
+#define TCE_CLKSEL_gp  1  /* Clock Selection group position. */
+#define TCE_CLKSEL_0_bm  (1<<1)  /* Clock Selection bit 0 mask. */
+#define TCE_CLKSEL_0_bp  1  /* Clock Selection bit 0 position. */
+#define TCE_CLKSEL_1_bm  (1<<2)  /* Clock Selection bit 1 mask. */
+#define TCE_CLKSEL_1_bp  2  /* Clock Selection bit 1 position. */
+#define TCE_CLKSEL_2_bm  (1<<3)  /* Clock Selection bit 2 mask. */
+#define TCE_CLKSEL_2_bp  3  /* Clock Selection bit 2 position. */
+#define TCE_RUNSTDBY_bm  0x80  /* Run in Standby bit mask. */
+#define TCE_RUNSTDBY_bp  7  /* Run in Standby bit position. */
+
+/* TCE.CTRLB  bit masks and bit positions */
+#define TCE_WGMODE_gm  0x07  /* Waveform generation mode group mask. */
+#define TCE_WGMODE_gp  0  /* Waveform generation mode group position. */
+#define TCE_WGMODE_0_bm  (1<<0)  /* Waveform generation mode bit 0 mask. */
+#define TCE_WGMODE_0_bp  0  /* Waveform generation mode bit 0 position. */
+#define TCE_WGMODE_1_bm  (1<<1)  /* Waveform generation mode bit 1 mask. */
+#define TCE_WGMODE_1_bp  1  /* Waveform generation mode bit 1 position. */
+#define TCE_WGMODE_2_bm  (1<<2)  /* Waveform generation mode bit 2 mask. */
+#define TCE_WGMODE_2_bp  2  /* Waveform generation mode bit 2 position. */
+#define TCE_ALUPD_bm  0x08  /* Auto Lock Update bit mask. */
+#define TCE_ALUPD_bp  3  /* Auto Lock Update bit position. */
+#define TCE_CMP0EN_bm  0x10  /* Compare 0 Enable bit mask. */
+#define TCE_CMP0EN_bp  4  /* Compare 0 Enable bit position. */
+#define TCE_CMP1EN_bm  0x20  /* Compare 1 Enable bit mask. */
+#define TCE_CMP1EN_bp  5  /* Compare 1 Enable bit position. */
+#define TCE_CMP2EN_bm  0x40  /* Compare 2 Enable bit mask. */
+#define TCE_CMP2EN_bp  6  /* Compare 2 Enable bit position. */
+#define TCE_CMP3EN_bm  0x80  /* Compare 3 Enable bit mask. */
+#define TCE_CMP3EN_bp  7  /* Compare 3 Enable bit position. */
+
+/* TCE.CTRLC  bit masks and bit positions */
+#define TCE_CMP0OV_bm  0x01  /* Compare 0 Waveform Output Value bit mask. */
+#define TCE_CMP0OV_bp  0  /* Compare 0 Waveform Output Value bit position. */
+#define TCE_CMP1OV_bm  0x02  /* Compare 1 Waveform Output Value bit mask. */
+#define TCE_CMP1OV_bp  1  /* Compare 1 Waveform Output Value bit position. */
+#define TCE_CMP2OV_bm  0x04  /* Compare 2 Waveform Output Value bit mask. */
+#define TCE_CMP2OV_bp  2  /* Compare 2 Waveform Output Value bit position. */
+#define TCE_CMP3OV_bm  0x08  /* Compare 3 Waveform Output Value bit mask. */
+#define TCE_CMP3OV_bp  3  /* Compare 3 Waveform Output Value bit position. */
+#define TCE_CMP0POL_bm  0x10  /* Compare 0 Polarity bit mask. */
+#define TCE_CMP0POL_bp  4  /* Compare 0 Polarity bit position. */
+#define TCE_CMP1POL_bm  0x20  /* Compare 1 Polarity bit mask. */
+#define TCE_CMP1POL_bp  5  /* Compare 1 Polarity bit position. */
+#define TCE_CMP2POL_bm  0x40  /* Compare 2 Polarity bit mask. */
+#define TCE_CMP2POL_bp  6  /* Compare 2 Polarity bit position. */
+#define TCE_CMP3POL_bm  0x80  /* Compare 3 Polarity bit mask. */
+#define TCE_CMP3POL_bp  7  /* Compare 3 Polarity bit position. */
+
+/* TCE.CTRLD  bit masks and bit positions */
+#define TCE_SCALE_bm  0x04  /* Scaled Write bit mask. */
+#define TCE_SCALE_bp  2  /* Scaled Write bit position. */
+#define TCE_AMPEN_bm  0x08  /* Amplitude Control Enable bit mask. */
+#define TCE_AMPEN_bp  3  /* Amplitude Control Enable bit position. */
+#define TCE_SCALEMODE_gm  0x30  /* Scaling Mode group mask. */
+#define TCE_SCALEMODE_gp  4  /* Scaling Mode group position. */
+#define TCE_SCALEMODE_0_bm  (1<<4)  /* Scaling Mode bit 0 mask. */
+#define TCE_SCALEMODE_0_bp  4  /* Scaling Mode bit 0 position. */
+#define TCE_SCALEMODE_1_bm  (1<<5)  /* Scaling Mode bit 1 mask. */
+#define TCE_SCALEMODE_1_bp  5  /* Scaling Mode bit 1 position. */
+#define TCE_HREN_gm  0xC0  /* High Resolution Enable group mask. */
+#define TCE_HREN_gp  6  /* High Resolution Enable group position. */
+#define TCE_HREN_0_bm  (1<<6)  /* High Resolution Enable bit 0 mask. */
+#define TCE_HREN_0_bp  6  /* High Resolution Enable bit 0 position. */
+#define TCE_HREN_1_bm  (1<<7)  /* High Resolution Enable bit 1 mask. */
+#define TCE_HREN_1_bp  7  /* High Resolution Enable bit 1 position. */
+
+/* TCE.CTRLECLR  bit masks and bit positions */
+#define TCE_DIR_bm  0x01  /* Direction bit mask. */
+#define TCE_DIR_bp  0  /* Direction bit position. */
+#define TCE_LUPD_bm  0x02  /* Lock Update bit mask. */
+#define TCE_LUPD_bp  1  /* Lock Update bit position. */
+#define TCE_CMD_gm  0x0C  /* Command group mask. */
+#define TCE_CMD_gp  2  /* Command group position. */
+#define TCE_CMD_0_bm  (1<<2)  /* Command bit 0 mask. */
+#define TCE_CMD_0_bp  2  /* Command bit 0 position. */
+#define TCE_CMD_1_bm  (1<<3)  /* Command bit 1 mask. */
+#define TCE_CMD_1_bp  3  /* Command bit 1 position. */
+
+/* TCE.CTRLESET  bit masks and bit positions */
+/* TCE_DIR  is already defined. */
+/* TCE_LUPD  is already defined. */
+/* TCE_CMD  is already defined. */
+
+/* TCE.CTRLFCLR  bit masks and bit positions */
+#define TCE_PERBV_bm  0x01  /* Period Buffer Valid bit mask. */
+#define TCE_PERBV_bp  0  /* Period Buffer Valid bit position. */
+#define TCE_CMP0BV_bm  0x02  /* Compare 0 Buffer Valid bit mask. */
+#define TCE_CMP0BV_bp  1  /* Compare 0 Buffer Valid bit position. */
+#define TCE_CMP1BV_bm  0x04  /* Compare 1 Buffer Valid bit mask. */
+#define TCE_CMP1BV_bp  2  /* Compare 1 Buffer Valid bit position. */
+#define TCE_CMP2BV_bm  0x08  /* Compare 2 Buffer Valid bit mask. */
+#define TCE_CMP2BV_bp  3  /* Compare 2 Buffer Valid bit position. */
+#define TCE_CMP3BV_bm  0x10  /* Compare 3 Buffer Valid bit mask. */
+#define TCE_CMP3BV_bp  4  /* Compare 3 Buffer Valid bit position. */
+
+/* TCE.CTRLFSET  bit masks and bit positions */
+/* TCE_PERBV  is already defined. */
+/* TCE_CMP0BV  is already defined. */
+/* TCE_CMP1BV  is already defined. */
+/* TCE_CMP2BV  is already defined. */
+/* TCE_CMP3BV  is already defined. */
+
+/* TCE.EVGENCTRL  bit masks and bit positions */
+#define TCE_CMP0EV_bm  0x10  /* Compare 0 Event bit mask. */
+#define TCE_CMP0EV_bp  4  /* Compare 0 Event bit position. */
+#define TCE_CMP1EV_bm  0x20  /* Compare 1 Event bit mask. */
+#define TCE_CMP1EV_bp  5  /* Compare 1 Event bit position. */
+#define TCE_CMP2EV_bm  0x40  /* Compare 2 Event bit mask. */
+#define TCE_CMP2EV_bp  6  /* Compare 2 Event bit position. */
+#define TCE_CMP3EV_bm  0x80  /* Compare 3 Event bit mask. */
+#define TCE_CMP3EV_bp  7  /* Compare 3 Event bit position. */
+
+/* TCE.EVCTRL  bit masks and bit positions */
+#define TCE_CNTAEI_bm  0x01  /* Count on Event Input A bit mask. */
+#define TCE_CNTAEI_bp  0  /* Count on Event Input A bit position. */
+#define TCE_EVACTA_gm  0x0E  /* Event Action A group mask. */
+#define TCE_EVACTA_gp  1  /* Event Action A group position. */
+#define TCE_EVACTA_0_bm  (1<<1)  /* Event Action A bit 0 mask. */
+#define TCE_EVACTA_0_bp  1  /* Event Action A bit 0 position. */
+#define TCE_EVACTA_1_bm  (1<<2)  /* Event Action A bit 1 mask. */
+#define TCE_EVACTA_1_bp  2  /* Event Action A bit 1 position. */
+#define TCE_EVACTA_2_bm  (1<<3)  /* Event Action A bit 2 mask. */
+#define TCE_EVACTA_2_bp  3  /* Event Action A bit 2 position. */
+#define TCE_CNTBEI_bm  0x10  /* Count on Event Input B bit mask. */
+#define TCE_CNTBEI_bp  4  /* Count on Event Input B bit position. */
+#define TCE_EVACTB_gm  0xE0  /* Event Action B group mask. */
+#define TCE_EVACTB_gp  5  /* Event Action B group position. */
+#define TCE_EVACTB_0_bm  (1<<5)  /* Event Action B bit 0 mask. */
+#define TCE_EVACTB_0_bp  5  /* Event Action B bit 0 position. */
+#define TCE_EVACTB_1_bm  (1<<6)  /* Event Action B bit 1 mask. */
+#define TCE_EVACTB_1_bp  6  /* Event Action B bit 1 position. */
+#define TCE_EVACTB_2_bm  (1<<7)  /* Event Action B bit 2 mask. */
+#define TCE_EVACTB_2_bp  7  /* Event Action B bit 2 position. */
+
+/* TCE.INTCTRL  bit masks and bit positions */
+#define TCE_OVF_bm  0x01  /* Overflow Interrupt Enable bit mask. */
+#define TCE_OVF_bp  0  /* Overflow Interrupt Enable bit position. */
+#define TCE_CMP0_bm  0x10  /* Compare 0 Interrupt Enable bit mask. */
+#define TCE_CMP0_bp  4  /* Compare 0 Interrupt Enable bit position. */
+#define TCE_CMP1_bm  0x20  /* Compare 1 Interrupt Enable bit mask. */
+#define TCE_CMP1_bp  5  /* Compare 1 Interrupt Enable bit position. */
+#define TCE_CMP2_bm  0x40  /* Compare 2 Interrupt Enable bit mask. */
+#define TCE_CMP2_bp  6  /* Compare 2 Interrupt Enable bit position. */
+#define TCE_CMP3_bm  0x80  /* Compare 3 Interrupt Enable bit mask. */
+#define TCE_CMP3_bp  7  /* Compare 3 Interrupt Enable bit position. */
+
+/* TCE.INTFLAGS  bit masks and bit positions */
+/* TCE_OVF  is already defined. */
+/* TCE_CMP0  is already defined. */
+/* TCE_CMP1  is already defined. */
+/* TCE_CMP2  is already defined. */
+/* TCE_CMP3  is already defined. */
+
+/* TCE.DBGCTRL  bit masks and bit positions */
+#define TCE_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define TCE_DBGRUN_bp  0  /* Debug Run bit position. */
+
+
+/* TCF - 24-bit Timer/Counter for frequency generation */
+/* TCF.CTRLA  bit masks and bit positions */
+#define TCF_ENABLE_bm  0x01  /* Enable bit mask. */
+#define TCF_ENABLE_bp  0  /* Enable bit position. */
+#define TCF_PRESC_gm  0x0E  /* Clock Prescaler group mask. */
+#define TCF_PRESC_gp  1  /* Clock Prescaler group position. */
+#define TCF_PRESC_0_bm  (1<<1)  /* Clock Prescaler bit 0 mask. */
+#define TCF_PRESC_0_bp  1  /* Clock Prescaler bit 0 position. */
+#define TCF_PRESC_1_bm  (1<<2)  /* Clock Prescaler bit 1 mask. */
+#define TCF_PRESC_1_bp  2  /* Clock Prescaler bit 1 position. */
+#define TCF_PRESC_2_bm  (1<<3)  /* Clock Prescaler bit 2 mask. */
+#define TCF_PRESC_2_bp  3  /* Clock Prescaler bit 2 position. */
+#define TCF_RUNSTDBY_bm  0x80  /* Run Standby bit mask. */
+#define TCF_RUNSTDBY_bp  7  /* Run Standby bit position. */
+
+/* TCF.CTRLB  bit masks and bit positions */
+#define TCF_WGMODE_gm  0x07  /* Waveform Generation Mode group mask. */
+#define TCF_WGMODE_gp  0  /* Waveform Generation Mode group position. */
+#define TCF_WGMODE_0_bm  (1<<0)  /* Waveform Generation Mode bit 0 mask. */
+#define TCF_WGMODE_0_bp  0  /* Waveform Generation Mode bit 0 position. */
+#define TCF_WGMODE_1_bm  (1<<1)  /* Waveform Generation Mode bit 1 mask. */
+#define TCF_WGMODE_1_bp  1  /* Waveform Generation Mode bit 1 position. */
+#define TCF_WGMODE_2_bm  (1<<2)  /* Waveform Generation Mode bit 2 mask. */
+#define TCF_WGMODE_2_bp  2  /* Waveform Generation Mode bit 2 position. */
+#define TCF_CLKSEL_gm  0x38  /* Clock Select group mask. */
+#define TCF_CLKSEL_gp  3  /* Clock Select group position. */
+#define TCF_CLKSEL_0_bm  (1<<3)  /* Clock Select bit 0 mask. */
+#define TCF_CLKSEL_0_bp  3  /* Clock Select bit 0 position. */
+#define TCF_CLKSEL_1_bm  (1<<4)  /* Clock Select bit 1 mask. */
+#define TCF_CLKSEL_1_bp  4  /* Clock Select bit 1 position. */
+#define TCF_CLKSEL_2_bm  (1<<5)  /* Clock Select bit 2 mask. */
+#define TCF_CLKSEL_2_bp  5  /* Clock Select bit 2 position. */
+#define TCF_CMP0EV_bm  0x40  /* Compare 0 Event Generation bit mask. */
+#define TCF_CMP0EV_bp  6  /* Compare 0 Event Generation bit position. */
+#define TCF_CMP1EV_bm  0x80  /* Compare 1 Event Generation bit mask. */
+#define TCF_CMP1EV_bp  7  /* Compare 1 Event Generation bit position. */
+
+/* TCF.CTRLC  bit masks and bit positions */
+#define TCF_WO0EN_bm  0x01  /* Waveform Output 0 Enable bit mask. */
+#define TCF_WO0EN_bp  0  /* Waveform Output 0 Enable bit position. */
+#define TCF_WO1EN_bm  0x02  /* Waveform Output 1 Enable bit mask. */
+#define TCF_WO1EN_bp  1  /* Waveform Output 1 Enable bit position. */
+#define TCF_WO0POL_bm  0x04  /* Waveform Output 0 Polarity bit mask. */
+#define TCF_WO0POL_bp  2  /* Waveform Output 0 Polarity bit position. */
+#define TCF_WO1POL_bm  0x08  /* Waveform Output 1 Polarity bit mask. */
+#define TCF_WO1POL_bp  3  /* Waveform Output 1 Polarity bit position. */
+#define TCF_WGPULSE_gm  0x70  /* Waveform Generation Pulse Length group mask. */
+#define TCF_WGPULSE_gp  4  /* Waveform Generation Pulse Length group position. */
+#define TCF_WGPULSE_0_bm  (1<<4)  /* Waveform Generation Pulse Length bit 0 mask. */
+#define TCF_WGPULSE_0_bp  4  /* Waveform Generation Pulse Length bit 0 position. */
+#define TCF_WGPULSE_1_bm  (1<<5)  /* Waveform Generation Pulse Length bit 1 mask. */
+#define TCF_WGPULSE_1_bp  5  /* Waveform Generation Pulse Length bit 1 position. */
+#define TCF_WGPULSE_2_bm  (1<<6)  /* Waveform Generation Pulse Length bit 2 mask. */
+#define TCF_WGPULSE_2_bp  6  /* Waveform Generation Pulse Length bit 2 position. */
+
+/* TCF.CTRLD  bit masks and bit positions */
+#define TCF_CMD_gm  0x03  /* Command group mask. */
+#define TCF_CMD_gp  0  /* Command group position. */
+#define TCF_CMD_0_bm  (1<<0)  /* Command bit 0 mask. */
+#define TCF_CMD_0_bp  0  /* Command bit 0 position. */
+#define TCF_CMD_1_bm  (1<<1)  /* Command bit 1 mask. */
+#define TCF_CMD_1_bp  1  /* Command bit 1 position. */
+
+/* TCF.EVCTRL  bit masks and bit positions */
+#define TCF_CNTAEI_bm  0x01  /* Event A Input Enable bit mask. */
+#define TCF_CNTAEI_bp  0  /* Event A Input Enable bit position. */
+#define TCF_EVACTA_gm  0x06  /* Event Action A group mask. */
+#define TCF_EVACTA_gp  1  /* Event Action A group position. */
+#define TCF_EVACTA_0_bm  (1<<1)  /* Event Action A bit 0 mask. */
+#define TCF_EVACTA_0_bp  1  /* Event Action A bit 0 position. */
+#define TCF_EVACTA_1_bm  (1<<2)  /* Event Action A bit 1 mask. */
+#define TCF_EVACTA_1_bp  2  /* Event Action A bit 1 position. */
+#define TCF_FILTERA_bm  0x08  /* Event A Filter bit mask. */
+#define TCF_FILTERA_bp  3  /* Event A Filter bit position. */
+
+/* TCF.INTCTRL  bit masks and bit positions */
+#define TCF_OVF_bm  0x01  /* Overflow bit mask. */
+#define TCF_OVF_bp  0  /* Overflow bit position. */
+#define TCF_CMP0_bm  0x02  /* Compare 0 Interrupt Enable bit mask. */
+#define TCF_CMP0_bp  1  /* Compare 0 Interrupt Enable bit position. */
+#define TCF_CMP1_bm  0x04  /* Compare 1 Interrupt Enable bit mask. */
+#define TCF_CMP1_bp  2  /* Compare 1 Interrupt Enable bit position. */
+
+/* TCF.INTFLAGS  bit masks and bit positions */
+/* TCF_OVF  is already defined. */
+/* TCF_CMP0  is already defined. */
+/* TCF_CMP1  is already defined. */
+
+/* TCF.STATUS  bit masks and bit positions */
+#define TCF_CTRLABUSY_bm  0x02  /* Control A Synchronization Busy bit mask. */
+#define TCF_CTRLABUSY_bp  1  /* Control A Synchronization Busy bit position. */
+#define TCF_CTRLCBUSY_bm  0x04  /* Control B Synchronization Busy bit mask. */
+#define TCF_CTRLCBUSY_bp  2  /* Control B Synchronization Busy bit position. */
+#define TCF_CTRLDBUSY_bm  0x08  /* Control D Synchronization Busy bit mask. */
+#define TCF_CTRLDBUSY_bp  3  /* Control D Synchronization Busy bit position. */
+#define TCF_CNTBUSY_bm  0x10  /* Counter Synchronization Busy bit mask. */
+#define TCF_CNTBUSY_bp  4  /* Counter Synchronization Busy bit position. */
+#define TCF_PERBUSY_bm  0x20  /* Period Synchronization Busy bit mask. */
+#define TCF_PERBUSY_bp  5  /* Period Synchronization Busy bit position. */
+#define TCF_CMP0BUSY_bm  0x40  /* Compare 0 Synchronization Busy bit mask. */
+#define TCF_CMP0BUSY_bp  6  /* Compare 0 Synchronization Busy bit position. */
+#define TCF_CMP1BUSY_bm  0x80  /* Compare 1 Synchronization Busy bit mask. */
+#define TCF_CMP1BUSY_bp  7  /* Compare 1 Synchronization Busy bit position. */
+
+/* TCF.DBGCTRL  bit masks and bit positions */
+#define TCF_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define TCF_DBGRUN_bp  0  /* Debug Run bit position. */
+
+/* TCF.CNT  bit masks and bit positions */
+#define TCF_CNT_gm  0xFFFFFF  /* Counter group mask. */
+#define TCF_CNT_gp  0  /* Counter group position. */
+#define TCF_CNT_0_bm  (1<<0)  /* Counter bit 0 mask. */
+#define TCF_CNT_0_bp  0  /* Counter bit 0 position. */
+#define TCF_CNT_1_bm  (1<<1)  /* Counter bit 1 mask. */
+#define TCF_CNT_1_bp  1  /* Counter bit 1 position. */
+#define TCF_CNT_2_bm  (1<<2)  /* Counter bit 2 mask. */
+#define TCF_CNT_2_bp  2  /* Counter bit 2 position. */
+#define TCF_CNT_3_bm  (1<<3)  /* Counter bit 3 mask. */
+#define TCF_CNT_3_bp  3  /* Counter bit 3 position. */
+#define TCF_CNT_4_bm  (1<<4)  /* Counter bit 4 mask. */
+#define TCF_CNT_4_bp  4  /* Counter bit 4 position. */
+#define TCF_CNT_5_bm  (1<<5)  /* Counter bit 5 mask. */
+#define TCF_CNT_5_bp  5  /* Counter bit 5 position. */
+#define TCF_CNT_6_bm  (1<<6)  /* Counter bit 6 mask. */
+#define TCF_CNT_6_bp  6  /* Counter bit 6 position. */
+#define TCF_CNT_7_bm  (1<<7)  /* Counter bit 7 mask. */
+#define TCF_CNT_7_bp  7  /* Counter bit 7 position. */
+#define TCF_CNT_8_bm  (1<<8)  /* Counter bit 8 mask. */
+#define TCF_CNT_8_bp  8  /* Counter bit 8 position. */
+#define TCF_CNT_9_bm  (1<<9)  /* Counter bit 9 mask. */
+#define TCF_CNT_9_bp  9  /* Counter bit 9 position. */
+#define TCF_CNT_10_bm  (1<<10)  /* Counter bit 10 mask. */
+#define TCF_CNT_10_bp  10  /* Counter bit 10 position. */
+#define TCF_CNT_11_bm  (1<<11)  /* Counter bit 11 mask. */
+#define TCF_CNT_11_bp  11  /* Counter bit 11 position. */
+#define TCF_CNT_12_bm  (1<<12)  /* Counter bit 12 mask. */
+#define TCF_CNT_12_bp  12  /* Counter bit 12 position. */
+#define TCF_CNT_13_bm  (1<<13)  /* Counter bit 13 mask. */
+#define TCF_CNT_13_bp  13  /* Counter bit 13 position. */
+#define TCF_CNT_14_bm  (1<<14)  /* Counter bit 14 mask. */
+#define TCF_CNT_14_bp  14  /* Counter bit 14 position. */
+#define TCF_CNT_15_bm  (1<<15)  /* Counter bit 15 mask. */
+#define TCF_CNT_15_bp  15  /* Counter bit 15 position. */
+#define TCF_CNT_16_bm  (1<<16)  /* Counter bit 16 mask. */
+#define TCF_CNT_16_bp  16  /* Counter bit 16 position. */
+#define TCF_CNT_17_bm  (1<<17)  /* Counter bit 17 mask. */
+#define TCF_CNT_17_bp  17  /* Counter bit 17 position. */
+#define TCF_CNT_18_bm  (1<<18)  /* Counter bit 18 mask. */
+#define TCF_CNT_18_bp  18  /* Counter bit 18 position. */
+#define TCF_CNT_19_bm  (1<<19)  /* Counter bit 19 mask. */
+#define TCF_CNT_19_bp  19  /* Counter bit 19 position. */
+#define TCF_CNT_20_bm  (1<<20)  /* Counter bit 20 mask. */
+#define TCF_CNT_20_bp  20  /* Counter bit 20 position. */
+#define TCF_CNT_21_bm  (1<<21)  /* Counter bit 21 mask. */
+#define TCF_CNT_21_bp  21  /* Counter bit 21 position. */
+#define TCF_CNT_22_bm  (1<<22)  /* Counter bit 22 mask. */
+#define TCF_CNT_22_bp  22  /* Counter bit 22 position. */
+#define TCF_CNT_23_bm  (1<<23)  /* Counter bit 23 mask. */
+#define TCF_CNT_23_bp  23  /* Counter bit 23 position. */
+
+/* TCF.CMP  bit masks and bit positions */
+#define TCF_CMP_gm  0xFFFFFF  /* Compare group mask. */
+#define TCF_CMP_gp  0  /* Compare group position. */
+#define TCF_CMP_0_bm  (1<<0)  /* Compare bit 0 mask. */
+#define TCF_CMP_0_bp  0  /* Compare bit 0 position. */
+#define TCF_CMP_1_bm  (1<<1)  /* Compare bit 1 mask. */
+#define TCF_CMP_1_bp  1  /* Compare bit 1 position. */
+#define TCF_CMP_2_bm  (1<<2)  /* Compare bit 2 mask. */
+#define TCF_CMP_2_bp  2  /* Compare bit 2 position. */
+#define TCF_CMP_3_bm  (1<<3)  /* Compare bit 3 mask. */
+#define TCF_CMP_3_bp  3  /* Compare bit 3 position. */
+#define TCF_CMP_4_bm  (1<<4)  /* Compare bit 4 mask. */
+#define TCF_CMP_4_bp  4  /* Compare bit 4 position. */
+#define TCF_CMP_5_bm  (1<<5)  /* Compare bit 5 mask. */
+#define TCF_CMP_5_bp  5  /* Compare bit 5 position. */
+#define TCF_CMP_6_bm  (1<<6)  /* Compare bit 6 mask. */
+#define TCF_CMP_6_bp  6  /* Compare bit 6 position. */
+#define TCF_CMP_7_bm  (1<<7)  /* Compare bit 7 mask. */
+#define TCF_CMP_7_bp  7  /* Compare bit 7 position. */
+#define TCF_CMP_8_bm  (1<<8)  /* Compare bit 8 mask. */
+#define TCF_CMP_8_bp  8  /* Compare bit 8 position. */
+#define TCF_CMP_9_bm  (1<<9)  /* Compare bit 9 mask. */
+#define TCF_CMP_9_bp  9  /* Compare bit 9 position. */
+#define TCF_CMP_10_bm  (1<<10)  /* Compare bit 10 mask. */
+#define TCF_CMP_10_bp  10  /* Compare bit 10 position. */
+#define TCF_CMP_11_bm  (1<<11)  /* Compare bit 11 mask. */
+#define TCF_CMP_11_bp  11  /* Compare bit 11 position. */
+#define TCF_CMP_12_bm  (1<<12)  /* Compare bit 12 mask. */
+#define TCF_CMP_12_bp  12  /* Compare bit 12 position. */
+#define TCF_CMP_13_bm  (1<<13)  /* Compare bit 13 mask. */
+#define TCF_CMP_13_bp  13  /* Compare bit 13 position. */
+#define TCF_CMP_14_bm  (1<<14)  /* Compare bit 14 mask. */
+#define TCF_CMP_14_bp  14  /* Compare bit 14 position. */
+#define TCF_CMP_15_bm  (1<<15)  /* Compare bit 15 mask. */
+#define TCF_CMP_15_bp  15  /* Compare bit 15 position. */
+#define TCF_CMP_16_bm  (1<<16)  /* Compare bit 16 mask. */
+#define TCF_CMP_16_bp  16  /* Compare bit 16 position. */
+#define TCF_CMP_17_bm  (1<<17)  /* Compare bit 17 mask. */
+#define TCF_CMP_17_bp  17  /* Compare bit 17 position. */
+#define TCF_CMP_18_bm  (1<<18)  /* Compare bit 18 mask. */
+#define TCF_CMP_18_bp  18  /* Compare bit 18 position. */
+#define TCF_CMP_19_bm  (1<<19)  /* Compare bit 19 mask. */
+#define TCF_CMP_19_bp  19  /* Compare bit 19 position. */
+#define TCF_CMP_20_bm  (1<<20)  /* Compare bit 20 mask. */
+#define TCF_CMP_20_bp  20  /* Compare bit 20 position. */
+#define TCF_CMP_21_bm  (1<<21)  /* Compare bit 21 mask. */
+#define TCF_CMP_21_bp  21  /* Compare bit 21 position. */
+#define TCF_CMP_22_bm  (1<<22)  /* Compare bit 22 mask. */
+#define TCF_CMP_22_bp  22  /* Compare bit 22 position. */
+#define TCF_CMP_23_bm  (1<<23)  /* Compare bit 23 mask. */
+#define TCF_CMP_23_bp  23  /* Compare bit 23 position. */
+
+
+/* TWI - Two-Wire Interface */
+/* TWI.CTRLA  bit masks and bit positions */
+#define TWI_FMEN_bm  0x01  /* Fast-mode Enable bit mask. */
+#define TWI_FMEN_bp  0  /* Fast-mode Enable bit position. */
+#define TWI_FMPEN_bm  0x02  /* Fast-mode Plus Enable bit mask. */
+#define TWI_FMPEN_bp  1  /* Fast-mode Plus Enable bit position. */
+#define TWI_SDAHOLD_gm  0x0C  /* SDA Hold Time group mask. */
+#define TWI_SDAHOLD_gp  2  /* SDA Hold Time group position. */
+#define TWI_SDAHOLD_0_bm  (1<<2)  /* SDA Hold Time bit 0 mask. */
+#define TWI_SDAHOLD_0_bp  2  /* SDA Hold Time bit 0 position. */
+#define TWI_SDAHOLD_1_bm  (1<<3)  /* SDA Hold Time bit 1 mask. */
+#define TWI_SDAHOLD_1_bp  3  /* SDA Hold Time bit 1 position. */
+#define TWI_SDASETUP_bm  0x10  /* SDA Setup Time bit mask. */
+#define TWI_SDASETUP_bp  4  /* SDA Setup Time bit position. */
+#define TWI_INPUTLVL_bm  0x40  /* Input voltage transition level bit mask. */
+#define TWI_INPUTLVL_bp  6  /* Input voltage transition level bit position. */
+
+/* TWI.DUALCTRL  bit masks and bit positions */
+#define TWI_ENABLE_bm  0x01  /* Enable bit mask. */
+#define TWI_ENABLE_bp  0  /* Enable bit position. */
+/* TWI_FMPEN  is already defined. */
+/* TWI_SDAHOLD  is already defined. */
+/* TWI_INPUTLVL  is already defined. */
+
+/* TWI.DBGCTRL  bit masks and bit positions */
+#define TWI_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define TWI_DBGRUN_bp  0  /* Debug Run bit position. */
+
+/* TWI.MCTRLA  bit masks and bit positions */
+/* TWI_ENABLE  is already defined. */
+#define TWI_SMEN_bm  0x02  /* Smart Mode Enable bit mask. */
+#define TWI_SMEN_bp  1  /* Smart Mode Enable bit position. */
+#define TWI_TIMEOUT_gm  0x0C  /* Inactive Bus Time-Out group mask. */
+#define TWI_TIMEOUT_gp  2  /* Inactive Bus Time-Out group position. */
+#define TWI_TIMEOUT_0_bm  (1<<2)  /* Inactive Bus Time-Out bit 0 mask. */
+#define TWI_TIMEOUT_0_bp  2  /* Inactive Bus Time-Out bit 0 position. */
+#define TWI_TIMEOUT_1_bm  (1<<3)  /* Inactive Bus Time-Out bit 1 mask. */
+#define TWI_TIMEOUT_1_bp  3  /* Inactive Bus Time-Out bit 1 position. */
+#define TWI_QCEN_bm  0x10  /* Quick Command Enable bit mask. */
+#define TWI_QCEN_bp  4  /* Quick Command Enable bit position. */
+#define TWI_WIEN_bm  0x40  /* Write Interrupt Enable bit mask. */
+#define TWI_WIEN_bp  6  /* Write Interrupt Enable bit position. */
+#define TWI_RIEN_bm  0x80  /* Read Interrupt Enable bit mask. */
+#define TWI_RIEN_bp  7  /* Read Interrupt Enable bit position. */
+
+/* TWI.MCTRLB  bit masks and bit positions */
+#define TWI_MCMD_gm  0x03  /* Command group mask. */
+#define TWI_MCMD_gp  0  /* Command group position. */
+#define TWI_MCMD_0_bm  (1<<0)  /* Command bit 0 mask. */
+#define TWI_MCMD_0_bp  0  /* Command bit 0 position. */
+#define TWI_MCMD_1_bm  (1<<1)  /* Command bit 1 mask. */
+#define TWI_MCMD_1_bp  1  /* Command bit 1 position. */
+#define TWI_ACKACT_bm  0x04  /* Acknowledge Action bit mask. */
+#define TWI_ACKACT_bp  2  /* Acknowledge Action bit position. */
+#define TWI_FLUSH_bm  0x08  /* Flush bit mask. */
+#define TWI_FLUSH_bp  3  /* Flush bit position. */
+
+/* TWI.MSTATUS  bit masks and bit positions */
+#define TWI_BUSSTATE_gm  0x03  /* Bus State group mask. */
+#define TWI_BUSSTATE_gp  0  /* Bus State group position. */
+#define TWI_BUSSTATE_0_bm  (1<<0)  /* Bus State bit 0 mask. */
+#define TWI_BUSSTATE_0_bp  0  /* Bus State bit 0 position. */
+#define TWI_BUSSTATE_1_bm  (1<<1)  /* Bus State bit 1 mask. */
+#define TWI_BUSSTATE_1_bp  1  /* Bus State bit 1 position. */
+#define TWI_BUSERR_bm  0x04  /* Bus Error bit mask. */
+#define TWI_BUSERR_bp  2  /* Bus Error bit position. */
+#define TWI_ARBLOST_bm  0x08  /* Arbitration Lost bit mask. */
+#define TWI_ARBLOST_bp  3  /* Arbitration Lost bit position. */
+#define TWI_RXACK_bm  0x10  /* Received Acknowledge bit mask. */
+#define TWI_RXACK_bp  4  /* Received Acknowledge bit position. */
+#define TWI_CLKHOLD_bm  0x20  /* Clock Hold bit mask. */
+#define TWI_CLKHOLD_bp  5  /* Clock Hold bit position. */
+#define TWI_WIF_bm  0x40  /* Write Interrupt Flag bit mask. */
+#define TWI_WIF_bp  6  /* Write Interrupt Flag bit position. */
+#define TWI_RIF_bm  0x80  /* Read Interrupt Flag bit mask. */
+#define TWI_RIF_bp  7  /* Read Interrupt Flag bit position. */
+
+/* TWI.MBAUD  bit masks and bit positions */
+#define TWI_BAUD_gm  0xFF  /* Baud Rate group mask. */
+#define TWI_BAUD_gp  0  /* Baud Rate group position. */
+#define TWI_BAUD_0_bm  (1<<0)  /* Baud Rate bit 0 mask. */
+#define TWI_BAUD_0_bp  0  /* Baud Rate bit 0 position. */
+#define TWI_BAUD_1_bm  (1<<1)  /* Baud Rate bit 1 mask. */
+#define TWI_BAUD_1_bp  1  /* Baud Rate bit 1 position. */
+#define TWI_BAUD_2_bm  (1<<2)  /* Baud Rate bit 2 mask. */
+#define TWI_BAUD_2_bp  2  /* Baud Rate bit 2 position. */
+#define TWI_BAUD_3_bm  (1<<3)  /* Baud Rate bit 3 mask. */
+#define TWI_BAUD_3_bp  3  /* Baud Rate bit 3 position. */
+#define TWI_BAUD_4_bm  (1<<4)  /* Baud Rate bit 4 mask. */
+#define TWI_BAUD_4_bp  4  /* Baud Rate bit 4 position. */
+#define TWI_BAUD_5_bm  (1<<5)  /* Baud Rate bit 5 mask. */
+#define TWI_BAUD_5_bp  5  /* Baud Rate bit 5 position. */
+#define TWI_BAUD_6_bm  (1<<6)  /* Baud Rate bit 6 mask. */
+#define TWI_BAUD_6_bp  6  /* Baud Rate bit 6 position. */
+#define TWI_BAUD_7_bm  (1<<7)  /* Baud Rate bit 7 mask. */
+#define TWI_BAUD_7_bp  7  /* Baud Rate bit 7 position. */
+
+/* TWI.MADDR  bit masks and bit positions */
+#define TWI_ADDR_gm  0xFF  /* Address group mask. */
+#define TWI_ADDR_gp  0  /* Address group position. */
+#define TWI_ADDR_0_bm  (1<<0)  /* Address bit 0 mask. */
+#define TWI_ADDR_0_bp  0  /* Address bit 0 position. */
+#define TWI_ADDR_1_bm  (1<<1)  /* Address bit 1 mask. */
+#define TWI_ADDR_1_bp  1  /* Address bit 1 position. */
+#define TWI_ADDR_2_bm  (1<<2)  /* Address bit 2 mask. */
+#define TWI_ADDR_2_bp  2  /* Address bit 2 position. */
+#define TWI_ADDR_3_bm  (1<<3)  /* Address bit 3 mask. */
+#define TWI_ADDR_3_bp  3  /* Address bit 3 position. */
+#define TWI_ADDR_4_bm  (1<<4)  /* Address bit 4 mask. */
+#define TWI_ADDR_4_bp  4  /* Address bit 4 position. */
+#define TWI_ADDR_5_bm  (1<<5)  /* Address bit 5 mask. */
+#define TWI_ADDR_5_bp  5  /* Address bit 5 position. */
+#define TWI_ADDR_6_bm  (1<<6)  /* Address bit 6 mask. */
+#define TWI_ADDR_6_bp  6  /* Address bit 6 position. */
+#define TWI_ADDR_7_bm  (1<<7)  /* Address bit 7 mask. */
+#define TWI_ADDR_7_bp  7  /* Address bit 7 position. */
+
+/* TWI.MDATA  bit masks and bit positions */
+#define TWI_DATA_gm  0xFF  /* Data group mask. */
+#define TWI_DATA_gp  0  /* Data group position. */
+#define TWI_DATA_0_bm  (1<<0)  /* Data bit 0 mask. */
+#define TWI_DATA_0_bp  0  /* Data bit 0 position. */
+#define TWI_DATA_1_bm  (1<<1)  /* Data bit 1 mask. */
+#define TWI_DATA_1_bp  1  /* Data bit 1 position. */
+#define TWI_DATA_2_bm  (1<<2)  /* Data bit 2 mask. */
+#define TWI_DATA_2_bp  2  /* Data bit 2 position. */
+#define TWI_DATA_3_bm  (1<<3)  /* Data bit 3 mask. */
+#define TWI_DATA_3_bp  3  /* Data bit 3 position. */
+#define TWI_DATA_4_bm  (1<<4)  /* Data bit 4 mask. */
+#define TWI_DATA_4_bp  4  /* Data bit 4 position. */
+#define TWI_DATA_5_bm  (1<<5)  /* Data bit 5 mask. */
+#define TWI_DATA_5_bp  5  /* Data bit 5 position. */
+#define TWI_DATA_6_bm  (1<<6)  /* Data bit 6 mask. */
+#define TWI_DATA_6_bp  6  /* Data bit 6 position. */
+#define TWI_DATA_7_bm  (1<<7)  /* Data bit 7 mask. */
+#define TWI_DATA_7_bp  7  /* Data bit 7 position. */
+
+/* TWI.SCTRLA  bit masks and bit positions */
+/* TWI_ENABLE  is already defined. */
+/* TWI_SMEN  is already defined. */
+#define TWI_PMEN_bm  0x04  /* Address Recognition Mode bit mask. */
+#define TWI_PMEN_bp  2  /* Address Recognition Mode bit position. */
+#define TWI_PIEN_bm  0x20  /* Stop Interrupt Enable bit mask. */
+#define TWI_PIEN_bp  5  /* Stop Interrupt Enable bit position. */
+#define TWI_APIEN_bm  0x40  /* Address or Stop Interrupt Enable bit mask. */
+#define TWI_APIEN_bp  6  /* Address or Stop Interrupt Enable bit position. */
+#define TWI_DIEN_bm  0x80  /* Data Interrupt Enable bit mask. */
+#define TWI_DIEN_bp  7  /* Data Interrupt Enable bit position. */
+
+/* TWI.SCTRLB  bit masks and bit positions */
+#define TWI_SCMD_gm  0x03  /* Command group mask. */
+#define TWI_SCMD_gp  0  /* Command group position. */
+#define TWI_SCMD_0_bm  (1<<0)  /* Command bit 0 mask. */
+#define TWI_SCMD_0_bp  0  /* Command bit 0 position. */
+#define TWI_SCMD_1_bm  (1<<1)  /* Command bit 1 mask. */
+#define TWI_SCMD_1_bp  1  /* Command bit 1 position. */
+/* TWI_ACKACT  is already defined. */
+
+/* TWI.SSTATUS  bit masks and bit positions */
+#define TWI_AP_bm  0x01  /* Address or Stop bit mask. */
+#define TWI_AP_bp  0  /* Address or Stop bit position. */
+#define TWI_DIR_bm  0x02  /* Read/Write Direction bit mask. */
+#define TWI_DIR_bp  1  /* Read/Write Direction bit position. */
+/* TWI_BUSERR  is already defined. */
+#define TWI_COLL_bm  0x08  /* Collision bit mask. */
+#define TWI_COLL_bp  3  /* Collision bit position. */
+/* TWI_RXACK  is already defined. */
+/* TWI_CLKHOLD  is already defined. */
+#define TWI_APIF_bm  0x40  /* Address or Stop Interrupt Flag bit mask. */
+#define TWI_APIF_bp  6  /* Address or Stop Interrupt Flag bit position. */
+#define TWI_DIF_bm  0x80  /* Data Interrupt Flag bit mask. */
+#define TWI_DIF_bp  7  /* Data Interrupt Flag bit position. */
+
+/* TWI.SADDR  bit masks and bit positions */
+/* TWI_ADDR  is already defined. */
+
+/* TWI.SDATA  bit masks and bit positions */
+/* TWI_DATA  is already defined. */
+
+/* TWI.SADDRMASK  bit masks and bit positions */
+#define TWI_ADDREN_bm  0x01  /* Address Mask Enable bit mask. */
+#define TWI_ADDREN_bp  0  /* Address Mask Enable bit position. */
+#define TWI_ADDRMASK_gm  0xFE  /* Address Mask group mask. */
+#define TWI_ADDRMASK_gp  1  /* Address Mask group position. */
+#define TWI_ADDRMASK_0_bm  (1<<1)  /* Address Mask bit 0 mask. */
+#define TWI_ADDRMASK_0_bp  1  /* Address Mask bit 0 position. */
+#define TWI_ADDRMASK_1_bm  (1<<2)  /* Address Mask bit 1 mask. */
+#define TWI_ADDRMASK_1_bp  2  /* Address Mask bit 1 position. */
+#define TWI_ADDRMASK_2_bm  (1<<3)  /* Address Mask bit 2 mask. */
+#define TWI_ADDRMASK_2_bp  3  /* Address Mask bit 2 position. */
+#define TWI_ADDRMASK_3_bm  (1<<4)  /* Address Mask bit 3 mask. */
+#define TWI_ADDRMASK_3_bp  4  /* Address Mask bit 3 position. */
+#define TWI_ADDRMASK_4_bm  (1<<5)  /* Address Mask bit 4 mask. */
+#define TWI_ADDRMASK_4_bp  5  /* Address Mask bit 4 position. */
+#define TWI_ADDRMASK_5_bm  (1<<6)  /* Address Mask bit 5 mask. */
+#define TWI_ADDRMASK_5_bp  6  /* Address Mask bit 5 position. */
+#define TWI_ADDRMASK_6_bm  (1<<7)  /* Address Mask bit 6 mask. */
+#define TWI_ADDRMASK_6_bp  7  /* Address Mask bit 6 position. */
+
+
+/* USART - Universal Synchronous and Asynchronous Receiver and Transmitter */
+/* USART.RXDATAL  bit masks and bit positions */
+#define USART_DATA_gm  0xFF  /* RX Data group mask. */
+#define USART_DATA_gp  0  /* RX Data group position. */
+#define USART_DATA_0_bm  (1<<0)  /* RX Data bit 0 mask. */
+#define USART_DATA_0_bp  0  /* RX Data bit 0 position. */
+#define USART_DATA_1_bm  (1<<1)  /* RX Data bit 1 mask. */
+#define USART_DATA_1_bp  1  /* RX Data bit 1 position. */
+#define USART_DATA_2_bm  (1<<2)  /* RX Data bit 2 mask. */
+#define USART_DATA_2_bp  2  /* RX Data bit 2 position. */
+#define USART_DATA_3_bm  (1<<3)  /* RX Data bit 3 mask. */
+#define USART_DATA_3_bp  3  /* RX Data bit 3 position. */
+#define USART_DATA_4_bm  (1<<4)  /* RX Data bit 4 mask. */
+#define USART_DATA_4_bp  4  /* RX Data bit 4 position. */
+#define USART_DATA_5_bm  (1<<5)  /* RX Data bit 5 mask. */
+#define USART_DATA_5_bp  5  /* RX Data bit 5 position. */
+#define USART_DATA_6_bm  (1<<6)  /* RX Data bit 6 mask. */
+#define USART_DATA_6_bp  6  /* RX Data bit 6 position. */
+#define USART_DATA_7_bm  (1<<7)  /* RX Data bit 7 mask. */
+#define USART_DATA_7_bp  7  /* RX Data bit 7 position. */
+
+/* USART.RXDATAH  bit masks and bit positions */
+#define USART_DATA8_bm  0x01  /* Receiver Data Register bit mask. */
+#define USART_DATA8_bp  0  /* Receiver Data Register bit position. */
+#define USART_PERR_bm  0x02  /* Parity Error bit mask. */
+#define USART_PERR_bp  1  /* Parity Error bit position. */
+#define USART_FERR_bm  0x04  /* Frame Error bit mask. */
+#define USART_FERR_bp  2  /* Frame Error bit position. */
+#define USART_BUFOVF_bm  0x40  /* Buffer Overflow bit mask. */
+#define USART_BUFOVF_bp  6  /* Buffer Overflow bit position. */
+#define USART_RXCIF_bm  0x80  /* Receive Complete Interrupt Flag bit mask. */
+#define USART_RXCIF_bp  7  /* Receive Complete Interrupt Flag bit position. */
+
+/* USART.TXDATAL  bit masks and bit positions */
+/* USART_DATA  is already defined. */
+
+/* USART.TXDATAH  bit masks and bit positions */
+/* USART_DATA8  is already defined. */
+
+/* USART.STATUS  bit masks and bit positions */
+#define USART_WFB_bm  0x01  /* Wait For Break bit mask. */
+#define USART_WFB_bp  0  /* Wait For Break bit position. */
+#define USART_BDF_bm  0x02  /* Break Detected Flag bit mask. */
+#define USART_BDF_bp  1  /* Break Detected Flag bit position. */
+#define USART_ISFIF_bm  0x08  /* Inconsistent Sync Field Interrupt Flag bit mask. */
+#define USART_ISFIF_bp  3  /* Inconsistent Sync Field Interrupt Flag bit position. */
+#define USART_RXSIF_bm  0x10  /* Receive Start Interrupt bit mask. */
+#define USART_RXSIF_bp  4  /* Receive Start Interrupt bit position. */
+#define USART_DREIF_bm  0x20  /* Data Register Empty Flag bit mask. */
+#define USART_DREIF_bp  5  /* Data Register Empty Flag bit position. */
+#define USART_TXCIF_bm  0x40  /* Transmit Interrupt Flag bit mask. */
+#define USART_TXCIF_bp  6  /* Transmit Interrupt Flag bit position. */
+/* USART_RXCIF  is already defined. */
+
+/* USART.CTRLA  bit masks and bit positions */
+#define USART_RS485_bm  0x01  /* RS485 Mode internal transmitter bit mask. */
+#define USART_RS485_bp  0  /* RS485 Mode internal transmitter bit position. */
+#define USART_ABEIE_bm  0x04  /* Auto-baud Error Interrupt Enable bit mask. */
+#define USART_ABEIE_bp  2  /* Auto-baud Error Interrupt Enable bit position. */
+#define USART_LBME_bm  0x08  /* Loop-back Mode Enable bit mask. */
+#define USART_LBME_bp  3  /* Loop-back Mode Enable bit position. */
+#define USART_RXSIE_bm  0x10  /* Receiver Start Frame Interrupt Enable bit mask. */
+#define USART_RXSIE_bp  4  /* Receiver Start Frame Interrupt Enable bit position. */
+#define USART_DREIE_bm  0x20  /* Data Register Empty Interrupt Enable bit mask. */
+#define USART_DREIE_bp  5  /* Data Register Empty Interrupt Enable bit position. */
+#define USART_TXCIE_bm  0x40  /* Transmit Complete Interrupt Enable bit mask. */
+#define USART_TXCIE_bp  6  /* Transmit Complete Interrupt Enable bit position. */
+#define USART_RXCIE_bm  0x80  /* Receive Complete Interrupt Enable bit mask. */
+#define USART_RXCIE_bp  7  /* Receive Complete Interrupt Enable bit position. */
+
+/* USART.CTRLB  bit masks and bit positions */
+#define USART_MPCM_bm  0x01  /* Multi-processor Communication Mode bit mask. */
+#define USART_MPCM_bp  0  /* Multi-processor Communication Mode bit position. */
+#define USART_RXMODE_gm  0x06  /* Receiver Mode group mask. */
+#define USART_RXMODE_gp  1  /* Receiver Mode group position. */
+#define USART_RXMODE_0_bm  (1<<1)  /* Receiver Mode bit 0 mask. */
+#define USART_RXMODE_0_bp  1  /* Receiver Mode bit 0 position. */
+#define USART_RXMODE_1_bm  (1<<2)  /* Receiver Mode bit 1 mask. */
+#define USART_RXMODE_1_bp  2  /* Receiver Mode bit 1 position. */
+#define USART_ODME_bm  0x08  /* Open Drain Mode Enable bit mask. */
+#define USART_ODME_bp  3  /* Open Drain Mode Enable bit position. */
+#define USART_SFDEN_bm  0x10  /* Start Frame Detection Enable bit mask. */
+#define USART_SFDEN_bp  4  /* Start Frame Detection Enable bit position. */
+#define USART_TXEN_bm  0x40  /* Transmitter Enable bit mask. */
+#define USART_TXEN_bp  6  /* Transmitter Enable bit position. */
+#define USART_RXEN_bm  0x80  /* Reciever enable bit mask. */
+#define USART_RXEN_bp  7  /* Reciever enable bit position. */
+
+/* USART.CTRLC  bit masks and bit positions */
+#define USART_UCPHA_bm  0x02  /* SPI Host Mode, Clock Phase bit mask. */
+#define USART_UCPHA_bp  1  /* SPI Host Mode, Clock Phase bit position. */
+#define USART_UDORD_bm  0x04  /* SPI Host Mode, Data Order bit mask. */
+#define USART_UDORD_bp  2  /* SPI Host Mode, Data Order bit position. */
+#define USART_CHSIZE_gm  0x07  /* Character Size group mask. */
+#define USART_CHSIZE_gp  0  /* Character Size group position. */
+#define USART_CHSIZE_0_bm  (1<<0)  /* Character Size bit 0 mask. */
+#define USART_CHSIZE_0_bp  0  /* Character Size bit 0 position. */
+#define USART_CHSIZE_1_bm  (1<<1)  /* Character Size bit 1 mask. */
+#define USART_CHSIZE_1_bp  1  /* Character Size bit 1 position. */
+#define USART_CHSIZE_2_bm  (1<<2)  /* Character Size bit 2 mask. */
+#define USART_CHSIZE_2_bp  2  /* Character Size bit 2 position. */
+#define USART_SBMODE_bm  0x08  /* Stop Bit Mode bit mask. */
+#define USART_SBMODE_bp  3  /* Stop Bit Mode bit position. */
+#define USART_PMODE_gm  0x30  /* Parity Mode group mask. */
+#define USART_PMODE_gp  4  /* Parity Mode group position. */
+#define USART_PMODE_0_bm  (1<<4)  /* Parity Mode bit 0 mask. */
+#define USART_PMODE_0_bp  4  /* Parity Mode bit 0 position. */
+#define USART_PMODE_1_bm  (1<<5)  /* Parity Mode bit 1 mask. */
+#define USART_PMODE_1_bp  5  /* Parity Mode bit 1 position. */
+#define USART_CMODE_gm  0xC0  /* Communication Mode group mask. */
+#define USART_CMODE_gp  6  /* Communication Mode group position. */
+#define USART_CMODE_0_bm  (1<<6)  /* Communication Mode bit 0 mask. */
+#define USART_CMODE_0_bp  6  /* Communication Mode bit 0 position. */
+#define USART_CMODE_1_bm  (1<<7)  /* Communication Mode bit 1 mask. */
+#define USART_CMODE_1_bp  7  /* Communication Mode bit 1 position. */
+
+/* USART.CTRLD  bit masks and bit positions */
+#define USART_ABW_gm  0xC0  /* Auto Baud Window group mask. */
+#define USART_ABW_gp  6  /* Auto Baud Window group position. */
+#define USART_ABW_0_bm  (1<<6)  /* Auto Baud Window bit 0 mask. */
+#define USART_ABW_0_bp  6  /* Auto Baud Window bit 0 position. */
+#define USART_ABW_1_bm  (1<<7)  /* Auto Baud Window bit 1 mask. */
+#define USART_ABW_1_bp  7  /* Auto Baud Window bit 1 position. */
+
+/* USART.DBGCTRL  bit masks and bit positions */
+#define USART_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define USART_DBGRUN_bp  0  /* Debug Run bit position. */
+
+/* USART.EVCTRL  bit masks and bit positions */
+#define USART_IREI_bm  0x01  /* IrDA Event Input Enable bit mask. */
+#define USART_IREI_bp  0  /* IrDA Event Input Enable bit position. */
+
+/* USART.TXPLCTRL  bit masks and bit positions */
+#define USART_TXPL_gm  0xFF  /* Transmit pulse length group mask. */
+#define USART_TXPL_gp  0  /* Transmit pulse length group position. */
+#define USART_TXPL_0_bm  (1<<0)  /* Transmit pulse length bit 0 mask. */
+#define USART_TXPL_0_bp  0  /* Transmit pulse length bit 0 position. */
+#define USART_TXPL_1_bm  (1<<1)  /* Transmit pulse length bit 1 mask. */
+#define USART_TXPL_1_bp  1  /* Transmit pulse length bit 1 position. */
+#define USART_TXPL_2_bm  (1<<2)  /* Transmit pulse length bit 2 mask. */
+#define USART_TXPL_2_bp  2  /* Transmit pulse length bit 2 position. */
+#define USART_TXPL_3_bm  (1<<3)  /* Transmit pulse length bit 3 mask. */
+#define USART_TXPL_3_bp  3  /* Transmit pulse length bit 3 position. */
+#define USART_TXPL_4_bm  (1<<4)  /* Transmit pulse length bit 4 mask. */
+#define USART_TXPL_4_bp  4  /* Transmit pulse length bit 4 position. */
+#define USART_TXPL_5_bm  (1<<5)  /* Transmit pulse length bit 5 mask. */
+#define USART_TXPL_5_bp  5  /* Transmit pulse length bit 5 position. */
+#define USART_TXPL_6_bm  (1<<6)  /* Transmit pulse length bit 6 mask. */
+#define USART_TXPL_6_bp  6  /* Transmit pulse length bit 6 position. */
+#define USART_TXPL_7_bm  (1<<7)  /* Transmit pulse length bit 7 mask. */
+#define USART_TXPL_7_bp  7  /* Transmit pulse length bit 7 position. */
+
+/* USART.RXPLCTRL  bit masks and bit positions */
+#define USART_RXPL_gm  0x7F  /* Receiver Pulse Lenght group mask. */
+#define USART_RXPL_gp  0  /* Receiver Pulse Lenght group position. */
+#define USART_RXPL_0_bm  (1<<0)  /* Receiver Pulse Lenght bit 0 mask. */
+#define USART_RXPL_0_bp  0  /* Receiver Pulse Lenght bit 0 position. */
+#define USART_RXPL_1_bm  (1<<1)  /* Receiver Pulse Lenght bit 1 mask. */
+#define USART_RXPL_1_bp  1  /* Receiver Pulse Lenght bit 1 position. */
+#define USART_RXPL_2_bm  (1<<2)  /* Receiver Pulse Lenght bit 2 mask. */
+#define USART_RXPL_2_bp  2  /* Receiver Pulse Lenght bit 2 position. */
+#define USART_RXPL_3_bm  (1<<3)  /* Receiver Pulse Lenght bit 3 mask. */
+#define USART_RXPL_3_bp  3  /* Receiver Pulse Lenght bit 3 position. */
+#define USART_RXPL_4_bm  (1<<4)  /* Receiver Pulse Lenght bit 4 mask. */
+#define USART_RXPL_4_bp  4  /* Receiver Pulse Lenght bit 4 position. */
+#define USART_RXPL_5_bm  (1<<5)  /* Receiver Pulse Lenght bit 5 mask. */
+#define USART_RXPL_5_bp  5  /* Receiver Pulse Lenght bit 5 position. */
+#define USART_RXPL_6_bm  (1<<6)  /* Receiver Pulse Lenght bit 6 mask. */
+#define USART_RXPL_6_bp  6  /* Receiver Pulse Lenght bit 6 position. */
+
+
+
+/* VPORT - Virtual Ports */
+/* VPORT.INTFLAGS  bit masks and bit positions */
+#define VPORT_INT_gm  0xFF  /* Pin Interrupt Flag group mask. */
+#define VPORT_INT_gp  0  /* Pin Interrupt Flag group position. */
+#define VPORT_INT_0_bm  (1<<0)  /* Pin Interrupt Flag bit 0 mask. */
+#define VPORT_INT_0_bp  0  /* Pin Interrupt Flag bit 0 position. */
+#define VPORT_INT_1_bm  (1<<1)  /* Pin Interrupt Flag bit 1 mask. */
+#define VPORT_INT_1_bp  1  /* Pin Interrupt Flag bit 1 position. */
+#define VPORT_INT_2_bm  (1<<2)  /* Pin Interrupt Flag bit 2 mask. */
+#define VPORT_INT_2_bp  2  /* Pin Interrupt Flag bit 2 position. */
+#define VPORT_INT_3_bm  (1<<3)  /* Pin Interrupt Flag bit 3 mask. */
+#define VPORT_INT_3_bp  3  /* Pin Interrupt Flag bit 3 position. */
+#define VPORT_INT_4_bm  (1<<4)  /* Pin Interrupt Flag bit 4 mask. */
+#define VPORT_INT_4_bp  4  /* Pin Interrupt Flag bit 4 position. */
+#define VPORT_INT_5_bm  (1<<5)  /* Pin Interrupt Flag bit 5 mask. */
+#define VPORT_INT_5_bp  5  /* Pin Interrupt Flag bit 5 position. */
+#define VPORT_INT_6_bm  (1<<6)  /* Pin Interrupt Flag bit 6 mask. */
+#define VPORT_INT_6_bp  6  /* Pin Interrupt Flag bit 6 position. */
+#define VPORT_INT_7_bm  (1<<7)  /* Pin Interrupt Flag bit 7 mask. */
+#define VPORT_INT_7_bp  7  /* Pin Interrupt Flag bit 7 position. */
+
+
+/* VREF - Voltage reference */
+/* VREF.DAC0REF  bit masks and bit positions */
+#define VREF_REFSEL_gm  0x07  /* Reference select group mask. */
+#define VREF_REFSEL_gp  0  /* Reference select group position. */
+#define VREF_REFSEL_0_bm  (1<<0)  /* Reference select bit 0 mask. */
+#define VREF_REFSEL_0_bp  0  /* Reference select bit 0 position. */
+#define VREF_REFSEL_1_bm  (1<<1)  /* Reference select bit 1 mask. */
+#define VREF_REFSEL_1_bp  1  /* Reference select bit 1 position. */
+#define VREF_REFSEL_2_bm  (1<<2)  /* Reference select bit 2 mask. */
+#define VREF_REFSEL_2_bp  2  /* Reference select bit 2 position. */
+#define VREF_ALWAYSON_bm  0x80  /* Always on bit mask. */
+#define VREF_ALWAYSON_bp  7  /* Always on bit position. */
+
+/* VREF.ACREF  bit masks and bit positions */
+/* VREF_REFSEL  is already defined. */
+/* VREF_ALWAYSON  is already defined. */
+
+
+/* WDT - Watch-Dog Timer */
+/* WDT.CTRLA  bit masks and bit positions */
+#define WDT_PERIOD_gm  0x0F  /* Period group mask. */
+#define WDT_PERIOD_gp  0  /* Period group position. */
+#define WDT_PERIOD_0_bm  (1<<0)  /* Period bit 0 mask. */
+#define WDT_PERIOD_0_bp  0  /* Period bit 0 position. */
+#define WDT_PERIOD_1_bm  (1<<1)  /* Period bit 1 mask. */
+#define WDT_PERIOD_1_bp  1  /* Period bit 1 position. */
+#define WDT_PERIOD_2_bm  (1<<2)  /* Period bit 2 mask. */
+#define WDT_PERIOD_2_bp  2  /* Period bit 2 position. */
+#define WDT_PERIOD_3_bm  (1<<3)  /* Period bit 3 mask. */
+#define WDT_PERIOD_3_bp  3  /* Period bit 3 position. */
+#define WDT_WINDOW_gm  0xF0  /* Window group mask. */
+#define WDT_WINDOW_gp  4  /* Window group position. */
+#define WDT_WINDOW_0_bm  (1<<4)  /* Window bit 0 mask. */
+#define WDT_WINDOW_0_bp  4  /* Window bit 0 position. */
+#define WDT_WINDOW_1_bm  (1<<5)  /* Window bit 1 mask. */
+#define WDT_WINDOW_1_bp  5  /* Window bit 1 position. */
+#define WDT_WINDOW_2_bm  (1<<6)  /* Window bit 2 mask. */
+#define WDT_WINDOW_2_bp  6  /* Window bit 2 position. */
+#define WDT_WINDOW_3_bm  (1<<7)  /* Window bit 3 mask. */
+#define WDT_WINDOW_3_bp  7  /* Window bit 3 position. */
+
+/* WDT.STATUS  bit masks and bit positions */
+#define WDT_SYNCBUSY_bm  0x01  /* Syncronization busy bit mask. */
+#define WDT_SYNCBUSY_bp  0  /* Syncronization busy bit position. */
+#define WDT_LOCK_bm  0x80  /* Lock enable bit mask. */
+#define WDT_LOCK_bp  7  /* Lock enable bit position. */
+
+
+/* WEX - Waveform Extension */
+/* WEX.CTRLA  bit masks and bit positions */
+#define WEX_DTI0EN_bm  0x01  /* Dead-Time Insertion CMP0 Enable bit mask. */
+#define WEX_DTI0EN_bp  0  /* Dead-Time Insertion CMP0 Enable bit position. */
+#define WEX_DTI1EN_bm  0x02  /* Dead-Time Insertion CMP1 Enable bit mask. */
+#define WEX_DTI1EN_bp  1  /* Dead-Time Insertion CMP1 Enable bit position. */
+#define WEX_DTI2EN_bm  0x04  /* Dead-Time Insertion CMP2 Enable bit mask. */
+#define WEX_DTI2EN_bp  2  /* Dead-Time Insertion CMP2 Enable bit position. */
+#define WEX_DTI3EN_bm  0x08  /* Dead-Time Insertion CMP3 Enable bit mask. */
+#define WEX_DTI3EN_bp  3  /* Dead-Time Insertion CMP3 Enable bit position. */
+#define WEX_INMX_gm  0x70  /* Input Matrix group mask. */
+#define WEX_INMX_gp  4  /* Input Matrix group position. */
+#define WEX_INMX_0_bm  (1<<4)  /* Input Matrix bit 0 mask. */
+#define WEX_INMX_0_bp  4  /* Input Matrix bit 0 position. */
+#define WEX_INMX_1_bm  (1<<5)  /* Input Matrix bit 1 mask. */
+#define WEX_INMX_1_bp  5  /* Input Matrix bit 1 position. */
+#define WEX_INMX_2_bm  (1<<6)  /* Input Matrix bit 2 mask. */
+#define WEX_INMX_2_bp  6  /* Input Matrix bit 2 position. */
+#define WEX_PGM_bm  0x80  /* Pattern Generation Mode bit mask. */
+#define WEX_PGM_bp  7  /* Pattern Generation Mode bit position. */
+
+/* WEX.CTRLB  bit masks and bit positions */
+#define WEX_UPDSRC_gm  0x03  /* Update Source group mask. */
+#define WEX_UPDSRC_gp  0  /* Update Source group position. */
+#define WEX_UPDSRC_0_bm  (1<<0)  /* Update Source bit 0 mask. */
+#define WEX_UPDSRC_0_bp  0  /* Update Source bit 0 position. */
+#define WEX_UPDSRC_1_bm  (1<<1)  /* Update Source bit 1 mask. */
+#define WEX_UPDSRC_1_bp  1  /* Update Source bit 1 position. */
+
+/* WEX.CTRLC  bit masks and bit positions */
+#define WEX_CMD_gm  0x07  /* Command group mask. */
+#define WEX_CMD_gp  0  /* Command group position. */
+#define WEX_CMD_0_bm  (1<<0)  /* Command bit 0 mask. */
+#define WEX_CMD_0_bp  0  /* Command bit 0 position. */
+#define WEX_CMD_1_bm  (1<<1)  /* Command bit 1 mask. */
+#define WEX_CMD_1_bp  1  /* Command bit 1 position. */
+#define WEX_CMD_2_bm  (1<<2)  /* Command bit 2 mask. */
+#define WEX_CMD_2_bp  2  /* Command bit 2 position. */
+
+/* WEX.EVCTRLA  bit masks and bit positions */
+#define WEX_FAULTEI_bm  0x01  /* Fault Event Input Enable bit mask. */
+#define WEX_FAULTEI_bp  0  /* Fault Event Input Enable bit position. */
+#define WEX_BLANK_bm  0x02  /* Fault Event Blanking Enable bit mask. */
+#define WEX_BLANK_bp  1  /* Fault Event Blanking Enable bit position. */
+#define WEX_FILTER_gm  0x1C  /* Fault Event Filter Enable group mask. */
+#define WEX_FILTER_gp  2  /* Fault Event Filter Enable group position. */
+#define WEX_FILTER_0_bm  (1<<2)  /* Fault Event Filter Enable bit 0 mask. */
+#define WEX_FILTER_0_bp  2  /* Fault Event Filter Enable bit 0 position. */
+#define WEX_FILTER_1_bm  (1<<3)  /* Fault Event Filter Enable bit 1 mask. */
+#define WEX_FILTER_1_bp  3  /* Fault Event Filter Enable bit 1 position. */
+#define WEX_FILTER_2_bm  (1<<4)  /* Fault Event Filter Enable bit 2 mask. */
+#define WEX_FILTER_2_bp  4  /* Fault Event Filter Enable bit 2 position. */
+
+/* WEX.EVCTRLB  bit masks and bit positions */
+/* WEX_FAULTEI  is already defined. */
+/* WEX_BLANK  is already defined. */
+/* WEX_FILTER  is already defined. */
+
+/* WEX.EVCTRLC  bit masks and bit positions */
+/* WEX_FAULTEI  is already defined. */
+/* WEX_BLANK  is already defined. */
+/* WEX_FILTER  is already defined. */
+
+/* WEX.BUFCTRL  bit masks and bit positions */
+#define WEX_DTLSBV_bm  0x01  /* Dead-time Low Side Buffer Valid bit mask. */
+#define WEX_DTLSBV_bp  0  /* Dead-time Low Side Buffer Valid bit position. */
+#define WEX_DTHSBV_bm  0x02  /* Dead-time High Side Buffer Valid bit mask. */
+#define WEX_DTHSBV_bp  1  /* Dead-time High Side Buffer Valid bit position. */
+#define WEX_SWAPBV_bm  0x04  /* Swap Buffer Valid bit mask. */
+#define WEX_SWAPBV_bp  2  /* Swap Buffer Valid bit position. */
+#define WEX_PGMOVRBV_bm  0x08  /* PGM Override Buffer Valid bit mask. */
+#define WEX_PGMOVRBV_bp  3  /* PGM Override Buffer Valid bit position. */
+#define WEX_PGMOUTBV_bm  0x10  /* PGM Output Value Buffer Valid bit mask. */
+#define WEX_PGMOUTBV_bp  4  /* PGM Output Value Buffer Valid bit position. */
+
+/* WEX.BLANKCTRL  bit masks and bit positions */
+#define WEX_BLANKTRIG_gm  0x1F  /* Blanking Trigger group mask. */
+#define WEX_BLANKTRIG_gp  0  /* Blanking Trigger group position. */
+#define WEX_BLANKTRIG_0_bm  (1<<0)  /* Blanking Trigger bit 0 mask. */
+#define WEX_BLANKTRIG_0_bp  0  /* Blanking Trigger bit 0 position. */
+#define WEX_BLANKTRIG_1_bm  (1<<1)  /* Blanking Trigger bit 1 mask. */
+#define WEX_BLANKTRIG_1_bp  1  /* Blanking Trigger bit 1 position. */
+#define WEX_BLANKTRIG_2_bm  (1<<2)  /* Blanking Trigger bit 2 mask. */
+#define WEX_BLANKTRIG_2_bp  2  /* Blanking Trigger bit 2 position. */
+#define WEX_BLANKTRIG_3_bm  (1<<3)  /* Blanking Trigger bit 3 mask. */
+#define WEX_BLANKTRIG_3_bp  3  /* Blanking Trigger bit 3 position. */
+#define WEX_BLANKTRIG_4_bm  (1<<4)  /* Blanking Trigger bit 4 mask. */
+#define WEX_BLANKTRIG_4_bp  4  /* Blanking Trigger bit 4 position. */
+#define WEX_BLANKPRESC_gm  0x60  /* Blanking Prescaler group mask. */
+#define WEX_BLANKPRESC_gp  5  /* Blanking Prescaler group position. */
+#define WEX_BLANKPRESC_0_bm  (1<<5)  /* Blanking Prescaler bit 0 mask. */
+#define WEX_BLANKPRESC_0_bp  5  /* Blanking Prescaler bit 0 position. */
+#define WEX_BLANKPRESC_1_bm  (1<<6)  /* Blanking Prescaler bit 1 mask. */
+#define WEX_BLANKPRESC_1_bp  6  /* Blanking Prescaler bit 1 position. */
+
+/* WEX.FAULTCTRL  bit masks and bit positions */
+#define WEX_FDACT_gm  0x03  /* Fault Detection Action group mask. */
+#define WEX_FDACT_gp  0  /* Fault Detection Action group position. */
+#define WEX_FDACT_0_bm  (1<<0)  /* Fault Detection Action bit 0 mask. */
+#define WEX_FDACT_0_bp  0  /* Fault Detection Action bit 0 position. */
+#define WEX_FDACT_1_bm  (1<<1)  /* Fault Detection Action bit 1 mask. */
+#define WEX_FDACT_1_bp  1  /* Fault Detection Action bit 1 position. */
+#define WEX_FDMODE_bm  0x04  /* Fault Detection Restart Mode bit mask. */
+#define WEX_FDMODE_bp  2  /* Fault Detection Restart Mode bit position. */
+#define WEX_FDDBD_bm  0x80  /* Fault Detection on Debug Break Detection bit mask. */
+#define WEX_FDDBD_bp  7  /* Fault Detection on Debug Break Detection bit position. */
+
+/* WEX.FAULTDRV  bit masks and bit positions */
+#define WEX_FAULTDRV0_bm  0x01  /* Fault Drive Enable Bit 0 bit mask. */
+#define WEX_FAULTDRV0_bp  0  /* Fault Drive Enable Bit 0 bit position. */
+#define WEX_FAULTDRV1_bm  0x02  /* Fault Drive Enable Bit 1 bit mask. */
+#define WEX_FAULTDRV1_bp  1  /* Fault Drive Enable Bit 1 bit position. */
+#define WEX_FAULTDRV2_bm  0x04  /* Fault Drive Enable Bit 2 bit mask. */
+#define WEX_FAULTDRV2_bp  2  /* Fault Drive Enable Bit 2 bit position. */
+#define WEX_FAULTDRV3_bm  0x08  /* Fault Drive Enable Bit 3 bit mask. */
+#define WEX_FAULTDRV3_bp  3  /* Fault Drive Enable Bit 3 bit position. */
+#define WEX_FAULTDRV4_bm  0x10  /* Fault Drive Enable Bit 4 bit mask. */
+#define WEX_FAULTDRV4_bp  4  /* Fault Drive Enable Bit 4 bit position. */
+#define WEX_FAULTDRV5_bm  0x20  /* Fault Drive Enable Bit 5 bit mask. */
+#define WEX_FAULTDRV5_bp  5  /* Fault Drive Enable Bit 5 bit position. */
+#define WEX_FAULTDRV6_bm  0x40  /* Fault Drive Enable Bit 6 bit mask. */
+#define WEX_FAULTDRV6_bp  6  /* Fault Drive Enable Bit 6 bit position. */
+#define WEX_FAULTDRV7_bm  0x80  /* Fault Drive Enable Bit 7 bit mask. */
+#define WEX_FAULTDRV7_bp  7  /* Fault Drive Enable Bit 7 bit position. */
+
+/* WEX.FAULTOUT  bit masks and bit positions */
+#define WEX_FAULTOUT0_bm  0x01  /* Fault Output Value Bit 0 bit mask. */
+#define WEX_FAULTOUT0_bp  0  /* Fault Output Value Bit 0 bit position. */
+#define WEX_FAULTOUT1_bm  0x02  /* Fault Output Value Bit 1 bit mask. */
+#define WEX_FAULTOUT1_bp  1  /* Fault Output Value Bit 1 bit position. */
+#define WEX_FAULTOUT2_bm  0x04  /* Fault Output Value Bit 2 bit mask. */
+#define WEX_FAULTOUT2_bp  2  /* Fault Output Value Bit 2 bit position. */
+#define WEX_FAULTOUT3_bm  0x08  /* Fault Output Value Bit 3 bit mask. */
+#define WEX_FAULTOUT3_bp  3  /* Fault Output Value Bit 3 bit position. */
+#define WEX_FAULTOUT4_bm  0x10  /* Fault Output Value Bit 4 bit mask. */
+#define WEX_FAULTOUT4_bp  4  /* Fault Output Value Bit 4 bit position. */
+#define WEX_FAULTOUT5_bm  0x20  /* Fault Output Value Bit 5 bit mask. */
+#define WEX_FAULTOUT5_bp  5  /* Fault Output Value Bit 5 bit position. */
+#define WEX_FAULTOUT6_bm  0x40  /* Fault Output Value Bit 6 bit mask. */
+#define WEX_FAULTOUT6_bp  6  /* Fault Output Value Bit 6 bit position. */
+#define WEX_FAULTOUT7_bm  0x80  /* Fault Output Value Bit 7 bit mask. */
+#define WEX_FAULTOUT7_bp  7  /* Fault Output Value Bit 7 bit position. */
+
+/* WEX.INTCTRL  bit masks and bit positions */
+#define WEX_FAULTDET_bm  0x01  /* Fault Detection Interrupt Enable bit mask. */
+#define WEX_FAULTDET_bp  0  /* Fault Detection Interrupt Enable bit position. */
+
+/* WEX.INTFLAGS  bit masks and bit positions */
+/* WEX_FAULTDET  is already defined. */
+#define WEX_FDFEVA_bm  0x04  /* Fault Detection Flag Event Input A bit mask. */
+#define WEX_FDFEVA_bp  2  /* Fault Detection Flag Event Input A bit position. */
+#define WEX_FDFEVB_bm  0x08  /* Fault Detection Flag Event Input B bit mask. */
+#define WEX_FDFEVB_bp  3  /* Fault Detection Flag Event Input B bit position. */
+#define WEX_FDFEVC_bm  0x10  /* Fault Detection Flag Event Input C bit mask. */
+#define WEX_FDFEVC_bp  4  /* Fault Detection Flag Event Input C bit position. */
+
+/* WEX.STATUS  bit masks and bit positions */
+#define WEX_FDSTATE_bm  0x01  /* Fault Detection State bit mask. */
+#define WEX_FDSTATE_bp  0  /* Fault Detection State bit position. */
+#define WEX_FDSEVA_bm  0x04  /* Fault Detection State Event A bit mask. */
+#define WEX_FDSEVA_bp  2  /* Fault Detection State Event A bit position. */
+#define WEX_FDSEVB_bm  0x08  /* Fault Detection State Event B bit mask. */
+#define WEX_FDSEVB_bp  3  /* Fault Detection State Event B bit position. */
+#define WEX_FDSEVC_bm  0x10  /* Fault Detection State Event C bit mask. */
+#define WEX_FDSEVC_bp  4  /* Fault Detection State Event C bit position. */
+#define WEX_BLANKSTATE_bm  0x80  /* Blanking State bit mask. */
+#define WEX_BLANKSTATE_bp  7  /* Blanking State bit position. */
+
+/* WEX.SWAP  bit masks and bit positions */
+#define WEX_SWAP0_bm  0x01  /* Swap DTI Output Pair 0 bit mask. */
+#define WEX_SWAP0_bp  0  /* Swap DTI Output Pair 0 bit position. */
+#define WEX_SWAP1_bm  0x02  /* Swap DTI Output Pair 1 bit mask. */
+#define WEX_SWAP1_bp  1  /* Swap DTI Output Pair 1 bit position. */
+#define WEX_SWAP2_bm  0x04  /* Swap DTI Output Pair 2 bit mask. */
+#define WEX_SWAP2_bp  2  /* Swap DTI Output Pair 2 bit position. */
+#define WEX_SWAP3_bm  0x08  /* Swap DTI Output Pair 3 bit mask. */
+#define WEX_SWAP3_bp  3  /* Swap DTI Output Pair 3 bit position. */
+
+/* WEX.PGMOVR  bit masks and bit positions */
+#define WEX_PGMOVR0_bm  0x01  /* Pattern Generation Override Enable Bit 0 bit mask. */
+#define WEX_PGMOVR0_bp  0  /* Pattern Generation Override Enable Bit 0 bit position. */
+#define WEX_PGMOVR1_bm  0x02  /* Pattern Generation Override Enable Bit 1 bit mask. */
+#define WEX_PGMOVR1_bp  1  /* Pattern Generation Override Enable Bit 1 bit position. */
+#define WEX_PGMOVR2_bm  0x04  /* Pattern Generation Override Enable Bit 2 bit mask. */
+#define WEX_PGMOVR2_bp  2  /* Pattern Generation Override Enable Bit 2 bit position. */
+#define WEX_PGMOVR3_bm  0x08  /* Pattern Generation Override Enable Bit 3 bit mask. */
+#define WEX_PGMOVR3_bp  3  /* Pattern Generation Override Enable Bit 3 bit position. */
+#define WEX_PGMOVR4_bm  0x10  /* Pattern Generation Override Enable Bit 4 bit mask. */
+#define WEX_PGMOVR4_bp  4  /* Pattern Generation Override Enable Bit 4 bit position. */
+#define WEX_PGMOVR5_bm  0x20  /* Pattern Generation Override Enable Bit 5 bit mask. */
+#define WEX_PGMOVR5_bp  5  /* Pattern Generation Override Enable Bit 5 bit position. */
+#define WEX_PGMOVR6_bm  0x40  /* Pattern Generation Override Enable Bit 6 bit mask. */
+#define WEX_PGMOVR6_bp  6  /* Pattern Generation Override Enable Bit 6 bit position. */
+#define WEX_PGMOVR7_bm  0x80  /* Pattern Generation Override Enable Bit 7 bit mask. */
+#define WEX_PGMOVR7_bp  7  /* Pattern Generation Override Enable Bit 7 bit position. */
+
+/* WEX.PGMOUT  bit masks and bit positions */
+#define WEX_PGMOUT0_bm  0x01  /* Pattern Generation Output Value Bit 0 bit mask. */
+#define WEX_PGMOUT0_bp  0  /* Pattern Generation Output Value Bit 0 bit position. */
+#define WEX_PGMOUT1_bm  0x02  /* Pattern Generation Output Value Bit 1 bit mask. */
+#define WEX_PGMOUT1_bp  1  /* Pattern Generation Output Value Bit 1 bit position. */
+#define WEX_PGMOUT2_bm  0x04  /* Pattern Generation Output Value Bit 2 bit mask. */
+#define WEX_PGMOUT2_bp  2  /* Pattern Generation Output Value Bit 2 bit position. */
+#define WEX_PGMOUT3_bm  0x08  /* Pattern Generation Output Value Bit 3 bit mask. */
+#define WEX_PGMOUT3_bp  3  /* Pattern Generation Output Value Bit 3 bit position. */
+#define WEX_PGMOUT4_bm  0x10  /* Pattern Generation Output Value Bit 4 bit mask. */
+#define WEX_PGMOUT4_bp  4  /* Pattern Generation Output Value Bit 4 bit position. */
+#define WEX_PGMOUT5_bm  0x20  /* Pattern Generation Output Value Bit 5 bit mask. */
+#define WEX_PGMOUT5_bp  5  /* Pattern Generation Output Value Bit 5 bit position. */
+#define WEX_PGMOUT6_bm  0x40  /* Pattern Generation Output Value Bit 6 bit mask. */
+#define WEX_PGMOUT6_bp  6  /* Pattern Generation Output Value Bit 6 bit position. */
+#define WEX_PGMOUT7_bm  0x80  /* Pattern Generation Output Value Bit 7 bit mask. */
+#define WEX_PGMOUT7_bp  7  /* Pattern Generation Output Value Bit 7 bit position. */
+
+/* WEX.OUTOVEN  bit masks and bit positions */
+#define WEX_OUTOVEN0_bm  0x01  /* Output Override Enable Bit 0 bit mask. */
+#define WEX_OUTOVEN0_bp  0  /* Output Override Enable Bit 0 bit position. */
+#define WEX_OUTOVEN1_bm  0x02  /* Output Override Enable Bit 1 bit mask. */
+#define WEX_OUTOVEN1_bp  1  /* Output Override Enable Bit 1 bit position. */
+#define WEX_OUTOVEN2_bm  0x04  /* Output Override Enable Bit 2 bit mask. */
+#define WEX_OUTOVEN2_bp  2  /* Output Override Enable Bit 2 bit position. */
+#define WEX_OUTOVEN3_bm  0x08  /* Output Override Enable Bit 3 bit mask. */
+#define WEX_OUTOVEN3_bp  3  /* Output Override Enable Bit 3 bit position. */
+#define WEX_OUTOVEN4_bm  0x10  /* Output Override Enable Bit 4 bit mask. */
+#define WEX_OUTOVEN4_bp  4  /* Output Override Enable Bit 4 bit position. */
+#define WEX_OUTOVEN5_bm  0x20  /* Output Override Enable Bit 5 bit mask. */
+#define WEX_OUTOVEN5_bp  5  /* Output Override Enable Bit 5 bit position. */
+#define WEX_OUTOVEN6_bm  0x40  /* Output Override Enable Bit 6 bit mask. */
+#define WEX_OUTOVEN6_bp  6  /* Output Override Enable Bit 6 bit position. */
+#define WEX_OUTOVEN7_bm  0x80  /* Output Override Enable Bit 7 bit mask. */
+#define WEX_OUTOVEN7_bp  7  /* Output Override Enable Bit 7 bit position. */
+
+/* WEX.SWAPBUF  bit masks and bit positions */
+#define WEX_SWAPBUF0_bm  0x01  /* Swap DTI Output Pair 0 Buffer bit mask. */
+#define WEX_SWAPBUF0_bp  0  /* Swap DTI Output Pair 0 Buffer bit position. */
+#define WEX_SWAPBUF1_bm  0x02  /* Swap DTI Output Pair 1 Buffer bit mask. */
+#define WEX_SWAPBUF1_bp  1  /* Swap DTI Output Pair 1 Buffer bit position. */
+#define WEX_SWAPBUF2_bm  0x04  /* Swap DTI Output Pair 2 Buffer bit mask. */
+#define WEX_SWAPBUF2_bp  2  /* Swap DTI Output Pair 2 Buffer bit position. */
+#define WEX_SWAPBUF3_bm  0x08  /* Swap DTI Output Pair 3 Buffer bit mask. */
+#define WEX_SWAPBUF3_bp  3  /* Swap DTI Output Pair 3 Buffer bit position. */
+
+/* WEX.PGMOVRBUF  bit masks and bit positions */
+#define WEX_PGMOVRBUF0_bm  0x01  /* Pattern Generation Override Enable Buffer Bit 0 bit mask. */
+#define WEX_PGMOVRBUF0_bp  0  /* Pattern Generation Override Enable Buffer Bit 0 bit position. */
+#define WEX_PGMOVRBUF1_bm  0x02  /* Pattern Generation Override Enable Buffer Bit 1 bit mask. */
+#define WEX_PGMOVRBUF1_bp  1  /* Pattern Generation Override Enable Buffer Bit 1 bit position. */
+#define WEX_PGMOVRBUF2_bm  0x04  /* Pattern Generation Override Enable Buffer Bit 2 bit mask. */
+#define WEX_PGMOVRBUF2_bp  2  /* Pattern Generation Override Enable Buffer Bit 2 bit position. */
+#define WEX_PGMOVRBUF3_bm  0x08  /* Pattern Generation Override Enable Buffer Bit 3 bit mask. */
+#define WEX_PGMOVRBUF3_bp  3  /* Pattern Generation Override Enable Buffer Bit 3 bit position. */
+#define WEX_PGMOVRBUF4_bm  0x10  /* Pattern Generation Override Enable Buffer Bit 4 bit mask. */
+#define WEX_PGMOVRBUF4_bp  4  /* Pattern Generation Override Enable Buffer Bit 4 bit position. */
+#define WEX_PGMOVRBUF5_bm  0x20  /* Pattern Generation Override Enable Buffer Bit 5 bit mask. */
+#define WEX_PGMOVRBUF5_bp  5  /* Pattern Generation Override Enable Buffer Bit 5 bit position. */
+#define WEX_PGMOVRBUF6_bm  0x40  /* Pattern Generation Override Enable Buffer Bit 6 bit mask. */
+#define WEX_PGMOVRBUF6_bp  6  /* Pattern Generation Override Enable Buffer Bit 6 bit position. */
+#define WEX_PGMOVRBUF7_bm  0x80  /* Pattern Generation Override Enable Buffer Bit 7 bit mask. */
+#define WEX_PGMOVRBUF7_bp  7  /* Pattern Generation Override Enable Buffer Bit 7 bit position. */
+
+/* WEX.PGMOUTBUF  bit masks and bit positions */
+#define WEX_PGMOUTBUF0_bm  0x01  /* Pattern Generation Output Value Buffer Bit 0 bit mask. */
+#define WEX_PGMOUTBUF0_bp  0  /* Pattern Generation Output Value Buffer Bit 0 bit position. */
+#define WEX_PGMOUTBUF1_bm  0x02  /* Pattern Generation Output Value Buffer Bit 1 bit mask. */
+#define WEX_PGMOUTBUF1_bp  1  /* Pattern Generation Output Value Buffer Bit 1 bit position. */
+#define WEX_PGMOUTBUF2_bm  0x04  /* Pattern Generation Output Value Buffer Bit 2 bit mask. */
+#define WEX_PGMOUTBUF2_bp  2  /* Pattern Generation Output Value Buffer Bit 2 bit position. */
+#define WEX_PGMOUTBUF3_bm  0x08  /* Pattern Generation Output Value Buffer Bit 3 bit mask. */
+#define WEX_PGMOUTBUF3_bp  3  /* Pattern Generation Output Value Buffer Bit 3 bit position. */
+#define WEX_PGMOUTBUF4_bm  0x10  /* Pattern Generation Output Value Buffer Bit 4 bit mask. */
+#define WEX_PGMOUTBUF4_bp  4  /* Pattern Generation Output Value Buffer Bit 4 bit position. */
+#define WEX_PGMOUTBUF5_bm  0x20  /* Pattern Generation Output Value Buffer Bit 5 bit mask. */
+#define WEX_PGMOUTBUF5_bp  5  /* Pattern Generation Output Value Buffer Bit 5 bit position. */
+#define WEX_PGMOUTBUF6_bm  0x40  /* Pattern Generation Output Value Buffer Bit 6 bit mask. */
+#define WEX_PGMOUTBUF6_bp  6  /* Pattern Generation Output Value Buffer Bit 6 bit position. */
+#define WEX_PGMOUTBUF7_bm  0x80  /* Pattern Generation Output Value Buffer Bit 7 bit mask. */
+#define WEX_PGMOUTBUF7_bp  7  /* Pattern Generation Output Value Buffer Bit 7 bit position. */
+
+
+/* ========== Generic Port Pins ========== */
+#define PIN0_bm 0x01
+#define PIN0_bp 0
+#define PIN1_bm 0x02
+#define PIN1_bp 1
+#define PIN2_bm 0x04
+#define PIN2_bp 2
+#define PIN3_bm 0x08
+#define PIN3_bp 3
+#define PIN4_bm 0x10
+#define PIN4_bp 4
+#define PIN5_bm 0x20
+#define PIN5_bp 5
+#define PIN6_bm 0x40
+#define PIN6_bp 6
+#define PIN7_bm 0x80
+#define PIN7_bp 7
+
+/* ========== Interrupt Vector Definitions ========== */
+/* Vector 0 is the reset vector */
+
+/* NMI interrupt vectors */
+#define NMI_vect_num  1
+#define NMI_vect      _VECTOR(1)  /*  */
+
+/* BOD interrupt vectors */
+#define BOD_VLM_vect_num  2
+#define BOD_VLM_vect      _VECTOR(2)  /*  */
+
+/* RTC interrupt vectors */
+#define RTC_CNT_vect_num  3
+#define RTC_CNT_vect      _VECTOR(3)  /*  */
+#define RTC_PIT_vect_num  4
+#define RTC_PIT_vect      _VECTOR(4)  /*  */
+
+/* CCL interrupt vectors */
+#define CCL_CCL_vect_num  5
+#define CCL_CCL_vect      _VECTOR(5)  /*  */
+
+/* PORTA interrupt vectors */
+#define PORTA_PORT_vect_num  6
+#define PORTA_PORT_vect      _VECTOR(6)  /*  */
+
+/* WEX0 interrupt vectors */
+#define WEX0_FDFEVA_vect_num  7
+#define WEX0_FDFEVA_vect      _VECTOR(7)  /*  */
+#define WEX0_FDFEVB_vect_num  7
+#define WEX0_FDFEVB_vect      _VECTOR(7)  /*  */
+#define WEX0_FDFEVC_vect_num  7
+#define WEX0_FDFEVC_vect      _VECTOR(7)  /*  */
+
+/* TCE0 interrupt vectors */
+#define TCE0_OVF_vect_num  8
+#define TCE0_OVF_vect      _VECTOR(8)  /*  */
+#define TCE0_CMP0_vect_num  9
+#define TCE0_CMP0_vect      _VECTOR(9)  /*  */
+#define TCE0_CMP1_vect_num  10
+#define TCE0_CMP1_vect      _VECTOR(10)  /*  */
+#define TCE0_CMP2_vect_num  11
+#define TCE0_CMP2_vect      _VECTOR(11)  /*  */
+#define TCE0_CMP3_vect_num  12
+#define TCE0_CMP3_vect      _VECTOR(12)  /*  */
+
+/* TCB0 interrupt vectors */
+#define TCB0_INT_vect_num  13
+#define TCB0_INT_vect      _VECTOR(13)  /*  */
+
+/* TCB1 interrupt vectors */
+#define TCB1_INT_vect_num  14
+#define TCB1_INT_vect      _VECTOR(14)  /*  */
+
+/* TWI0 interrupt vectors */
+#define TWI0_TWIS_vect_num  15
+#define TWI0_TWIS_vect      _VECTOR(15)  /*  */
+#define TWI0_TWIM_vect_num  16
+#define TWI0_TWIM_vect      _VECTOR(16)  /*  */
+
+/* SPI0 interrupt vectors */
+#define SPI0_INT_vect_num  17
+#define SPI0_INT_vect      _VECTOR(17)  /*  */
+
+/* USART0 interrupt vectors */
+#define USART0_RXC_vect_num  18
+#define USART0_RXC_vect      _VECTOR(18)  /*  */
+#define USART0_DRE_vect_num  19
+#define USART0_DRE_vect      _VECTOR(19)  /*  */
+#define USART0_TXC_vect_num  20
+#define USART0_TXC_vect      _VECTOR(20)  /*  */
+
+/* PORTD interrupt vectors */
+#define PORTD_PORT_vect_num  21
+#define PORTD_PORT_vect      _VECTOR(21)  /*  */
+
+/* TCF0 interrupt vectors */
+#define TCF0_INT_vect_num  22
+#define TCF0_INT_vect      _VECTOR(22)  /*  */
+
+/* AC0 interrupt vectors */
+#define AC0_AC_vect_num  23
+#define AC0_AC_vect      _VECTOR(23)  /*  */
+
+/* ADC0 interrupt vectors */
+#define ADC0_ERROR_vect_num  24
+#define ADC0_ERROR_vect      _VECTOR(24)  /*  */
+#define ADC0_RESRDY_vect_num  25
+#define ADC0_RESRDY_vect      _VECTOR(25)  /*  */
+#define ADC0_SAMPRDY_vect_num  26
+#define ADC0_SAMPRDY_vect      _VECTOR(26)  /*  */
+
+/* AC1 interrupt vectors */
+#define AC1_AC_vect_num  27
+#define AC1_AC_vect      _VECTOR(27)  /*  */
+
+/* PORTC interrupt vectors */
+#define PORTC_PORT_vect_num  28
+#define PORTC_PORT_vect      _VECTOR(28)  /*  */
+
+/* PORTF interrupt vectors */
+#define PORTF_PORT_vect_num  29
+#define PORTF_PORT_vect      _VECTOR(29)  /*  */
+
+/* NVMCTRL interrupt vectors */
+#define NVMCTRL_EEREADY_vect_num  30
+#define NVMCTRL_EEREADY_vect      _VECTOR(30)  /*  */
+#define NVMCTRL_FLREADY_vect_num  30
+#define NVMCTRL_FLREADY_vect      _VECTOR(30)  /*  */
+#define NVMCTRL_NVMREADY_vect_num  30
+#define NVMCTRL_NVMREADY_vect      _VECTOR(30)  /*  */
+
+#define _VECTOR_SIZE 4 /* Size of individual vector. */
+#define _VECTORS_SIZE (31 * _VECTOR_SIZE)
+
+
+/* ========== Constants ========== */
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define DATAMEM_START     (0x0000)
+#  define DATAMEM_SIZE      (65536)
+#else
+#  define DATAMEM_START     (0x0000U)
+#  define DATAMEM_SIZE      (65536U)
+#endif
+#define DATAMEM_END       (DATAMEM_START + DATAMEM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define IO_START     (0x0000)
+#  define IO_SIZE      (4159)
+#  define IO_PAGE_SIZE (0)
+#else
+#  define IO_START     (0x0000U)
+#  define IO_SIZE      (4159U)
+#  define IO_PAGE_SIZE (0U)
+#endif
+#define IO_END       (IO_START + IO_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define LOCKBITS_START     (0x1040)
+#  define LOCKBITS_SIZE      (4)
+#  define LOCKBITS_PAGE_SIZE (4)
+#else
+#  define LOCKBITS_START     (0x1040U)
+#  define LOCKBITS_SIZE      (4U)
+#  define LOCKBITS_PAGE_SIZE (4U)
+#endif
+#define LOCKBITS_END       (LOCKBITS_START + LOCKBITS_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define FUSES_START     (0x1050)
+#  define FUSES_SIZE      (16)
+#  define FUSES_PAGE_SIZE (8)
+#else
+#  define FUSES_START     (0x1050U)
+#  define FUSES_SIZE      (16U)
+#  define FUSES_PAGE_SIZE (8U)
+#endif
+#define FUSES_END       (FUSES_START + FUSES_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define SIGNATURES_START     (0x1080)
+#  define SIGNATURES_SIZE      (3)
+#  define SIGNATURES_PAGE_SIZE (128)
+#else
+#  define SIGNATURES_START     (0x1080U)
+#  define SIGNATURES_SIZE      (3U)
+#  define SIGNATURES_PAGE_SIZE (128U)
+#endif
+#define SIGNATURES_END       (SIGNATURES_START + SIGNATURES_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define PROD_SIGNATURES_START     (0x1083)
+#  define PROD_SIGNATURES_SIZE      (125)
+#  define PROD_SIGNATURES_PAGE_SIZE (128)
+#else
+#  define PROD_SIGNATURES_START     (0x1083U)
+#  define PROD_SIGNATURES_SIZE      (125U)
+#  define PROD_SIGNATURES_PAGE_SIZE (128U)
+#endif
+#define PROD_SIGNATURES_END       (PROD_SIGNATURES_START + PROD_SIGNATURES_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define BOOTROW_START     (0x1100)
+#  define BOOTROW_SIZE      (64)
+#  define BOOTROW_PAGE_SIZE (64)
+#else
+#  define BOOTROW_START     (0x1100U)
+#  define BOOTROW_SIZE      (64U)
+#  define BOOTROW_PAGE_SIZE (64U)
+#endif
+#define BOOTROW_END       (BOOTROW_START + BOOTROW_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define USER_SIGNATURES_START     (0x1200)
+#  define USER_SIGNATURES_SIZE      (64)
+#  define USER_SIGNATURES_PAGE_SIZE (64)
+#else
+#  define USER_SIGNATURES_START     (0x1200U)
+#  define USER_SIGNATURES_SIZE      (64U)
+#  define USER_SIGNATURES_PAGE_SIZE (64U)
+#endif
+#define USER_SIGNATURES_END       (USER_SIGNATURES_START + USER_SIGNATURES_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define EEPROM_START     (0x1400)
+#  define EEPROM_SIZE      (512)
+#  define EEPROM_PAGE_SIZE (8)
+#else
+#  define EEPROM_START     (0x1400U)
+#  define EEPROM_SIZE      (512U)
+#  define EEPROM_PAGE_SIZE (8U)
+#endif
+#define EEPROM_END       (EEPROM_START + EEPROM_SIZE - 1)
+
+/* Added MAPPED_EEPROM segment names for avr-libc */
+#define MAPPED_EEPROM_START     (EEPROM_START)
+#define MAPPED_EEPROM_SIZE      (EEPROM_SIZE)
+#define MAPPED_EEPROM_PAGE_SIZE (EEPROM_PAGE_SIZE)
+#define MAPPED_EEPROM_END       (MAPPED_EEPROM_START + MAPPED_EEPROM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define INTERNAL_SRAM_START     (0x7800)
+#  define INTERNAL_SRAM_SIZE      (2048)
+#  define INTERNAL_SRAM_PAGE_SIZE (0)
+#else
+#  define INTERNAL_SRAM_START     (0x7800U)
+#  define INTERNAL_SRAM_SIZE      (2048U)
+#  define INTERNAL_SRAM_PAGE_SIZE (0U)
+#endif
+#define INTERNAL_SRAM_END       (INTERNAL_SRAM_START + INTERNAL_SRAM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define MAPPED_PROGMEM_START     (0x8000)
+#  define MAPPED_PROGMEM_SIZE      (16384)
+#  define MAPPED_PROGMEM_PAGE_SIZE (64)
+#else
+#  define MAPPED_PROGMEM_START     (0x8000U)
+#  define MAPPED_PROGMEM_SIZE      (16384U)
+#  define MAPPED_PROGMEM_PAGE_SIZE (64U)
+#endif
+#define MAPPED_PROGMEM_END       (MAPPED_PROGMEM_START + MAPPED_PROGMEM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define PROGMEM_START     (0x0000)
+#  define PROGMEM_SIZE      (16384)
+#  define PROGMEM_PAGE_SIZE (64)
+#else
+#  define PROGMEM_START     (0x0000U)
+#  define PROGMEM_SIZE      (16384U)
+#  define PROGMEM_PAGE_SIZE (64U)
+#endif
+#define PROGMEM_END       (PROGMEM_START + PROGMEM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define PROGMEM_NRWW_START     (0x0000)
+#  define PROGMEM_NRWW_SIZE      (4096)
+#  define PROGMEM_NRWW_PAGE_SIZE (64)
+#else
+#  define PROGMEM_NRWW_START     (0x0000U)
+#  define PROGMEM_NRWW_SIZE      (4096U)
+#  define PROGMEM_NRWW_PAGE_SIZE (64U)
+#endif
+#define PROGMEM_NRWW_END       (PROGMEM_NRWW_START + PROGMEM_NRWW_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define PROGMEM_RWW_START     (0x1000)
+#  define PROGMEM_RWW_SIZE      (12288)
+#  define PROGMEM_RWW_PAGE_SIZE (64)
+#else
+#  define PROGMEM_RWW_START     (0x1000U)
+#  define PROGMEM_RWW_SIZE      (12288U)
+#  define PROGMEM_RWW_PAGE_SIZE (64U)
+#endif
+#define PROGMEM_RWW_END       (PROGMEM_RWW_START + PROGMEM_RWW_SIZE - 1)
+
+#define FLASHSTART   PROGMEM_START
+#define FLASHEND     PROGMEM_END
+#define RAMSTART     INTERNAL_SRAM_START
+#define RAMSIZE      INTERNAL_SRAM_SIZE
+#define RAMEND       INTERNAL_SRAM_END
+#define E2END        EEPROM_END
+#define E2PAGESIZE   EEPROM_PAGE_SIZE
+
+/* ========== Fuses ========== */
+#define FUSE_MEMORY_SIZE 16
+
+/* Fuse Byte 0 (WDTCFG) */
+#define FUSE_PERIOD0  (unsigned char)_BV(0)  /* Watchdog Timeout Period Bit 0 */
+#define FUSE_PERIOD1  (unsigned char)_BV(1)  /* Watchdog Timeout Period Bit 1 */
+#define FUSE_PERIOD2  (unsigned char)_BV(2)  /* Watchdog Timeout Period Bit 2 */
+#define FUSE_PERIOD3  (unsigned char)_BV(3)  /* Watchdog Timeout Period Bit 3 */
+#define FUSE_WINDOW0  (unsigned char)_BV(4)  /* Watchdog Window Timeout Period Bit 0 */
+#define FUSE_WINDOW1  (unsigned char)_BV(5)  /* Watchdog Window Timeout Period Bit 1 */
+#define FUSE_WINDOW2  (unsigned char)_BV(6)  /* Watchdog Window Timeout Period Bit 2 */
+#define FUSE_WINDOW3  (unsigned char)_BV(7)  /* Watchdog Window Timeout Period Bit 3 */
+#define FUSE0_DEFAULT  (0x0)
+#define FUSE_WDTCFG_DEFAULT  (0x0)
+
+/* Fuse Byte 1 (BODCFG) */
+#define FUSE_SLEEP0  (unsigned char)_BV(0)  /* BOD Operation in Sleep Mode Bit 0 */
+#define FUSE_SLEEP1  (unsigned char)_BV(1)  /* BOD Operation in Sleep Mode Bit 1 */
+#define FUSE_ACTIVE0  (unsigned char)_BV(2)  /* BOD Operation in Active Mode Bit 0 */
+#define FUSE_ACTIVE1  (unsigned char)_BV(3)  /* BOD Operation in Active Mode Bit 1 */
+#define FUSE_SAMPFREQ  (unsigned char)_BV(4)  /* BOD Sample Frequency */
+#define FUSE_LVL0  (unsigned char)_BV(5)  /* BOD Level Bit 0 */
+#define FUSE_LVL1  (unsigned char)_BV(6)  /* BOD Level Bit 1 */
+#define FUSE_LVL2  (unsigned char)_BV(7)  /* BOD Level Bit 2 */
+#define FUSE1_DEFAULT  (0x0)
+#define FUSE_BODCFG_DEFAULT  (0x0)
+
+/* Fuse Byte 2 (OSCCFG) */
+#define FUSE_OSCHFFRQ  (unsigned char)_BV(3)  /* High-frequency Oscillator Frequency */
+#define FUSE2_DEFAULT  (0x0)
+#define FUSE_OSCCFG_DEFAULT  (0x0)
+
+/* Fuse Byte 3 Reserved */
+
+/* Fuse Byte 4 Reserved */
+
+/* Fuse Byte 5 (SYSCFG0) */
+#define FUSE_EESAVE  (unsigned char)_BV(0)  /* EEPROM Save */
+#define FUSE_RSTPINCFG  (unsigned char)_BV(3)  /* Reset Pin Configuration */
+#define FUSE_UPDIPINCFG  (unsigned char)_BV(4)  /* UPDI Pin Configuration */
+#define FUSE_CRCSEL  (unsigned char)_BV(5)  /* CRC Select */
+#define FUSE_CRCSRC0  (unsigned char)_BV(6)  /* CRC Source Bit 0 */
+#define FUSE_CRCSRC1  (unsigned char)_BV(7)  /* CRC Source Bit 1 */
+#define FUSE5_DEFAULT  (0xD0)
+#define FUSE_SYSCFG0_DEFAULT  (0xD0)
+
+/* Fuse Byte 6 (SYSCFG1) */
+#define FUSE_SUT0  (unsigned char)_BV(0)  /* Startup Time Bit 0 */
+#define FUSE_SUT1  (unsigned char)_BV(1)  /* Startup Time Bit 1 */
+#define FUSE_SUT2  (unsigned char)_BV(2)  /* Startup Time Bit 2 */
+#define FUSE6_DEFAULT  (0x7)
+#define FUSE_SYSCFG1_DEFAULT  (0x7)
+
+/* Fuse Byte 7 (CODESIZE) */
+#define FUSE7_DEFAULT  (0x0)
+#define FUSE_CODESIZE_DEFAULT  (0x0)
+
+/* Fuse Byte 8 (BOOTSIZE) */
+#define FUSE8_DEFAULT  (0x0)
+#define FUSE_BOOTSIZE_DEFAULT  (0x0)
+
+/* Fuse Byte 9 Reserved */
+
+/* Fuse Byte 10 (PDICFG) */
+#define FUSE_LEVEL0  (unsigned char)_BV(0)  /* Protection Level Bit 0 */
+#define FUSE_LEVEL1  (unsigned char)_BV(1)  /* Protection Level Bit 1 */
+#define FUSE_KEY0  (unsigned char)_BV(4)  /* NVM Protection Activation Key Bit 0 */
+#define FUSE_KEY1  (unsigned char)_BV(5)  /* NVM Protection Activation Key Bit 1 */
+#define FUSE_KEY2  (unsigned char)_BV(6)  /* NVM Protection Activation Key Bit 2 */
+#define FUSE_KEY3  (unsigned char)_BV(7)  /* NVM Protection Activation Key Bit 3 */
+#define FUSE_KEY4  (unsigned char)_BV(8)  /* NVM Protection Activation Key Bit 4 */
+#define FUSE_KEY5  (unsigned char)_BV(9)  /* NVM Protection Activation Key Bit 5 */
+#define FUSE_KEY6  (unsigned char)_BV(10)  /* NVM Protection Activation Key Bit 6 */
+#define FUSE_KEY7  (unsigned char)_BV(11)  /* NVM Protection Activation Key Bit 7 */
+#define FUSE_KEY8  (unsigned char)_BV(12)  /* NVM Protection Activation Key Bit 8 */
+#define FUSE_KEY9  (unsigned char)_BV(13)  /* NVM Protection Activation Key Bit 9 */
+#define FUSE_KEY10  (unsigned char)_BV(14)  /* NVM Protection Activation Key Bit 10 */
+#define FUSE_KEY11  (unsigned char)_BV(15)  /* NVM Protection Activation Key Bit 11 */
+#define FUSE10_DEFAULT  (0x3)
+#define FUSE_PDICFG_DEFAULT  (0x3)
+
+/* ========== Lock Bits ========== */
+#define __LOCK_KEY_EXIST
+#ifdef LOCKBITS_DEFAULT
+#undef LOCKBITS_DEFAULT
+#endif //LOCKBITS_DEFAULT
+#define LOCKBITS_DEFAULT  (0x5CC5C55C)
+
+/* ========== Signature ========== */
+#define SIGNATURE_0 0x1E
+#define SIGNATURE_1 0x94
+#define SIGNATURE_2 0x3E
+
+#endif /* #ifdef _AVR_AVR16EB32_H_INCLUDED */
+

--- a/include/avr/ioavr32ea28.h
+++ b/include/avr/ioavr32ea28.h
@@ -1,0 +1,5800 @@
+/*
+ * Copyright (C) 2023, Microchip Technology Inc. and its subsidiaries ("Microchip")
+ * All rights reserved.
+ *
+ * This software is developed by Microchip Technology Inc. and its subsidiaries ("Microchip").
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other
+ *        materials provided with the distribution. Publication is not required when
+ *        this file is used in an embedded application.
+ *
+ *     3. Microchip's name may not be used to endorse or promote products derived from this
+ *        software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY MICROCHIP "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL MICROCHIP BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING BUT NOT LIMITED TO
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWSOEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _AVR_IO_H_
+#  error "Include <avr/io.h> instead of this file."
+#endif
+
+#ifndef _AVR_IOXXX_H_
+#  define _AVR_IOXXX_H_ "ioavr32ea28.h"
+#else
+#  error "Attempt to include more than one <avr/ioXXX.h> file."
+#endif
+
+#ifndef _AVR_AVR32EA28_H_INCLUDED
+#define _AVR_AVR32EA28_H_INCLUDED
+
+/* Ungrouped common registers */
+#define CCP  _SFR_MEM8(0x0034)  /* Configuration Change Protection */
+#define SP  _SFR_MEM16(0x003D)  /* Stack Pointer */
+#define SPL  _SFR_MEM8(0x003D)  /* Stack Pointer Low */
+#define SPH  _SFR_MEM8(0x003E)  /* Stack Pointer High */
+#define SREG  _SFR_MEM8(0x003F)  /* Status Register */
+
+/* C Language Only */
+#if !defined (__ASSEMBLER__)
+
+#include <stdint.h>
+
+typedef volatile uint8_t register8_t;
+typedef volatile uint16_t register16_t;
+typedef volatile uint32_t register32_t;
+
+
+#ifdef _WORDREGISTER
+#undef _WORDREGISTER
+#endif
+#define _WORDREGISTER(regname)   \
+    __extension__ union \
+    { \
+        register16_t regname; \
+        struct \
+        { \
+            register8_t regname ## L; \
+            register8_t regname ## H; \
+        }; \
+    }
+
+#ifdef _DWORDREGISTER
+#undef _DWORDREGISTER
+#endif
+#define _DWORDREGISTER(regname)  \
+    __extension__ union \
+    { \
+        register32_t regname; \
+        struct \
+        { \
+            register8_t regname ## 0; \
+            register8_t regname ## 1; \
+            register8_t regname ## 2; \
+            register8_t regname ## 3; \
+        }; \
+    }
+
+
+/*
+==========================================================================
+IO Module Structures
+==========================================================================
+*/
+
+
+/*
+--------------------------------------------------------------------------
+AC - Analog Comparator
+--------------------------------------------------------------------------
+*/
+
+/* Analog Comparator */
+typedef struct AC_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t MUXCTRL;  /* Mux Control A */
+    register8_t reserved_1[2];
+    register8_t DACREF;  /* DAC Voltage Reference */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t STATUS;  /* Status */
+} AC_t;
+
+/* Hysteresis Mode select */
+typedef enum AC_HYSMODE_enum
+{
+    AC_HYSMODE_NONE_gc = (0x00<<1),  /* No hysteresis */
+    AC_HYSMODE_SMALL_gc = (0x01<<1),  /* Small hysteresis */
+    AC_HYSMODE_MEDIUM_gc = (0x02<<1),  /* Medium hysteresis */
+    AC_HYSMODE_LARGE_gc = (0x03<<1)  /* Large hysteresis */
+} AC_HYSMODE_t;
+
+/* AC Output Initial Value select */
+typedef enum AC_INITVAL_enum
+{
+    AC_INITVAL_LOW_gc = (0x00<<6),  /* Output initialized to 0 */
+    AC_INITVAL_HIGH_gc = (0x01<<6)  /* Output initialized to 1 */
+} AC_INITVAL_t;
+
+/* Interrupt Mode select */
+typedef enum AC_INTMODE_NORMAL_enum
+{
+    AC_INTMODE_NORMAL_BOTHEDGE_gc = (0x00<<4),  /* Positive and negative inputs crosses */
+    AC_INTMODE_NORMAL_NEGEDGE_gc = (0x02<<4),  /* Positive input goes below negative input */
+    AC_INTMODE_NORMAL_POSEDGE_gc = (0x03<<4)  /* Positive input goes above negative input */
+} AC_INTMODE_NORMAL_t;
+
+/* Interrupt Mode select */
+typedef enum AC_INTMODE_WINDOW_enum
+{
+    AC_INTMODE_WINDOW_ABOVE_gc = (0x00<<4),  /* Window interrupt when input above both references */
+    AC_INTMODE_WINDOW_INSIDE_gc = (0x01<<4),  /* Window interrupt when input betweeen references */
+    AC_INTMODE_WINDOW_BELOW_gc = (0x02<<4),  /* Window interrupt when input below both references */
+    AC_INTMODE_WINDOW_OUTSIDE_gc = (0x03<<4)  /* Window interrupt when input outside reference */
+} AC_INTMODE_WINDOW_t;
+
+/* Negative Input MUX Selection */
+typedef enum AC_MUXNEG_enum
+{
+    AC_MUXNEG_AINN0_gc = (0x00<<0),  /* Negative Pin 0 */
+    AC_MUXNEG_AINN1_gc = (0x01<<0),  /* Negative Pin 1 */
+    AC_MUXNEG_AINN2_gc = (0x02<<0),  /* Negative Pin 2 */
+    AC_MUXNEG_AINN3_gc = (0x03<<0),  /* Negative Pin 3 */
+    AC_MUXNEG_DACREF_gc = (0x04<<0)  /* DAC Reference */
+} AC_MUXNEG_t;
+
+/* Positive Input MUX Selection */
+typedef enum AC_MUXPOS_enum
+{
+    AC_MUXPOS_AINP0_gc = (0x00<<3),  /* Positive Pin 0 */
+    AC_MUXPOS_AINP1_gc = (0x01<<3),  /* Positive Pin 1 */
+    AC_MUXPOS_AINP2_gc = (0x02<<3),  /* Positive Pin 2 */
+    AC_MUXPOS_AINP3_gc = (0x03<<3),  /* Positive Pin 3 */
+    AC_MUXPOS_AINP4_gc = (0x04<<3)  /* Positive Pin 4 */
+} AC_MUXPOS_t;
+
+/* Power profile select */
+typedef enum AC_POWER_enum
+{
+    AC_POWER_PROFILE0_gc = (0x00<<3),  /* Power profile 0, Fastest response time, highest consumption */
+    AC_POWER_PROFILE1_gc = (0x01<<3)  /* Power profile 1 */
+} AC_POWER_t;
+
+/* Window selection mode */
+typedef enum AC_WINSEL_enum
+{
+    AC_WINSEL_DISABLED_gc = (0x00<<0),  /* Window function disabled */
+    AC_WINSEL_UPSEL1_gc = (0x01<<0)  /* Select ACn+1 as upper limit in window compare */
+} AC_WINSEL_t;
+
+/* Analog Comparator Window State select */
+typedef enum AC_WINSTATE_enum
+{
+    AC_WINSTATE_ABOVE_gc = (0x00<<6),  /* Above window */
+    AC_WINSTATE_INSIDE_gc = (0x01<<6),  /* Inside window */
+    AC_WINSTATE_BELOW_gc = (0x02<<6)  /* Below window */
+} AC_WINSTATE_t;
+
+/*
+--------------------------------------------------------------------------
+ADC - Analog to Digital Converter
+--------------------------------------------------------------------------
+*/
+
+/* Analog to Digital Converter */
+typedef struct ADC_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    register8_t CTRLD;  /* Control D */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t STATUS;  /* Status register */
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t CTRLE;  /* Control E */
+    register8_t CTRLF;  /* Control F */
+    register8_t COMMAND;  /* Command register */
+    register8_t PGACTRL;  /* PGA Control */
+    register8_t MUXPOS;  /* Positive Input Multiplexer */
+    register8_t MUXNEG;  /* Negative Input Multiplexer */
+    register8_t reserved_1[2];
+    _DWORDREGISTER(RESULT);  /* Result */
+    _WORDREGISTER(SAMPLE);  /* Sample */
+    register8_t reserved_2[2];
+    register8_t TEMP0;  /* Temporary Data 0 */
+    register8_t TEMP1;  /* Temporary Data 1 */
+    register8_t TEMP2;  /* Temporary Data 2 */
+    register8_t reserved_3[1];
+    _WORDREGISTER(WINLT);  /* Window Low Threshold */
+    _WORDREGISTER(WINHT);  /* Window High Threshold */
+    register8_t reserved_4[32];
+} ADC_t;
+
+/* Sign Chopping select */
+typedef enum ADC_CHOPPING_enum
+{
+    ADC_CHOPPING_DISABLE_gc = (0x00<<6),  /* Sign Chopping Disabled */
+    ADC_CHOPPING_ENABLE_gc = (0x01<<6)  /* Sign Chopping Enabled */
+} ADC_CHOPPING_t;
+
+/* Gain select */
+typedef enum ADC_GAIN_enum
+{
+    ADC_GAIN_1X_gc = (0x00<<5),  /* 1x gain */
+    ADC_GAIN_2X_gc = (0x01<<5),  /* 2x gain */
+    ADC_GAIN_4X_gc = (0x02<<5),  /* 4x gain */
+    ADC_GAIN_8X_gc = (0x03<<5),  /* 8x gain */
+    ADC_GAIN_16X_gc = (0x04<<5)  /* 16x gain */
+} ADC_GAIN_t;
+
+/* Mode select */
+typedef enum ADC_MODE_enum
+{
+    ADC_MODE_SINGLE_8BIT_gc = (0x00<<4),  /* Single Conversion with 8-bit resolution */
+    ADC_MODE_SINGLE_12BIT_gc = (0x01<<4),  /* Single Conversion with 12-bit resolution */
+    ADC_MODE_SERIES_gc = (0x02<<4),  /* Series with accumulation, separate trigger for every 12-bit conversion */
+    ADC_MODE_SERIES_SCALING_gc = (0x03<<4),  /* Series with accumulation and scaling, separate trigger for every 12-bit conversion */
+    ADC_MODE_BURST_gc = (0x04<<4),  /* Burst with accumulation, one trigger will run SAMPNUM 12-bit conversions */
+    ADC_MODE_BURST_SCALING_gc = (0x05<<4)  /* Burst with accumulation and scaling, one trigger will run SAMPNUM 12-bit conversions */
+} ADC_MODE_t;
+
+/* Analog Channel Selection Bits */
+typedef enum ADC_MUXNEG_enum
+{
+    ADC_MUXNEG_AIN0_gc = (0x00<<0),  /* ADC input pin 0 */
+    ADC_MUXNEG_AIN1_gc = (0x01<<0),  /* ADC input pin 1 */
+    ADC_MUXNEG_AIN2_gc = (0x02<<0),  /* ADC input pin 2 */
+    ADC_MUXNEG_AIN3_gc = (0x03<<0),  /* ADC input pin 3 */
+    ADC_MUXNEG_AIN4_gc = (0x04<<0),  /* ADC input pin 4 */
+    ADC_MUXNEG_AIN5_gc = (0x05<<0),  /* ADC input pin 5 */
+    ADC_MUXNEG_AIN6_gc = (0x06<<0),  /* ADC input pin 6 */
+    ADC_MUXNEG_AIN7_gc = (0x07<<0),  /* ADC input pin 7 */
+    ADC_MUXNEG_AIN16_gc = (0x10<<0),  /* ADC input pin 16 */
+    ADC_MUXNEG_AIN17_gc = (0x11<<0),  /* ADC input pin 17 */
+    ADC_MUXNEG_AIN22_gc = (0x16<<0),  /* ADC input pin 22 */
+    ADC_MUXNEG_AIN23_gc = (0x17<<0),  /* ADC input pin 23 */
+    ADC_MUXNEG_AIN24_gc = (0x18<<0),  /* ADC input pin 24 */
+    ADC_MUXNEG_AIN25_gc = (0x19<<0),  /* ADC input pin 25 */
+    ADC_MUXNEG_AIN26_gc = (0x1A<<0),  /* ADC input pin 26 */
+    ADC_MUXNEG_AIN27_gc = (0x1B<<0),  /* ADC input pin 27 */
+    ADC_MUXNEG_AIN28_gc = (0x1C<<0),  /* ADC input pin 28 */
+    ADC_MUXNEG_AIN29_gc = (0x1D<<0),  /* ADC input pin 29 */
+    ADC_MUXNEG_AIN30_gc = (0x1E<<0),  /* ADC input pin 30 */
+    ADC_MUXNEG_AIN31_gc = (0x1F<<0),  /* ADC input pin 31 */
+    ADC_MUXNEG_GND_gc = (0x30<<0),  /* Ground */
+    ADC_MUXNEG_DAC0_gc = (0x38<<0),  /* Digital to Analog Converter 0 */
+    ADC_MUXNEG_DACREF0_gc = (0x39<<0),  /* AC0 DAC reference */
+    ADC_MUXNEG_DACREF1_gc = (0x3A<<0)  /* AC1 DAC reference */
+} ADC_MUXNEG_t;
+
+/* Analog Channel Selection Bits */
+typedef enum ADC_MUXPOS_enum
+{
+    ADC_MUXPOS_AIN0_gc = (0x00<<0),  /* ADC input pin 0 */
+    ADC_MUXPOS_AIN1_gc = (0x01<<0),  /* ADC input pin 1 */
+    ADC_MUXPOS_AIN2_gc = (0x02<<0),  /* ADC input pin 2 */
+    ADC_MUXPOS_AIN3_gc = (0x03<<0),  /* ADC input pin 3 */
+    ADC_MUXPOS_AIN4_gc = (0x04<<0),  /* ADC input pin 4 */
+    ADC_MUXPOS_AIN5_gc = (0x05<<0),  /* ADC input pin 5 */
+    ADC_MUXPOS_AIN6_gc = (0x06<<0),  /* ADC input pin 6 */
+    ADC_MUXPOS_AIN7_gc = (0x07<<0),  /* ADC input pin 7 */
+    ADC_MUXPOS_AIN16_gc = (0x10<<0),  /* ADC input pin 16 */
+    ADC_MUXPOS_AIN17_gc = (0x11<<0),  /* ADC input pin 17 */
+    ADC_MUXPOS_AIN22_gc = (0x16<<0),  /* ADC input pin 22 */
+    ADC_MUXPOS_AIN23_gc = (0x17<<0),  /* ADC input pin 23 */
+    ADC_MUXPOS_AIN24_gc = (0x18<<0),  /* ADC input pin 24 */
+    ADC_MUXPOS_AIN25_gc = (0x19<<0),  /* ADC input pin 25 */
+    ADC_MUXPOS_AIN26_gc = (0x1A<<0),  /* ADC input pin 26 */
+    ADC_MUXPOS_AIN27_gc = (0x1B<<0),  /* ADC input pin 27 */
+    ADC_MUXPOS_AIN28_gc = (0x1C<<0),  /* ADC input pin 28 */
+    ADC_MUXPOS_AIN29_gc = (0x1D<<0),  /* ADC input pin 29 */
+    ADC_MUXPOS_AIN30_gc = (0x1E<<0),  /* ADC input pin 30 */
+    ADC_MUXPOS_AIN31_gc = (0x1F<<0),  /* ADC input pin 31 */
+    ADC_MUXPOS_GND_gc = (0x30<<0),  /* Ground */
+    ADC_MUXPOS_VDD10_gc = (0x31<<0),  /* VDD Divided by 10 */
+    ADC_MUXPOS_TEMPSENSE_gc = (0x32<<0),  /* Temperature Sensor */
+    ADC_MUXPOS_DAC0_gc = (0x38<<0)  /* Digital to Analog Converter 0 */
+} ADC_MUXPOS_t;
+
+/* PGA BIAS Select */
+typedef enum ADC_PGABIASSEL_enum
+{
+    ADC_PGABIASSEL_100PCT_gc = (0x00<<3),  /* 100% BIAS current. */
+    ADC_PGABIASSEL_75PCT_gc = (0x01<<3),  /* 75% BIAS current. Usable for CLK_ADC<4.5MHz */
+    ADC_PGABIASSEL_50PCT_gc = (0x02<<3),  /* 50% BIAS current. Usable for CLK_ADC<3MHz */
+    ADC_PGABIASSEL_25PCT_gc = (0x03<<3)  /* 25% BIAS current. Usable for CLK_ADC<1.5MHz */
+} ADC_PGABIASSEL_t;
+
+/* Prescaler Value select */
+typedef enum ADC_PRESC_enum
+{
+    ADC_PRESC_DIV2_gc = (0x00<<0),  /* System clock divided by 2 */
+    ADC_PRESC_DIV4_gc = (0x01<<0),  /* System clock divided by 4 */
+    ADC_PRESC_DIV6_gc = (0x02<<0),  /* System clock divided by 6 */
+    ADC_PRESC_DIV8_gc = (0x03<<0),  /* System clock divided by 8 */
+    ADC_PRESC_DIV10_gc = (0x04<<0),  /* System clock divided by 10 */
+    ADC_PRESC_DIV12_gc = (0x05<<0),  /* System clock divided by 12 */
+    ADC_PRESC_DIV14_gc = (0x06<<0),  /* System clock divided by 14 */
+    ADC_PRESC_DIV16_gc = (0x07<<0),  /* System clock divided by 16 */
+    ADC_PRESC_DIV20_gc = (0x08<<0),  /* System clock divided by 20 */
+    ADC_PRESC_DIV24_gc = (0x09<<0),  /* System clock divided by 24 */
+    ADC_PRESC_DIV28_gc = (0x0A<<0),  /* System clock divided by 28 */
+    ADC_PRESC_DIV32_gc = (0x0B<<0),  /* System clock divided by 32 */
+    ADC_PRESC_DIV40_gc = (0x0C<<0),  /* System clock divided by 40 */
+    ADC_PRESC_DIV48_gc = (0x0D<<0),  /* System clock divided by 48 */
+    ADC_PRESC_DIV56_gc = (0x0E<<0),  /* System clock divided by 56 */
+    ADC_PRESC_DIV64_gc = (0x0F<<0)  /* System clock divided by 64 */
+} ADC_PRESC_t;
+
+/* Reference select */
+typedef enum ADC_REFSEL_enum
+{
+    ADC_REFSEL_VDD_gc = (0x00<<0),  /* VDD */
+    ADC_REFSEL_VREFA_gc = (0x02<<0),  /* External Reference */
+    ADC_REFSEL_1V024_gc = (0x04<<0),  /* Internal 1.024V Reference */
+    ADC_REFSEL_2V048_gc = (0x05<<0),  /* Internal 2.048V Reference */
+    ADC_REFSEL_4V096_gc = (0x06<<0),  /* Internal 4.096V Reference */
+    ADC_REFSEL_2V500_gc = (0x07<<0)  /* Internal 2.500V Reference */
+} ADC_REFSEL_t;
+
+/* Sample numbers select */
+typedef enum ADC_SAMPNUM_enum
+{
+    ADC_SAMPNUM_NONE_gc = (0x00<<0),  /* No accumulation */
+    ADC_SAMPNUM_ACC2_gc = (0x01<<0),  /* 2 samples accumulated */
+    ADC_SAMPNUM_ACC4_gc = (0x02<<0),  /* 4 samples accumulated */
+    ADC_SAMPNUM_ACC8_gc = (0x03<<0),  /* 8 samples accumulated */
+    ADC_SAMPNUM_ACC16_gc = (0x04<<0),  /* 16 samples accumulated */
+    ADC_SAMPNUM_ACC32_gc = (0x05<<0),  /* 32 samples accumulated */
+    ADC_SAMPNUM_ACC64_gc = (0x06<<0),  /* 64 samples accumulated */
+    ADC_SAMPNUM_ACC128_gc = (0x07<<0),  /* 128 samples accumulated */
+    ADC_SAMPNUM_ACC256_gc = (0x08<<0),  /* 256 samples accumulated */
+    ADC_SAMPNUM_ACC512_gc = (0x09<<0),  /* 512 samples accumulated */
+    ADC_SAMPNUM_ACC1024_gc = (0x0A<<0)  /* 1024 samples accumulated */
+} ADC_SAMPNUM_t;
+
+/* Start command select */
+typedef enum ADC_START_enum
+{
+    ADC_START_STOP_gc = (0x00<<0),  /* Stop an ongoing conversion */
+    ADC_START_IMMEDIATE_gc = (0x01<<0),  /* Start a conversion immediately. This will be set back to STOP when the first conversion is done, unless Free-Running mode is enabled */
+    ADC_START_MUXPOS_WRITE_gc = (0x02<<0),  /* Start when MUXPOS register is written */
+    ADC_START_MUXNEG_WRITE_gc = (0x03<<0),  /* Start when MUXNEG register is written */
+    ADC_START_EVENT_TRIGGER_gc = (0x04<<0)  /* Start when an event is received */
+} ADC_START_t;
+
+/* VIA select */
+typedef enum ADC_VIA_enum
+{
+    ADC_VIA_DIRECT_gc = (0x00<<6),  /* Inputs connected directly to ADC */
+    ADC_VIA_PGA_gc = (0x01<<6)  /* Inputs connected via PGA */
+} ADC_VIA_t;
+
+/* Window Comparator Mode select */
+typedef enum ADC_WINCM_enum
+{
+    ADC_WINCM_NONE_gc = (0x00<<0),  /* No Window Comparison */
+    ADC_WINCM_BELOW_gc = (0x01<<0),  /* Below Window */
+    ADC_WINCM_ABOVE_gc = (0x02<<0),  /* Above Window */
+    ADC_WINCM_INSIDE_gc = (0x03<<0),  /* Inside Window */
+    ADC_WINCM_OUTSIDE_gc = (0x04<<0)  /* Outside Window */
+} ADC_WINCM_t;
+
+/* Window Mode Source select */
+typedef enum ADC_WINSRC_enum
+{
+    ADC_WINSRC_RESULT_gc = (0x00<<3),  /* Result register used as Window Comparator Source */
+    ADC_WINSRC_SAMPLE_gc = (0x01<<3)  /* Sample register used as Window Comparator Source */
+} ADC_WINSRC_t;
+
+/*
+--------------------------------------------------------------------------
+BOD - Bod interface
+--------------------------------------------------------------------------
+*/
+
+/* Bod interface */
+typedef struct BOD_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t reserved_1[6];
+    register8_t VLMCTRLA;  /* Voltage level monitor Control */
+    register8_t INTCTRL;  /* Voltage level monitor interrupt Control */
+    register8_t INTFLAGS;  /* Voltage level monitor interrupt Flags */
+    register8_t STATUS;  /* Voltage level monitor status */
+    register8_t reserved_2[4];
+} BOD_t;
+
+/* Operation in active mode select */
+typedef enum BOD_ACTIVE_enum
+{
+    BOD_ACTIVE_DISABLE_gc = (0x00<<2),  /* Disabled */
+    BOD_ACTIVE_ENABLED_gc = (0x01<<2),  /* Enabled in continuous mode */
+    BOD_ACTIVE_SAMPLED_gc = (0x02<<2),  /* Enabled in sampled mode */
+    BOD_ACTIVE_ENABLEWAIT_gc = (0x03<<2)  /* Enabled in continuous mode. Execution halted at wake-up until BOD is running */
+} BOD_ACTIVE_t;
+
+/* Bod level select */
+typedef enum BOD_LVL_enum
+{
+    BOD_LVL_BODLEVEL0_gc = (0x00<<0),  /* BOD Disabled during normal operation */
+    BOD_LVL_BODLEVEL1_gc = (0x01<<0),  /* 1.9 V */
+    BOD_LVL_BODLEVEL2_gc = (0x02<<0),  /* 2.7 V */
+    BOD_LVL_BODLEVEL3_gc = (0x03<<0)  /* 4.5 V */
+} BOD_LVL_t;
+
+/* Sample frequency select */
+typedef enum BOD_SAMPFREQ_enum
+{
+    BOD_SAMPFREQ_128HZ_gc = (0x00<<4),  /* Sampling frequency is 128 Hz */
+    BOD_SAMPFREQ_32HZ_gc = (0x01<<4)  /* Sample frequency is 32 Hz */
+} BOD_SAMPFREQ_t;
+
+/* Operation in sleep mode select */
+typedef enum BOD_SLEEP_enum
+{
+    BOD_SLEEP_DISABLE_gc = (0x00<<0),  /* Disabled */
+    BOD_SLEEP_ENABLE_gc = (0x01<<0),  /* Enabled in continuous mode */
+    BOD_SLEEP_SAMPLE_gc = (0x02<<0)  /* Enabled in sampled mode */
+} BOD_SLEEP_t;
+
+/* Configuration select */
+typedef enum BOD_VLMCFG_enum
+{
+    BOD_VLMCFG_FALLING_gc = (0x00<<1),  /* VDD falls below VLM threshold */
+    BOD_VLMCFG_RISING_gc = (0x01<<1),  /* VDD rises above VLM threshold */
+    BOD_VLMCFG_BOTH_gc = (0x02<<1)  /* VDD crosses VLM threshold */
+} BOD_VLMCFG_t;
+
+/* voltage level monitor level select */
+typedef enum BOD_VLMLVL_enum
+{
+    BOD_VLMLVL_OFF_gc = (0x00<<0),  /* VLM Disabled */
+    BOD_VLMLVL_5ABOVE_gc = (0x01<<0),  /* VLM threshold 5% above BOD level */
+    BOD_VLMLVL_15ABOVE_gc = (0x02<<0),  /* VLM threshold 15% above BOD level */
+    BOD_VLMLVL_25ABOVE_gc = (0x03<<0)  /* VLM threshold 25% above BOD level */
+} BOD_VLMLVL_t;
+
+/* Voltage level monitor status select */
+typedef enum BOD_VLMS_enum
+{
+    BOD_VLMS_ABOVE_gc = (0x00<<0),  /* The voltage is above the VLM threshold level */
+    BOD_VLMS_BELOW_gc = (0x01<<0)  /* The voltage is below the VLM threshold level */
+} BOD_VLMS_t;
+
+/*
+--------------------------------------------------------------------------
+CCL - Configurable Custom Logic
+--------------------------------------------------------------------------
+*/
+
+/* Configurable Custom Logic */
+typedef struct CCL_struct
+{
+    register8_t CTRLA;  /* Control Register A */
+    register8_t SEQCTRL0;  /* Sequential Control 0 */
+    register8_t SEQCTRL1;  /* Sequential Control 1 */
+    register8_t reserved_1[2];
+    register8_t INTCTRL0;  /* Interrupt Control 0 */
+    register8_t reserved_2[1];
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t LUT0CTRLA;  /* LUT 0 Control A */
+    register8_t LUT0CTRLB;  /* LUT 0 Control B */
+    register8_t LUT0CTRLC;  /* LUT 0 Control C */
+    register8_t TRUTH0;  /* Truth 0 */
+    register8_t LUT1CTRLA;  /* LUT 1 Control A */
+    register8_t LUT1CTRLB;  /* LUT 1 Control B */
+    register8_t LUT1CTRLC;  /* LUT 1 Control C */
+    register8_t TRUTH1;  /* Truth 1 */
+    register8_t LUT2CTRLA;  /* LUT 2 Control A */
+    register8_t LUT2CTRLB;  /* LUT 2 Control B */
+    register8_t LUT2CTRLC;  /* LUT 2 Control C */
+    register8_t TRUTH2;  /* Truth 2 */
+    register8_t LUT3CTRLA;  /* LUT 3 Control A */
+    register8_t LUT3CTRLB;  /* LUT 3 Control B */
+    register8_t LUT3CTRLC;  /* LUT 3 Control C */
+    register8_t TRUTH3;  /* Truth 3 */
+    register8_t reserved_3[40];
+} CCL_t;
+
+/* Clock Source Selection */
+typedef enum CCL_CLKSRC_enum
+{
+    CCL_CLKSRC_CLKPER_gc = (0x00<<1),  /* Peripheral Clock */
+    CCL_CLKSRC_IN2_gc = (0x01<<1),  /* INSEL2 selection */
+    CCL_CLKSRC_OSCHF_gc = (0x04<<1),  /* Internal High Frequency oscillator */
+    CCL_CLKSRC_OSC32K_gc = (0x05<<1),  /* Internal 32.768 kHz oscillator */
+    CCL_CLKSRC_OSC1K_gc = (0x06<<1)  /* Internal 32.768 kHz oscillator divided by 32 */
+} CCL_CLKSRC_t;
+
+/* Edge Detection Enable select */
+typedef enum CCL_EDGEDET_enum
+{
+    CCL_EDGEDET_DIS_gc = (0x00<<7),  /* Edge detector is disabled */
+    CCL_EDGEDET_EN_gc = (0x01<<7)  /* Edge detector is enabled */
+} CCL_EDGEDET_t;
+
+/* Filter Selection */
+typedef enum CCL_FILTSEL_enum
+{
+    CCL_FILTSEL_DISABLE_gc = (0x00<<4),  /* Filter disabled */
+    CCL_FILTSEL_SYNCH_gc = (0x01<<4),  /* Synchronizer enabled */
+    CCL_FILTSEL_FILTER_gc = (0x02<<4)  /* Filter enabled */
+} CCL_FILTSEL_t;
+
+/* LUT Input 0 Source Selection */
+typedef enum CCL_INSEL0_enum
+{
+    CCL_INSEL0_MASK_gc = (0x00<<0),  /* Masked input */
+    CCL_INSEL0_FEEDBACK_gc = (0x01<<0),  /* Feedback input */
+    CCL_INSEL0_LINK_gc = (0x02<<0),  /* Output from LUT[n+1] as input source */
+    CCL_INSEL0_EVENTA_gc = (0x03<<0),  /* Event A as input source */
+    CCL_INSEL0_EVENTB_gc = (0x04<<0),  /* Event B as input source */
+    CCL_INSEL0_IO_gc = (0x05<<0),  /* IN0 input source */
+    CCL_INSEL0_AC0_gc = (0x06<<0),  /* AC0 output input source */
+    CCL_INSEL0_USART0_gc = (0x07<<0),  /* USART0 TxD input source */
+    CCL_INSEL0_SPI0_gc = (0x08<<0),  /* SPI0 MISO input source */
+    CCL_INSEL0_TCA0_gc = (0x09<<0),  /* TCA0 WO0 input source */
+    CCL_INSEL0_TCA1_gc = (0x0A<<0),  /* TCA1 WO0 input source */
+    CCL_INSEL0_TCB0_gc = (0x0B<<0)  /* TCB0 WO input source */
+} CCL_INSEL0_t;
+
+/* LUT Input 1 Source Selection */
+typedef enum CCL_INSEL1_enum
+{
+    CCL_INSEL1_MASK_gc = (0x00<<4),  /* Masked input */
+    CCL_INSEL1_FEEDBACK_gc = (0x01<<4),  /* Feedback input */
+    CCL_INSEL1_LINK_gc = (0x02<<4),  /* Output from LUT[n+1] as input source */
+    CCL_INSEL1_EVENTA_gc = (0x03<<4),  /* Event A as input source */
+    CCL_INSEL1_EVENTB_gc = (0x04<<4),  /* Event B as input source */
+    CCL_INSEL1_IO_gc = (0x05<<4),  /* IN0 input source */
+    CCL_INSEL1_AC1_gc = (0x06<<4),  /* AC1 output input source */
+    CCL_INSEL1_USART1_gc = (0x07<<4),  /* USART1 TxD input source */
+    CCL_INSEL1_SPI0_gc = (0x08<<4),  /* SPI0 MISO input source */
+    CCL_INSEL1_TCA0_gc = (0x09<<4),  /* TCA0 WO1 input source */
+    CCL_INSEL1_TCA1_gc = (0x0A<<4),  /* TCA1 WO1 input source */
+    CCL_INSEL1_TCB1_gc = (0x0B<<4)  /* TCB1 WO input source */
+} CCL_INSEL1_t;
+
+/* LUT Input 2 Source Selection */
+typedef enum CCL_INSEL2_enum
+{
+    CCL_INSEL2_MASK_gc = (0x00<<0),  /* Masked input */
+    CCL_INSEL2_FEEDBACK_gc = (0x01<<0),  /* Feedback input */
+    CCL_INSEL2_LINK_gc = (0x02<<0),  /* Output from LUT[n+1] as input source */
+    CCL_INSEL2_EVENTA_gc = (0x03<<0),  /* Event A as input source */
+    CCL_INSEL2_EVENTB_gc = (0x04<<0),  /* Event B as input source */
+    CCL_INSEL2_IO_gc = (0x05<<0),  /* IN0 input source */
+    CCL_INSEL2_AC1_gc = (0x06<<0),  /* AC1 output input source */
+    CCL_INSEL2_USART2_gc = (0x07<<0),  /* USART2 TxD input source */
+    CCL_INSEL2_SPI0_gc = (0x08<<0),  /* SPI0 MISO input source */
+    CCL_INSEL2_TCA0_gc = (0x09<<0),  /* TCA0 WO2 input source */
+    CCL_INSEL2_TCA1_gc = (0x0A<<0),  /* TCA1 WO2 input source */
+    CCL_INSEL2_TCB2_gc = (0x0B<<0)  /* TCB2 WO input source */
+} CCL_INSEL2_t;
+
+/* Interrupt Mode for LUT0 select */
+typedef enum CCL_INTMODE0_enum
+{
+    CCL_INTMODE0_INTDISABLE_gc = (0x00<<0),  /* Interrupt disabled */
+    CCL_INTMODE0_RISING_gc = (0x01<<0),  /* Sense rising edge */
+    CCL_INTMODE0_FALLING_gc = (0x02<<0),  /* Sense falling edge */
+    CCL_INTMODE0_BOTH_gc = (0x03<<0)  /* Sense both edges */
+} CCL_INTMODE0_t;
+
+/* Interrupt Mode for LUT1 select */
+typedef enum CCL_INTMODE1_enum
+{
+    CCL_INTMODE1_INTDISABLE_gc = (0x00<<2),  /* Interrupt disabled */
+    CCL_INTMODE1_RISING_gc = (0x01<<2),  /* Sense rising edge */
+    CCL_INTMODE1_FALLING_gc = (0x02<<2),  /* Sense falling edge */
+    CCL_INTMODE1_BOTH_gc = (0x03<<2)  /* Sense both edges */
+} CCL_INTMODE1_t;
+
+/* Interrupt Mode for LUT2 select */
+typedef enum CCL_INTMODE2_enum
+{
+    CCL_INTMODE2_INTDISABLE_gc = (0x00<<4),  /* Interrupt disabled */
+    CCL_INTMODE2_RISING_gc = (0x01<<4),  /* Sense rising edge */
+    CCL_INTMODE2_FALLING_gc = (0x02<<4),  /* Sense falling edge */
+    CCL_INTMODE2_BOTH_gc = (0x03<<4)  /* Sense both edges */
+} CCL_INTMODE2_t;
+
+/* Interrupt Mode for LUT3 select */
+typedef enum CCL_INTMODE3_enum
+{
+    CCL_INTMODE3_INTDISABLE_gc = (0x00<<6),  /* Interrupt disabled */
+    CCL_INTMODE3_RISING_gc = (0x01<<6),  /* Sense rising edge */
+    CCL_INTMODE3_FALLING_gc = (0x02<<6),  /* Sense falling edge */
+    CCL_INTMODE3_BOTH_gc = (0x03<<6)  /* Sense both edges */
+} CCL_INTMODE3_t;
+
+/* Sequential Selection */
+typedef enum CCL_SEQSEL_enum
+{
+    CCL_SEQSEL_DISABLE_gc = (0x00<<0),  /* Sequential logic disabled */
+    CCL_SEQSEL_DFF_gc = (0x01<<0),  /* D FlipFlop */
+    CCL_SEQSEL_JK_gc = (0x02<<0),  /* JK FlipFlop */
+    CCL_SEQSEL_LATCH_gc = (0x03<<0),  /* D Latch */
+    CCL_SEQSEL_RS_gc = (0x04<<0)  /* RS Latch */
+} CCL_SEQSEL_t;
+
+/*
+--------------------------------------------------------------------------
+CLKCTRL - Clock controller
+--------------------------------------------------------------------------
+*/
+
+/* Clock controller */
+typedef struct CLKCTRL_struct
+{
+    register8_t MCLKCTRLA;  /* MCLK Control A */
+    register8_t MCLKCTRLB;  /* MCLK Control B */
+    register8_t MCLKCTRLC;  /* MCLK Control C */
+    register8_t MCLKINTCTRL;  /* MCLK Interrupt Control */
+    register8_t MCLKINTFLAGS;  /* MCLK Interrupt Flags */
+    register8_t MCLKSTATUS;  /* MCLK Status */
+    register8_t MCLKTIMEBASE;  /* MCLK Timebase */
+    register8_t reserved_1[1];
+    register8_t OSCHFCTRLA;  /* OSCHF Control A */
+    register8_t OSCHFTUNE;  /* OSCHF Tune */
+    register8_t reserved_2[14];
+    register8_t OSC32KCTRLA;  /* OSC32K Control A */
+    register8_t reserved_3[3];
+    register8_t XOSC32KCTRLA;  /* XOSC32K Control A */
+    register8_t reserved_4[3];
+    register8_t XOSCHFCTRLA;  /* XOSCHF Control A */
+} CLKCTRL_t;
+
+/* Automatic Oscillator Tune select */
+typedef enum CLKCTRL_AUTOTUNE_enum
+{
+    CLKCTRL_AUTOTUNE_OFF_gc = (0x00<<0),  /* Disabled */
+    CLKCTRL_AUTOTUNE_XOSC32K_gc = (0x01<<0)  /* Tune against 32.768 kHz Crystal Oscillator */
+} CLKCTRL_AUTOTUNE_t;
+
+/* CFD Source select */
+typedef enum CLKCTRL_CFDSRC_enum
+{
+    CLKCTRL_CFDSRC_CLKMAIN_gc = (0x00<<2),  /* Main Clock */
+    CLKCTRL_CFDSRC_XOSCHF_gc = (0x01<<2),  /* High Frequency Crystal Oscillator */
+    CLKCTRL_CFDSRC_XOSC32K_gc = (0x02<<2)  /* 32.768 kHz Crystal Oscillator */
+} CLKCTRL_CFDSRC_t;
+
+/* Clock select */
+typedef enum CLKCTRL_CLKSEL_enum
+{
+    CLKCTRL_CLKSEL_OSCHF_gc = (0x00<<0),  /* Internal high-frequency oscillator */
+    CLKCTRL_CLKSEL_OSC32K_gc = (0x01<<0),  /* Internal 32.768 kHz oscillator */
+    CLKCTRL_CLKSEL_XOSC32K_gc = (0x02<<0),  /* 32.768 kHz crystal oscillator */
+    CLKCTRL_CLKSEL_EXTCLK_gc = (0x03<<0)  /* External clock */
+} CLKCTRL_CLKSEL_t;
+
+/* Crystal startup time select */
+typedef enum CLKCTRL_CSUT_enum
+{
+    CLKCTRL_CSUT_1K_gc = (0x00<<4),  /* 1k cycles */
+    CLKCTRL_CSUT_16K_gc = (0x01<<4),  /* 16k cycles */
+    CLKCTRL_CSUT_32K_gc = (0x02<<4),  /* 32k cycles */
+    CLKCTRL_CSUT_64K_gc = (0x03<<4)  /* 64k cycles */
+} CLKCTRL_CSUT_t;
+
+/* Start-Up Time select */
+typedef enum CLKCTRL_CSUTHF_enum
+{
+    CLKCTRL_CSUTHF_256CYC_gc = (0x00<<4),  /* 256 XOSCHF Cycles */
+    CLKCTRL_CSUTHF_1KCYC_gc = (0x01<<4),  /* 1K XOSCHF Cycles */
+    CLKCTRL_CSUTHF_4KCYC_gc = (0x02<<4)  /* 4K XOSCHF Cycles */
+} CLKCTRL_CSUTHF_t;
+
+/* Interrupt Type select */
+typedef enum CLKCTRL_INTTYPE_enum
+{
+    CLKCTRL_INTTYPE_INT_gc = (0x00<<7),  /* Regular interrupt */
+    CLKCTRL_INTTYPE_NMI_gc = (0x01<<7)  /* Non-maskable interrupt */
+} CLKCTRL_INTTYPE_t;
+
+/* Prescaler division select */
+typedef enum CLKCTRL_PDIV_enum
+{
+    CLKCTRL_PDIV_DIV2_gc = (0x00<<1),  /* Divide by 2 */
+    CLKCTRL_PDIV_DIV4_gc = (0x01<<1),  /* Divide by 4 */
+    CLKCTRL_PDIV_DIV8_gc = (0x02<<1),  /* Divide by 8 */
+    CLKCTRL_PDIV_DIV16_gc = (0x03<<1),  /* Divide by 16 */
+    CLKCTRL_PDIV_DIV32_gc = (0x04<<1),  /* Divide by 32 */
+    CLKCTRL_PDIV_DIV64_gc = (0x05<<1),  /* Divide by 64 */
+    CLKCTRL_PDIV_DIV6_gc = (0x08<<1),  /* Divide by 6 */
+    CLKCTRL_PDIV_DIV10_gc = (0x09<<1),  /* Divide by 10 */
+    CLKCTRL_PDIV_DIV12_gc = (0x0A<<1),  /* Divide by 12 */
+    CLKCTRL_PDIV_DIV24_gc = (0x0B<<1),  /* Divide by 24 */
+    CLKCTRL_PDIV_DIV48_gc = (0x0C<<1)  /* Divide by 48 */
+} CLKCTRL_PDIV_t;
+
+/* Source Select */
+typedef enum CLKCTRL_SELHF_enum
+{
+    CLKCTRL_SELHF_CRYSTAL_gc = (0x00<<1),  /* External Crystal */
+    CLKCTRL_SELHF_EXTCLK_gc = (0x01<<1)  /* Extenal Clock on XTALHF1 pin */
+} CLKCTRL_SELHF_t;
+
+/*
+--------------------------------------------------------------------------
+CPU - CPU
+--------------------------------------------------------------------------
+*/
+
+#define CORE_VERSION  V4S
+
+/* CCP signature select */
+typedef enum CCP_enum
+{
+    CCP_SPM_gc = (0x9D<<0),  /* SPM Instruction Protection */
+    CCP_IOREG_gc = (0xD8<<0)  /* IO Register Protection */
+} CCP_t;
+
+/*
+--------------------------------------------------------------------------
+CPUINT - Interrupt Controller
+--------------------------------------------------------------------------
+*/
+
+/* Interrupt Controller */
+typedef struct CPUINT_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t STATUS;  /* Status */
+    register8_t LVL0PRI;  /* Interrupt Level 0 Priority */
+    register8_t LVL1VEC;  /* Interrupt Level 1 Priority Vector */
+} CPUINT_t;
+
+
+/*
+--------------------------------------------------------------------------
+CRCSCAN - CRCSCAN
+--------------------------------------------------------------------------
+*/
+
+/* CRCSCAN */
+typedef struct CRCSCAN_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t STATUS;  /* Status */
+    register8_t reserved_1[13];
+} CRCSCAN_t;
+
+/* CRC Source select */
+typedef enum CRCSCAN_SRC_enum
+{
+    CRCSCAN_SRC_FLASH_gc = (0x00<<0),  /* CRC on entire flash */
+    CRCSCAN_SRC_APPLICATION_gc = (0x01<<0),  /* CRC on boot and appl section of flash */
+    CRCSCAN_SRC_BOOT_gc = (0x02<<0)  /* CRC on boot section of flash */
+} CRCSCAN_SRC_t;
+
+/*
+--------------------------------------------------------------------------
+DAC - Digital to Analog Converter
+--------------------------------------------------------------------------
+*/
+
+/* Digital to Analog Converter */
+typedef struct DAC_struct
+{
+    register8_t CTRLA;  /* Control Register A */
+    register8_t reserved_1[1];
+    _WORDREGISTER(DATA);  /* DATA Register */
+    register8_t reserved_2[12];
+} DAC_t;
+
+/* Output Buffer Range select */
+typedef enum DAC_OUTRANGE_enum
+{
+    DAC_OUTRANGE_AUTO_gc = (0x00<<4),  /* Output buffer automatically choose best range */
+    DAC_OUTRANGE_LOW_gc = (0x02<<4),  /* Output buffer configured to low range */
+    DAC_OUTRANGE_HIGH_gc = (0x03<<4)  /* Output buffer configured to high range */
+} DAC_OUTRANGE_t;
+
+/*
+--------------------------------------------------------------------------
+EVSYS - Event System
+--------------------------------------------------------------------------
+*/
+
+/* Event System */
+typedef struct EVSYS_struct
+{
+    register8_t SWEVENTA;  /* Software Event A */
+    register8_t reserved_1[15];
+    register8_t CHANNEL0;  /* Multiplexer Channel 0 */
+    register8_t CHANNEL1;  /* Multiplexer Channel 1 */
+    register8_t CHANNEL2;  /* Multiplexer Channel 2 */
+    register8_t CHANNEL3;  /* Multiplexer Channel 3 */
+    register8_t CHANNEL4;  /* Multiplexer Channel 4 */
+    register8_t CHANNEL5;  /* Multiplexer Channel 5 */
+    register8_t reserved_2[10];
+    register8_t USERCCLLUT0A;  /* CCL0 Event A */
+    register8_t USERCCLLUT0B;  /* CCL0 Event B */
+    register8_t USERCCLLUT1A;  /* CCL1 Event A */
+    register8_t USERCCLLUT1B;  /* CCL1 Event B */
+    register8_t USERCCLLUT2A;  /* CCL2 Event A */
+    register8_t USERCCLLUT2B;  /* CCL2 Event B */
+    register8_t USERCCLLUT3A;  /* CCL3 Event A */
+    register8_t USERCCLLUT3B;  /* CCL3 Event B */
+    register8_t USERADC0START;  /* ADC0 */
+    register8_t USEREVSYSEVOUTA;  /* EVOUTA */
+    register8_t reserved_3[1];
+    register8_t USEREVSYSEVOUTC;  /* EVOUTC */
+    register8_t USEREVSYSEVOUTD;  /* EVOUTD */
+    register8_t reserved_4[1];
+    register8_t USEREVSYSEVOUTF;  /* EVOUTF */
+    register8_t USERUSART0IRDA;  /* USART0 */
+    register8_t USERUSART1IRDA;  /* USART1 */
+    register8_t USERUSART2IRDA;  /* USART2 */
+    register8_t USERTCA0CNTA;  /* TCA0 Event A */
+    register8_t USERTCA0CNTB;  /* TCA0 Event B */
+    register8_t USERTCA1CNTA;  /* TCA1 Event A */
+    register8_t USERTCA1CNTB;  /* TCA1 Event B */
+    register8_t USERTCB0CAPT;  /* TCB0 Event A */
+    register8_t USERTCB0COUNT;  /* TCB0 Event B */
+    register8_t USERTCB1CAPT;  /* TCB1 Event A */
+    register8_t USERTCB1COUNT;  /* TCB1 Event B */
+    register8_t USERTCB2CAPT;  /* TCB2 Event A */
+    register8_t USERTCB2COUNT;  /* TCB2 Event B */
+    register8_t USERTCB3CAPT;  /* TCB3 Event A */
+    register8_t USERTCB3COUNT;  /* TCB3 Event B */
+    register8_t reserved_5[2];
+} EVSYS_t;
+
+/* Channel generator select */
+typedef enum EVSYS_CHANNEL_enum
+{
+    EVSYS_CHANNEL_OFF_gc = (0x00<<0),  /* Off */
+    EVSYS_CHANNEL_UPDI_SYNCH_gc = (0x01<<0),  /* UPDI SYNCH character */
+    EVSYS_CHANNEL_RTC_OVF_gc = (0x06<<0),  /* Real Time Counter overflow */
+    EVSYS_CHANNEL_RTC_CMP_gc = (0x07<<0),  /* Real Time Counter compare */
+    EVSYS_CHANNEL_RTC_PITEV0_gc = (0x08<<0),  /* Periodic Interrupt Timer Event 0 */
+    EVSYS_CHANNEL_RTC_PITEV1_gc = (0x09<<0),  /* Periodic Interrupt Timer Event 1 */
+    EVSYS_CHANNEL_CCL_LUT0_gc = (0x10<<0),  /* Configurable Custom Logic LUT0 */
+    EVSYS_CHANNEL_CCL_LUT1_gc = (0x11<<0),  /* Configurable Custom Logic LUT1 */
+    EVSYS_CHANNEL_CCL_LUT2_gc = (0x12<<0),  /* Configurable Custom Logic LUT2 */
+    EVSYS_CHANNEL_CCL_LUT3_gc = (0x13<<0),  /* Configurable Custom Logic LUT3 */
+    EVSYS_CHANNEL_AC0_OUT_gc = (0x20<<0),  /* Analog Comparator 0 out */
+    EVSYS_CHANNEL_AC1_OUT_gc = (0x21<<0),  /* Analog Comparator 1 out */
+    EVSYS_CHANNEL_ADC0_RES_gc = (0x24<<0),  /* ADC 0 Result Ready */
+    EVSYS_CHANNEL_ADC0_SAMP_gc = (0x25<<0),  /* ADC 0 Sample Ready */
+    EVSYS_CHANNEL_ADC0_WCMP_gc = (0x26<<0),  /* ADC 0 Window Compare */
+    EVSYS_CHANNEL_PORTA_EV0_gc = (0x40<<0),  /* Port A Event 0 */
+    EVSYS_CHANNEL_PORTA_EV1_gc = (0x41<<0),  /* Port A Event 1 */
+    EVSYS_CHANNEL_PORTC_EV0_gc = (0x44<<0),  /* Port C Event 0 */
+    EVSYS_CHANNEL_PORTC_EV1_gc = (0x45<<0),  /* Port C Event 1 */
+    EVSYS_CHANNEL_PORTD_EV0_gc = (0x46<<0),  /* Port D Event 0 */
+    EVSYS_CHANNEL_PORTD_EV1_gc = (0x47<<0),  /* Port D Event 1 */
+    EVSYS_CHANNEL_PORTF_EV0_gc = (0x4A<<0),  /* Port F Event 0 */
+    EVSYS_CHANNEL_PORTF_EV1_gc = (0x4B<<0),  /* Port F Event 1 */
+    EVSYS_CHANNEL_USART0_XCK_gc = (0x60<<0),  /* USART 0 XCK */
+    EVSYS_CHANNEL_USART1_XCK_gc = (0x61<<0),  /* USART 1 XCK */
+    EVSYS_CHANNEL_USART2_XCK_gc = (0x62<<0),  /* USART 2 XCK */
+    EVSYS_CHANNEL_SPI0_SCK_gc = (0x68<<0),  /* SPI 0 SCK */
+    EVSYS_CHANNEL_TCA0_OVF_LUNF_gc = (0x80<<0),  /* Timer/Counter A0 overflow / low byte timer underflow */
+    EVSYS_CHANNEL_TCA0_HUNF_gc = (0x81<<0),  /* Timer/Counter A0 high byte timer underflow */
+    EVSYS_CHANNEL_TCA0_CMP0_LCMP0_gc = (0x84<<0),  /* Timer/Counter A0 compare 0 / low byte timer compare 0 */
+    EVSYS_CHANNEL_TCA0_CMP1_LCMP1_gc = (0x85<<0),  /* Timer/Counter A0 compare 1 / low byte timer compare 1 */
+    EVSYS_CHANNEL_TCA0_CMP2_LCMP2_gc = (0x86<<0),  /* Timer/Counter A0 compare 2 / low byte timer compare 2 */
+    EVSYS_CHANNEL_TCA1_OVF_LUNF_gc = (0x88<<0),  /* Timer/Counter A1 overflow / low byte timer underflow */
+    EVSYS_CHANNEL_TCA1_HUNF_gc = (0x89<<0),  /* Timer/Counter A1 high byte timer underflow */
+    EVSYS_CHANNEL_TCA1_CMP0_LCMP0_gc = (0x8C<<0),  /* Timer/Counter A1 compare 0 / low byte timer compare 0 */
+    EVSYS_CHANNEL_TCA1_CMP1_LCMP1_gc = (0x8D<<0),  /* Timer/Counter A1 compare 1 / low byte timer compare 1 */
+    EVSYS_CHANNEL_TCA1_CMP2_LCMP2_gc = (0x8E<<0),  /* Timer/Counter A1 compare 2 / low byte timer compare 2 */
+    EVSYS_CHANNEL_TCB0_CAPT_gc = (0xA0<<0),  /* Timer/Counter B0 capture */
+    EVSYS_CHANNEL_TCB0_OVF_gc = (0xA1<<0),  /* Timer/Counter B0 overflow */
+    EVSYS_CHANNEL_TCB1_CAPT_gc = (0xA2<<0),  /* Timer/Counter B1 capture */
+    EVSYS_CHANNEL_TCB1_OVF_gc = (0xA3<<0),  /* Timer/Counter B1 overflow */
+    EVSYS_CHANNEL_TCB2_CAPT_gc = (0xA4<<0),  /* Timer/Counter B2 capture */
+    EVSYS_CHANNEL_TCB2_OVF_gc = (0xA5<<0),  /* Timer/Counter B2 overflow */
+    EVSYS_CHANNEL_TCB3_CAPT_gc = (0xA6<<0),  /* Timer/Counter B3 capture */
+    EVSYS_CHANNEL_TCB3_OVF_gc = (0xA7<<0)  /* Timer/Counter B3 overflow */
+} EVSYS_CHANNEL_t;
+
+/* Software event on channel select */
+typedef enum EVSYS_SWEVENTA_enum
+{
+    EVSYS_SWEVENTA_CH0_gc = (0x01<<0),  /* Software event on channel 0 */
+    EVSYS_SWEVENTA_CH1_gc = (0x02<<0),  /* Software event on channel 1 */
+    EVSYS_SWEVENTA_CH2_gc = (0x04<<0),  /* Software event on channel 2 */
+    EVSYS_SWEVENTA_CH3_gc = (0x08<<0),  /* Software event on channel 3 */
+    EVSYS_SWEVENTA_CH4_gc = (0x10<<0),  /* Software event on channel 4 */
+    EVSYS_SWEVENTA_CH5_gc = (0x20<<0),  /* Software event on channel 5 */
+    EVSYS_SWEVENTA_CH6_gc = (0x40<<0),  /* Software event on channel 6 */
+    EVSYS_SWEVENTA_CH7_gc = (0x80<<0)  /* Software event on channel 7 */
+} EVSYS_SWEVENTA_t;
+
+/* User channel select */
+typedef enum EVSYS_USER_enum
+{
+    EVSYS_USER_OFF_gc = (0x00<<0),  /* Off, No Eventsys Channel connected */
+    EVSYS_USER_CHANNEL0_gc = (0x01<<0),  /* Connect user to event channel 0 */
+    EVSYS_USER_CHANNEL1_gc = (0x02<<0),  /* Connect user to event channel 1 */
+    EVSYS_USER_CHANNEL2_gc = (0x03<<0),  /* Connect user to event channel 2 */
+    EVSYS_USER_CHANNEL3_gc = (0x04<<0),  /* Connect user to event channel 3 */
+    EVSYS_USER_CHANNEL4_gc = (0x05<<0),  /* Connect user to event channel 4 */
+    EVSYS_USER_CHANNEL5_gc = (0x06<<0)  /* Connect user to event channel 5 */
+} EVSYS_USER_t;
+
+/*
+--------------------------------------------------------------------------
+FUSE - Fuses
+--------------------------------------------------------------------------
+*/
+
+/* Fuses */
+typedef struct FUSE_struct
+{
+    register8_t WDTCFG;  /* Watchdog Configuration */
+    register8_t BODCFG;  /* BOD Configuration */
+    register8_t OSCCFG;  /* Oscillator Configuration */
+    register8_t reserved_1[2];
+    register8_t SYSCFG0;  /* System Configuration 0 */
+    register8_t SYSCFG1;  /* System Configuration 1 */
+    register8_t CODESIZE;  /* Code Section Size */
+    register8_t BOOTSIZE;  /* Boot Section Size */
+} FUSE_t;
+
+/* avr-libc typedef for avr/fuse.h */
+typedef FUSE_t NVM_FUSES_t;
+
+/* BOD Operation in Active Mode select */
+typedef enum ACTIVE_enum
+{
+    ACTIVE_DISABLE_gc = (0x00<<2),  /* Disabled */
+    ACTIVE_ENABLED_gc = (0x01<<2),  /* Enabled in continuous mode */
+    ACTIVE_SAMPLED_gc = (0x02<<2),  /* Enabled in sampled mode */
+    ACTIVE_ENABLEWAIT_gc = (0x03<<2)  /* Enabled in continuous mode. Execution halted at wake-up until BOD is running */
+} ACTIVE_t;
+
+/* CRC Select */
+typedef enum CRCSEL_enum
+{
+    CRCSEL_CRC16_gc = (0x00<<5),  /* Enable CRC16 */
+    CRCSEL_CRC32_gc = (0x01<<5)  /* Enable CRC32 */
+} CRCSEL_t;
+
+/* CRC Source select */
+typedef enum CRCSRC_enum
+{
+    CRCSRC_FLASH_gc = (0x00<<6),  /* CRC of full Flash (boot, application code and application data) */
+    CRCSRC_BOOT_gc = (0x01<<6),  /* CRC of boot section */
+    CRCSRC_BOOTAPP_gc = (0x02<<6),  /* CRC of application code and boot sections */
+    CRCSRC_NOCRC_gc = (0x03<<6)  /* No CRC */
+} CRCSRC_t;
+
+/* EEPROM Save select */
+typedef enum EESAVE_enum
+{
+    EESAVE_DISABLE_gc = (0x00<<0),  /* EEPROM content is erased during chip erase */
+    EESAVE_ENABLE_gc = (0x01<<0)  /* EEPROM content is preserved during chip erase */
+} EESAVE_t;
+
+/* BOD Level select */
+typedef enum LVL_enum
+{
+    LVL_BODLEVEL0_gc = (0x00<<5),  /* BOD Disabled during normal operation */
+    LVL_BODLEVEL1_gc = (0x01<<5),  /* 1.9 V */
+    LVL_BODLEVEL2_gc = (0x02<<5),  /* 2.7 V */
+    LVL_BODLEVEL3_gc = (0x03<<5)  /* 4.5 V */
+} LVL_t;
+
+/* High-frequency Oscillator Frequency select */
+typedef enum OSCHFFRQ_enum
+{
+    OSCHFFRQ_20M_gc = (0x00<<3),  /* OSCHF running at 20 MHz */
+    OSCHFFRQ_16M_gc = (0x01<<3)  /* OSCHF running at 16 MHz */
+} OSCHFFRQ_t;
+
+/* Watchdog Timeout Period select */
+typedef enum PERIOD_enum
+{
+    PERIOD_OFF_gc = (0x00<<0),  /* Watch-Dog timer Off */
+    PERIOD_8CLK_gc = (0x01<<0),  /* 8 cycles (8ms) */
+    PERIOD_16CLK_gc = (0x02<<0),  /* 16 cycles (16ms) */
+    PERIOD_32CLK_gc = (0x03<<0),  /* 32 cycles (32ms) */
+    PERIOD_64CLK_gc = (0x04<<0),  /* 64 cycles (64ms) */
+    PERIOD_128CLK_gc = (0x05<<0),  /* 128 cycles (0.128s) */
+    PERIOD_256CLK_gc = (0x06<<0),  /* 256 cycles (0.256s) */
+    PERIOD_512CLK_gc = (0x07<<0),  /* 512 cycles (0.512s) */
+    PERIOD_1KCLK_gc = (0x08<<0),  /* 1K cycles (1.0s) */
+    PERIOD_2KCLK_gc = (0x09<<0),  /* 2K cycles (2.0s) */
+    PERIOD_4KCLK_gc = (0x0A<<0),  /* 4K cycles (4.0s) */
+    PERIOD_8KCLK_gc = (0x0B<<0)  /* 8K cycles (8.0s) */
+} PERIOD_t;
+
+/* Reset Pin Configuration select */
+typedef enum RSTPINCFG_enum
+{
+    RSTPINCFG_NONE_gc = (0x00<<3),  /* No External Reset */
+    RSTPINCFG_RESET_gc = (0x01<<3)  /* PF6 configured as RESET pin */
+} RSTPINCFG_t;
+
+/* BOD Sample Frequency select */
+typedef enum SAMPFREQ_enum
+{
+    SAMPFREQ_128HZ_gc = (0x00<<4),  /* Sampling frequency is 128 Hz */
+    SAMPFREQ_32HZ_gc = (0x01<<4)  /* Sample frequency is 32 Hz */
+} SAMPFREQ_t;
+
+/* BOD Operation in Sleep Mode select */
+typedef enum SLEEP_enum
+{
+    SLEEP_DISABLE_gc = (0x00<<0),  /* Disabled */
+    SLEEP_ENABLE_gc = (0x01<<0),  /* Enabled in continuous mode */
+    SLEEP_SAMPLE_gc = (0x02<<0)  /* Enabled in sampled mode */
+} SLEEP_t;
+
+/* Startup Time select */
+typedef enum SUT_enum
+{
+    SUT_0MS_gc = (0x00<<0),  /* 0 ms */
+    SUT_1MS_gc = (0x01<<0),  /* 1 ms */
+    SUT_2MS_gc = (0x02<<0),  /* 2 ms */
+    SUT_4MS_gc = (0x03<<0),  /* 4 ms */
+    SUT_8MS_gc = (0x04<<0),  /* 8 ms */
+    SUT_16MS_gc = (0x05<<0),  /* 16 ms */
+    SUT_32MS_gc = (0x06<<0),  /* 32 ms */
+    SUT_64MS_gc = (0x07<<0)  /* 64 ms */
+} SUT_t;
+
+/* UPDI Pin Configuration select */
+typedef enum UPDIPINCFG_enum
+{
+    UPDIPINCFG_GPIO_gc = (0x00<<4),  /* PF7 Configured as GPIO pin */
+    UPDIPINCFG_UPDI_gc = (0x01<<4)  /* PF7 Configured as UPDI pin */
+} UPDIPINCFG_t;
+
+/* Watchdog Window Timeout Period select */
+typedef enum WINDOW_enum
+{
+    WINDOW_OFF_gc = (0x00<<4),  /* Window mode off */
+    WINDOW_8CLK_gc = (0x01<<4),  /* 8 cycles (8ms) */
+    WINDOW_16CLK_gc = (0x02<<4),  /* 16 cycles (16ms) */
+    WINDOW_32CLK_gc = (0x03<<4),  /* 32 cycles (32ms) */
+    WINDOW_64CLK_gc = (0x04<<4),  /* 64 cycles (64ms) */
+    WINDOW_128CLK_gc = (0x05<<4),  /* 128 cycles (0.128s) */
+    WINDOW_256CLK_gc = (0x06<<4),  /* 256 cycles (0.256s) */
+    WINDOW_512CLK_gc = (0x07<<4),  /* 512 cycles (0.512s) */
+    WINDOW_1KCLK_gc = (0x08<<4),  /* 1K cycles (1.0s) */
+    WINDOW_2KCLK_gc = (0x09<<4),  /* 2K cycles (2.0s) */
+    WINDOW_4KCLK_gc = (0x0A<<4),  /* 4K cycles (4.0s) */
+    WINDOW_8KCLK_gc = (0x0B<<4)  /* 8K cycles (8.0s) */
+} WINDOW_t;
+
+/*
+--------------------------------------------------------------------------
+GPR - General Purpose Registers
+--------------------------------------------------------------------------
+*/
+
+/* General Purpose Registers */
+typedef struct GPR_struct
+{
+    register8_t GPR0;  /* General Purpose Register 0 */
+    register8_t GPR1;  /* General Purpose Register 1 */
+    register8_t GPR2;  /* General Purpose Register 2 */
+    register8_t GPR3;  /* General Purpose Register 3 */
+} GPR_t;
+
+
+/*
+--------------------------------------------------------------------------
+LOCK - Lockbits
+--------------------------------------------------------------------------
+*/
+
+/* Lockbits */
+typedef struct LOCK_struct
+{
+    _DWORDREGISTER(KEY);  /* Lock Key Bits */
+} LOCK_t;
+
+/* Lock Key select */
+typedef enum LOCK_KEY_enum
+{
+    LOCK_KEY_NOLOCK_gc = (0x5CC5C55C<<0),  /* No locks */
+    LOCK_KEY_RWLOCK_gc = (0xA33A3AA3<<0)  /* Read and write lock */
+} LOCK_KEY_t;
+
+/*
+--------------------------------------------------------------------------
+NVMCTRL - Non-volatile Memory Controller
+--------------------------------------------------------------------------
+*/
+
+/* Non-volatile Memory Controller */
+typedef struct NVMCTRL_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t reserved_1[2];
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t STATUS;  /* Status */
+    register8_t reserved_2[1];
+    _WORDREGISTER(DATA);  /* Data */
+    register8_t reserved_3[2];
+    _DWORDREGISTER(ADDR);  /* Address */
+    register8_t reserved_4[48];
+} NVMCTRL_t;
+
+/* Command select */
+typedef enum NVMCTRL_CMD_enum
+{
+    NVMCTRL_CMD_NOCMD_gc = (0x00<<0),  /* No Command */
+    NVMCTRL_CMD_NOOP_gc = (0x01<<0),  /* No Operation */
+    NVMCTRL_CMD_FLPW_gc = (0x04<<0),  /* Flash Page Write */
+    NVMCTRL_CMD_FLPERW_gc = (0x05<<0),  /* Flash Page Erase and Write */
+    NVMCTRL_CMD_FLPER_gc = (0x08<<0),  /* Flash Page Erase */
+    NVMCTRL_CMD_FLMPER2_gc = (0x09<<0),  /* Flash 2-page erase enable */
+    NVMCTRL_CMD_FLMPER4_gc = (0x0A<<0),  /* Flash 4-page erase enable */
+    NVMCTRL_CMD_FLMPER8_gc = (0x0B<<0),  /* Flash 8-page erase enable */
+    NVMCTRL_CMD_FLMPER16_gc = (0x0C<<0),  /* Flash 16-page erase enable */
+    NVMCTRL_CMD_FLMPER32_gc = (0x0D<<0),  /* Flash 32-page erase enable */
+    NVMCTRL_CMD_FLPBCLR_gc = (0x0F<<0),  /* Flash Page Buffer Clear */
+    NVMCTRL_CMD_EEPW_gc = (0x14<<0),  /* EEPROM Page Write */
+    NVMCTRL_CMD_EEPERW_gc = (0x15<<0),  /* EEPROM Page Erase and Write */
+    NVMCTRL_CMD_EEPER_gc = (0x17<<0),  /* EEPROM Page Erase */
+    NVMCTRL_CMD_EEPBCLR_gc = (0x1F<<0),  /* EEPROM Page Buffer Clear */
+    NVMCTRL_CMD_CHER_gc = (0x20<<0),  /* Chip Erase Command (UPDI only) */
+    NVMCTRL_CMD_EECHER_gc = (0x30<<0)  /* EEPROM Erase Command (UPDI only) */
+} NVMCTRL_CMD_t;
+
+/* Write error select */
+typedef enum NVMCTRL_ERROR_enum
+{
+    NVMCTRL_ERROR_NOERROR_gc = (0x00<<4),  /* No Error */
+    NVMCTRL_ERROR_WRITEPROTECT_gc = (0x02<<4),  /* Attempt to program write protected area */
+    NVMCTRL_ERROR_CMDCOLLISION_gc = (0x03<<4),  /* Selecting new write command while write command already seleted */
+    NVMCTRL_ERROR_WRONGSECTION_gc = (0x04<<4)  /* Address cannot be written with selected command */
+} NVMCTRL_ERROR_t;
+
+/* Flash Mapping in Data space select */
+typedef enum NVMCTRL_FLMAP_enum
+{
+    NVMCTRL_FLMAP_SECTION0_gc = (0x00<<4),  /* Flash section 0, 0 - 32KB */
+    NVMCTRL_FLMAP_SECTION1_gc = (0x01<<4),  /* Flash section 1, 32 - 64KB */
+    NVMCTRL_FLMAP_SECTION2_gc = (0x02<<4),  /* Flash section 2, 64 - 96KB */
+    NVMCTRL_FLMAP_SECTION3_gc = (0x03<<4)  /* Flash section 3, 96 - 128KB */
+} NVMCTRL_FLMAP_t;
+
+/*
+--------------------------------------------------------------------------
+PORT - I/O Ports
+--------------------------------------------------------------------------
+*/
+
+/* I/O Ports */
+typedef struct PORT_struct
+{
+    register8_t DIR;  /* Data Direction */
+    register8_t DIRSET;  /* Data Direction Set */
+    register8_t DIRCLR;  /* Data Direction Clear */
+    register8_t DIRTGL;  /* Data Direction Toggle */
+    register8_t OUT;  /* Output Value */
+    register8_t OUTSET;  /* Output Value Set */
+    register8_t OUTCLR;  /* Output Value Clear */
+    register8_t OUTTGL;  /* Output Value Toggle */
+    register8_t IN;  /* Input Value */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t PORTCTRL;  /* Port Control */
+    register8_t PINCONFIG;  /* Pin Control Config */
+    register8_t PINCTRLUPD;  /* Pin Control Update */
+    register8_t PINCTRLSET;  /* Pin Control Set */
+    register8_t PINCTRLCLR;  /* Pin Control Clear */
+    register8_t reserved_1[1];
+    register8_t PIN0CTRL;  /* Pin 0 Control */
+    register8_t PIN1CTRL;  /* Pin 1 Control */
+    register8_t PIN2CTRL;  /* Pin 2 Control */
+    register8_t PIN3CTRL;  /* Pin 3 Control */
+    register8_t PIN4CTRL;  /* Pin 4 Control */
+    register8_t PIN5CTRL;  /* Pin 5 Control */
+    register8_t PIN6CTRL;  /* Pin 6 Control */
+    register8_t PIN7CTRL;  /* Pin 7 Control */
+    register8_t EVGENCTRL;  /* Event Generation Control */
+    register8_t reserved_2[7];
+} PORT_t;
+
+/* Event Generator 0 Select */
+typedef enum PORT_EVGEN0SEL_enum
+{
+    PORT_EVGEN0SEL_PIN0_gc = (0x00<<0),  /* Pin 0 used as event generator */
+    PORT_EVGEN0SEL_PIN1_gc = (0x01<<0),  /* Pin 1 used as event generator */
+    PORT_EVGEN0SEL_PIN2_gc = (0x02<<0),  /* Pin 2 used as event generator */
+    PORT_EVGEN0SEL_PIN3_gc = (0x03<<0),  /* Pin 3 used as event generator */
+    PORT_EVGEN0SEL_PIN4_gc = (0x04<<0),  /* Pin 4 used as event generator */
+    PORT_EVGEN0SEL_PIN5_gc = (0x05<<0),  /* Pin 5 used as event generator */
+    PORT_EVGEN0SEL_PIN6_gc = (0x06<<0),  /* Pin 6 used as event generator */
+    PORT_EVGEN0SEL_PIN7_gc = (0x07<<0)  /* Pin 7 used as event generator */
+} PORT_EVGEN0SEL_t;
+
+/* Event Generator 1 Select */
+typedef enum PORT_EVGEN1SEL_enum
+{
+    PORT_EVGEN1SEL_PIN0_gc = (0x00<<4),  /* Pin 0 used as event generator */
+    PORT_EVGEN1SEL_PIN1_gc = (0x01<<4),  /* Pin 1 used as event generator */
+    PORT_EVGEN1SEL_PIN2_gc = (0x02<<4),  /* Pin 2 used as event generator */
+    PORT_EVGEN1SEL_PIN3_gc = (0x03<<4),  /* Pin 3 used as event generator */
+    PORT_EVGEN1SEL_PIN4_gc = (0x04<<4),  /* Pin 4 used as event generator */
+    PORT_EVGEN1SEL_PIN5_gc = (0x05<<4),  /* Pin 5 used as event generator */
+    PORT_EVGEN1SEL_PIN6_gc = (0x06<<4),  /* Pin 6 used as event generator */
+    PORT_EVGEN1SEL_PIN7_gc = (0x07<<4)  /* Pin 7 used as event generator */
+} PORT_EVGEN1SEL_t;
+
+/* Input Level Select */
+typedef enum PORT_INLVL_enum
+{
+    PORT_INLVL_ST_gc = (0x00<<6),  /* Schmitt-Trigger input level */
+    PORT_INLVL_TTL_gc = (0x01<<6)  /* TTL Input level */
+} PORT_INLVL_t;
+
+/* Input/Sense Configuration select */
+typedef enum PORT_ISC_enum
+{
+    PORT_ISC_INTDISABLE_gc = (0x00<<0),  /* Interrupt disabled but input buffer enabled */
+    PORT_ISC_BOTHEDGES_gc = (0x01<<0),  /* Sense Both Edges */
+    PORT_ISC_RISING_gc = (0x02<<0),  /* Sense Rising Edge */
+    PORT_ISC_FALLING_gc = (0x03<<0),  /* Sense Falling Edge */
+    PORT_ISC_INPUT_DISABLE_gc = (0x04<<0),  /* Digital Input Buffer disabled */
+    PORT_ISC_LEVEL_gc = (0x05<<0)  /* Sense low Level */
+} PORT_ISC_t;
+
+/*
+--------------------------------------------------------------------------
+PORTMUX - Port Multiplexer
+--------------------------------------------------------------------------
+*/
+
+/* Port Multiplexer */
+typedef struct PORTMUX_struct
+{
+    register8_t EVSYSROUTEA;  /* EVSYS route A */
+    register8_t CCLROUTEA;  /* CCL route A */
+    register8_t USARTROUTEA;  /* USART route A */
+    register8_t USARTROUTEB;  /* USART route B */
+    register8_t reserved_1[1];
+    register8_t SPIROUTEA;  /* SPI route A */
+    register8_t TWIROUTEA;  /* TWI route A */
+    register8_t TCAROUTEA;  /* TCA route A */
+    register8_t TCBROUTEA;  /* TCB route A */
+    register8_t reserved_2[1];
+    register8_t ACROUTEA;  /* AC route A */
+    register8_t reserved_3[21];
+} PORTMUX_t;
+
+/* Analog Comparator 0 Output select */
+typedef enum PORTMUX_AC0_enum
+{
+    PORTMUX_AC0_DEFAULT_gc = (0x00<<0)  /* OUT: PA7 */
+} PORTMUX_AC0_t;
+
+/* Analog Comparator 1 Output select */
+typedef enum PORTMUX_AC1_enum
+{
+    PORTMUX_AC1_DEFAULT_gc = (0x00<<1)  /* OUT: PA7 */
+} PORTMUX_AC1_t;
+
+/* Event Output A select */
+typedef enum PORTMUX_EVOUTA_enum
+{
+    PORTMUX_EVOUTA_DEFAULT_gc = (0x00<<0),  /* EVOUTA: PA2 */
+    PORTMUX_EVOUTA_ALT1_gc = (0x01<<0)  /* EVOUTA: PA7 */
+} PORTMUX_EVOUTA_t;
+
+/* Event Output C select */
+typedef enum PORTMUX_EVOUTC_enum
+{
+    PORTMUX_EVOUTC_DEFAULT_gc = (0x00<<2)  /* EVOUTC: PC2 */
+} PORTMUX_EVOUTC_t;
+
+/* Event Output D select */
+typedef enum PORTMUX_EVOUTD_enum
+{
+    PORTMUX_EVOUTD_DEFAULT_gc = (0x00<<3),  /* EVOUTD: PD2 */
+    PORTMUX_EVOUTD_ALT1_gc = (0x01<<3)  /* EVOUTD: PD7 */
+} PORTMUX_EVOUTD_t;
+
+/* Event Output F select */
+typedef enum PORTMUX_EVOUTF_enum
+{
+    PORTMUX_EVOUTF_DEFAULT_gc = (0x00<<5),  /* Not connected to any pins */
+    PORTMUX_EVOUTF_ALT1_gc = (0x01<<5)  /* EVOUTF: PF7 */
+} PORTMUX_EVOUTF_t;
+
+/* CCL Look-Up Table 0 Signals select */
+typedef enum PORTMUX_LUT0_enum
+{
+    PORTMUX_LUT0_DEFAULT_gc = (0x00<<0),  /* In: PA0, PA1, PA2, Out: PA3 */
+    PORTMUX_LUT0_ALT1_gc = (0x01<<0)  /* In: PA0, PA1, PA2, Out: PA6 */
+} PORTMUX_LUT0_t;
+
+/* CCL Look-Up Table 1 Signals select */
+typedef enum PORTMUX_LUT1_enum
+{
+    PORTMUX_LUT1_DEFAULT_gc = (0x00<<1),  /* In: PC0, PC1, PC2, Out: PC3 */
+    PORTMUX_LUT1_ALT1_gc = (0x01<<1)  /* In: PC0, PC1, PC2, Out: - */
+} PORTMUX_LUT1_t;
+
+/* CCL Look-Up Table 2 Signals select */
+typedef enum PORTMUX_LUT2_enum
+{
+    PORTMUX_LUT2_DEFAULT_gc = (0x00<<2),  /* In: PD0, PD1, PD2, Out: PD3 */
+    PORTMUX_LUT2_ALT1_gc = (0x01<<2)  /* In: PD0, PD1, PD2, Out: PD6 */
+} PORTMUX_LUT2_t;
+
+/* SPI0 Signals select */
+typedef enum PORTMUX_SPI0_enum
+{
+    PORTMUX_SPI0_DEFAULT_gc = (0x00<<0),  /* MOSI: PA4, MISO: PA5, SCK: PA6, SS: PA7 */
+    PORTMUX_SPI0_ALT3_gc = (0x03<<0),  /* MOSI: PA0, MISO: PA1, SCK: PC0, SS: PC1 */
+    PORTMUX_SPI0_ALT4_gc = (0x04<<0),  /* MOSI: PD4, MISO: PD5, SCK: PD6, SS: PD7 */
+    PORTMUX_SPI0_ALT5_gc = (0x05<<0),  /* MOSI: PC0, MISO: PC1, SCK: PC2, SS: PC3 */
+    PORTMUX_SPI0_ALT6_gc = (0x06<<0),  /* MOSI: PC1, MISO: PC2, SCK: PC3, SS: PF7 */
+    PORTMUX_SPI0_NONE_gc = (0x07<<0)  /* Not connected to any pins, SS set to 1 */
+} PORTMUX_SPI0_t;
+
+/* TCA0 Signals select */
+typedef enum PORTMUX_TCA0_enum
+{
+    PORTMUX_TCA0_PORTA_gc = (0x00<<0),  /* WOn: PA0, PA1, PA2, PA3, PA4, PA5 */
+    PORTMUX_TCA0_PORTC_gc = (0x02<<0),  /* WOn: PC0, PC1, PC2, PC3, -, - */
+    PORTMUX_TCA0_PORTD_gc = (0x03<<0),  /* WOn: PD0, PD1, PD2, PD3, PD4, PD5 */
+    PORTMUX_TCA0_PORTF_gc = (0x05<<0)  /* WOn: PF0, PF1, -, -, -, - */
+} PORTMUX_TCA0_t;
+
+/* TCA1 Signals select */
+typedef enum PORTMUX_TCA1_enum
+{
+    PORTMUX_TCA1_PORTB_gc = (0x00<<3),  /* Not connected to any pins */
+    PORTMUX_TCA1_PORTA_gc = (0x04<<3),  /* WOn: PA4, PA5, PA6, -, -, - */
+    PORTMUX_TCA1_PORTD_gc = (0x05<<3)  /* WOn: PD4, PD5, PD6, -, -, - */
+} PORTMUX_TCA1_t;
+
+/* TCB0 Output select */
+typedef enum PORTMUX_TCB0_enum
+{
+    PORTMUX_TCB0_DEFAULT_gc = (0x00<<0)  /* WO: PA2 */
+} PORTMUX_TCB0_t;
+
+/* TCB1 Output select */
+typedef enum PORTMUX_TCB1_enum
+{
+    PORTMUX_TCB1_DEFAULT_gc = (0x00<<1)  /* WO: PA3 */
+} PORTMUX_TCB1_t;
+
+/* TCB2 Output select */
+typedef enum PORTMUX_TCB2_enum
+{
+    PORTMUX_TCB2_DEFAULT_gc = (0x00<<2)  /* WO: PC0 */
+} PORTMUX_TCB2_t;
+
+/* TCB3 Output select */
+typedef enum PORTMUX_TCB3_enum
+{
+    PORTMUX_TCB3_DEFAULT_gc = (0x00<<3),  /* Not connected to any pins */
+    PORTMUX_TCB3_ALT1_gc = (0x01<<3)  /* WO: PC1 */
+} PORTMUX_TCB3_t;
+
+/* TWI0 Signals select */
+typedef enum PORTMUX_TWI0_enum
+{
+    PORTMUX_TWI0_DEFAULT_gc = (0x00<<0),  /* SDA: PA2, SCL: PA3. Dual mode: SDA: PC2, SCL: PC3 */
+    PORTMUX_TWI0_ALT1_gc = (0x01<<0),  /* SDA: PA2, SCL: PA3. Dual mode: SDA: -, SCL: - */
+    PORTMUX_TWI0_ALT2_gc = (0x02<<0),  /* SDA: PC2, SCL: PC3. Dual mode: SDA: -, SCL: - */
+    PORTMUX_TWI0_ALT3_gc = (0x03<<0)  /* SDA: PA0, SCL: PA1. Dual mode: SDA: PC2, SCL: PC3 */
+} PORTMUX_TWI0_t;
+
+/* USART0 Routing select */
+typedef enum PORTMUX_USART0_enum
+{
+    PORTMUX_USART0_DEFAULT_gc = (0x00<<0),  /* TxD: PA0, RxD: PA1, XCK: PA2, XDIR: PA3 */
+    PORTMUX_USART0_ALT1_gc = (0x01<<0),  /* TxD: PA4, RxD: PA5, XCK: PA6, XDIR: PA7 */
+    PORTMUX_USART0_ALT2_gc = (0x02<<0),  /* TxD: PA2, RxD: PA3, XCK: -, XDIR: - */
+    PORTMUX_USART0_ALT3_gc = (0x03<<0),  /* TxD: PD4, RxD: PD5, XCK: PD6, XDIR: PD7 */
+    PORTMUX_USART0_ALT4_gc = (0x04<<0),  /* TxD: PC1, RxD: PC2, XCK: PC3, XDIR: - */
+    PORTMUX_USART0_NONE_gc = (0x05<<0)  /* Not connected to any pins */
+} PORTMUX_USART0_t;
+
+/* USART1 Routing select */
+typedef enum PORTMUX_USART1_enum
+{
+    PORTMUX_USART1_DEFAULT_gc = (0x00<<3),  /* TxD: PC0, RxD: PC1, XCK: PC2, XDIR: PC3 */
+    PORTMUX_USART1_ALT2_gc = (0x02<<3),  /* TxD: PD6, RxD: PD7, XCK: -, XDIR: - */
+    PORTMUX_USART1_NONE_gc = (0x03<<3)  /* Not connected to any pins */
+} PORTMUX_USART1_t;
+
+/* USART2 Routing select */
+typedef enum PORTMUX_USART2_enum
+{
+    PORTMUX_USART2_DEFAULT_gc = (0x00<<0),  /* TxD: PF0, RxD: PF1, XCK: -, XDIR: - */
+    PORTMUX_USART2_NONE_gc = (0x03<<0)  /* Not connected to any pins */
+} PORTMUX_USART2_t;
+
+/*
+--------------------------------------------------------------------------
+RSTCTRL - Reset controller
+--------------------------------------------------------------------------
+*/
+
+/* Reset controller */
+typedef struct RSTCTRL_struct
+{
+    register8_t RSTFR;  /* Reset Flags */
+    register8_t SWRR;  /* Software Reset */
+    register8_t reserved_1[14];
+} RSTCTRL_t;
+
+
+/*
+--------------------------------------------------------------------------
+RTC - Real-Time Counter
+--------------------------------------------------------------------------
+*/
+
+/* Real-Time Counter */
+typedef struct RTC_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t STATUS;  /* Status */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t TEMP;  /* Temporary */
+    register8_t DBGCTRL;  /* Debug control */
+    register8_t CALIB;  /* Calibration */
+    register8_t CLKSEL;  /* Clock Select */
+    _WORDREGISTER(CNT);  /* Counter */
+    _WORDREGISTER(PER);  /* Period */
+    _WORDREGISTER(CMP);  /* Compare */
+    register8_t reserved_1[2];
+    register8_t PITCTRLA;  /* PIT Control A */
+    register8_t PITSTATUS;  /* PIT Status */
+    register8_t PITINTCTRL;  /* PIT Interrupt Control */
+    register8_t PITINTFLAGS;  /* PIT Interrupt Flags */
+    register8_t reserved_2[1];
+    register8_t PITDBGCTRL;  /* PIT Debug control */
+    register8_t PITEVGENCTRLA;  /* PIT Event Generation Control A */
+    register8_t reserved_3[9];
+} RTC_t;
+
+/* Clock Select */
+typedef enum RTC_CLKSEL_enum
+{
+    RTC_CLKSEL_OSC32K_gc = (0x00<<0),  /* Internal 32.768 kHz Oscillator */
+    RTC_CLKSEL_OSC1K_gc = (0x01<<0),  /* Internal 32.768 kHz Oscillator Divided by 32 */
+    RTC_CLKSEL_XOSC32K_gc = (0x02<<0),  /* 32.768 kHz Crystal Oscillator */
+    RTC_CLKSEL_EXTCLK_gc = (0x03<<0)  /* External Clock */
+} RTC_CLKSEL_t;
+
+/* Event Generation 0 Select */
+typedef enum RTC_EVGEN0SEL_enum
+{
+    RTC_EVGEN0SEL_OFF_gc = (0x00<<0),  /* No Event Generated */
+    RTC_EVGEN0SEL_DIV4_gc = (0x01<<0),  /* CLK_RTC divided by 4 */
+    RTC_EVGEN0SEL_DIV8_gc = (0x02<<0),  /* CLK_RTC divided by 8 */
+    RTC_EVGEN0SEL_DIV16_gc = (0x03<<0),  /* CLK_RTC divided by 16 */
+    RTC_EVGEN0SEL_DIV32_gc = (0x04<<0),  /* CLK_RTC divided by 32 */
+    RTC_EVGEN0SEL_DIV64_gc = (0x05<<0),  /* CLK_RTC divided by 64 */
+    RTC_EVGEN0SEL_DIV128_gc = (0x06<<0),  /* CLK_RTC divided by 128 */
+    RTC_EVGEN0SEL_DIV256_gc = (0x07<<0),  /* CLK_RTC divided by 256 */
+    RTC_EVGEN0SEL_DIV512_gc = (0x08<<0),  /* CLK_RTC divided by 512 */
+    RTC_EVGEN0SEL_DIV1024_gc = (0x09<<0),  /* CLK_RTC divided by 1024 */
+    RTC_EVGEN0SEL_DIV2048_gc = (0x0A<<0),  /* CLK_RTC divided by 2048 */
+    RTC_EVGEN0SEL_DIV4096_gc = (0x0B<<0),  /* CLK_RTC divided by 4096 */
+    RTC_EVGEN0SEL_DIV8192_gc = (0x0C<<0),  /* CLK_RTC divided by 8192 */
+    RTC_EVGEN0SEL_DIV16384_gc = (0x0D<<0),  /* CLK_RTC divided by 16384 */
+    RTC_EVGEN0SEL_DIV32768_gc = (0x0E<<0)  /* CLK_RTC divided by 32768 */
+} RTC_EVGEN0SEL_t;
+
+/* Event Generation 1 Select */
+typedef enum RTC_EVGEN1SEL_enum
+{
+    RTC_EVGEN1SEL_OFF_gc = (0x00<<4),  /* No Event Generated */
+    RTC_EVGEN1SEL_DIV4_gc = (0x01<<4),  /* CLK_RTC divided by 4 */
+    RTC_EVGEN1SEL_DIV8_gc = (0x02<<4),  /* CLK_RTC divided by 8 */
+    RTC_EVGEN1SEL_DIV16_gc = (0x03<<4),  /* CLK_RTC divided by 16 */
+    RTC_EVGEN1SEL_DIV32_gc = (0x04<<4),  /* CLK_RTC divided by 32 */
+    RTC_EVGEN1SEL_DIV64_gc = (0x05<<4),  /* CLK_RTC divided by 64 */
+    RTC_EVGEN1SEL_DIV128_gc = (0x06<<4),  /* CLK_RTC divided by 128 */
+    RTC_EVGEN1SEL_DIV256_gc = (0x07<<4),  /* CLK_RTC divided by 256 */
+    RTC_EVGEN1SEL_DIV512_gc = (0x08<<4),  /* CLK_RTC divided by 512 */
+    RTC_EVGEN1SEL_DIV1024_gc = (0x09<<4),  /* CLK_RTC divided by 1024 */
+    RTC_EVGEN1SEL_DIV2048_gc = (0x0A<<4),  /* CLK_RTC divided by 2048 */
+    RTC_EVGEN1SEL_DIV4096_gc = (0x0B<<4),  /* CLK_RTC divided by 4096 */
+    RTC_EVGEN1SEL_DIV8192_gc = (0x0C<<4),  /* CLK_RTC divided by 8192 */
+    RTC_EVGEN1SEL_DIV16384_gc = (0x0D<<4),  /* CLK_RTC divided by 16384 */
+    RTC_EVGEN1SEL_DIV32768_gc = (0x0E<<4)  /* CLK_RTC divided by 32768 */
+} RTC_EVGEN1SEL_t;
+
+/* Period select */
+typedef enum RTC_PERIOD_enum
+{
+    RTC_PERIOD_OFF_gc = (0x00<<3),  /* Off */
+    RTC_PERIOD_CYC4_gc = (0x01<<3),  /* RTC Clock Cycles 4 */
+    RTC_PERIOD_CYC8_gc = (0x02<<3),  /* RTC Clock Cycles 8 */
+    RTC_PERIOD_CYC16_gc = (0x03<<3),  /* RTC Clock Cycles 16 */
+    RTC_PERIOD_CYC32_gc = (0x04<<3),  /* RTC Clock Cycles 32 */
+    RTC_PERIOD_CYC64_gc = (0x05<<3),  /* RTC Clock Cycles 64 */
+    RTC_PERIOD_CYC128_gc = (0x06<<3),  /* RTC Clock Cycles 128 */
+    RTC_PERIOD_CYC256_gc = (0x07<<3),  /* RTC Clock Cycles 256 */
+    RTC_PERIOD_CYC512_gc = (0x08<<3),  /* RTC Clock Cycles 512 */
+    RTC_PERIOD_CYC1024_gc = (0x09<<3),  /* RTC Clock Cycles 1024 */
+    RTC_PERIOD_CYC2048_gc = (0x0A<<3),  /* RTC Clock Cycles 2048 */
+    RTC_PERIOD_CYC4096_gc = (0x0B<<3),  /* RTC Clock Cycles 4096 */
+    RTC_PERIOD_CYC8192_gc = (0x0C<<3),  /* RTC Clock Cycles 8192 */
+    RTC_PERIOD_CYC16384_gc = (0x0D<<3),  /* RTC Clock Cycles 16384 */
+    RTC_PERIOD_CYC32768_gc = (0x0E<<3)  /* RTC Clock Cycles 32768 */
+} RTC_PERIOD_t;
+
+/* Prescaling Factor select */
+typedef enum RTC_PRESCALER_enum
+{
+    RTC_PRESCALER_DIV1_gc = (0x00<<3),  /* RTC Clock / 1 */
+    RTC_PRESCALER_DIV2_gc = (0x01<<3),  /* RTC Clock / 2 */
+    RTC_PRESCALER_DIV4_gc = (0x02<<3),  /* RTC Clock / 4 */
+    RTC_PRESCALER_DIV8_gc = (0x03<<3),  /* RTC Clock / 8 */
+    RTC_PRESCALER_DIV16_gc = (0x04<<3),  /* RTC Clock / 16 */
+    RTC_PRESCALER_DIV32_gc = (0x05<<3),  /* RTC Clock / 32 */
+    RTC_PRESCALER_DIV64_gc = (0x06<<3),  /* RTC Clock / 64 */
+    RTC_PRESCALER_DIV128_gc = (0x07<<3),  /* RTC Clock / 128 */
+    RTC_PRESCALER_DIV256_gc = (0x08<<3),  /* RTC Clock / 256 */
+    RTC_PRESCALER_DIV512_gc = (0x09<<3),  /* RTC Clock / 512 */
+    RTC_PRESCALER_DIV1024_gc = (0x0A<<3),  /* RTC Clock / 1024 */
+    RTC_PRESCALER_DIV2048_gc = (0x0B<<3),  /* RTC Clock / 2048 */
+    RTC_PRESCALER_DIV4096_gc = (0x0C<<3),  /* RTC Clock / 4096 */
+    RTC_PRESCALER_DIV8192_gc = (0x0D<<3),  /* RTC Clock / 8192 */
+    RTC_PRESCALER_DIV16384_gc = (0x0E<<3),  /* RTC Clock / 16384 */
+    RTC_PRESCALER_DIV32768_gc = (0x0F<<3)  /* RTC Clock / 32768 */
+} RTC_PRESCALER_t;
+
+/*
+--------------------------------------------------------------------------
+SIGROW - Signature row
+--------------------------------------------------------------------------
+*/
+
+/* Signature row */
+typedef struct SIGROW_struct
+{
+    register8_t DEVICEID0;  /* Device ID Byte 0 */
+    register8_t DEVICEID1;  /* Device ID Byte 1 */
+    register8_t DEVICEID2;  /* Device ID Byte 2 */
+    register8_t reserved_1[1];
+    _WORDREGISTER(TEMPSENSE0);  /* Temperature Calibration 0 */
+    _WORDREGISTER(TEMPSENSE1);  /* Temperature Calibration 1 */
+    register8_t reserved_2[8];
+    register8_t SERNUM0;  /* Serial Number Byte 0 */
+    register8_t SERNUM1;  /* Serial Number Byte 1 */
+    register8_t SERNUM2;  /* Serial Number Byte 2 */
+    register8_t SERNUM3;  /* Serial Number Byte 3 */
+    register8_t SERNUM4;  /* Serial Number Byte 4 */
+    register8_t SERNUM5;  /* Serial Number Byte 5 */
+    register8_t SERNUM6;  /* Serial Number Byte 6 */
+    register8_t SERNUM7;  /* Serial Number Byte 7 */
+    register8_t SERNUM8;  /* Serial Number Byte 8 */
+    register8_t SERNUM9;  /* Serial Number Byte 9 */
+    register8_t SERNUM10;  /* Serial Number Byte 10 */
+    register8_t SERNUM11;  /* Serial Number Byte 11 */
+    register8_t SERNUM12;  /* Serial Number Byte 12 */
+    register8_t SERNUM13;  /* Serial Number Byte 13 */
+    register8_t SERNUM14;  /* Serial Number Byte 14 */
+    register8_t SERNUM15;  /* Serial Number Byte 15 */
+    register8_t reserved_3[32];
+} SIGROW_t;
+
+
+/*
+--------------------------------------------------------------------------
+SLPCTRL - Sleep Controller
+--------------------------------------------------------------------------
+*/
+
+/* Sleep Controller */
+typedef struct SLPCTRL_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t reserved_1[1];
+} SLPCTRL_t;
+
+/* Sleep mode select */
+typedef enum SLPCTRL_SMODE_enum
+{
+    SLPCTRL_SMODE_IDLE_gc = (0x00<<1),  /* Idle mode */
+    SLPCTRL_SMODE_STDBY_gc = (0x01<<1),  /* Standby Mode */
+    SLPCTRL_SMODE_PDOWN_gc = (0x02<<1)  /* Power-down Mode */
+} SLPCTRL_SMODE_t;
+
+#define SLEEP_MODE_IDLE (0x00<<1)
+#define SLEEP_MODE_STANDBY (0x01<<1)
+#define SLEEP_MODE_PWR_DOWN (0x02<<1)
+/*
+--------------------------------------------------------------------------
+SPI - Serial Peripheral Interface
+--------------------------------------------------------------------------
+*/
+
+/* Serial Peripheral Interface */
+typedef struct SPI_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t DATA;  /* Data */
+    register8_t reserved_1[3];
+} SPI_t;
+
+/* SPI Mode select */
+typedef enum SPI_MODE_enum
+{
+    SPI_MODE_0_gc = (0x00<<0),  /* SPI Mode 0 */
+    SPI_MODE_1_gc = (0x01<<0),  /* SPI Mode 1 */
+    SPI_MODE_2_gc = (0x02<<0),  /* SPI Mode 2 */
+    SPI_MODE_3_gc = (0x03<<0)  /* SPI Mode 3 */
+} SPI_MODE_t;
+
+/* Prescaler select */
+typedef enum SPI_PRESC_enum
+{
+    SPI_PRESC_DIV4_gc = (0x00<<1),  /* CLK_PER / 4 */
+    SPI_PRESC_DIV16_gc = (0x01<<1),  /* CLK_PER / 16 */
+    SPI_PRESC_DIV64_gc = (0x02<<1),  /* CLK_PER / 64 */
+    SPI_PRESC_DIV128_gc = (0x03<<1)  /* CLK_PER / 128 */
+} SPI_PRESC_t;
+
+/*
+--------------------------------------------------------------------------
+SYSCFG - System Configuration Registers
+--------------------------------------------------------------------------
+*/
+
+/* System Configuration Registers */
+typedef struct SYSCFG_struct
+{
+    register8_t reserved_1[1];
+    register8_t REVID;  /* Revision ID */
+    register8_t reserved_2[2];
+    register8_t OCDMCTRL;  /* OCD Message Control */
+    register8_t OCDMSTATUS;  /* OCD Message Status */
+    register8_t reserved_3[26];
+} SYSCFG_t;
+
+
+/*
+--------------------------------------------------------------------------
+TCA - 16-bit Timer/Counter Type A
+--------------------------------------------------------------------------
+*/
+
+/* 16-bit Timer/Counter Type A - Single Mode */
+typedef struct TCA_SINGLE_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    register8_t CTRLD;  /* Control D */
+    register8_t CTRLECLR;  /* Control E Clear */
+    register8_t CTRLESET;  /* Control E Set */
+    register8_t CTRLFCLR;  /* Control F Clear */
+    register8_t CTRLFSET;  /* Control F Set */
+    register8_t reserved_1[1];
+    register8_t EVCTRL;  /* Event Control */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t reserved_2[2];
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t TEMP;  /* Temporary data for 16-bit Access */
+    register8_t reserved_3[16];
+    _WORDREGISTER(CNT);  /* Count */
+    register8_t reserved_4[4];
+    _WORDREGISTER(PER);  /* Period */
+    _WORDREGISTER(CMP0);  /* Compare 0 */
+    _WORDREGISTER(CMP1);  /* Compare 1 */
+    _WORDREGISTER(CMP2);  /* Compare 2 */
+    register8_t reserved_5[8];
+    _WORDREGISTER(PERBUF);  /* Period Buffer */
+    _WORDREGISTER(CMP0BUF);  /* Compare 0 Buffer */
+    _WORDREGISTER(CMP1BUF);  /* Compare 1 Buffer */
+    _WORDREGISTER(CMP2BUF);  /* Compare 2 Buffer */
+    register8_t reserved_6[2];
+} TCA_SINGLE_t;
+
+/* 16-bit Timer/Counter Type A - Split Mode */
+typedef struct TCA_SPLIT_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    register8_t CTRLD;  /* Control D */
+    register8_t CTRLECLR;  /* Control E Clear */
+    register8_t CTRLESET;  /* Control E Set */
+    register8_t reserved_1[4];
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t reserved_2[2];
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t reserved_3[17];
+    register8_t LCNT;  /* Low Count */
+    register8_t HCNT;  /* High Count */
+    register8_t reserved_4[4];
+    register8_t LPER;  /* Low Period */
+    register8_t HPER;  /* High Period */
+    register8_t LCMP0;  /* Low Compare */
+    register8_t HCMP0;  /* High Compare */
+    register8_t LCMP1;  /* Low Compare */
+    register8_t HCMP1;  /* High Compare */
+    register8_t LCMP2;  /* Low Compare */
+    register8_t HCMP2;  /* High Compare */
+    register8_t reserved_5[18];
+} TCA_SPLIT_t;
+
+/* 16-bit Timer/Counter Type A */
+typedef union TCA_union
+{
+    TCA_SINGLE_t SINGLE;  /* Single Mode */
+    TCA_SPLIT_t SPLIT;  /* Split Mode */
+} TCA_t;
+
+/* Clock Selection */
+typedef enum TCA_SINGLE_CLKSEL_enum
+{
+    TCA_SINGLE_CLKSEL_DIV1_gc = (0x00<<1),  /* CLK_PER */
+    TCA_SINGLE_CLKSEL_DIV2_gc = (0x01<<1),  /* CLK_PER / 2 */
+    TCA_SINGLE_CLKSEL_DIV4_gc = (0x02<<1),  /* CLK_PER / 4 */
+    TCA_SINGLE_CLKSEL_DIV8_gc = (0x03<<1),  /* CLK_PER / 8 */
+    TCA_SINGLE_CLKSEL_DIV16_gc = (0x04<<1),  /* CLK_PER / 16 */
+    TCA_SINGLE_CLKSEL_DIV64_gc = (0x05<<1),  /* CLK_PER / 64 */
+    TCA_SINGLE_CLKSEL_DIV256_gc = (0x06<<1),  /* CLK_PER / 256 */
+    TCA_SINGLE_CLKSEL_DIV1024_gc = (0x07<<1)  /* CLK_PER / 1024 */
+} TCA_SINGLE_CLKSEL_t;
+
+/* Command select */
+typedef enum TCA_SINGLE_CMD_enum
+{
+    TCA_SINGLE_CMD_NONE_gc = (0x00<<2),  /* No Command */
+    TCA_SINGLE_CMD_UPDATE_gc = (0x01<<2),  /* Force Update */
+    TCA_SINGLE_CMD_RESTART_gc = (0x02<<2),  /* Force Restart */
+    TCA_SINGLE_CMD_RESET_gc = (0x03<<2)  /* Force Hard Reset */
+} TCA_SINGLE_CMD_t;
+
+/* Direction select */
+typedef enum TCA_SINGLE_DIR_enum
+{
+    TCA_SINGLE_DIR_UP_gc = (0x00<<0),  /* Count up */
+    TCA_SINGLE_DIR_DOWN_gc = (0x01<<0)  /* Count down */
+} TCA_SINGLE_DIR_t;
+
+/* Event Action A select */
+typedef enum TCA_SINGLE_EVACTA_enum
+{
+    TCA_SINGLE_EVACTA_CNT_POSEDGE_gc = (0x00<<1),  /* Count on positive edge event */
+    TCA_SINGLE_EVACTA_CNT_ANYEDGE_gc = (0x01<<1),  /* Count on any edge event */
+    TCA_SINGLE_EVACTA_CNT_HIGHLVL_gc = (0x02<<1),  /* Count on prescaled clock while event line is 1. */
+    TCA_SINGLE_EVACTA_UPDOWN_gc = (0x03<<1)  /* Count on prescaled clock. Event controls count direction. Up-count when event line is 0, down-count when event line is 1. */
+} TCA_SINGLE_EVACTA_t;
+
+/* Event Action B select */
+typedef enum TCA_SINGLE_EVACTB_enum
+{
+    TCA_SINGLE_EVACTB_NONE_gc = (0x00<<5),  /* No Action */
+    TCA_SINGLE_EVACTB_UPDOWN_gc = (0x03<<5),  /* Count on prescaled clock. Event controls count direction. Up-count when event line is 0, down-count when event line is 1. */
+    TCA_SINGLE_EVACTB_RESTART_POSEDGE_gc = (0x04<<5),  /* Restart counter at positive edge event */
+    TCA_SINGLE_EVACTB_RESTART_ANYEDGE_gc = (0x05<<5),  /* Restart counter on any edge event */
+    TCA_SINGLE_EVACTB_RESTART_HIGHLVL_gc = (0x06<<5)  /* Restart counter while event line is 1. */
+} TCA_SINGLE_EVACTB_t;
+
+/* Waveform generation mode select */
+typedef enum TCA_SINGLE_WGMODE_enum
+{
+    TCA_SINGLE_WGMODE_NORMAL_gc = (0x00<<0),  /* Normal Mode */
+    TCA_SINGLE_WGMODE_FRQ_gc = (0x01<<0),  /* Frequency Generation Mode */
+    TCA_SINGLE_WGMODE_SINGLESLOPE_gc = (0x03<<0),  /* Single Slope PWM */
+    TCA_SINGLE_WGMODE_DSTOP_gc = (0x05<<0),  /* Dual Slope PWM, overflow on TOP */
+    TCA_SINGLE_WGMODE_DSBOTH_gc = (0x06<<0),  /* Dual Slope PWM, overflow on TOP and BOTTOM */
+    TCA_SINGLE_WGMODE_DSBOTTOM_gc = (0x07<<0)  /* Dual Slope PWM, overflow on BOTTOM */
+} TCA_SINGLE_WGMODE_t;
+
+/* Clock Selection */
+typedef enum TCA_SPLIT_CLKSEL_enum
+{
+    TCA_SPLIT_CLKSEL_DIV1_gc = (0x00<<1),  /* CLK_PER */
+    TCA_SPLIT_CLKSEL_DIV2_gc = (0x01<<1),  /* CLK_PER / 2 */
+    TCA_SPLIT_CLKSEL_DIV4_gc = (0x02<<1),  /* CLK_PER / 4 */
+    TCA_SPLIT_CLKSEL_DIV8_gc = (0x03<<1),  /* CLK_PER / 8 */
+    TCA_SPLIT_CLKSEL_DIV16_gc = (0x04<<1),  /* CLK_PER / 16 */
+    TCA_SPLIT_CLKSEL_DIV64_gc = (0x05<<1),  /* CLK_PER / 64 */
+    TCA_SPLIT_CLKSEL_DIV256_gc = (0x06<<1),  /* CLK_PER / 256 */
+    TCA_SPLIT_CLKSEL_DIV1024_gc = (0x07<<1)  /* CLK_PER / 1024 */
+} TCA_SPLIT_CLKSEL_t;
+
+/* Command select */
+typedef enum TCA_SPLIT_CMD_enum
+{
+    TCA_SPLIT_CMD_NONE_gc = (0x00<<2),  /* No Command */
+    TCA_SPLIT_CMD_UPDATE_gc = (0x01<<2),  /* Force Update */
+    TCA_SPLIT_CMD_RESTART_gc = (0x02<<2),  /* Force Restart */
+    TCA_SPLIT_CMD_RESET_gc = (0x03<<2)  /* Force Hard Reset */
+} TCA_SPLIT_CMD_t;
+
+/* Command Enable select */
+typedef enum TCA_SPLIT_CMDEN_enum
+{
+    TCA_SPLIT_CMDEN_NONE_gc = (0x00<<0),  /* None */
+    TCA_SPLIT_CMDEN_BOTH_gc = (0x03<<0)  /* Both low byte and high byte counter */
+} TCA_SPLIT_CMDEN_t;
+
+/*
+--------------------------------------------------------------------------
+TCB - 16-bit Timer Type B
+--------------------------------------------------------------------------
+*/
+
+/* 16-bit Timer Type B */
+typedef struct TCB_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control Register B */
+    register8_t reserved_1[2];
+    register8_t EVCTRL;  /* Event Control */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t STATUS;  /* Status */
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t TEMP;  /* Temporary Value */
+    _WORDREGISTER(CNT);  /* Count */
+    _WORDREGISTER(CCMP);  /* Compare or Capture */
+    register8_t reserved_2[2];
+} TCB_t;
+
+/* Clock Select */
+typedef enum TCB_CLKSEL_enum
+{
+    TCB_CLKSEL_DIV1_gc = (0x00<<1),  /* CLK_PER */
+    TCB_CLKSEL_DIV2_gc = (0x01<<1),  /* CLK_PER/2 */
+    TCB_CLKSEL_TCA0_gc = (0x02<<1),  /* Use CLK_TCA from TCA0 */
+    TCB_CLKSEL_TCA1_gc = (0x03<<1),  /* Use CLK_TCA from TCA1 */
+    TCB_CLKSEL_EVENT_gc = (0x07<<1)  /* Count on event edge */
+} TCB_CLKSEL_t;
+
+/* Timer Mode select */
+typedef enum TCB_CNTMODE_enum
+{
+    TCB_CNTMODE_INT_gc = (0x00<<0),  /* Periodic Interrupt */
+    TCB_CNTMODE_TIMEOUT_gc = (0x01<<0),  /* Periodic Timeout */
+    TCB_CNTMODE_CAPT_gc = (0x02<<0),  /* Input Capture Event */
+    TCB_CNTMODE_FRQ_gc = (0x03<<0),  /* Input Capture Frequency measurement */
+    TCB_CNTMODE_PW_gc = (0x04<<0),  /* Input Capture Pulse-Width measurement */
+    TCB_CNTMODE_FRQPW_gc = (0x05<<0),  /* Input Capture Frequency and Pulse-Width measurement */
+    TCB_CNTMODE_SINGLE_gc = (0x06<<0),  /* Single Shot */
+    TCB_CNTMODE_PWM8_gc = (0x07<<0)  /* 8-bit PWM */
+} TCB_CNTMODE_t;
+
+/*
+--------------------------------------------------------------------------
+TWI - Two-Wire Interface
+--------------------------------------------------------------------------
+*/
+
+/* Two-Wire Interface */
+typedef struct TWI_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t DUALCTRL;  /* Dual Mode Control */
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t MCTRLA;  /* Host Control A */
+    register8_t MCTRLB;  /* Host Control B */
+    register8_t MSTATUS;  /* Host STATUS */
+    register8_t MBAUD;  /* Host Baud Rate */
+    register8_t MADDR;  /* Host Address */
+    register8_t MDATA;  /* Host Data */
+    register8_t SCTRLA;  /* Client Control A */
+    register8_t SCTRLB;  /* Client Control B */
+    register8_t SSTATUS;  /* Client Status */
+    register8_t SADDR;  /* Client Address */
+    register8_t SDATA;  /* Client Data */
+    register8_t SADDRMASK;  /* Client Address Mask */
+    register8_t reserved_1[1];
+} TWI_t;
+
+/* Acknowledge Action select */
+typedef enum TWI_ACKACT_enum
+{
+    TWI_ACKACT_ACK_gc = (0x00<<2),  /* Send ACK */
+    TWI_ACKACT_NACK_gc = (0x01<<2)  /* Send NACK */
+} TWI_ACKACT_t;
+
+/* Address or Stop select */
+typedef enum TWI_AP_enum
+{
+    TWI_AP_STOP_gc = (0x00<<0),  /* A Stop condition generated the interrupt on APIF flag */
+    TWI_AP_ADR_gc = (0x01<<0)  /* Address detection generated the interrupt on APIF flag */
+} TWI_AP_t;
+
+/* Bus State select */
+typedef enum TWI_BUSSTATE_enum
+{
+    TWI_BUSSTATE_UNKNOWN_gc = (0x00<<0),  /* Unknown bus state */
+    TWI_BUSSTATE_IDLE_gc = (0x01<<0),  /* Bus is idle */
+    TWI_BUSSTATE_OWNER_gc = (0x02<<0),  /* This TWI controls the bus */
+    TWI_BUSSTATE_BUSY_gc = (0x03<<0)  /* The bus is busy */
+} TWI_BUSSTATE_t;
+
+/* Debug Run select */
+typedef enum TWI_DBGRUN_enum
+{
+    TWI_DBGRUN_HALT_gc = (0x00<<0),  /* The peripheral is halted in Break Debug mode and ignores events */
+    TWI_DBGRUN_RUN_gc = (0x01<<0)  /* The peripheral will continue to run in Break Debug mode when the CPU is halted */
+} TWI_DBGRUN_t;
+
+/* Fast-mode Enable select */
+typedef enum TWI_FMEN_enum
+{
+    TWI_FMEN_OFF_gc = (0x00<<0),  /* SCL duty cycle operating according to Sm specification */
+    TWI_FMEN_ON_gc = (0x01<<0)  /* SCL duty cycle operating according to Fm specification */
+} TWI_FMEN_t;
+
+/* Fast-mode Plus Enable select */
+typedef enum TWI_FMPEN_enum
+{
+    TWI_FMPEN_OFF_gc = (0x00<<1),  /* Operating in Standard-mode or Fast-mode */
+    TWI_FMPEN_ON_gc = (0x01<<1)  /* Operating in Fast-mode Plus */
+} TWI_FMPEN_t;
+
+/* Input voltage transition level select */
+typedef enum TWI_INPUTLVL_enum
+{
+    TWI_INPUTLVL_I2C_gc = (0x00<<6),  /* I2C input voltage transition level */
+    TWI_INPUTLVL_SMBUS_gc = (0x01<<6)  /* SMBus 3.0 input voltage transition level */
+} TWI_INPUTLVL_t;
+
+/* Command select */
+typedef enum TWI_MCMD_enum
+{
+    TWI_MCMD_NOACT_gc = (0x00<<0),  /* No action */
+    TWI_MCMD_REPSTART_gc = (0x01<<0),  /* Execute Acknowledge Action followed by repeated Start. */
+    TWI_MCMD_RECVTRANS_gc = (0x02<<0),  /* Execute Acknowledge Action followed by a byte read/write operation. Read/write is defined by DIR. */
+    TWI_MCMD_STOP_gc = (0x03<<0)  /* Execute Acknowledge Action followed by issuing a Stop condition. */
+} TWI_MCMD_t;
+
+/* Command select */
+typedef enum TWI_SCMD_enum
+{
+    TWI_SCMD_NOACT_gc = (0x00<<0),  /* No Action */
+    TWI_SCMD_COMPTRANS_gc = (0x02<<0),  /* Complete transaction */
+    TWI_SCMD_RESPONSE_gc = (0x03<<0)  /* Used in response to an interrupt */
+} TWI_SCMD_t;
+
+/* SDA Hold Time select */
+typedef enum TWI_SDAHOLD_enum
+{
+    TWI_SDAHOLD_OFF_gc = (0x00<<2),  /* No SDA Hold Delay */
+    TWI_SDAHOLD_50NS_gc = (0x01<<2),  /* Short SDA hold time */
+    TWI_SDAHOLD_300NS_gc = (0x02<<2),  /* Meets SMBUS 2.0 specification under typical conditions */
+    TWI_SDAHOLD_500NS_gc = (0x03<<2)  /* Meets SMBUS 2.0 specificaiton across all corners */
+} TWI_SDAHOLD_t;
+
+/* SDA Setup Time select */
+typedef enum TWI_SDASETUP_enum
+{
+    TWI_SDASETUP_4CYC_gc = (0x00<<4),  /* SDA setup time is four clock cycles */
+    TWI_SDASETUP_8CYC_gc = (0x01<<4)  /* SDA setup time is eight clock cycle */
+} TWI_SDASETUP_t;
+
+/* Inactive Bus Time-Out select */
+typedef enum TWI_TIMEOUT_enum
+{
+    TWI_TIMEOUT_DISABLED_gc = (0x00<<2),  /* Bus time-out disabled. I2C. */
+    TWI_TIMEOUT_50US_gc = (0x01<<2),  /* 50us - SMBus */
+    TWI_TIMEOUT_100US_gc = (0x02<<2),  /* 100us */
+    TWI_TIMEOUT_200US_gc = (0x03<<2)  /* 200us */
+} TWI_TIMEOUT_t;
+
+/*
+--------------------------------------------------------------------------
+USART - Universal Synchronous and Asynchronous Receiver and Transmitter
+--------------------------------------------------------------------------
+*/
+
+/* Universal Synchronous and Asynchronous Receiver and Transmitter */
+typedef struct USART_struct
+{
+    register8_t RXDATAL;  /* Receive Data Low Byte */
+    register8_t RXDATAH;  /* Receive Data High Byte */
+    register8_t TXDATAL;  /* Transmit Data Low Byte */
+    register8_t TXDATAH;  /* Transmit Data High Byte */
+    register8_t STATUS;  /* Status */
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    _WORDREGISTER(BAUD);  /* Baud Rate */
+    register8_t CTRLD;  /* Control D */
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t EVCTRL;  /* Event Control */
+    register8_t TXPLCTRL;  /* IRCOM Transmitter Pulse Length Control */
+    register8_t RXPLCTRL;  /* IRCOM Receiver Pulse Length Control */
+    register8_t reserved_1[1];
+} USART_t;
+
+/* Auto Baud Window select */
+typedef enum USART_ABW_enum
+{
+    USART_ABW_WDW0_gc = (0x00<<6),  /* 18% tolerance */
+    USART_ABW_WDW1_gc = (0x01<<6),  /* 15% tolerance */
+    USART_ABW_WDW2_gc = (0x02<<6),  /* 21% tolerance */
+    USART_ABW_WDW3_gc = (0x03<<6)  /* 25% tolerance */
+} USART_ABW_t;
+
+/* Character Size select */
+typedef enum USART_CHSIZE_enum
+{
+    USART_CHSIZE_5BIT_gc = (0x00<<0),  /* Character size: 5 bit */
+    USART_CHSIZE_6BIT_gc = (0x01<<0),  /* Character size: 6 bit */
+    USART_CHSIZE_7BIT_gc = (0x02<<0),  /* Character size: 7 bit */
+    USART_CHSIZE_8BIT_gc = (0x03<<0),  /* Character size: 8 bit */
+    USART_CHSIZE_9BITL_gc = (0x06<<0),  /* Character size: 9 bit read low byte first */
+    USART_CHSIZE_9BITH_gc = (0x07<<0)  /* Character size: 9 bit read high byte first */
+} USART_CHSIZE_t;
+
+/* Communication Mode select */
+typedef enum USART_CMODE_enum
+{
+    USART_CMODE_ASYNCHRONOUS_gc = (0x00<<6),  /* Asynchronous Mode */
+    USART_CMODE_SYNCHRONOUS_gc = (0x01<<6),  /* Synchronous Mode */
+    USART_CMODE_IRCOM_gc = (0x02<<6),  /* Infrared Communication */
+    USART_CMODE_MSPI_gc = (0x03<<6)  /* SPI Host Mode */
+} USART_CMODE_t;
+
+/* Parity Mode select */
+typedef enum USART_PMODE_enum
+{
+    USART_PMODE_DISABLED_gc = (0x00<<4),  /* No Parity */
+    USART_PMODE_EVEN_gc = (0x02<<4),  /* Even Parity */
+    USART_PMODE_ODD_gc = (0x03<<4)  /* Odd Parity */
+} USART_PMODE_t;
+
+/* RS485 Mode internal transmitter select */
+typedef enum USART_RS485_enum
+{
+    USART_RS485_DISABLE_gc = (0x00<<0),  /* RS485 Mode disabled */
+    USART_RS485_ENABLE_gc = (0x01<<0)  /* RS485 Mode enabled */
+} USART_RS485_t;
+
+/* Receiver Mode select */
+typedef enum USART_RXMODE_enum
+{
+    USART_RXMODE_NORMAL_gc = (0x00<<1),  /* Normal mode */
+    USART_RXMODE_CLK2X_gc = (0x01<<1),  /* CLK2x mode */
+    USART_RXMODE_GENAUTO_gc = (0x02<<1),  /* Generic autobaud mode */
+    USART_RXMODE_LINAUTO_gc = (0x03<<1)  /* LIN constrained autobaud mode */
+} USART_RXMODE_t;
+
+/* Stop Bit Mode select */
+typedef enum USART_SBMODE_enum
+{
+    USART_SBMODE_1BIT_gc = (0x00<<3),  /* 1 stop bit */
+    USART_SBMODE_2BIT_gc = (0x01<<3)  /* 2 stop bits */
+} USART_SBMODE_t;
+
+/*
+--------------------------------------------------------------------------
+USERROW - User Row
+--------------------------------------------------------------------------
+*/
+
+/* User Row */
+typedef struct USERROW_struct
+{
+    register8_t USERROW0;  /* User Row Byte 0 */
+    register8_t USERROW1;  /* User Row Byte 1 */
+    register8_t USERROW2;  /* User Row Byte 2 */
+    register8_t USERROW3;  /* User Row Byte 3 */
+    register8_t USERROW4;  /* User Row Byte 4 */
+    register8_t USERROW5;  /* User Row Byte 5 */
+    register8_t USERROW6;  /* User Row Byte 6 */
+    register8_t USERROW7;  /* User Row Byte 7 */
+    register8_t USERROW8;  /* User Row Byte 8 */
+    register8_t USERROW9;  /* User Row Byte 9 */
+    register8_t USERROW10;  /* User Row Byte 10 */
+    register8_t USERROW11;  /* User Row Byte 11 */
+    register8_t USERROW12;  /* User Row Byte 12 */
+    register8_t USERROW13;  /* User Row Byte 13 */
+    register8_t USERROW14;  /* User Row Byte 14 */
+    register8_t USERROW15;  /* User Row Byte 15 */
+    register8_t USERROW16;  /* User Row Byte 16 */
+    register8_t USERROW17;  /* User Row Byte 17 */
+    register8_t USERROW18;  /* User Row Byte 18 */
+    register8_t USERROW19;  /* User Row Byte 19 */
+    register8_t USERROW20;  /* User Row Byte 20 */
+    register8_t USERROW21;  /* User Row Byte 21 */
+    register8_t USERROW22;  /* User Row Byte 22 */
+    register8_t USERROW23;  /* User Row Byte 23 */
+    register8_t USERROW24;  /* User Row Byte 24 */
+    register8_t USERROW25;  /* User Row Byte 25 */
+    register8_t USERROW26;  /* User Row Byte 26 */
+    register8_t USERROW27;  /* User Row Byte 27 */
+    register8_t USERROW28;  /* User Row Byte 28 */
+    register8_t USERROW29;  /* User Row Byte 29 */
+    register8_t USERROW30;  /* User Row Byte 30 */
+    register8_t USERROW31;  /* User Row Byte 31 */
+    register8_t USERROW32;  /* User Row Byte 32 */
+    register8_t USERROW33;  /* User Row Byte 33 */
+    register8_t USERROW34;  /* User Row Byte 34 */
+    register8_t USERROW35;  /* User Row Byte 35 */
+    register8_t USERROW36;  /* User Row Byte 36 */
+    register8_t USERROW37;  /* User Row Byte 37 */
+    register8_t USERROW38;  /* User Row Byte 38 */
+    register8_t USERROW39;  /* User Row Byte 39 */
+    register8_t USERROW40;  /* User Row Byte 40 */
+    register8_t USERROW41;  /* User Row Byte 41 */
+    register8_t USERROW42;  /* User Row Byte 42 */
+    register8_t USERROW43;  /* User Row Byte 43 */
+    register8_t USERROW44;  /* User Row Byte 44 */
+    register8_t USERROW45;  /* User Row Byte 45 */
+    register8_t USERROW46;  /* User Row Byte 46 */
+    register8_t USERROW47;  /* User Row Byte 47 */
+    register8_t USERROW48;  /* User Row Byte 48 */
+    register8_t USERROW49;  /* User Row Byte 49 */
+    register8_t USERROW50;  /* User Row Byte 50 */
+    register8_t USERROW51;  /* User Row Byte 51 */
+    register8_t USERROW52;  /* User Row Byte 52 */
+    register8_t USERROW53;  /* User Row Byte 53 */
+    register8_t USERROW54;  /* User Row Byte 54 */
+    register8_t USERROW55;  /* User Row Byte 55 */
+    register8_t USERROW56;  /* User Row Byte 56 */
+    register8_t USERROW57;  /* User Row Byte 57 */
+    register8_t USERROW58;  /* User Row Byte 58 */
+    register8_t USERROW59;  /* User Row Byte 59 */
+    register8_t USERROW60;  /* User Row Byte 60 */
+    register8_t USERROW61;  /* User Row Byte 61 */
+    register8_t USERROW62;  /* User Row Byte 62 */
+    register8_t USERROW63;  /* User Row Byte 63 */
+} USERROW_t;
+
+
+/*
+--------------------------------------------------------------------------
+VPORT - Virtual Ports
+--------------------------------------------------------------------------
+*/
+
+/* Virtual Ports */
+typedef struct VPORT_struct
+{
+    register8_t DIR;  /* Data Direction */
+    register8_t OUT;  /* Output Value */
+    register8_t IN;  /* Input Value */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+} VPORT_t;
+
+
+/*
+--------------------------------------------------------------------------
+VREF - Voltage reference
+--------------------------------------------------------------------------
+*/
+
+/* Voltage reference */
+typedef struct VREF_struct
+{
+    register8_t reserved_1[2];
+    register8_t DAC0REF;  /* DAC0 Reference */
+    register8_t reserved_2[1];
+    register8_t ACREF;  /* AC Reference */
+} VREF_t;
+
+/* Reference select */
+typedef enum VREF_REFSEL_enum
+{
+    VREF_REFSEL_1V024_gc = (0x00<<0),  /* Internal 1.024V reference */
+    VREF_REFSEL_2V048_gc = (0x01<<0),  /* Internal 2.048V reference */
+    VREF_REFSEL_4V096_gc = (0x02<<0),  /* Internal 4.096V reference */
+    VREF_REFSEL_2V500_gc = (0x03<<0),  /* Internal 2.500V reference */
+    VREF_REFSEL_VDD_gc = (0x05<<0),  /* VDD as reference */
+    VREF_REFSEL_VREFA_gc = (0x06<<0)  /* External reference on VREFA pin */
+} VREF_REFSEL_t;
+
+/*
+--------------------------------------------------------------------------
+WDT - Watch-Dog Timer
+--------------------------------------------------------------------------
+*/
+
+/* Watch-Dog Timer */
+typedef struct WDT_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t STATUS;  /* Status */
+    register8_t reserved_1[14];
+} WDT_t;
+
+/* Period select */
+typedef enum WDT_PERIOD_enum
+{
+    WDT_PERIOD_OFF_gc = (0x00<<0),  /* Off */
+    WDT_PERIOD_8CLK_gc = (0x01<<0),  /* 8 cycles (8ms) */
+    WDT_PERIOD_16CLK_gc = (0x02<<0),  /* 16 cycles (16ms) */
+    WDT_PERIOD_32CLK_gc = (0x03<<0),  /* 32 cycles (32ms) */
+    WDT_PERIOD_64CLK_gc = (0x04<<0),  /* 64 cycles (64ms) */
+    WDT_PERIOD_128CLK_gc = (0x05<<0),  /* 128 cycles (0.128s) */
+    WDT_PERIOD_256CLK_gc = (0x06<<0),  /* 256 cycles (0.256s) */
+    WDT_PERIOD_512CLK_gc = (0x07<<0),  /* 512 cycles (0.512s) */
+    WDT_PERIOD_1KCLK_gc = (0x08<<0),  /* 1K cycles (1.0s) */
+    WDT_PERIOD_2KCLK_gc = (0x09<<0),  /* 2K cycles (2.0s) */
+    WDT_PERIOD_4KCLK_gc = (0x0A<<0),  /* 4K cycles (4.1s) */
+    WDT_PERIOD_8KCLK_gc = (0x0B<<0)  /* 8K cycles (8.2s) */
+} WDT_PERIOD_t;
+
+/* Window select */
+typedef enum WDT_WINDOW_enum
+{
+    WDT_WINDOW_OFF_gc = (0x00<<4),  /* Off */
+    WDT_WINDOW_8CLK_gc = (0x01<<4),  /* 8 cycles (8ms) */
+    WDT_WINDOW_16CLK_gc = (0x02<<4),  /* 16 cycles (16ms) */
+    WDT_WINDOW_32CLK_gc = (0x03<<4),  /* 32 cycles (32ms) */
+    WDT_WINDOW_64CLK_gc = (0x04<<4),  /* 64 cycles (64ms) */
+    WDT_WINDOW_128CLK_gc = (0x05<<4),  /* 128 cycles (0.128s) */
+    WDT_WINDOW_256CLK_gc = (0x06<<4),  /* 256 cycles (0.256s) */
+    WDT_WINDOW_512CLK_gc = (0x07<<4),  /* 512 cycles (0.512s) */
+    WDT_WINDOW_1KCLK_gc = (0x08<<4),  /* 1K cycles (1.0s) */
+    WDT_WINDOW_2KCLK_gc = (0x09<<4),  /* 2K cycles (2.0s) */
+    WDT_WINDOW_4KCLK_gc = (0x0A<<4),  /* 4K cycles (4.1s) */
+    WDT_WINDOW_8KCLK_gc = (0x0B<<4)  /* 8K cycles (8.2s) */
+} WDT_WINDOW_t;
+/*
+==========================================================================
+IO Module Instances. Mapped to memory.
+==========================================================================
+*/
+
+#define VPORTA              (*(VPORT_t *) 0x0000) /* Virtual Ports */
+#define VPORTC              (*(VPORT_t *) 0x0008) /* Virtual Ports */
+#define VPORTD              (*(VPORT_t *) 0x000C) /* Virtual Ports */
+#define VPORTF              (*(VPORT_t *) 0x0014) /* Virtual Ports */
+#define GPR                   (*(GPR_t *) 0x001C) /* General Purpose Registers */
+#define RSTCTRL           (*(RSTCTRL_t *) 0x0040) /* Reset controller */
+#define SLPCTRL           (*(SLPCTRL_t *) 0x0050) /* Sleep Controller */
+#define CLKCTRL           (*(CLKCTRL_t *) 0x0060) /* Clock controller */
+#define BOD                   (*(BOD_t *) 0x00A0) /* Bod interface */
+#define VREF                 (*(VREF_t *) 0x00B0) /* Voltage reference */
+#define WDT                   (*(WDT_t *) 0x0100) /* Watch-Dog Timer */
+#define CPUINT             (*(CPUINT_t *) 0x0110) /* Interrupt Controller */
+#define CRCSCAN           (*(CRCSCAN_t *) 0x0120) /* CRCSCAN */
+#define RTC                   (*(RTC_t *) 0x0140) /* Real-Time Counter */
+#define CCL                   (*(CCL_t *) 0x01C0) /* Configurable Custom Logic */
+#define EVSYS               (*(EVSYS_t *) 0x0200) /* Event System */
+#define PORTA                (*(PORT_t *) 0x0400) /* I/O Ports */
+#define PORTC                (*(PORT_t *) 0x0440) /* I/O Ports */
+#define PORTD                (*(PORT_t *) 0x0460) /* I/O Ports */
+#define PORTF                (*(PORT_t *) 0x04A0) /* I/O Ports */
+#define PORTMUX           (*(PORTMUX_t *) 0x05E0) /* Port Multiplexer */
+#define ADC0                  (*(ADC_t *) 0x0600) /* Analog to Digital Converter */
+#define AC0                    (*(AC_t *) 0x0680) /* Analog Comparator */
+#define AC1                    (*(AC_t *) 0x0688) /* Analog Comparator */
+#define DAC0                  (*(DAC_t *) 0x06A0) /* Digital to Analog Converter */
+#define USART0              (*(USART_t *) 0x0800) /* Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define USART1              (*(USART_t *) 0x0820) /* Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define USART2              (*(USART_t *) 0x0840) /* Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define TWI0                  (*(TWI_t *) 0x0900) /* Two-Wire Interface */
+#define SPI0                  (*(SPI_t *) 0x0940) /* Serial Peripheral Interface */
+#define TCA0                  (*(TCA_t *) 0x0A00) /* 16-bit Timer/Counter Type A */
+#define TCB0                  (*(TCB_t *) 0x0B00) /* 16-bit Timer Type B */
+#define TCB1                  (*(TCB_t *) 0x0B10) /* 16-bit Timer Type B */
+#define TCB2                  (*(TCB_t *) 0x0B20) /* 16-bit Timer Type B */
+#define SYSCFG             (*(SYSCFG_t *) 0x0F00) /* System Configuration Registers */
+#define NVMCTRL           (*(NVMCTRL_t *) 0x1000) /* Non-volatile Memory Controller */
+#define LOCK                 (*(LOCK_t *) 0x1040) /* Lockbits */
+#define FUSE                 (*(FUSE_t *) 0x1050) /* Fuses */
+#define USERROW           (*(USERROW_t *) 0x1080) /* User Row */
+#define SIGROW             (*(SIGROW_t *) 0x1100) /* Signature row */
+
+#endif /* !defined (__ASSEMBLER__) */
+
+
+/* ========== Flattened fully qualified IO register names ========== */
+
+
+/* VPORT (VPORTA) - Virtual Ports */
+#define VPORTA_DIR  _SFR_MEM8(0x0000)
+#define VPORTA_OUT  _SFR_MEM8(0x0001)
+#define VPORTA_IN  _SFR_MEM8(0x0002)
+#define VPORTA_INTFLAGS  _SFR_MEM8(0x0003)
+
+
+/* VPORT (VPORTC) - Virtual Ports */
+#define VPORTC_DIR  _SFR_MEM8(0x0008)
+#define VPORTC_OUT  _SFR_MEM8(0x0009)
+#define VPORTC_IN  _SFR_MEM8(0x000A)
+#define VPORTC_INTFLAGS  _SFR_MEM8(0x000B)
+
+
+/* VPORT (VPORTD) - Virtual Ports */
+#define VPORTD_DIR  _SFR_MEM8(0x000C)
+#define VPORTD_OUT  _SFR_MEM8(0x000D)
+#define VPORTD_IN  _SFR_MEM8(0x000E)
+#define VPORTD_INTFLAGS  _SFR_MEM8(0x000F)
+
+
+/* VPORT (VPORTF) - Virtual Ports */
+#define VPORTF_DIR  _SFR_MEM8(0x0014)
+#define VPORTF_OUT  _SFR_MEM8(0x0015)
+#define VPORTF_IN  _SFR_MEM8(0x0016)
+#define VPORTF_INTFLAGS  _SFR_MEM8(0x0017)
+
+
+/* GPR - General Purpose Registers */
+#define GPR_GPR0  _SFR_MEM8(0x001C)
+#define GPR_GPR1  _SFR_MEM8(0x001D)
+#define GPR_GPR2  _SFR_MEM8(0x001E)
+#define GPR_GPR3  _SFR_MEM8(0x001F)
+
+
+/* CPU - CPU */
+#define CPU_CCP  _SFR_MEM8(0x0034)
+#define CPU_SP  _SFR_MEM16(0x003D)
+#define CPU_SPL  _SFR_MEM8(0x003D)
+#define CPU_SPH  _SFR_MEM8(0x003E)
+#define CPU_SREG  _SFR_MEM8(0x003F)
+
+
+/* RSTCTRL - Reset controller */
+#define RSTCTRL_RSTFR  _SFR_MEM8(0x0040)
+#define RSTCTRL_SWRR  _SFR_MEM8(0x0041)
+
+
+/* SLPCTRL - Sleep Controller */
+#define SLPCTRL_CTRLA  _SFR_MEM8(0x0050)
+
+
+/* CLKCTRL - Clock controller */
+#define CLKCTRL_MCLKCTRLA  _SFR_MEM8(0x0060)
+#define CLKCTRL_MCLKCTRLB  _SFR_MEM8(0x0061)
+#define CLKCTRL_MCLKCTRLC  _SFR_MEM8(0x0062)
+#define CLKCTRL_MCLKINTCTRL  _SFR_MEM8(0x0063)
+#define CLKCTRL_MCLKINTFLAGS  _SFR_MEM8(0x0064)
+#define CLKCTRL_MCLKSTATUS  _SFR_MEM8(0x0065)
+#define CLKCTRL_MCLKTIMEBASE  _SFR_MEM8(0x0066)
+#define CLKCTRL_OSCHFCTRLA  _SFR_MEM8(0x0068)
+#define CLKCTRL_OSCHFTUNE  _SFR_MEM8(0x0069)
+#define CLKCTRL_OSC32KCTRLA  _SFR_MEM8(0x0078)
+#define CLKCTRL_XOSC32KCTRLA  _SFR_MEM8(0x007C)
+#define CLKCTRL_XOSCHFCTRLA  _SFR_MEM8(0x0080)
+
+
+/* BOD - Bod interface */
+#define BOD_CTRLA  _SFR_MEM8(0x00A0)
+#define BOD_CTRLB  _SFR_MEM8(0x00A1)
+#define BOD_VLMCTRLA  _SFR_MEM8(0x00A8)
+#define BOD_INTCTRL  _SFR_MEM8(0x00A9)
+#define BOD_INTFLAGS  _SFR_MEM8(0x00AA)
+#define BOD_STATUS  _SFR_MEM8(0x00AB)
+
+
+/* VREF - Voltage reference */
+#define VREF_DAC0REF  _SFR_MEM8(0x00B2)
+#define VREF_ACREF  _SFR_MEM8(0x00B4)
+
+
+/* WDT - Watch-Dog Timer */
+#define WDT_CTRLA  _SFR_MEM8(0x0100)
+#define WDT_STATUS  _SFR_MEM8(0x0101)
+
+
+/* CPUINT - Interrupt Controller */
+#define CPUINT_CTRLA  _SFR_MEM8(0x0110)
+#define CPUINT_STATUS  _SFR_MEM8(0x0111)
+#define CPUINT_LVL0PRI  _SFR_MEM8(0x0112)
+#define CPUINT_LVL1VEC  _SFR_MEM8(0x0113)
+
+
+/* CRCSCAN - CRCSCAN */
+#define CRCSCAN_CTRLA  _SFR_MEM8(0x0120)
+#define CRCSCAN_CTRLB  _SFR_MEM8(0x0121)
+#define CRCSCAN_STATUS  _SFR_MEM8(0x0122)
+
+
+/* RTC - Real-Time Counter */
+#define RTC_CTRLA  _SFR_MEM8(0x0140)
+#define RTC_STATUS  _SFR_MEM8(0x0141)
+#define RTC_INTCTRL  _SFR_MEM8(0x0142)
+#define RTC_INTFLAGS  _SFR_MEM8(0x0143)
+#define RTC_TEMP  _SFR_MEM8(0x0144)
+#define RTC_DBGCTRL  _SFR_MEM8(0x0145)
+#define RTC_CALIB  _SFR_MEM8(0x0146)
+#define RTC_CLKSEL  _SFR_MEM8(0x0147)
+#define RTC_CNT  _SFR_MEM16(0x0148)
+#define RTC_CNTL  _SFR_MEM8(0x0148)
+#define RTC_CNTH  _SFR_MEM8(0x0149)
+#define RTC_PER  _SFR_MEM16(0x014A)
+#define RTC_PERL  _SFR_MEM8(0x014A)
+#define RTC_PERH  _SFR_MEM8(0x014B)
+#define RTC_CMP  _SFR_MEM16(0x014C)
+#define RTC_CMPL  _SFR_MEM8(0x014C)
+#define RTC_CMPH  _SFR_MEM8(0x014D)
+#define RTC_PITCTRLA  _SFR_MEM8(0x0150)
+#define RTC_PITSTATUS  _SFR_MEM8(0x0151)
+#define RTC_PITINTCTRL  _SFR_MEM8(0x0152)
+#define RTC_PITINTFLAGS  _SFR_MEM8(0x0153)
+#define RTC_PITDBGCTRL  _SFR_MEM8(0x0155)
+#define RTC_PITEVGENCTRLA  _SFR_MEM8(0x0156)
+
+
+/* CCL - Configurable Custom Logic */
+#define CCL_CTRLA  _SFR_MEM8(0x01C0)
+#define CCL_SEQCTRL0  _SFR_MEM8(0x01C1)
+#define CCL_SEQCTRL1  _SFR_MEM8(0x01C2)
+#define CCL_INTCTRL0  _SFR_MEM8(0x01C5)
+#define CCL_INTFLAGS  _SFR_MEM8(0x01C7)
+#define CCL_LUT0CTRLA  _SFR_MEM8(0x01C8)
+#define CCL_LUT0CTRLB  _SFR_MEM8(0x01C9)
+#define CCL_LUT0CTRLC  _SFR_MEM8(0x01CA)
+#define CCL_TRUTH0  _SFR_MEM8(0x01CB)
+#define CCL_LUT1CTRLA  _SFR_MEM8(0x01CC)
+#define CCL_LUT1CTRLB  _SFR_MEM8(0x01CD)
+#define CCL_LUT1CTRLC  _SFR_MEM8(0x01CE)
+#define CCL_TRUTH1  _SFR_MEM8(0x01CF)
+#define CCL_LUT2CTRLA  _SFR_MEM8(0x01D0)
+#define CCL_LUT2CTRLB  _SFR_MEM8(0x01D1)
+#define CCL_LUT2CTRLC  _SFR_MEM8(0x01D2)
+#define CCL_TRUTH2  _SFR_MEM8(0x01D3)
+#define CCL_LUT3CTRLA  _SFR_MEM8(0x01D4)
+#define CCL_LUT3CTRLB  _SFR_MEM8(0x01D5)
+#define CCL_LUT3CTRLC  _SFR_MEM8(0x01D6)
+#define CCL_TRUTH3  _SFR_MEM8(0x01D7)
+
+
+/* EVSYS - Event System */
+#define EVSYS_SWEVENTA  _SFR_MEM8(0x0200)
+#define EVSYS_CHANNEL0  _SFR_MEM8(0x0210)
+#define EVSYS_CHANNEL1  _SFR_MEM8(0x0211)
+#define EVSYS_CHANNEL2  _SFR_MEM8(0x0212)
+#define EVSYS_CHANNEL3  _SFR_MEM8(0x0213)
+#define EVSYS_CHANNEL4  _SFR_MEM8(0x0214)
+#define EVSYS_CHANNEL5  _SFR_MEM8(0x0215)
+#define EVSYS_USERCCLLUT0A  _SFR_MEM8(0x0220)
+#define EVSYS_USERCCLLUT0B  _SFR_MEM8(0x0221)
+#define EVSYS_USERCCLLUT1A  _SFR_MEM8(0x0222)
+#define EVSYS_USERCCLLUT1B  _SFR_MEM8(0x0223)
+#define EVSYS_USERCCLLUT2A  _SFR_MEM8(0x0224)
+#define EVSYS_USERCCLLUT2B  _SFR_MEM8(0x0225)
+#define EVSYS_USERCCLLUT3A  _SFR_MEM8(0x0226)
+#define EVSYS_USERCCLLUT3B  _SFR_MEM8(0x0227)
+#define EVSYS_USERADC0START  _SFR_MEM8(0x0228)
+#define EVSYS_USEREVSYSEVOUTA  _SFR_MEM8(0x0229)
+#define EVSYS_USEREVSYSEVOUTC  _SFR_MEM8(0x022B)
+#define EVSYS_USEREVSYSEVOUTD  _SFR_MEM8(0x022C)
+#define EVSYS_USEREVSYSEVOUTF  _SFR_MEM8(0x022E)
+#define EVSYS_USERUSART0IRDA  _SFR_MEM8(0x022F)
+#define EVSYS_USERUSART1IRDA  _SFR_MEM8(0x0230)
+#define EVSYS_USERUSART2IRDA  _SFR_MEM8(0x0231)
+#define EVSYS_USERTCA0CNTA  _SFR_MEM8(0x0232)
+#define EVSYS_USERTCA0CNTB  _SFR_MEM8(0x0233)
+#define EVSYS_USERTCA1CNTA  _SFR_MEM8(0x0234)
+#define EVSYS_USERTCA1CNTB  _SFR_MEM8(0x0235)
+#define EVSYS_USERTCB0CAPT  _SFR_MEM8(0x0236)
+#define EVSYS_USERTCB0COUNT  _SFR_MEM8(0x0237)
+#define EVSYS_USERTCB1CAPT  _SFR_MEM8(0x0238)
+#define EVSYS_USERTCB1COUNT  _SFR_MEM8(0x0239)
+#define EVSYS_USERTCB2CAPT  _SFR_MEM8(0x023A)
+#define EVSYS_USERTCB2COUNT  _SFR_MEM8(0x023B)
+#define EVSYS_USERTCB3CAPT  _SFR_MEM8(0x023C)
+#define EVSYS_USERTCB3COUNT  _SFR_MEM8(0x023D)
+
+
+/* PORT (PORTA) - I/O Ports */
+#define PORTA_DIR  _SFR_MEM8(0x0400)
+#define PORTA_DIRSET  _SFR_MEM8(0x0401)
+#define PORTA_DIRCLR  _SFR_MEM8(0x0402)
+#define PORTA_DIRTGL  _SFR_MEM8(0x0403)
+#define PORTA_OUT  _SFR_MEM8(0x0404)
+#define PORTA_OUTSET  _SFR_MEM8(0x0405)
+#define PORTA_OUTCLR  _SFR_MEM8(0x0406)
+#define PORTA_OUTTGL  _SFR_MEM8(0x0407)
+#define PORTA_IN  _SFR_MEM8(0x0408)
+#define PORTA_INTFLAGS  _SFR_MEM8(0x0409)
+#define PORTA_PORTCTRL  _SFR_MEM8(0x040A)
+#define PORTA_PINCONFIG  _SFR_MEM8(0x040B)
+#define PORTA_PINCTRLUPD  _SFR_MEM8(0x040C)
+#define PORTA_PINCTRLSET  _SFR_MEM8(0x040D)
+#define PORTA_PINCTRLCLR  _SFR_MEM8(0x040E)
+#define PORTA_PIN0CTRL  _SFR_MEM8(0x0410)
+#define PORTA_PIN1CTRL  _SFR_MEM8(0x0411)
+#define PORTA_PIN2CTRL  _SFR_MEM8(0x0412)
+#define PORTA_PIN3CTRL  _SFR_MEM8(0x0413)
+#define PORTA_PIN4CTRL  _SFR_MEM8(0x0414)
+#define PORTA_PIN5CTRL  _SFR_MEM8(0x0415)
+#define PORTA_PIN6CTRL  _SFR_MEM8(0x0416)
+#define PORTA_PIN7CTRL  _SFR_MEM8(0x0417)
+#define PORTA_EVGENCTRL  _SFR_MEM8(0x0418)
+
+
+/* PORT (PORTC) - I/O Ports */
+#define PORTC_DIR  _SFR_MEM8(0x0440)
+#define PORTC_DIRSET  _SFR_MEM8(0x0441)
+#define PORTC_DIRCLR  _SFR_MEM8(0x0442)
+#define PORTC_DIRTGL  _SFR_MEM8(0x0443)
+#define PORTC_OUT  _SFR_MEM8(0x0444)
+#define PORTC_OUTSET  _SFR_MEM8(0x0445)
+#define PORTC_OUTCLR  _SFR_MEM8(0x0446)
+#define PORTC_OUTTGL  _SFR_MEM8(0x0447)
+#define PORTC_IN  _SFR_MEM8(0x0448)
+#define PORTC_INTFLAGS  _SFR_MEM8(0x0449)
+#define PORTC_PORTCTRL  _SFR_MEM8(0x044A)
+#define PORTC_PINCONFIG  _SFR_MEM8(0x044B)
+#define PORTC_PINCTRLUPD  _SFR_MEM8(0x044C)
+#define PORTC_PINCTRLSET  _SFR_MEM8(0x044D)
+#define PORTC_PINCTRLCLR  _SFR_MEM8(0x044E)
+#define PORTC_PIN0CTRL  _SFR_MEM8(0x0450)
+#define PORTC_PIN1CTRL  _SFR_MEM8(0x0451)
+#define PORTC_PIN2CTRL  _SFR_MEM8(0x0452)
+#define PORTC_PIN3CTRL  _SFR_MEM8(0x0453)
+#define PORTC_PIN4CTRL  _SFR_MEM8(0x0454)
+#define PORTC_PIN5CTRL  _SFR_MEM8(0x0455)
+#define PORTC_PIN6CTRL  _SFR_MEM8(0x0456)
+#define PORTC_PIN7CTRL  _SFR_MEM8(0x0457)
+#define PORTC_EVGENCTRL  _SFR_MEM8(0x0458)
+
+
+/* PORT (PORTD) - I/O Ports */
+#define PORTD_DIR  _SFR_MEM8(0x0460)
+#define PORTD_DIRSET  _SFR_MEM8(0x0461)
+#define PORTD_DIRCLR  _SFR_MEM8(0x0462)
+#define PORTD_DIRTGL  _SFR_MEM8(0x0463)
+#define PORTD_OUT  _SFR_MEM8(0x0464)
+#define PORTD_OUTSET  _SFR_MEM8(0x0465)
+#define PORTD_OUTCLR  _SFR_MEM8(0x0466)
+#define PORTD_OUTTGL  _SFR_MEM8(0x0467)
+#define PORTD_IN  _SFR_MEM8(0x0468)
+#define PORTD_INTFLAGS  _SFR_MEM8(0x0469)
+#define PORTD_PORTCTRL  _SFR_MEM8(0x046A)
+#define PORTD_PINCONFIG  _SFR_MEM8(0x046B)
+#define PORTD_PINCTRLUPD  _SFR_MEM8(0x046C)
+#define PORTD_PINCTRLSET  _SFR_MEM8(0x046D)
+#define PORTD_PINCTRLCLR  _SFR_MEM8(0x046E)
+#define PORTD_PIN0CTRL  _SFR_MEM8(0x0470)
+#define PORTD_PIN1CTRL  _SFR_MEM8(0x0471)
+#define PORTD_PIN2CTRL  _SFR_MEM8(0x0472)
+#define PORTD_PIN3CTRL  _SFR_MEM8(0x0473)
+#define PORTD_PIN4CTRL  _SFR_MEM8(0x0474)
+#define PORTD_PIN5CTRL  _SFR_MEM8(0x0475)
+#define PORTD_PIN6CTRL  _SFR_MEM8(0x0476)
+#define PORTD_PIN7CTRL  _SFR_MEM8(0x0477)
+#define PORTD_EVGENCTRL  _SFR_MEM8(0x0478)
+
+
+/* PORT (PORTF) - I/O Ports */
+#define PORTF_DIR  _SFR_MEM8(0x04A0)
+#define PORTF_DIRSET  _SFR_MEM8(0x04A1)
+#define PORTF_DIRCLR  _SFR_MEM8(0x04A2)
+#define PORTF_DIRTGL  _SFR_MEM8(0x04A3)
+#define PORTF_OUT  _SFR_MEM8(0x04A4)
+#define PORTF_OUTSET  _SFR_MEM8(0x04A5)
+#define PORTF_OUTCLR  _SFR_MEM8(0x04A6)
+#define PORTF_OUTTGL  _SFR_MEM8(0x04A7)
+#define PORTF_IN  _SFR_MEM8(0x04A8)
+#define PORTF_INTFLAGS  _SFR_MEM8(0x04A9)
+#define PORTF_PORTCTRL  _SFR_MEM8(0x04AA)
+#define PORTF_PINCONFIG  _SFR_MEM8(0x04AB)
+#define PORTF_PINCTRLUPD  _SFR_MEM8(0x04AC)
+#define PORTF_PINCTRLSET  _SFR_MEM8(0x04AD)
+#define PORTF_PINCTRLCLR  _SFR_MEM8(0x04AE)
+#define PORTF_PIN0CTRL  _SFR_MEM8(0x04B0)
+#define PORTF_PIN1CTRL  _SFR_MEM8(0x04B1)
+#define PORTF_PIN2CTRL  _SFR_MEM8(0x04B2)
+#define PORTF_PIN3CTRL  _SFR_MEM8(0x04B3)
+#define PORTF_PIN4CTRL  _SFR_MEM8(0x04B4)
+#define PORTF_PIN5CTRL  _SFR_MEM8(0x04B5)
+#define PORTF_PIN6CTRL  _SFR_MEM8(0x04B6)
+#define PORTF_PIN7CTRL  _SFR_MEM8(0x04B7)
+#define PORTF_EVGENCTRL  _SFR_MEM8(0x04B8)
+
+
+/* PORTMUX - Port Multiplexer */
+#define PORTMUX_EVSYSROUTEA  _SFR_MEM8(0x05E0)
+#define PORTMUX_CCLROUTEA  _SFR_MEM8(0x05E1)
+#define PORTMUX_USARTROUTEA  _SFR_MEM8(0x05E2)
+#define PORTMUX_USARTROUTEB  _SFR_MEM8(0x05E3)
+#define PORTMUX_SPIROUTEA  _SFR_MEM8(0x05E5)
+#define PORTMUX_TWIROUTEA  _SFR_MEM8(0x05E6)
+#define PORTMUX_TCAROUTEA  _SFR_MEM8(0x05E7)
+#define PORTMUX_TCBROUTEA  _SFR_MEM8(0x05E8)
+#define PORTMUX_ACROUTEA  _SFR_MEM8(0x05EA)
+
+
+/* ADC (ADC0) - Analog to Digital Converter */
+#define ADC0_CTRLA  _SFR_MEM8(0x0600)
+#define ADC0_CTRLB  _SFR_MEM8(0x0601)
+#define ADC0_CTRLC  _SFR_MEM8(0x0602)
+#define ADC0_CTRLD  _SFR_MEM8(0x0603)
+#define ADC0_INTCTRL  _SFR_MEM8(0x0604)
+#define ADC0_INTFLAGS  _SFR_MEM8(0x0605)
+#define ADC0_STATUS  _SFR_MEM8(0x0606)
+#define ADC0_DBGCTRL  _SFR_MEM8(0x0607)
+#define ADC0_CTRLE  _SFR_MEM8(0x0608)
+#define ADC0_CTRLF  _SFR_MEM8(0x0609)
+#define ADC0_COMMAND  _SFR_MEM8(0x060A)
+#define ADC0_PGACTRL  _SFR_MEM8(0x060B)
+#define ADC0_MUXPOS  _SFR_MEM8(0x060C)
+#define ADC0_MUXNEG  _SFR_MEM8(0x060D)
+#define ADC0_RESULT  _SFR_MEM32(0x0610)
+#define ADC0_RESULT0  _SFR_MEM8(0x0610)
+#define ADC0_RESULT1  _SFR_MEM8(0x0611)
+#define ADC0_RESULT2  _SFR_MEM8(0x0612)
+#define ADC0_RESULT3  _SFR_MEM8(0x0613)
+#define ADC0_SAMPLE  _SFR_MEM16(0x0614)
+#define ADC0_SAMPLEL  _SFR_MEM8(0x0614)
+#define ADC0_SAMPLEH  _SFR_MEM8(0x0615)
+#define ADC0_TEMP0  _SFR_MEM8(0x0618)
+#define ADC0_TEMP1  _SFR_MEM8(0x0619)
+#define ADC0_TEMP2  _SFR_MEM8(0x061A)
+#define ADC0_WINLT  _SFR_MEM16(0x061C)
+#define ADC0_WINLTL  _SFR_MEM8(0x061C)
+#define ADC0_WINLTH  _SFR_MEM8(0x061D)
+#define ADC0_WINHT  _SFR_MEM16(0x061E)
+#define ADC0_WINHTL  _SFR_MEM8(0x061E)
+#define ADC0_WINHTH  _SFR_MEM8(0x061F)
+
+
+/* AC (AC0) - Analog Comparator */
+#define AC0_CTRLA  _SFR_MEM8(0x0680)
+#define AC0_CTRLB  _SFR_MEM8(0x0681)
+#define AC0_MUXCTRL  _SFR_MEM8(0x0682)
+#define AC0_DACREF  _SFR_MEM8(0x0685)
+#define AC0_INTCTRL  _SFR_MEM8(0x0686)
+#define AC0_STATUS  _SFR_MEM8(0x0687)
+
+
+/* AC (AC1) - Analog Comparator */
+#define AC1_CTRLA  _SFR_MEM8(0x0688)
+#define AC1_CTRLB  _SFR_MEM8(0x0689)
+#define AC1_MUXCTRL  _SFR_MEM8(0x068A)
+#define AC1_DACREF  _SFR_MEM8(0x068D)
+#define AC1_INTCTRL  _SFR_MEM8(0x068E)
+#define AC1_STATUS  _SFR_MEM8(0x068F)
+
+
+/* DAC (DAC0) - Digital to Analog Converter */
+#define DAC0_CTRLA  _SFR_MEM8(0x06A0)
+#define DAC0_DATA  _SFR_MEM16(0x06A2)
+#define DAC0_DATAL  _SFR_MEM8(0x06A2)
+#define DAC0_DATAH  _SFR_MEM8(0x06A3)
+
+
+/* USART (USART0) - Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define USART0_RXDATAL  _SFR_MEM8(0x0800)
+#define USART0_RXDATAH  _SFR_MEM8(0x0801)
+#define USART0_TXDATAL  _SFR_MEM8(0x0802)
+#define USART0_TXDATAH  _SFR_MEM8(0x0803)
+#define USART0_STATUS  _SFR_MEM8(0x0804)
+#define USART0_CTRLA  _SFR_MEM8(0x0805)
+#define USART0_CTRLB  _SFR_MEM8(0x0806)
+#define USART0_CTRLC  _SFR_MEM8(0x0807)
+#define USART0_BAUD  _SFR_MEM16(0x0808)
+#define USART0_BAUDL  _SFR_MEM8(0x0808)
+#define USART0_BAUDH  _SFR_MEM8(0x0809)
+#define USART0_CTRLD  _SFR_MEM8(0x080A)
+#define USART0_DBGCTRL  _SFR_MEM8(0x080B)
+#define USART0_EVCTRL  _SFR_MEM8(0x080C)
+#define USART0_TXPLCTRL  _SFR_MEM8(0x080D)
+#define USART0_RXPLCTRL  _SFR_MEM8(0x080E)
+
+
+/* USART (USART1) - Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define USART1_RXDATAL  _SFR_MEM8(0x0820)
+#define USART1_RXDATAH  _SFR_MEM8(0x0821)
+#define USART1_TXDATAL  _SFR_MEM8(0x0822)
+#define USART1_TXDATAH  _SFR_MEM8(0x0823)
+#define USART1_STATUS  _SFR_MEM8(0x0824)
+#define USART1_CTRLA  _SFR_MEM8(0x0825)
+#define USART1_CTRLB  _SFR_MEM8(0x0826)
+#define USART1_CTRLC  _SFR_MEM8(0x0827)
+#define USART1_BAUD  _SFR_MEM16(0x0828)
+#define USART1_BAUDL  _SFR_MEM8(0x0828)
+#define USART1_BAUDH  _SFR_MEM8(0x0829)
+#define USART1_CTRLD  _SFR_MEM8(0x082A)
+#define USART1_DBGCTRL  _SFR_MEM8(0x082B)
+#define USART1_EVCTRL  _SFR_MEM8(0x082C)
+#define USART1_TXPLCTRL  _SFR_MEM8(0x082D)
+#define USART1_RXPLCTRL  _SFR_MEM8(0x082E)
+
+
+/* USART (USART2) - Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define USART2_RXDATAL  _SFR_MEM8(0x0840)
+#define USART2_RXDATAH  _SFR_MEM8(0x0841)
+#define USART2_TXDATAL  _SFR_MEM8(0x0842)
+#define USART2_TXDATAH  _SFR_MEM8(0x0843)
+#define USART2_STATUS  _SFR_MEM8(0x0844)
+#define USART2_CTRLA  _SFR_MEM8(0x0845)
+#define USART2_CTRLB  _SFR_MEM8(0x0846)
+#define USART2_CTRLC  _SFR_MEM8(0x0847)
+#define USART2_BAUD  _SFR_MEM16(0x0848)
+#define USART2_BAUDL  _SFR_MEM8(0x0848)
+#define USART2_BAUDH  _SFR_MEM8(0x0849)
+#define USART2_CTRLD  _SFR_MEM8(0x084A)
+#define USART2_DBGCTRL  _SFR_MEM8(0x084B)
+#define USART2_EVCTRL  _SFR_MEM8(0x084C)
+#define USART2_TXPLCTRL  _SFR_MEM8(0x084D)
+#define USART2_RXPLCTRL  _SFR_MEM8(0x084E)
+
+
+/* TWI (TWI0) - Two-Wire Interface */
+#define TWI0_CTRLA  _SFR_MEM8(0x0900)
+#define TWI0_DUALCTRL  _SFR_MEM8(0x0901)
+#define TWI0_DBGCTRL  _SFR_MEM8(0x0902)
+#define TWI0_MCTRLA  _SFR_MEM8(0x0903)
+#define TWI0_MCTRLB  _SFR_MEM8(0x0904)
+#define TWI0_MSTATUS  _SFR_MEM8(0x0905)
+#define TWI0_MBAUD  _SFR_MEM8(0x0906)
+#define TWI0_MADDR  _SFR_MEM8(0x0907)
+#define TWI0_MDATA  _SFR_MEM8(0x0908)
+#define TWI0_SCTRLA  _SFR_MEM8(0x0909)
+#define TWI0_SCTRLB  _SFR_MEM8(0x090A)
+#define TWI0_SSTATUS  _SFR_MEM8(0x090B)
+#define TWI0_SADDR  _SFR_MEM8(0x090C)
+#define TWI0_SDATA  _SFR_MEM8(0x090D)
+#define TWI0_SADDRMASK  _SFR_MEM8(0x090E)
+
+
+/* SPI (SPI0) - Serial Peripheral Interface */
+#define SPI0_CTRLA  _SFR_MEM8(0x0940)
+#define SPI0_CTRLB  _SFR_MEM8(0x0941)
+#define SPI0_INTCTRL  _SFR_MEM8(0x0942)
+#define SPI0_INTFLAGS  _SFR_MEM8(0x0943)
+#define SPI0_DATA  _SFR_MEM8(0x0944)
+
+
+/* TCA (TCA0) - 16-bit Timer/Counter Type A - Single Mode */
+#define TCA0_SINGLE_CTRLA  _SFR_MEM8(0x0A00)
+#define TCA0_SINGLE_CTRLB  _SFR_MEM8(0x0A01)
+#define TCA0_SINGLE_CTRLC  _SFR_MEM8(0x0A02)
+#define TCA0_SINGLE_CTRLD  _SFR_MEM8(0x0A03)
+#define TCA0_SINGLE_CTRLECLR  _SFR_MEM8(0x0A04)
+#define TCA0_SINGLE_CTRLESET  _SFR_MEM8(0x0A05)
+#define TCA0_SINGLE_CTRLFCLR  _SFR_MEM8(0x0A06)
+#define TCA0_SINGLE_CTRLFSET  _SFR_MEM8(0x0A07)
+#define TCA0_SINGLE_EVCTRL  _SFR_MEM8(0x0A09)
+#define TCA0_SINGLE_INTCTRL  _SFR_MEM8(0x0A0A)
+#define TCA0_SINGLE_INTFLAGS  _SFR_MEM8(0x0A0B)
+#define TCA0_SINGLE_DBGCTRL  _SFR_MEM8(0x0A0E)
+#define TCA0_SINGLE_TEMP  _SFR_MEM8(0x0A0F)
+#define TCA0_SINGLE_CNT  _SFR_MEM16(0x0A20)
+#define TCA0_SINGLE_CNTL  _SFR_MEM8(0x0A20)
+#define TCA0_SINGLE_CNTH  _SFR_MEM8(0x0A21)
+#define TCA0_SINGLE_PER  _SFR_MEM16(0x0A26)
+#define TCA0_SINGLE_PERL  _SFR_MEM8(0x0A26)
+#define TCA0_SINGLE_PERH  _SFR_MEM8(0x0A27)
+#define TCA0_SINGLE_CMP0  _SFR_MEM16(0x0A28)
+#define TCA0_SINGLE_CMP0L  _SFR_MEM8(0x0A28)
+#define TCA0_SINGLE_CMP0H  _SFR_MEM8(0x0A29)
+#define TCA0_SINGLE_CMP1  _SFR_MEM16(0x0A2A)
+#define TCA0_SINGLE_CMP1L  _SFR_MEM8(0x0A2A)
+#define TCA0_SINGLE_CMP1H  _SFR_MEM8(0x0A2B)
+#define TCA0_SINGLE_CMP2  _SFR_MEM16(0x0A2C)
+#define TCA0_SINGLE_CMP2L  _SFR_MEM8(0x0A2C)
+#define TCA0_SINGLE_CMP2H  _SFR_MEM8(0x0A2D)
+#define TCA0_SINGLE_PERBUF  _SFR_MEM16(0x0A36)
+#define TCA0_SINGLE_PERBUFL  _SFR_MEM8(0x0A36)
+#define TCA0_SINGLE_PERBUFH  _SFR_MEM8(0x0A37)
+#define TCA0_SINGLE_CMP0BUF  _SFR_MEM16(0x0A38)
+#define TCA0_SINGLE_CMP0BUFL  _SFR_MEM8(0x0A38)
+#define TCA0_SINGLE_CMP0BUFH  _SFR_MEM8(0x0A39)
+#define TCA0_SINGLE_CMP1BUF  _SFR_MEM16(0x0A3A)
+#define TCA0_SINGLE_CMP1BUFL  _SFR_MEM8(0x0A3A)
+#define TCA0_SINGLE_CMP1BUFH  _SFR_MEM8(0x0A3B)
+#define TCA0_SINGLE_CMP2BUF  _SFR_MEM16(0x0A3C)
+#define TCA0_SINGLE_CMP2BUFL  _SFR_MEM8(0x0A3C)
+#define TCA0_SINGLE_CMP2BUFH  _SFR_MEM8(0x0A3D)
+
+
+/* TCA (TCA0) - 16-bit Timer/Counter Type A - Split Mode */
+#define TCA0_SPLIT_CTRLA  _SFR_MEM8(0x0A00)
+#define TCA0_SPLIT_CTRLB  _SFR_MEM8(0x0A01)
+#define TCA0_SPLIT_CTRLC  _SFR_MEM8(0x0A02)
+#define TCA0_SPLIT_CTRLD  _SFR_MEM8(0x0A03)
+#define TCA0_SPLIT_CTRLECLR  _SFR_MEM8(0x0A04)
+#define TCA0_SPLIT_CTRLESET  _SFR_MEM8(0x0A05)
+#define TCA0_SPLIT_INTCTRL  _SFR_MEM8(0x0A0A)
+#define TCA0_SPLIT_INTFLAGS  _SFR_MEM8(0x0A0B)
+#define TCA0_SPLIT_DBGCTRL  _SFR_MEM8(0x0A0E)
+#define TCA0_SPLIT_LCNT  _SFR_MEM8(0x0A20)
+#define TCA0_SPLIT_HCNT  _SFR_MEM8(0x0A21)
+#define TCA0_SPLIT_LPER  _SFR_MEM8(0x0A26)
+#define TCA0_SPLIT_HPER  _SFR_MEM8(0x0A27)
+#define TCA0_SPLIT_LCMP0  _SFR_MEM8(0x0A28)
+#define TCA0_SPLIT_HCMP0  _SFR_MEM8(0x0A29)
+#define TCA0_SPLIT_LCMP1  _SFR_MEM8(0x0A2A)
+#define TCA0_SPLIT_HCMP1  _SFR_MEM8(0x0A2B)
+#define TCA0_SPLIT_LCMP2  _SFR_MEM8(0x0A2C)
+#define TCA0_SPLIT_HCMP2  _SFR_MEM8(0x0A2D)
+
+
+/* TCB (TCB0) - 16-bit Timer Type B */
+#define TCB0_CTRLA  _SFR_MEM8(0x0B00)
+#define TCB0_CTRLB  _SFR_MEM8(0x0B01)
+#define TCB0_EVCTRL  _SFR_MEM8(0x0B04)
+#define TCB0_INTCTRL  _SFR_MEM8(0x0B05)
+#define TCB0_INTFLAGS  _SFR_MEM8(0x0B06)
+#define TCB0_STATUS  _SFR_MEM8(0x0B07)
+#define TCB0_DBGCTRL  _SFR_MEM8(0x0B08)
+#define TCB0_TEMP  _SFR_MEM8(0x0B09)
+#define TCB0_CNT  _SFR_MEM16(0x0B0A)
+#define TCB0_CNTL  _SFR_MEM8(0x0B0A)
+#define TCB0_CNTH  _SFR_MEM8(0x0B0B)
+#define TCB0_CCMP  _SFR_MEM16(0x0B0C)
+#define TCB0_CCMPL  _SFR_MEM8(0x0B0C)
+#define TCB0_CCMPH  _SFR_MEM8(0x0B0D)
+
+
+/* TCB (TCB1) - 16-bit Timer Type B */
+#define TCB1_CTRLA  _SFR_MEM8(0x0B10)
+#define TCB1_CTRLB  _SFR_MEM8(0x0B11)
+#define TCB1_EVCTRL  _SFR_MEM8(0x0B14)
+#define TCB1_INTCTRL  _SFR_MEM8(0x0B15)
+#define TCB1_INTFLAGS  _SFR_MEM8(0x0B16)
+#define TCB1_STATUS  _SFR_MEM8(0x0B17)
+#define TCB1_DBGCTRL  _SFR_MEM8(0x0B18)
+#define TCB1_TEMP  _SFR_MEM8(0x0B19)
+#define TCB1_CNT  _SFR_MEM16(0x0B1A)
+#define TCB1_CNTL  _SFR_MEM8(0x0B1A)
+#define TCB1_CNTH  _SFR_MEM8(0x0B1B)
+#define TCB1_CCMP  _SFR_MEM16(0x0B1C)
+#define TCB1_CCMPL  _SFR_MEM8(0x0B1C)
+#define TCB1_CCMPH  _SFR_MEM8(0x0B1D)
+
+
+/* TCB (TCB2) - 16-bit Timer Type B */
+#define TCB2_CTRLA  _SFR_MEM8(0x0B20)
+#define TCB2_CTRLB  _SFR_MEM8(0x0B21)
+#define TCB2_EVCTRL  _SFR_MEM8(0x0B24)
+#define TCB2_INTCTRL  _SFR_MEM8(0x0B25)
+#define TCB2_INTFLAGS  _SFR_MEM8(0x0B26)
+#define TCB2_STATUS  _SFR_MEM8(0x0B27)
+#define TCB2_DBGCTRL  _SFR_MEM8(0x0B28)
+#define TCB2_TEMP  _SFR_MEM8(0x0B29)
+#define TCB2_CNT  _SFR_MEM16(0x0B2A)
+#define TCB2_CNTL  _SFR_MEM8(0x0B2A)
+#define TCB2_CNTH  _SFR_MEM8(0x0B2B)
+#define TCB2_CCMP  _SFR_MEM16(0x0B2C)
+#define TCB2_CCMPL  _SFR_MEM8(0x0B2C)
+#define TCB2_CCMPH  _SFR_MEM8(0x0B2D)
+
+
+/* SYSCFG - System Configuration Registers */
+#define SYSCFG_REVID  _SFR_MEM8(0x0F01)
+#define SYSCFG_OCDMCTRL  _SFR_MEM8(0x0F04)
+#define SYSCFG_OCDMSTATUS  _SFR_MEM8(0x0F05)
+
+
+/* NVMCTRL - Non-volatile Memory Controller */
+#define NVMCTRL_CTRLA  _SFR_MEM8(0x1000)
+#define NVMCTRL_CTRLB  _SFR_MEM8(0x1001)
+#define NVMCTRL_INTCTRL  _SFR_MEM8(0x1004)
+#define NVMCTRL_INTFLAGS  _SFR_MEM8(0x1005)
+#define NVMCTRL_STATUS  _SFR_MEM8(0x1006)
+#define NVMCTRL_DATA  _SFR_MEM16(0x1008)
+#define NVMCTRL_DATAL  _SFR_MEM8(0x1008)
+#define NVMCTRL_DATAH  _SFR_MEM8(0x1009)
+#define NVMCTRL_ADDR  _SFR_MEM32(0x100C)
+#define NVMCTRL_ADDR0  _SFR_MEM8(0x100C)
+#define NVMCTRL_ADDR1  _SFR_MEM8(0x100D)
+#define NVMCTRL_ADDR2  _SFR_MEM8(0x100E)
+#define NVMCTRL_ADDR3  _SFR_MEM8(0x100F)
+
+
+/* LOCK - Lockbits */
+#define LOCK_KEY  _SFR_MEM32(0x1040)
+#define LOCK_KEY0  _SFR_MEM8(0x1040)
+#define LOCK_KEY1  _SFR_MEM8(0x1041)
+#define LOCK_KEY2  _SFR_MEM8(0x1042)
+#define LOCK_KEY3  _SFR_MEM8(0x1043)
+
+
+/* FUSE - Fuses */
+#define FUSE_WDTCFG  _SFR_MEM8(0x1050)
+#define FUSE_BODCFG  _SFR_MEM8(0x1051)
+#define FUSE_OSCCFG  _SFR_MEM8(0x1052)
+#define FUSE_SYSCFG0  _SFR_MEM8(0x1055)
+#define FUSE_SYSCFG1  _SFR_MEM8(0x1056)
+#define FUSE_CODESIZE  _SFR_MEM8(0x1057)
+#define FUSE_BOOTSIZE  _SFR_MEM8(0x1058)
+
+
+/* USERROW - User Row */
+#define USERROW_USERROW0  _SFR_MEM8(0x1080)
+#define USERROW_USERROW1  _SFR_MEM8(0x1081)
+#define USERROW_USERROW2  _SFR_MEM8(0x1082)
+#define USERROW_USERROW3  _SFR_MEM8(0x1083)
+#define USERROW_USERROW4  _SFR_MEM8(0x1084)
+#define USERROW_USERROW5  _SFR_MEM8(0x1085)
+#define USERROW_USERROW6  _SFR_MEM8(0x1086)
+#define USERROW_USERROW7  _SFR_MEM8(0x1087)
+#define USERROW_USERROW8  _SFR_MEM8(0x1088)
+#define USERROW_USERROW9  _SFR_MEM8(0x1089)
+#define USERROW_USERROW10  _SFR_MEM8(0x108A)
+#define USERROW_USERROW11  _SFR_MEM8(0x108B)
+#define USERROW_USERROW12  _SFR_MEM8(0x108C)
+#define USERROW_USERROW13  _SFR_MEM8(0x108D)
+#define USERROW_USERROW14  _SFR_MEM8(0x108E)
+#define USERROW_USERROW15  _SFR_MEM8(0x108F)
+#define USERROW_USERROW16  _SFR_MEM8(0x1090)
+#define USERROW_USERROW17  _SFR_MEM8(0x1091)
+#define USERROW_USERROW18  _SFR_MEM8(0x1092)
+#define USERROW_USERROW19  _SFR_MEM8(0x1093)
+#define USERROW_USERROW20  _SFR_MEM8(0x1094)
+#define USERROW_USERROW21  _SFR_MEM8(0x1095)
+#define USERROW_USERROW22  _SFR_MEM8(0x1096)
+#define USERROW_USERROW23  _SFR_MEM8(0x1097)
+#define USERROW_USERROW24  _SFR_MEM8(0x1098)
+#define USERROW_USERROW25  _SFR_MEM8(0x1099)
+#define USERROW_USERROW26  _SFR_MEM8(0x109A)
+#define USERROW_USERROW27  _SFR_MEM8(0x109B)
+#define USERROW_USERROW28  _SFR_MEM8(0x109C)
+#define USERROW_USERROW29  _SFR_MEM8(0x109D)
+#define USERROW_USERROW30  _SFR_MEM8(0x109E)
+#define USERROW_USERROW31  _SFR_MEM8(0x109F)
+#define USERROW_USERROW32  _SFR_MEM8(0x10A0)
+#define USERROW_USERROW33  _SFR_MEM8(0x10A1)
+#define USERROW_USERROW34  _SFR_MEM8(0x10A2)
+#define USERROW_USERROW35  _SFR_MEM8(0x10A3)
+#define USERROW_USERROW36  _SFR_MEM8(0x10A4)
+#define USERROW_USERROW37  _SFR_MEM8(0x10A5)
+#define USERROW_USERROW38  _SFR_MEM8(0x10A6)
+#define USERROW_USERROW39  _SFR_MEM8(0x10A7)
+#define USERROW_USERROW40  _SFR_MEM8(0x10A8)
+#define USERROW_USERROW41  _SFR_MEM8(0x10A9)
+#define USERROW_USERROW42  _SFR_MEM8(0x10AA)
+#define USERROW_USERROW43  _SFR_MEM8(0x10AB)
+#define USERROW_USERROW44  _SFR_MEM8(0x10AC)
+#define USERROW_USERROW45  _SFR_MEM8(0x10AD)
+#define USERROW_USERROW46  _SFR_MEM8(0x10AE)
+#define USERROW_USERROW47  _SFR_MEM8(0x10AF)
+#define USERROW_USERROW48  _SFR_MEM8(0x10B0)
+#define USERROW_USERROW49  _SFR_MEM8(0x10B1)
+#define USERROW_USERROW50  _SFR_MEM8(0x10B2)
+#define USERROW_USERROW51  _SFR_MEM8(0x10B3)
+#define USERROW_USERROW52  _SFR_MEM8(0x10B4)
+#define USERROW_USERROW53  _SFR_MEM8(0x10B5)
+#define USERROW_USERROW54  _SFR_MEM8(0x10B6)
+#define USERROW_USERROW55  _SFR_MEM8(0x10B7)
+#define USERROW_USERROW56  _SFR_MEM8(0x10B8)
+#define USERROW_USERROW57  _SFR_MEM8(0x10B9)
+#define USERROW_USERROW58  _SFR_MEM8(0x10BA)
+#define USERROW_USERROW59  _SFR_MEM8(0x10BB)
+#define USERROW_USERROW60  _SFR_MEM8(0x10BC)
+#define USERROW_USERROW61  _SFR_MEM8(0x10BD)
+#define USERROW_USERROW62  _SFR_MEM8(0x10BE)
+#define USERROW_USERROW63  _SFR_MEM8(0x10BF)
+
+
+/* SIGROW - Signature row */
+#define SIGROW_DEVICEID0  _SFR_MEM8(0x1100)
+#define SIGROW_DEVICEID1  _SFR_MEM8(0x1101)
+#define SIGROW_DEVICEID2  _SFR_MEM8(0x1102)
+#define SIGROW_TEMPSENSE0  _SFR_MEM16(0x1104)
+#define SIGROW_TEMPSENSE0L  _SFR_MEM8(0x1104)
+#define SIGROW_TEMPSENSE0H  _SFR_MEM8(0x1105)
+#define SIGROW_TEMPSENSE1  _SFR_MEM16(0x1106)
+#define SIGROW_TEMPSENSE1L  _SFR_MEM8(0x1106)
+#define SIGROW_TEMPSENSE1H  _SFR_MEM8(0x1107)
+#define SIGROW_SERNUM0  _SFR_MEM8(0x1110)
+#define SIGROW_SERNUM1  _SFR_MEM8(0x1111)
+#define SIGROW_SERNUM2  _SFR_MEM8(0x1112)
+#define SIGROW_SERNUM3  _SFR_MEM8(0x1113)
+#define SIGROW_SERNUM4  _SFR_MEM8(0x1114)
+#define SIGROW_SERNUM5  _SFR_MEM8(0x1115)
+#define SIGROW_SERNUM6  _SFR_MEM8(0x1116)
+#define SIGROW_SERNUM7  _SFR_MEM8(0x1117)
+#define SIGROW_SERNUM8  _SFR_MEM8(0x1118)
+#define SIGROW_SERNUM9  _SFR_MEM8(0x1119)
+#define SIGROW_SERNUM10  _SFR_MEM8(0x111A)
+#define SIGROW_SERNUM11  _SFR_MEM8(0x111B)
+#define SIGROW_SERNUM12  _SFR_MEM8(0x111C)
+#define SIGROW_SERNUM13  _SFR_MEM8(0x111D)
+#define SIGROW_SERNUM14  _SFR_MEM8(0x111E)
+#define SIGROW_SERNUM15  _SFR_MEM8(0x111F)
+
+
+
+/*================== Bitfield Definitions ================== */
+
+/* AC - Analog Comparator */
+/* AC.CTRLA  bit masks and bit positions */
+#define AC_ENABLE_bm  0x01  /* Enable bit mask. */
+#define AC_ENABLE_bp  0  /* Enable bit position. */
+#define AC_HYSMODE_gm  0x06  /* Hysteresis Mode group mask. */
+#define AC_HYSMODE_gp  1  /* Hysteresis Mode group position. */
+#define AC_HYSMODE_0_bm  (1<<1)  /* Hysteresis Mode bit 0 mask. */
+#define AC_HYSMODE_0_bp  1  /* Hysteresis Mode bit 0 position. */
+#define AC_HYSMODE_1_bm  (1<<2)  /* Hysteresis Mode bit 1 mask. */
+#define AC_HYSMODE_1_bp  2  /* Hysteresis Mode bit 1 position. */
+#define AC_POWER_gm  0x18  /* Power profile group mask. */
+#define AC_POWER_gp  3  /* Power profile group position. */
+#define AC_POWER_0_bm  (1<<3)  /* Power profile bit 0 mask. */
+#define AC_POWER_0_bp  3  /* Power profile bit 0 position. */
+#define AC_POWER_1_bm  (1<<4)  /* Power profile bit 1 mask. */
+#define AC_POWER_1_bp  4  /* Power profile bit 1 position. */
+#define AC_OUTEN_bm  0x40  /* Output Pad Enable bit mask. */
+#define AC_OUTEN_bp  6  /* Output Pad Enable bit position. */
+#define AC_RUNSTDBY_bm  0x80  /* Run in Standby Mode bit mask. */
+#define AC_RUNSTDBY_bp  7  /* Run in Standby Mode bit position. */
+
+/* AC.CTRLB  bit masks and bit positions */
+#define AC_WINSEL_gm  0x03  /* Window selection mode group mask. */
+#define AC_WINSEL_gp  0  /* Window selection mode group position. */
+#define AC_WINSEL_0_bm  (1<<0)  /* Window selection mode bit 0 mask. */
+#define AC_WINSEL_0_bp  0  /* Window selection mode bit 0 position. */
+#define AC_WINSEL_1_bm  (1<<1)  /* Window selection mode bit 1 mask. */
+#define AC_WINSEL_1_bp  1  /* Window selection mode bit 1 position. */
+
+/* AC.MUXCTRL  bit masks and bit positions */
+#define AC_MUXNEG_gm  0x07  /* Negative Input MUX Selection group mask. */
+#define AC_MUXNEG_gp  0  /* Negative Input MUX Selection group position. */
+#define AC_MUXNEG_0_bm  (1<<0)  /* Negative Input MUX Selection bit 0 mask. */
+#define AC_MUXNEG_0_bp  0  /* Negative Input MUX Selection bit 0 position. */
+#define AC_MUXNEG_1_bm  (1<<1)  /* Negative Input MUX Selection bit 1 mask. */
+#define AC_MUXNEG_1_bp  1  /* Negative Input MUX Selection bit 1 position. */
+#define AC_MUXNEG_2_bm  (1<<2)  /* Negative Input MUX Selection bit 2 mask. */
+#define AC_MUXNEG_2_bp  2  /* Negative Input MUX Selection bit 2 position. */
+#define AC_MUXPOS_gm  0x38  /* Positive Input MUX Selection group mask. */
+#define AC_MUXPOS_gp  3  /* Positive Input MUX Selection group position. */
+#define AC_MUXPOS_0_bm  (1<<3)  /* Positive Input MUX Selection bit 0 mask. */
+#define AC_MUXPOS_0_bp  3  /* Positive Input MUX Selection bit 0 position. */
+#define AC_MUXPOS_1_bm  (1<<4)  /* Positive Input MUX Selection bit 1 mask. */
+#define AC_MUXPOS_1_bp  4  /* Positive Input MUX Selection bit 1 position. */
+#define AC_MUXPOS_2_bm  (1<<5)  /* Positive Input MUX Selection bit 2 mask. */
+#define AC_MUXPOS_2_bp  5  /* Positive Input MUX Selection bit 2 position. */
+#define AC_INITVAL_bm  0x40  /* AC Output Initial Value bit mask. */
+#define AC_INITVAL_bp  6  /* AC Output Initial Value bit position. */
+#define AC_INVERT_bm  0x80  /* Invert AC Output bit mask. */
+#define AC_INVERT_bp  7  /* Invert AC Output bit position. */
+
+/* AC.DACREF  bit masks and bit positions */
+#define AC_DACREF_gm  0xFF  /* DACREF group mask. */
+#define AC_DACREF_gp  0  /* DACREF group position. */
+#define AC_DACREF_0_bm  (1<<0)  /* DACREF bit 0 mask. */
+#define AC_DACREF_0_bp  0  /* DACREF bit 0 position. */
+#define AC_DACREF_1_bm  (1<<1)  /* DACREF bit 1 mask. */
+#define AC_DACREF_1_bp  1  /* DACREF bit 1 position. */
+#define AC_DACREF_2_bm  (1<<2)  /* DACREF bit 2 mask. */
+#define AC_DACREF_2_bp  2  /* DACREF bit 2 position. */
+#define AC_DACREF_3_bm  (1<<3)  /* DACREF bit 3 mask. */
+#define AC_DACREF_3_bp  3  /* DACREF bit 3 position. */
+#define AC_DACREF_4_bm  (1<<4)  /* DACREF bit 4 mask. */
+#define AC_DACREF_4_bp  4  /* DACREF bit 4 position. */
+#define AC_DACREF_5_bm  (1<<5)  /* DACREF bit 5 mask. */
+#define AC_DACREF_5_bp  5  /* DACREF bit 5 position. */
+#define AC_DACREF_6_bm  (1<<6)  /* DACREF bit 6 mask. */
+#define AC_DACREF_6_bp  6  /* DACREF bit 6 position. */
+#define AC_DACREF_7_bm  (1<<7)  /* DACREF bit 7 mask. */
+#define AC_DACREF_7_bp  7  /* DACREF bit 7 position. */
+
+/* AC.INTCTRL  bit masks and bit positions */
+#define AC_CMP_bm  0x01  /* Interrupt Enable bit mask. */
+#define AC_CMP_bp  0  /* Interrupt Enable bit position. */
+#define AC_INTMODE_NORMAL_gm  0x30  /* Interrupt Mode group mask. */
+#define AC_INTMODE_NORMAL_gp  4  /* Interrupt Mode group position. */
+#define AC_INTMODE_NORMAL_0_bm  (1<<4)  /* Interrupt Mode bit 0 mask. */
+#define AC_INTMODE_NORMAL_0_bp  4  /* Interrupt Mode bit 0 position. */
+#define AC_INTMODE_NORMAL_1_bm  (1<<5)  /* Interrupt Mode bit 1 mask. */
+#define AC_INTMODE_NORMAL_1_bp  5  /* Interrupt Mode bit 1 position. */
+#define AC_INTMODE_WINDOW_gm  0x30  /* Interrupt Mode group mask. */
+#define AC_INTMODE_WINDOW_gp  4  /* Interrupt Mode group position. */
+#define AC_INTMODE_WINDOW_0_bm  (1<<4)  /* Interrupt Mode bit 0 mask. */
+#define AC_INTMODE_WINDOW_0_bp  4  /* Interrupt Mode bit 0 position. */
+#define AC_INTMODE_WINDOW_1_bm  (1<<5)  /* Interrupt Mode bit 1 mask. */
+#define AC_INTMODE_WINDOW_1_bp  5  /* Interrupt Mode bit 1 position. */
+
+/* AC.STATUS  bit masks and bit positions */
+#define AC_CMPIF_bm  0x01  /* Analog Comparator Interrupt Flag bit mask. */
+#define AC_CMPIF_bp  0  /* Analog Comparator Interrupt Flag bit position. */
+#define AC_CMPSTATE_bm  0x10  /* Analog Comparator State bit mask. */
+#define AC_CMPSTATE_bp  4  /* Analog Comparator State bit position. */
+#define AC_WINSTATE_gm  0xC0  /* Analog Comparator Window State group mask. */
+#define AC_WINSTATE_gp  6  /* Analog Comparator Window State group position. */
+#define AC_WINSTATE_0_bm  (1<<6)  /* Analog Comparator Window State bit 0 mask. */
+#define AC_WINSTATE_0_bp  6  /* Analog Comparator Window State bit 0 position. */
+#define AC_WINSTATE_1_bm  (1<<7)  /* Analog Comparator Window State bit 1 mask. */
+#define AC_WINSTATE_1_bp  7  /* Analog Comparator Window State bit 1 position. */
+
+
+/* ADC - Analog to Digital Converter */
+/* ADC.CTRLA  bit masks and bit positions */
+#define ADC_ENABLE_bm  0x01  /* ADC Enable bit mask. */
+#define ADC_ENABLE_bp  0  /* ADC Enable bit position. */
+#define ADC_LOWLAT_bm  0x20  /* Low Latency bit mask. */
+#define ADC_LOWLAT_bp  5  /* Low Latency bit position. */
+#define ADC_RUNSTDBY_bm  0x80  /* Run in Standby bit mask. */
+#define ADC_RUNSTDBY_bp  7  /* Run in Standby bit position. */
+
+/* ADC.CTRLB  bit masks and bit positions */
+#define ADC_PRESC_gm  0x0F  /* Prescaler Value group mask. */
+#define ADC_PRESC_gp  0  /* Prescaler Value group position. */
+#define ADC_PRESC_0_bm  (1<<0)  /* Prescaler Value bit 0 mask. */
+#define ADC_PRESC_0_bp  0  /* Prescaler Value bit 0 position. */
+#define ADC_PRESC_1_bm  (1<<1)  /* Prescaler Value bit 1 mask. */
+#define ADC_PRESC_1_bp  1  /* Prescaler Value bit 1 position. */
+#define ADC_PRESC_2_bm  (1<<2)  /* Prescaler Value bit 2 mask. */
+#define ADC_PRESC_2_bp  2  /* Prescaler Value bit 2 position. */
+#define ADC_PRESC_3_bm  (1<<3)  /* Prescaler Value bit 3 mask. */
+#define ADC_PRESC_3_bp  3  /* Prescaler Value bit 3 position. */
+
+/* ADC.CTRLC  bit masks and bit positions */
+#define ADC_REFSEL_gm  0x07  /* Reference select group mask. */
+#define ADC_REFSEL_gp  0  /* Reference select group position. */
+#define ADC_REFSEL_0_bm  (1<<0)  /* Reference select bit 0 mask. */
+#define ADC_REFSEL_0_bp  0  /* Reference select bit 0 position. */
+#define ADC_REFSEL_1_bm  (1<<1)  /* Reference select bit 1 mask. */
+#define ADC_REFSEL_1_bp  1  /* Reference select bit 1 position. */
+#define ADC_REFSEL_2_bm  (1<<2)  /* Reference select bit 2 mask. */
+#define ADC_REFSEL_2_bp  2  /* Reference select bit 2 position. */
+
+/* ADC.CTRLD  bit masks and bit positions */
+#define ADC_WINCM_gm  0x07  /* Window Comparator Mode group mask. */
+#define ADC_WINCM_gp  0  /* Window Comparator Mode group position. */
+#define ADC_WINCM_0_bm  (1<<0)  /* Window Comparator Mode bit 0 mask. */
+#define ADC_WINCM_0_bp  0  /* Window Comparator Mode bit 0 position. */
+#define ADC_WINCM_1_bm  (1<<1)  /* Window Comparator Mode bit 1 mask. */
+#define ADC_WINCM_1_bp  1  /* Window Comparator Mode bit 1 position. */
+#define ADC_WINCM_2_bm  (1<<2)  /* Window Comparator Mode bit 2 mask. */
+#define ADC_WINCM_2_bp  2  /* Window Comparator Mode bit 2 position. */
+#define ADC_WINSRC_bm  0x08  /* Window Mode Source bit mask. */
+#define ADC_WINSRC_bp  3  /* Window Mode Source bit position. */
+
+/* ADC.INTCTRL  bit masks and bit positions */
+#define ADC_RESRDY_bm  0x01  /* Result Ready Interrupt Enable bit mask. */
+#define ADC_RESRDY_bp  0  /* Result Ready Interrupt Enable bit position. */
+#define ADC_SAMPRDY_bm  0x02  /* Sample Ready Interrupt Enable bit mask. */
+#define ADC_SAMPRDY_bp  1  /* Sample Ready Interrupt Enable bit position. */
+#define ADC_WCMP_bm  0x04  /* Window Comparator Interrupt Enable bit mask. */
+#define ADC_WCMP_bp  2  /* Window Comparator Interrupt Enable bit position. */
+#define ADC_RESOVR_bm  0x08  /* Result Overwrite Interrupt Enable bit mask. */
+#define ADC_RESOVR_bp  3  /* Result Overwrite Interrupt Enable bit position. */
+#define ADC_SAMPOVR_bm  0x10  /* Sample Overwrite Interrupt Enable bit mask. */
+#define ADC_SAMPOVR_bp  4  /* Sample Overwrite Interrupt Enable bit position. */
+#define ADC_TRIGOVR_bm  0x20  /* Trigger Overrun Interrupt Enable bit mask. */
+#define ADC_TRIGOVR_bp  5  /* Trigger Overrun Interrupt Enable bit position. */
+
+/* ADC.INTFLAGS  bit masks and bit positions */
+/* ADC_RESRDY  is already defined. */
+/* ADC_SAMPRDY  is already defined. */
+/* ADC_WCMP  is already defined. */
+/* ADC_RESOVR  is already defined. */
+/* ADC_SAMPOVR  is already defined. */
+/* ADC_TRIGOVR  is already defined. */
+
+/* ADC.STATUS  bit masks and bit positions */
+#define ADC_ADCBUSY_bm  0x01  /* ADC Busy bit mask. */
+#define ADC_ADCBUSY_bp  0  /* ADC Busy bit position. */
+
+/* ADC.DBGCTRL  bit masks and bit positions */
+#define ADC_DBGRUN_bm  0x01  /* Run in Debug Mode bit mask. */
+#define ADC_DBGRUN_bp  0  /* Run in Debug Mode bit position. */
+
+/* ADC.CTRLE  bit masks and bit positions */
+#define ADC_SAMPDUR_gm  0xFF  /* Sample Duration group mask. */
+#define ADC_SAMPDUR_gp  0  /* Sample Duration group position. */
+#define ADC_SAMPDUR_0_bm  (1<<0)  /* Sample Duration bit 0 mask. */
+#define ADC_SAMPDUR_0_bp  0  /* Sample Duration bit 0 position. */
+#define ADC_SAMPDUR_1_bm  (1<<1)  /* Sample Duration bit 1 mask. */
+#define ADC_SAMPDUR_1_bp  1  /* Sample Duration bit 1 position. */
+#define ADC_SAMPDUR_2_bm  (1<<2)  /* Sample Duration bit 2 mask. */
+#define ADC_SAMPDUR_2_bp  2  /* Sample Duration bit 2 position. */
+#define ADC_SAMPDUR_3_bm  (1<<3)  /* Sample Duration bit 3 mask. */
+#define ADC_SAMPDUR_3_bp  3  /* Sample Duration bit 3 position. */
+#define ADC_SAMPDUR_4_bm  (1<<4)  /* Sample Duration bit 4 mask. */
+#define ADC_SAMPDUR_4_bp  4  /* Sample Duration bit 4 position. */
+#define ADC_SAMPDUR_5_bm  (1<<5)  /* Sample Duration bit 5 mask. */
+#define ADC_SAMPDUR_5_bp  5  /* Sample Duration bit 5 position. */
+#define ADC_SAMPDUR_6_bm  (1<<6)  /* Sample Duration bit 6 mask. */
+#define ADC_SAMPDUR_6_bp  6  /* Sample Duration bit 6 position. */
+#define ADC_SAMPDUR_7_bm  (1<<7)  /* Sample Duration bit 7 mask. */
+#define ADC_SAMPDUR_7_bp  7  /* Sample Duration bit 7 position. */
+
+/* ADC.CTRLF  bit masks and bit positions */
+#define ADC_SAMPNUM_gm  0x0F  /* Sample numbers group mask. */
+#define ADC_SAMPNUM_gp  0  /* Sample numbers group position. */
+#define ADC_SAMPNUM_0_bm  (1<<0)  /* Sample numbers bit 0 mask. */
+#define ADC_SAMPNUM_0_bp  0  /* Sample numbers bit 0 position. */
+#define ADC_SAMPNUM_1_bm  (1<<1)  /* Sample numbers bit 1 mask. */
+#define ADC_SAMPNUM_1_bp  1  /* Sample numbers bit 1 position. */
+#define ADC_SAMPNUM_2_bm  (1<<2)  /* Sample numbers bit 2 mask. */
+#define ADC_SAMPNUM_2_bp  2  /* Sample numbers bit 2 position. */
+#define ADC_SAMPNUM_3_bm  (1<<3)  /* Sample numbers bit 3 mask. */
+#define ADC_SAMPNUM_3_bp  3  /* Sample numbers bit 3 position. */
+#define ADC_LEFTADJ_bm  0x10  /* Left Adjust bit mask. */
+#define ADC_LEFTADJ_bp  4  /* Left Adjust bit position. */
+#define ADC_FREERUN_bm  0x20  /* Free-Running mode bit mask. */
+#define ADC_FREERUN_bp  5  /* Free-Running mode bit position. */
+#define ADC_CHOPPING_bm  0x40  /* Sign Chopping bit mask. */
+#define ADC_CHOPPING_bp  6  /* Sign Chopping bit position. */
+
+/* ADC.COMMAND  bit masks and bit positions */
+#define ADC_START_gm  0x07  /* Start command group mask. */
+#define ADC_START_gp  0  /* Start command group position. */
+#define ADC_START_0_bm  (1<<0)  /* Start command bit 0 mask. */
+#define ADC_START_0_bp  0  /* Start command bit 0 position. */
+#define ADC_START_1_bm  (1<<1)  /* Start command bit 1 mask. */
+#define ADC_START_1_bp  1  /* Start command bit 1 position. */
+#define ADC_START_2_bm  (1<<2)  /* Start command bit 2 mask. */
+#define ADC_START_2_bp  2  /* Start command bit 2 position. */
+#define ADC_MODE_gm  0x70  /* Mode group mask. */
+#define ADC_MODE_gp  4  /* Mode group position. */
+#define ADC_MODE_0_bm  (1<<4)  /* Mode bit 0 mask. */
+#define ADC_MODE_0_bp  4  /* Mode bit 0 position. */
+#define ADC_MODE_1_bm  (1<<5)  /* Mode bit 1 mask. */
+#define ADC_MODE_1_bp  5  /* Mode bit 1 position. */
+#define ADC_MODE_2_bm  (1<<6)  /* Mode bit 2 mask. */
+#define ADC_MODE_2_bp  6  /* Mode bit 2 position. */
+#define ADC_DIFF_bm  0x80  /* Differential mode bit mask. */
+#define ADC_DIFF_bp  7  /* Differential mode bit position. */
+
+/* ADC.PGACTRL  bit masks and bit positions */
+#define ADC_PGAEN_bm  0x01  /* PGA Enable bit mask. */
+#define ADC_PGAEN_bp  0  /* PGA Enable bit position. */
+#define ADC_PGABIASSEL_gm  0x18  /* PGA BIAS Select group mask. */
+#define ADC_PGABIASSEL_gp  3  /* PGA BIAS Select group position. */
+#define ADC_PGABIASSEL_0_bm  (1<<3)  /* PGA BIAS Select bit 0 mask. */
+#define ADC_PGABIASSEL_0_bp  3  /* PGA BIAS Select bit 0 position. */
+#define ADC_PGABIASSEL_1_bm  (1<<4)  /* PGA BIAS Select bit 1 mask. */
+#define ADC_PGABIASSEL_1_bp  4  /* PGA BIAS Select bit 1 position. */
+#define ADC_GAIN_gm  0xE0  /* Gain group mask. */
+#define ADC_GAIN_gp  5  /* Gain group position. */
+#define ADC_GAIN_0_bm  (1<<5)  /* Gain bit 0 mask. */
+#define ADC_GAIN_0_bp  5  /* Gain bit 0 position. */
+#define ADC_GAIN_1_bm  (1<<6)  /* Gain bit 1 mask. */
+#define ADC_GAIN_1_bp  6  /* Gain bit 1 position. */
+#define ADC_GAIN_2_bm  (1<<7)  /* Gain bit 2 mask. */
+#define ADC_GAIN_2_bp  7  /* Gain bit 2 position. */
+
+/* ADC.MUXPOS  bit masks and bit positions */
+#define ADC_MUXPOS_gm  0x3F  /* Analog Channel Selection Bits group mask. */
+#define ADC_MUXPOS_gp  0  /* Analog Channel Selection Bits group position. */
+#define ADC_MUXPOS_0_bm  (1<<0)  /* Analog Channel Selection Bits bit 0 mask. */
+#define ADC_MUXPOS_0_bp  0  /* Analog Channel Selection Bits bit 0 position. */
+#define ADC_MUXPOS_1_bm  (1<<1)  /* Analog Channel Selection Bits bit 1 mask. */
+#define ADC_MUXPOS_1_bp  1  /* Analog Channel Selection Bits bit 1 position. */
+#define ADC_MUXPOS_2_bm  (1<<2)  /* Analog Channel Selection Bits bit 2 mask. */
+#define ADC_MUXPOS_2_bp  2  /* Analog Channel Selection Bits bit 2 position. */
+#define ADC_MUXPOS_3_bm  (1<<3)  /* Analog Channel Selection Bits bit 3 mask. */
+#define ADC_MUXPOS_3_bp  3  /* Analog Channel Selection Bits bit 3 position. */
+#define ADC_MUXPOS_4_bm  (1<<4)  /* Analog Channel Selection Bits bit 4 mask. */
+#define ADC_MUXPOS_4_bp  4  /* Analog Channel Selection Bits bit 4 position. */
+#define ADC_MUXPOS_5_bm  (1<<5)  /* Analog Channel Selection Bits bit 5 mask. */
+#define ADC_MUXPOS_5_bp  5  /* Analog Channel Selection Bits bit 5 position. */
+#define ADC_VIA_gm  0xC0  /* VIA group mask. */
+#define ADC_VIA_gp  6  /* VIA group position. */
+#define ADC_VIA_0_bm  (1<<6)  /* VIA bit 0 mask. */
+#define ADC_VIA_0_bp  6  /* VIA bit 0 position. */
+#define ADC_VIA_1_bm  (1<<7)  /* VIA bit 1 mask. */
+#define ADC_VIA_1_bp  7  /* VIA bit 1 position. */
+
+/* ADC.MUXNEG  bit masks and bit positions */
+#define ADC_MUXNEG_gm  0x3F  /* Analog Channel Selection Bits group mask. */
+#define ADC_MUXNEG_gp  0  /* Analog Channel Selection Bits group position. */
+#define ADC_MUXNEG_0_bm  (1<<0)  /* Analog Channel Selection Bits bit 0 mask. */
+#define ADC_MUXNEG_0_bp  0  /* Analog Channel Selection Bits bit 0 position. */
+#define ADC_MUXNEG_1_bm  (1<<1)  /* Analog Channel Selection Bits bit 1 mask. */
+#define ADC_MUXNEG_1_bp  1  /* Analog Channel Selection Bits bit 1 position. */
+#define ADC_MUXNEG_2_bm  (1<<2)  /* Analog Channel Selection Bits bit 2 mask. */
+#define ADC_MUXNEG_2_bp  2  /* Analog Channel Selection Bits bit 2 position. */
+#define ADC_MUXNEG_3_bm  (1<<3)  /* Analog Channel Selection Bits bit 3 mask. */
+#define ADC_MUXNEG_3_bp  3  /* Analog Channel Selection Bits bit 3 position. */
+#define ADC_MUXNEG_4_bm  (1<<4)  /* Analog Channel Selection Bits bit 4 mask. */
+#define ADC_MUXNEG_4_bp  4  /* Analog Channel Selection Bits bit 4 position. */
+#define ADC_MUXNEG_5_bm  (1<<5)  /* Analog Channel Selection Bits bit 5 mask. */
+#define ADC_MUXNEG_5_bp  5  /* Analog Channel Selection Bits bit 5 position. */
+/* ADC_VIA  is already defined. */
+
+
+/* BOD - Bod interface */
+/* BOD.CTRLA  bit masks and bit positions */
+#define BOD_SLEEP_gm  0x03  /* Operation in sleep mode group mask. */
+#define BOD_SLEEP_gp  0  /* Operation in sleep mode group position. */
+#define BOD_SLEEP_0_bm  (1<<0)  /* Operation in sleep mode bit 0 mask. */
+#define BOD_SLEEP_0_bp  0  /* Operation in sleep mode bit 0 position. */
+#define BOD_SLEEP_1_bm  (1<<1)  /* Operation in sleep mode bit 1 mask. */
+#define BOD_SLEEP_1_bp  1  /* Operation in sleep mode bit 1 position. */
+#define BOD_ACTIVE_gm  0x0C  /* Operation in active mode group mask. */
+#define BOD_ACTIVE_gp  2  /* Operation in active mode group position. */
+#define BOD_ACTIVE_0_bm  (1<<2)  /* Operation in active mode bit 0 mask. */
+#define BOD_ACTIVE_0_bp  2  /* Operation in active mode bit 0 position. */
+#define BOD_ACTIVE_1_bm  (1<<3)  /* Operation in active mode bit 1 mask. */
+#define BOD_ACTIVE_1_bp  3  /* Operation in active mode bit 1 position. */
+#define BOD_SAMPFREQ_bm  0x10  /* Sample frequency bit mask. */
+#define BOD_SAMPFREQ_bp  4  /* Sample frequency bit position. */
+
+/* BOD.CTRLB  bit masks and bit positions */
+#define BOD_LVL_gm  0x07  /* Bod level group mask. */
+#define BOD_LVL_gp  0  /* Bod level group position. */
+#define BOD_LVL_0_bm  (1<<0)  /* Bod level bit 0 mask. */
+#define BOD_LVL_0_bp  0  /* Bod level bit 0 position. */
+#define BOD_LVL_1_bm  (1<<1)  /* Bod level bit 1 mask. */
+#define BOD_LVL_1_bp  1  /* Bod level bit 1 position. */
+#define BOD_LVL_2_bm  (1<<2)  /* Bod level bit 2 mask. */
+#define BOD_LVL_2_bp  2  /* Bod level bit 2 position. */
+
+/* BOD.VLMCTRLA  bit masks and bit positions */
+#define BOD_VLMLVL_gm  0x03  /* voltage level monitor level group mask. */
+#define BOD_VLMLVL_gp  0  /* voltage level monitor level group position. */
+#define BOD_VLMLVL_0_bm  (1<<0)  /* voltage level monitor level bit 0 mask. */
+#define BOD_VLMLVL_0_bp  0  /* voltage level monitor level bit 0 position. */
+#define BOD_VLMLVL_1_bm  (1<<1)  /* voltage level monitor level bit 1 mask. */
+#define BOD_VLMLVL_1_bp  1  /* voltage level monitor level bit 1 position. */
+
+/* BOD.INTCTRL  bit masks and bit positions */
+#define BOD_VLMIE_bm  0x01  /* voltage level monitor interrrupt enable bit mask. */
+#define BOD_VLMIE_bp  0  /* voltage level monitor interrrupt enable bit position. */
+#define BOD_VLMCFG_gm  0x06  /* Configuration group mask. */
+#define BOD_VLMCFG_gp  1  /* Configuration group position. */
+#define BOD_VLMCFG_0_bm  (1<<1)  /* Configuration bit 0 mask. */
+#define BOD_VLMCFG_0_bp  1  /* Configuration bit 0 position. */
+#define BOD_VLMCFG_1_bm  (1<<2)  /* Configuration bit 1 mask. */
+#define BOD_VLMCFG_1_bp  2  /* Configuration bit 1 position. */
+
+/* BOD.INTFLAGS  bit masks and bit positions */
+#define BOD_VLMIF_bm  0x01  /* Voltage level monitor interrupt flag bit mask. */
+#define BOD_VLMIF_bp  0  /* Voltage level monitor interrupt flag bit position. */
+
+/* BOD.STATUS  bit masks and bit positions */
+#define BOD_VLMS_bm  0x01  /* Voltage level monitor status bit mask. */
+#define BOD_VLMS_bp  0  /* Voltage level monitor status bit position. */
+
+
+/* CCL - Configurable Custom Logic */
+/* CCL.CTRLA  bit masks and bit positions */
+#define CCL_ENABLE_bm  0x01  /* Enable bit mask. */
+#define CCL_ENABLE_bp  0  /* Enable bit position. */
+#define CCL_RUNSTDBY_bm  0x40  /* Run in Standby bit mask. */
+#define CCL_RUNSTDBY_bp  6  /* Run in Standby bit position. */
+
+/* CCL.SEQCTRL0  bit masks and bit positions */
+#define CCL_SEQSEL_gm  0x07  /* Sequential Selection group mask. */
+#define CCL_SEQSEL_gp  0  /* Sequential Selection group position. */
+#define CCL_SEQSEL_0_bm  (1<<0)  /* Sequential Selection bit 0 mask. */
+#define CCL_SEQSEL_0_bp  0  /* Sequential Selection bit 0 position. */
+#define CCL_SEQSEL_1_bm  (1<<1)  /* Sequential Selection bit 1 mask. */
+#define CCL_SEQSEL_1_bp  1  /* Sequential Selection bit 1 position. */
+#define CCL_SEQSEL_2_bm  (1<<2)  /* Sequential Selection bit 2 mask. */
+#define CCL_SEQSEL_2_bp  2  /* Sequential Selection bit 2 position. */
+
+/* CCL.SEQCTRL1  bit masks and bit positions */
+/* CCL_SEQSEL  is already defined. */
+
+/* CCL.INTCTRL0  bit masks and bit positions */
+#define CCL_INTMODE0_gm  0x03  /* Interrupt Mode for LUT0 group mask. */
+#define CCL_INTMODE0_gp  0  /* Interrupt Mode for LUT0 group position. */
+#define CCL_INTMODE0_0_bm  (1<<0)  /* Interrupt Mode for LUT0 bit 0 mask. */
+#define CCL_INTMODE0_0_bp  0  /* Interrupt Mode for LUT0 bit 0 position. */
+#define CCL_INTMODE0_1_bm  (1<<1)  /* Interrupt Mode for LUT0 bit 1 mask. */
+#define CCL_INTMODE0_1_bp  1  /* Interrupt Mode for LUT0 bit 1 position. */
+#define CCL_INTMODE1_gm  0x0C  /* Interrupt Mode for LUT1 group mask. */
+#define CCL_INTMODE1_gp  2  /* Interrupt Mode for LUT1 group position. */
+#define CCL_INTMODE1_0_bm  (1<<2)  /* Interrupt Mode for LUT1 bit 0 mask. */
+#define CCL_INTMODE1_0_bp  2  /* Interrupt Mode for LUT1 bit 0 position. */
+#define CCL_INTMODE1_1_bm  (1<<3)  /* Interrupt Mode for LUT1 bit 1 mask. */
+#define CCL_INTMODE1_1_bp  3  /* Interrupt Mode for LUT1 bit 1 position. */
+#define CCL_INTMODE2_gm  0x30  /* Interrupt Mode for LUT2 group mask. */
+#define CCL_INTMODE2_gp  4  /* Interrupt Mode for LUT2 group position. */
+#define CCL_INTMODE2_0_bm  (1<<4)  /* Interrupt Mode for LUT2 bit 0 mask. */
+#define CCL_INTMODE2_0_bp  4  /* Interrupt Mode for LUT2 bit 0 position. */
+#define CCL_INTMODE2_1_bm  (1<<5)  /* Interrupt Mode for LUT2 bit 1 mask. */
+#define CCL_INTMODE2_1_bp  5  /* Interrupt Mode for LUT2 bit 1 position. */
+#define CCL_INTMODE3_gm  0xC0  /* Interrupt Mode for LUT3 group mask. */
+#define CCL_INTMODE3_gp  6  /* Interrupt Mode for LUT3 group position. */
+#define CCL_INTMODE3_0_bm  (1<<6)  /* Interrupt Mode for LUT3 bit 0 mask. */
+#define CCL_INTMODE3_0_bp  6  /* Interrupt Mode for LUT3 bit 0 position. */
+#define CCL_INTMODE3_1_bm  (1<<7)  /* Interrupt Mode for LUT3 bit 1 mask. */
+#define CCL_INTMODE3_1_bp  7  /* Interrupt Mode for LUT3 bit 1 position. */
+
+/* CCL.INTFLAGS  bit masks and bit positions */
+#define CCL_INT_gm  0x0F  /* Interrupt Flag group mask. */
+#define CCL_INT_gp  0  /* Interrupt Flag group position. */
+#define CCL_INT_0_bm  (1<<0)  /* Interrupt Flag bit 0 mask. */
+#define CCL_INT_0_bp  0  /* Interrupt Flag bit 0 position. */
+#define CCL_INT0_bm  CCL_INT_0_bm  /* This define is deprecated and should not be used */
+#define CCL_INT0_bp  CCL_INT_0_bp  /* This define is deprecated and should not be used */
+#define CCL_INT_1_bm  (1<<1)  /* Interrupt Flag bit 1 mask. */
+#define CCL_INT_1_bp  1  /* Interrupt Flag bit 1 position. */
+#define CCL_INT1_bm  CCL_INT_1_bm  /* This define is deprecated and should not be used */
+#define CCL_INT1_bp  CCL_INT_1_bp  /* This define is deprecated and should not be used */
+#define CCL_INT_2_bm  (1<<2)  /* Interrupt Flag bit 2 mask. */
+#define CCL_INT_2_bp  2  /* Interrupt Flag bit 2 position. */
+#define CCL_INT2_bm  CCL_INT_2_bm  /* This define is deprecated and should not be used */
+#define CCL_INT2_bp  CCL_INT_2_bp  /* This define is deprecated and should not be used */
+#define CCL_INT_3_bm  (1<<3)  /* Interrupt Flag bit 3 mask. */
+#define CCL_INT_3_bp  3  /* Interrupt Flag bit 3 position. */
+#define CCL_INT3_bm  CCL_INT_3_bm  /* This define is deprecated and should not be used */
+#define CCL_INT3_bp  CCL_INT_3_bp  /* This define is deprecated and should not be used */
+
+/* CCL.LUT0CTRLA  bit masks and bit positions */
+/* CCL_ENABLE  is already defined. */
+#define CCL_CLKSRC_gm  0x0E  /* Clock Source Selection group mask. */
+#define CCL_CLKSRC_gp  1  /* Clock Source Selection group position. */
+#define CCL_CLKSRC_0_bm  (1<<1)  /* Clock Source Selection bit 0 mask. */
+#define CCL_CLKSRC_0_bp  1  /* Clock Source Selection bit 0 position. */
+#define CCL_CLKSRC_1_bm  (1<<2)  /* Clock Source Selection bit 1 mask. */
+#define CCL_CLKSRC_1_bp  2  /* Clock Source Selection bit 1 position. */
+#define CCL_CLKSRC_2_bm  (1<<3)  /* Clock Source Selection bit 2 mask. */
+#define CCL_CLKSRC_2_bp  3  /* Clock Source Selection bit 2 position. */
+#define CCL_FILTSEL_gm  0x30  /* Filter Selection group mask. */
+#define CCL_FILTSEL_gp  4  /* Filter Selection group position. */
+#define CCL_FILTSEL_0_bm  (1<<4)  /* Filter Selection bit 0 mask. */
+#define CCL_FILTSEL_0_bp  4  /* Filter Selection bit 0 position. */
+#define CCL_FILTSEL_1_bm  (1<<5)  /* Filter Selection bit 1 mask. */
+#define CCL_FILTSEL_1_bp  5  /* Filter Selection bit 1 position. */
+#define CCL_OUTEN_bm  0x40  /* Output Enable bit mask. */
+#define CCL_OUTEN_bp  6  /* Output Enable bit position. */
+#define CCL_EDGEDET_bm  0x80  /* Edge Detection Enable bit mask. */
+#define CCL_EDGEDET_bp  7  /* Edge Detection Enable bit position. */
+
+/* CCL.LUT0CTRLB  bit masks and bit positions */
+#define CCL_INSEL0_gm  0x0F  /* LUT Input 0 Source Selection group mask. */
+#define CCL_INSEL0_gp  0  /* LUT Input 0 Source Selection group position. */
+#define CCL_INSEL0_0_bm  (1<<0)  /* LUT Input 0 Source Selection bit 0 mask. */
+#define CCL_INSEL0_0_bp  0  /* LUT Input 0 Source Selection bit 0 position. */
+#define CCL_INSEL0_1_bm  (1<<1)  /* LUT Input 0 Source Selection bit 1 mask. */
+#define CCL_INSEL0_1_bp  1  /* LUT Input 0 Source Selection bit 1 position. */
+#define CCL_INSEL0_2_bm  (1<<2)  /* LUT Input 0 Source Selection bit 2 mask. */
+#define CCL_INSEL0_2_bp  2  /* LUT Input 0 Source Selection bit 2 position. */
+#define CCL_INSEL0_3_bm  (1<<3)  /* LUT Input 0 Source Selection bit 3 mask. */
+#define CCL_INSEL0_3_bp  3  /* LUT Input 0 Source Selection bit 3 position. */
+#define CCL_INSEL1_gm  0xF0  /* LUT Input 1 Source Selection group mask. */
+#define CCL_INSEL1_gp  4  /* LUT Input 1 Source Selection group position. */
+#define CCL_INSEL1_0_bm  (1<<4)  /* LUT Input 1 Source Selection bit 0 mask. */
+#define CCL_INSEL1_0_bp  4  /* LUT Input 1 Source Selection bit 0 position. */
+#define CCL_INSEL1_1_bm  (1<<5)  /* LUT Input 1 Source Selection bit 1 mask. */
+#define CCL_INSEL1_1_bp  5  /* LUT Input 1 Source Selection bit 1 position. */
+#define CCL_INSEL1_2_bm  (1<<6)  /* LUT Input 1 Source Selection bit 2 mask. */
+#define CCL_INSEL1_2_bp  6  /* LUT Input 1 Source Selection bit 2 position. */
+#define CCL_INSEL1_3_bm  (1<<7)  /* LUT Input 1 Source Selection bit 3 mask. */
+#define CCL_INSEL1_3_bp  7  /* LUT Input 1 Source Selection bit 3 position. */
+
+/* CCL.LUT0CTRLC  bit masks and bit positions */
+#define CCL_INSEL2_gm  0x0F  /* LUT Input 2 Source Selection group mask. */
+#define CCL_INSEL2_gp  0  /* LUT Input 2 Source Selection group position. */
+#define CCL_INSEL2_0_bm  (1<<0)  /* LUT Input 2 Source Selection bit 0 mask. */
+#define CCL_INSEL2_0_bp  0  /* LUT Input 2 Source Selection bit 0 position. */
+#define CCL_INSEL2_1_bm  (1<<1)  /* LUT Input 2 Source Selection bit 1 mask. */
+#define CCL_INSEL2_1_bp  1  /* LUT Input 2 Source Selection bit 1 position. */
+#define CCL_INSEL2_2_bm  (1<<2)  /* LUT Input 2 Source Selection bit 2 mask. */
+#define CCL_INSEL2_2_bp  2  /* LUT Input 2 Source Selection bit 2 position. */
+#define CCL_INSEL2_3_bm  (1<<3)  /* LUT Input 2 Source Selection bit 3 mask. */
+#define CCL_INSEL2_3_bp  3  /* LUT Input 2 Source Selection bit 3 position. */
+
+/* CCL.TRUTH0  bit masks and bit positions */
+#define CCL_TRUTH_gm  0xFF  /* Truth Table group mask. */
+#define CCL_TRUTH_gp  0  /* Truth Table group position. */
+#define CCL_TRUTH_0_bm  (1<<0)  /* Truth Table bit 0 mask. */
+#define CCL_TRUTH_0_bp  0  /* Truth Table bit 0 position. */
+#define CCL_TRUTH_1_bm  (1<<1)  /* Truth Table bit 1 mask. */
+#define CCL_TRUTH_1_bp  1  /* Truth Table bit 1 position. */
+#define CCL_TRUTH_2_bm  (1<<2)  /* Truth Table bit 2 mask. */
+#define CCL_TRUTH_2_bp  2  /* Truth Table bit 2 position. */
+#define CCL_TRUTH_3_bm  (1<<3)  /* Truth Table bit 3 mask. */
+#define CCL_TRUTH_3_bp  3  /* Truth Table bit 3 position. */
+#define CCL_TRUTH_4_bm  (1<<4)  /* Truth Table bit 4 mask. */
+#define CCL_TRUTH_4_bp  4  /* Truth Table bit 4 position. */
+#define CCL_TRUTH_5_bm  (1<<5)  /* Truth Table bit 5 mask. */
+#define CCL_TRUTH_5_bp  5  /* Truth Table bit 5 position. */
+#define CCL_TRUTH_6_bm  (1<<6)  /* Truth Table bit 6 mask. */
+#define CCL_TRUTH_6_bp  6  /* Truth Table bit 6 position. */
+#define CCL_TRUTH_7_bm  (1<<7)  /* Truth Table bit 7 mask. */
+#define CCL_TRUTH_7_bp  7  /* Truth Table bit 7 position. */
+
+/* CCL.LUT1CTRLA  bit masks and bit positions */
+/* CCL_ENABLE  is already defined. */
+/* CCL_CLKSRC  is already defined. */
+/* CCL_FILTSEL  is already defined. */
+/* CCL_OUTEN  is already defined. */
+/* CCL_EDGEDET  is already defined. */
+
+/* CCL.LUT1CTRLB  bit masks and bit positions */
+/* CCL_INSEL0  is already defined. */
+/* CCL_INSEL1  is already defined. */
+
+/* CCL.LUT1CTRLC  bit masks and bit positions */
+/* CCL_INSEL2  is already defined. */
+
+/* CCL.TRUTH1  bit masks and bit positions */
+/* CCL_TRUTH  is already defined. */
+
+/* CCL.LUT2CTRLA  bit masks and bit positions */
+/* CCL_ENABLE  is already defined. */
+/* CCL_CLKSRC  is already defined. */
+/* CCL_FILTSEL  is already defined. */
+/* CCL_OUTEN  is already defined. */
+/* CCL_EDGEDET  is already defined. */
+
+/* CCL.LUT2CTRLB  bit masks and bit positions */
+/* CCL_INSEL0  is already defined. */
+/* CCL_INSEL1  is already defined. */
+
+/* CCL.LUT2CTRLC  bit masks and bit positions */
+/* CCL_INSEL2  is already defined. */
+
+/* CCL.TRUTH2  bit masks and bit positions */
+/* CCL_TRUTH  is already defined. */
+
+/* CCL.LUT3CTRLA  bit masks and bit positions */
+/* CCL_ENABLE  is already defined. */
+/* CCL_CLKSRC  is already defined. */
+/* CCL_FILTSEL  is already defined. */
+/* CCL_OUTEN  is already defined. */
+/* CCL_EDGEDET  is already defined. */
+
+/* CCL.LUT3CTRLB  bit masks and bit positions */
+/* CCL_INSEL0  is already defined. */
+/* CCL_INSEL1  is already defined. */
+
+/* CCL.LUT3CTRLC  bit masks and bit positions */
+/* CCL_INSEL2  is already defined. */
+
+/* CCL.TRUTH3  bit masks and bit positions */
+/* CCL_TRUTH  is already defined. */
+
+
+/* CLKCTRL - Clock controller */
+/* CLKCTRL.MCLKCTRLA  bit masks and bit positions */
+#define CLKCTRL_CLKSEL_gm  0x07  /* Clock select group mask. */
+#define CLKCTRL_CLKSEL_gp  0  /* Clock select group position. */
+#define CLKCTRL_CLKSEL_0_bm  (1<<0)  /* Clock select bit 0 mask. */
+#define CLKCTRL_CLKSEL_0_bp  0  /* Clock select bit 0 position. */
+#define CLKCTRL_CLKSEL_1_bm  (1<<1)  /* Clock select bit 1 mask. */
+#define CLKCTRL_CLKSEL_1_bp  1  /* Clock select bit 1 position. */
+#define CLKCTRL_CLKSEL_2_bm  (1<<2)  /* Clock select bit 2 mask. */
+#define CLKCTRL_CLKSEL_2_bp  2  /* Clock select bit 2 position. */
+#define CLKCTRL_CLKOUT_bm  0x80  /* System clock out bit mask. */
+#define CLKCTRL_CLKOUT_bp  7  /* System clock out bit position. */
+
+/* CLKCTRL.MCLKCTRLB  bit masks and bit positions */
+#define CLKCTRL_PEN_bm  0x01  /* Prescaler enable bit mask. */
+#define CLKCTRL_PEN_bp  0  /* Prescaler enable bit position. */
+#define CLKCTRL_PDIV_gm  0x1E  /* Prescaler division group mask. */
+#define CLKCTRL_PDIV_gp  1  /* Prescaler division group position. */
+#define CLKCTRL_PDIV_0_bm  (1<<1)  /* Prescaler division bit 0 mask. */
+#define CLKCTRL_PDIV_0_bp  1  /* Prescaler division bit 0 position. */
+#define CLKCTRL_PDIV_1_bm  (1<<2)  /* Prescaler division bit 1 mask. */
+#define CLKCTRL_PDIV_1_bp  2  /* Prescaler division bit 1 position. */
+#define CLKCTRL_PDIV_2_bm  (1<<3)  /* Prescaler division bit 2 mask. */
+#define CLKCTRL_PDIV_2_bp  3  /* Prescaler division bit 2 position. */
+#define CLKCTRL_PDIV_3_bm  (1<<4)  /* Prescaler division bit 3 mask. */
+#define CLKCTRL_PDIV_3_bp  4  /* Prescaler division bit 3 position. */
+
+/* CLKCTRL.MCLKCTRLC  bit masks and bit positions */
+#define CLKCTRL_CFDEN_bm  0x01  /* Clock Failure Detect Enable bit mask. */
+#define CLKCTRL_CFDEN_bp  0  /* Clock Failure Detect Enable bit position. */
+#define CLKCTRL_CFDTST_bm  0x02  /* CFD Test bit mask. */
+#define CLKCTRL_CFDTST_bp  1  /* CFD Test bit position. */
+#define CLKCTRL_CFDSRC_gm  0x0C  /* CFD Source group mask. */
+#define CLKCTRL_CFDSRC_gp  2  /* CFD Source group position. */
+#define CLKCTRL_CFDSRC_0_bm  (1<<2)  /* CFD Source bit 0 mask. */
+#define CLKCTRL_CFDSRC_0_bp  2  /* CFD Source bit 0 position. */
+#define CLKCTRL_CFDSRC_1_bm  (1<<3)  /* CFD Source bit 1 mask. */
+#define CLKCTRL_CFDSRC_1_bp  3  /* CFD Source bit 1 position. */
+
+/* CLKCTRL.MCLKINTCTRL  bit masks and bit positions */
+#define CLKCTRL_CFD_bm  0x01  /* Interrupt Enable bit mask. */
+#define CLKCTRL_CFD_bp  0  /* Interrupt Enable bit position. */
+#define CLKCTRL_INTTYPE_bm  0x80  /* Interrupt Type bit mask. */
+#define CLKCTRL_INTTYPE_bp  7  /* Interrupt Type bit position. */
+
+/* CLKCTRL.MCLKINTFLAGS  bit masks and bit positions */
+/* CLKCTRL_CFD  is already defined. */
+
+/* CLKCTRL.MCLKSTATUS  bit masks and bit positions */
+#define CLKCTRL_SOSC_bm  0x01  /* System Oscillator changing bit mask. */
+#define CLKCTRL_SOSC_bp  0  /* System Oscillator changing bit position. */
+#define CLKCTRL_OSCHFS_bm  0x02  /* High frequency oscillator status bit mask. */
+#define CLKCTRL_OSCHFS_bp  1  /* High frequency oscillator status bit position. */
+#define CLKCTRL_OSC32KS_bm  0x04  /* 32KHz oscillator status bit mask. */
+#define CLKCTRL_OSC32KS_bp  2  /* 32KHz oscillator status bit position. */
+#define CLKCTRL_XOSC32KS_bm  0x08  /* 32.768 kHz Crystal Oscillator status bit mask. */
+#define CLKCTRL_XOSC32KS_bp  3  /* 32.768 kHz Crystal Oscillator status bit position. */
+#define CLKCTRL_EXTS_bm  0x10  /* External Clock status / XOSCHF status bit mask. */
+#define CLKCTRL_EXTS_bp  4  /* External Clock status / XOSCHF status bit position. */
+
+/* CLKCTRL.MCLKTIMEBASE  bit masks and bit positions */
+#define CLKCTRL_TIMEBASE_gm  0x1F  /* Timebase group mask. */
+#define CLKCTRL_TIMEBASE_gp  0  /* Timebase group position. */
+#define CLKCTRL_TIMEBASE_0_bm  (1<<0)  /* Timebase bit 0 mask. */
+#define CLKCTRL_TIMEBASE_0_bp  0  /* Timebase bit 0 position. */
+#define CLKCTRL_TIMEBASE_1_bm  (1<<1)  /* Timebase bit 1 mask. */
+#define CLKCTRL_TIMEBASE_1_bp  1  /* Timebase bit 1 position. */
+#define CLKCTRL_TIMEBASE_2_bm  (1<<2)  /* Timebase bit 2 mask. */
+#define CLKCTRL_TIMEBASE_2_bp  2  /* Timebase bit 2 position. */
+#define CLKCTRL_TIMEBASE_3_bm  (1<<3)  /* Timebase bit 3 mask. */
+#define CLKCTRL_TIMEBASE_3_bp  3  /* Timebase bit 3 position. */
+#define CLKCTRL_TIMEBASE_4_bm  (1<<4)  /* Timebase bit 4 mask. */
+#define CLKCTRL_TIMEBASE_4_bp  4  /* Timebase bit 4 position. */
+
+/* CLKCTRL.OSCHFCTRLA  bit masks and bit positions */
+#define CLKCTRL_AUTOTUNE_gm  0x03  /* Automatic Oscillator Tune group mask. */
+#define CLKCTRL_AUTOTUNE_gp  0  /* Automatic Oscillator Tune group position. */
+#define CLKCTRL_AUTOTUNE_0_bm  (1<<0)  /* Automatic Oscillator Tune bit 0 mask. */
+#define CLKCTRL_AUTOTUNE_0_bp  0  /* Automatic Oscillator Tune bit 0 position. */
+#define CLKCTRL_AUTOTUNE_1_bm  (1<<1)  /* Automatic Oscillator Tune bit 1 mask. */
+#define CLKCTRL_AUTOTUNE_1_bp  1  /* Automatic Oscillator Tune bit 1 position. */
+#define CLKCTRL_RUNSTDBY_bm  0x80  /* Run in standby bit mask. */
+#define CLKCTRL_RUNSTDBY_bp  7  /* Run in standby bit position. */
+
+/* CLKCTRL.OSCHFTUNE  bit masks and bit positions */
+#define CLKCTRL_TUNE_gm  0xFF  /* Oscillator Tune group mask. */
+#define CLKCTRL_TUNE_gp  0  /* Oscillator Tune group position. */
+#define CLKCTRL_TUNE_0_bm  (1<<0)  /* Oscillator Tune bit 0 mask. */
+#define CLKCTRL_TUNE_0_bp  0  /* Oscillator Tune bit 0 position. */
+#define CLKCTRL_TUNE_1_bm  (1<<1)  /* Oscillator Tune bit 1 mask. */
+#define CLKCTRL_TUNE_1_bp  1  /* Oscillator Tune bit 1 position. */
+#define CLKCTRL_TUNE_2_bm  (1<<2)  /* Oscillator Tune bit 2 mask. */
+#define CLKCTRL_TUNE_2_bp  2  /* Oscillator Tune bit 2 position. */
+#define CLKCTRL_TUNE_3_bm  (1<<3)  /* Oscillator Tune bit 3 mask. */
+#define CLKCTRL_TUNE_3_bp  3  /* Oscillator Tune bit 3 position. */
+#define CLKCTRL_TUNE_4_bm  (1<<4)  /* Oscillator Tune bit 4 mask. */
+#define CLKCTRL_TUNE_4_bp  4  /* Oscillator Tune bit 4 position. */
+#define CLKCTRL_TUNE_5_bm  (1<<5)  /* Oscillator Tune bit 5 mask. */
+#define CLKCTRL_TUNE_5_bp  5  /* Oscillator Tune bit 5 position. */
+#define CLKCTRL_TUNE_6_bm  (1<<6)  /* Oscillator Tune bit 6 mask. */
+#define CLKCTRL_TUNE_6_bp  6  /* Oscillator Tune bit 6 position. */
+#define CLKCTRL_TUNE_7_bm  (1<<7)  /* Oscillator Tune bit 7 mask. */
+#define CLKCTRL_TUNE_7_bp  7  /* Oscillator Tune bit 7 position. */
+
+/* CLKCTRL.OSC32KCTRLA  bit masks and bit positions */
+/* CLKCTRL_RUNSTDBY  is already defined. */
+
+/* CLKCTRL.XOSC32KCTRLA  bit masks and bit positions */
+#define CLKCTRL_ENABLE_bm  0x01  /* Enable bit mask. */
+#define CLKCTRL_ENABLE_bp  0  /* Enable bit position. */
+#define CLKCTRL_LPMODE_bm  0x02  /* Low power mode bit mask. */
+#define CLKCTRL_LPMODE_bp  1  /* Low power mode bit position. */
+#define CLKCTRL_SEL_bm  0x04  /* Select bit mask. */
+#define CLKCTRL_SEL_bp  2  /* Select bit position. */
+#define CLKCTRL_CSUT_gm  0x30  /* Crystal startup time group mask. */
+#define CLKCTRL_CSUT_gp  4  /* Crystal startup time group position. */
+#define CLKCTRL_CSUT_0_bm  (1<<4)  /* Crystal startup time bit 0 mask. */
+#define CLKCTRL_CSUT_0_bp  4  /* Crystal startup time bit 0 position. */
+#define CLKCTRL_CSUT_1_bm  (1<<5)  /* Crystal startup time bit 1 mask. */
+#define CLKCTRL_CSUT_1_bp  5  /* Crystal startup time bit 1 position. */
+/* CLKCTRL_RUNSTDBY  is already defined. */
+
+/* CLKCTRL.XOSCHFCTRLA  bit masks and bit positions */
+/* CLKCTRL_ENABLE  is already defined. */
+#define CLKCTRL_SELHF_bm  0x02  /* Source Select bit mask. */
+#define CLKCTRL_SELHF_bp  1  /* Source Select bit position. */
+#define CLKCTRL_CSUTHF_gm  0x30  /* Start-Up Time group mask. */
+#define CLKCTRL_CSUTHF_gp  4  /* Start-Up Time group position. */
+#define CLKCTRL_CSUTHF_0_bm  (1<<4)  /* Start-Up Time bit 0 mask. */
+#define CLKCTRL_CSUTHF_0_bp  4  /* Start-Up Time bit 0 position. */
+#define CLKCTRL_CSUTHF_1_bm  (1<<5)  /* Start-Up Time bit 1 mask. */
+#define CLKCTRL_CSUTHF_1_bp  5  /* Start-Up Time bit 1 position. */
+/* CLKCTRL_RUNSTDBY  is already defined. */
+
+
+/* CPU - CPU */
+/* CPU.CCP  bit masks and bit positions */
+#define CPU_CCP_gm  0xFF  /* CCP signature group mask. */
+#define CPU_CCP_gp  0  /* CCP signature group position. */
+#define CPU_CCP_0_bm  (1<<0)  /* CCP signature bit 0 mask. */
+#define CPU_CCP_0_bp  0  /* CCP signature bit 0 position. */
+#define CPU_CCP_1_bm  (1<<1)  /* CCP signature bit 1 mask. */
+#define CPU_CCP_1_bp  1  /* CCP signature bit 1 position. */
+#define CPU_CCP_2_bm  (1<<2)  /* CCP signature bit 2 mask. */
+#define CPU_CCP_2_bp  2  /* CCP signature bit 2 position. */
+#define CPU_CCP_3_bm  (1<<3)  /* CCP signature bit 3 mask. */
+#define CPU_CCP_3_bp  3  /* CCP signature bit 3 position. */
+#define CPU_CCP_4_bm  (1<<4)  /* CCP signature bit 4 mask. */
+#define CPU_CCP_4_bp  4  /* CCP signature bit 4 position. */
+#define CPU_CCP_5_bm  (1<<5)  /* CCP signature bit 5 mask. */
+#define CPU_CCP_5_bp  5  /* CCP signature bit 5 position. */
+#define CPU_CCP_6_bm  (1<<6)  /* CCP signature bit 6 mask. */
+#define CPU_CCP_6_bp  6  /* CCP signature bit 6 position. */
+#define CPU_CCP_7_bm  (1<<7)  /* CCP signature bit 7 mask. */
+#define CPU_CCP_7_bp  7  /* CCP signature bit 7 position. */
+
+/* CPU.SREG  bit masks and bit positions */
+#define CPU_C_bm  0x01  /* Carry Flag bit mask. */
+#define CPU_C_bp  0  /* Carry Flag bit position. */
+#define CPU_Z_bm  0x02  /* Zero Flag bit mask. */
+#define CPU_Z_bp  1  /* Zero Flag bit position. */
+#define CPU_N_bm  0x04  /* Negative Flag bit mask. */
+#define CPU_N_bp  2  /* Negative Flag bit position. */
+#define CPU_V_bm  0x08  /* Two's Complement Overflow Flag bit mask. */
+#define CPU_V_bp  3  /* Two's Complement Overflow Flag bit position. */
+#define CPU_S_bm  0x10  /* N Exclusive Or V Flag bit mask. */
+#define CPU_S_bp  4  /* N Exclusive Or V Flag bit position. */
+#define CPU_H_bm  0x20  /* Half Carry Flag bit mask. */
+#define CPU_H_bp  5  /* Half Carry Flag bit position. */
+#define CPU_T_bm  0x40  /* Transfer Bit bit mask. */
+#define CPU_T_bp  6  /* Transfer Bit bit position. */
+#define CPU_I_bm  0x80  /* Global Interrupt Enable Flag bit mask. */
+#define CPU_I_bp  7  /* Global Interrupt Enable Flag bit position. */
+
+
+/* CPUINT - Interrupt Controller */
+/* CPUINT.CTRLA  bit masks and bit positions */
+#define CPUINT_LVL0RR_bm  0x01  /* Round-robin Scheduling Enable bit mask. */
+#define CPUINT_LVL0RR_bp  0  /* Round-robin Scheduling Enable bit position. */
+#define CPUINT_CVT_bm  0x20  /* Compact Vector Table bit mask. */
+#define CPUINT_CVT_bp  5  /* Compact Vector Table bit position. */
+#define CPUINT_IVSEL_bm  0x40  /* Interrupt Vector Select bit mask. */
+#define CPUINT_IVSEL_bp  6  /* Interrupt Vector Select bit position. */
+
+/* CPUINT.STATUS  bit masks and bit positions */
+#define CPUINT_LVL0EX_bm  0x01  /* Level 0 Interrupt Executing bit mask. */
+#define CPUINT_LVL0EX_bp  0  /* Level 0 Interrupt Executing bit position. */
+#define CPUINT_LVL1EX_bm  0x02  /* Level 1 Interrupt Executing bit mask. */
+#define CPUINT_LVL1EX_bp  1  /* Level 1 Interrupt Executing bit position. */
+#define CPUINT_NMIEX_bm  0x80  /* Non-maskable Interrupt Executing bit mask. */
+#define CPUINT_NMIEX_bp  7  /* Non-maskable Interrupt Executing bit position. */
+
+/* CPUINT.LVL0PRI  bit masks and bit positions */
+#define CPUINT_LVL0PRI_gm  0xFF  /* Interrupt Level Priority group mask. */
+#define CPUINT_LVL0PRI_gp  0  /* Interrupt Level Priority group position. */
+#define CPUINT_LVL0PRI_0_bm  (1<<0)  /* Interrupt Level Priority bit 0 mask. */
+#define CPUINT_LVL0PRI_0_bp  0  /* Interrupt Level Priority bit 0 position. */
+#define CPUINT_LVL0PRI_1_bm  (1<<1)  /* Interrupt Level Priority bit 1 mask. */
+#define CPUINT_LVL0PRI_1_bp  1  /* Interrupt Level Priority bit 1 position. */
+#define CPUINT_LVL0PRI_2_bm  (1<<2)  /* Interrupt Level Priority bit 2 mask. */
+#define CPUINT_LVL0PRI_2_bp  2  /* Interrupt Level Priority bit 2 position. */
+#define CPUINT_LVL0PRI_3_bm  (1<<3)  /* Interrupt Level Priority bit 3 mask. */
+#define CPUINT_LVL0PRI_3_bp  3  /* Interrupt Level Priority bit 3 position. */
+#define CPUINT_LVL0PRI_4_bm  (1<<4)  /* Interrupt Level Priority bit 4 mask. */
+#define CPUINT_LVL0PRI_4_bp  4  /* Interrupt Level Priority bit 4 position. */
+#define CPUINT_LVL0PRI_5_bm  (1<<5)  /* Interrupt Level Priority bit 5 mask. */
+#define CPUINT_LVL0PRI_5_bp  5  /* Interrupt Level Priority bit 5 position. */
+#define CPUINT_LVL0PRI_6_bm  (1<<6)  /* Interrupt Level Priority bit 6 mask. */
+#define CPUINT_LVL0PRI_6_bp  6  /* Interrupt Level Priority bit 6 position. */
+#define CPUINT_LVL0PRI_7_bm  (1<<7)  /* Interrupt Level Priority bit 7 mask. */
+#define CPUINT_LVL0PRI_7_bp  7  /* Interrupt Level Priority bit 7 position. */
+
+/* CPUINT.LVL1VEC  bit masks and bit positions */
+#define CPUINT_LVL1VEC_gm  0xFF  /* Interrupt Vector with High Priority group mask. */
+#define CPUINT_LVL1VEC_gp  0  /* Interrupt Vector with High Priority group position. */
+#define CPUINT_LVL1VEC_0_bm  (1<<0)  /* Interrupt Vector with High Priority bit 0 mask. */
+#define CPUINT_LVL1VEC_0_bp  0  /* Interrupt Vector with High Priority bit 0 position. */
+#define CPUINT_LVL1VEC_1_bm  (1<<1)  /* Interrupt Vector with High Priority bit 1 mask. */
+#define CPUINT_LVL1VEC_1_bp  1  /* Interrupt Vector with High Priority bit 1 position. */
+#define CPUINT_LVL1VEC_2_bm  (1<<2)  /* Interrupt Vector with High Priority bit 2 mask. */
+#define CPUINT_LVL1VEC_2_bp  2  /* Interrupt Vector with High Priority bit 2 position. */
+#define CPUINT_LVL1VEC_3_bm  (1<<3)  /* Interrupt Vector with High Priority bit 3 mask. */
+#define CPUINT_LVL1VEC_3_bp  3  /* Interrupt Vector with High Priority bit 3 position. */
+#define CPUINT_LVL1VEC_4_bm  (1<<4)  /* Interrupt Vector with High Priority bit 4 mask. */
+#define CPUINT_LVL1VEC_4_bp  4  /* Interrupt Vector with High Priority bit 4 position. */
+#define CPUINT_LVL1VEC_5_bm  (1<<5)  /* Interrupt Vector with High Priority bit 5 mask. */
+#define CPUINT_LVL1VEC_5_bp  5  /* Interrupt Vector with High Priority bit 5 position. */
+#define CPUINT_LVL1VEC_6_bm  (1<<6)  /* Interrupt Vector with High Priority bit 6 mask. */
+#define CPUINT_LVL1VEC_6_bp  6  /* Interrupt Vector with High Priority bit 6 position. */
+#define CPUINT_LVL1VEC_7_bm  (1<<7)  /* Interrupt Vector with High Priority bit 7 mask. */
+#define CPUINT_LVL1VEC_7_bp  7  /* Interrupt Vector with High Priority bit 7 position. */
+
+
+/* CRCSCAN - CRCSCAN */
+/* CRCSCAN.CTRLA  bit masks and bit positions */
+#define CRCSCAN_ENABLE_bm  0x01  /* Enable CRC scan bit mask. */
+#define CRCSCAN_ENABLE_bp  0  /* Enable CRC scan bit position. */
+#define CRCSCAN_NMIEN_bm  0x02  /* Enable NMI Trigger bit mask. */
+#define CRCSCAN_NMIEN_bp  1  /* Enable NMI Trigger bit position. */
+#define CRCSCAN_RESET_bm  0x80  /* Reset CRC scan bit mask. */
+#define CRCSCAN_RESET_bp  7  /* Reset CRC scan bit position. */
+
+/* CRCSCAN.CTRLB  bit masks and bit positions */
+#define CRCSCAN_SRC_gm  0x03  /* CRC Source group mask. */
+#define CRCSCAN_SRC_gp  0  /* CRC Source group position. */
+#define CRCSCAN_SRC_0_bm  (1<<0)  /* CRC Source bit 0 mask. */
+#define CRCSCAN_SRC_0_bp  0  /* CRC Source bit 0 position. */
+#define CRCSCAN_SRC_1_bm  (1<<1)  /* CRC Source bit 1 mask. */
+#define CRCSCAN_SRC_1_bp  1  /* CRC Source bit 1 position. */
+
+/* CRCSCAN.STATUS  bit masks and bit positions */
+#define CRCSCAN_BUSY_bm  0x01  /* CRC Busy bit mask. */
+#define CRCSCAN_BUSY_bp  0  /* CRC Busy bit position. */
+#define CRCSCAN_OK_bm  0x02  /* CRC Ok bit mask. */
+#define CRCSCAN_OK_bp  1  /* CRC Ok bit position. */
+
+
+/* DAC - Digital to Analog Converter */
+/* DAC.CTRLA  bit masks and bit positions */
+#define DAC_ENABLE_bm  0x01  /* DAC Enable bit mask. */
+#define DAC_ENABLE_bp  0  /* DAC Enable bit position. */
+#define DAC_OUTRANGE_gm  0x30  /* Output Buffer Range group mask. */
+#define DAC_OUTRANGE_gp  4  /* Output Buffer Range group position. */
+#define DAC_OUTRANGE_0_bm  (1<<4)  /* Output Buffer Range bit 0 mask. */
+#define DAC_OUTRANGE_0_bp  4  /* Output Buffer Range bit 0 position. */
+#define DAC_OUTRANGE_1_bm  (1<<5)  /* Output Buffer Range bit 1 mask. */
+#define DAC_OUTRANGE_1_bp  5  /* Output Buffer Range bit 1 position. */
+#define DAC_OUTEN_bm  0x40  /* Output Buffer Enable bit mask. */
+#define DAC_OUTEN_bp  6  /* Output Buffer Enable bit position. */
+#define DAC_RUNSTDBY_bm  0x80  /* Run in Standby Mode bit mask. */
+#define DAC_RUNSTDBY_bp  7  /* Run in Standby Mode bit position. */
+
+/* DAC.DATA  bit masks and bit positions */
+#define DAC_DATA_gm  0xFFC0  /* Data group mask. */
+#define DAC_DATA_gp  6  /* Data group position. */
+#define DAC_DATA_0_bm  (1<<6)  /* Data bit 0 mask. */
+#define DAC_DATA_0_bp  6  /* Data bit 0 position. */
+#define DAC_DATA_1_bm  (1<<7)  /* Data bit 1 mask. */
+#define DAC_DATA_1_bp  7  /* Data bit 1 position. */
+#define DAC_DATA_2_bm  (1<<8)  /* Data bit 2 mask. */
+#define DAC_DATA_2_bp  8  /* Data bit 2 position. */
+#define DAC_DATA_3_bm  (1<<9)  /* Data bit 3 mask. */
+#define DAC_DATA_3_bp  9  /* Data bit 3 position. */
+#define DAC_DATA_4_bm  (1<<10)  /* Data bit 4 mask. */
+#define DAC_DATA_4_bp  10  /* Data bit 4 position. */
+#define DAC_DATA_5_bm  (1<<11)  /* Data bit 5 mask. */
+#define DAC_DATA_5_bp  11  /* Data bit 5 position. */
+#define DAC_DATA_6_bm  (1<<12)  /* Data bit 6 mask. */
+#define DAC_DATA_6_bp  12  /* Data bit 6 position. */
+#define DAC_DATA_7_bm  (1<<13)  /* Data bit 7 mask. */
+#define DAC_DATA_7_bp  13  /* Data bit 7 position. */
+#define DAC_DATA_8_bm  (1<<14)  /* Data bit 8 mask. */
+#define DAC_DATA_8_bp  14  /* Data bit 8 position. */
+#define DAC_DATA_9_bm  (1<<15)  /* Data bit 9 mask. */
+#define DAC_DATA_9_bp  15  /* Data bit 9 position. */
+
+
+/* EVSYS - Event System */
+/* EVSYS.SWEVENTA  bit masks and bit positions */
+#define EVSYS_SWEVENTA_gm  0xFF  /* Software event on channel select group mask. */
+#define EVSYS_SWEVENTA_gp  0  /* Software event on channel select group position. */
+#define EVSYS_SWEVENTA_0_bm  (1<<0)  /* Software event on channel select bit 0 mask. */
+#define EVSYS_SWEVENTA_0_bp  0  /* Software event on channel select bit 0 position. */
+#define EVSYS_SWEVENTA_1_bm  (1<<1)  /* Software event on channel select bit 1 mask. */
+#define EVSYS_SWEVENTA_1_bp  1  /* Software event on channel select bit 1 position. */
+#define EVSYS_SWEVENTA_2_bm  (1<<2)  /* Software event on channel select bit 2 mask. */
+#define EVSYS_SWEVENTA_2_bp  2  /* Software event on channel select bit 2 position. */
+#define EVSYS_SWEVENTA_3_bm  (1<<3)  /* Software event on channel select bit 3 mask. */
+#define EVSYS_SWEVENTA_3_bp  3  /* Software event on channel select bit 3 position. */
+#define EVSYS_SWEVENTA_4_bm  (1<<4)  /* Software event on channel select bit 4 mask. */
+#define EVSYS_SWEVENTA_4_bp  4  /* Software event on channel select bit 4 position. */
+#define EVSYS_SWEVENTA_5_bm  (1<<5)  /* Software event on channel select bit 5 mask. */
+#define EVSYS_SWEVENTA_5_bp  5  /* Software event on channel select bit 5 position. */
+#define EVSYS_SWEVENTA_6_bm  (1<<6)  /* Software event on channel select bit 6 mask. */
+#define EVSYS_SWEVENTA_6_bp  6  /* Software event on channel select bit 6 position. */
+#define EVSYS_SWEVENTA_7_bm  (1<<7)  /* Software event on channel select bit 7 mask. */
+#define EVSYS_SWEVENTA_7_bp  7  /* Software event on channel select bit 7 position. */
+
+/* EVSYS.CHANNEL0  bit masks and bit positions */
+#define EVSYS_CHANNEL_gm  0xFF  /* Channel generator select group mask. */
+#define EVSYS_CHANNEL_gp  0  /* Channel generator select group position. */
+#define EVSYS_CHANNEL_0_bm  (1<<0)  /* Channel generator select bit 0 mask. */
+#define EVSYS_CHANNEL_0_bp  0  /* Channel generator select bit 0 position. */
+#define EVSYS_CHANNEL_1_bm  (1<<1)  /* Channel generator select bit 1 mask. */
+#define EVSYS_CHANNEL_1_bp  1  /* Channel generator select bit 1 position. */
+#define EVSYS_CHANNEL_2_bm  (1<<2)  /* Channel generator select bit 2 mask. */
+#define EVSYS_CHANNEL_2_bp  2  /* Channel generator select bit 2 position. */
+#define EVSYS_CHANNEL_3_bm  (1<<3)  /* Channel generator select bit 3 mask. */
+#define EVSYS_CHANNEL_3_bp  3  /* Channel generator select bit 3 position. */
+#define EVSYS_CHANNEL_4_bm  (1<<4)  /* Channel generator select bit 4 mask. */
+#define EVSYS_CHANNEL_4_bp  4  /* Channel generator select bit 4 position. */
+#define EVSYS_CHANNEL_5_bm  (1<<5)  /* Channel generator select bit 5 mask. */
+#define EVSYS_CHANNEL_5_bp  5  /* Channel generator select bit 5 position. */
+#define EVSYS_CHANNEL_6_bm  (1<<6)  /* Channel generator select bit 6 mask. */
+#define EVSYS_CHANNEL_6_bp  6  /* Channel generator select bit 6 position. */
+#define EVSYS_CHANNEL_7_bm  (1<<7)  /* Channel generator select bit 7 mask. */
+#define EVSYS_CHANNEL_7_bp  7  /* Channel generator select bit 7 position. */
+
+/* EVSYS.CHANNEL1  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.CHANNEL2  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.CHANNEL3  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.CHANNEL4  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.CHANNEL5  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.USERCCLLUT0A  bit masks and bit positions */
+#define EVSYS_USER_gm  0xFF  /* User channel select group mask. */
+#define EVSYS_USER_gp  0  /* User channel select group position. */
+#define EVSYS_USER_0_bm  (1<<0)  /* User channel select bit 0 mask. */
+#define EVSYS_USER_0_bp  0  /* User channel select bit 0 position. */
+#define EVSYS_USER_1_bm  (1<<1)  /* User channel select bit 1 mask. */
+#define EVSYS_USER_1_bp  1  /* User channel select bit 1 position. */
+#define EVSYS_USER_2_bm  (1<<2)  /* User channel select bit 2 mask. */
+#define EVSYS_USER_2_bp  2  /* User channel select bit 2 position. */
+#define EVSYS_USER_3_bm  (1<<3)  /* User channel select bit 3 mask. */
+#define EVSYS_USER_3_bp  3  /* User channel select bit 3 position. */
+#define EVSYS_USER_4_bm  (1<<4)  /* User channel select bit 4 mask. */
+#define EVSYS_USER_4_bp  4  /* User channel select bit 4 position. */
+#define EVSYS_USER_5_bm  (1<<5)  /* User channel select bit 5 mask. */
+#define EVSYS_USER_5_bp  5  /* User channel select bit 5 position. */
+#define EVSYS_USER_6_bm  (1<<6)  /* User channel select bit 6 mask. */
+#define EVSYS_USER_6_bp  6  /* User channel select bit 6 position. */
+#define EVSYS_USER_7_bm  (1<<7)  /* User channel select bit 7 mask. */
+#define EVSYS_USER_7_bp  7  /* User channel select bit 7 position. */
+
+/* EVSYS.USERCCLLUT0B  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT1A  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT1B  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT2A  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT2B  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT3A  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT3B  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERADC0START  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTC  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTD  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTF  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERUSART0IRDA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERUSART1IRDA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERUSART2IRDA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCA0CNTA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCA0CNTB  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCA1CNTA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCA1CNTB  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB0CAPT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB0COUNT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB1CAPT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB1COUNT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB2CAPT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB2COUNT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB3CAPT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB3COUNT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+
+/* FUSE - Fuses */
+/* FUSE.WDTCFG  bit masks and bit positions */
+#define FUSE_PERIOD_gm  0x0F  /* Watchdog Timeout Period group mask. */
+#define FUSE_PERIOD_gp  0  /* Watchdog Timeout Period group position. */
+#define FUSE_PERIOD_0_bm  (1<<0)  /* Watchdog Timeout Period bit 0 mask. */
+#define FUSE_PERIOD_0_bp  0  /* Watchdog Timeout Period bit 0 position. */
+#define FUSE_PERIOD_1_bm  (1<<1)  /* Watchdog Timeout Period bit 1 mask. */
+#define FUSE_PERIOD_1_bp  1  /* Watchdog Timeout Period bit 1 position. */
+#define FUSE_PERIOD_2_bm  (1<<2)  /* Watchdog Timeout Period bit 2 mask. */
+#define FUSE_PERIOD_2_bp  2  /* Watchdog Timeout Period bit 2 position. */
+#define FUSE_PERIOD_3_bm  (1<<3)  /* Watchdog Timeout Period bit 3 mask. */
+#define FUSE_PERIOD_3_bp  3  /* Watchdog Timeout Period bit 3 position. */
+#define FUSE_WINDOW_gm  0xF0  /* Watchdog Window Timeout Period group mask. */
+#define FUSE_WINDOW_gp  4  /* Watchdog Window Timeout Period group position. */
+#define FUSE_WINDOW_0_bm  (1<<4)  /* Watchdog Window Timeout Period bit 0 mask. */
+#define FUSE_WINDOW_0_bp  4  /* Watchdog Window Timeout Period bit 0 position. */
+#define FUSE_WINDOW_1_bm  (1<<5)  /* Watchdog Window Timeout Period bit 1 mask. */
+#define FUSE_WINDOW_1_bp  5  /* Watchdog Window Timeout Period bit 1 position. */
+#define FUSE_WINDOW_2_bm  (1<<6)  /* Watchdog Window Timeout Period bit 2 mask. */
+#define FUSE_WINDOW_2_bp  6  /* Watchdog Window Timeout Period bit 2 position. */
+#define FUSE_WINDOW_3_bm  (1<<7)  /* Watchdog Window Timeout Period bit 3 mask. */
+#define FUSE_WINDOW_3_bp  7  /* Watchdog Window Timeout Period bit 3 position. */
+
+/* FUSE.BODCFG  bit masks and bit positions */
+#define FUSE_SLEEP_gm  0x03  /* BOD Operation in Sleep Mode group mask. */
+#define FUSE_SLEEP_gp  0  /* BOD Operation in Sleep Mode group position. */
+#define FUSE_SLEEP_0_bm  (1<<0)  /* BOD Operation in Sleep Mode bit 0 mask. */
+#define FUSE_SLEEP_0_bp  0  /* BOD Operation in Sleep Mode bit 0 position. */
+#define FUSE_SLEEP_1_bm  (1<<1)  /* BOD Operation in Sleep Mode bit 1 mask. */
+#define FUSE_SLEEP_1_bp  1  /* BOD Operation in Sleep Mode bit 1 position. */
+#define FUSE_ACTIVE_gm  0x0C  /* BOD Operation in Active Mode group mask. */
+#define FUSE_ACTIVE_gp  2  /* BOD Operation in Active Mode group position. */
+#define FUSE_ACTIVE_0_bm  (1<<2)  /* BOD Operation in Active Mode bit 0 mask. */
+#define FUSE_ACTIVE_0_bp  2  /* BOD Operation in Active Mode bit 0 position. */
+#define FUSE_ACTIVE_1_bm  (1<<3)  /* BOD Operation in Active Mode bit 1 mask. */
+#define FUSE_ACTIVE_1_bp  3  /* BOD Operation in Active Mode bit 1 position. */
+#define FUSE_SAMPFREQ_bm  0x10  /* BOD Sample Frequency bit mask. */
+#define FUSE_SAMPFREQ_bp  4  /* BOD Sample Frequency bit position. */
+#define FUSE_LVL_gm  0xE0  /* BOD Level group mask. */
+#define FUSE_LVL_gp  5  /* BOD Level group position. */
+#define FUSE_LVL_0_bm  (1<<5)  /* BOD Level bit 0 mask. */
+#define FUSE_LVL_0_bp  5  /* BOD Level bit 0 position. */
+#define FUSE_LVL_1_bm  (1<<6)  /* BOD Level bit 1 mask. */
+#define FUSE_LVL_1_bp  6  /* BOD Level bit 1 position. */
+#define FUSE_LVL_2_bm  (1<<7)  /* BOD Level bit 2 mask. */
+#define FUSE_LVL_2_bp  7  /* BOD Level bit 2 position. */
+
+/* FUSE.OSCCFG  bit masks and bit positions */
+#define FUSE_OSCHFFRQ_bm  0x08  /* High-frequency Oscillator Frequency bit mask. */
+#define FUSE_OSCHFFRQ_bp  3  /* High-frequency Oscillator Frequency bit position. */
+
+/* FUSE.SYSCFG0  bit masks and bit positions */
+#define FUSE_EESAVE_bm  0x01  /* EEPROM Save bit mask. */
+#define FUSE_EESAVE_bp  0  /* EEPROM Save bit position. */
+#define FUSE_RSTPINCFG_bm  0x08  /* Reset Pin Configuration bit mask. */
+#define FUSE_RSTPINCFG_bp  3  /* Reset Pin Configuration bit position. */
+#define FUSE_UPDIPINCFG_bm  0x10  /* UPDI Pin Configuration bit mask. */
+#define FUSE_UPDIPINCFG_bp  4  /* UPDI Pin Configuration bit position. */
+#define FUSE_CRCSEL_bm  0x20  /* CRC Select bit mask. */
+#define FUSE_CRCSEL_bp  5  /* CRC Select bit position. */
+#define FUSE_CRCSRC_gm  0xC0  /* CRC Source group mask. */
+#define FUSE_CRCSRC_gp  6  /* CRC Source group position. */
+#define FUSE_CRCSRC_0_bm  (1<<6)  /* CRC Source bit 0 mask. */
+#define FUSE_CRCSRC_0_bp  6  /* CRC Source bit 0 position. */
+#define FUSE_CRCSRC_1_bm  (1<<7)  /* CRC Source bit 1 mask. */
+#define FUSE_CRCSRC_1_bp  7  /* CRC Source bit 1 position. */
+
+/* FUSE.SYSCFG1  bit masks and bit positions */
+#define FUSE_SUT_gm  0x07  /* Startup Time group mask. */
+#define FUSE_SUT_gp  0  /* Startup Time group position. */
+#define FUSE_SUT_0_bm  (1<<0)  /* Startup Time bit 0 mask. */
+#define FUSE_SUT_0_bp  0  /* Startup Time bit 0 position. */
+#define FUSE_SUT_1_bm  (1<<1)  /* Startup Time bit 1 mask. */
+#define FUSE_SUT_1_bp  1  /* Startup Time bit 1 position. */
+#define FUSE_SUT_2_bm  (1<<2)  /* Startup Time bit 2 mask. */
+#define FUSE_SUT_2_bp  2  /* Startup Time bit 2 position. */
+
+
+
+/* LOCK - Lockbits */
+/* LOCK.KEY  bit masks and bit positions */
+#define LOCK_KEY_gm  0xFFFFFFFF  /* Lock Key group mask. */
+#define LOCK_KEY_gp  0  /* Lock Key group position. */
+#define LOCK_KEY_0_bm  (1<<0)  /* Lock Key bit 0 mask. */
+#define LOCK_KEY_0_bp  0  /* Lock Key bit 0 position. */
+#define LOCK_KEY_1_bm  (1<<1)  /* Lock Key bit 1 mask. */
+#define LOCK_KEY_1_bp  1  /* Lock Key bit 1 position. */
+#define LOCK_KEY_2_bm  (1<<2)  /* Lock Key bit 2 mask. */
+#define LOCK_KEY_2_bp  2  /* Lock Key bit 2 position. */
+#define LOCK_KEY_3_bm  (1<<3)  /* Lock Key bit 3 mask. */
+#define LOCK_KEY_3_bp  3  /* Lock Key bit 3 position. */
+#define LOCK_KEY_4_bm  (1<<4)  /* Lock Key bit 4 mask. */
+#define LOCK_KEY_4_bp  4  /* Lock Key bit 4 position. */
+#define LOCK_KEY_5_bm  (1<<5)  /* Lock Key bit 5 mask. */
+#define LOCK_KEY_5_bp  5  /* Lock Key bit 5 position. */
+#define LOCK_KEY_6_bm  (1<<6)  /* Lock Key bit 6 mask. */
+#define LOCK_KEY_6_bp  6  /* Lock Key bit 6 position. */
+#define LOCK_KEY_7_bm  (1<<7)  /* Lock Key bit 7 mask. */
+#define LOCK_KEY_7_bp  7  /* Lock Key bit 7 position. */
+#define LOCK_KEY_8_bm  (1<<8)  /* Lock Key bit 8 mask. */
+#define LOCK_KEY_8_bp  8  /* Lock Key bit 8 position. */
+#define LOCK_KEY_9_bm  (1<<9)  /* Lock Key bit 9 mask. */
+#define LOCK_KEY_9_bp  9  /* Lock Key bit 9 position. */
+#define LOCK_KEY_10_bm  (1<<10)  /* Lock Key bit 10 mask. */
+#define LOCK_KEY_10_bp  10  /* Lock Key bit 10 position. */
+#define LOCK_KEY_11_bm  (1<<11)  /* Lock Key bit 11 mask. */
+#define LOCK_KEY_11_bp  11  /* Lock Key bit 11 position. */
+#define LOCK_KEY_12_bm  (1<<12)  /* Lock Key bit 12 mask. */
+#define LOCK_KEY_12_bp  12  /* Lock Key bit 12 position. */
+#define LOCK_KEY_13_bm  (1<<13)  /* Lock Key bit 13 mask. */
+#define LOCK_KEY_13_bp  13  /* Lock Key bit 13 position. */
+#define LOCK_KEY_14_bm  (1<<14)  /* Lock Key bit 14 mask. */
+#define LOCK_KEY_14_bp  14  /* Lock Key bit 14 position. */
+#define LOCK_KEY_15_bm  (1<<15)  /* Lock Key bit 15 mask. */
+#define LOCK_KEY_15_bp  15  /* Lock Key bit 15 position. */
+#define LOCK_KEY_16_bm  (1<<16)  /* Lock Key bit 16 mask. */
+#define LOCK_KEY_16_bp  16  /* Lock Key bit 16 position. */
+#define LOCK_KEY_17_bm  (1<<17)  /* Lock Key bit 17 mask. */
+#define LOCK_KEY_17_bp  17  /* Lock Key bit 17 position. */
+#define LOCK_KEY_18_bm  (1<<18)  /* Lock Key bit 18 mask. */
+#define LOCK_KEY_18_bp  18  /* Lock Key bit 18 position. */
+#define LOCK_KEY_19_bm  (1<<19)  /* Lock Key bit 19 mask. */
+#define LOCK_KEY_19_bp  19  /* Lock Key bit 19 position. */
+#define LOCK_KEY_20_bm  (1<<20)  /* Lock Key bit 20 mask. */
+#define LOCK_KEY_20_bp  20  /* Lock Key bit 20 position. */
+#define LOCK_KEY_21_bm  (1<<21)  /* Lock Key bit 21 mask. */
+#define LOCK_KEY_21_bp  21  /* Lock Key bit 21 position. */
+#define LOCK_KEY_22_bm  (1<<22)  /* Lock Key bit 22 mask. */
+#define LOCK_KEY_22_bp  22  /* Lock Key bit 22 position. */
+#define LOCK_KEY_23_bm  (1<<23)  /* Lock Key bit 23 mask. */
+#define LOCK_KEY_23_bp  23  /* Lock Key bit 23 position. */
+#define LOCK_KEY_24_bm  (1<<24)  /* Lock Key bit 24 mask. */
+#define LOCK_KEY_24_bp  24  /* Lock Key bit 24 position. */
+#define LOCK_KEY_25_bm  (1<<25)  /* Lock Key bit 25 mask. */
+#define LOCK_KEY_25_bp  25  /* Lock Key bit 25 position. */
+#define LOCK_KEY_26_bm  (1<<26)  /* Lock Key bit 26 mask. */
+#define LOCK_KEY_26_bp  26  /* Lock Key bit 26 position. */
+#define LOCK_KEY_27_bm  (1<<27)  /* Lock Key bit 27 mask. */
+#define LOCK_KEY_27_bp  27  /* Lock Key bit 27 position. */
+#define LOCK_KEY_28_bm  (1<<28)  /* Lock Key bit 28 mask. */
+#define LOCK_KEY_28_bp  28  /* Lock Key bit 28 position. */
+#define LOCK_KEY_29_bm  (1<<29)  /* Lock Key bit 29 mask. */
+#define LOCK_KEY_29_bp  29  /* Lock Key bit 29 position. */
+#define LOCK_KEY_30_bm  (1<<30)  /* Lock Key bit 30 mask. */
+#define LOCK_KEY_30_bp  30  /* Lock Key bit 30 position. */
+#define LOCK_KEY_31_bm  (1<<31)  /* Lock Key bit 31 mask. */
+#define LOCK_KEY_31_bp  31  /* Lock Key bit 31 position. */
+
+
+/* NVMCTRL - Non-volatile Memory Controller */
+/* NVMCTRL.CTRLA  bit masks and bit positions */
+#define NVMCTRL_CMD_gm  0x7F  /* Command group mask. */
+#define NVMCTRL_CMD_gp  0  /* Command group position. */
+#define NVMCTRL_CMD_0_bm  (1<<0)  /* Command bit 0 mask. */
+#define NVMCTRL_CMD_0_bp  0  /* Command bit 0 position. */
+#define NVMCTRL_CMD_1_bm  (1<<1)  /* Command bit 1 mask. */
+#define NVMCTRL_CMD_1_bp  1  /* Command bit 1 position. */
+#define NVMCTRL_CMD_2_bm  (1<<2)  /* Command bit 2 mask. */
+#define NVMCTRL_CMD_2_bp  2  /* Command bit 2 position. */
+#define NVMCTRL_CMD_3_bm  (1<<3)  /* Command bit 3 mask. */
+#define NVMCTRL_CMD_3_bp  3  /* Command bit 3 position. */
+#define NVMCTRL_CMD_4_bm  (1<<4)  /* Command bit 4 mask. */
+#define NVMCTRL_CMD_4_bp  4  /* Command bit 4 position. */
+#define NVMCTRL_CMD_5_bm  (1<<5)  /* Command bit 5 mask. */
+#define NVMCTRL_CMD_5_bp  5  /* Command bit 5 position. */
+#define NVMCTRL_CMD_6_bm  (1<<6)  /* Command bit 6 mask. */
+#define NVMCTRL_CMD_6_bp  6  /* Command bit 6 position. */
+
+/* NVMCTRL.CTRLB  bit masks and bit positions */
+#define NVMCTRL_APPCODEWP_bm  0x01  /* Application Code Write Protect bit mask. */
+#define NVMCTRL_APPCODEWP_bp  0  /* Application Code Write Protect bit position. */
+#define NVMCTRL_BOOTRP_bm  0x02  /* Boot Read Protect bit mask. */
+#define NVMCTRL_BOOTRP_bp  1  /* Boot Read Protect bit position. */
+#define NVMCTRL_APPDATAWP_bm  0x04  /* Application Data Write Protect bit mask. */
+#define NVMCTRL_APPDATAWP_bp  2  /* Application Data Write Protect bit position. */
+#define NVMCTRL_EEWP_bm  0x08  /* EEPROM Write Protect bit mask. */
+#define NVMCTRL_EEWP_bp  3  /* EEPROM Write Protect bit position. */
+#define NVMCTRL_FLMAP_gm  0x30  /* Flash Mapping in Data space group mask. */
+#define NVMCTRL_FLMAP_gp  4  /* Flash Mapping in Data space group position. */
+#define NVMCTRL_FLMAP_0_bm  (1<<4)  /* Flash Mapping in Data space bit 0 mask. */
+#define NVMCTRL_FLMAP_0_bp  4  /* Flash Mapping in Data space bit 0 position. */
+#define NVMCTRL_FLMAP_1_bm  (1<<5)  /* Flash Mapping in Data space bit 1 mask. */
+#define NVMCTRL_FLMAP_1_bp  5  /* Flash Mapping in Data space bit 1 position. */
+#define NVMCTRL_FLMAPLOCK_bm  0x80  /* Flash Mapping Lock bit mask. */
+#define NVMCTRL_FLMAPLOCK_bp  7  /* Flash Mapping Lock bit position. */
+
+/* NVMCTRL.INTCTRL  bit masks and bit positions */
+#define NVMCTRL_EEREADY_bm  0x01  /* EEPROM Ready bit mask. */
+#define NVMCTRL_EEREADY_bp  0  /* EEPROM Ready bit position. */
+#define NVMCTRL_FLREADY_bm  0x02  /* Flash Ready bit mask. */
+#define NVMCTRL_FLREADY_bp  1  /* Flash Ready bit position. */
+
+/* NVMCTRL.INTFLAGS  bit masks and bit positions */
+/* NVMCTRL_EEREADY  is already defined. */
+/* NVMCTRL_FLREADY  is already defined. */
+
+/* NVMCTRL.STATUS  bit masks and bit positions */
+#define NVMCTRL_EEBUSY_bm  0x01  /* EEPROM busy bit mask. */
+#define NVMCTRL_EEBUSY_bp  0  /* EEPROM busy bit position. */
+#define NVMCTRL_FLBUSY_bm  0x02  /* Flash busy bit mask. */
+#define NVMCTRL_FLBUSY_bp  1  /* Flash busy bit position. */
+#define NVMCTRL_ERROR_gm  0x70  /* Write error group mask. */
+#define NVMCTRL_ERROR_gp  4  /* Write error group position. */
+#define NVMCTRL_ERROR_0_bm  (1<<4)  /* Write error bit 0 mask. */
+#define NVMCTRL_ERROR_0_bp  4  /* Write error bit 0 position. */
+#define NVMCTRL_ERROR_1_bm  (1<<5)  /* Write error bit 1 mask. */
+#define NVMCTRL_ERROR_1_bp  5  /* Write error bit 1 position. */
+#define NVMCTRL_ERROR_2_bm  (1<<6)  /* Write error bit 2 mask. */
+#define NVMCTRL_ERROR_2_bp  6  /* Write error bit 2 position. */
+
+
+/* PORT - I/O Ports */
+/* PORT.INTFLAGS  bit masks and bit positions */
+#define PORT_INT_gm  0xFF  /* Pin Interrupt Flag group mask. */
+#define PORT_INT_gp  0  /* Pin Interrupt Flag group position. */
+#define PORT_INT_0_bm  (1<<0)  /* Pin Interrupt Flag bit 0 mask. */
+#define PORT_INT_0_bp  0  /* Pin Interrupt Flag bit 0 position. */
+#define PORT_INT0_bm  PORT_INT_0_bm  /* This define is deprecated and should not be used */
+#define PORT_INT0_bp  PORT_INT_0_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_1_bm  (1<<1)  /* Pin Interrupt Flag bit 1 mask. */
+#define PORT_INT_1_bp  1  /* Pin Interrupt Flag bit 1 position. */
+#define PORT_INT1_bm  PORT_INT_1_bm  /* This define is deprecated and should not be used */
+#define PORT_INT1_bp  PORT_INT_1_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_2_bm  (1<<2)  /* Pin Interrupt Flag bit 2 mask. */
+#define PORT_INT_2_bp  2  /* Pin Interrupt Flag bit 2 position. */
+#define PORT_INT2_bm  PORT_INT_2_bm  /* This define is deprecated and should not be used */
+#define PORT_INT2_bp  PORT_INT_2_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_3_bm  (1<<3)  /* Pin Interrupt Flag bit 3 mask. */
+#define PORT_INT_3_bp  3  /* Pin Interrupt Flag bit 3 position. */
+#define PORT_INT3_bm  PORT_INT_3_bm  /* This define is deprecated and should not be used */
+#define PORT_INT3_bp  PORT_INT_3_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_4_bm  (1<<4)  /* Pin Interrupt Flag bit 4 mask. */
+#define PORT_INT_4_bp  4  /* Pin Interrupt Flag bit 4 position. */
+#define PORT_INT4_bm  PORT_INT_4_bm  /* This define is deprecated and should not be used */
+#define PORT_INT4_bp  PORT_INT_4_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_5_bm  (1<<5)  /* Pin Interrupt Flag bit 5 mask. */
+#define PORT_INT_5_bp  5  /* Pin Interrupt Flag bit 5 position. */
+#define PORT_INT5_bm  PORT_INT_5_bm  /* This define is deprecated and should not be used */
+#define PORT_INT5_bp  PORT_INT_5_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_6_bm  (1<<6)  /* Pin Interrupt Flag bit 6 mask. */
+#define PORT_INT_6_bp  6  /* Pin Interrupt Flag bit 6 position. */
+#define PORT_INT6_bm  PORT_INT_6_bm  /* This define is deprecated and should not be used */
+#define PORT_INT6_bp  PORT_INT_6_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_7_bm  (1<<7)  /* Pin Interrupt Flag bit 7 mask. */
+#define PORT_INT_7_bp  7  /* Pin Interrupt Flag bit 7 position. */
+#define PORT_INT7_bm  PORT_INT_7_bm  /* This define is deprecated and should not be used */
+#define PORT_INT7_bp  PORT_INT_7_bp  /* This define is deprecated and should not be used */
+
+/* PORT.PORTCTRL  bit masks and bit positions */
+#define PORT_SRL_bm  0x01  /* Slew Rate Limit Enable bit mask. */
+#define PORT_SRL_bp  0  /* Slew Rate Limit Enable bit position. */
+
+/* PORT.PINCONFIG  bit masks and bit positions */
+#define PORT_ISC_gm  0x07  /* Input/Sense Configuration group mask. */
+#define PORT_ISC_gp  0  /* Input/Sense Configuration group position. */
+#define PORT_ISC_0_bm  (1<<0)  /* Input/Sense Configuration bit 0 mask. */
+#define PORT_ISC_0_bp  0  /* Input/Sense Configuration bit 0 position. */
+#define PORT_ISC_1_bm  (1<<1)  /* Input/Sense Configuration bit 1 mask. */
+#define PORT_ISC_1_bp  1  /* Input/Sense Configuration bit 1 position. */
+#define PORT_ISC_2_bm  (1<<2)  /* Input/Sense Configuration bit 2 mask. */
+#define PORT_ISC_2_bp  2  /* Input/Sense Configuration bit 2 position. */
+#define PORT_PULLUPEN_bm  0x08  /* Pullup enable bit mask. */
+#define PORT_PULLUPEN_bp  3  /* Pullup enable bit position. */
+#define PORT_INLVL_bm  0x40  /* Input Level Select bit mask. */
+#define PORT_INLVL_bp  6  /* Input Level Select bit position. */
+#define PORT_INVEN_bm  0x80  /* Inverted I/O Enable bit mask. */
+#define PORT_INVEN_bp  7  /* Inverted I/O Enable bit position. */
+
+/* PORT.PIN0CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN1CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN2CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN3CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN4CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN5CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN6CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN7CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.EVGENCTRL  bit masks and bit positions */
+#define PORT_EVGEN0SEL_gm  0x07  /* Event Generator 0 Select group mask. */
+#define PORT_EVGEN0SEL_gp  0  /* Event Generator 0 Select group position. */
+#define PORT_EVGEN0SEL_0_bm  (1<<0)  /* Event Generator 0 Select bit 0 mask. */
+#define PORT_EVGEN0SEL_0_bp  0  /* Event Generator 0 Select bit 0 position. */
+#define PORT_EVGEN0SEL_1_bm  (1<<1)  /* Event Generator 0 Select bit 1 mask. */
+#define PORT_EVGEN0SEL_1_bp  1  /* Event Generator 0 Select bit 1 position. */
+#define PORT_EVGEN0SEL_2_bm  (1<<2)  /* Event Generator 0 Select bit 2 mask. */
+#define PORT_EVGEN0SEL_2_bp  2  /* Event Generator 0 Select bit 2 position. */
+#define PORT_EVGEN1SEL_gm  0x70  /* Event Generator 1 Select group mask. */
+#define PORT_EVGEN1SEL_gp  4  /* Event Generator 1 Select group position. */
+#define PORT_EVGEN1SEL_0_bm  (1<<4)  /* Event Generator 1 Select bit 0 mask. */
+#define PORT_EVGEN1SEL_0_bp  4  /* Event Generator 1 Select bit 0 position. */
+#define PORT_EVGEN1SEL_1_bm  (1<<5)  /* Event Generator 1 Select bit 1 mask. */
+#define PORT_EVGEN1SEL_1_bp  5  /* Event Generator 1 Select bit 1 position. */
+#define PORT_EVGEN1SEL_2_bm  (1<<6)  /* Event Generator 1 Select bit 2 mask. */
+#define PORT_EVGEN1SEL_2_bp  6  /* Event Generator 1 Select bit 2 position. */
+
+
+/* PORTMUX - Port Multiplexer */
+/* PORTMUX.EVSYSROUTEA  bit masks and bit positions */
+#define PORTMUX_EVOUTA_bm  0x01  /* Event Output A bit mask. */
+#define PORTMUX_EVOUTA_bp  0  /* Event Output A bit position. */
+#define PORTMUX_EVOUTC_bm  0x04  /* Event Output C bit mask. */
+#define PORTMUX_EVOUTC_bp  2  /* Event Output C bit position. */
+#define PORTMUX_EVOUTD_bm  0x08  /* Event Output D bit mask. */
+#define PORTMUX_EVOUTD_bp  3  /* Event Output D bit position. */
+#define PORTMUX_EVOUTF_bm  0x20  /* Event Output F bit mask. */
+#define PORTMUX_EVOUTF_bp  5  /* Event Output F bit position. */
+
+/* PORTMUX.CCLROUTEA  bit masks and bit positions */
+#define PORTMUX_LUT0_bm  0x01  /* CCL Look-Up Table 0 Signals bit mask. */
+#define PORTMUX_LUT0_bp  0  /* CCL Look-Up Table 0 Signals bit position. */
+#define PORTMUX_LUT1_bm  0x02  /* CCL Look-Up Table 1 Signals bit mask. */
+#define PORTMUX_LUT1_bp  1  /* CCL Look-Up Table 1 Signals bit position. */
+#define PORTMUX_LUT2_bm  0x04  /* CCL Look-Up Table 2 Signals bit mask. */
+#define PORTMUX_LUT2_bp  2  /* CCL Look-Up Table 2 Signals bit position. */
+
+/* PORTMUX.USARTROUTEA  bit masks and bit positions */
+#define PORTMUX_USART0_gm  0x07  /* USART0 Routing group mask. */
+#define PORTMUX_USART0_gp  0  /* USART0 Routing group position. */
+#define PORTMUX_USART0_0_bm  (1<<0)  /* USART0 Routing bit 0 mask. */
+#define PORTMUX_USART0_0_bp  0  /* USART0 Routing bit 0 position. */
+#define PORTMUX_USART0_1_bm  (1<<1)  /* USART0 Routing bit 1 mask. */
+#define PORTMUX_USART0_1_bp  1  /* USART0 Routing bit 1 position. */
+#define PORTMUX_USART0_2_bm  (1<<2)  /* USART0 Routing bit 2 mask. */
+#define PORTMUX_USART0_2_bp  2  /* USART0 Routing bit 2 position. */
+#define PORTMUX_USART1_gm  0x18  /* USART1 Routing group mask. */
+#define PORTMUX_USART1_gp  3  /* USART1 Routing group position. */
+#define PORTMUX_USART1_0_bm  (1<<3)  /* USART1 Routing bit 0 mask. */
+#define PORTMUX_USART1_0_bp  3  /* USART1 Routing bit 0 position. */
+#define PORTMUX_USART1_1_bm  (1<<4)  /* USART1 Routing bit 1 mask. */
+#define PORTMUX_USART1_1_bp  4  /* USART1 Routing bit 1 position. */
+
+/* PORTMUX.USARTROUTEB  bit masks and bit positions */
+#define PORTMUX_USART2_gm  0x03  /* USART2 Routing group mask. */
+#define PORTMUX_USART2_gp  0  /* USART2 Routing group position. */
+#define PORTMUX_USART2_0_bm  (1<<0)  /* USART2 Routing bit 0 mask. */
+#define PORTMUX_USART2_0_bp  0  /* USART2 Routing bit 0 position. */
+#define PORTMUX_USART2_1_bm  (1<<1)  /* USART2 Routing bit 1 mask. */
+#define PORTMUX_USART2_1_bp  1  /* USART2 Routing bit 1 position. */
+
+/* PORTMUX.SPIROUTEA  bit masks and bit positions */
+#define PORTMUX_SPI0_gm  0x07  /* SPI0 Signals group mask. */
+#define PORTMUX_SPI0_gp  0  /* SPI0 Signals group position. */
+#define PORTMUX_SPI0_0_bm  (1<<0)  /* SPI0 Signals bit 0 mask. */
+#define PORTMUX_SPI0_0_bp  0  /* SPI0 Signals bit 0 position. */
+#define PORTMUX_SPI0_1_bm  (1<<1)  /* SPI0 Signals bit 1 mask. */
+#define PORTMUX_SPI0_1_bp  1  /* SPI0 Signals bit 1 position. */
+#define PORTMUX_SPI0_2_bm  (1<<2)  /* SPI0 Signals bit 2 mask. */
+#define PORTMUX_SPI0_2_bp  2  /* SPI0 Signals bit 2 position. */
+
+/* PORTMUX.TWIROUTEA  bit masks and bit positions */
+#define PORTMUX_TWI0_gm  0x03  /* TWI0 Signals group mask. */
+#define PORTMUX_TWI0_gp  0  /* TWI0 Signals group position. */
+#define PORTMUX_TWI0_0_bm  (1<<0)  /* TWI0 Signals bit 0 mask. */
+#define PORTMUX_TWI0_0_bp  0  /* TWI0 Signals bit 0 position. */
+#define PORTMUX_TWI0_1_bm  (1<<1)  /* TWI0 Signals bit 1 mask. */
+#define PORTMUX_TWI0_1_bp  1  /* TWI0 Signals bit 1 position. */
+
+/* PORTMUX.TCAROUTEA  bit masks and bit positions */
+#define PORTMUX_TCA0_gm  0x07  /* TCA0 Signals group mask. */
+#define PORTMUX_TCA0_gp  0  /* TCA0 Signals group position. */
+#define PORTMUX_TCA0_0_bm  (1<<0)  /* TCA0 Signals bit 0 mask. */
+#define PORTMUX_TCA0_0_bp  0  /* TCA0 Signals bit 0 position. */
+#define PORTMUX_TCA0_1_bm  (1<<1)  /* TCA0 Signals bit 1 mask. */
+#define PORTMUX_TCA0_1_bp  1  /* TCA0 Signals bit 1 position. */
+#define PORTMUX_TCA0_2_bm  (1<<2)  /* TCA0 Signals bit 2 mask. */
+#define PORTMUX_TCA0_2_bp  2  /* TCA0 Signals bit 2 position. */
+#define PORTMUX_TCA1_gm  0x38  /* TCA1 Signals group mask. */
+#define PORTMUX_TCA1_gp  3  /* TCA1 Signals group position. */
+#define PORTMUX_TCA1_0_bm  (1<<3)  /* TCA1 Signals bit 0 mask. */
+#define PORTMUX_TCA1_0_bp  3  /* TCA1 Signals bit 0 position. */
+#define PORTMUX_TCA1_1_bm  (1<<4)  /* TCA1 Signals bit 1 mask. */
+#define PORTMUX_TCA1_1_bp  4  /* TCA1 Signals bit 1 position. */
+#define PORTMUX_TCA1_2_bm  (1<<5)  /* TCA1 Signals bit 2 mask. */
+#define PORTMUX_TCA1_2_bp  5  /* TCA1 Signals bit 2 position. */
+
+/* PORTMUX.TCBROUTEA  bit masks and bit positions */
+#define PORTMUX_TCB0_bm  0x01  /* TCB0 Output bit mask. */
+#define PORTMUX_TCB0_bp  0  /* TCB0 Output bit position. */
+#define PORTMUX_TCB1_bm  0x02  /* TCB1 Output bit mask. */
+#define PORTMUX_TCB1_bp  1  /* TCB1 Output bit position. */
+#define PORTMUX_TCB2_bm  0x04  /* TCB2 Output bit mask. */
+#define PORTMUX_TCB2_bp  2  /* TCB2 Output bit position. */
+#define PORTMUX_TCB3_bm  0x08  /* TCB3 Output bit mask. */
+#define PORTMUX_TCB3_bp  3  /* TCB3 Output bit position. */
+
+/* PORTMUX.ACROUTEA  bit masks and bit positions */
+#define PORTMUX_AC0_bm  0x01  /* Analog Comparator 0 Output bit mask. */
+#define PORTMUX_AC0_bp  0  /* Analog Comparator 0 Output bit position. */
+#define PORTMUX_AC1_bm  0x02  /* Analog Comparator 1 Output bit mask. */
+#define PORTMUX_AC1_bp  1  /* Analog Comparator 1 Output bit position. */
+
+
+/* RSTCTRL - Reset controller */
+/* RSTCTRL.RSTFR  bit masks and bit positions */
+#define RSTCTRL_PORF_bm  0x01  /* Power on Reset flag bit mask. */
+#define RSTCTRL_PORF_bp  0  /* Power on Reset flag bit position. */
+#define RSTCTRL_BORF_bm  0x02  /* Brown out detector Reset flag bit mask. */
+#define RSTCTRL_BORF_bp  1  /* Brown out detector Reset flag bit position. */
+#define RSTCTRL_EXTRF_bm  0x04  /* External Reset flag bit mask. */
+#define RSTCTRL_EXTRF_bp  2  /* External Reset flag bit position. */
+#define RSTCTRL_WDRF_bm  0x08  /* Watch dog Reset flag bit mask. */
+#define RSTCTRL_WDRF_bp  3  /* Watch dog Reset flag bit position. */
+#define RSTCTRL_SWRF_bm  0x10  /* Software Reset flag bit mask. */
+#define RSTCTRL_SWRF_bp  4  /* Software Reset flag bit position. */
+#define RSTCTRL_UPDIRF_bm  0x20  /* UPDI Reset flag bit mask. */
+#define RSTCTRL_UPDIRF_bp  5  /* UPDI Reset flag bit position. */
+
+/* RSTCTRL.SWRR  bit masks and bit positions */
+#define RSTCTRL_SWRE_bm  0x01  /* Software Reset Enable bit mask. */
+#define RSTCTRL_SWRE_bp  0  /* Software Reset Enable bit position. */
+
+
+/* RTC - Real-Time Counter */
+/* RTC.CTRLA  bit masks and bit positions */
+#define RTC_RTCEN_bm  0x01  /* Enable bit mask. */
+#define RTC_RTCEN_bp  0  /* Enable bit position. */
+#define RTC_CORREN_bm  0x04  /* Correction enable bit mask. */
+#define RTC_CORREN_bp  2  /* Correction enable bit position. */
+#define RTC_PRESCALER_gm  0x78  /* Prescaling Factor group mask. */
+#define RTC_PRESCALER_gp  3  /* Prescaling Factor group position. */
+#define RTC_PRESCALER_0_bm  (1<<3)  /* Prescaling Factor bit 0 mask. */
+#define RTC_PRESCALER_0_bp  3  /* Prescaling Factor bit 0 position. */
+#define RTC_PRESCALER_1_bm  (1<<4)  /* Prescaling Factor bit 1 mask. */
+#define RTC_PRESCALER_1_bp  4  /* Prescaling Factor bit 1 position. */
+#define RTC_PRESCALER_2_bm  (1<<5)  /* Prescaling Factor bit 2 mask. */
+#define RTC_PRESCALER_2_bp  5  /* Prescaling Factor bit 2 position. */
+#define RTC_PRESCALER_3_bm  (1<<6)  /* Prescaling Factor bit 3 mask. */
+#define RTC_PRESCALER_3_bp  6  /* Prescaling Factor bit 3 position. */
+#define RTC_RUNSTDBY_bm  0x80  /* Run In Standby bit mask. */
+#define RTC_RUNSTDBY_bp  7  /* Run In Standby bit position. */
+
+/* RTC.STATUS  bit masks and bit positions */
+#define RTC_CTRLABUSY_bm  0x01  /* CTRLA Synchronization Busy Flag bit mask. */
+#define RTC_CTRLABUSY_bp  0  /* CTRLA Synchronization Busy Flag bit position. */
+#define RTC_CNTBUSY_bm  0x02  /* Count Synchronization Busy Flag bit mask. */
+#define RTC_CNTBUSY_bp  1  /* Count Synchronization Busy Flag bit position. */
+#define RTC_PERBUSY_bm  0x04  /* Period Synchronization Busy Flag bit mask. */
+#define RTC_PERBUSY_bp  2  /* Period Synchronization Busy Flag bit position. */
+#define RTC_CMPBUSY_bm  0x08  /* Comparator Synchronization Busy Flag bit mask. */
+#define RTC_CMPBUSY_bp  3  /* Comparator Synchronization Busy Flag bit position. */
+
+/* RTC.INTCTRL  bit masks and bit positions */
+#define RTC_OVF_bm  0x01  /* Overflow Interrupt enable bit mask. */
+#define RTC_OVF_bp  0  /* Overflow Interrupt enable bit position. */
+#define RTC_CMP_bm  0x02  /* Compare Match Interrupt enable bit mask. */
+#define RTC_CMP_bp  1  /* Compare Match Interrupt enable bit position. */
+
+/* RTC.INTFLAGS  bit masks and bit positions */
+/* RTC_OVF  is already defined. */
+/* RTC_CMP  is already defined. */
+
+/* RTC.DBGCTRL  bit masks and bit positions */
+#define RTC_DBGRUN_bm  0x01  /* Run in debug bit mask. */
+#define RTC_DBGRUN_bp  0  /* Run in debug bit position. */
+
+/* RTC.CALIB  bit masks and bit positions */
+#define RTC_ERROR_gm  0x7F  /* Error Correction Value group mask. */
+#define RTC_ERROR_gp  0  /* Error Correction Value group position. */
+#define RTC_ERROR_0_bm  (1<<0)  /* Error Correction Value bit 0 mask. */
+#define RTC_ERROR_0_bp  0  /* Error Correction Value bit 0 position. */
+#define RTC_ERROR_1_bm  (1<<1)  /* Error Correction Value bit 1 mask. */
+#define RTC_ERROR_1_bp  1  /* Error Correction Value bit 1 position. */
+#define RTC_ERROR_2_bm  (1<<2)  /* Error Correction Value bit 2 mask. */
+#define RTC_ERROR_2_bp  2  /* Error Correction Value bit 2 position. */
+#define RTC_ERROR_3_bm  (1<<3)  /* Error Correction Value bit 3 mask. */
+#define RTC_ERROR_3_bp  3  /* Error Correction Value bit 3 position. */
+#define RTC_ERROR_4_bm  (1<<4)  /* Error Correction Value bit 4 mask. */
+#define RTC_ERROR_4_bp  4  /* Error Correction Value bit 4 position. */
+#define RTC_ERROR_5_bm  (1<<5)  /* Error Correction Value bit 5 mask. */
+#define RTC_ERROR_5_bp  5  /* Error Correction Value bit 5 position. */
+#define RTC_ERROR_6_bm  (1<<6)  /* Error Correction Value bit 6 mask. */
+#define RTC_ERROR_6_bp  6  /* Error Correction Value bit 6 position. */
+#define RTC_SIGN_bm  0x80  /* Error Correction Sign Bit bit mask. */
+#define RTC_SIGN_bp  7  /* Error Correction Sign Bit bit position. */
+
+/* RTC.CLKSEL  bit masks and bit positions */
+#define RTC_CLKSEL_gm  0x03  /* Clock Select group mask. */
+#define RTC_CLKSEL_gp  0  /* Clock Select group position. */
+#define RTC_CLKSEL_0_bm  (1<<0)  /* Clock Select bit 0 mask. */
+#define RTC_CLKSEL_0_bp  0  /* Clock Select bit 0 position. */
+#define RTC_CLKSEL_1_bm  (1<<1)  /* Clock Select bit 1 mask. */
+#define RTC_CLKSEL_1_bp  1  /* Clock Select bit 1 position. */
+
+/* RTC.PITCTRLA  bit masks and bit positions */
+#define RTC_PITEN_bm  0x01  /* Enable bit mask. */
+#define RTC_PITEN_bp  0  /* Enable bit position. */
+#define RTC_PERIOD_gm  0x78  /* Period group mask. */
+#define RTC_PERIOD_gp  3  /* Period group position. */
+#define RTC_PERIOD_0_bm  (1<<3)  /* Period bit 0 mask. */
+#define RTC_PERIOD_0_bp  3  /* Period bit 0 position. */
+#define RTC_PERIOD_1_bm  (1<<4)  /* Period bit 1 mask. */
+#define RTC_PERIOD_1_bp  4  /* Period bit 1 position. */
+#define RTC_PERIOD_2_bm  (1<<5)  /* Period bit 2 mask. */
+#define RTC_PERIOD_2_bp  5  /* Period bit 2 position. */
+#define RTC_PERIOD_3_bm  (1<<6)  /* Period bit 3 mask. */
+#define RTC_PERIOD_3_bp  6  /* Period bit 3 position. */
+
+/* RTC.PITSTATUS  bit masks and bit positions */
+#define RTC_CTRLBUSY_bm  0x01  /* CTRLA Synchronization Busy Flag bit mask. */
+#define RTC_CTRLBUSY_bp  0  /* CTRLA Synchronization Busy Flag bit position. */
+
+/* RTC.PITINTCTRL  bit masks and bit positions */
+#define RTC_PI_bm  0x01  /* Periodic Interrupt bit mask. */
+#define RTC_PI_bp  0  /* Periodic Interrupt bit position. */
+
+/* RTC.PITINTFLAGS  bit masks and bit positions */
+/* RTC_PI  is already defined. */
+
+/* RTC.PITDBGCTRL  bit masks and bit positions */
+/* RTC_DBGRUN  is already defined. */
+
+/* RTC.PITEVGENCTRLA  bit masks and bit positions */
+#define RTC_EVGEN0SEL_gm  0x0F  /* Event Generation 0 Select group mask. */
+#define RTC_EVGEN0SEL_gp  0  /* Event Generation 0 Select group position. */
+#define RTC_EVGEN0SEL_0_bm  (1<<0)  /* Event Generation 0 Select bit 0 mask. */
+#define RTC_EVGEN0SEL_0_bp  0  /* Event Generation 0 Select bit 0 position. */
+#define RTC_EVGEN0SEL_1_bm  (1<<1)  /* Event Generation 0 Select bit 1 mask. */
+#define RTC_EVGEN0SEL_1_bp  1  /* Event Generation 0 Select bit 1 position. */
+#define RTC_EVGEN0SEL_2_bm  (1<<2)  /* Event Generation 0 Select bit 2 mask. */
+#define RTC_EVGEN0SEL_2_bp  2  /* Event Generation 0 Select bit 2 position. */
+#define RTC_EVGEN0SEL_3_bm  (1<<3)  /* Event Generation 0 Select bit 3 mask. */
+#define RTC_EVGEN0SEL_3_bp  3  /* Event Generation 0 Select bit 3 position. */
+#define RTC_EVGEN1SEL_gm  0xF0  /* Event Generation 1 Select group mask. */
+#define RTC_EVGEN1SEL_gp  4  /* Event Generation 1 Select group position. */
+#define RTC_EVGEN1SEL_0_bm  (1<<4)  /* Event Generation 1 Select bit 0 mask. */
+#define RTC_EVGEN1SEL_0_bp  4  /* Event Generation 1 Select bit 0 position. */
+#define RTC_EVGEN1SEL_1_bm  (1<<5)  /* Event Generation 1 Select bit 1 mask. */
+#define RTC_EVGEN1SEL_1_bp  5  /* Event Generation 1 Select bit 1 position. */
+#define RTC_EVGEN1SEL_2_bm  (1<<6)  /* Event Generation 1 Select bit 2 mask. */
+#define RTC_EVGEN1SEL_2_bp  6  /* Event Generation 1 Select bit 2 position. */
+#define RTC_EVGEN1SEL_3_bm  (1<<7)  /* Event Generation 1 Select bit 3 mask. */
+#define RTC_EVGEN1SEL_3_bp  7  /* Event Generation 1 Select bit 3 position. */
+
+
+
+/* SLPCTRL - Sleep Controller */
+/* SLPCTRL.CTRLA  bit masks and bit positions */
+#define SLPCTRL_SEN_bm  0x01  /* Sleep enable bit mask. */
+#define SLPCTRL_SEN_bp  0  /* Sleep enable bit position. */
+#define SLPCTRL_SMODE_gm  0x06  /* Sleep mode group mask. */
+#define SLPCTRL_SMODE_gp  1  /* Sleep mode group position. */
+#define SLPCTRL_SMODE_0_bm  (1<<1)  /* Sleep mode bit 0 mask. */
+#define SLPCTRL_SMODE_0_bp  1  /* Sleep mode bit 0 position. */
+#define SLPCTRL_SMODE_1_bm  (1<<2)  /* Sleep mode bit 1 mask. */
+#define SLPCTRL_SMODE_1_bp  2  /* Sleep mode bit 1 position. */
+
+
+/* SPI - Serial Peripheral Interface */
+/* SPI.CTRLA  bit masks and bit positions */
+#define SPI_ENABLE_bm  0x01  /* Enable Module bit mask. */
+#define SPI_ENABLE_bp  0  /* Enable Module bit position. */
+#define SPI_PRESC_gm  0x06  /* Prescaler group mask. */
+#define SPI_PRESC_gp  1  /* Prescaler group position. */
+#define SPI_PRESC_0_bm  (1<<1)  /* Prescaler bit 0 mask. */
+#define SPI_PRESC_0_bp  1  /* Prescaler bit 0 position. */
+#define SPI_PRESC_1_bm  (1<<2)  /* Prescaler bit 1 mask. */
+#define SPI_PRESC_1_bp  2  /* Prescaler bit 1 position. */
+#define SPI_CLK2X_bm  0x10  /* Enable Double Speed bit mask. */
+#define SPI_CLK2X_bp  4  /* Enable Double Speed bit position. */
+#define SPI_MASTER_bm  0x20  /* Host Operation Enable bit mask. */
+#define SPI_MASTER_bp  5  /* Host Operation Enable bit position. */
+#define SPI_DORD_bm  0x40  /* Data Order Setting bit mask. */
+#define SPI_DORD_bp  6  /* Data Order Setting bit position. */
+
+/* SPI.CTRLB  bit masks and bit positions */
+#define SPI_MODE_gm  0x03  /* SPI Mode group mask. */
+#define SPI_MODE_gp  0  /* SPI Mode group position. */
+#define SPI_MODE_0_bm  (1<<0)  /* SPI Mode bit 0 mask. */
+#define SPI_MODE_0_bp  0  /* SPI Mode bit 0 position. */
+#define SPI_MODE_1_bm  (1<<1)  /* SPI Mode bit 1 mask. */
+#define SPI_MODE_1_bp  1  /* SPI Mode bit 1 position. */
+#define SPI_SSD_bm  0x04  /* SPI Select Disable bit mask. */
+#define SPI_SSD_bp  2  /* SPI Select Disable bit position. */
+#define SPI_BUFWR_bm  0x40  /* Buffer Mode Wait for Receive bit mask. */
+#define SPI_BUFWR_bp  6  /* Buffer Mode Wait for Receive bit position. */
+#define SPI_BUFEN_bm  0x80  /* Buffer Mode Enable bit mask. */
+#define SPI_BUFEN_bp  7  /* Buffer Mode Enable bit position. */
+
+/* SPI.INTCTRL  bit masks and bit positions */
+#define SPI_IE_bm  0x01  /* Interrupt Enable bit mask. */
+#define SPI_IE_bp  0  /* Interrupt Enable bit position. */
+#define SPI_SSIE_bm  0x10  /* SPI Select Trigger Interrupt Enable bit mask. */
+#define SPI_SSIE_bp  4  /* SPI Select Trigger Interrupt Enable bit position. */
+#define SPI_DREIE_bm  0x20  /* Data Register Empty Interrupt Enable bit mask. */
+#define SPI_DREIE_bp  5  /* Data Register Empty Interrupt Enable bit position. */
+#define SPI_TXCIE_bm  0x40  /* Transfer Complete Interrupt Enable bit mask. */
+#define SPI_TXCIE_bp  6  /* Transfer Complete Interrupt Enable bit position. */
+#define SPI_RXCIE_bm  0x80  /* Receive Complete Interrupt Enable bit mask. */
+#define SPI_RXCIE_bp  7  /* Receive Complete Interrupt Enable bit position. */
+
+/* SPI.INTFLAGS  bit masks and bit positions */
+#define SPI_BUFOVF_bm  0x01  /* Buffer Overflow bit mask. */
+#define SPI_BUFOVF_bp  0  /* Buffer Overflow bit position. */
+#define SPI_SSIF_bm  0x10  /* SPI Select Trigger Interrupt Flag bit mask. */
+#define SPI_SSIF_bp  4  /* SPI Select Trigger Interrupt Flag bit position. */
+#define SPI_DREIF_bm  0x20  /* Data Register Empty Interrupt Flag bit mask. */
+#define SPI_DREIF_bp  5  /* Data Register Empty Interrupt Flag bit position. */
+#define SPI_TXCIF_bm  0x40  /* Transfer Complete Interrupt Flag bit mask. */
+#define SPI_TXCIF_bp  6  /* Transfer Complete Interrupt Flag bit position. */
+#define SPI_WRCOL_bm  0x40  /* Write Collision bit mask. */
+#define SPI_WRCOL_bp  6  /* Write Collision bit position. */
+#define SPI_RXCIF_bm  0x80  /* Receive Complete Interrupt Flag bit mask. */
+#define SPI_RXCIF_bp  7  /* Receive Complete Interrupt Flag bit position. */
+#define SPI_IF_bm  0x80  /* Interrupt Flag bit mask. */
+#define SPI_IF_bp  7  /* Interrupt Flag bit position. */
+
+
+/* SYSCFG - System Configuration Registers */
+/* SYSCFG.REVID  bit masks and bit positions */
+#define SYSCFG_MINOR_gm  0x0F  /* Minor Revision group mask. */
+#define SYSCFG_MINOR_gp  0  /* Minor Revision group position. */
+#define SYSCFG_MINOR_0_bm  (1<<0)  /* Minor Revision bit 0 mask. */
+#define SYSCFG_MINOR_0_bp  0  /* Minor Revision bit 0 position. */
+#define SYSCFG_MINOR_1_bm  (1<<1)  /* Minor Revision bit 1 mask. */
+#define SYSCFG_MINOR_1_bp  1  /* Minor Revision bit 1 position. */
+#define SYSCFG_MINOR_2_bm  (1<<2)  /* Minor Revision bit 2 mask. */
+#define SYSCFG_MINOR_2_bp  2  /* Minor Revision bit 2 position. */
+#define SYSCFG_MINOR_3_bm  (1<<3)  /* Minor Revision bit 3 mask. */
+#define SYSCFG_MINOR_3_bp  3  /* Minor Revision bit 3 position. */
+#define SYSCFG_MAJOR_gm  0xF0  /* Major Revision group mask. */
+#define SYSCFG_MAJOR_gp  4  /* Major Revision group position. */
+#define SYSCFG_MAJOR_0_bm  (1<<4)  /* Major Revision bit 0 mask. */
+#define SYSCFG_MAJOR_0_bp  4  /* Major Revision bit 0 position. */
+#define SYSCFG_MAJOR_1_bm  (1<<5)  /* Major Revision bit 1 mask. */
+#define SYSCFG_MAJOR_1_bp  5  /* Major Revision bit 1 position. */
+#define SYSCFG_MAJOR_2_bm  (1<<6)  /* Major Revision bit 2 mask. */
+#define SYSCFG_MAJOR_2_bp  6  /* Major Revision bit 2 position. */
+#define SYSCFG_MAJOR_3_bm  (1<<7)  /* Major Revision bit 3 mask. */
+#define SYSCFG_MAJOR_3_bp  7  /* Major Revision bit 3 position. */
+
+/* SYSCFG.OCDMCTRL  bit masks and bit positions */
+#define SYSCFG_OCDM_gm  0xFF  /* OCD Message group mask. */
+#define SYSCFG_OCDM_gp  0  /* OCD Message group position. */
+#define SYSCFG_OCDM_0_bm  (1<<0)  /* OCD Message bit 0 mask. */
+#define SYSCFG_OCDM_0_bp  0  /* OCD Message bit 0 position. */
+#define SYSCFG_OCDM_1_bm  (1<<1)  /* OCD Message bit 1 mask. */
+#define SYSCFG_OCDM_1_bp  1  /* OCD Message bit 1 position. */
+#define SYSCFG_OCDM_2_bm  (1<<2)  /* OCD Message bit 2 mask. */
+#define SYSCFG_OCDM_2_bp  2  /* OCD Message bit 2 position. */
+#define SYSCFG_OCDM_3_bm  (1<<3)  /* OCD Message bit 3 mask. */
+#define SYSCFG_OCDM_3_bp  3  /* OCD Message bit 3 position. */
+#define SYSCFG_OCDM_4_bm  (1<<4)  /* OCD Message bit 4 mask. */
+#define SYSCFG_OCDM_4_bp  4  /* OCD Message bit 4 position. */
+#define SYSCFG_OCDM_5_bm  (1<<5)  /* OCD Message bit 5 mask. */
+#define SYSCFG_OCDM_5_bp  5  /* OCD Message bit 5 position. */
+#define SYSCFG_OCDM_6_bm  (1<<6)  /* OCD Message bit 6 mask. */
+#define SYSCFG_OCDM_6_bp  6  /* OCD Message bit 6 position. */
+#define SYSCFG_OCDM_7_bm  (1<<7)  /* OCD Message bit 7 mask. */
+#define SYSCFG_OCDM_7_bp  7  /* OCD Message bit 7 position. */
+
+/* SYSCFG.OCDMSTATUS  bit masks and bit positions */
+#define SYSCFG_VALID_bm  0x01  /* OCD Message Valid bit mask. */
+#define SYSCFG_VALID_bp  0  /* OCD Message Valid bit position. */
+
+
+/* TCA - 16-bit Timer/Counter Type A */
+/* TCA_SINGLE.CTRLA  bit masks and bit positions */
+#define TCA_SINGLE_ENABLE_bm  0x01  /* Module Enable bit mask. */
+#define TCA_SINGLE_ENABLE_bp  0  /* Module Enable bit position. */
+#define TCA_SINGLE_CLKSEL_gm  0x0E  /* Clock Selection group mask. */
+#define TCA_SINGLE_CLKSEL_gp  1  /* Clock Selection group position. */
+#define TCA_SINGLE_CLKSEL_0_bm  (1<<1)  /* Clock Selection bit 0 mask. */
+#define TCA_SINGLE_CLKSEL_0_bp  1  /* Clock Selection bit 0 position. */
+#define TCA_SINGLE_CLKSEL_1_bm  (1<<2)  /* Clock Selection bit 1 mask. */
+#define TCA_SINGLE_CLKSEL_1_bp  2  /* Clock Selection bit 1 position. */
+#define TCA_SINGLE_CLKSEL_2_bm  (1<<3)  /* Clock Selection bit 2 mask. */
+#define TCA_SINGLE_CLKSEL_2_bp  3  /* Clock Selection bit 2 position. */
+#define TCA_SINGLE_RUNSTDBY_bm  0x80  /* Run in Standby bit mask. */
+#define TCA_SINGLE_RUNSTDBY_bp  7  /* Run in Standby bit position. */
+
+/* TCA_SINGLE.CTRLB  bit masks and bit positions */
+#define TCA_SINGLE_WGMODE_gm  0x07  /* Waveform generation mode group mask. */
+#define TCA_SINGLE_WGMODE_gp  0  /* Waveform generation mode group position. */
+#define TCA_SINGLE_WGMODE_0_bm  (1<<0)  /* Waveform generation mode bit 0 mask. */
+#define TCA_SINGLE_WGMODE_0_bp  0  /* Waveform generation mode bit 0 position. */
+#define TCA_SINGLE_WGMODE_1_bm  (1<<1)  /* Waveform generation mode bit 1 mask. */
+#define TCA_SINGLE_WGMODE_1_bp  1  /* Waveform generation mode bit 1 position. */
+#define TCA_SINGLE_WGMODE_2_bm  (1<<2)  /* Waveform generation mode bit 2 mask. */
+#define TCA_SINGLE_WGMODE_2_bp  2  /* Waveform generation mode bit 2 position. */
+#define TCA_SINGLE_ALUPD_bm  0x08  /* Auto Lock Update bit mask. */
+#define TCA_SINGLE_ALUPD_bp  3  /* Auto Lock Update bit position. */
+#define TCA_SINGLE_CMP0EN_bm  0x10  /* Compare 0 Enable bit mask. */
+#define TCA_SINGLE_CMP0EN_bp  4  /* Compare 0 Enable bit position. */
+#define TCA_SINGLE_CMP1EN_bm  0x20  /* Compare 1 Enable bit mask. */
+#define TCA_SINGLE_CMP1EN_bp  5  /* Compare 1 Enable bit position. */
+#define TCA_SINGLE_CMP2EN_bm  0x40  /* Compare 2 Enable bit mask. */
+#define TCA_SINGLE_CMP2EN_bp  6  /* Compare 2 Enable bit position. */
+
+/* TCA_SINGLE.CTRLC  bit masks and bit positions */
+#define TCA_SINGLE_CMP0OV_bm  0x01  /* Compare 0 Waveform Output Value bit mask. */
+#define TCA_SINGLE_CMP0OV_bp  0  /* Compare 0 Waveform Output Value bit position. */
+#define TCA_SINGLE_CMP1OV_bm  0x02  /* Compare 1 Waveform Output Value bit mask. */
+#define TCA_SINGLE_CMP1OV_bp  1  /* Compare 1 Waveform Output Value bit position. */
+#define TCA_SINGLE_CMP2OV_bm  0x04  /* Compare 2 Waveform Output Value bit mask. */
+#define TCA_SINGLE_CMP2OV_bp  2  /* Compare 2 Waveform Output Value bit position. */
+
+/* TCA_SINGLE.CTRLD  bit masks and bit positions */
+#define TCA_SINGLE_SPLITM_bm  0x01  /* Split Mode Enable bit mask. */
+#define TCA_SINGLE_SPLITM_bp  0  /* Split Mode Enable bit position. */
+
+/* TCA_SINGLE.CTRLECLR  bit masks and bit positions */
+#define TCA_SINGLE_DIR_bm  0x01  /* Direction bit mask. */
+#define TCA_SINGLE_DIR_bp  0  /* Direction bit position. */
+#define TCA_SINGLE_LUPD_bm  0x02  /* Lock Update bit mask. */
+#define TCA_SINGLE_LUPD_bp  1  /* Lock Update bit position. */
+#define TCA_SINGLE_CMD_gm  0x0C  /* Command group mask. */
+#define TCA_SINGLE_CMD_gp  2  /* Command group position. */
+#define TCA_SINGLE_CMD_0_bm  (1<<2)  /* Command bit 0 mask. */
+#define TCA_SINGLE_CMD_0_bp  2  /* Command bit 0 position. */
+#define TCA_SINGLE_CMD_1_bm  (1<<3)  /* Command bit 1 mask. */
+#define TCA_SINGLE_CMD_1_bp  3  /* Command bit 1 position. */
+
+/* TCA_SINGLE.CTRLESET  bit masks and bit positions */
+/* TCA_SINGLE_DIR  is already defined. */
+/* TCA_SINGLE_LUPD  is already defined. */
+/* TCA_SINGLE_CMD  is already defined. */
+
+/* TCA_SINGLE.CTRLFCLR  bit masks and bit positions */
+#define TCA_SINGLE_PERBV_bm  0x01  /* Period Buffer Valid bit mask. */
+#define TCA_SINGLE_PERBV_bp  0  /* Period Buffer Valid bit position. */
+#define TCA_SINGLE_CMP0BV_bm  0x02  /* Compare 0 Buffer Valid bit mask. */
+#define TCA_SINGLE_CMP0BV_bp  1  /* Compare 0 Buffer Valid bit position. */
+#define TCA_SINGLE_CMP1BV_bm  0x04  /* Compare 1 Buffer Valid bit mask. */
+#define TCA_SINGLE_CMP1BV_bp  2  /* Compare 1 Buffer Valid bit position. */
+#define TCA_SINGLE_CMP2BV_bm  0x08  /* Compare 2 Buffer Valid bit mask. */
+#define TCA_SINGLE_CMP2BV_bp  3  /* Compare 2 Buffer Valid bit position. */
+
+/* TCA_SINGLE.CTRLFSET  bit masks and bit positions */
+/* TCA_SINGLE_PERBV  is already defined. */
+/* TCA_SINGLE_CMP0BV  is already defined. */
+/* TCA_SINGLE_CMP1BV  is already defined. */
+/* TCA_SINGLE_CMP2BV  is already defined. */
+
+/* TCA_SINGLE.EVCTRL  bit masks and bit positions */
+#define TCA_SINGLE_CNTAEI_bm  0x01  /* Count on Event Input A bit mask. */
+#define TCA_SINGLE_CNTAEI_bp  0  /* Count on Event Input A bit position. */
+#define TCA_SINGLE_EVACTA_gm  0x0E  /* Event Action A group mask. */
+#define TCA_SINGLE_EVACTA_gp  1  /* Event Action A group position. */
+#define TCA_SINGLE_EVACTA_0_bm  (1<<1)  /* Event Action A bit 0 mask. */
+#define TCA_SINGLE_EVACTA_0_bp  1  /* Event Action A bit 0 position. */
+#define TCA_SINGLE_EVACTA_1_bm  (1<<2)  /* Event Action A bit 1 mask. */
+#define TCA_SINGLE_EVACTA_1_bp  2  /* Event Action A bit 1 position. */
+#define TCA_SINGLE_EVACTA_2_bm  (1<<3)  /* Event Action A bit 2 mask. */
+#define TCA_SINGLE_EVACTA_2_bp  3  /* Event Action A bit 2 position. */
+#define TCA_SINGLE_CNTBEI_bm  0x10  /* Count on Event Input B bit mask. */
+#define TCA_SINGLE_CNTBEI_bp  4  /* Count on Event Input B bit position. */
+#define TCA_SINGLE_EVACTB_gm  0xE0  /* Event Action B group mask. */
+#define TCA_SINGLE_EVACTB_gp  5  /* Event Action B group position. */
+#define TCA_SINGLE_EVACTB_0_bm  (1<<5)  /* Event Action B bit 0 mask. */
+#define TCA_SINGLE_EVACTB_0_bp  5  /* Event Action B bit 0 position. */
+#define TCA_SINGLE_EVACTB_1_bm  (1<<6)  /* Event Action B bit 1 mask. */
+#define TCA_SINGLE_EVACTB_1_bp  6  /* Event Action B bit 1 position. */
+#define TCA_SINGLE_EVACTB_2_bm  (1<<7)  /* Event Action B bit 2 mask. */
+#define TCA_SINGLE_EVACTB_2_bp  7  /* Event Action B bit 2 position. */
+
+/* TCA_SINGLE.INTCTRL  bit masks and bit positions */
+#define TCA_SINGLE_OVF_bm  0x01  /* Overflow Interrupt bit mask. */
+#define TCA_SINGLE_OVF_bp  0  /* Overflow Interrupt bit position. */
+#define TCA_SINGLE_CMP0_bm  0x10  /* Compare 0 Interrupt bit mask. */
+#define TCA_SINGLE_CMP0_bp  4  /* Compare 0 Interrupt bit position. */
+#define TCA_SINGLE_CMP1_bm  0x20  /* Compare 1 Interrupt bit mask. */
+#define TCA_SINGLE_CMP1_bp  5  /* Compare 1 Interrupt bit position. */
+#define TCA_SINGLE_CMP2_bm  0x40  /* Compare 2 Interrupt bit mask. */
+#define TCA_SINGLE_CMP2_bp  6  /* Compare 2 Interrupt bit position. */
+
+/* TCA_SINGLE.INTFLAGS  bit masks and bit positions */
+/* TCA_SINGLE_OVF  is already defined. */
+/* TCA_SINGLE_CMP0  is already defined. */
+/* TCA_SINGLE_CMP1  is already defined. */
+/* TCA_SINGLE_CMP2  is already defined. */
+
+/* TCA_SINGLE.DBGCTRL  bit masks and bit positions */
+#define TCA_SINGLE_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define TCA_SINGLE_DBGRUN_bp  0  /* Debug Run bit position. */
+
+/* TCA_SPLIT.CTRLA  bit masks and bit positions */
+#define TCA_SPLIT_ENABLE_bm  0x01  /* Module Enable bit mask. */
+#define TCA_SPLIT_ENABLE_bp  0  /* Module Enable bit position. */
+#define TCA_SPLIT_CLKSEL_gm  0x0E  /* Clock Selection group mask. */
+#define TCA_SPLIT_CLKSEL_gp  1  /* Clock Selection group position. */
+#define TCA_SPLIT_CLKSEL_0_bm  (1<<1)  /* Clock Selection bit 0 mask. */
+#define TCA_SPLIT_CLKSEL_0_bp  1  /* Clock Selection bit 0 position. */
+#define TCA_SPLIT_CLKSEL_1_bm  (1<<2)  /* Clock Selection bit 1 mask. */
+#define TCA_SPLIT_CLKSEL_1_bp  2  /* Clock Selection bit 1 position. */
+#define TCA_SPLIT_CLKSEL_2_bm  (1<<3)  /* Clock Selection bit 2 mask. */
+#define TCA_SPLIT_CLKSEL_2_bp  3  /* Clock Selection bit 2 position. */
+#define TCA_SPLIT_RUNSTDBY_bm  0x80  /* Run in Standby bit mask. */
+#define TCA_SPLIT_RUNSTDBY_bp  7  /* Run in Standby bit position. */
+
+/* TCA_SPLIT.CTRLB  bit masks and bit positions */
+#define TCA_SPLIT_LCMP0EN_bm  0x01  /* Low Compare 0 Enable bit mask. */
+#define TCA_SPLIT_LCMP0EN_bp  0  /* Low Compare 0 Enable bit position. */
+#define TCA_SPLIT_LCMP1EN_bm  0x02  /* Low Compare 1 Enable bit mask. */
+#define TCA_SPLIT_LCMP1EN_bp  1  /* Low Compare 1 Enable bit position. */
+#define TCA_SPLIT_LCMP2EN_bm  0x04  /* Low Compare 2 Enable bit mask. */
+#define TCA_SPLIT_LCMP2EN_bp  2  /* Low Compare 2 Enable bit position. */
+#define TCA_SPLIT_HCMP0EN_bm  0x10  /* High Compare 0 Enable bit mask. */
+#define TCA_SPLIT_HCMP0EN_bp  4  /* High Compare 0 Enable bit position. */
+#define TCA_SPLIT_HCMP1EN_bm  0x20  /* High Compare 1 Enable bit mask. */
+#define TCA_SPLIT_HCMP1EN_bp  5  /* High Compare 1 Enable bit position. */
+#define TCA_SPLIT_HCMP2EN_bm  0x40  /* High Compare 2 Enable bit mask. */
+#define TCA_SPLIT_HCMP2EN_bp  6  /* High Compare 2 Enable bit position. */
+
+/* TCA_SPLIT.CTRLC  bit masks and bit positions */
+#define TCA_SPLIT_LCMP0OV_bm  0x01  /* Low Compare 0 Output Value bit mask. */
+#define TCA_SPLIT_LCMP0OV_bp  0  /* Low Compare 0 Output Value bit position. */
+#define TCA_SPLIT_LCMP1OV_bm  0x02  /* Low Compare 1 Output Value bit mask. */
+#define TCA_SPLIT_LCMP1OV_bp  1  /* Low Compare 1 Output Value bit position. */
+#define TCA_SPLIT_LCMP2OV_bm  0x04  /* Low Compare 2 Output Value bit mask. */
+#define TCA_SPLIT_LCMP2OV_bp  2  /* Low Compare 2 Output Value bit position. */
+#define TCA_SPLIT_HCMP0OV_bm  0x10  /* High Compare 0 Output Value bit mask. */
+#define TCA_SPLIT_HCMP0OV_bp  4  /* High Compare 0 Output Value bit position. */
+#define TCA_SPLIT_HCMP1OV_bm  0x20  /* High Compare 1 Output Value bit mask. */
+#define TCA_SPLIT_HCMP1OV_bp  5  /* High Compare 1 Output Value bit position. */
+#define TCA_SPLIT_HCMP2OV_bm  0x40  /* High Compare 2 Output Value bit mask. */
+#define TCA_SPLIT_HCMP2OV_bp  6  /* High Compare 2 Output Value bit position. */
+
+/* TCA_SPLIT.CTRLD  bit masks and bit positions */
+#define TCA_SPLIT_SPLITM_bm  0x01  /* Split Mode Enable bit mask. */
+#define TCA_SPLIT_SPLITM_bp  0  /* Split Mode Enable bit position. */
+
+/* TCA_SPLIT.CTRLECLR  bit masks and bit positions */
+#define TCA_SPLIT_CMDEN_gm  0x03  /* Command Enable group mask. */
+#define TCA_SPLIT_CMDEN_gp  0  /* Command Enable group position. */
+#define TCA_SPLIT_CMDEN_0_bm  (1<<0)  /* Command Enable bit 0 mask. */
+#define TCA_SPLIT_CMDEN_0_bp  0  /* Command Enable bit 0 position. */
+#define TCA_SPLIT_CMDEN_1_bm  (1<<1)  /* Command Enable bit 1 mask. */
+#define TCA_SPLIT_CMDEN_1_bp  1  /* Command Enable bit 1 position. */
+#define TCA_SPLIT_CMD_gm  0x0C  /* Command group mask. */
+#define TCA_SPLIT_CMD_gp  2  /* Command group position. */
+#define TCA_SPLIT_CMD_0_bm  (1<<2)  /* Command bit 0 mask. */
+#define TCA_SPLIT_CMD_0_bp  2  /* Command bit 0 position. */
+#define TCA_SPLIT_CMD_1_bm  (1<<3)  /* Command bit 1 mask. */
+#define TCA_SPLIT_CMD_1_bp  3  /* Command bit 1 position. */
+
+/* TCA_SPLIT.CTRLESET  bit masks and bit positions */
+/* TCA_SPLIT_CMDEN  is already defined. */
+/* TCA_SPLIT_CMD  is already defined. */
+
+/* TCA_SPLIT.INTCTRL  bit masks and bit positions */
+#define TCA_SPLIT_LUNF_bm  0x01  /* Low Underflow Interrupt Enable bit mask. */
+#define TCA_SPLIT_LUNF_bp  0  /* Low Underflow Interrupt Enable bit position. */
+#define TCA_SPLIT_HUNF_bm  0x02  /* High Underflow Interrupt Enable bit mask. */
+#define TCA_SPLIT_HUNF_bp  1  /* High Underflow Interrupt Enable bit position. */
+#define TCA_SPLIT_LCMP0_bm  0x10  /* Low Compare 0 Interrupt Enable bit mask. */
+#define TCA_SPLIT_LCMP0_bp  4  /* Low Compare 0 Interrupt Enable bit position. */
+#define TCA_SPLIT_LCMP1_bm  0x20  /* Low Compare 1 Interrupt Enable bit mask. */
+#define TCA_SPLIT_LCMP1_bp  5  /* Low Compare 1 Interrupt Enable bit position. */
+#define TCA_SPLIT_LCMP2_bm  0x40  /* Low Compare 2 Interrupt Enable bit mask. */
+#define TCA_SPLIT_LCMP2_bp  6  /* Low Compare 2 Interrupt Enable bit position. */
+
+/* TCA_SPLIT.INTFLAGS  bit masks and bit positions */
+/* TCA_SPLIT_LUNF  is already defined. */
+/* TCA_SPLIT_HUNF  is already defined. */
+/* TCA_SPLIT_LCMP0  is already defined. */
+/* TCA_SPLIT_LCMP1  is already defined. */
+/* TCA_SPLIT_LCMP2  is already defined. */
+
+/* TCA_SPLIT.DBGCTRL  bit masks and bit positions */
+#define TCA_SPLIT_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define TCA_SPLIT_DBGRUN_bp  0  /* Debug Run bit position. */
+
+
+/* TCB - 16-bit Timer Type B */
+/* TCB.CTRLA  bit masks and bit positions */
+#define TCB_ENABLE_bm  0x01  /* Enable bit mask. */
+#define TCB_ENABLE_bp  0  /* Enable bit position. */
+#define TCB_CLKSEL_gm  0x0E  /* Clock Select group mask. */
+#define TCB_CLKSEL_gp  1  /* Clock Select group position. */
+#define TCB_CLKSEL_0_bm  (1<<1)  /* Clock Select bit 0 mask. */
+#define TCB_CLKSEL_0_bp  1  /* Clock Select bit 0 position. */
+#define TCB_CLKSEL_1_bm  (1<<2)  /* Clock Select bit 1 mask. */
+#define TCB_CLKSEL_1_bp  2  /* Clock Select bit 1 position. */
+#define TCB_CLKSEL_2_bm  (1<<3)  /* Clock Select bit 2 mask. */
+#define TCB_CLKSEL_2_bp  3  /* Clock Select bit 2 position. */
+#define TCB_SYNCUPD_bm  0x10  /* Synchronize Update bit mask. */
+#define TCB_SYNCUPD_bp  4  /* Synchronize Update bit position. */
+#define TCB_CASCADE_bm  0x20  /* Cascade two timers bit mask. */
+#define TCB_CASCADE_bp  5  /* Cascade two timers bit position. */
+#define TCB_RUNSTDBY_bm  0x40  /* Run Standby bit mask. */
+#define TCB_RUNSTDBY_bp  6  /* Run Standby bit position. */
+
+/* TCB.CTRLB  bit masks and bit positions */
+#define TCB_CNTMODE_gm  0x07  /* Timer Mode group mask. */
+#define TCB_CNTMODE_gp  0  /* Timer Mode group position. */
+#define TCB_CNTMODE_0_bm  (1<<0)  /* Timer Mode bit 0 mask. */
+#define TCB_CNTMODE_0_bp  0  /* Timer Mode bit 0 position. */
+#define TCB_CNTMODE_1_bm  (1<<1)  /* Timer Mode bit 1 mask. */
+#define TCB_CNTMODE_1_bp  1  /* Timer Mode bit 1 position. */
+#define TCB_CNTMODE_2_bm  (1<<2)  /* Timer Mode bit 2 mask. */
+#define TCB_CNTMODE_2_bp  2  /* Timer Mode bit 2 position. */
+#define TCB_CCMPEN_bm  0x10  /* Pin Output Enable bit mask. */
+#define TCB_CCMPEN_bp  4  /* Pin Output Enable bit position. */
+#define TCB_CCMPINIT_bm  0x20  /* Pin Initial State bit mask. */
+#define TCB_CCMPINIT_bp  5  /* Pin Initial State bit position. */
+#define TCB_ASYNC_bm  0x40  /* Asynchronous Enable bit mask. */
+#define TCB_ASYNC_bp  6  /* Asynchronous Enable bit position. */
+
+/* TCB.EVCTRL  bit masks and bit positions */
+#define TCB_CAPTEI_bm  0x01  /* Event Input Enable bit mask. */
+#define TCB_CAPTEI_bp  0  /* Event Input Enable bit position. */
+#define TCB_EDGE_bm  0x10  /* Event Edge bit mask. */
+#define TCB_EDGE_bp  4  /* Event Edge bit position. */
+#define TCB_FILTER_bm  0x40  /* Input Capture Noise Cancellation Filter bit mask. */
+#define TCB_FILTER_bp  6  /* Input Capture Noise Cancellation Filter bit position. */
+
+/* TCB.INTCTRL  bit masks and bit positions */
+#define TCB_CAPT_bm  0x01  /* Capture or Timeout bit mask. */
+#define TCB_CAPT_bp  0  /* Capture or Timeout bit position. */
+#define TCB_OVF_bm  0x02  /* Overflow bit mask. */
+#define TCB_OVF_bp  1  /* Overflow bit position. */
+
+/* TCB.INTFLAGS  bit masks and bit positions */
+/* TCB_CAPT  is already defined. */
+/* TCB_OVF  is already defined. */
+
+/* TCB.STATUS  bit masks and bit positions */
+#define TCB_RUN_bm  0x01  /* Run bit mask. */
+#define TCB_RUN_bp  0  /* Run bit position. */
+
+/* TCB.DBGCTRL  bit masks and bit positions */
+#define TCB_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define TCB_DBGRUN_bp  0  /* Debug Run bit position. */
+
+
+/* TWI - Two-Wire Interface */
+/* TWI.CTRLA  bit masks and bit positions */
+#define TWI_FMEN_bm  0x01  /* Fast-mode Enable bit mask. */
+#define TWI_FMEN_bp  0  /* Fast-mode Enable bit position. */
+#define TWI_FMPEN_bm  0x02  /* Fast-mode Plus Enable bit mask. */
+#define TWI_FMPEN_bp  1  /* Fast-mode Plus Enable bit position. */
+#define TWI_SDAHOLD_gm  0x0C  /* SDA Hold Time group mask. */
+#define TWI_SDAHOLD_gp  2  /* SDA Hold Time group position. */
+#define TWI_SDAHOLD_0_bm  (1<<2)  /* SDA Hold Time bit 0 mask. */
+#define TWI_SDAHOLD_0_bp  2  /* SDA Hold Time bit 0 position. */
+#define TWI_SDAHOLD_1_bm  (1<<3)  /* SDA Hold Time bit 1 mask. */
+#define TWI_SDAHOLD_1_bp  3  /* SDA Hold Time bit 1 position. */
+#define TWI_SDASETUP_bm  0x10  /* SDA Setup Time bit mask. */
+#define TWI_SDASETUP_bp  4  /* SDA Setup Time bit position. */
+#define TWI_INPUTLVL_bm  0x40  /* Input voltage transition level bit mask. */
+#define TWI_INPUTLVL_bp  6  /* Input voltage transition level bit position. */
+
+/* TWI.DUALCTRL  bit masks and bit positions */
+#define TWI_ENABLE_bm  0x01  /* Enable bit mask. */
+#define TWI_ENABLE_bp  0  /* Enable bit position. */
+/* TWI_FMPEN  is already defined. */
+/* TWI_SDAHOLD  is already defined. */
+/* TWI_INPUTLVL  is already defined. */
+
+/* TWI.DBGCTRL  bit masks and bit positions */
+#define TWI_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define TWI_DBGRUN_bp  0  /* Debug Run bit position. */
+
+/* TWI.MCTRLA  bit masks and bit positions */
+/* TWI_ENABLE  is already defined. */
+#define TWI_SMEN_bm  0x02  /* Smart Mode Enable bit mask. */
+#define TWI_SMEN_bp  1  /* Smart Mode Enable bit position. */
+#define TWI_TIMEOUT_gm  0x0C  /* Inactive Bus Time-Out group mask. */
+#define TWI_TIMEOUT_gp  2  /* Inactive Bus Time-Out group position. */
+#define TWI_TIMEOUT_0_bm  (1<<2)  /* Inactive Bus Time-Out bit 0 mask. */
+#define TWI_TIMEOUT_0_bp  2  /* Inactive Bus Time-Out bit 0 position. */
+#define TWI_TIMEOUT_1_bm  (1<<3)  /* Inactive Bus Time-Out bit 1 mask. */
+#define TWI_TIMEOUT_1_bp  3  /* Inactive Bus Time-Out bit 1 position. */
+#define TWI_QCEN_bm  0x10  /* Quick Command Enable bit mask. */
+#define TWI_QCEN_bp  4  /* Quick Command Enable bit position. */
+#define TWI_WIEN_bm  0x40  /* Write Interrupt Enable bit mask. */
+#define TWI_WIEN_bp  6  /* Write Interrupt Enable bit position. */
+#define TWI_RIEN_bm  0x80  /* Read Interrupt Enable bit mask. */
+#define TWI_RIEN_bp  7  /* Read Interrupt Enable bit position. */
+
+/* TWI.MCTRLB  bit masks and bit positions */
+#define TWI_MCMD_gm  0x03  /* Command group mask. */
+#define TWI_MCMD_gp  0  /* Command group position. */
+#define TWI_MCMD_0_bm  (1<<0)  /* Command bit 0 mask. */
+#define TWI_MCMD_0_bp  0  /* Command bit 0 position. */
+#define TWI_MCMD_1_bm  (1<<1)  /* Command bit 1 mask. */
+#define TWI_MCMD_1_bp  1  /* Command bit 1 position. */
+#define TWI_ACKACT_bm  0x04  /* Acknowledge Action bit mask. */
+#define TWI_ACKACT_bp  2  /* Acknowledge Action bit position. */
+#define TWI_FLUSH_bm  0x08  /* Flush bit mask. */
+#define TWI_FLUSH_bp  3  /* Flush bit position. */
+
+/* TWI.MSTATUS  bit masks and bit positions */
+#define TWI_BUSSTATE_gm  0x03  /* Bus State group mask. */
+#define TWI_BUSSTATE_gp  0  /* Bus State group position. */
+#define TWI_BUSSTATE_0_bm  (1<<0)  /* Bus State bit 0 mask. */
+#define TWI_BUSSTATE_0_bp  0  /* Bus State bit 0 position. */
+#define TWI_BUSSTATE_1_bm  (1<<1)  /* Bus State bit 1 mask. */
+#define TWI_BUSSTATE_1_bp  1  /* Bus State bit 1 position. */
+#define TWI_BUSERR_bm  0x04  /* Bus Error bit mask. */
+#define TWI_BUSERR_bp  2  /* Bus Error bit position. */
+#define TWI_ARBLOST_bm  0x08  /* Arbitration Lost bit mask. */
+#define TWI_ARBLOST_bp  3  /* Arbitration Lost bit position. */
+#define TWI_RXACK_bm  0x10  /* Received Acknowledge bit mask. */
+#define TWI_RXACK_bp  4  /* Received Acknowledge bit position. */
+#define TWI_CLKHOLD_bm  0x20  /* Clock Hold bit mask. */
+#define TWI_CLKHOLD_bp  5  /* Clock Hold bit position. */
+#define TWI_WIF_bm  0x40  /* Write Interrupt Flag bit mask. */
+#define TWI_WIF_bp  6  /* Write Interrupt Flag bit position. */
+#define TWI_RIF_bm  0x80  /* Read Interrupt Flag bit mask. */
+#define TWI_RIF_bp  7  /* Read Interrupt Flag bit position. */
+
+/* TWI.MBAUD  bit masks and bit positions */
+#define TWI_BAUD_gm  0xFF  /* Baud Rate group mask. */
+#define TWI_BAUD_gp  0  /* Baud Rate group position. */
+#define TWI_BAUD_0_bm  (1<<0)  /* Baud Rate bit 0 mask. */
+#define TWI_BAUD_0_bp  0  /* Baud Rate bit 0 position. */
+#define TWI_BAUD_1_bm  (1<<1)  /* Baud Rate bit 1 mask. */
+#define TWI_BAUD_1_bp  1  /* Baud Rate bit 1 position. */
+#define TWI_BAUD_2_bm  (1<<2)  /* Baud Rate bit 2 mask. */
+#define TWI_BAUD_2_bp  2  /* Baud Rate bit 2 position. */
+#define TWI_BAUD_3_bm  (1<<3)  /* Baud Rate bit 3 mask. */
+#define TWI_BAUD_3_bp  3  /* Baud Rate bit 3 position. */
+#define TWI_BAUD_4_bm  (1<<4)  /* Baud Rate bit 4 mask. */
+#define TWI_BAUD_4_bp  4  /* Baud Rate bit 4 position. */
+#define TWI_BAUD_5_bm  (1<<5)  /* Baud Rate bit 5 mask. */
+#define TWI_BAUD_5_bp  5  /* Baud Rate bit 5 position. */
+#define TWI_BAUD_6_bm  (1<<6)  /* Baud Rate bit 6 mask. */
+#define TWI_BAUD_6_bp  6  /* Baud Rate bit 6 position. */
+#define TWI_BAUD_7_bm  (1<<7)  /* Baud Rate bit 7 mask. */
+#define TWI_BAUD_7_bp  7  /* Baud Rate bit 7 position. */
+
+/* TWI.MADDR  bit masks and bit positions */
+#define TWI_ADDR_gm  0xFF  /* Address group mask. */
+#define TWI_ADDR_gp  0  /* Address group position. */
+#define TWI_ADDR_0_bm  (1<<0)  /* Address bit 0 mask. */
+#define TWI_ADDR_0_bp  0  /* Address bit 0 position. */
+#define TWI_ADDR_1_bm  (1<<1)  /* Address bit 1 mask. */
+#define TWI_ADDR_1_bp  1  /* Address bit 1 position. */
+#define TWI_ADDR_2_bm  (1<<2)  /* Address bit 2 mask. */
+#define TWI_ADDR_2_bp  2  /* Address bit 2 position. */
+#define TWI_ADDR_3_bm  (1<<3)  /* Address bit 3 mask. */
+#define TWI_ADDR_3_bp  3  /* Address bit 3 position. */
+#define TWI_ADDR_4_bm  (1<<4)  /* Address bit 4 mask. */
+#define TWI_ADDR_4_bp  4  /* Address bit 4 position. */
+#define TWI_ADDR_5_bm  (1<<5)  /* Address bit 5 mask. */
+#define TWI_ADDR_5_bp  5  /* Address bit 5 position. */
+#define TWI_ADDR_6_bm  (1<<6)  /* Address bit 6 mask. */
+#define TWI_ADDR_6_bp  6  /* Address bit 6 position. */
+#define TWI_ADDR_7_bm  (1<<7)  /* Address bit 7 mask. */
+#define TWI_ADDR_7_bp  7  /* Address bit 7 position. */
+
+/* TWI.MDATA  bit masks and bit positions */
+#define TWI_DATA_gm  0xFF  /* Data group mask. */
+#define TWI_DATA_gp  0  /* Data group position. */
+#define TWI_DATA_0_bm  (1<<0)  /* Data bit 0 mask. */
+#define TWI_DATA_0_bp  0  /* Data bit 0 position. */
+#define TWI_DATA_1_bm  (1<<1)  /* Data bit 1 mask. */
+#define TWI_DATA_1_bp  1  /* Data bit 1 position. */
+#define TWI_DATA_2_bm  (1<<2)  /* Data bit 2 mask. */
+#define TWI_DATA_2_bp  2  /* Data bit 2 position. */
+#define TWI_DATA_3_bm  (1<<3)  /* Data bit 3 mask. */
+#define TWI_DATA_3_bp  3  /* Data bit 3 position. */
+#define TWI_DATA_4_bm  (1<<4)  /* Data bit 4 mask. */
+#define TWI_DATA_4_bp  4  /* Data bit 4 position. */
+#define TWI_DATA_5_bm  (1<<5)  /* Data bit 5 mask. */
+#define TWI_DATA_5_bp  5  /* Data bit 5 position. */
+#define TWI_DATA_6_bm  (1<<6)  /* Data bit 6 mask. */
+#define TWI_DATA_6_bp  6  /* Data bit 6 position. */
+#define TWI_DATA_7_bm  (1<<7)  /* Data bit 7 mask. */
+#define TWI_DATA_7_bp  7  /* Data bit 7 position. */
+
+/* TWI.SCTRLA  bit masks and bit positions */
+/* TWI_ENABLE  is already defined. */
+/* TWI_SMEN  is already defined. */
+#define TWI_PMEN_bm  0x04  /* Address Recognition Mode bit mask. */
+#define TWI_PMEN_bp  2  /* Address Recognition Mode bit position. */
+#define TWI_PIEN_bm  0x20  /* Stop Interrupt Enable bit mask. */
+#define TWI_PIEN_bp  5  /* Stop Interrupt Enable bit position. */
+#define TWI_APIEN_bm  0x40  /* Address or Stop Interrupt Enable bit mask. */
+#define TWI_APIEN_bp  6  /* Address or Stop Interrupt Enable bit position. */
+#define TWI_DIEN_bm  0x80  /* Data Interrupt Enable bit mask. */
+#define TWI_DIEN_bp  7  /* Data Interrupt Enable bit position. */
+
+/* TWI.SCTRLB  bit masks and bit positions */
+#define TWI_SCMD_gm  0x03  /* Command group mask. */
+#define TWI_SCMD_gp  0  /* Command group position. */
+#define TWI_SCMD_0_bm  (1<<0)  /* Command bit 0 mask. */
+#define TWI_SCMD_0_bp  0  /* Command bit 0 position. */
+#define TWI_SCMD_1_bm  (1<<1)  /* Command bit 1 mask. */
+#define TWI_SCMD_1_bp  1  /* Command bit 1 position. */
+/* TWI_ACKACT  is already defined. */
+
+/* TWI.SSTATUS  bit masks and bit positions */
+#define TWI_AP_bm  0x01  /* Address or Stop bit mask. */
+#define TWI_AP_bp  0  /* Address or Stop bit position. */
+#define TWI_DIR_bm  0x02  /* Read/Write Direction bit mask. */
+#define TWI_DIR_bp  1  /* Read/Write Direction bit position. */
+/* TWI_BUSERR  is already defined. */
+#define TWI_COLL_bm  0x08  /* Collision bit mask. */
+#define TWI_COLL_bp  3  /* Collision bit position. */
+/* TWI_RXACK  is already defined. */
+/* TWI_CLKHOLD  is already defined. */
+#define TWI_APIF_bm  0x40  /* Address or Stop Interrupt Flag bit mask. */
+#define TWI_APIF_bp  6  /* Address or Stop Interrupt Flag bit position. */
+#define TWI_DIF_bm  0x80  /* Data Interrupt Flag bit mask. */
+#define TWI_DIF_bp  7  /* Data Interrupt Flag bit position. */
+
+/* TWI.SADDR  bit masks and bit positions */
+/* TWI_ADDR  is already defined. */
+
+/* TWI.SDATA  bit masks and bit positions */
+/* TWI_DATA  is already defined. */
+
+/* TWI.SADDRMASK  bit masks and bit positions */
+#define TWI_ADDREN_bm  0x01  /* Address Mask Enable bit mask. */
+#define TWI_ADDREN_bp  0  /* Address Mask Enable bit position. */
+#define TWI_ADDRMASK_gm  0xFE  /* Address Mask group mask. */
+#define TWI_ADDRMASK_gp  1  /* Address Mask group position. */
+#define TWI_ADDRMASK_0_bm  (1<<1)  /* Address Mask bit 0 mask. */
+#define TWI_ADDRMASK_0_bp  1  /* Address Mask bit 0 position. */
+#define TWI_ADDRMASK_1_bm  (1<<2)  /* Address Mask bit 1 mask. */
+#define TWI_ADDRMASK_1_bp  2  /* Address Mask bit 1 position. */
+#define TWI_ADDRMASK_2_bm  (1<<3)  /* Address Mask bit 2 mask. */
+#define TWI_ADDRMASK_2_bp  3  /* Address Mask bit 2 position. */
+#define TWI_ADDRMASK_3_bm  (1<<4)  /* Address Mask bit 3 mask. */
+#define TWI_ADDRMASK_3_bp  4  /* Address Mask bit 3 position. */
+#define TWI_ADDRMASK_4_bm  (1<<5)  /* Address Mask bit 4 mask. */
+#define TWI_ADDRMASK_4_bp  5  /* Address Mask bit 4 position. */
+#define TWI_ADDRMASK_5_bm  (1<<6)  /* Address Mask bit 5 mask. */
+#define TWI_ADDRMASK_5_bp  6  /* Address Mask bit 5 position. */
+#define TWI_ADDRMASK_6_bm  (1<<7)  /* Address Mask bit 6 mask. */
+#define TWI_ADDRMASK_6_bp  7  /* Address Mask bit 6 position. */
+
+
+/* USART - Universal Synchronous and Asynchronous Receiver and Transmitter */
+/* USART.RXDATAL  bit masks and bit positions */
+#define USART_DATA_gm  0xFF  /* RX Data group mask. */
+#define USART_DATA_gp  0  /* RX Data group position. */
+#define USART_DATA_0_bm  (1<<0)  /* RX Data bit 0 mask. */
+#define USART_DATA_0_bp  0  /* RX Data bit 0 position. */
+#define USART_DATA_1_bm  (1<<1)  /* RX Data bit 1 mask. */
+#define USART_DATA_1_bp  1  /* RX Data bit 1 position. */
+#define USART_DATA_2_bm  (1<<2)  /* RX Data bit 2 mask. */
+#define USART_DATA_2_bp  2  /* RX Data bit 2 position. */
+#define USART_DATA_3_bm  (1<<3)  /* RX Data bit 3 mask. */
+#define USART_DATA_3_bp  3  /* RX Data bit 3 position. */
+#define USART_DATA_4_bm  (1<<4)  /* RX Data bit 4 mask. */
+#define USART_DATA_4_bp  4  /* RX Data bit 4 position. */
+#define USART_DATA_5_bm  (1<<5)  /* RX Data bit 5 mask. */
+#define USART_DATA_5_bp  5  /* RX Data bit 5 position. */
+#define USART_DATA_6_bm  (1<<6)  /* RX Data bit 6 mask. */
+#define USART_DATA_6_bp  6  /* RX Data bit 6 position. */
+#define USART_DATA_7_bm  (1<<7)  /* RX Data bit 7 mask. */
+#define USART_DATA_7_bp  7  /* RX Data bit 7 position. */
+
+/* USART.RXDATAH  bit masks and bit positions */
+#define USART_DATA8_bm  0x01  /* Receiver Data Register bit mask. */
+#define USART_DATA8_bp  0  /* Receiver Data Register bit position. */
+#define USART_PERR_bm  0x02  /* Parity Error bit mask. */
+#define USART_PERR_bp  1  /* Parity Error bit position. */
+#define USART_FERR_bm  0x04  /* Frame Error bit mask. */
+#define USART_FERR_bp  2  /* Frame Error bit position. */
+#define USART_BUFOVF_bm  0x40  /* Buffer Overflow bit mask. */
+#define USART_BUFOVF_bp  6  /* Buffer Overflow bit position. */
+#define USART_RXCIF_bm  0x80  /* Receive Complete Interrupt Flag bit mask. */
+#define USART_RXCIF_bp  7  /* Receive Complete Interrupt Flag bit position. */
+
+/* USART.TXDATAL  bit masks and bit positions */
+/* USART_DATA  is already defined. */
+
+/* USART.TXDATAH  bit masks and bit positions */
+/* USART_DATA8  is already defined. */
+
+/* USART.STATUS  bit masks and bit positions */
+#define USART_WFB_bm  0x01  /* Wait For Break bit mask. */
+#define USART_WFB_bp  0  /* Wait For Break bit position. */
+#define USART_BDF_bm  0x02  /* Break Detected Flag bit mask. */
+#define USART_BDF_bp  1  /* Break Detected Flag bit position. */
+#define USART_ISFIF_bm  0x08  /* Inconsistent Sync Field Interrupt Flag bit mask. */
+#define USART_ISFIF_bp  3  /* Inconsistent Sync Field Interrupt Flag bit position. */
+#define USART_RXSIF_bm  0x10  /* Receive Start Interrupt bit mask. */
+#define USART_RXSIF_bp  4  /* Receive Start Interrupt bit position. */
+#define USART_DREIF_bm  0x20  /* Data Register Empty Flag bit mask. */
+#define USART_DREIF_bp  5  /* Data Register Empty Flag bit position. */
+#define USART_TXCIF_bm  0x40  /* Transmit Interrupt Flag bit mask. */
+#define USART_TXCIF_bp  6  /* Transmit Interrupt Flag bit position. */
+/* USART_RXCIF  is already defined. */
+
+/* USART.CTRLA  bit masks and bit positions */
+#define USART_RS485_bm  0x01  /* RS485 Mode internal transmitter bit mask. */
+#define USART_RS485_bp  0  /* RS485 Mode internal transmitter bit position. */
+#define USART_ABEIE_bm  0x04  /* Auto-baud Error Interrupt Enable bit mask. */
+#define USART_ABEIE_bp  2  /* Auto-baud Error Interrupt Enable bit position. */
+#define USART_LBME_bm  0x08  /* Loop-back Mode Enable bit mask. */
+#define USART_LBME_bp  3  /* Loop-back Mode Enable bit position. */
+#define USART_RXSIE_bm  0x10  /* Receiver Start Frame Interrupt Enable bit mask. */
+#define USART_RXSIE_bp  4  /* Receiver Start Frame Interrupt Enable bit position. */
+#define USART_DREIE_bm  0x20  /* Data Register Empty Interrupt Enable bit mask. */
+#define USART_DREIE_bp  5  /* Data Register Empty Interrupt Enable bit position. */
+#define USART_TXCIE_bm  0x40  /* Transmit Complete Interrupt Enable bit mask. */
+#define USART_TXCIE_bp  6  /* Transmit Complete Interrupt Enable bit position. */
+#define USART_RXCIE_bm  0x80  /* Receive Complete Interrupt Enable bit mask. */
+#define USART_RXCIE_bp  7  /* Receive Complete Interrupt Enable bit position. */
+
+/* USART.CTRLB  bit masks and bit positions */
+#define USART_MPCM_bm  0x01  /* Multi-processor Communication Mode bit mask. */
+#define USART_MPCM_bp  0  /* Multi-processor Communication Mode bit position. */
+#define USART_RXMODE_gm  0x06  /* Receiver Mode group mask. */
+#define USART_RXMODE_gp  1  /* Receiver Mode group position. */
+#define USART_RXMODE_0_bm  (1<<1)  /* Receiver Mode bit 0 mask. */
+#define USART_RXMODE_0_bp  1  /* Receiver Mode bit 0 position. */
+#define USART_RXMODE_1_bm  (1<<2)  /* Receiver Mode bit 1 mask. */
+#define USART_RXMODE_1_bp  2  /* Receiver Mode bit 1 position. */
+#define USART_ODME_bm  0x08  /* Open Drain Mode Enable bit mask. */
+#define USART_ODME_bp  3  /* Open Drain Mode Enable bit position. */
+#define USART_SFDEN_bm  0x10  /* Start Frame Detection Enable bit mask. */
+#define USART_SFDEN_bp  4  /* Start Frame Detection Enable bit position. */
+#define USART_TXEN_bm  0x40  /* Transmitter Enable bit mask. */
+#define USART_TXEN_bp  6  /* Transmitter Enable bit position. */
+#define USART_RXEN_bm  0x80  /* Reciever enable bit mask. */
+#define USART_RXEN_bp  7  /* Reciever enable bit position. */
+
+/* USART.CTRLC  bit masks and bit positions */
+#define USART_UCPHA_bm  0x02  /* SPI Host Mode, Clock Phase bit mask. */
+#define USART_UCPHA_bp  1  /* SPI Host Mode, Clock Phase bit position. */
+#define USART_UDORD_bm  0x04  /* SPI Host Mode, Data Order bit mask. */
+#define USART_UDORD_bp  2  /* SPI Host Mode, Data Order bit position. */
+#define USART_CHSIZE_gm  0x07  /* Character Size group mask. */
+#define USART_CHSIZE_gp  0  /* Character Size group position. */
+#define USART_CHSIZE_0_bm  (1<<0)  /* Character Size bit 0 mask. */
+#define USART_CHSIZE_0_bp  0  /* Character Size bit 0 position. */
+#define USART_CHSIZE_1_bm  (1<<1)  /* Character Size bit 1 mask. */
+#define USART_CHSIZE_1_bp  1  /* Character Size bit 1 position. */
+#define USART_CHSIZE_2_bm  (1<<2)  /* Character Size bit 2 mask. */
+#define USART_CHSIZE_2_bp  2  /* Character Size bit 2 position. */
+#define USART_SBMODE_bm  0x08  /* Stop Bit Mode bit mask. */
+#define USART_SBMODE_bp  3  /* Stop Bit Mode bit position. */
+#define USART_PMODE_gm  0x30  /* Parity Mode group mask. */
+#define USART_PMODE_gp  4  /* Parity Mode group position. */
+#define USART_PMODE_0_bm  (1<<4)  /* Parity Mode bit 0 mask. */
+#define USART_PMODE_0_bp  4  /* Parity Mode bit 0 position. */
+#define USART_PMODE_1_bm  (1<<5)  /* Parity Mode bit 1 mask. */
+#define USART_PMODE_1_bp  5  /* Parity Mode bit 1 position. */
+#define USART_CMODE_gm  0xC0  /* Communication Mode group mask. */
+#define USART_CMODE_gp  6  /* Communication Mode group position. */
+#define USART_CMODE_0_bm  (1<<6)  /* Communication Mode bit 0 mask. */
+#define USART_CMODE_0_bp  6  /* Communication Mode bit 0 position. */
+#define USART_CMODE_1_bm  (1<<7)  /* Communication Mode bit 1 mask. */
+#define USART_CMODE_1_bp  7  /* Communication Mode bit 1 position. */
+
+/* USART.CTRLD  bit masks and bit positions */
+#define USART_ABW_gm  0xC0  /* Auto Baud Window group mask. */
+#define USART_ABW_gp  6  /* Auto Baud Window group position. */
+#define USART_ABW_0_bm  (1<<6)  /* Auto Baud Window bit 0 mask. */
+#define USART_ABW_0_bp  6  /* Auto Baud Window bit 0 position. */
+#define USART_ABW_1_bm  (1<<7)  /* Auto Baud Window bit 1 mask. */
+#define USART_ABW_1_bp  7  /* Auto Baud Window bit 1 position. */
+
+/* USART.DBGCTRL  bit masks and bit positions */
+#define USART_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define USART_DBGRUN_bp  0  /* Debug Run bit position. */
+
+/* USART.EVCTRL  bit masks and bit positions */
+#define USART_IREI_bm  0x01  /* IrDA Event Input Enable bit mask. */
+#define USART_IREI_bp  0  /* IrDA Event Input Enable bit position. */
+
+/* USART.TXPLCTRL  bit masks and bit positions */
+#define USART_TXPL_gm  0xFF  /* Transmit pulse length group mask. */
+#define USART_TXPL_gp  0  /* Transmit pulse length group position. */
+#define USART_TXPL_0_bm  (1<<0)  /* Transmit pulse length bit 0 mask. */
+#define USART_TXPL_0_bp  0  /* Transmit pulse length bit 0 position. */
+#define USART_TXPL_1_bm  (1<<1)  /* Transmit pulse length bit 1 mask. */
+#define USART_TXPL_1_bp  1  /* Transmit pulse length bit 1 position. */
+#define USART_TXPL_2_bm  (1<<2)  /* Transmit pulse length bit 2 mask. */
+#define USART_TXPL_2_bp  2  /* Transmit pulse length bit 2 position. */
+#define USART_TXPL_3_bm  (1<<3)  /* Transmit pulse length bit 3 mask. */
+#define USART_TXPL_3_bp  3  /* Transmit pulse length bit 3 position. */
+#define USART_TXPL_4_bm  (1<<4)  /* Transmit pulse length bit 4 mask. */
+#define USART_TXPL_4_bp  4  /* Transmit pulse length bit 4 position. */
+#define USART_TXPL_5_bm  (1<<5)  /* Transmit pulse length bit 5 mask. */
+#define USART_TXPL_5_bp  5  /* Transmit pulse length bit 5 position. */
+#define USART_TXPL_6_bm  (1<<6)  /* Transmit pulse length bit 6 mask. */
+#define USART_TXPL_6_bp  6  /* Transmit pulse length bit 6 position. */
+#define USART_TXPL_7_bm  (1<<7)  /* Transmit pulse length bit 7 mask. */
+#define USART_TXPL_7_bp  7  /* Transmit pulse length bit 7 position. */
+
+/* USART.RXPLCTRL  bit masks and bit positions */
+#define USART_RXPL_gm  0x7F  /* Receiver Pulse Lenght group mask. */
+#define USART_RXPL_gp  0  /* Receiver Pulse Lenght group position. */
+#define USART_RXPL_0_bm  (1<<0)  /* Receiver Pulse Lenght bit 0 mask. */
+#define USART_RXPL_0_bp  0  /* Receiver Pulse Lenght bit 0 position. */
+#define USART_RXPL_1_bm  (1<<1)  /* Receiver Pulse Lenght bit 1 mask. */
+#define USART_RXPL_1_bp  1  /* Receiver Pulse Lenght bit 1 position. */
+#define USART_RXPL_2_bm  (1<<2)  /* Receiver Pulse Lenght bit 2 mask. */
+#define USART_RXPL_2_bp  2  /* Receiver Pulse Lenght bit 2 position. */
+#define USART_RXPL_3_bm  (1<<3)  /* Receiver Pulse Lenght bit 3 mask. */
+#define USART_RXPL_3_bp  3  /* Receiver Pulse Lenght bit 3 position. */
+#define USART_RXPL_4_bm  (1<<4)  /* Receiver Pulse Lenght bit 4 mask. */
+#define USART_RXPL_4_bp  4  /* Receiver Pulse Lenght bit 4 position. */
+#define USART_RXPL_5_bm  (1<<5)  /* Receiver Pulse Lenght bit 5 mask. */
+#define USART_RXPL_5_bp  5  /* Receiver Pulse Lenght bit 5 position. */
+#define USART_RXPL_6_bm  (1<<6)  /* Receiver Pulse Lenght bit 6 mask. */
+#define USART_RXPL_6_bp  6  /* Receiver Pulse Lenght bit 6 position. */
+
+
+
+/* VPORT - Virtual Ports */
+/* VPORT.INTFLAGS  bit masks and bit positions */
+#define VPORT_INT_gm  0xFF  /* Pin Interrupt Flag group mask. */
+#define VPORT_INT_gp  0  /* Pin Interrupt Flag group position. */
+#define VPORT_INT_0_bm  (1<<0)  /* Pin Interrupt Flag bit 0 mask. */
+#define VPORT_INT_0_bp  0  /* Pin Interrupt Flag bit 0 position. */
+#define VPORT_INT_1_bm  (1<<1)  /* Pin Interrupt Flag bit 1 mask. */
+#define VPORT_INT_1_bp  1  /* Pin Interrupt Flag bit 1 position. */
+#define VPORT_INT_2_bm  (1<<2)  /* Pin Interrupt Flag bit 2 mask. */
+#define VPORT_INT_2_bp  2  /* Pin Interrupt Flag bit 2 position. */
+#define VPORT_INT_3_bm  (1<<3)  /* Pin Interrupt Flag bit 3 mask. */
+#define VPORT_INT_3_bp  3  /* Pin Interrupt Flag bit 3 position. */
+#define VPORT_INT_4_bm  (1<<4)  /* Pin Interrupt Flag bit 4 mask. */
+#define VPORT_INT_4_bp  4  /* Pin Interrupt Flag bit 4 position. */
+#define VPORT_INT_5_bm  (1<<5)  /* Pin Interrupt Flag bit 5 mask. */
+#define VPORT_INT_5_bp  5  /* Pin Interrupt Flag bit 5 position. */
+#define VPORT_INT_6_bm  (1<<6)  /* Pin Interrupt Flag bit 6 mask. */
+#define VPORT_INT_6_bp  6  /* Pin Interrupt Flag bit 6 position. */
+#define VPORT_INT_7_bm  (1<<7)  /* Pin Interrupt Flag bit 7 mask. */
+#define VPORT_INT_7_bp  7  /* Pin Interrupt Flag bit 7 position. */
+
+
+/* VREF - Voltage reference */
+/* VREF.DAC0REF  bit masks and bit positions */
+#define VREF_REFSEL_gm  0x07  /* Reference select group mask. */
+#define VREF_REFSEL_gp  0  /* Reference select group position. */
+#define VREF_REFSEL_0_bm  (1<<0)  /* Reference select bit 0 mask. */
+#define VREF_REFSEL_0_bp  0  /* Reference select bit 0 position. */
+#define VREF_REFSEL_1_bm  (1<<1)  /* Reference select bit 1 mask. */
+#define VREF_REFSEL_1_bp  1  /* Reference select bit 1 position. */
+#define VREF_REFSEL_2_bm  (1<<2)  /* Reference select bit 2 mask. */
+#define VREF_REFSEL_2_bp  2  /* Reference select bit 2 position. */
+#define VREF_ALWAYSON_bm  0x80  /* Always on bit mask. */
+#define VREF_ALWAYSON_bp  7  /* Always on bit position. */
+
+/* VREF.ACREF  bit masks and bit positions */
+/* VREF_REFSEL  is already defined. */
+/* VREF_ALWAYSON  is already defined. */
+
+
+/* WDT - Watch-Dog Timer */
+/* WDT.CTRLA  bit masks and bit positions */
+#define WDT_PERIOD_gm  0x0F  /* Period group mask. */
+#define WDT_PERIOD_gp  0  /* Period group position. */
+#define WDT_PERIOD_0_bm  (1<<0)  /* Period bit 0 mask. */
+#define WDT_PERIOD_0_bp  0  /* Period bit 0 position. */
+#define WDT_PERIOD_1_bm  (1<<1)  /* Period bit 1 mask. */
+#define WDT_PERIOD_1_bp  1  /* Period bit 1 position. */
+#define WDT_PERIOD_2_bm  (1<<2)  /* Period bit 2 mask. */
+#define WDT_PERIOD_2_bp  2  /* Period bit 2 position. */
+#define WDT_PERIOD_3_bm  (1<<3)  /* Period bit 3 mask. */
+#define WDT_PERIOD_3_bp  3  /* Period bit 3 position. */
+#define WDT_WINDOW_gm  0xF0  /* Window group mask. */
+#define WDT_WINDOW_gp  4  /* Window group position. */
+#define WDT_WINDOW_0_bm  (1<<4)  /* Window bit 0 mask. */
+#define WDT_WINDOW_0_bp  4  /* Window bit 0 position. */
+#define WDT_WINDOW_1_bm  (1<<5)  /* Window bit 1 mask. */
+#define WDT_WINDOW_1_bp  5  /* Window bit 1 position. */
+#define WDT_WINDOW_2_bm  (1<<6)  /* Window bit 2 mask. */
+#define WDT_WINDOW_2_bp  6  /* Window bit 2 position. */
+#define WDT_WINDOW_3_bm  (1<<7)  /* Window bit 3 mask. */
+#define WDT_WINDOW_3_bp  7  /* Window bit 3 position. */
+
+/* WDT.STATUS  bit masks and bit positions */
+#define WDT_SYNCBUSY_bm  0x01  /* Syncronization busy bit mask. */
+#define WDT_SYNCBUSY_bp  0  /* Syncronization busy bit position. */
+#define WDT_LOCK_bm  0x80  /* Lock enable bit mask. */
+#define WDT_LOCK_bp  7  /* Lock enable bit position. */
+
+
+/* ========== Generic Port Pins ========== */
+#define PIN0_bm 0x01
+#define PIN0_bp 0
+#define PIN1_bm 0x02
+#define PIN1_bp 1
+#define PIN2_bm 0x04
+#define PIN2_bp 2
+#define PIN3_bm 0x08
+#define PIN3_bp 3
+#define PIN4_bm 0x10
+#define PIN4_bp 4
+#define PIN5_bm 0x20
+#define PIN5_bp 5
+#define PIN6_bm 0x40
+#define PIN6_bp 6
+#define PIN7_bm 0x80
+#define PIN7_bp 7
+
+/* ========== Interrupt Vector Definitions ========== */
+/* Vector 0 is the reset vector */
+
+/* NMI interrupt vectors */
+#define NMI_vect_num  1
+#define NMI_vect      _VECTOR(1)  /*  */
+
+/* BOD interrupt vectors */
+#define BOD_VLM_vect_num  2
+#define BOD_VLM_vect      _VECTOR(2)  /*  */
+
+/* CLKCTRL interrupt vectors */
+#define CLKCTRL_CFD_vect_num  3
+#define CLKCTRL_CFD_vect      _VECTOR(3)  /*  */
+
+/* RTC interrupt vectors */
+#define RTC_CNT_vect_num  4
+#define RTC_CNT_vect      _VECTOR(4)  /*  */
+#define RTC_PIT_vect_num  5
+#define RTC_PIT_vect      _VECTOR(5)  /*  */
+
+/* CCL interrupt vectors */
+#define CCL_CCL_vect_num  6
+#define CCL_CCL_vect      _VECTOR(6)  /*  */
+
+/* PORTA interrupt vectors */
+#define PORTA_PORT_vect_num  7
+#define PORTA_PORT_vect      _VECTOR(7)  /*  */
+
+/* TCA0 interrupt vectors */
+#define TCA0_LUNF_vect_num  8
+#define TCA0_LUNF_vect      _VECTOR(8)  /*  */
+#define TCA0_OVF_vect_num  8
+#define TCA0_OVF_vect      _VECTOR(8)  /*  */
+#define TCA0_HUNF_vect_num  9
+#define TCA0_HUNF_vect      _VECTOR(9)  /*  */
+#define TCA0_CMP0_vect_num  10
+#define TCA0_CMP0_vect      _VECTOR(10)  /*  */
+#define TCA0_LCMP0_vect_num  10
+#define TCA0_LCMP0_vect      _VECTOR(10)  /*  */
+#define TCA0_CMP1_vect_num  11
+#define TCA0_CMP1_vect      _VECTOR(11)  /*  */
+#define TCA0_LCMP1_vect_num  11
+#define TCA0_LCMP1_vect      _VECTOR(11)  /*  */
+#define TCA0_CMP2_vect_num  12
+#define TCA0_CMP2_vect      _VECTOR(12)  /*  */
+#define TCA0_LCMP2_vect_num  12
+#define TCA0_LCMP2_vect      _VECTOR(12)  /*  */
+
+/* TCB0 interrupt vectors */
+#define TCB0_INT_vect_num  13
+#define TCB0_INT_vect      _VECTOR(13)  /*  */
+
+/* TCB1 interrupt vectors */
+#define TCB1_INT_vect_num  14
+#define TCB1_INT_vect      _VECTOR(14)  /*  */
+
+/* TWI0 interrupt vectors */
+#define TWI0_TWIS_vect_num  15
+#define TWI0_TWIS_vect      _VECTOR(15)  /*  */
+#define TWI0_TWIM_vect_num  16
+#define TWI0_TWIM_vect      _VECTOR(16)  /*  */
+
+/* SPI0 interrupt vectors */
+#define SPI0_INT_vect_num  17
+#define SPI0_INT_vect      _VECTOR(17)  /*  */
+
+/* USART0 interrupt vectors */
+#define USART0_RXC_vect_num  18
+#define USART0_RXC_vect      _VECTOR(18)  /*  */
+#define USART0_DRE_vect_num  19
+#define USART0_DRE_vect      _VECTOR(19)  /*  */
+#define USART0_TXC_vect_num  20
+#define USART0_TXC_vect      _VECTOR(20)  /*  */
+
+/* PORTD interrupt vectors */
+#define PORTD_PORT_vect_num  21
+#define PORTD_PORT_vect      _VECTOR(21)  /*  */
+
+/* AC0 interrupt vectors */
+#define AC0_AC_vect_num  22
+#define AC0_AC_vect      _VECTOR(22)  /*  */
+
+/* ADC0 interrupt vectors */
+#define ADC0_ERROR_vect_num  23
+#define ADC0_ERROR_vect      _VECTOR(23)  /*  */
+#define ADC0_RESRDY_vect_num  24
+#define ADC0_RESRDY_vect      _VECTOR(24)  /*  */
+#define ADC0_SAMPRDY_vect_num  25
+#define ADC0_SAMPRDY_vect      _VECTOR(25)  /*  */
+
+/* AC1 interrupt vectors */
+#define AC1_AC_vect_num  26
+#define AC1_AC_vect      _VECTOR(26)  /*  */
+
+/* PORTC interrupt vectors */
+#define PORTC_PORT_vect_num  27
+#define PORTC_PORT_vect      _VECTOR(27)  /*  */
+
+/* TCB2 interrupt vectors */
+#define TCB2_INT_vect_num  28
+#define TCB2_INT_vect      _VECTOR(28)  /*  */
+
+/* USART1 interrupt vectors */
+#define USART1_RXC_vect_num  29
+#define USART1_RXC_vect      _VECTOR(29)  /*  */
+#define USART1_DRE_vect_num  30
+#define USART1_DRE_vect      _VECTOR(30)  /*  */
+#define USART1_TXC_vect_num  31
+#define USART1_TXC_vect      _VECTOR(31)  /*  */
+
+/* PORTF interrupt vectors */
+#define PORTF_PORT_vect_num  32
+#define PORTF_PORT_vect      _VECTOR(32)  /*  */
+
+/* NVMCTRL interrupt vectors */
+#define NVMCTRL_EEREADY_vect_num  33
+#define NVMCTRL_EEREADY_vect      _VECTOR(33)  /*  */
+#define NVMCTRL_FLREADY_vect_num  33
+#define NVMCTRL_FLREADY_vect      _VECTOR(33)  /*  */
+#define NVMCTRL_NVMREADY_vect_num  33
+#define NVMCTRL_NVMREADY_vect      _VECTOR(33)  /*  */
+
+/* USART2 interrupt vectors */
+#define USART2_RXC_vect_num  34
+#define USART2_RXC_vect      _VECTOR(34)  /*  */
+#define USART2_DRE_vect_num  35
+#define USART2_DRE_vect      _VECTOR(35)  /*  */
+#define USART2_TXC_vect_num  36
+#define USART2_TXC_vect      _VECTOR(36)  /*  */
+
+#define _VECTOR_SIZE 4 /* Size of individual vector. */
+#define _VECTORS_SIZE (37 * _VECTOR_SIZE)
+
+
+/* ========== Constants ========== */
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define DATAMEM_START     (0x0000)
+#  define DATAMEM_SIZE      (65536)
+#else
+#  define DATAMEM_START     (0x0000U)
+#  define DATAMEM_SIZE      (65536U)
+#endif
+#define DATAMEM_END       (DATAMEM_START + DATAMEM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define IO_START     (0x0000)
+#  define IO_SIZE      (4159)
+#  define IO_PAGE_SIZE (0)
+#else
+#  define IO_START     (0x0000U)
+#  define IO_SIZE      (4159U)
+#  define IO_PAGE_SIZE (0U)
+#endif
+#define IO_END       (IO_START + IO_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define LOCKBITS_START     (0x1040)
+#  define LOCKBITS_SIZE      (4)
+#  define LOCKBITS_PAGE_SIZE (4)
+#else
+#  define LOCKBITS_START     (0x1040U)
+#  define LOCKBITS_SIZE      (4U)
+#  define LOCKBITS_PAGE_SIZE (4U)
+#endif
+#define LOCKBITS_END       (LOCKBITS_START + LOCKBITS_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define FUSES_START     (0x1050)
+#  define FUSES_SIZE      (16)
+#  define FUSES_PAGE_SIZE (8)
+#else
+#  define FUSES_START     (0x1050U)
+#  define FUSES_SIZE      (16U)
+#  define FUSES_PAGE_SIZE (8U)
+#endif
+#define FUSES_END       (FUSES_START + FUSES_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define USER_SIGNATURES_START     (0x1080)
+#  define USER_SIGNATURES_SIZE      (64)
+#  define USER_SIGNATURES_PAGE_SIZE (64)
+#else
+#  define USER_SIGNATURES_START     (0x1080U)
+#  define USER_SIGNATURES_SIZE      (64U)
+#  define USER_SIGNATURES_PAGE_SIZE (64U)
+#endif
+#define USER_SIGNATURES_END       (USER_SIGNATURES_START + USER_SIGNATURES_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define SIGNATURES_START     (0x1100)
+#  define SIGNATURES_SIZE      (3)
+#  define SIGNATURES_PAGE_SIZE (128)
+#else
+#  define SIGNATURES_START     (0x1100U)
+#  define SIGNATURES_SIZE      (3U)
+#  define SIGNATURES_PAGE_SIZE (128U)
+#endif
+#define SIGNATURES_END       (SIGNATURES_START + SIGNATURES_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define PROD_SIGNATURES_START     (0x1103)
+#  define PROD_SIGNATURES_SIZE      (125)
+#  define PROD_SIGNATURES_PAGE_SIZE (128)
+#else
+#  define PROD_SIGNATURES_START     (0x1103U)
+#  define PROD_SIGNATURES_SIZE      (125U)
+#  define PROD_SIGNATURES_PAGE_SIZE (128U)
+#endif
+#define PROD_SIGNATURES_END       (PROD_SIGNATURES_START + PROD_SIGNATURES_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define EEPROM_START     (0x1400)
+#  define EEPROM_SIZE      (512)
+#  define EEPROM_PAGE_SIZE (8)
+#else
+#  define EEPROM_START     (0x1400U)
+#  define EEPROM_SIZE      (512U)
+#  define EEPROM_PAGE_SIZE (8U)
+#endif
+#define EEPROM_END       (EEPROM_START + EEPROM_SIZE - 1)
+
+/* Added MAPPED_EEPROM segment names for avr-libc */
+#define MAPPED_EEPROM_START     (EEPROM_START)
+#define MAPPED_EEPROM_SIZE      (EEPROM_SIZE)
+#define MAPPED_EEPROM_PAGE_SIZE (EEPROM_PAGE_SIZE)
+#define MAPPED_EEPROM_END       (MAPPED_EEPROM_START + MAPPED_EEPROM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define INTERNAL_SRAM_START     (0x7000)
+#  define INTERNAL_SRAM_SIZE      (4096)
+#  define INTERNAL_SRAM_PAGE_SIZE (0)
+#else
+#  define INTERNAL_SRAM_START     (0x7000U)
+#  define INTERNAL_SRAM_SIZE      (4096U)
+#  define INTERNAL_SRAM_PAGE_SIZE (0U)
+#endif
+#define INTERNAL_SRAM_END       (INTERNAL_SRAM_START + INTERNAL_SRAM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define MAPPED_PROGMEM_START     (0x8000)
+#  define MAPPED_PROGMEM_SIZE      (32768)
+#  define MAPPED_PROGMEM_PAGE_SIZE (64)
+#else
+#  define MAPPED_PROGMEM_START     (0x8000U)
+#  define MAPPED_PROGMEM_SIZE      (32768U)
+#  define MAPPED_PROGMEM_PAGE_SIZE (64U)
+#endif
+#define MAPPED_PROGMEM_END       (MAPPED_PROGMEM_START + MAPPED_PROGMEM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define PROGMEM_START     (0x0000)
+#  define PROGMEM_SIZE      (32768)
+#  define PROGMEM_PAGE_SIZE (64)
+#else
+#  define PROGMEM_START     (0x0000U)
+#  define PROGMEM_SIZE      (32768U)
+#  define PROGMEM_PAGE_SIZE (64U)
+#endif
+#define PROGMEM_END       (PROGMEM_START + PROGMEM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define PROGMEM_NRWW_START     (0x0000)
+#  define PROGMEM_NRWW_SIZE      (4096)
+#  define PROGMEM_NRWW_PAGE_SIZE (64)
+#else
+#  define PROGMEM_NRWW_START     (0x0000U)
+#  define PROGMEM_NRWW_SIZE      (4096U)
+#  define PROGMEM_NRWW_PAGE_SIZE (64U)
+#endif
+#define PROGMEM_NRWW_END       (PROGMEM_NRWW_START + PROGMEM_NRWW_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define PROGMEM_RWW_START     (0x1000)
+#  define PROGMEM_RWW_SIZE      (28672)
+#  define PROGMEM_RWW_PAGE_SIZE (64)
+#else
+#  define PROGMEM_RWW_START     (0x1000U)
+#  define PROGMEM_RWW_SIZE      (28672U)
+#  define PROGMEM_RWW_PAGE_SIZE (64U)
+#endif
+#define PROGMEM_RWW_END       (PROGMEM_RWW_START + PROGMEM_RWW_SIZE - 1)
+
+#define FLASHSTART   PROGMEM_START
+#define FLASHEND     PROGMEM_END
+#define RAMSTART     INTERNAL_SRAM_START
+#define RAMSIZE      INTERNAL_SRAM_SIZE
+#define RAMEND       INTERNAL_SRAM_END
+#define E2END        EEPROM_END
+#define E2PAGESIZE   EEPROM_PAGE_SIZE
+
+/* ========== Fuses ========== */
+#define FUSE_MEMORY_SIZE 16
+
+/* Fuse Byte 0 (WDTCFG) */
+#define FUSE_PERIOD0  (unsigned char)_BV(0)  /* Watchdog Timeout Period Bit 0 */
+#define FUSE_PERIOD1  (unsigned char)_BV(1)  /* Watchdog Timeout Period Bit 1 */
+#define FUSE_PERIOD2  (unsigned char)_BV(2)  /* Watchdog Timeout Period Bit 2 */
+#define FUSE_PERIOD3  (unsigned char)_BV(3)  /* Watchdog Timeout Period Bit 3 */
+#define FUSE_WINDOW0  (unsigned char)_BV(4)  /* Watchdog Window Timeout Period Bit 0 */
+#define FUSE_WINDOW1  (unsigned char)_BV(5)  /* Watchdog Window Timeout Period Bit 1 */
+#define FUSE_WINDOW2  (unsigned char)_BV(6)  /* Watchdog Window Timeout Period Bit 2 */
+#define FUSE_WINDOW3  (unsigned char)_BV(7)  /* Watchdog Window Timeout Period Bit 3 */
+#define FUSE0_DEFAULT  (0x0)
+#define FUSE_WDTCFG_DEFAULT  (0x0)
+
+/* Fuse Byte 1 (BODCFG) */
+#define FUSE_SLEEP0  (unsigned char)_BV(0)  /* BOD Operation in Sleep Mode Bit 0 */
+#define FUSE_SLEEP1  (unsigned char)_BV(1)  /* BOD Operation in Sleep Mode Bit 1 */
+#define FUSE_ACTIVE0  (unsigned char)_BV(2)  /* BOD Operation in Active Mode Bit 0 */
+#define FUSE_ACTIVE1  (unsigned char)_BV(3)  /* BOD Operation in Active Mode Bit 1 */
+#define FUSE_SAMPFREQ  (unsigned char)_BV(4)  /* BOD Sample Frequency */
+#define FUSE_LVL0  (unsigned char)_BV(5)  /* BOD Level Bit 0 */
+#define FUSE_LVL1  (unsigned char)_BV(6)  /* BOD Level Bit 1 */
+#define FUSE_LVL2  (unsigned char)_BV(7)  /* BOD Level Bit 2 */
+#define FUSE1_DEFAULT  (0x0)
+#define FUSE_BODCFG_DEFAULT  (0x0)
+
+/* Fuse Byte 2 (OSCCFG) */
+#define FUSE_OSCHFFRQ  (unsigned char)_BV(3)  /* High-frequency Oscillator Frequency */
+#define FUSE2_DEFAULT  (0x0)
+#define FUSE_OSCCFG_DEFAULT  (0x0)
+
+/* Fuse Byte 3 Reserved */
+
+/* Fuse Byte 4 Reserved */
+
+/* Fuse Byte 5 (SYSCFG0) */
+#define FUSE_EESAVE  (unsigned char)_BV(0)  /* EEPROM Save */
+#define FUSE_RSTPINCFG  (unsigned char)_BV(3)  /* Reset Pin Configuration */
+#define FUSE_UPDIPINCFG  (unsigned char)_BV(4)  /* UPDI Pin Configuration */
+#define FUSE_CRCSEL  (unsigned char)_BV(5)  /* CRC Select */
+#define FUSE_CRCSRC0  (unsigned char)_BV(6)  /* CRC Source Bit 0 */
+#define FUSE_CRCSRC1  (unsigned char)_BV(7)  /* CRC Source Bit 1 */
+#define FUSE5_DEFAULT  (0xD0)
+#define FUSE_SYSCFG0_DEFAULT  (0xD0)
+
+/* Fuse Byte 6 (SYSCFG1) */
+#define FUSE_SUT0  (unsigned char)_BV(0)  /* Startup Time Bit 0 */
+#define FUSE_SUT1  (unsigned char)_BV(1)  /* Startup Time Bit 1 */
+#define FUSE_SUT2  (unsigned char)_BV(2)  /* Startup Time Bit 2 */
+#define FUSE6_DEFAULT  (0x7)
+#define FUSE_SYSCFG1_DEFAULT  (0x7)
+
+/* Fuse Byte 7 (CODESIZE) */
+#define FUSE7_DEFAULT  (0x0)
+#define FUSE_CODESIZE_DEFAULT  (0x0)
+
+/* Fuse Byte 8 (BOOTSIZE) */
+#define FUSE8_DEFAULT  (0x0)
+#define FUSE_BOOTSIZE_DEFAULT  (0x0)
+
+/* ========== Lock Bits ========== */
+#define __LOCK_KEY_EXIST
+#ifdef LOCKBITS_DEFAULT
+#undef LOCKBITS_DEFAULT
+#endif //LOCKBITS_DEFAULT
+#define LOCKBITS_DEFAULT  (0x5CC5C55C)
+
+/* ========== Signature ========== */
+#define SIGNATURE_0 0x1E
+#define SIGNATURE_1 0x95
+#define SIGNATURE_2 0x3E
+
+#endif /* #ifdef _AVR_AVR32EA28_H_INCLUDED */
+

--- a/include/avr/ioavr32ea32.h
+++ b/include/avr/ioavr32ea32.h
@@ -1,0 +1,5811 @@
+/*
+ * Copyright (C) 2023, Microchip Technology Inc. and its subsidiaries ("Microchip")
+ * All rights reserved.
+ *
+ * This software is developed by Microchip Technology Inc. and its subsidiaries ("Microchip").
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other
+ *        materials provided with the distribution. Publication is not required when
+ *        this file is used in an embedded application.
+ *
+ *     3. Microchip's name may not be used to endorse or promote products derived from this
+ *        software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY MICROCHIP "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL MICROCHIP BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING BUT NOT LIMITED TO
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWSOEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _AVR_IO_H_
+#  error "Include <avr/io.h> instead of this file."
+#endif
+
+#ifndef _AVR_IOXXX_H_
+#  define _AVR_IOXXX_H_ "ioavr32ea32.h"
+#else
+#  error "Attempt to include more than one <avr/ioXXX.h> file."
+#endif
+
+#ifndef _AVR_AVR32EA32_H_INCLUDED
+#define _AVR_AVR32EA32_H_INCLUDED
+
+/* Ungrouped common registers */
+#define CCP  _SFR_MEM8(0x0034)  /* Configuration Change Protection */
+#define SP  _SFR_MEM16(0x003D)  /* Stack Pointer */
+#define SPL  _SFR_MEM8(0x003D)  /* Stack Pointer Low */
+#define SPH  _SFR_MEM8(0x003E)  /* Stack Pointer High */
+#define SREG  _SFR_MEM8(0x003F)  /* Status Register */
+
+/* C Language Only */
+#if !defined (__ASSEMBLER__)
+
+#include <stdint.h>
+
+typedef volatile uint8_t register8_t;
+typedef volatile uint16_t register16_t;
+typedef volatile uint32_t register32_t;
+
+
+#ifdef _WORDREGISTER
+#undef _WORDREGISTER
+#endif
+#define _WORDREGISTER(regname)   \
+    __extension__ union \
+    { \
+        register16_t regname; \
+        struct \
+        { \
+            register8_t regname ## L; \
+            register8_t regname ## H; \
+        }; \
+    }
+
+#ifdef _DWORDREGISTER
+#undef _DWORDREGISTER
+#endif
+#define _DWORDREGISTER(regname)  \
+    __extension__ union \
+    { \
+        register32_t regname; \
+        struct \
+        { \
+            register8_t regname ## 0; \
+            register8_t regname ## 1; \
+            register8_t regname ## 2; \
+            register8_t regname ## 3; \
+        }; \
+    }
+
+
+/*
+==========================================================================
+IO Module Structures
+==========================================================================
+*/
+
+
+/*
+--------------------------------------------------------------------------
+AC - Analog Comparator
+--------------------------------------------------------------------------
+*/
+
+/* Analog Comparator */
+typedef struct AC_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t MUXCTRL;  /* Mux Control A */
+    register8_t reserved_1[2];
+    register8_t DACREF;  /* DAC Voltage Reference */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t STATUS;  /* Status */
+} AC_t;
+
+/* Hysteresis Mode select */
+typedef enum AC_HYSMODE_enum
+{
+    AC_HYSMODE_NONE_gc = (0x00<<1),  /* No hysteresis */
+    AC_HYSMODE_SMALL_gc = (0x01<<1),  /* Small hysteresis */
+    AC_HYSMODE_MEDIUM_gc = (0x02<<1),  /* Medium hysteresis */
+    AC_HYSMODE_LARGE_gc = (0x03<<1)  /* Large hysteresis */
+} AC_HYSMODE_t;
+
+/* AC Output Initial Value select */
+typedef enum AC_INITVAL_enum
+{
+    AC_INITVAL_LOW_gc = (0x00<<6),  /* Output initialized to 0 */
+    AC_INITVAL_HIGH_gc = (0x01<<6)  /* Output initialized to 1 */
+} AC_INITVAL_t;
+
+/* Interrupt Mode select */
+typedef enum AC_INTMODE_NORMAL_enum
+{
+    AC_INTMODE_NORMAL_BOTHEDGE_gc = (0x00<<4),  /* Positive and negative inputs crosses */
+    AC_INTMODE_NORMAL_NEGEDGE_gc = (0x02<<4),  /* Positive input goes below negative input */
+    AC_INTMODE_NORMAL_POSEDGE_gc = (0x03<<4)  /* Positive input goes above negative input */
+} AC_INTMODE_NORMAL_t;
+
+/* Interrupt Mode select */
+typedef enum AC_INTMODE_WINDOW_enum
+{
+    AC_INTMODE_WINDOW_ABOVE_gc = (0x00<<4),  /* Window interrupt when input above both references */
+    AC_INTMODE_WINDOW_INSIDE_gc = (0x01<<4),  /* Window interrupt when input betweeen references */
+    AC_INTMODE_WINDOW_BELOW_gc = (0x02<<4),  /* Window interrupt when input below both references */
+    AC_INTMODE_WINDOW_OUTSIDE_gc = (0x03<<4)  /* Window interrupt when input outside reference */
+} AC_INTMODE_WINDOW_t;
+
+/* Negative Input MUX Selection */
+typedef enum AC_MUXNEG_enum
+{
+    AC_MUXNEG_AINN0_gc = (0x00<<0),  /* Negative Pin 0 */
+    AC_MUXNEG_AINN1_gc = (0x01<<0),  /* Negative Pin 1 */
+    AC_MUXNEG_AINN2_gc = (0x02<<0),  /* Negative Pin 2 */
+    AC_MUXNEG_AINN3_gc = (0x03<<0),  /* Negative Pin 3 */
+    AC_MUXNEG_DACREF_gc = (0x04<<0)  /* DAC Reference */
+} AC_MUXNEG_t;
+
+/* Positive Input MUX Selection */
+typedef enum AC_MUXPOS_enum
+{
+    AC_MUXPOS_AINP0_gc = (0x00<<3),  /* Positive Pin 0 */
+    AC_MUXPOS_AINP1_gc = (0x01<<3),  /* Positive Pin 1 */
+    AC_MUXPOS_AINP2_gc = (0x02<<3),  /* Positive Pin 2 */
+    AC_MUXPOS_AINP3_gc = (0x03<<3),  /* Positive Pin 3 */
+    AC_MUXPOS_AINP4_gc = (0x04<<3)  /* Positive Pin 4 */
+} AC_MUXPOS_t;
+
+/* Power profile select */
+typedef enum AC_POWER_enum
+{
+    AC_POWER_PROFILE0_gc = (0x00<<3),  /* Power profile 0, Fastest response time, highest consumption */
+    AC_POWER_PROFILE1_gc = (0x01<<3)  /* Power profile 1 */
+} AC_POWER_t;
+
+/* Window selection mode */
+typedef enum AC_WINSEL_enum
+{
+    AC_WINSEL_DISABLED_gc = (0x00<<0),  /* Window function disabled */
+    AC_WINSEL_UPSEL1_gc = (0x01<<0)  /* Select ACn+1 as upper limit in window compare */
+} AC_WINSEL_t;
+
+/* Analog Comparator Window State select */
+typedef enum AC_WINSTATE_enum
+{
+    AC_WINSTATE_ABOVE_gc = (0x00<<6),  /* Above window */
+    AC_WINSTATE_INSIDE_gc = (0x01<<6),  /* Inside window */
+    AC_WINSTATE_BELOW_gc = (0x02<<6)  /* Below window */
+} AC_WINSTATE_t;
+
+/*
+--------------------------------------------------------------------------
+ADC - Analog to Digital Converter
+--------------------------------------------------------------------------
+*/
+
+/* Analog to Digital Converter */
+typedef struct ADC_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    register8_t CTRLD;  /* Control D */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t STATUS;  /* Status register */
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t CTRLE;  /* Control E */
+    register8_t CTRLF;  /* Control F */
+    register8_t COMMAND;  /* Command register */
+    register8_t PGACTRL;  /* PGA Control */
+    register8_t MUXPOS;  /* Positive Input Multiplexer */
+    register8_t MUXNEG;  /* Negative Input Multiplexer */
+    register8_t reserved_1[2];
+    _DWORDREGISTER(RESULT);  /* Result */
+    _WORDREGISTER(SAMPLE);  /* Sample */
+    register8_t reserved_2[2];
+    register8_t TEMP0;  /* Temporary Data 0 */
+    register8_t TEMP1;  /* Temporary Data 1 */
+    register8_t TEMP2;  /* Temporary Data 2 */
+    register8_t reserved_3[1];
+    _WORDREGISTER(WINLT);  /* Window Low Threshold */
+    _WORDREGISTER(WINHT);  /* Window High Threshold */
+    register8_t reserved_4[32];
+} ADC_t;
+
+/* Sign Chopping select */
+typedef enum ADC_CHOPPING_enum
+{
+    ADC_CHOPPING_DISABLE_gc = (0x00<<6),  /* Sign Chopping Disabled */
+    ADC_CHOPPING_ENABLE_gc = (0x01<<6)  /* Sign Chopping Enabled */
+} ADC_CHOPPING_t;
+
+/* Gain select */
+typedef enum ADC_GAIN_enum
+{
+    ADC_GAIN_1X_gc = (0x00<<5),  /* 1x gain */
+    ADC_GAIN_2X_gc = (0x01<<5),  /* 2x gain */
+    ADC_GAIN_4X_gc = (0x02<<5),  /* 4x gain */
+    ADC_GAIN_8X_gc = (0x03<<5),  /* 8x gain */
+    ADC_GAIN_16X_gc = (0x04<<5)  /* 16x gain */
+} ADC_GAIN_t;
+
+/* Mode select */
+typedef enum ADC_MODE_enum
+{
+    ADC_MODE_SINGLE_8BIT_gc = (0x00<<4),  /* Single Conversion with 8-bit resolution */
+    ADC_MODE_SINGLE_12BIT_gc = (0x01<<4),  /* Single Conversion with 12-bit resolution */
+    ADC_MODE_SERIES_gc = (0x02<<4),  /* Series with accumulation, separate trigger for every 12-bit conversion */
+    ADC_MODE_SERIES_SCALING_gc = (0x03<<4),  /* Series with accumulation and scaling, separate trigger for every 12-bit conversion */
+    ADC_MODE_BURST_gc = (0x04<<4),  /* Burst with accumulation, one trigger will run SAMPNUM 12-bit conversions */
+    ADC_MODE_BURST_SCALING_gc = (0x05<<4)  /* Burst with accumulation and scaling, one trigger will run SAMPNUM 12-bit conversions */
+} ADC_MODE_t;
+
+/* Analog Channel Selection Bits */
+typedef enum ADC_MUXNEG_enum
+{
+    ADC_MUXNEG_AIN0_gc = (0x00<<0),  /* ADC input pin 0 */
+    ADC_MUXNEG_AIN1_gc = (0x01<<0),  /* ADC input pin 1 */
+    ADC_MUXNEG_AIN2_gc = (0x02<<0),  /* ADC input pin 2 */
+    ADC_MUXNEG_AIN3_gc = (0x03<<0),  /* ADC input pin 3 */
+    ADC_MUXNEG_AIN4_gc = (0x04<<0),  /* ADC input pin 4 */
+    ADC_MUXNEG_AIN5_gc = (0x05<<0),  /* ADC input pin 5 */
+    ADC_MUXNEG_AIN6_gc = (0x06<<0),  /* ADC input pin 6 */
+    ADC_MUXNEG_AIN7_gc = (0x07<<0),  /* ADC input pin 7 */
+    ADC_MUXNEG_AIN16_gc = (0x10<<0),  /* ADC input pin 16 */
+    ADC_MUXNEG_AIN17_gc = (0x11<<0),  /* ADC input pin 17 */
+    ADC_MUXNEG_AIN18_gc = (0x12<<0),  /* ADC input pin 18 */
+    ADC_MUXNEG_AIN19_gc = (0x13<<0),  /* ADC input pin 19 */
+    ADC_MUXNEG_AIN20_gc = (0x14<<0),  /* ADC input pin 20 */
+    ADC_MUXNEG_AIN21_gc = (0x15<<0),  /* ADC input pin 21 */
+    ADC_MUXNEG_AIN22_gc = (0x16<<0),  /* ADC input pin 22 */
+    ADC_MUXNEG_AIN23_gc = (0x17<<0),  /* ADC input pin 23 */
+    ADC_MUXNEG_AIN24_gc = (0x18<<0),  /* ADC input pin 24 */
+    ADC_MUXNEG_AIN25_gc = (0x19<<0),  /* ADC input pin 25 */
+    ADC_MUXNEG_AIN26_gc = (0x1A<<0),  /* ADC input pin 26 */
+    ADC_MUXNEG_AIN27_gc = (0x1B<<0),  /* ADC input pin 27 */
+    ADC_MUXNEG_AIN28_gc = (0x1C<<0),  /* ADC input pin 28 */
+    ADC_MUXNEG_AIN29_gc = (0x1D<<0),  /* ADC input pin 29 */
+    ADC_MUXNEG_AIN30_gc = (0x1E<<0),  /* ADC input pin 30 */
+    ADC_MUXNEG_AIN31_gc = (0x1F<<0),  /* ADC input pin 31 */
+    ADC_MUXNEG_GND_gc = (0x30<<0),  /* Ground */
+    ADC_MUXNEG_DAC0_gc = (0x38<<0),  /* Digital to Analog Converter 0 */
+    ADC_MUXNEG_DACREF0_gc = (0x39<<0),  /* AC0 DAC reference */
+    ADC_MUXNEG_DACREF1_gc = (0x3A<<0)  /* AC1 DAC reference */
+} ADC_MUXNEG_t;
+
+/* Analog Channel Selection Bits */
+typedef enum ADC_MUXPOS_enum
+{
+    ADC_MUXPOS_AIN0_gc = (0x00<<0),  /* ADC input pin 0 */
+    ADC_MUXPOS_AIN1_gc = (0x01<<0),  /* ADC input pin 1 */
+    ADC_MUXPOS_AIN2_gc = (0x02<<0),  /* ADC input pin 2 */
+    ADC_MUXPOS_AIN3_gc = (0x03<<0),  /* ADC input pin 3 */
+    ADC_MUXPOS_AIN4_gc = (0x04<<0),  /* ADC input pin 4 */
+    ADC_MUXPOS_AIN5_gc = (0x05<<0),  /* ADC input pin 5 */
+    ADC_MUXPOS_AIN6_gc = (0x06<<0),  /* ADC input pin 6 */
+    ADC_MUXPOS_AIN7_gc = (0x07<<0),  /* ADC input pin 7 */
+    ADC_MUXPOS_AIN16_gc = (0x10<<0),  /* ADC input pin 16 */
+    ADC_MUXPOS_AIN17_gc = (0x11<<0),  /* ADC input pin 17 */
+    ADC_MUXPOS_AIN18_gc = (0x12<<0),  /* ADC input pin 18 */
+    ADC_MUXPOS_AIN19_gc = (0x13<<0),  /* ADC input pin 19 */
+    ADC_MUXPOS_AIN20_gc = (0x14<<0),  /* ADC input pin 20 */
+    ADC_MUXPOS_AIN21_gc = (0x15<<0),  /* ADC input pin 21 */
+    ADC_MUXPOS_AIN22_gc = (0x16<<0),  /* ADC input pin 22 */
+    ADC_MUXPOS_AIN23_gc = (0x17<<0),  /* ADC input pin 23 */
+    ADC_MUXPOS_AIN24_gc = (0x18<<0),  /* ADC input pin 24 */
+    ADC_MUXPOS_AIN25_gc = (0x19<<0),  /* ADC input pin 25 */
+    ADC_MUXPOS_AIN26_gc = (0x1A<<0),  /* ADC input pin 26 */
+    ADC_MUXPOS_AIN27_gc = (0x1B<<0),  /* ADC input pin 27 */
+    ADC_MUXPOS_AIN28_gc = (0x1C<<0),  /* ADC input pin 28 */
+    ADC_MUXPOS_AIN29_gc = (0x1D<<0),  /* ADC input pin 29 */
+    ADC_MUXPOS_AIN30_gc = (0x1E<<0),  /* ADC input pin 30 */
+    ADC_MUXPOS_AIN31_gc = (0x1F<<0),  /* ADC input pin 31 */
+    ADC_MUXPOS_GND_gc = (0x30<<0),  /* Ground */
+    ADC_MUXPOS_VDD10_gc = (0x31<<0),  /* VDD Divided by 10 */
+    ADC_MUXPOS_TEMPSENSE_gc = (0x32<<0),  /* Temperature Sensor */
+    ADC_MUXPOS_DAC0_gc = (0x38<<0)  /* Digital to Analog Converter 0 */
+} ADC_MUXPOS_t;
+
+/* PGA BIAS Select */
+typedef enum ADC_PGABIASSEL_enum
+{
+    ADC_PGABIASSEL_100PCT_gc = (0x00<<3),  /* 100% BIAS current. */
+    ADC_PGABIASSEL_75PCT_gc = (0x01<<3),  /* 75% BIAS current. Usable for CLK_ADC<4.5MHz */
+    ADC_PGABIASSEL_50PCT_gc = (0x02<<3),  /* 50% BIAS current. Usable for CLK_ADC<3MHz */
+    ADC_PGABIASSEL_25PCT_gc = (0x03<<3)  /* 25% BIAS current. Usable for CLK_ADC<1.5MHz */
+} ADC_PGABIASSEL_t;
+
+/* Prescaler Value select */
+typedef enum ADC_PRESC_enum
+{
+    ADC_PRESC_DIV2_gc = (0x00<<0),  /* System clock divided by 2 */
+    ADC_PRESC_DIV4_gc = (0x01<<0),  /* System clock divided by 4 */
+    ADC_PRESC_DIV6_gc = (0x02<<0),  /* System clock divided by 6 */
+    ADC_PRESC_DIV8_gc = (0x03<<0),  /* System clock divided by 8 */
+    ADC_PRESC_DIV10_gc = (0x04<<0),  /* System clock divided by 10 */
+    ADC_PRESC_DIV12_gc = (0x05<<0),  /* System clock divided by 12 */
+    ADC_PRESC_DIV14_gc = (0x06<<0),  /* System clock divided by 14 */
+    ADC_PRESC_DIV16_gc = (0x07<<0),  /* System clock divided by 16 */
+    ADC_PRESC_DIV20_gc = (0x08<<0),  /* System clock divided by 20 */
+    ADC_PRESC_DIV24_gc = (0x09<<0),  /* System clock divided by 24 */
+    ADC_PRESC_DIV28_gc = (0x0A<<0),  /* System clock divided by 28 */
+    ADC_PRESC_DIV32_gc = (0x0B<<0),  /* System clock divided by 32 */
+    ADC_PRESC_DIV40_gc = (0x0C<<0),  /* System clock divided by 40 */
+    ADC_PRESC_DIV48_gc = (0x0D<<0),  /* System clock divided by 48 */
+    ADC_PRESC_DIV56_gc = (0x0E<<0),  /* System clock divided by 56 */
+    ADC_PRESC_DIV64_gc = (0x0F<<0)  /* System clock divided by 64 */
+} ADC_PRESC_t;
+
+/* Reference select */
+typedef enum ADC_REFSEL_enum
+{
+    ADC_REFSEL_VDD_gc = (0x00<<0),  /* VDD */
+    ADC_REFSEL_VREFA_gc = (0x02<<0),  /* External Reference */
+    ADC_REFSEL_1V024_gc = (0x04<<0),  /* Internal 1.024V Reference */
+    ADC_REFSEL_2V048_gc = (0x05<<0),  /* Internal 2.048V Reference */
+    ADC_REFSEL_4V096_gc = (0x06<<0),  /* Internal 4.096V Reference */
+    ADC_REFSEL_2V500_gc = (0x07<<0)  /* Internal 2.500V Reference */
+} ADC_REFSEL_t;
+
+/* Sample numbers select */
+typedef enum ADC_SAMPNUM_enum
+{
+    ADC_SAMPNUM_NONE_gc = (0x00<<0),  /* No accumulation */
+    ADC_SAMPNUM_ACC2_gc = (0x01<<0),  /* 2 samples accumulated */
+    ADC_SAMPNUM_ACC4_gc = (0x02<<0),  /* 4 samples accumulated */
+    ADC_SAMPNUM_ACC8_gc = (0x03<<0),  /* 8 samples accumulated */
+    ADC_SAMPNUM_ACC16_gc = (0x04<<0),  /* 16 samples accumulated */
+    ADC_SAMPNUM_ACC32_gc = (0x05<<0),  /* 32 samples accumulated */
+    ADC_SAMPNUM_ACC64_gc = (0x06<<0),  /* 64 samples accumulated */
+    ADC_SAMPNUM_ACC128_gc = (0x07<<0),  /* 128 samples accumulated */
+    ADC_SAMPNUM_ACC256_gc = (0x08<<0),  /* 256 samples accumulated */
+    ADC_SAMPNUM_ACC512_gc = (0x09<<0),  /* 512 samples accumulated */
+    ADC_SAMPNUM_ACC1024_gc = (0x0A<<0)  /* 1024 samples accumulated */
+} ADC_SAMPNUM_t;
+
+/* Start command select */
+typedef enum ADC_START_enum
+{
+    ADC_START_STOP_gc = (0x00<<0),  /* Stop an ongoing conversion */
+    ADC_START_IMMEDIATE_gc = (0x01<<0),  /* Start a conversion immediately. This will be set back to STOP when the first conversion is done, unless Free-Running mode is enabled */
+    ADC_START_MUXPOS_WRITE_gc = (0x02<<0),  /* Start when MUXPOS register is written */
+    ADC_START_MUXNEG_WRITE_gc = (0x03<<0),  /* Start when MUXNEG register is written */
+    ADC_START_EVENT_TRIGGER_gc = (0x04<<0)  /* Start when an event is received */
+} ADC_START_t;
+
+/* VIA select */
+typedef enum ADC_VIA_enum
+{
+    ADC_VIA_DIRECT_gc = (0x00<<6),  /* Inputs connected directly to ADC */
+    ADC_VIA_PGA_gc = (0x01<<6)  /* Inputs connected via PGA */
+} ADC_VIA_t;
+
+/* Window Comparator Mode select */
+typedef enum ADC_WINCM_enum
+{
+    ADC_WINCM_NONE_gc = (0x00<<0),  /* No Window Comparison */
+    ADC_WINCM_BELOW_gc = (0x01<<0),  /* Below Window */
+    ADC_WINCM_ABOVE_gc = (0x02<<0),  /* Above Window */
+    ADC_WINCM_INSIDE_gc = (0x03<<0),  /* Inside Window */
+    ADC_WINCM_OUTSIDE_gc = (0x04<<0)  /* Outside Window */
+} ADC_WINCM_t;
+
+/* Window Mode Source select */
+typedef enum ADC_WINSRC_enum
+{
+    ADC_WINSRC_RESULT_gc = (0x00<<3),  /* Result register used as Window Comparator Source */
+    ADC_WINSRC_SAMPLE_gc = (0x01<<3)  /* Sample register used as Window Comparator Source */
+} ADC_WINSRC_t;
+
+/*
+--------------------------------------------------------------------------
+BOD - Bod interface
+--------------------------------------------------------------------------
+*/
+
+/* Bod interface */
+typedef struct BOD_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t reserved_1[6];
+    register8_t VLMCTRLA;  /* Voltage level monitor Control */
+    register8_t INTCTRL;  /* Voltage level monitor interrupt Control */
+    register8_t INTFLAGS;  /* Voltage level monitor interrupt Flags */
+    register8_t STATUS;  /* Voltage level monitor status */
+    register8_t reserved_2[4];
+} BOD_t;
+
+/* Operation in active mode select */
+typedef enum BOD_ACTIVE_enum
+{
+    BOD_ACTIVE_DISABLE_gc = (0x00<<2),  /* Disabled */
+    BOD_ACTIVE_ENABLED_gc = (0x01<<2),  /* Enabled in continuous mode */
+    BOD_ACTIVE_SAMPLED_gc = (0x02<<2),  /* Enabled in sampled mode */
+    BOD_ACTIVE_ENABLEWAIT_gc = (0x03<<2)  /* Enabled in continuous mode. Execution halted at wake-up until BOD is running */
+} BOD_ACTIVE_t;
+
+/* Bod level select */
+typedef enum BOD_LVL_enum
+{
+    BOD_LVL_BODLEVEL0_gc = (0x00<<0),  /* BOD Disabled during normal operation */
+    BOD_LVL_BODLEVEL1_gc = (0x01<<0),  /* 1.9 V */
+    BOD_LVL_BODLEVEL2_gc = (0x02<<0),  /* 2.7 V */
+    BOD_LVL_BODLEVEL3_gc = (0x03<<0)  /* 4.5 V */
+} BOD_LVL_t;
+
+/* Sample frequency select */
+typedef enum BOD_SAMPFREQ_enum
+{
+    BOD_SAMPFREQ_128HZ_gc = (0x00<<4),  /* Sampling frequency is 128 Hz */
+    BOD_SAMPFREQ_32HZ_gc = (0x01<<4)  /* Sample frequency is 32 Hz */
+} BOD_SAMPFREQ_t;
+
+/* Operation in sleep mode select */
+typedef enum BOD_SLEEP_enum
+{
+    BOD_SLEEP_DISABLE_gc = (0x00<<0),  /* Disabled */
+    BOD_SLEEP_ENABLE_gc = (0x01<<0),  /* Enabled in continuous mode */
+    BOD_SLEEP_SAMPLE_gc = (0x02<<0)  /* Enabled in sampled mode */
+} BOD_SLEEP_t;
+
+/* Configuration select */
+typedef enum BOD_VLMCFG_enum
+{
+    BOD_VLMCFG_FALLING_gc = (0x00<<1),  /* VDD falls below VLM threshold */
+    BOD_VLMCFG_RISING_gc = (0x01<<1),  /* VDD rises above VLM threshold */
+    BOD_VLMCFG_BOTH_gc = (0x02<<1)  /* VDD crosses VLM threshold */
+} BOD_VLMCFG_t;
+
+/* voltage level monitor level select */
+typedef enum BOD_VLMLVL_enum
+{
+    BOD_VLMLVL_OFF_gc = (0x00<<0),  /* VLM Disabled */
+    BOD_VLMLVL_5ABOVE_gc = (0x01<<0),  /* VLM threshold 5% above BOD level */
+    BOD_VLMLVL_15ABOVE_gc = (0x02<<0),  /* VLM threshold 15% above BOD level */
+    BOD_VLMLVL_25ABOVE_gc = (0x03<<0)  /* VLM threshold 25% above BOD level */
+} BOD_VLMLVL_t;
+
+/* Voltage level monitor status select */
+typedef enum BOD_VLMS_enum
+{
+    BOD_VLMS_ABOVE_gc = (0x00<<0),  /* The voltage is above the VLM threshold level */
+    BOD_VLMS_BELOW_gc = (0x01<<0)  /* The voltage is below the VLM threshold level */
+} BOD_VLMS_t;
+
+/*
+--------------------------------------------------------------------------
+CCL - Configurable Custom Logic
+--------------------------------------------------------------------------
+*/
+
+/* Configurable Custom Logic */
+typedef struct CCL_struct
+{
+    register8_t CTRLA;  /* Control Register A */
+    register8_t SEQCTRL0;  /* Sequential Control 0 */
+    register8_t SEQCTRL1;  /* Sequential Control 1 */
+    register8_t reserved_1[2];
+    register8_t INTCTRL0;  /* Interrupt Control 0 */
+    register8_t reserved_2[1];
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t LUT0CTRLA;  /* LUT 0 Control A */
+    register8_t LUT0CTRLB;  /* LUT 0 Control B */
+    register8_t LUT0CTRLC;  /* LUT 0 Control C */
+    register8_t TRUTH0;  /* Truth 0 */
+    register8_t LUT1CTRLA;  /* LUT 1 Control A */
+    register8_t LUT1CTRLB;  /* LUT 1 Control B */
+    register8_t LUT1CTRLC;  /* LUT 1 Control C */
+    register8_t TRUTH1;  /* Truth 1 */
+    register8_t LUT2CTRLA;  /* LUT 2 Control A */
+    register8_t LUT2CTRLB;  /* LUT 2 Control B */
+    register8_t LUT2CTRLC;  /* LUT 2 Control C */
+    register8_t TRUTH2;  /* Truth 2 */
+    register8_t LUT3CTRLA;  /* LUT 3 Control A */
+    register8_t LUT3CTRLB;  /* LUT 3 Control B */
+    register8_t LUT3CTRLC;  /* LUT 3 Control C */
+    register8_t TRUTH3;  /* Truth 3 */
+    register8_t reserved_3[40];
+} CCL_t;
+
+/* Clock Source Selection */
+typedef enum CCL_CLKSRC_enum
+{
+    CCL_CLKSRC_CLKPER_gc = (0x00<<1),  /* Peripheral Clock */
+    CCL_CLKSRC_IN2_gc = (0x01<<1),  /* INSEL2 selection */
+    CCL_CLKSRC_OSCHF_gc = (0x04<<1),  /* Internal High Frequency oscillator */
+    CCL_CLKSRC_OSC32K_gc = (0x05<<1),  /* Internal 32.768 kHz oscillator */
+    CCL_CLKSRC_OSC1K_gc = (0x06<<1)  /* Internal 32.768 kHz oscillator divided by 32 */
+} CCL_CLKSRC_t;
+
+/* Edge Detection Enable select */
+typedef enum CCL_EDGEDET_enum
+{
+    CCL_EDGEDET_DIS_gc = (0x00<<7),  /* Edge detector is disabled */
+    CCL_EDGEDET_EN_gc = (0x01<<7)  /* Edge detector is enabled */
+} CCL_EDGEDET_t;
+
+/* Filter Selection */
+typedef enum CCL_FILTSEL_enum
+{
+    CCL_FILTSEL_DISABLE_gc = (0x00<<4),  /* Filter disabled */
+    CCL_FILTSEL_SYNCH_gc = (0x01<<4),  /* Synchronizer enabled */
+    CCL_FILTSEL_FILTER_gc = (0x02<<4)  /* Filter enabled */
+} CCL_FILTSEL_t;
+
+/* LUT Input 0 Source Selection */
+typedef enum CCL_INSEL0_enum
+{
+    CCL_INSEL0_MASK_gc = (0x00<<0),  /* Masked input */
+    CCL_INSEL0_FEEDBACK_gc = (0x01<<0),  /* Feedback input */
+    CCL_INSEL0_LINK_gc = (0x02<<0),  /* Output from LUT[n+1] as input source */
+    CCL_INSEL0_EVENTA_gc = (0x03<<0),  /* Event A as input source */
+    CCL_INSEL0_EVENTB_gc = (0x04<<0),  /* Event B as input source */
+    CCL_INSEL0_IO_gc = (0x05<<0),  /* IN0 input source */
+    CCL_INSEL0_AC0_gc = (0x06<<0),  /* AC0 output input source */
+    CCL_INSEL0_USART0_gc = (0x07<<0),  /* USART0 TxD input source */
+    CCL_INSEL0_SPI0_gc = (0x08<<0),  /* SPI0 MISO input source */
+    CCL_INSEL0_TCA0_gc = (0x09<<0),  /* TCA0 WO0 input source */
+    CCL_INSEL0_TCA1_gc = (0x0A<<0),  /* TCA1 WO0 input source */
+    CCL_INSEL0_TCB0_gc = (0x0B<<0)  /* TCB0 WO input source */
+} CCL_INSEL0_t;
+
+/* LUT Input 1 Source Selection */
+typedef enum CCL_INSEL1_enum
+{
+    CCL_INSEL1_MASK_gc = (0x00<<4),  /* Masked input */
+    CCL_INSEL1_FEEDBACK_gc = (0x01<<4),  /* Feedback input */
+    CCL_INSEL1_LINK_gc = (0x02<<4),  /* Output from LUT[n+1] as input source */
+    CCL_INSEL1_EVENTA_gc = (0x03<<4),  /* Event A as input source */
+    CCL_INSEL1_EVENTB_gc = (0x04<<4),  /* Event B as input source */
+    CCL_INSEL1_IO_gc = (0x05<<4),  /* IN0 input source */
+    CCL_INSEL1_AC1_gc = (0x06<<4),  /* AC1 output input source */
+    CCL_INSEL1_USART1_gc = (0x07<<4),  /* USART1 TxD input source */
+    CCL_INSEL1_SPI0_gc = (0x08<<4),  /* SPI0 MISO input source */
+    CCL_INSEL1_TCA0_gc = (0x09<<4),  /* TCA0 WO1 input source */
+    CCL_INSEL1_TCA1_gc = (0x0A<<4),  /* TCA1 WO1 input source */
+    CCL_INSEL1_TCB1_gc = (0x0B<<4)  /* TCB1 WO input source */
+} CCL_INSEL1_t;
+
+/* LUT Input 2 Source Selection */
+typedef enum CCL_INSEL2_enum
+{
+    CCL_INSEL2_MASK_gc = (0x00<<0),  /* Masked input */
+    CCL_INSEL2_FEEDBACK_gc = (0x01<<0),  /* Feedback input */
+    CCL_INSEL2_LINK_gc = (0x02<<0),  /* Output from LUT[n+1] as input source */
+    CCL_INSEL2_EVENTA_gc = (0x03<<0),  /* Event A as input source */
+    CCL_INSEL2_EVENTB_gc = (0x04<<0),  /* Event B as input source */
+    CCL_INSEL2_IO_gc = (0x05<<0),  /* IN0 input source */
+    CCL_INSEL2_AC1_gc = (0x06<<0),  /* AC1 output input source */
+    CCL_INSEL2_USART2_gc = (0x07<<0),  /* USART2 TxD input source */
+    CCL_INSEL2_SPI0_gc = (0x08<<0),  /* SPI0 MISO input source */
+    CCL_INSEL2_TCA0_gc = (0x09<<0),  /* TCA0 WO2 input source */
+    CCL_INSEL2_TCA1_gc = (0x0A<<0),  /* TCA1 WO2 input source */
+    CCL_INSEL2_TCB2_gc = (0x0B<<0)  /* TCB2 WO input source */
+} CCL_INSEL2_t;
+
+/* Interrupt Mode for LUT0 select */
+typedef enum CCL_INTMODE0_enum
+{
+    CCL_INTMODE0_INTDISABLE_gc = (0x00<<0),  /* Interrupt disabled */
+    CCL_INTMODE0_RISING_gc = (0x01<<0),  /* Sense rising edge */
+    CCL_INTMODE0_FALLING_gc = (0x02<<0),  /* Sense falling edge */
+    CCL_INTMODE0_BOTH_gc = (0x03<<0)  /* Sense both edges */
+} CCL_INTMODE0_t;
+
+/* Interrupt Mode for LUT1 select */
+typedef enum CCL_INTMODE1_enum
+{
+    CCL_INTMODE1_INTDISABLE_gc = (0x00<<2),  /* Interrupt disabled */
+    CCL_INTMODE1_RISING_gc = (0x01<<2),  /* Sense rising edge */
+    CCL_INTMODE1_FALLING_gc = (0x02<<2),  /* Sense falling edge */
+    CCL_INTMODE1_BOTH_gc = (0x03<<2)  /* Sense both edges */
+} CCL_INTMODE1_t;
+
+/* Interrupt Mode for LUT2 select */
+typedef enum CCL_INTMODE2_enum
+{
+    CCL_INTMODE2_INTDISABLE_gc = (0x00<<4),  /* Interrupt disabled */
+    CCL_INTMODE2_RISING_gc = (0x01<<4),  /* Sense rising edge */
+    CCL_INTMODE2_FALLING_gc = (0x02<<4),  /* Sense falling edge */
+    CCL_INTMODE2_BOTH_gc = (0x03<<4)  /* Sense both edges */
+} CCL_INTMODE2_t;
+
+/* Interrupt Mode for LUT3 select */
+typedef enum CCL_INTMODE3_enum
+{
+    CCL_INTMODE3_INTDISABLE_gc = (0x00<<6),  /* Interrupt disabled */
+    CCL_INTMODE3_RISING_gc = (0x01<<6),  /* Sense rising edge */
+    CCL_INTMODE3_FALLING_gc = (0x02<<6),  /* Sense falling edge */
+    CCL_INTMODE3_BOTH_gc = (0x03<<6)  /* Sense both edges */
+} CCL_INTMODE3_t;
+
+/* Sequential Selection */
+typedef enum CCL_SEQSEL_enum
+{
+    CCL_SEQSEL_DISABLE_gc = (0x00<<0),  /* Sequential logic disabled */
+    CCL_SEQSEL_DFF_gc = (0x01<<0),  /* D FlipFlop */
+    CCL_SEQSEL_JK_gc = (0x02<<0),  /* JK FlipFlop */
+    CCL_SEQSEL_LATCH_gc = (0x03<<0),  /* D Latch */
+    CCL_SEQSEL_RS_gc = (0x04<<0)  /* RS Latch */
+} CCL_SEQSEL_t;
+
+/*
+--------------------------------------------------------------------------
+CLKCTRL - Clock controller
+--------------------------------------------------------------------------
+*/
+
+/* Clock controller */
+typedef struct CLKCTRL_struct
+{
+    register8_t MCLKCTRLA;  /* MCLK Control A */
+    register8_t MCLKCTRLB;  /* MCLK Control B */
+    register8_t MCLKCTRLC;  /* MCLK Control C */
+    register8_t MCLKINTCTRL;  /* MCLK Interrupt Control */
+    register8_t MCLKINTFLAGS;  /* MCLK Interrupt Flags */
+    register8_t MCLKSTATUS;  /* MCLK Status */
+    register8_t MCLKTIMEBASE;  /* MCLK Timebase */
+    register8_t reserved_1[1];
+    register8_t OSCHFCTRLA;  /* OSCHF Control A */
+    register8_t OSCHFTUNE;  /* OSCHF Tune */
+    register8_t reserved_2[14];
+    register8_t OSC32KCTRLA;  /* OSC32K Control A */
+    register8_t reserved_3[3];
+    register8_t XOSC32KCTRLA;  /* XOSC32K Control A */
+    register8_t reserved_4[3];
+    register8_t XOSCHFCTRLA;  /* XOSCHF Control A */
+} CLKCTRL_t;
+
+/* Automatic Oscillator Tune select */
+typedef enum CLKCTRL_AUTOTUNE_enum
+{
+    CLKCTRL_AUTOTUNE_OFF_gc = (0x00<<0),  /* Disabled */
+    CLKCTRL_AUTOTUNE_XOSC32K_gc = (0x01<<0)  /* Tune against 32.768 kHz Crystal Oscillator */
+} CLKCTRL_AUTOTUNE_t;
+
+/* CFD Source select */
+typedef enum CLKCTRL_CFDSRC_enum
+{
+    CLKCTRL_CFDSRC_CLKMAIN_gc = (0x00<<2),  /* Main Clock */
+    CLKCTRL_CFDSRC_XOSCHF_gc = (0x01<<2),  /* High Frequency Crystal Oscillator */
+    CLKCTRL_CFDSRC_XOSC32K_gc = (0x02<<2)  /* 32.768 kHz Crystal Oscillator */
+} CLKCTRL_CFDSRC_t;
+
+/* Clock select */
+typedef enum CLKCTRL_CLKSEL_enum
+{
+    CLKCTRL_CLKSEL_OSCHF_gc = (0x00<<0),  /* Internal high-frequency oscillator */
+    CLKCTRL_CLKSEL_OSC32K_gc = (0x01<<0),  /* Internal 32.768 kHz oscillator */
+    CLKCTRL_CLKSEL_XOSC32K_gc = (0x02<<0),  /* 32.768 kHz crystal oscillator */
+    CLKCTRL_CLKSEL_EXTCLK_gc = (0x03<<0)  /* External clock */
+} CLKCTRL_CLKSEL_t;
+
+/* Crystal startup time select */
+typedef enum CLKCTRL_CSUT_enum
+{
+    CLKCTRL_CSUT_1K_gc = (0x00<<4),  /* 1k cycles */
+    CLKCTRL_CSUT_16K_gc = (0x01<<4),  /* 16k cycles */
+    CLKCTRL_CSUT_32K_gc = (0x02<<4),  /* 32k cycles */
+    CLKCTRL_CSUT_64K_gc = (0x03<<4)  /* 64k cycles */
+} CLKCTRL_CSUT_t;
+
+/* Start-Up Time select */
+typedef enum CLKCTRL_CSUTHF_enum
+{
+    CLKCTRL_CSUTHF_256CYC_gc = (0x00<<4),  /* 256 XOSCHF Cycles */
+    CLKCTRL_CSUTHF_1KCYC_gc = (0x01<<4),  /* 1K XOSCHF Cycles */
+    CLKCTRL_CSUTHF_4KCYC_gc = (0x02<<4)  /* 4K XOSCHF Cycles */
+} CLKCTRL_CSUTHF_t;
+
+/* Interrupt Type select */
+typedef enum CLKCTRL_INTTYPE_enum
+{
+    CLKCTRL_INTTYPE_INT_gc = (0x00<<7),  /* Regular interrupt */
+    CLKCTRL_INTTYPE_NMI_gc = (0x01<<7)  /* Non-maskable interrupt */
+} CLKCTRL_INTTYPE_t;
+
+/* Prescaler division select */
+typedef enum CLKCTRL_PDIV_enum
+{
+    CLKCTRL_PDIV_DIV2_gc = (0x00<<1),  /* Divide by 2 */
+    CLKCTRL_PDIV_DIV4_gc = (0x01<<1),  /* Divide by 4 */
+    CLKCTRL_PDIV_DIV8_gc = (0x02<<1),  /* Divide by 8 */
+    CLKCTRL_PDIV_DIV16_gc = (0x03<<1),  /* Divide by 16 */
+    CLKCTRL_PDIV_DIV32_gc = (0x04<<1),  /* Divide by 32 */
+    CLKCTRL_PDIV_DIV64_gc = (0x05<<1),  /* Divide by 64 */
+    CLKCTRL_PDIV_DIV6_gc = (0x08<<1),  /* Divide by 6 */
+    CLKCTRL_PDIV_DIV10_gc = (0x09<<1),  /* Divide by 10 */
+    CLKCTRL_PDIV_DIV12_gc = (0x0A<<1),  /* Divide by 12 */
+    CLKCTRL_PDIV_DIV24_gc = (0x0B<<1),  /* Divide by 24 */
+    CLKCTRL_PDIV_DIV48_gc = (0x0C<<1)  /* Divide by 48 */
+} CLKCTRL_PDIV_t;
+
+/* Source Select */
+typedef enum CLKCTRL_SELHF_enum
+{
+    CLKCTRL_SELHF_CRYSTAL_gc = (0x00<<1),  /* External Crystal */
+    CLKCTRL_SELHF_EXTCLK_gc = (0x01<<1)  /* Extenal Clock on XTALHF1 pin */
+} CLKCTRL_SELHF_t;
+
+/*
+--------------------------------------------------------------------------
+CPU - CPU
+--------------------------------------------------------------------------
+*/
+
+#define CORE_VERSION  V4S
+
+/* CCP signature select */
+typedef enum CCP_enum
+{
+    CCP_SPM_gc = (0x9D<<0),  /* SPM Instruction Protection */
+    CCP_IOREG_gc = (0xD8<<0)  /* IO Register Protection */
+} CCP_t;
+
+/*
+--------------------------------------------------------------------------
+CPUINT - Interrupt Controller
+--------------------------------------------------------------------------
+*/
+
+/* Interrupt Controller */
+typedef struct CPUINT_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t STATUS;  /* Status */
+    register8_t LVL0PRI;  /* Interrupt Level 0 Priority */
+    register8_t LVL1VEC;  /* Interrupt Level 1 Priority Vector */
+} CPUINT_t;
+
+
+/*
+--------------------------------------------------------------------------
+CRCSCAN - CRCSCAN
+--------------------------------------------------------------------------
+*/
+
+/* CRCSCAN */
+typedef struct CRCSCAN_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t STATUS;  /* Status */
+    register8_t reserved_1[13];
+} CRCSCAN_t;
+
+/* CRC Source select */
+typedef enum CRCSCAN_SRC_enum
+{
+    CRCSCAN_SRC_FLASH_gc = (0x00<<0),  /* CRC on entire flash */
+    CRCSCAN_SRC_APPLICATION_gc = (0x01<<0),  /* CRC on boot and appl section of flash */
+    CRCSCAN_SRC_BOOT_gc = (0x02<<0)  /* CRC on boot section of flash */
+} CRCSCAN_SRC_t;
+
+/*
+--------------------------------------------------------------------------
+DAC - Digital to Analog Converter
+--------------------------------------------------------------------------
+*/
+
+/* Digital to Analog Converter */
+typedef struct DAC_struct
+{
+    register8_t CTRLA;  /* Control Register A */
+    register8_t reserved_1[1];
+    _WORDREGISTER(DATA);  /* DATA Register */
+    register8_t reserved_2[12];
+} DAC_t;
+
+/* Output Buffer Range select */
+typedef enum DAC_OUTRANGE_enum
+{
+    DAC_OUTRANGE_AUTO_gc = (0x00<<4),  /* Output buffer automatically choose best range */
+    DAC_OUTRANGE_LOW_gc = (0x02<<4),  /* Output buffer configured to low range */
+    DAC_OUTRANGE_HIGH_gc = (0x03<<4)  /* Output buffer configured to high range */
+} DAC_OUTRANGE_t;
+
+/*
+--------------------------------------------------------------------------
+EVSYS - Event System
+--------------------------------------------------------------------------
+*/
+
+/* Event System */
+typedef struct EVSYS_struct
+{
+    register8_t SWEVENTA;  /* Software Event A */
+    register8_t reserved_1[15];
+    register8_t CHANNEL0;  /* Multiplexer Channel 0 */
+    register8_t CHANNEL1;  /* Multiplexer Channel 1 */
+    register8_t CHANNEL2;  /* Multiplexer Channel 2 */
+    register8_t CHANNEL3;  /* Multiplexer Channel 3 */
+    register8_t CHANNEL4;  /* Multiplexer Channel 4 */
+    register8_t CHANNEL5;  /* Multiplexer Channel 5 */
+    register8_t reserved_2[10];
+    register8_t USERCCLLUT0A;  /* CCL0 Event A */
+    register8_t USERCCLLUT0B;  /* CCL0 Event B */
+    register8_t USERCCLLUT1A;  /* CCL1 Event A */
+    register8_t USERCCLLUT1B;  /* CCL1 Event B */
+    register8_t USERCCLLUT2A;  /* CCL2 Event A */
+    register8_t USERCCLLUT2B;  /* CCL2 Event B */
+    register8_t USERCCLLUT3A;  /* CCL3 Event A */
+    register8_t USERCCLLUT3B;  /* CCL3 Event B */
+    register8_t USERADC0START;  /* ADC0 */
+    register8_t USEREVSYSEVOUTA;  /* EVOUTA */
+    register8_t reserved_3[1];
+    register8_t USEREVSYSEVOUTC;  /* EVOUTC */
+    register8_t USEREVSYSEVOUTD;  /* EVOUTD */
+    register8_t reserved_4[1];
+    register8_t USEREVSYSEVOUTF;  /* EVOUTF */
+    register8_t USERUSART0IRDA;  /* USART0 */
+    register8_t USERUSART1IRDA;  /* USART1 */
+    register8_t USERUSART2IRDA;  /* USART2 */
+    register8_t USERTCA0CNTA;  /* TCA0 Event A */
+    register8_t USERTCA0CNTB;  /* TCA0 Event B */
+    register8_t USERTCA1CNTA;  /* TCA1 Event A */
+    register8_t USERTCA1CNTB;  /* TCA1 Event B */
+    register8_t USERTCB0CAPT;  /* TCB0 Event A */
+    register8_t USERTCB0COUNT;  /* TCB0 Event B */
+    register8_t USERTCB1CAPT;  /* TCB1 Event A */
+    register8_t USERTCB1COUNT;  /* TCB1 Event B */
+    register8_t USERTCB2CAPT;  /* TCB2 Event A */
+    register8_t USERTCB2COUNT;  /* TCB2 Event B */
+    register8_t USERTCB3CAPT;  /* TCB3 Event A */
+    register8_t USERTCB3COUNT;  /* TCB3 Event B */
+    register8_t reserved_5[2];
+} EVSYS_t;
+
+/* Channel generator select */
+typedef enum EVSYS_CHANNEL_enum
+{
+    EVSYS_CHANNEL_OFF_gc = (0x00<<0),  /* Off */
+    EVSYS_CHANNEL_UPDI_SYNCH_gc = (0x01<<0),  /* UPDI SYNCH character */
+    EVSYS_CHANNEL_RTC_OVF_gc = (0x06<<0),  /* Real Time Counter overflow */
+    EVSYS_CHANNEL_RTC_CMP_gc = (0x07<<0),  /* Real Time Counter compare */
+    EVSYS_CHANNEL_RTC_PITEV0_gc = (0x08<<0),  /* Periodic Interrupt Timer Event 0 */
+    EVSYS_CHANNEL_RTC_PITEV1_gc = (0x09<<0),  /* Periodic Interrupt Timer Event 1 */
+    EVSYS_CHANNEL_CCL_LUT0_gc = (0x10<<0),  /* Configurable Custom Logic LUT0 */
+    EVSYS_CHANNEL_CCL_LUT1_gc = (0x11<<0),  /* Configurable Custom Logic LUT1 */
+    EVSYS_CHANNEL_CCL_LUT2_gc = (0x12<<0),  /* Configurable Custom Logic LUT2 */
+    EVSYS_CHANNEL_CCL_LUT3_gc = (0x13<<0),  /* Configurable Custom Logic LUT3 */
+    EVSYS_CHANNEL_AC0_OUT_gc = (0x20<<0),  /* Analog Comparator 0 out */
+    EVSYS_CHANNEL_AC1_OUT_gc = (0x21<<0),  /* Analog Comparator 1 out */
+    EVSYS_CHANNEL_ADC0_RES_gc = (0x24<<0),  /* ADC 0 Result Ready */
+    EVSYS_CHANNEL_ADC0_SAMP_gc = (0x25<<0),  /* ADC 0 Sample Ready */
+    EVSYS_CHANNEL_ADC0_WCMP_gc = (0x26<<0),  /* ADC 0 Window Compare */
+    EVSYS_CHANNEL_PORTA_EV0_gc = (0x40<<0),  /* Port A Event 0 */
+    EVSYS_CHANNEL_PORTA_EV1_gc = (0x41<<0),  /* Port A Event 1 */
+    EVSYS_CHANNEL_PORTC_EV0_gc = (0x44<<0),  /* Port C Event 0 */
+    EVSYS_CHANNEL_PORTC_EV1_gc = (0x45<<0),  /* Port C Event 1 */
+    EVSYS_CHANNEL_PORTD_EV0_gc = (0x46<<0),  /* Port D Event 0 */
+    EVSYS_CHANNEL_PORTD_EV1_gc = (0x47<<0),  /* Port D Event 1 */
+    EVSYS_CHANNEL_PORTF_EV0_gc = (0x4A<<0),  /* Port F Event 0 */
+    EVSYS_CHANNEL_PORTF_EV1_gc = (0x4B<<0),  /* Port F Event 1 */
+    EVSYS_CHANNEL_USART0_XCK_gc = (0x60<<0),  /* USART 0 XCK */
+    EVSYS_CHANNEL_USART1_XCK_gc = (0x61<<0),  /* USART 1 XCK */
+    EVSYS_CHANNEL_USART2_XCK_gc = (0x62<<0),  /* USART 2 XCK */
+    EVSYS_CHANNEL_SPI0_SCK_gc = (0x68<<0),  /* SPI 0 SCK */
+    EVSYS_CHANNEL_TCA0_OVF_LUNF_gc = (0x80<<0),  /* Timer/Counter A0 overflow / low byte timer underflow */
+    EVSYS_CHANNEL_TCA0_HUNF_gc = (0x81<<0),  /* Timer/Counter A0 high byte timer underflow */
+    EVSYS_CHANNEL_TCA0_CMP0_LCMP0_gc = (0x84<<0),  /* Timer/Counter A0 compare 0 / low byte timer compare 0 */
+    EVSYS_CHANNEL_TCA0_CMP1_LCMP1_gc = (0x85<<0),  /* Timer/Counter A0 compare 1 / low byte timer compare 1 */
+    EVSYS_CHANNEL_TCA0_CMP2_LCMP2_gc = (0x86<<0),  /* Timer/Counter A0 compare 2 / low byte timer compare 2 */
+    EVSYS_CHANNEL_TCA1_OVF_LUNF_gc = (0x88<<0),  /* Timer/Counter A1 overflow / low byte timer underflow */
+    EVSYS_CHANNEL_TCA1_HUNF_gc = (0x89<<0),  /* Timer/Counter A1 high byte timer underflow */
+    EVSYS_CHANNEL_TCA1_CMP0_LCMP0_gc = (0x8C<<0),  /* Timer/Counter A1 compare 0 / low byte timer compare 0 */
+    EVSYS_CHANNEL_TCA1_CMP1_LCMP1_gc = (0x8D<<0),  /* Timer/Counter A1 compare 1 / low byte timer compare 1 */
+    EVSYS_CHANNEL_TCA1_CMP2_LCMP2_gc = (0x8E<<0),  /* Timer/Counter A1 compare 2 / low byte timer compare 2 */
+    EVSYS_CHANNEL_TCB0_CAPT_gc = (0xA0<<0),  /* Timer/Counter B0 capture */
+    EVSYS_CHANNEL_TCB0_OVF_gc = (0xA1<<0),  /* Timer/Counter B0 overflow */
+    EVSYS_CHANNEL_TCB1_CAPT_gc = (0xA2<<0),  /* Timer/Counter B1 capture */
+    EVSYS_CHANNEL_TCB1_OVF_gc = (0xA3<<0),  /* Timer/Counter B1 overflow */
+    EVSYS_CHANNEL_TCB2_CAPT_gc = (0xA4<<0),  /* Timer/Counter B2 capture */
+    EVSYS_CHANNEL_TCB2_OVF_gc = (0xA5<<0),  /* Timer/Counter B2 overflow */
+    EVSYS_CHANNEL_TCB3_CAPT_gc = (0xA6<<0),  /* Timer/Counter B3 capture */
+    EVSYS_CHANNEL_TCB3_OVF_gc = (0xA7<<0)  /* Timer/Counter B3 overflow */
+} EVSYS_CHANNEL_t;
+
+/* Software event on channel select */
+typedef enum EVSYS_SWEVENTA_enum
+{
+    EVSYS_SWEVENTA_CH0_gc = (0x01<<0),  /* Software event on channel 0 */
+    EVSYS_SWEVENTA_CH1_gc = (0x02<<0),  /* Software event on channel 1 */
+    EVSYS_SWEVENTA_CH2_gc = (0x04<<0),  /* Software event on channel 2 */
+    EVSYS_SWEVENTA_CH3_gc = (0x08<<0),  /* Software event on channel 3 */
+    EVSYS_SWEVENTA_CH4_gc = (0x10<<0),  /* Software event on channel 4 */
+    EVSYS_SWEVENTA_CH5_gc = (0x20<<0),  /* Software event on channel 5 */
+    EVSYS_SWEVENTA_CH6_gc = (0x40<<0),  /* Software event on channel 6 */
+    EVSYS_SWEVENTA_CH7_gc = (0x80<<0)  /* Software event on channel 7 */
+} EVSYS_SWEVENTA_t;
+
+/* User channel select */
+typedef enum EVSYS_USER_enum
+{
+    EVSYS_USER_OFF_gc = (0x00<<0),  /* Off, No Eventsys Channel connected */
+    EVSYS_USER_CHANNEL0_gc = (0x01<<0),  /* Connect user to event channel 0 */
+    EVSYS_USER_CHANNEL1_gc = (0x02<<0),  /* Connect user to event channel 1 */
+    EVSYS_USER_CHANNEL2_gc = (0x03<<0),  /* Connect user to event channel 2 */
+    EVSYS_USER_CHANNEL3_gc = (0x04<<0),  /* Connect user to event channel 3 */
+    EVSYS_USER_CHANNEL4_gc = (0x05<<0),  /* Connect user to event channel 4 */
+    EVSYS_USER_CHANNEL5_gc = (0x06<<0)  /* Connect user to event channel 5 */
+} EVSYS_USER_t;
+
+/*
+--------------------------------------------------------------------------
+FUSE - Fuses
+--------------------------------------------------------------------------
+*/
+
+/* Fuses */
+typedef struct FUSE_struct
+{
+    register8_t WDTCFG;  /* Watchdog Configuration */
+    register8_t BODCFG;  /* BOD Configuration */
+    register8_t OSCCFG;  /* Oscillator Configuration */
+    register8_t reserved_1[2];
+    register8_t SYSCFG0;  /* System Configuration 0 */
+    register8_t SYSCFG1;  /* System Configuration 1 */
+    register8_t CODESIZE;  /* Code Section Size */
+    register8_t BOOTSIZE;  /* Boot Section Size */
+} FUSE_t;
+
+/* avr-libc typedef for avr/fuse.h */
+typedef FUSE_t NVM_FUSES_t;
+
+/* BOD Operation in Active Mode select */
+typedef enum ACTIVE_enum
+{
+    ACTIVE_DISABLE_gc = (0x00<<2),  /* Disabled */
+    ACTIVE_ENABLED_gc = (0x01<<2),  /* Enabled in continuous mode */
+    ACTIVE_SAMPLED_gc = (0x02<<2),  /* Enabled in sampled mode */
+    ACTIVE_ENABLEWAIT_gc = (0x03<<2)  /* Enabled in continuous mode. Execution halted at wake-up until BOD is running */
+} ACTIVE_t;
+
+/* CRC Select */
+typedef enum CRCSEL_enum
+{
+    CRCSEL_CRC16_gc = (0x00<<5),  /* Enable CRC16 */
+    CRCSEL_CRC32_gc = (0x01<<5)  /* Enable CRC32 */
+} CRCSEL_t;
+
+/* CRC Source select */
+typedef enum CRCSRC_enum
+{
+    CRCSRC_FLASH_gc = (0x00<<6),  /* CRC of full Flash (boot, application code and application data) */
+    CRCSRC_BOOT_gc = (0x01<<6),  /* CRC of boot section */
+    CRCSRC_BOOTAPP_gc = (0x02<<6),  /* CRC of application code and boot sections */
+    CRCSRC_NOCRC_gc = (0x03<<6)  /* No CRC */
+} CRCSRC_t;
+
+/* EEPROM Save select */
+typedef enum EESAVE_enum
+{
+    EESAVE_DISABLE_gc = (0x00<<0),  /* EEPROM content is erased during chip erase */
+    EESAVE_ENABLE_gc = (0x01<<0)  /* EEPROM content is preserved during chip erase */
+} EESAVE_t;
+
+/* BOD Level select */
+typedef enum LVL_enum
+{
+    LVL_BODLEVEL0_gc = (0x00<<5),  /* BOD Disabled during normal operation */
+    LVL_BODLEVEL1_gc = (0x01<<5),  /* 1.9 V */
+    LVL_BODLEVEL2_gc = (0x02<<5),  /* 2.7 V */
+    LVL_BODLEVEL3_gc = (0x03<<5)  /* 4.5 V */
+} LVL_t;
+
+/* High-frequency Oscillator Frequency select */
+typedef enum OSCHFFRQ_enum
+{
+    OSCHFFRQ_20M_gc = (0x00<<3),  /* OSCHF running at 20 MHz */
+    OSCHFFRQ_16M_gc = (0x01<<3)  /* OSCHF running at 16 MHz */
+} OSCHFFRQ_t;
+
+/* Watchdog Timeout Period select */
+typedef enum PERIOD_enum
+{
+    PERIOD_OFF_gc = (0x00<<0),  /* Watch-Dog timer Off */
+    PERIOD_8CLK_gc = (0x01<<0),  /* 8 cycles (8ms) */
+    PERIOD_16CLK_gc = (0x02<<0),  /* 16 cycles (16ms) */
+    PERIOD_32CLK_gc = (0x03<<0),  /* 32 cycles (32ms) */
+    PERIOD_64CLK_gc = (0x04<<0),  /* 64 cycles (64ms) */
+    PERIOD_128CLK_gc = (0x05<<0),  /* 128 cycles (0.128s) */
+    PERIOD_256CLK_gc = (0x06<<0),  /* 256 cycles (0.256s) */
+    PERIOD_512CLK_gc = (0x07<<0),  /* 512 cycles (0.512s) */
+    PERIOD_1KCLK_gc = (0x08<<0),  /* 1K cycles (1.0s) */
+    PERIOD_2KCLK_gc = (0x09<<0),  /* 2K cycles (2.0s) */
+    PERIOD_4KCLK_gc = (0x0A<<0),  /* 4K cycles (4.0s) */
+    PERIOD_8KCLK_gc = (0x0B<<0)  /* 8K cycles (8.0s) */
+} PERIOD_t;
+
+/* Reset Pin Configuration select */
+typedef enum RSTPINCFG_enum
+{
+    RSTPINCFG_NONE_gc = (0x00<<3),  /* No External Reset */
+    RSTPINCFG_RESET_gc = (0x01<<3)  /* PF6 configured as RESET pin */
+} RSTPINCFG_t;
+
+/* BOD Sample Frequency select */
+typedef enum SAMPFREQ_enum
+{
+    SAMPFREQ_128HZ_gc = (0x00<<4),  /* Sampling frequency is 128 Hz */
+    SAMPFREQ_32HZ_gc = (0x01<<4)  /* Sample frequency is 32 Hz */
+} SAMPFREQ_t;
+
+/* BOD Operation in Sleep Mode select */
+typedef enum SLEEP_enum
+{
+    SLEEP_DISABLE_gc = (0x00<<0),  /* Disabled */
+    SLEEP_ENABLE_gc = (0x01<<0),  /* Enabled in continuous mode */
+    SLEEP_SAMPLE_gc = (0x02<<0)  /* Enabled in sampled mode */
+} SLEEP_t;
+
+/* Startup Time select */
+typedef enum SUT_enum
+{
+    SUT_0MS_gc = (0x00<<0),  /* 0 ms */
+    SUT_1MS_gc = (0x01<<0),  /* 1 ms */
+    SUT_2MS_gc = (0x02<<0),  /* 2 ms */
+    SUT_4MS_gc = (0x03<<0),  /* 4 ms */
+    SUT_8MS_gc = (0x04<<0),  /* 8 ms */
+    SUT_16MS_gc = (0x05<<0),  /* 16 ms */
+    SUT_32MS_gc = (0x06<<0),  /* 32 ms */
+    SUT_64MS_gc = (0x07<<0)  /* 64 ms */
+} SUT_t;
+
+/* UPDI Pin Configuration select */
+typedef enum UPDIPINCFG_enum
+{
+    UPDIPINCFG_GPIO_gc = (0x00<<4),  /* PF7 Configured as GPIO pin */
+    UPDIPINCFG_UPDI_gc = (0x01<<4)  /* PF7 Configured as UPDI pin */
+} UPDIPINCFG_t;
+
+/* Watchdog Window Timeout Period select */
+typedef enum WINDOW_enum
+{
+    WINDOW_OFF_gc = (0x00<<4),  /* Window mode off */
+    WINDOW_8CLK_gc = (0x01<<4),  /* 8 cycles (8ms) */
+    WINDOW_16CLK_gc = (0x02<<4),  /* 16 cycles (16ms) */
+    WINDOW_32CLK_gc = (0x03<<4),  /* 32 cycles (32ms) */
+    WINDOW_64CLK_gc = (0x04<<4),  /* 64 cycles (64ms) */
+    WINDOW_128CLK_gc = (0x05<<4),  /* 128 cycles (0.128s) */
+    WINDOW_256CLK_gc = (0x06<<4),  /* 256 cycles (0.256s) */
+    WINDOW_512CLK_gc = (0x07<<4),  /* 512 cycles (0.512s) */
+    WINDOW_1KCLK_gc = (0x08<<4),  /* 1K cycles (1.0s) */
+    WINDOW_2KCLK_gc = (0x09<<4),  /* 2K cycles (2.0s) */
+    WINDOW_4KCLK_gc = (0x0A<<4),  /* 4K cycles (4.0s) */
+    WINDOW_8KCLK_gc = (0x0B<<4)  /* 8K cycles (8.0s) */
+} WINDOW_t;
+
+/*
+--------------------------------------------------------------------------
+GPR - General Purpose Registers
+--------------------------------------------------------------------------
+*/
+
+/* General Purpose Registers */
+typedef struct GPR_struct
+{
+    register8_t GPR0;  /* General Purpose Register 0 */
+    register8_t GPR1;  /* General Purpose Register 1 */
+    register8_t GPR2;  /* General Purpose Register 2 */
+    register8_t GPR3;  /* General Purpose Register 3 */
+} GPR_t;
+
+
+/*
+--------------------------------------------------------------------------
+LOCK - Lockbits
+--------------------------------------------------------------------------
+*/
+
+/* Lockbits */
+typedef struct LOCK_struct
+{
+    _DWORDREGISTER(KEY);  /* Lock Key Bits */
+} LOCK_t;
+
+/* Lock Key select */
+typedef enum LOCK_KEY_enum
+{
+    LOCK_KEY_NOLOCK_gc = (0x5CC5C55C<<0),  /* No locks */
+    LOCK_KEY_RWLOCK_gc = (0xA33A3AA3<<0)  /* Read and write lock */
+} LOCK_KEY_t;
+
+/*
+--------------------------------------------------------------------------
+NVMCTRL - Non-volatile Memory Controller
+--------------------------------------------------------------------------
+*/
+
+/* Non-volatile Memory Controller */
+typedef struct NVMCTRL_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t reserved_1[2];
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t STATUS;  /* Status */
+    register8_t reserved_2[1];
+    _WORDREGISTER(DATA);  /* Data */
+    register8_t reserved_3[2];
+    _DWORDREGISTER(ADDR);  /* Address */
+    register8_t reserved_4[48];
+} NVMCTRL_t;
+
+/* Command select */
+typedef enum NVMCTRL_CMD_enum
+{
+    NVMCTRL_CMD_NOCMD_gc = (0x00<<0),  /* No Command */
+    NVMCTRL_CMD_NOOP_gc = (0x01<<0),  /* No Operation */
+    NVMCTRL_CMD_FLPW_gc = (0x04<<0),  /* Flash Page Write */
+    NVMCTRL_CMD_FLPERW_gc = (0x05<<0),  /* Flash Page Erase and Write */
+    NVMCTRL_CMD_FLPER_gc = (0x08<<0),  /* Flash Page Erase */
+    NVMCTRL_CMD_FLMPER2_gc = (0x09<<0),  /* Flash 2-page erase enable */
+    NVMCTRL_CMD_FLMPER4_gc = (0x0A<<0),  /* Flash 4-page erase enable */
+    NVMCTRL_CMD_FLMPER8_gc = (0x0B<<0),  /* Flash 8-page erase enable */
+    NVMCTRL_CMD_FLMPER16_gc = (0x0C<<0),  /* Flash 16-page erase enable */
+    NVMCTRL_CMD_FLMPER32_gc = (0x0D<<0),  /* Flash 32-page erase enable */
+    NVMCTRL_CMD_FLPBCLR_gc = (0x0F<<0),  /* Flash Page Buffer Clear */
+    NVMCTRL_CMD_EEPW_gc = (0x14<<0),  /* EEPROM Page Write */
+    NVMCTRL_CMD_EEPERW_gc = (0x15<<0),  /* EEPROM Page Erase and Write */
+    NVMCTRL_CMD_EEPER_gc = (0x17<<0),  /* EEPROM Page Erase */
+    NVMCTRL_CMD_EEPBCLR_gc = (0x1F<<0),  /* EEPROM Page Buffer Clear */
+    NVMCTRL_CMD_CHER_gc = (0x20<<0),  /* Chip Erase Command (UPDI only) */
+    NVMCTRL_CMD_EECHER_gc = (0x30<<0)  /* EEPROM Erase Command (UPDI only) */
+} NVMCTRL_CMD_t;
+
+/* Write error select */
+typedef enum NVMCTRL_ERROR_enum
+{
+    NVMCTRL_ERROR_NOERROR_gc = (0x00<<4),  /* No Error */
+    NVMCTRL_ERROR_WRITEPROTECT_gc = (0x02<<4),  /* Attempt to program write protected area */
+    NVMCTRL_ERROR_CMDCOLLISION_gc = (0x03<<4),  /* Selecting new write command while write command already seleted */
+    NVMCTRL_ERROR_WRONGSECTION_gc = (0x04<<4)  /* Address cannot be written with selected command */
+} NVMCTRL_ERROR_t;
+
+/* Flash Mapping in Data space select */
+typedef enum NVMCTRL_FLMAP_enum
+{
+    NVMCTRL_FLMAP_SECTION0_gc = (0x00<<4),  /* Flash section 0, 0 - 32KB */
+    NVMCTRL_FLMAP_SECTION1_gc = (0x01<<4),  /* Flash section 1, 32 - 64KB */
+    NVMCTRL_FLMAP_SECTION2_gc = (0x02<<4),  /* Flash section 2, 64 - 96KB */
+    NVMCTRL_FLMAP_SECTION3_gc = (0x03<<4)  /* Flash section 3, 96 - 128KB */
+} NVMCTRL_FLMAP_t;
+
+/*
+--------------------------------------------------------------------------
+PORT - I/O Ports
+--------------------------------------------------------------------------
+*/
+
+/* I/O Ports */
+typedef struct PORT_struct
+{
+    register8_t DIR;  /* Data Direction */
+    register8_t DIRSET;  /* Data Direction Set */
+    register8_t DIRCLR;  /* Data Direction Clear */
+    register8_t DIRTGL;  /* Data Direction Toggle */
+    register8_t OUT;  /* Output Value */
+    register8_t OUTSET;  /* Output Value Set */
+    register8_t OUTCLR;  /* Output Value Clear */
+    register8_t OUTTGL;  /* Output Value Toggle */
+    register8_t IN;  /* Input Value */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t PORTCTRL;  /* Port Control */
+    register8_t PINCONFIG;  /* Pin Control Config */
+    register8_t PINCTRLUPD;  /* Pin Control Update */
+    register8_t PINCTRLSET;  /* Pin Control Set */
+    register8_t PINCTRLCLR;  /* Pin Control Clear */
+    register8_t reserved_1[1];
+    register8_t PIN0CTRL;  /* Pin 0 Control */
+    register8_t PIN1CTRL;  /* Pin 1 Control */
+    register8_t PIN2CTRL;  /* Pin 2 Control */
+    register8_t PIN3CTRL;  /* Pin 3 Control */
+    register8_t PIN4CTRL;  /* Pin 4 Control */
+    register8_t PIN5CTRL;  /* Pin 5 Control */
+    register8_t PIN6CTRL;  /* Pin 6 Control */
+    register8_t PIN7CTRL;  /* Pin 7 Control */
+    register8_t EVGENCTRL;  /* Event Generation Control */
+    register8_t reserved_2[7];
+} PORT_t;
+
+/* Event Generator 0 Select */
+typedef enum PORT_EVGEN0SEL_enum
+{
+    PORT_EVGEN0SEL_PIN0_gc = (0x00<<0),  /* Pin 0 used as event generator */
+    PORT_EVGEN0SEL_PIN1_gc = (0x01<<0),  /* Pin 1 used as event generator */
+    PORT_EVGEN0SEL_PIN2_gc = (0x02<<0),  /* Pin 2 used as event generator */
+    PORT_EVGEN0SEL_PIN3_gc = (0x03<<0),  /* Pin 3 used as event generator */
+    PORT_EVGEN0SEL_PIN4_gc = (0x04<<0),  /* Pin 4 used as event generator */
+    PORT_EVGEN0SEL_PIN5_gc = (0x05<<0),  /* Pin 5 used as event generator */
+    PORT_EVGEN0SEL_PIN6_gc = (0x06<<0),  /* Pin 6 used as event generator */
+    PORT_EVGEN0SEL_PIN7_gc = (0x07<<0)  /* Pin 7 used as event generator */
+} PORT_EVGEN0SEL_t;
+
+/* Event Generator 1 Select */
+typedef enum PORT_EVGEN1SEL_enum
+{
+    PORT_EVGEN1SEL_PIN0_gc = (0x00<<4),  /* Pin 0 used as event generator */
+    PORT_EVGEN1SEL_PIN1_gc = (0x01<<4),  /* Pin 1 used as event generator */
+    PORT_EVGEN1SEL_PIN2_gc = (0x02<<4),  /* Pin 2 used as event generator */
+    PORT_EVGEN1SEL_PIN3_gc = (0x03<<4),  /* Pin 3 used as event generator */
+    PORT_EVGEN1SEL_PIN4_gc = (0x04<<4),  /* Pin 4 used as event generator */
+    PORT_EVGEN1SEL_PIN5_gc = (0x05<<4),  /* Pin 5 used as event generator */
+    PORT_EVGEN1SEL_PIN6_gc = (0x06<<4),  /* Pin 6 used as event generator */
+    PORT_EVGEN1SEL_PIN7_gc = (0x07<<4)  /* Pin 7 used as event generator */
+} PORT_EVGEN1SEL_t;
+
+/* Input Level Select */
+typedef enum PORT_INLVL_enum
+{
+    PORT_INLVL_ST_gc = (0x00<<6),  /* Schmitt-Trigger input level */
+    PORT_INLVL_TTL_gc = (0x01<<6)  /* TTL Input level */
+} PORT_INLVL_t;
+
+/* Input/Sense Configuration select */
+typedef enum PORT_ISC_enum
+{
+    PORT_ISC_INTDISABLE_gc = (0x00<<0),  /* Interrupt disabled but input buffer enabled */
+    PORT_ISC_BOTHEDGES_gc = (0x01<<0),  /* Sense Both Edges */
+    PORT_ISC_RISING_gc = (0x02<<0),  /* Sense Rising Edge */
+    PORT_ISC_FALLING_gc = (0x03<<0),  /* Sense Falling Edge */
+    PORT_ISC_INPUT_DISABLE_gc = (0x04<<0),  /* Digital Input Buffer disabled */
+    PORT_ISC_LEVEL_gc = (0x05<<0)  /* Sense low Level */
+} PORT_ISC_t;
+
+/*
+--------------------------------------------------------------------------
+PORTMUX - Port Multiplexer
+--------------------------------------------------------------------------
+*/
+
+/* Port Multiplexer */
+typedef struct PORTMUX_struct
+{
+    register8_t EVSYSROUTEA;  /* EVSYS route A */
+    register8_t CCLROUTEA;  /* CCL route A */
+    register8_t USARTROUTEA;  /* USART route A */
+    register8_t USARTROUTEB;  /* USART route B */
+    register8_t reserved_1[1];
+    register8_t SPIROUTEA;  /* SPI route A */
+    register8_t TWIROUTEA;  /* TWI route A */
+    register8_t TCAROUTEA;  /* TCA route A */
+    register8_t TCBROUTEA;  /* TCB route A */
+    register8_t reserved_2[1];
+    register8_t ACROUTEA;  /* AC route A */
+    register8_t reserved_3[21];
+} PORTMUX_t;
+
+/* Analog Comparator 0 Output select */
+typedef enum PORTMUX_AC0_enum
+{
+    PORTMUX_AC0_DEFAULT_gc = (0x00<<0)  /* OUT: PA7 */
+} PORTMUX_AC0_t;
+
+/* Analog Comparator 1 Output select */
+typedef enum PORTMUX_AC1_enum
+{
+    PORTMUX_AC1_DEFAULT_gc = (0x00<<1)  /* OUT: PA7 */
+} PORTMUX_AC1_t;
+
+/* Event Output A select */
+typedef enum PORTMUX_EVOUTA_enum
+{
+    PORTMUX_EVOUTA_DEFAULT_gc = (0x00<<0),  /* EVOUTA: PA2 */
+    PORTMUX_EVOUTA_ALT1_gc = (0x01<<0)  /* EVOUTA: PA7 */
+} PORTMUX_EVOUTA_t;
+
+/* Event Output C select */
+typedef enum PORTMUX_EVOUTC_enum
+{
+    PORTMUX_EVOUTC_DEFAULT_gc = (0x00<<2)  /* EVOUTC: PC2 */
+} PORTMUX_EVOUTC_t;
+
+/* Event Output D select */
+typedef enum PORTMUX_EVOUTD_enum
+{
+    PORTMUX_EVOUTD_DEFAULT_gc = (0x00<<3),  /* EVOUTD: PD2 */
+    PORTMUX_EVOUTD_ALT1_gc = (0x01<<3)  /* EVOUTD: PD7 */
+} PORTMUX_EVOUTD_t;
+
+/* Event Output F select */
+typedef enum PORTMUX_EVOUTF_enum
+{
+    PORTMUX_EVOUTF_DEFAULT_gc = (0x00<<5),  /* EVOUTF: PF2 */
+    PORTMUX_EVOUTF_ALT1_gc = (0x01<<5)  /* EVOUTF: PF7 */
+} PORTMUX_EVOUTF_t;
+
+/* CCL Look-Up Table 0 Signals select */
+typedef enum PORTMUX_LUT0_enum
+{
+    PORTMUX_LUT0_DEFAULT_gc = (0x00<<0),  /* In: PA0, PA1, PA2, Out: PA3 */
+    PORTMUX_LUT0_ALT1_gc = (0x01<<0)  /* In: PA0, PA1, PA2, Out: PA6 */
+} PORTMUX_LUT0_t;
+
+/* CCL Look-Up Table 1 Signals select */
+typedef enum PORTMUX_LUT1_enum
+{
+    PORTMUX_LUT1_DEFAULT_gc = (0x00<<1),  /* In: PC0, PC1, PC2, Out: PC3 */
+    PORTMUX_LUT1_ALT1_gc = (0x01<<1)  /* In: PC0, PC1, PC2, Out: - */
+} PORTMUX_LUT1_t;
+
+/* CCL Look-Up Table 2 Signals select */
+typedef enum PORTMUX_LUT2_enum
+{
+    PORTMUX_LUT2_DEFAULT_gc = (0x00<<2),  /* In: PD0, PD1, PD2, Out: PD3 */
+    PORTMUX_LUT2_ALT1_gc = (0x01<<2)  /* In: PD0, PD1, PD2, Out: PD6 */
+} PORTMUX_LUT2_t;
+
+/* SPI0 Signals select */
+typedef enum PORTMUX_SPI0_enum
+{
+    PORTMUX_SPI0_DEFAULT_gc = (0x00<<0),  /* MOSI: PA4, MISO: PA5, SCK: PA6, SS: PA7 */
+    PORTMUX_SPI0_ALT3_gc = (0x03<<0),  /* MOSI: PA0, MISO: PA1, SCK: PC0, SS: PC1 */
+    PORTMUX_SPI0_ALT4_gc = (0x04<<0),  /* MOSI: PD4, MISO: PD5, SCK: PD6, SS: PD7 */
+    PORTMUX_SPI0_ALT5_gc = (0x05<<0),  /* MOSI: PC0, MISO: PC1, SCK: PC2, SS: PC3 */
+    PORTMUX_SPI0_ALT6_gc = (0x06<<0),  /* MOSI: PC1, MISO: PC2, SCK: PC3, SS: PF7 */
+    PORTMUX_SPI0_NONE_gc = (0x07<<0)  /* Not connected to any pins, SS set to 1 */
+} PORTMUX_SPI0_t;
+
+/* TCA0 Signals select */
+typedef enum PORTMUX_TCA0_enum
+{
+    PORTMUX_TCA0_PORTA_gc = (0x00<<0),  /* WOn: PA0, PA1, PA2, PA3, PA4, PA5 */
+    PORTMUX_TCA0_PORTC_gc = (0x02<<0),  /* WOn: PC0, PC1, PC2, PC3, -, - */
+    PORTMUX_TCA0_PORTD_gc = (0x03<<0),  /* WOn: PD0, PD1, PD2, PD3, PD4, PD5 */
+    PORTMUX_TCA0_PORTF_gc = (0x05<<0)  /* WOn: PF0, PF1, PF2, PF3, PF4, PF5 */
+} PORTMUX_TCA0_t;
+
+/* TCA1 Signals select */
+typedef enum PORTMUX_TCA1_enum
+{
+    PORTMUX_TCA1_PORTB_gc = (0x00<<3),  /* Not connected to any pins */
+    PORTMUX_TCA1_PORTA_gc = (0x04<<3),  /* WOn: PA4, PA5, PA6, -, -, - */
+    PORTMUX_TCA1_PORTD_gc = (0x05<<3)  /* WOn: PD4, PD5, PD6, -, -, - */
+} PORTMUX_TCA1_t;
+
+/* TCB0 Output select */
+typedef enum PORTMUX_TCB0_enum
+{
+    PORTMUX_TCB0_DEFAULT_gc = (0x00<<0),  /* WO: PA2 */
+    PORTMUX_TCB0_ALT1_gc = (0x01<<0)  /* WO: PF4 */
+} PORTMUX_TCB0_t;
+
+/* TCB1 Output select */
+typedef enum PORTMUX_TCB1_enum
+{
+    PORTMUX_TCB1_DEFAULT_gc = (0x00<<1),  /* WO: PA3 */
+    PORTMUX_TCB1_ALT1_gc = (0x01<<1)  /* WO: PF5 */
+} PORTMUX_TCB1_t;
+
+/* TCB2 Output select */
+typedef enum PORTMUX_TCB2_enum
+{
+    PORTMUX_TCB2_DEFAULT_gc = (0x00<<2)  /* WO: PC0 */
+} PORTMUX_TCB2_t;
+
+/* TCB3 Output select */
+typedef enum PORTMUX_TCB3_enum
+{
+    PORTMUX_TCB3_DEFAULT_gc = (0x00<<3),  /* Not connected to any pins */
+    PORTMUX_TCB3_ALT1_gc = (0x01<<3)  /* WO: PC1 */
+} PORTMUX_TCB3_t;
+
+/* TWI0 Signals select */
+typedef enum PORTMUX_TWI0_enum
+{
+    PORTMUX_TWI0_DEFAULT_gc = (0x00<<0),  /* SDA: PA2, SCL: PA3. Dual mode: SDA: PC2, SCL: PC3 */
+    PORTMUX_TWI0_ALT1_gc = (0x01<<0),  /* SDA: PA2, SCL: PA3. Dual mode: SDA: -, SCL: - */
+    PORTMUX_TWI0_ALT2_gc = (0x02<<0),  /* SDA: PC2, SCL: PC3. Dual mode: SDA: -, SCL: - */
+    PORTMUX_TWI0_ALT3_gc = (0x03<<0)  /* SDA: PA0, SCL: PA1. Dual mode: SDA: PC2, SCL: PC3 */
+} PORTMUX_TWI0_t;
+
+/* USART0 Routing select */
+typedef enum PORTMUX_USART0_enum
+{
+    PORTMUX_USART0_DEFAULT_gc = (0x00<<0),  /* TxD: PA0, RxD: PA1, XCK: PA2, XDIR: PA3 */
+    PORTMUX_USART0_ALT1_gc = (0x01<<0),  /* TxD: PA4, RxD: PA5, XCK: PA6, XDIR: PA7 */
+    PORTMUX_USART0_ALT2_gc = (0x02<<0),  /* TxD: PA2, RxD: PA3, XCK: -, XDIR: - */
+    PORTMUX_USART0_ALT3_gc = (0x03<<0),  /* TxD: PD4, RxD: PD5, XCK: PD6, XDIR: PD7 */
+    PORTMUX_USART0_ALT4_gc = (0x04<<0),  /* TxD: PC1, RxD: PC2, XCK: PC3, XDIR: - */
+    PORTMUX_USART0_NONE_gc = (0x05<<0)  /* Not connected to any pins */
+} PORTMUX_USART0_t;
+
+/* USART1 Routing select */
+typedef enum PORTMUX_USART1_enum
+{
+    PORTMUX_USART1_DEFAULT_gc = (0x00<<3),  /* TxD: PC0, RxD: PC1, XCK: PC2, XDIR: PC3 */
+    PORTMUX_USART1_ALT2_gc = (0x02<<3),  /* TxD: PD6, RxD: PD7, XCK: -, XDIR: - */
+    PORTMUX_USART1_NONE_gc = (0x03<<3)  /* Not connected to any pins */
+} PORTMUX_USART1_t;
+
+/* USART2 Routing select */
+typedef enum PORTMUX_USART2_enum
+{
+    PORTMUX_USART2_DEFAULT_gc = (0x00<<0),  /* TxD: PF0, RxD: PF1, XCK: PF2, XDIR: PF3 */
+    PORTMUX_USART2_ALT1_gc = (0x01<<0),  /* TxD: PF4, RxD: PF5, XCK: - , XDIR: - */
+    PORTMUX_USART2_NONE_gc = (0x03<<0)  /* Not connected to any pins */
+} PORTMUX_USART2_t;
+
+/*
+--------------------------------------------------------------------------
+RSTCTRL - Reset controller
+--------------------------------------------------------------------------
+*/
+
+/* Reset controller */
+typedef struct RSTCTRL_struct
+{
+    register8_t RSTFR;  /* Reset Flags */
+    register8_t SWRR;  /* Software Reset */
+    register8_t reserved_1[14];
+} RSTCTRL_t;
+
+
+/*
+--------------------------------------------------------------------------
+RTC - Real-Time Counter
+--------------------------------------------------------------------------
+*/
+
+/* Real-Time Counter */
+typedef struct RTC_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t STATUS;  /* Status */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t TEMP;  /* Temporary */
+    register8_t DBGCTRL;  /* Debug control */
+    register8_t CALIB;  /* Calibration */
+    register8_t CLKSEL;  /* Clock Select */
+    _WORDREGISTER(CNT);  /* Counter */
+    _WORDREGISTER(PER);  /* Period */
+    _WORDREGISTER(CMP);  /* Compare */
+    register8_t reserved_1[2];
+    register8_t PITCTRLA;  /* PIT Control A */
+    register8_t PITSTATUS;  /* PIT Status */
+    register8_t PITINTCTRL;  /* PIT Interrupt Control */
+    register8_t PITINTFLAGS;  /* PIT Interrupt Flags */
+    register8_t reserved_2[1];
+    register8_t PITDBGCTRL;  /* PIT Debug control */
+    register8_t PITEVGENCTRLA;  /* PIT Event Generation Control A */
+    register8_t reserved_3[9];
+} RTC_t;
+
+/* Clock Select */
+typedef enum RTC_CLKSEL_enum
+{
+    RTC_CLKSEL_OSC32K_gc = (0x00<<0),  /* Internal 32.768 kHz Oscillator */
+    RTC_CLKSEL_OSC1K_gc = (0x01<<0),  /* Internal 32.768 kHz Oscillator Divided by 32 */
+    RTC_CLKSEL_XOSC32K_gc = (0x02<<0),  /* 32.768 kHz Crystal Oscillator */
+    RTC_CLKSEL_EXTCLK_gc = (0x03<<0)  /* External Clock */
+} RTC_CLKSEL_t;
+
+/* Event Generation 0 Select */
+typedef enum RTC_EVGEN0SEL_enum
+{
+    RTC_EVGEN0SEL_OFF_gc = (0x00<<0),  /* No Event Generated */
+    RTC_EVGEN0SEL_DIV4_gc = (0x01<<0),  /* CLK_RTC divided by 4 */
+    RTC_EVGEN0SEL_DIV8_gc = (0x02<<0),  /* CLK_RTC divided by 8 */
+    RTC_EVGEN0SEL_DIV16_gc = (0x03<<0),  /* CLK_RTC divided by 16 */
+    RTC_EVGEN0SEL_DIV32_gc = (0x04<<0),  /* CLK_RTC divided by 32 */
+    RTC_EVGEN0SEL_DIV64_gc = (0x05<<0),  /* CLK_RTC divided by 64 */
+    RTC_EVGEN0SEL_DIV128_gc = (0x06<<0),  /* CLK_RTC divided by 128 */
+    RTC_EVGEN0SEL_DIV256_gc = (0x07<<0),  /* CLK_RTC divided by 256 */
+    RTC_EVGEN0SEL_DIV512_gc = (0x08<<0),  /* CLK_RTC divided by 512 */
+    RTC_EVGEN0SEL_DIV1024_gc = (0x09<<0),  /* CLK_RTC divided by 1024 */
+    RTC_EVGEN0SEL_DIV2048_gc = (0x0A<<0),  /* CLK_RTC divided by 2048 */
+    RTC_EVGEN0SEL_DIV4096_gc = (0x0B<<0),  /* CLK_RTC divided by 4096 */
+    RTC_EVGEN0SEL_DIV8192_gc = (0x0C<<0),  /* CLK_RTC divided by 8192 */
+    RTC_EVGEN0SEL_DIV16384_gc = (0x0D<<0),  /* CLK_RTC divided by 16384 */
+    RTC_EVGEN0SEL_DIV32768_gc = (0x0E<<0)  /* CLK_RTC divided by 32768 */
+} RTC_EVGEN0SEL_t;
+
+/* Event Generation 1 Select */
+typedef enum RTC_EVGEN1SEL_enum
+{
+    RTC_EVGEN1SEL_OFF_gc = (0x00<<4),  /* No Event Generated */
+    RTC_EVGEN1SEL_DIV4_gc = (0x01<<4),  /* CLK_RTC divided by 4 */
+    RTC_EVGEN1SEL_DIV8_gc = (0x02<<4),  /* CLK_RTC divided by 8 */
+    RTC_EVGEN1SEL_DIV16_gc = (0x03<<4),  /* CLK_RTC divided by 16 */
+    RTC_EVGEN1SEL_DIV32_gc = (0x04<<4),  /* CLK_RTC divided by 32 */
+    RTC_EVGEN1SEL_DIV64_gc = (0x05<<4),  /* CLK_RTC divided by 64 */
+    RTC_EVGEN1SEL_DIV128_gc = (0x06<<4),  /* CLK_RTC divided by 128 */
+    RTC_EVGEN1SEL_DIV256_gc = (0x07<<4),  /* CLK_RTC divided by 256 */
+    RTC_EVGEN1SEL_DIV512_gc = (0x08<<4),  /* CLK_RTC divided by 512 */
+    RTC_EVGEN1SEL_DIV1024_gc = (0x09<<4),  /* CLK_RTC divided by 1024 */
+    RTC_EVGEN1SEL_DIV2048_gc = (0x0A<<4),  /* CLK_RTC divided by 2048 */
+    RTC_EVGEN1SEL_DIV4096_gc = (0x0B<<4),  /* CLK_RTC divided by 4096 */
+    RTC_EVGEN1SEL_DIV8192_gc = (0x0C<<4),  /* CLK_RTC divided by 8192 */
+    RTC_EVGEN1SEL_DIV16384_gc = (0x0D<<4),  /* CLK_RTC divided by 16384 */
+    RTC_EVGEN1SEL_DIV32768_gc = (0x0E<<4)  /* CLK_RTC divided by 32768 */
+} RTC_EVGEN1SEL_t;
+
+/* Period select */
+typedef enum RTC_PERIOD_enum
+{
+    RTC_PERIOD_OFF_gc = (0x00<<3),  /* Off */
+    RTC_PERIOD_CYC4_gc = (0x01<<3),  /* RTC Clock Cycles 4 */
+    RTC_PERIOD_CYC8_gc = (0x02<<3),  /* RTC Clock Cycles 8 */
+    RTC_PERIOD_CYC16_gc = (0x03<<3),  /* RTC Clock Cycles 16 */
+    RTC_PERIOD_CYC32_gc = (0x04<<3),  /* RTC Clock Cycles 32 */
+    RTC_PERIOD_CYC64_gc = (0x05<<3),  /* RTC Clock Cycles 64 */
+    RTC_PERIOD_CYC128_gc = (0x06<<3),  /* RTC Clock Cycles 128 */
+    RTC_PERIOD_CYC256_gc = (0x07<<3),  /* RTC Clock Cycles 256 */
+    RTC_PERIOD_CYC512_gc = (0x08<<3),  /* RTC Clock Cycles 512 */
+    RTC_PERIOD_CYC1024_gc = (0x09<<3),  /* RTC Clock Cycles 1024 */
+    RTC_PERIOD_CYC2048_gc = (0x0A<<3),  /* RTC Clock Cycles 2048 */
+    RTC_PERIOD_CYC4096_gc = (0x0B<<3),  /* RTC Clock Cycles 4096 */
+    RTC_PERIOD_CYC8192_gc = (0x0C<<3),  /* RTC Clock Cycles 8192 */
+    RTC_PERIOD_CYC16384_gc = (0x0D<<3),  /* RTC Clock Cycles 16384 */
+    RTC_PERIOD_CYC32768_gc = (0x0E<<3)  /* RTC Clock Cycles 32768 */
+} RTC_PERIOD_t;
+
+/* Prescaling Factor select */
+typedef enum RTC_PRESCALER_enum
+{
+    RTC_PRESCALER_DIV1_gc = (0x00<<3),  /* RTC Clock / 1 */
+    RTC_PRESCALER_DIV2_gc = (0x01<<3),  /* RTC Clock / 2 */
+    RTC_PRESCALER_DIV4_gc = (0x02<<3),  /* RTC Clock / 4 */
+    RTC_PRESCALER_DIV8_gc = (0x03<<3),  /* RTC Clock / 8 */
+    RTC_PRESCALER_DIV16_gc = (0x04<<3),  /* RTC Clock / 16 */
+    RTC_PRESCALER_DIV32_gc = (0x05<<3),  /* RTC Clock / 32 */
+    RTC_PRESCALER_DIV64_gc = (0x06<<3),  /* RTC Clock / 64 */
+    RTC_PRESCALER_DIV128_gc = (0x07<<3),  /* RTC Clock / 128 */
+    RTC_PRESCALER_DIV256_gc = (0x08<<3),  /* RTC Clock / 256 */
+    RTC_PRESCALER_DIV512_gc = (0x09<<3),  /* RTC Clock / 512 */
+    RTC_PRESCALER_DIV1024_gc = (0x0A<<3),  /* RTC Clock / 1024 */
+    RTC_PRESCALER_DIV2048_gc = (0x0B<<3),  /* RTC Clock / 2048 */
+    RTC_PRESCALER_DIV4096_gc = (0x0C<<3),  /* RTC Clock / 4096 */
+    RTC_PRESCALER_DIV8192_gc = (0x0D<<3),  /* RTC Clock / 8192 */
+    RTC_PRESCALER_DIV16384_gc = (0x0E<<3),  /* RTC Clock / 16384 */
+    RTC_PRESCALER_DIV32768_gc = (0x0F<<3)  /* RTC Clock / 32768 */
+} RTC_PRESCALER_t;
+
+/*
+--------------------------------------------------------------------------
+SIGROW - Signature row
+--------------------------------------------------------------------------
+*/
+
+/* Signature row */
+typedef struct SIGROW_struct
+{
+    register8_t DEVICEID0;  /* Device ID Byte 0 */
+    register8_t DEVICEID1;  /* Device ID Byte 1 */
+    register8_t DEVICEID2;  /* Device ID Byte 2 */
+    register8_t reserved_1[1];
+    _WORDREGISTER(TEMPSENSE0);  /* Temperature Calibration 0 */
+    _WORDREGISTER(TEMPSENSE1);  /* Temperature Calibration 1 */
+    register8_t reserved_2[8];
+    register8_t SERNUM0;  /* Serial Number Byte 0 */
+    register8_t SERNUM1;  /* Serial Number Byte 1 */
+    register8_t SERNUM2;  /* Serial Number Byte 2 */
+    register8_t SERNUM3;  /* Serial Number Byte 3 */
+    register8_t SERNUM4;  /* Serial Number Byte 4 */
+    register8_t SERNUM5;  /* Serial Number Byte 5 */
+    register8_t SERNUM6;  /* Serial Number Byte 6 */
+    register8_t SERNUM7;  /* Serial Number Byte 7 */
+    register8_t SERNUM8;  /* Serial Number Byte 8 */
+    register8_t SERNUM9;  /* Serial Number Byte 9 */
+    register8_t SERNUM10;  /* Serial Number Byte 10 */
+    register8_t SERNUM11;  /* Serial Number Byte 11 */
+    register8_t SERNUM12;  /* Serial Number Byte 12 */
+    register8_t SERNUM13;  /* Serial Number Byte 13 */
+    register8_t SERNUM14;  /* Serial Number Byte 14 */
+    register8_t SERNUM15;  /* Serial Number Byte 15 */
+    register8_t reserved_3[32];
+} SIGROW_t;
+
+
+/*
+--------------------------------------------------------------------------
+SLPCTRL - Sleep Controller
+--------------------------------------------------------------------------
+*/
+
+/* Sleep Controller */
+typedef struct SLPCTRL_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t reserved_1[1];
+} SLPCTRL_t;
+
+/* Sleep mode select */
+typedef enum SLPCTRL_SMODE_enum
+{
+    SLPCTRL_SMODE_IDLE_gc = (0x00<<1),  /* Idle mode */
+    SLPCTRL_SMODE_STDBY_gc = (0x01<<1),  /* Standby Mode */
+    SLPCTRL_SMODE_PDOWN_gc = (0x02<<1)  /* Power-down Mode */
+} SLPCTRL_SMODE_t;
+
+#define SLEEP_MODE_IDLE (0x00<<1)
+#define SLEEP_MODE_STANDBY (0x01<<1)
+#define SLEEP_MODE_PWR_DOWN (0x02<<1)
+/*
+--------------------------------------------------------------------------
+SPI - Serial Peripheral Interface
+--------------------------------------------------------------------------
+*/
+
+/* Serial Peripheral Interface */
+typedef struct SPI_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t DATA;  /* Data */
+    register8_t reserved_1[3];
+} SPI_t;
+
+/* SPI Mode select */
+typedef enum SPI_MODE_enum
+{
+    SPI_MODE_0_gc = (0x00<<0),  /* SPI Mode 0 */
+    SPI_MODE_1_gc = (0x01<<0),  /* SPI Mode 1 */
+    SPI_MODE_2_gc = (0x02<<0),  /* SPI Mode 2 */
+    SPI_MODE_3_gc = (0x03<<0)  /* SPI Mode 3 */
+} SPI_MODE_t;
+
+/* Prescaler select */
+typedef enum SPI_PRESC_enum
+{
+    SPI_PRESC_DIV4_gc = (0x00<<1),  /* CLK_PER / 4 */
+    SPI_PRESC_DIV16_gc = (0x01<<1),  /* CLK_PER / 16 */
+    SPI_PRESC_DIV64_gc = (0x02<<1),  /* CLK_PER / 64 */
+    SPI_PRESC_DIV128_gc = (0x03<<1)  /* CLK_PER / 128 */
+} SPI_PRESC_t;
+
+/*
+--------------------------------------------------------------------------
+SYSCFG - System Configuration Registers
+--------------------------------------------------------------------------
+*/
+
+/* System Configuration Registers */
+typedef struct SYSCFG_struct
+{
+    register8_t reserved_1[1];
+    register8_t REVID;  /* Revision ID */
+    register8_t reserved_2[2];
+    register8_t OCDMCTRL;  /* OCD Message Control */
+    register8_t OCDMSTATUS;  /* OCD Message Status */
+    register8_t reserved_3[26];
+} SYSCFG_t;
+
+
+/*
+--------------------------------------------------------------------------
+TCA - 16-bit Timer/Counter Type A
+--------------------------------------------------------------------------
+*/
+
+/* 16-bit Timer/Counter Type A - Single Mode */
+typedef struct TCA_SINGLE_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    register8_t CTRLD;  /* Control D */
+    register8_t CTRLECLR;  /* Control E Clear */
+    register8_t CTRLESET;  /* Control E Set */
+    register8_t CTRLFCLR;  /* Control F Clear */
+    register8_t CTRLFSET;  /* Control F Set */
+    register8_t reserved_1[1];
+    register8_t EVCTRL;  /* Event Control */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t reserved_2[2];
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t TEMP;  /* Temporary data for 16-bit Access */
+    register8_t reserved_3[16];
+    _WORDREGISTER(CNT);  /* Count */
+    register8_t reserved_4[4];
+    _WORDREGISTER(PER);  /* Period */
+    _WORDREGISTER(CMP0);  /* Compare 0 */
+    _WORDREGISTER(CMP1);  /* Compare 1 */
+    _WORDREGISTER(CMP2);  /* Compare 2 */
+    register8_t reserved_5[8];
+    _WORDREGISTER(PERBUF);  /* Period Buffer */
+    _WORDREGISTER(CMP0BUF);  /* Compare 0 Buffer */
+    _WORDREGISTER(CMP1BUF);  /* Compare 1 Buffer */
+    _WORDREGISTER(CMP2BUF);  /* Compare 2 Buffer */
+    register8_t reserved_6[2];
+} TCA_SINGLE_t;
+
+/* 16-bit Timer/Counter Type A - Split Mode */
+typedef struct TCA_SPLIT_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    register8_t CTRLD;  /* Control D */
+    register8_t CTRLECLR;  /* Control E Clear */
+    register8_t CTRLESET;  /* Control E Set */
+    register8_t reserved_1[4];
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t reserved_2[2];
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t reserved_3[17];
+    register8_t LCNT;  /* Low Count */
+    register8_t HCNT;  /* High Count */
+    register8_t reserved_4[4];
+    register8_t LPER;  /* Low Period */
+    register8_t HPER;  /* High Period */
+    register8_t LCMP0;  /* Low Compare */
+    register8_t HCMP0;  /* High Compare */
+    register8_t LCMP1;  /* Low Compare */
+    register8_t HCMP1;  /* High Compare */
+    register8_t LCMP2;  /* Low Compare */
+    register8_t HCMP2;  /* High Compare */
+    register8_t reserved_5[18];
+} TCA_SPLIT_t;
+
+/* 16-bit Timer/Counter Type A */
+typedef union TCA_union
+{
+    TCA_SINGLE_t SINGLE;  /* Single Mode */
+    TCA_SPLIT_t SPLIT;  /* Split Mode */
+} TCA_t;
+
+/* Clock Selection */
+typedef enum TCA_SINGLE_CLKSEL_enum
+{
+    TCA_SINGLE_CLKSEL_DIV1_gc = (0x00<<1),  /* CLK_PER */
+    TCA_SINGLE_CLKSEL_DIV2_gc = (0x01<<1),  /* CLK_PER / 2 */
+    TCA_SINGLE_CLKSEL_DIV4_gc = (0x02<<1),  /* CLK_PER / 4 */
+    TCA_SINGLE_CLKSEL_DIV8_gc = (0x03<<1),  /* CLK_PER / 8 */
+    TCA_SINGLE_CLKSEL_DIV16_gc = (0x04<<1),  /* CLK_PER / 16 */
+    TCA_SINGLE_CLKSEL_DIV64_gc = (0x05<<1),  /* CLK_PER / 64 */
+    TCA_SINGLE_CLKSEL_DIV256_gc = (0x06<<1),  /* CLK_PER / 256 */
+    TCA_SINGLE_CLKSEL_DIV1024_gc = (0x07<<1)  /* CLK_PER / 1024 */
+} TCA_SINGLE_CLKSEL_t;
+
+/* Command select */
+typedef enum TCA_SINGLE_CMD_enum
+{
+    TCA_SINGLE_CMD_NONE_gc = (0x00<<2),  /* No Command */
+    TCA_SINGLE_CMD_UPDATE_gc = (0x01<<2),  /* Force Update */
+    TCA_SINGLE_CMD_RESTART_gc = (0x02<<2),  /* Force Restart */
+    TCA_SINGLE_CMD_RESET_gc = (0x03<<2)  /* Force Hard Reset */
+} TCA_SINGLE_CMD_t;
+
+/* Direction select */
+typedef enum TCA_SINGLE_DIR_enum
+{
+    TCA_SINGLE_DIR_UP_gc = (0x00<<0),  /* Count up */
+    TCA_SINGLE_DIR_DOWN_gc = (0x01<<0)  /* Count down */
+} TCA_SINGLE_DIR_t;
+
+/* Event Action A select */
+typedef enum TCA_SINGLE_EVACTA_enum
+{
+    TCA_SINGLE_EVACTA_CNT_POSEDGE_gc = (0x00<<1),  /* Count on positive edge event */
+    TCA_SINGLE_EVACTA_CNT_ANYEDGE_gc = (0x01<<1),  /* Count on any edge event */
+    TCA_SINGLE_EVACTA_CNT_HIGHLVL_gc = (0x02<<1),  /* Count on prescaled clock while event line is 1. */
+    TCA_SINGLE_EVACTA_UPDOWN_gc = (0x03<<1)  /* Count on prescaled clock. Event controls count direction. Up-count when event line is 0, down-count when event line is 1. */
+} TCA_SINGLE_EVACTA_t;
+
+/* Event Action B select */
+typedef enum TCA_SINGLE_EVACTB_enum
+{
+    TCA_SINGLE_EVACTB_NONE_gc = (0x00<<5),  /* No Action */
+    TCA_SINGLE_EVACTB_UPDOWN_gc = (0x03<<5),  /* Count on prescaled clock. Event controls count direction. Up-count when event line is 0, down-count when event line is 1. */
+    TCA_SINGLE_EVACTB_RESTART_POSEDGE_gc = (0x04<<5),  /* Restart counter at positive edge event */
+    TCA_SINGLE_EVACTB_RESTART_ANYEDGE_gc = (0x05<<5),  /* Restart counter on any edge event */
+    TCA_SINGLE_EVACTB_RESTART_HIGHLVL_gc = (0x06<<5)  /* Restart counter while event line is 1. */
+} TCA_SINGLE_EVACTB_t;
+
+/* Waveform generation mode select */
+typedef enum TCA_SINGLE_WGMODE_enum
+{
+    TCA_SINGLE_WGMODE_NORMAL_gc = (0x00<<0),  /* Normal Mode */
+    TCA_SINGLE_WGMODE_FRQ_gc = (0x01<<0),  /* Frequency Generation Mode */
+    TCA_SINGLE_WGMODE_SINGLESLOPE_gc = (0x03<<0),  /* Single Slope PWM */
+    TCA_SINGLE_WGMODE_DSTOP_gc = (0x05<<0),  /* Dual Slope PWM, overflow on TOP */
+    TCA_SINGLE_WGMODE_DSBOTH_gc = (0x06<<0),  /* Dual Slope PWM, overflow on TOP and BOTTOM */
+    TCA_SINGLE_WGMODE_DSBOTTOM_gc = (0x07<<0)  /* Dual Slope PWM, overflow on BOTTOM */
+} TCA_SINGLE_WGMODE_t;
+
+/* Clock Selection */
+typedef enum TCA_SPLIT_CLKSEL_enum
+{
+    TCA_SPLIT_CLKSEL_DIV1_gc = (0x00<<1),  /* CLK_PER */
+    TCA_SPLIT_CLKSEL_DIV2_gc = (0x01<<1),  /* CLK_PER / 2 */
+    TCA_SPLIT_CLKSEL_DIV4_gc = (0x02<<1),  /* CLK_PER / 4 */
+    TCA_SPLIT_CLKSEL_DIV8_gc = (0x03<<1),  /* CLK_PER / 8 */
+    TCA_SPLIT_CLKSEL_DIV16_gc = (0x04<<1),  /* CLK_PER / 16 */
+    TCA_SPLIT_CLKSEL_DIV64_gc = (0x05<<1),  /* CLK_PER / 64 */
+    TCA_SPLIT_CLKSEL_DIV256_gc = (0x06<<1),  /* CLK_PER / 256 */
+    TCA_SPLIT_CLKSEL_DIV1024_gc = (0x07<<1)  /* CLK_PER / 1024 */
+} TCA_SPLIT_CLKSEL_t;
+
+/* Command select */
+typedef enum TCA_SPLIT_CMD_enum
+{
+    TCA_SPLIT_CMD_NONE_gc = (0x00<<2),  /* No Command */
+    TCA_SPLIT_CMD_UPDATE_gc = (0x01<<2),  /* Force Update */
+    TCA_SPLIT_CMD_RESTART_gc = (0x02<<2),  /* Force Restart */
+    TCA_SPLIT_CMD_RESET_gc = (0x03<<2)  /* Force Hard Reset */
+} TCA_SPLIT_CMD_t;
+
+/* Command Enable select */
+typedef enum TCA_SPLIT_CMDEN_enum
+{
+    TCA_SPLIT_CMDEN_NONE_gc = (0x00<<0),  /* None */
+    TCA_SPLIT_CMDEN_BOTH_gc = (0x03<<0)  /* Both low byte and high byte counter */
+} TCA_SPLIT_CMDEN_t;
+
+/*
+--------------------------------------------------------------------------
+TCB - 16-bit Timer Type B
+--------------------------------------------------------------------------
+*/
+
+/* 16-bit Timer Type B */
+typedef struct TCB_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control Register B */
+    register8_t reserved_1[2];
+    register8_t EVCTRL;  /* Event Control */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t STATUS;  /* Status */
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t TEMP;  /* Temporary Value */
+    _WORDREGISTER(CNT);  /* Count */
+    _WORDREGISTER(CCMP);  /* Compare or Capture */
+    register8_t reserved_2[2];
+} TCB_t;
+
+/* Clock Select */
+typedef enum TCB_CLKSEL_enum
+{
+    TCB_CLKSEL_DIV1_gc = (0x00<<1),  /* CLK_PER */
+    TCB_CLKSEL_DIV2_gc = (0x01<<1),  /* CLK_PER/2 */
+    TCB_CLKSEL_TCA0_gc = (0x02<<1),  /* Use CLK_TCA from TCA0 */
+    TCB_CLKSEL_TCA1_gc = (0x03<<1),  /* Use CLK_TCA from TCA1 */
+    TCB_CLKSEL_EVENT_gc = (0x07<<1)  /* Count on event edge */
+} TCB_CLKSEL_t;
+
+/* Timer Mode select */
+typedef enum TCB_CNTMODE_enum
+{
+    TCB_CNTMODE_INT_gc = (0x00<<0),  /* Periodic Interrupt */
+    TCB_CNTMODE_TIMEOUT_gc = (0x01<<0),  /* Periodic Timeout */
+    TCB_CNTMODE_CAPT_gc = (0x02<<0),  /* Input Capture Event */
+    TCB_CNTMODE_FRQ_gc = (0x03<<0),  /* Input Capture Frequency measurement */
+    TCB_CNTMODE_PW_gc = (0x04<<0),  /* Input Capture Pulse-Width measurement */
+    TCB_CNTMODE_FRQPW_gc = (0x05<<0),  /* Input Capture Frequency and Pulse-Width measurement */
+    TCB_CNTMODE_SINGLE_gc = (0x06<<0),  /* Single Shot */
+    TCB_CNTMODE_PWM8_gc = (0x07<<0)  /* 8-bit PWM */
+} TCB_CNTMODE_t;
+
+/*
+--------------------------------------------------------------------------
+TWI - Two-Wire Interface
+--------------------------------------------------------------------------
+*/
+
+/* Two-Wire Interface */
+typedef struct TWI_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t DUALCTRL;  /* Dual Mode Control */
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t MCTRLA;  /* Host Control A */
+    register8_t MCTRLB;  /* Host Control B */
+    register8_t MSTATUS;  /* Host STATUS */
+    register8_t MBAUD;  /* Host Baud Rate */
+    register8_t MADDR;  /* Host Address */
+    register8_t MDATA;  /* Host Data */
+    register8_t SCTRLA;  /* Client Control A */
+    register8_t SCTRLB;  /* Client Control B */
+    register8_t SSTATUS;  /* Client Status */
+    register8_t SADDR;  /* Client Address */
+    register8_t SDATA;  /* Client Data */
+    register8_t SADDRMASK;  /* Client Address Mask */
+    register8_t reserved_1[1];
+} TWI_t;
+
+/* Acknowledge Action select */
+typedef enum TWI_ACKACT_enum
+{
+    TWI_ACKACT_ACK_gc = (0x00<<2),  /* Send ACK */
+    TWI_ACKACT_NACK_gc = (0x01<<2)  /* Send NACK */
+} TWI_ACKACT_t;
+
+/* Address or Stop select */
+typedef enum TWI_AP_enum
+{
+    TWI_AP_STOP_gc = (0x00<<0),  /* A Stop condition generated the interrupt on APIF flag */
+    TWI_AP_ADR_gc = (0x01<<0)  /* Address detection generated the interrupt on APIF flag */
+} TWI_AP_t;
+
+/* Bus State select */
+typedef enum TWI_BUSSTATE_enum
+{
+    TWI_BUSSTATE_UNKNOWN_gc = (0x00<<0),  /* Unknown bus state */
+    TWI_BUSSTATE_IDLE_gc = (0x01<<0),  /* Bus is idle */
+    TWI_BUSSTATE_OWNER_gc = (0x02<<0),  /* This TWI controls the bus */
+    TWI_BUSSTATE_BUSY_gc = (0x03<<0)  /* The bus is busy */
+} TWI_BUSSTATE_t;
+
+/* Debug Run select */
+typedef enum TWI_DBGRUN_enum
+{
+    TWI_DBGRUN_HALT_gc = (0x00<<0),  /* The peripheral is halted in Break Debug mode and ignores events */
+    TWI_DBGRUN_RUN_gc = (0x01<<0)  /* The peripheral will continue to run in Break Debug mode when the CPU is halted */
+} TWI_DBGRUN_t;
+
+/* Fast-mode Enable select */
+typedef enum TWI_FMEN_enum
+{
+    TWI_FMEN_OFF_gc = (0x00<<0),  /* SCL duty cycle operating according to Sm specification */
+    TWI_FMEN_ON_gc = (0x01<<0)  /* SCL duty cycle operating according to Fm specification */
+} TWI_FMEN_t;
+
+/* Fast-mode Plus Enable select */
+typedef enum TWI_FMPEN_enum
+{
+    TWI_FMPEN_OFF_gc = (0x00<<1),  /* Operating in Standard-mode or Fast-mode */
+    TWI_FMPEN_ON_gc = (0x01<<1)  /* Operating in Fast-mode Plus */
+} TWI_FMPEN_t;
+
+/* Input voltage transition level select */
+typedef enum TWI_INPUTLVL_enum
+{
+    TWI_INPUTLVL_I2C_gc = (0x00<<6),  /* I2C input voltage transition level */
+    TWI_INPUTLVL_SMBUS_gc = (0x01<<6)  /* SMBus 3.0 input voltage transition level */
+} TWI_INPUTLVL_t;
+
+/* Command select */
+typedef enum TWI_MCMD_enum
+{
+    TWI_MCMD_NOACT_gc = (0x00<<0),  /* No action */
+    TWI_MCMD_REPSTART_gc = (0x01<<0),  /* Execute Acknowledge Action followed by repeated Start. */
+    TWI_MCMD_RECVTRANS_gc = (0x02<<0),  /* Execute Acknowledge Action followed by a byte read/write operation. Read/write is defined by DIR. */
+    TWI_MCMD_STOP_gc = (0x03<<0)  /* Execute Acknowledge Action followed by issuing a Stop condition. */
+} TWI_MCMD_t;
+
+/* Command select */
+typedef enum TWI_SCMD_enum
+{
+    TWI_SCMD_NOACT_gc = (0x00<<0),  /* No Action */
+    TWI_SCMD_COMPTRANS_gc = (0x02<<0),  /* Complete transaction */
+    TWI_SCMD_RESPONSE_gc = (0x03<<0)  /* Used in response to an interrupt */
+} TWI_SCMD_t;
+
+/* SDA Hold Time select */
+typedef enum TWI_SDAHOLD_enum
+{
+    TWI_SDAHOLD_OFF_gc = (0x00<<2),  /* No SDA Hold Delay */
+    TWI_SDAHOLD_50NS_gc = (0x01<<2),  /* Short SDA hold time */
+    TWI_SDAHOLD_300NS_gc = (0x02<<2),  /* Meets SMBUS 2.0 specification under typical conditions */
+    TWI_SDAHOLD_500NS_gc = (0x03<<2)  /* Meets SMBUS 2.0 specificaiton across all corners */
+} TWI_SDAHOLD_t;
+
+/* SDA Setup Time select */
+typedef enum TWI_SDASETUP_enum
+{
+    TWI_SDASETUP_4CYC_gc = (0x00<<4),  /* SDA setup time is four clock cycles */
+    TWI_SDASETUP_8CYC_gc = (0x01<<4)  /* SDA setup time is eight clock cycle */
+} TWI_SDASETUP_t;
+
+/* Inactive Bus Time-Out select */
+typedef enum TWI_TIMEOUT_enum
+{
+    TWI_TIMEOUT_DISABLED_gc = (0x00<<2),  /* Bus time-out disabled. I2C. */
+    TWI_TIMEOUT_50US_gc = (0x01<<2),  /* 50us - SMBus */
+    TWI_TIMEOUT_100US_gc = (0x02<<2),  /* 100us */
+    TWI_TIMEOUT_200US_gc = (0x03<<2)  /* 200us */
+} TWI_TIMEOUT_t;
+
+/*
+--------------------------------------------------------------------------
+USART - Universal Synchronous and Asynchronous Receiver and Transmitter
+--------------------------------------------------------------------------
+*/
+
+/* Universal Synchronous and Asynchronous Receiver and Transmitter */
+typedef struct USART_struct
+{
+    register8_t RXDATAL;  /* Receive Data Low Byte */
+    register8_t RXDATAH;  /* Receive Data High Byte */
+    register8_t TXDATAL;  /* Transmit Data Low Byte */
+    register8_t TXDATAH;  /* Transmit Data High Byte */
+    register8_t STATUS;  /* Status */
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    _WORDREGISTER(BAUD);  /* Baud Rate */
+    register8_t CTRLD;  /* Control D */
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t EVCTRL;  /* Event Control */
+    register8_t TXPLCTRL;  /* IRCOM Transmitter Pulse Length Control */
+    register8_t RXPLCTRL;  /* IRCOM Receiver Pulse Length Control */
+    register8_t reserved_1[1];
+} USART_t;
+
+/* Auto Baud Window select */
+typedef enum USART_ABW_enum
+{
+    USART_ABW_WDW0_gc = (0x00<<6),  /* 18% tolerance */
+    USART_ABW_WDW1_gc = (0x01<<6),  /* 15% tolerance */
+    USART_ABW_WDW2_gc = (0x02<<6),  /* 21% tolerance */
+    USART_ABW_WDW3_gc = (0x03<<6)  /* 25% tolerance */
+} USART_ABW_t;
+
+/* Character Size select */
+typedef enum USART_CHSIZE_enum
+{
+    USART_CHSIZE_5BIT_gc = (0x00<<0),  /* Character size: 5 bit */
+    USART_CHSIZE_6BIT_gc = (0x01<<0),  /* Character size: 6 bit */
+    USART_CHSIZE_7BIT_gc = (0x02<<0),  /* Character size: 7 bit */
+    USART_CHSIZE_8BIT_gc = (0x03<<0),  /* Character size: 8 bit */
+    USART_CHSIZE_9BITL_gc = (0x06<<0),  /* Character size: 9 bit read low byte first */
+    USART_CHSIZE_9BITH_gc = (0x07<<0)  /* Character size: 9 bit read high byte first */
+} USART_CHSIZE_t;
+
+/* Communication Mode select */
+typedef enum USART_CMODE_enum
+{
+    USART_CMODE_ASYNCHRONOUS_gc = (0x00<<6),  /* Asynchronous Mode */
+    USART_CMODE_SYNCHRONOUS_gc = (0x01<<6),  /* Synchronous Mode */
+    USART_CMODE_IRCOM_gc = (0x02<<6),  /* Infrared Communication */
+    USART_CMODE_MSPI_gc = (0x03<<6)  /* SPI Host Mode */
+} USART_CMODE_t;
+
+/* Parity Mode select */
+typedef enum USART_PMODE_enum
+{
+    USART_PMODE_DISABLED_gc = (0x00<<4),  /* No Parity */
+    USART_PMODE_EVEN_gc = (0x02<<4),  /* Even Parity */
+    USART_PMODE_ODD_gc = (0x03<<4)  /* Odd Parity */
+} USART_PMODE_t;
+
+/* RS485 Mode internal transmitter select */
+typedef enum USART_RS485_enum
+{
+    USART_RS485_DISABLE_gc = (0x00<<0),  /* RS485 Mode disabled */
+    USART_RS485_ENABLE_gc = (0x01<<0)  /* RS485 Mode enabled */
+} USART_RS485_t;
+
+/* Receiver Mode select */
+typedef enum USART_RXMODE_enum
+{
+    USART_RXMODE_NORMAL_gc = (0x00<<1),  /* Normal mode */
+    USART_RXMODE_CLK2X_gc = (0x01<<1),  /* CLK2x mode */
+    USART_RXMODE_GENAUTO_gc = (0x02<<1),  /* Generic autobaud mode */
+    USART_RXMODE_LINAUTO_gc = (0x03<<1)  /* LIN constrained autobaud mode */
+} USART_RXMODE_t;
+
+/* Stop Bit Mode select */
+typedef enum USART_SBMODE_enum
+{
+    USART_SBMODE_1BIT_gc = (0x00<<3),  /* 1 stop bit */
+    USART_SBMODE_2BIT_gc = (0x01<<3)  /* 2 stop bits */
+} USART_SBMODE_t;
+
+/*
+--------------------------------------------------------------------------
+USERROW - User Row
+--------------------------------------------------------------------------
+*/
+
+/* User Row */
+typedef struct USERROW_struct
+{
+    register8_t USERROW0;  /* User Row Byte 0 */
+    register8_t USERROW1;  /* User Row Byte 1 */
+    register8_t USERROW2;  /* User Row Byte 2 */
+    register8_t USERROW3;  /* User Row Byte 3 */
+    register8_t USERROW4;  /* User Row Byte 4 */
+    register8_t USERROW5;  /* User Row Byte 5 */
+    register8_t USERROW6;  /* User Row Byte 6 */
+    register8_t USERROW7;  /* User Row Byte 7 */
+    register8_t USERROW8;  /* User Row Byte 8 */
+    register8_t USERROW9;  /* User Row Byte 9 */
+    register8_t USERROW10;  /* User Row Byte 10 */
+    register8_t USERROW11;  /* User Row Byte 11 */
+    register8_t USERROW12;  /* User Row Byte 12 */
+    register8_t USERROW13;  /* User Row Byte 13 */
+    register8_t USERROW14;  /* User Row Byte 14 */
+    register8_t USERROW15;  /* User Row Byte 15 */
+    register8_t USERROW16;  /* User Row Byte 16 */
+    register8_t USERROW17;  /* User Row Byte 17 */
+    register8_t USERROW18;  /* User Row Byte 18 */
+    register8_t USERROW19;  /* User Row Byte 19 */
+    register8_t USERROW20;  /* User Row Byte 20 */
+    register8_t USERROW21;  /* User Row Byte 21 */
+    register8_t USERROW22;  /* User Row Byte 22 */
+    register8_t USERROW23;  /* User Row Byte 23 */
+    register8_t USERROW24;  /* User Row Byte 24 */
+    register8_t USERROW25;  /* User Row Byte 25 */
+    register8_t USERROW26;  /* User Row Byte 26 */
+    register8_t USERROW27;  /* User Row Byte 27 */
+    register8_t USERROW28;  /* User Row Byte 28 */
+    register8_t USERROW29;  /* User Row Byte 29 */
+    register8_t USERROW30;  /* User Row Byte 30 */
+    register8_t USERROW31;  /* User Row Byte 31 */
+    register8_t USERROW32;  /* User Row Byte 32 */
+    register8_t USERROW33;  /* User Row Byte 33 */
+    register8_t USERROW34;  /* User Row Byte 34 */
+    register8_t USERROW35;  /* User Row Byte 35 */
+    register8_t USERROW36;  /* User Row Byte 36 */
+    register8_t USERROW37;  /* User Row Byte 37 */
+    register8_t USERROW38;  /* User Row Byte 38 */
+    register8_t USERROW39;  /* User Row Byte 39 */
+    register8_t USERROW40;  /* User Row Byte 40 */
+    register8_t USERROW41;  /* User Row Byte 41 */
+    register8_t USERROW42;  /* User Row Byte 42 */
+    register8_t USERROW43;  /* User Row Byte 43 */
+    register8_t USERROW44;  /* User Row Byte 44 */
+    register8_t USERROW45;  /* User Row Byte 45 */
+    register8_t USERROW46;  /* User Row Byte 46 */
+    register8_t USERROW47;  /* User Row Byte 47 */
+    register8_t USERROW48;  /* User Row Byte 48 */
+    register8_t USERROW49;  /* User Row Byte 49 */
+    register8_t USERROW50;  /* User Row Byte 50 */
+    register8_t USERROW51;  /* User Row Byte 51 */
+    register8_t USERROW52;  /* User Row Byte 52 */
+    register8_t USERROW53;  /* User Row Byte 53 */
+    register8_t USERROW54;  /* User Row Byte 54 */
+    register8_t USERROW55;  /* User Row Byte 55 */
+    register8_t USERROW56;  /* User Row Byte 56 */
+    register8_t USERROW57;  /* User Row Byte 57 */
+    register8_t USERROW58;  /* User Row Byte 58 */
+    register8_t USERROW59;  /* User Row Byte 59 */
+    register8_t USERROW60;  /* User Row Byte 60 */
+    register8_t USERROW61;  /* User Row Byte 61 */
+    register8_t USERROW62;  /* User Row Byte 62 */
+    register8_t USERROW63;  /* User Row Byte 63 */
+} USERROW_t;
+
+
+/*
+--------------------------------------------------------------------------
+VPORT - Virtual Ports
+--------------------------------------------------------------------------
+*/
+
+/* Virtual Ports */
+typedef struct VPORT_struct
+{
+    register8_t DIR;  /* Data Direction */
+    register8_t OUT;  /* Output Value */
+    register8_t IN;  /* Input Value */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+} VPORT_t;
+
+
+/*
+--------------------------------------------------------------------------
+VREF - Voltage reference
+--------------------------------------------------------------------------
+*/
+
+/* Voltage reference */
+typedef struct VREF_struct
+{
+    register8_t reserved_1[2];
+    register8_t DAC0REF;  /* DAC0 Reference */
+    register8_t reserved_2[1];
+    register8_t ACREF;  /* AC Reference */
+} VREF_t;
+
+/* Reference select */
+typedef enum VREF_REFSEL_enum
+{
+    VREF_REFSEL_1V024_gc = (0x00<<0),  /* Internal 1.024V reference */
+    VREF_REFSEL_2V048_gc = (0x01<<0),  /* Internal 2.048V reference */
+    VREF_REFSEL_4V096_gc = (0x02<<0),  /* Internal 4.096V reference */
+    VREF_REFSEL_2V500_gc = (0x03<<0),  /* Internal 2.500V reference */
+    VREF_REFSEL_VDD_gc = (0x05<<0),  /* VDD as reference */
+    VREF_REFSEL_VREFA_gc = (0x06<<0)  /* External reference on VREFA pin */
+} VREF_REFSEL_t;
+
+/*
+--------------------------------------------------------------------------
+WDT - Watch-Dog Timer
+--------------------------------------------------------------------------
+*/
+
+/* Watch-Dog Timer */
+typedef struct WDT_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t STATUS;  /* Status */
+    register8_t reserved_1[14];
+} WDT_t;
+
+/* Period select */
+typedef enum WDT_PERIOD_enum
+{
+    WDT_PERIOD_OFF_gc = (0x00<<0),  /* Off */
+    WDT_PERIOD_8CLK_gc = (0x01<<0),  /* 8 cycles (8ms) */
+    WDT_PERIOD_16CLK_gc = (0x02<<0),  /* 16 cycles (16ms) */
+    WDT_PERIOD_32CLK_gc = (0x03<<0),  /* 32 cycles (32ms) */
+    WDT_PERIOD_64CLK_gc = (0x04<<0),  /* 64 cycles (64ms) */
+    WDT_PERIOD_128CLK_gc = (0x05<<0),  /* 128 cycles (0.128s) */
+    WDT_PERIOD_256CLK_gc = (0x06<<0),  /* 256 cycles (0.256s) */
+    WDT_PERIOD_512CLK_gc = (0x07<<0),  /* 512 cycles (0.512s) */
+    WDT_PERIOD_1KCLK_gc = (0x08<<0),  /* 1K cycles (1.0s) */
+    WDT_PERIOD_2KCLK_gc = (0x09<<0),  /* 2K cycles (2.0s) */
+    WDT_PERIOD_4KCLK_gc = (0x0A<<0),  /* 4K cycles (4.1s) */
+    WDT_PERIOD_8KCLK_gc = (0x0B<<0)  /* 8K cycles (8.2s) */
+} WDT_PERIOD_t;
+
+/* Window select */
+typedef enum WDT_WINDOW_enum
+{
+    WDT_WINDOW_OFF_gc = (0x00<<4),  /* Off */
+    WDT_WINDOW_8CLK_gc = (0x01<<4),  /* 8 cycles (8ms) */
+    WDT_WINDOW_16CLK_gc = (0x02<<4),  /* 16 cycles (16ms) */
+    WDT_WINDOW_32CLK_gc = (0x03<<4),  /* 32 cycles (32ms) */
+    WDT_WINDOW_64CLK_gc = (0x04<<4),  /* 64 cycles (64ms) */
+    WDT_WINDOW_128CLK_gc = (0x05<<4),  /* 128 cycles (0.128s) */
+    WDT_WINDOW_256CLK_gc = (0x06<<4),  /* 256 cycles (0.256s) */
+    WDT_WINDOW_512CLK_gc = (0x07<<4),  /* 512 cycles (0.512s) */
+    WDT_WINDOW_1KCLK_gc = (0x08<<4),  /* 1K cycles (1.0s) */
+    WDT_WINDOW_2KCLK_gc = (0x09<<4),  /* 2K cycles (2.0s) */
+    WDT_WINDOW_4KCLK_gc = (0x0A<<4),  /* 4K cycles (4.1s) */
+    WDT_WINDOW_8KCLK_gc = (0x0B<<4)  /* 8K cycles (8.2s) */
+} WDT_WINDOW_t;
+/*
+==========================================================================
+IO Module Instances. Mapped to memory.
+==========================================================================
+*/
+
+#define VPORTA              (*(VPORT_t *) 0x0000) /* Virtual Ports */
+#define VPORTC              (*(VPORT_t *) 0x0008) /* Virtual Ports */
+#define VPORTD              (*(VPORT_t *) 0x000C) /* Virtual Ports */
+#define VPORTF              (*(VPORT_t *) 0x0014) /* Virtual Ports */
+#define GPR                   (*(GPR_t *) 0x001C) /* General Purpose Registers */
+#define RSTCTRL           (*(RSTCTRL_t *) 0x0040) /* Reset controller */
+#define SLPCTRL           (*(SLPCTRL_t *) 0x0050) /* Sleep Controller */
+#define CLKCTRL           (*(CLKCTRL_t *) 0x0060) /* Clock controller */
+#define BOD                   (*(BOD_t *) 0x00A0) /* Bod interface */
+#define VREF                 (*(VREF_t *) 0x00B0) /* Voltage reference */
+#define WDT                   (*(WDT_t *) 0x0100) /* Watch-Dog Timer */
+#define CPUINT             (*(CPUINT_t *) 0x0110) /* Interrupt Controller */
+#define CRCSCAN           (*(CRCSCAN_t *) 0x0120) /* CRCSCAN */
+#define RTC                   (*(RTC_t *) 0x0140) /* Real-Time Counter */
+#define CCL                   (*(CCL_t *) 0x01C0) /* Configurable Custom Logic */
+#define EVSYS               (*(EVSYS_t *) 0x0200) /* Event System */
+#define PORTA                (*(PORT_t *) 0x0400) /* I/O Ports */
+#define PORTC                (*(PORT_t *) 0x0440) /* I/O Ports */
+#define PORTD                (*(PORT_t *) 0x0460) /* I/O Ports */
+#define PORTF                (*(PORT_t *) 0x04A0) /* I/O Ports */
+#define PORTMUX           (*(PORTMUX_t *) 0x05E0) /* Port Multiplexer */
+#define ADC0                  (*(ADC_t *) 0x0600) /* Analog to Digital Converter */
+#define AC0                    (*(AC_t *) 0x0680) /* Analog Comparator */
+#define AC1                    (*(AC_t *) 0x0688) /* Analog Comparator */
+#define DAC0                  (*(DAC_t *) 0x06A0) /* Digital to Analog Converter */
+#define USART0              (*(USART_t *) 0x0800) /* Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define USART1              (*(USART_t *) 0x0820) /* Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define USART2              (*(USART_t *) 0x0840) /* Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define TWI0                  (*(TWI_t *) 0x0900) /* Two-Wire Interface */
+#define SPI0                  (*(SPI_t *) 0x0940) /* Serial Peripheral Interface */
+#define TCA0                  (*(TCA_t *) 0x0A00) /* 16-bit Timer/Counter Type A */
+#define TCB0                  (*(TCB_t *) 0x0B00) /* 16-bit Timer Type B */
+#define TCB1                  (*(TCB_t *) 0x0B10) /* 16-bit Timer Type B */
+#define TCB2                  (*(TCB_t *) 0x0B20) /* 16-bit Timer Type B */
+#define SYSCFG             (*(SYSCFG_t *) 0x0F00) /* System Configuration Registers */
+#define NVMCTRL           (*(NVMCTRL_t *) 0x1000) /* Non-volatile Memory Controller */
+#define LOCK                 (*(LOCK_t *) 0x1040) /* Lockbits */
+#define FUSE                 (*(FUSE_t *) 0x1050) /* Fuses */
+#define USERROW           (*(USERROW_t *) 0x1080) /* User Row */
+#define SIGROW             (*(SIGROW_t *) 0x1100) /* Signature row */
+
+#endif /* !defined (__ASSEMBLER__) */
+
+
+/* ========== Flattened fully qualified IO register names ========== */
+
+
+/* VPORT (VPORTA) - Virtual Ports */
+#define VPORTA_DIR  _SFR_MEM8(0x0000)
+#define VPORTA_OUT  _SFR_MEM8(0x0001)
+#define VPORTA_IN  _SFR_MEM8(0x0002)
+#define VPORTA_INTFLAGS  _SFR_MEM8(0x0003)
+
+
+/* VPORT (VPORTC) - Virtual Ports */
+#define VPORTC_DIR  _SFR_MEM8(0x0008)
+#define VPORTC_OUT  _SFR_MEM8(0x0009)
+#define VPORTC_IN  _SFR_MEM8(0x000A)
+#define VPORTC_INTFLAGS  _SFR_MEM8(0x000B)
+
+
+/* VPORT (VPORTD) - Virtual Ports */
+#define VPORTD_DIR  _SFR_MEM8(0x000C)
+#define VPORTD_OUT  _SFR_MEM8(0x000D)
+#define VPORTD_IN  _SFR_MEM8(0x000E)
+#define VPORTD_INTFLAGS  _SFR_MEM8(0x000F)
+
+
+/* VPORT (VPORTF) - Virtual Ports */
+#define VPORTF_DIR  _SFR_MEM8(0x0014)
+#define VPORTF_OUT  _SFR_MEM8(0x0015)
+#define VPORTF_IN  _SFR_MEM8(0x0016)
+#define VPORTF_INTFLAGS  _SFR_MEM8(0x0017)
+
+
+/* GPR - General Purpose Registers */
+#define GPR_GPR0  _SFR_MEM8(0x001C)
+#define GPR_GPR1  _SFR_MEM8(0x001D)
+#define GPR_GPR2  _SFR_MEM8(0x001E)
+#define GPR_GPR3  _SFR_MEM8(0x001F)
+
+
+/* CPU - CPU */
+#define CPU_CCP  _SFR_MEM8(0x0034)
+#define CPU_SP  _SFR_MEM16(0x003D)
+#define CPU_SPL  _SFR_MEM8(0x003D)
+#define CPU_SPH  _SFR_MEM8(0x003E)
+#define CPU_SREG  _SFR_MEM8(0x003F)
+
+
+/* RSTCTRL - Reset controller */
+#define RSTCTRL_RSTFR  _SFR_MEM8(0x0040)
+#define RSTCTRL_SWRR  _SFR_MEM8(0x0041)
+
+
+/* SLPCTRL - Sleep Controller */
+#define SLPCTRL_CTRLA  _SFR_MEM8(0x0050)
+
+
+/* CLKCTRL - Clock controller */
+#define CLKCTRL_MCLKCTRLA  _SFR_MEM8(0x0060)
+#define CLKCTRL_MCLKCTRLB  _SFR_MEM8(0x0061)
+#define CLKCTRL_MCLKCTRLC  _SFR_MEM8(0x0062)
+#define CLKCTRL_MCLKINTCTRL  _SFR_MEM8(0x0063)
+#define CLKCTRL_MCLKINTFLAGS  _SFR_MEM8(0x0064)
+#define CLKCTRL_MCLKSTATUS  _SFR_MEM8(0x0065)
+#define CLKCTRL_MCLKTIMEBASE  _SFR_MEM8(0x0066)
+#define CLKCTRL_OSCHFCTRLA  _SFR_MEM8(0x0068)
+#define CLKCTRL_OSCHFTUNE  _SFR_MEM8(0x0069)
+#define CLKCTRL_OSC32KCTRLA  _SFR_MEM8(0x0078)
+#define CLKCTRL_XOSC32KCTRLA  _SFR_MEM8(0x007C)
+#define CLKCTRL_XOSCHFCTRLA  _SFR_MEM8(0x0080)
+
+
+/* BOD - Bod interface */
+#define BOD_CTRLA  _SFR_MEM8(0x00A0)
+#define BOD_CTRLB  _SFR_MEM8(0x00A1)
+#define BOD_VLMCTRLA  _SFR_MEM8(0x00A8)
+#define BOD_INTCTRL  _SFR_MEM8(0x00A9)
+#define BOD_INTFLAGS  _SFR_MEM8(0x00AA)
+#define BOD_STATUS  _SFR_MEM8(0x00AB)
+
+
+/* VREF - Voltage reference */
+#define VREF_DAC0REF  _SFR_MEM8(0x00B2)
+#define VREF_ACREF  _SFR_MEM8(0x00B4)
+
+
+/* WDT - Watch-Dog Timer */
+#define WDT_CTRLA  _SFR_MEM8(0x0100)
+#define WDT_STATUS  _SFR_MEM8(0x0101)
+
+
+/* CPUINT - Interrupt Controller */
+#define CPUINT_CTRLA  _SFR_MEM8(0x0110)
+#define CPUINT_STATUS  _SFR_MEM8(0x0111)
+#define CPUINT_LVL0PRI  _SFR_MEM8(0x0112)
+#define CPUINT_LVL1VEC  _SFR_MEM8(0x0113)
+
+
+/* CRCSCAN - CRCSCAN */
+#define CRCSCAN_CTRLA  _SFR_MEM8(0x0120)
+#define CRCSCAN_CTRLB  _SFR_MEM8(0x0121)
+#define CRCSCAN_STATUS  _SFR_MEM8(0x0122)
+
+
+/* RTC - Real-Time Counter */
+#define RTC_CTRLA  _SFR_MEM8(0x0140)
+#define RTC_STATUS  _SFR_MEM8(0x0141)
+#define RTC_INTCTRL  _SFR_MEM8(0x0142)
+#define RTC_INTFLAGS  _SFR_MEM8(0x0143)
+#define RTC_TEMP  _SFR_MEM8(0x0144)
+#define RTC_DBGCTRL  _SFR_MEM8(0x0145)
+#define RTC_CALIB  _SFR_MEM8(0x0146)
+#define RTC_CLKSEL  _SFR_MEM8(0x0147)
+#define RTC_CNT  _SFR_MEM16(0x0148)
+#define RTC_CNTL  _SFR_MEM8(0x0148)
+#define RTC_CNTH  _SFR_MEM8(0x0149)
+#define RTC_PER  _SFR_MEM16(0x014A)
+#define RTC_PERL  _SFR_MEM8(0x014A)
+#define RTC_PERH  _SFR_MEM8(0x014B)
+#define RTC_CMP  _SFR_MEM16(0x014C)
+#define RTC_CMPL  _SFR_MEM8(0x014C)
+#define RTC_CMPH  _SFR_MEM8(0x014D)
+#define RTC_PITCTRLA  _SFR_MEM8(0x0150)
+#define RTC_PITSTATUS  _SFR_MEM8(0x0151)
+#define RTC_PITINTCTRL  _SFR_MEM8(0x0152)
+#define RTC_PITINTFLAGS  _SFR_MEM8(0x0153)
+#define RTC_PITDBGCTRL  _SFR_MEM8(0x0155)
+#define RTC_PITEVGENCTRLA  _SFR_MEM8(0x0156)
+
+
+/* CCL - Configurable Custom Logic */
+#define CCL_CTRLA  _SFR_MEM8(0x01C0)
+#define CCL_SEQCTRL0  _SFR_MEM8(0x01C1)
+#define CCL_SEQCTRL1  _SFR_MEM8(0x01C2)
+#define CCL_INTCTRL0  _SFR_MEM8(0x01C5)
+#define CCL_INTFLAGS  _SFR_MEM8(0x01C7)
+#define CCL_LUT0CTRLA  _SFR_MEM8(0x01C8)
+#define CCL_LUT0CTRLB  _SFR_MEM8(0x01C9)
+#define CCL_LUT0CTRLC  _SFR_MEM8(0x01CA)
+#define CCL_TRUTH0  _SFR_MEM8(0x01CB)
+#define CCL_LUT1CTRLA  _SFR_MEM8(0x01CC)
+#define CCL_LUT1CTRLB  _SFR_MEM8(0x01CD)
+#define CCL_LUT1CTRLC  _SFR_MEM8(0x01CE)
+#define CCL_TRUTH1  _SFR_MEM8(0x01CF)
+#define CCL_LUT2CTRLA  _SFR_MEM8(0x01D0)
+#define CCL_LUT2CTRLB  _SFR_MEM8(0x01D1)
+#define CCL_LUT2CTRLC  _SFR_MEM8(0x01D2)
+#define CCL_TRUTH2  _SFR_MEM8(0x01D3)
+#define CCL_LUT3CTRLA  _SFR_MEM8(0x01D4)
+#define CCL_LUT3CTRLB  _SFR_MEM8(0x01D5)
+#define CCL_LUT3CTRLC  _SFR_MEM8(0x01D6)
+#define CCL_TRUTH3  _SFR_MEM8(0x01D7)
+
+
+/* EVSYS - Event System */
+#define EVSYS_SWEVENTA  _SFR_MEM8(0x0200)
+#define EVSYS_CHANNEL0  _SFR_MEM8(0x0210)
+#define EVSYS_CHANNEL1  _SFR_MEM8(0x0211)
+#define EVSYS_CHANNEL2  _SFR_MEM8(0x0212)
+#define EVSYS_CHANNEL3  _SFR_MEM8(0x0213)
+#define EVSYS_CHANNEL4  _SFR_MEM8(0x0214)
+#define EVSYS_CHANNEL5  _SFR_MEM8(0x0215)
+#define EVSYS_USERCCLLUT0A  _SFR_MEM8(0x0220)
+#define EVSYS_USERCCLLUT0B  _SFR_MEM8(0x0221)
+#define EVSYS_USERCCLLUT1A  _SFR_MEM8(0x0222)
+#define EVSYS_USERCCLLUT1B  _SFR_MEM8(0x0223)
+#define EVSYS_USERCCLLUT2A  _SFR_MEM8(0x0224)
+#define EVSYS_USERCCLLUT2B  _SFR_MEM8(0x0225)
+#define EVSYS_USERCCLLUT3A  _SFR_MEM8(0x0226)
+#define EVSYS_USERCCLLUT3B  _SFR_MEM8(0x0227)
+#define EVSYS_USERADC0START  _SFR_MEM8(0x0228)
+#define EVSYS_USEREVSYSEVOUTA  _SFR_MEM8(0x0229)
+#define EVSYS_USEREVSYSEVOUTC  _SFR_MEM8(0x022B)
+#define EVSYS_USEREVSYSEVOUTD  _SFR_MEM8(0x022C)
+#define EVSYS_USEREVSYSEVOUTF  _SFR_MEM8(0x022E)
+#define EVSYS_USERUSART0IRDA  _SFR_MEM8(0x022F)
+#define EVSYS_USERUSART1IRDA  _SFR_MEM8(0x0230)
+#define EVSYS_USERUSART2IRDA  _SFR_MEM8(0x0231)
+#define EVSYS_USERTCA0CNTA  _SFR_MEM8(0x0232)
+#define EVSYS_USERTCA0CNTB  _SFR_MEM8(0x0233)
+#define EVSYS_USERTCA1CNTA  _SFR_MEM8(0x0234)
+#define EVSYS_USERTCA1CNTB  _SFR_MEM8(0x0235)
+#define EVSYS_USERTCB0CAPT  _SFR_MEM8(0x0236)
+#define EVSYS_USERTCB0COUNT  _SFR_MEM8(0x0237)
+#define EVSYS_USERTCB1CAPT  _SFR_MEM8(0x0238)
+#define EVSYS_USERTCB1COUNT  _SFR_MEM8(0x0239)
+#define EVSYS_USERTCB2CAPT  _SFR_MEM8(0x023A)
+#define EVSYS_USERTCB2COUNT  _SFR_MEM8(0x023B)
+#define EVSYS_USERTCB3CAPT  _SFR_MEM8(0x023C)
+#define EVSYS_USERTCB3COUNT  _SFR_MEM8(0x023D)
+
+
+/* PORT (PORTA) - I/O Ports */
+#define PORTA_DIR  _SFR_MEM8(0x0400)
+#define PORTA_DIRSET  _SFR_MEM8(0x0401)
+#define PORTA_DIRCLR  _SFR_MEM8(0x0402)
+#define PORTA_DIRTGL  _SFR_MEM8(0x0403)
+#define PORTA_OUT  _SFR_MEM8(0x0404)
+#define PORTA_OUTSET  _SFR_MEM8(0x0405)
+#define PORTA_OUTCLR  _SFR_MEM8(0x0406)
+#define PORTA_OUTTGL  _SFR_MEM8(0x0407)
+#define PORTA_IN  _SFR_MEM8(0x0408)
+#define PORTA_INTFLAGS  _SFR_MEM8(0x0409)
+#define PORTA_PORTCTRL  _SFR_MEM8(0x040A)
+#define PORTA_PINCONFIG  _SFR_MEM8(0x040B)
+#define PORTA_PINCTRLUPD  _SFR_MEM8(0x040C)
+#define PORTA_PINCTRLSET  _SFR_MEM8(0x040D)
+#define PORTA_PINCTRLCLR  _SFR_MEM8(0x040E)
+#define PORTA_PIN0CTRL  _SFR_MEM8(0x0410)
+#define PORTA_PIN1CTRL  _SFR_MEM8(0x0411)
+#define PORTA_PIN2CTRL  _SFR_MEM8(0x0412)
+#define PORTA_PIN3CTRL  _SFR_MEM8(0x0413)
+#define PORTA_PIN4CTRL  _SFR_MEM8(0x0414)
+#define PORTA_PIN5CTRL  _SFR_MEM8(0x0415)
+#define PORTA_PIN6CTRL  _SFR_MEM8(0x0416)
+#define PORTA_PIN7CTRL  _SFR_MEM8(0x0417)
+#define PORTA_EVGENCTRL  _SFR_MEM8(0x0418)
+
+
+/* PORT (PORTC) - I/O Ports */
+#define PORTC_DIR  _SFR_MEM8(0x0440)
+#define PORTC_DIRSET  _SFR_MEM8(0x0441)
+#define PORTC_DIRCLR  _SFR_MEM8(0x0442)
+#define PORTC_DIRTGL  _SFR_MEM8(0x0443)
+#define PORTC_OUT  _SFR_MEM8(0x0444)
+#define PORTC_OUTSET  _SFR_MEM8(0x0445)
+#define PORTC_OUTCLR  _SFR_MEM8(0x0446)
+#define PORTC_OUTTGL  _SFR_MEM8(0x0447)
+#define PORTC_IN  _SFR_MEM8(0x0448)
+#define PORTC_INTFLAGS  _SFR_MEM8(0x0449)
+#define PORTC_PORTCTRL  _SFR_MEM8(0x044A)
+#define PORTC_PINCONFIG  _SFR_MEM8(0x044B)
+#define PORTC_PINCTRLUPD  _SFR_MEM8(0x044C)
+#define PORTC_PINCTRLSET  _SFR_MEM8(0x044D)
+#define PORTC_PINCTRLCLR  _SFR_MEM8(0x044E)
+#define PORTC_PIN0CTRL  _SFR_MEM8(0x0450)
+#define PORTC_PIN1CTRL  _SFR_MEM8(0x0451)
+#define PORTC_PIN2CTRL  _SFR_MEM8(0x0452)
+#define PORTC_PIN3CTRL  _SFR_MEM8(0x0453)
+#define PORTC_PIN4CTRL  _SFR_MEM8(0x0454)
+#define PORTC_PIN5CTRL  _SFR_MEM8(0x0455)
+#define PORTC_PIN6CTRL  _SFR_MEM8(0x0456)
+#define PORTC_PIN7CTRL  _SFR_MEM8(0x0457)
+#define PORTC_EVGENCTRL  _SFR_MEM8(0x0458)
+
+
+/* PORT (PORTD) - I/O Ports */
+#define PORTD_DIR  _SFR_MEM8(0x0460)
+#define PORTD_DIRSET  _SFR_MEM8(0x0461)
+#define PORTD_DIRCLR  _SFR_MEM8(0x0462)
+#define PORTD_DIRTGL  _SFR_MEM8(0x0463)
+#define PORTD_OUT  _SFR_MEM8(0x0464)
+#define PORTD_OUTSET  _SFR_MEM8(0x0465)
+#define PORTD_OUTCLR  _SFR_MEM8(0x0466)
+#define PORTD_OUTTGL  _SFR_MEM8(0x0467)
+#define PORTD_IN  _SFR_MEM8(0x0468)
+#define PORTD_INTFLAGS  _SFR_MEM8(0x0469)
+#define PORTD_PORTCTRL  _SFR_MEM8(0x046A)
+#define PORTD_PINCONFIG  _SFR_MEM8(0x046B)
+#define PORTD_PINCTRLUPD  _SFR_MEM8(0x046C)
+#define PORTD_PINCTRLSET  _SFR_MEM8(0x046D)
+#define PORTD_PINCTRLCLR  _SFR_MEM8(0x046E)
+#define PORTD_PIN0CTRL  _SFR_MEM8(0x0470)
+#define PORTD_PIN1CTRL  _SFR_MEM8(0x0471)
+#define PORTD_PIN2CTRL  _SFR_MEM8(0x0472)
+#define PORTD_PIN3CTRL  _SFR_MEM8(0x0473)
+#define PORTD_PIN4CTRL  _SFR_MEM8(0x0474)
+#define PORTD_PIN5CTRL  _SFR_MEM8(0x0475)
+#define PORTD_PIN6CTRL  _SFR_MEM8(0x0476)
+#define PORTD_PIN7CTRL  _SFR_MEM8(0x0477)
+#define PORTD_EVGENCTRL  _SFR_MEM8(0x0478)
+
+
+/* PORT (PORTF) - I/O Ports */
+#define PORTF_DIR  _SFR_MEM8(0x04A0)
+#define PORTF_DIRSET  _SFR_MEM8(0x04A1)
+#define PORTF_DIRCLR  _SFR_MEM8(0x04A2)
+#define PORTF_DIRTGL  _SFR_MEM8(0x04A3)
+#define PORTF_OUT  _SFR_MEM8(0x04A4)
+#define PORTF_OUTSET  _SFR_MEM8(0x04A5)
+#define PORTF_OUTCLR  _SFR_MEM8(0x04A6)
+#define PORTF_OUTTGL  _SFR_MEM8(0x04A7)
+#define PORTF_IN  _SFR_MEM8(0x04A8)
+#define PORTF_INTFLAGS  _SFR_MEM8(0x04A9)
+#define PORTF_PORTCTRL  _SFR_MEM8(0x04AA)
+#define PORTF_PINCONFIG  _SFR_MEM8(0x04AB)
+#define PORTF_PINCTRLUPD  _SFR_MEM8(0x04AC)
+#define PORTF_PINCTRLSET  _SFR_MEM8(0x04AD)
+#define PORTF_PINCTRLCLR  _SFR_MEM8(0x04AE)
+#define PORTF_PIN0CTRL  _SFR_MEM8(0x04B0)
+#define PORTF_PIN1CTRL  _SFR_MEM8(0x04B1)
+#define PORTF_PIN2CTRL  _SFR_MEM8(0x04B2)
+#define PORTF_PIN3CTRL  _SFR_MEM8(0x04B3)
+#define PORTF_PIN4CTRL  _SFR_MEM8(0x04B4)
+#define PORTF_PIN5CTRL  _SFR_MEM8(0x04B5)
+#define PORTF_PIN6CTRL  _SFR_MEM8(0x04B6)
+#define PORTF_PIN7CTRL  _SFR_MEM8(0x04B7)
+#define PORTF_EVGENCTRL  _SFR_MEM8(0x04B8)
+
+
+/* PORTMUX - Port Multiplexer */
+#define PORTMUX_EVSYSROUTEA  _SFR_MEM8(0x05E0)
+#define PORTMUX_CCLROUTEA  _SFR_MEM8(0x05E1)
+#define PORTMUX_USARTROUTEA  _SFR_MEM8(0x05E2)
+#define PORTMUX_USARTROUTEB  _SFR_MEM8(0x05E3)
+#define PORTMUX_SPIROUTEA  _SFR_MEM8(0x05E5)
+#define PORTMUX_TWIROUTEA  _SFR_MEM8(0x05E6)
+#define PORTMUX_TCAROUTEA  _SFR_MEM8(0x05E7)
+#define PORTMUX_TCBROUTEA  _SFR_MEM8(0x05E8)
+#define PORTMUX_ACROUTEA  _SFR_MEM8(0x05EA)
+
+
+/* ADC (ADC0) - Analog to Digital Converter */
+#define ADC0_CTRLA  _SFR_MEM8(0x0600)
+#define ADC0_CTRLB  _SFR_MEM8(0x0601)
+#define ADC0_CTRLC  _SFR_MEM8(0x0602)
+#define ADC0_CTRLD  _SFR_MEM8(0x0603)
+#define ADC0_INTCTRL  _SFR_MEM8(0x0604)
+#define ADC0_INTFLAGS  _SFR_MEM8(0x0605)
+#define ADC0_STATUS  _SFR_MEM8(0x0606)
+#define ADC0_DBGCTRL  _SFR_MEM8(0x0607)
+#define ADC0_CTRLE  _SFR_MEM8(0x0608)
+#define ADC0_CTRLF  _SFR_MEM8(0x0609)
+#define ADC0_COMMAND  _SFR_MEM8(0x060A)
+#define ADC0_PGACTRL  _SFR_MEM8(0x060B)
+#define ADC0_MUXPOS  _SFR_MEM8(0x060C)
+#define ADC0_MUXNEG  _SFR_MEM8(0x060D)
+#define ADC0_RESULT  _SFR_MEM32(0x0610)
+#define ADC0_RESULT0  _SFR_MEM8(0x0610)
+#define ADC0_RESULT1  _SFR_MEM8(0x0611)
+#define ADC0_RESULT2  _SFR_MEM8(0x0612)
+#define ADC0_RESULT3  _SFR_MEM8(0x0613)
+#define ADC0_SAMPLE  _SFR_MEM16(0x0614)
+#define ADC0_SAMPLEL  _SFR_MEM8(0x0614)
+#define ADC0_SAMPLEH  _SFR_MEM8(0x0615)
+#define ADC0_TEMP0  _SFR_MEM8(0x0618)
+#define ADC0_TEMP1  _SFR_MEM8(0x0619)
+#define ADC0_TEMP2  _SFR_MEM8(0x061A)
+#define ADC0_WINLT  _SFR_MEM16(0x061C)
+#define ADC0_WINLTL  _SFR_MEM8(0x061C)
+#define ADC0_WINLTH  _SFR_MEM8(0x061D)
+#define ADC0_WINHT  _SFR_MEM16(0x061E)
+#define ADC0_WINHTL  _SFR_MEM8(0x061E)
+#define ADC0_WINHTH  _SFR_MEM8(0x061F)
+
+
+/* AC (AC0) - Analog Comparator */
+#define AC0_CTRLA  _SFR_MEM8(0x0680)
+#define AC0_CTRLB  _SFR_MEM8(0x0681)
+#define AC0_MUXCTRL  _SFR_MEM8(0x0682)
+#define AC0_DACREF  _SFR_MEM8(0x0685)
+#define AC0_INTCTRL  _SFR_MEM8(0x0686)
+#define AC0_STATUS  _SFR_MEM8(0x0687)
+
+
+/* AC (AC1) - Analog Comparator */
+#define AC1_CTRLA  _SFR_MEM8(0x0688)
+#define AC1_CTRLB  _SFR_MEM8(0x0689)
+#define AC1_MUXCTRL  _SFR_MEM8(0x068A)
+#define AC1_DACREF  _SFR_MEM8(0x068D)
+#define AC1_INTCTRL  _SFR_MEM8(0x068E)
+#define AC1_STATUS  _SFR_MEM8(0x068F)
+
+
+/* DAC (DAC0) - Digital to Analog Converter */
+#define DAC0_CTRLA  _SFR_MEM8(0x06A0)
+#define DAC0_DATA  _SFR_MEM16(0x06A2)
+#define DAC0_DATAL  _SFR_MEM8(0x06A2)
+#define DAC0_DATAH  _SFR_MEM8(0x06A3)
+
+
+/* USART (USART0) - Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define USART0_RXDATAL  _SFR_MEM8(0x0800)
+#define USART0_RXDATAH  _SFR_MEM8(0x0801)
+#define USART0_TXDATAL  _SFR_MEM8(0x0802)
+#define USART0_TXDATAH  _SFR_MEM8(0x0803)
+#define USART0_STATUS  _SFR_MEM8(0x0804)
+#define USART0_CTRLA  _SFR_MEM8(0x0805)
+#define USART0_CTRLB  _SFR_MEM8(0x0806)
+#define USART0_CTRLC  _SFR_MEM8(0x0807)
+#define USART0_BAUD  _SFR_MEM16(0x0808)
+#define USART0_BAUDL  _SFR_MEM8(0x0808)
+#define USART0_BAUDH  _SFR_MEM8(0x0809)
+#define USART0_CTRLD  _SFR_MEM8(0x080A)
+#define USART0_DBGCTRL  _SFR_MEM8(0x080B)
+#define USART0_EVCTRL  _SFR_MEM8(0x080C)
+#define USART0_TXPLCTRL  _SFR_MEM8(0x080D)
+#define USART0_RXPLCTRL  _SFR_MEM8(0x080E)
+
+
+/* USART (USART1) - Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define USART1_RXDATAL  _SFR_MEM8(0x0820)
+#define USART1_RXDATAH  _SFR_MEM8(0x0821)
+#define USART1_TXDATAL  _SFR_MEM8(0x0822)
+#define USART1_TXDATAH  _SFR_MEM8(0x0823)
+#define USART1_STATUS  _SFR_MEM8(0x0824)
+#define USART1_CTRLA  _SFR_MEM8(0x0825)
+#define USART1_CTRLB  _SFR_MEM8(0x0826)
+#define USART1_CTRLC  _SFR_MEM8(0x0827)
+#define USART1_BAUD  _SFR_MEM16(0x0828)
+#define USART1_BAUDL  _SFR_MEM8(0x0828)
+#define USART1_BAUDH  _SFR_MEM8(0x0829)
+#define USART1_CTRLD  _SFR_MEM8(0x082A)
+#define USART1_DBGCTRL  _SFR_MEM8(0x082B)
+#define USART1_EVCTRL  _SFR_MEM8(0x082C)
+#define USART1_TXPLCTRL  _SFR_MEM8(0x082D)
+#define USART1_RXPLCTRL  _SFR_MEM8(0x082E)
+
+
+/* USART (USART2) - Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define USART2_RXDATAL  _SFR_MEM8(0x0840)
+#define USART2_RXDATAH  _SFR_MEM8(0x0841)
+#define USART2_TXDATAL  _SFR_MEM8(0x0842)
+#define USART2_TXDATAH  _SFR_MEM8(0x0843)
+#define USART2_STATUS  _SFR_MEM8(0x0844)
+#define USART2_CTRLA  _SFR_MEM8(0x0845)
+#define USART2_CTRLB  _SFR_MEM8(0x0846)
+#define USART2_CTRLC  _SFR_MEM8(0x0847)
+#define USART2_BAUD  _SFR_MEM16(0x0848)
+#define USART2_BAUDL  _SFR_MEM8(0x0848)
+#define USART2_BAUDH  _SFR_MEM8(0x0849)
+#define USART2_CTRLD  _SFR_MEM8(0x084A)
+#define USART2_DBGCTRL  _SFR_MEM8(0x084B)
+#define USART2_EVCTRL  _SFR_MEM8(0x084C)
+#define USART2_TXPLCTRL  _SFR_MEM8(0x084D)
+#define USART2_RXPLCTRL  _SFR_MEM8(0x084E)
+
+
+/* TWI (TWI0) - Two-Wire Interface */
+#define TWI0_CTRLA  _SFR_MEM8(0x0900)
+#define TWI0_DUALCTRL  _SFR_MEM8(0x0901)
+#define TWI0_DBGCTRL  _SFR_MEM8(0x0902)
+#define TWI0_MCTRLA  _SFR_MEM8(0x0903)
+#define TWI0_MCTRLB  _SFR_MEM8(0x0904)
+#define TWI0_MSTATUS  _SFR_MEM8(0x0905)
+#define TWI0_MBAUD  _SFR_MEM8(0x0906)
+#define TWI0_MADDR  _SFR_MEM8(0x0907)
+#define TWI0_MDATA  _SFR_MEM8(0x0908)
+#define TWI0_SCTRLA  _SFR_MEM8(0x0909)
+#define TWI0_SCTRLB  _SFR_MEM8(0x090A)
+#define TWI0_SSTATUS  _SFR_MEM8(0x090B)
+#define TWI0_SADDR  _SFR_MEM8(0x090C)
+#define TWI0_SDATA  _SFR_MEM8(0x090D)
+#define TWI0_SADDRMASK  _SFR_MEM8(0x090E)
+
+
+/* SPI (SPI0) - Serial Peripheral Interface */
+#define SPI0_CTRLA  _SFR_MEM8(0x0940)
+#define SPI0_CTRLB  _SFR_MEM8(0x0941)
+#define SPI0_INTCTRL  _SFR_MEM8(0x0942)
+#define SPI0_INTFLAGS  _SFR_MEM8(0x0943)
+#define SPI0_DATA  _SFR_MEM8(0x0944)
+
+
+/* TCA (TCA0) - 16-bit Timer/Counter Type A - Single Mode */
+#define TCA0_SINGLE_CTRLA  _SFR_MEM8(0x0A00)
+#define TCA0_SINGLE_CTRLB  _SFR_MEM8(0x0A01)
+#define TCA0_SINGLE_CTRLC  _SFR_MEM8(0x0A02)
+#define TCA0_SINGLE_CTRLD  _SFR_MEM8(0x0A03)
+#define TCA0_SINGLE_CTRLECLR  _SFR_MEM8(0x0A04)
+#define TCA0_SINGLE_CTRLESET  _SFR_MEM8(0x0A05)
+#define TCA0_SINGLE_CTRLFCLR  _SFR_MEM8(0x0A06)
+#define TCA0_SINGLE_CTRLFSET  _SFR_MEM8(0x0A07)
+#define TCA0_SINGLE_EVCTRL  _SFR_MEM8(0x0A09)
+#define TCA0_SINGLE_INTCTRL  _SFR_MEM8(0x0A0A)
+#define TCA0_SINGLE_INTFLAGS  _SFR_MEM8(0x0A0B)
+#define TCA0_SINGLE_DBGCTRL  _SFR_MEM8(0x0A0E)
+#define TCA0_SINGLE_TEMP  _SFR_MEM8(0x0A0F)
+#define TCA0_SINGLE_CNT  _SFR_MEM16(0x0A20)
+#define TCA0_SINGLE_CNTL  _SFR_MEM8(0x0A20)
+#define TCA0_SINGLE_CNTH  _SFR_MEM8(0x0A21)
+#define TCA0_SINGLE_PER  _SFR_MEM16(0x0A26)
+#define TCA0_SINGLE_PERL  _SFR_MEM8(0x0A26)
+#define TCA0_SINGLE_PERH  _SFR_MEM8(0x0A27)
+#define TCA0_SINGLE_CMP0  _SFR_MEM16(0x0A28)
+#define TCA0_SINGLE_CMP0L  _SFR_MEM8(0x0A28)
+#define TCA0_SINGLE_CMP0H  _SFR_MEM8(0x0A29)
+#define TCA0_SINGLE_CMP1  _SFR_MEM16(0x0A2A)
+#define TCA0_SINGLE_CMP1L  _SFR_MEM8(0x0A2A)
+#define TCA0_SINGLE_CMP1H  _SFR_MEM8(0x0A2B)
+#define TCA0_SINGLE_CMP2  _SFR_MEM16(0x0A2C)
+#define TCA0_SINGLE_CMP2L  _SFR_MEM8(0x0A2C)
+#define TCA0_SINGLE_CMP2H  _SFR_MEM8(0x0A2D)
+#define TCA0_SINGLE_PERBUF  _SFR_MEM16(0x0A36)
+#define TCA0_SINGLE_PERBUFL  _SFR_MEM8(0x0A36)
+#define TCA0_SINGLE_PERBUFH  _SFR_MEM8(0x0A37)
+#define TCA0_SINGLE_CMP0BUF  _SFR_MEM16(0x0A38)
+#define TCA0_SINGLE_CMP0BUFL  _SFR_MEM8(0x0A38)
+#define TCA0_SINGLE_CMP0BUFH  _SFR_MEM8(0x0A39)
+#define TCA0_SINGLE_CMP1BUF  _SFR_MEM16(0x0A3A)
+#define TCA0_SINGLE_CMP1BUFL  _SFR_MEM8(0x0A3A)
+#define TCA0_SINGLE_CMP1BUFH  _SFR_MEM8(0x0A3B)
+#define TCA0_SINGLE_CMP2BUF  _SFR_MEM16(0x0A3C)
+#define TCA0_SINGLE_CMP2BUFL  _SFR_MEM8(0x0A3C)
+#define TCA0_SINGLE_CMP2BUFH  _SFR_MEM8(0x0A3D)
+
+
+/* TCA (TCA0) - 16-bit Timer/Counter Type A - Split Mode */
+#define TCA0_SPLIT_CTRLA  _SFR_MEM8(0x0A00)
+#define TCA0_SPLIT_CTRLB  _SFR_MEM8(0x0A01)
+#define TCA0_SPLIT_CTRLC  _SFR_MEM8(0x0A02)
+#define TCA0_SPLIT_CTRLD  _SFR_MEM8(0x0A03)
+#define TCA0_SPLIT_CTRLECLR  _SFR_MEM8(0x0A04)
+#define TCA0_SPLIT_CTRLESET  _SFR_MEM8(0x0A05)
+#define TCA0_SPLIT_INTCTRL  _SFR_MEM8(0x0A0A)
+#define TCA0_SPLIT_INTFLAGS  _SFR_MEM8(0x0A0B)
+#define TCA0_SPLIT_DBGCTRL  _SFR_MEM8(0x0A0E)
+#define TCA0_SPLIT_LCNT  _SFR_MEM8(0x0A20)
+#define TCA0_SPLIT_HCNT  _SFR_MEM8(0x0A21)
+#define TCA0_SPLIT_LPER  _SFR_MEM8(0x0A26)
+#define TCA0_SPLIT_HPER  _SFR_MEM8(0x0A27)
+#define TCA0_SPLIT_LCMP0  _SFR_MEM8(0x0A28)
+#define TCA0_SPLIT_HCMP0  _SFR_MEM8(0x0A29)
+#define TCA0_SPLIT_LCMP1  _SFR_MEM8(0x0A2A)
+#define TCA0_SPLIT_HCMP1  _SFR_MEM8(0x0A2B)
+#define TCA0_SPLIT_LCMP2  _SFR_MEM8(0x0A2C)
+#define TCA0_SPLIT_HCMP2  _SFR_MEM8(0x0A2D)
+
+
+/* TCB (TCB0) - 16-bit Timer Type B */
+#define TCB0_CTRLA  _SFR_MEM8(0x0B00)
+#define TCB0_CTRLB  _SFR_MEM8(0x0B01)
+#define TCB0_EVCTRL  _SFR_MEM8(0x0B04)
+#define TCB0_INTCTRL  _SFR_MEM8(0x0B05)
+#define TCB0_INTFLAGS  _SFR_MEM8(0x0B06)
+#define TCB0_STATUS  _SFR_MEM8(0x0B07)
+#define TCB0_DBGCTRL  _SFR_MEM8(0x0B08)
+#define TCB0_TEMP  _SFR_MEM8(0x0B09)
+#define TCB0_CNT  _SFR_MEM16(0x0B0A)
+#define TCB0_CNTL  _SFR_MEM8(0x0B0A)
+#define TCB0_CNTH  _SFR_MEM8(0x0B0B)
+#define TCB0_CCMP  _SFR_MEM16(0x0B0C)
+#define TCB0_CCMPL  _SFR_MEM8(0x0B0C)
+#define TCB0_CCMPH  _SFR_MEM8(0x0B0D)
+
+
+/* TCB (TCB1) - 16-bit Timer Type B */
+#define TCB1_CTRLA  _SFR_MEM8(0x0B10)
+#define TCB1_CTRLB  _SFR_MEM8(0x0B11)
+#define TCB1_EVCTRL  _SFR_MEM8(0x0B14)
+#define TCB1_INTCTRL  _SFR_MEM8(0x0B15)
+#define TCB1_INTFLAGS  _SFR_MEM8(0x0B16)
+#define TCB1_STATUS  _SFR_MEM8(0x0B17)
+#define TCB1_DBGCTRL  _SFR_MEM8(0x0B18)
+#define TCB1_TEMP  _SFR_MEM8(0x0B19)
+#define TCB1_CNT  _SFR_MEM16(0x0B1A)
+#define TCB1_CNTL  _SFR_MEM8(0x0B1A)
+#define TCB1_CNTH  _SFR_MEM8(0x0B1B)
+#define TCB1_CCMP  _SFR_MEM16(0x0B1C)
+#define TCB1_CCMPL  _SFR_MEM8(0x0B1C)
+#define TCB1_CCMPH  _SFR_MEM8(0x0B1D)
+
+
+/* TCB (TCB2) - 16-bit Timer Type B */
+#define TCB2_CTRLA  _SFR_MEM8(0x0B20)
+#define TCB2_CTRLB  _SFR_MEM8(0x0B21)
+#define TCB2_EVCTRL  _SFR_MEM8(0x0B24)
+#define TCB2_INTCTRL  _SFR_MEM8(0x0B25)
+#define TCB2_INTFLAGS  _SFR_MEM8(0x0B26)
+#define TCB2_STATUS  _SFR_MEM8(0x0B27)
+#define TCB2_DBGCTRL  _SFR_MEM8(0x0B28)
+#define TCB2_TEMP  _SFR_MEM8(0x0B29)
+#define TCB2_CNT  _SFR_MEM16(0x0B2A)
+#define TCB2_CNTL  _SFR_MEM8(0x0B2A)
+#define TCB2_CNTH  _SFR_MEM8(0x0B2B)
+#define TCB2_CCMP  _SFR_MEM16(0x0B2C)
+#define TCB2_CCMPL  _SFR_MEM8(0x0B2C)
+#define TCB2_CCMPH  _SFR_MEM8(0x0B2D)
+
+
+/* SYSCFG - System Configuration Registers */
+#define SYSCFG_REVID  _SFR_MEM8(0x0F01)
+#define SYSCFG_OCDMCTRL  _SFR_MEM8(0x0F04)
+#define SYSCFG_OCDMSTATUS  _SFR_MEM8(0x0F05)
+
+
+/* NVMCTRL - Non-volatile Memory Controller */
+#define NVMCTRL_CTRLA  _SFR_MEM8(0x1000)
+#define NVMCTRL_CTRLB  _SFR_MEM8(0x1001)
+#define NVMCTRL_INTCTRL  _SFR_MEM8(0x1004)
+#define NVMCTRL_INTFLAGS  _SFR_MEM8(0x1005)
+#define NVMCTRL_STATUS  _SFR_MEM8(0x1006)
+#define NVMCTRL_DATA  _SFR_MEM16(0x1008)
+#define NVMCTRL_DATAL  _SFR_MEM8(0x1008)
+#define NVMCTRL_DATAH  _SFR_MEM8(0x1009)
+#define NVMCTRL_ADDR  _SFR_MEM32(0x100C)
+#define NVMCTRL_ADDR0  _SFR_MEM8(0x100C)
+#define NVMCTRL_ADDR1  _SFR_MEM8(0x100D)
+#define NVMCTRL_ADDR2  _SFR_MEM8(0x100E)
+#define NVMCTRL_ADDR3  _SFR_MEM8(0x100F)
+
+
+/* LOCK - Lockbits */
+#define LOCK_KEY  _SFR_MEM32(0x1040)
+#define LOCK_KEY0  _SFR_MEM8(0x1040)
+#define LOCK_KEY1  _SFR_MEM8(0x1041)
+#define LOCK_KEY2  _SFR_MEM8(0x1042)
+#define LOCK_KEY3  _SFR_MEM8(0x1043)
+
+
+/* FUSE - Fuses */
+#define FUSE_WDTCFG  _SFR_MEM8(0x1050)
+#define FUSE_BODCFG  _SFR_MEM8(0x1051)
+#define FUSE_OSCCFG  _SFR_MEM8(0x1052)
+#define FUSE_SYSCFG0  _SFR_MEM8(0x1055)
+#define FUSE_SYSCFG1  _SFR_MEM8(0x1056)
+#define FUSE_CODESIZE  _SFR_MEM8(0x1057)
+#define FUSE_BOOTSIZE  _SFR_MEM8(0x1058)
+
+
+/* USERROW - User Row */
+#define USERROW_USERROW0  _SFR_MEM8(0x1080)
+#define USERROW_USERROW1  _SFR_MEM8(0x1081)
+#define USERROW_USERROW2  _SFR_MEM8(0x1082)
+#define USERROW_USERROW3  _SFR_MEM8(0x1083)
+#define USERROW_USERROW4  _SFR_MEM8(0x1084)
+#define USERROW_USERROW5  _SFR_MEM8(0x1085)
+#define USERROW_USERROW6  _SFR_MEM8(0x1086)
+#define USERROW_USERROW7  _SFR_MEM8(0x1087)
+#define USERROW_USERROW8  _SFR_MEM8(0x1088)
+#define USERROW_USERROW9  _SFR_MEM8(0x1089)
+#define USERROW_USERROW10  _SFR_MEM8(0x108A)
+#define USERROW_USERROW11  _SFR_MEM8(0x108B)
+#define USERROW_USERROW12  _SFR_MEM8(0x108C)
+#define USERROW_USERROW13  _SFR_MEM8(0x108D)
+#define USERROW_USERROW14  _SFR_MEM8(0x108E)
+#define USERROW_USERROW15  _SFR_MEM8(0x108F)
+#define USERROW_USERROW16  _SFR_MEM8(0x1090)
+#define USERROW_USERROW17  _SFR_MEM8(0x1091)
+#define USERROW_USERROW18  _SFR_MEM8(0x1092)
+#define USERROW_USERROW19  _SFR_MEM8(0x1093)
+#define USERROW_USERROW20  _SFR_MEM8(0x1094)
+#define USERROW_USERROW21  _SFR_MEM8(0x1095)
+#define USERROW_USERROW22  _SFR_MEM8(0x1096)
+#define USERROW_USERROW23  _SFR_MEM8(0x1097)
+#define USERROW_USERROW24  _SFR_MEM8(0x1098)
+#define USERROW_USERROW25  _SFR_MEM8(0x1099)
+#define USERROW_USERROW26  _SFR_MEM8(0x109A)
+#define USERROW_USERROW27  _SFR_MEM8(0x109B)
+#define USERROW_USERROW28  _SFR_MEM8(0x109C)
+#define USERROW_USERROW29  _SFR_MEM8(0x109D)
+#define USERROW_USERROW30  _SFR_MEM8(0x109E)
+#define USERROW_USERROW31  _SFR_MEM8(0x109F)
+#define USERROW_USERROW32  _SFR_MEM8(0x10A0)
+#define USERROW_USERROW33  _SFR_MEM8(0x10A1)
+#define USERROW_USERROW34  _SFR_MEM8(0x10A2)
+#define USERROW_USERROW35  _SFR_MEM8(0x10A3)
+#define USERROW_USERROW36  _SFR_MEM8(0x10A4)
+#define USERROW_USERROW37  _SFR_MEM8(0x10A5)
+#define USERROW_USERROW38  _SFR_MEM8(0x10A6)
+#define USERROW_USERROW39  _SFR_MEM8(0x10A7)
+#define USERROW_USERROW40  _SFR_MEM8(0x10A8)
+#define USERROW_USERROW41  _SFR_MEM8(0x10A9)
+#define USERROW_USERROW42  _SFR_MEM8(0x10AA)
+#define USERROW_USERROW43  _SFR_MEM8(0x10AB)
+#define USERROW_USERROW44  _SFR_MEM8(0x10AC)
+#define USERROW_USERROW45  _SFR_MEM8(0x10AD)
+#define USERROW_USERROW46  _SFR_MEM8(0x10AE)
+#define USERROW_USERROW47  _SFR_MEM8(0x10AF)
+#define USERROW_USERROW48  _SFR_MEM8(0x10B0)
+#define USERROW_USERROW49  _SFR_MEM8(0x10B1)
+#define USERROW_USERROW50  _SFR_MEM8(0x10B2)
+#define USERROW_USERROW51  _SFR_MEM8(0x10B3)
+#define USERROW_USERROW52  _SFR_MEM8(0x10B4)
+#define USERROW_USERROW53  _SFR_MEM8(0x10B5)
+#define USERROW_USERROW54  _SFR_MEM8(0x10B6)
+#define USERROW_USERROW55  _SFR_MEM8(0x10B7)
+#define USERROW_USERROW56  _SFR_MEM8(0x10B8)
+#define USERROW_USERROW57  _SFR_MEM8(0x10B9)
+#define USERROW_USERROW58  _SFR_MEM8(0x10BA)
+#define USERROW_USERROW59  _SFR_MEM8(0x10BB)
+#define USERROW_USERROW60  _SFR_MEM8(0x10BC)
+#define USERROW_USERROW61  _SFR_MEM8(0x10BD)
+#define USERROW_USERROW62  _SFR_MEM8(0x10BE)
+#define USERROW_USERROW63  _SFR_MEM8(0x10BF)
+
+
+/* SIGROW - Signature row */
+#define SIGROW_DEVICEID0  _SFR_MEM8(0x1100)
+#define SIGROW_DEVICEID1  _SFR_MEM8(0x1101)
+#define SIGROW_DEVICEID2  _SFR_MEM8(0x1102)
+#define SIGROW_TEMPSENSE0  _SFR_MEM16(0x1104)
+#define SIGROW_TEMPSENSE0L  _SFR_MEM8(0x1104)
+#define SIGROW_TEMPSENSE0H  _SFR_MEM8(0x1105)
+#define SIGROW_TEMPSENSE1  _SFR_MEM16(0x1106)
+#define SIGROW_TEMPSENSE1L  _SFR_MEM8(0x1106)
+#define SIGROW_TEMPSENSE1H  _SFR_MEM8(0x1107)
+#define SIGROW_SERNUM0  _SFR_MEM8(0x1110)
+#define SIGROW_SERNUM1  _SFR_MEM8(0x1111)
+#define SIGROW_SERNUM2  _SFR_MEM8(0x1112)
+#define SIGROW_SERNUM3  _SFR_MEM8(0x1113)
+#define SIGROW_SERNUM4  _SFR_MEM8(0x1114)
+#define SIGROW_SERNUM5  _SFR_MEM8(0x1115)
+#define SIGROW_SERNUM6  _SFR_MEM8(0x1116)
+#define SIGROW_SERNUM7  _SFR_MEM8(0x1117)
+#define SIGROW_SERNUM8  _SFR_MEM8(0x1118)
+#define SIGROW_SERNUM9  _SFR_MEM8(0x1119)
+#define SIGROW_SERNUM10  _SFR_MEM8(0x111A)
+#define SIGROW_SERNUM11  _SFR_MEM8(0x111B)
+#define SIGROW_SERNUM12  _SFR_MEM8(0x111C)
+#define SIGROW_SERNUM13  _SFR_MEM8(0x111D)
+#define SIGROW_SERNUM14  _SFR_MEM8(0x111E)
+#define SIGROW_SERNUM15  _SFR_MEM8(0x111F)
+
+
+
+/*================== Bitfield Definitions ================== */
+
+/* AC - Analog Comparator */
+/* AC.CTRLA  bit masks and bit positions */
+#define AC_ENABLE_bm  0x01  /* Enable bit mask. */
+#define AC_ENABLE_bp  0  /* Enable bit position. */
+#define AC_HYSMODE_gm  0x06  /* Hysteresis Mode group mask. */
+#define AC_HYSMODE_gp  1  /* Hysteresis Mode group position. */
+#define AC_HYSMODE_0_bm  (1<<1)  /* Hysteresis Mode bit 0 mask. */
+#define AC_HYSMODE_0_bp  1  /* Hysteresis Mode bit 0 position. */
+#define AC_HYSMODE_1_bm  (1<<2)  /* Hysteresis Mode bit 1 mask. */
+#define AC_HYSMODE_1_bp  2  /* Hysteresis Mode bit 1 position. */
+#define AC_POWER_gm  0x18  /* Power profile group mask. */
+#define AC_POWER_gp  3  /* Power profile group position. */
+#define AC_POWER_0_bm  (1<<3)  /* Power profile bit 0 mask. */
+#define AC_POWER_0_bp  3  /* Power profile bit 0 position. */
+#define AC_POWER_1_bm  (1<<4)  /* Power profile bit 1 mask. */
+#define AC_POWER_1_bp  4  /* Power profile bit 1 position. */
+#define AC_OUTEN_bm  0x40  /* Output Pad Enable bit mask. */
+#define AC_OUTEN_bp  6  /* Output Pad Enable bit position. */
+#define AC_RUNSTDBY_bm  0x80  /* Run in Standby Mode bit mask. */
+#define AC_RUNSTDBY_bp  7  /* Run in Standby Mode bit position. */
+
+/* AC.CTRLB  bit masks and bit positions */
+#define AC_WINSEL_gm  0x03  /* Window selection mode group mask. */
+#define AC_WINSEL_gp  0  /* Window selection mode group position. */
+#define AC_WINSEL_0_bm  (1<<0)  /* Window selection mode bit 0 mask. */
+#define AC_WINSEL_0_bp  0  /* Window selection mode bit 0 position. */
+#define AC_WINSEL_1_bm  (1<<1)  /* Window selection mode bit 1 mask. */
+#define AC_WINSEL_1_bp  1  /* Window selection mode bit 1 position. */
+
+/* AC.MUXCTRL  bit masks and bit positions */
+#define AC_MUXNEG_gm  0x07  /* Negative Input MUX Selection group mask. */
+#define AC_MUXNEG_gp  0  /* Negative Input MUX Selection group position. */
+#define AC_MUXNEG_0_bm  (1<<0)  /* Negative Input MUX Selection bit 0 mask. */
+#define AC_MUXNEG_0_bp  0  /* Negative Input MUX Selection bit 0 position. */
+#define AC_MUXNEG_1_bm  (1<<1)  /* Negative Input MUX Selection bit 1 mask. */
+#define AC_MUXNEG_1_bp  1  /* Negative Input MUX Selection bit 1 position. */
+#define AC_MUXNEG_2_bm  (1<<2)  /* Negative Input MUX Selection bit 2 mask. */
+#define AC_MUXNEG_2_bp  2  /* Negative Input MUX Selection bit 2 position. */
+#define AC_MUXPOS_gm  0x38  /* Positive Input MUX Selection group mask. */
+#define AC_MUXPOS_gp  3  /* Positive Input MUX Selection group position. */
+#define AC_MUXPOS_0_bm  (1<<3)  /* Positive Input MUX Selection bit 0 mask. */
+#define AC_MUXPOS_0_bp  3  /* Positive Input MUX Selection bit 0 position. */
+#define AC_MUXPOS_1_bm  (1<<4)  /* Positive Input MUX Selection bit 1 mask. */
+#define AC_MUXPOS_1_bp  4  /* Positive Input MUX Selection bit 1 position. */
+#define AC_MUXPOS_2_bm  (1<<5)  /* Positive Input MUX Selection bit 2 mask. */
+#define AC_MUXPOS_2_bp  5  /* Positive Input MUX Selection bit 2 position. */
+#define AC_INITVAL_bm  0x40  /* AC Output Initial Value bit mask. */
+#define AC_INITVAL_bp  6  /* AC Output Initial Value bit position. */
+#define AC_INVERT_bm  0x80  /* Invert AC Output bit mask. */
+#define AC_INVERT_bp  7  /* Invert AC Output bit position. */
+
+/* AC.DACREF  bit masks and bit positions */
+#define AC_DACREF_gm  0xFF  /* DACREF group mask. */
+#define AC_DACREF_gp  0  /* DACREF group position. */
+#define AC_DACREF_0_bm  (1<<0)  /* DACREF bit 0 mask. */
+#define AC_DACREF_0_bp  0  /* DACREF bit 0 position. */
+#define AC_DACREF_1_bm  (1<<1)  /* DACREF bit 1 mask. */
+#define AC_DACREF_1_bp  1  /* DACREF bit 1 position. */
+#define AC_DACREF_2_bm  (1<<2)  /* DACREF bit 2 mask. */
+#define AC_DACREF_2_bp  2  /* DACREF bit 2 position. */
+#define AC_DACREF_3_bm  (1<<3)  /* DACREF bit 3 mask. */
+#define AC_DACREF_3_bp  3  /* DACREF bit 3 position. */
+#define AC_DACREF_4_bm  (1<<4)  /* DACREF bit 4 mask. */
+#define AC_DACREF_4_bp  4  /* DACREF bit 4 position. */
+#define AC_DACREF_5_bm  (1<<5)  /* DACREF bit 5 mask. */
+#define AC_DACREF_5_bp  5  /* DACREF bit 5 position. */
+#define AC_DACREF_6_bm  (1<<6)  /* DACREF bit 6 mask. */
+#define AC_DACREF_6_bp  6  /* DACREF bit 6 position. */
+#define AC_DACREF_7_bm  (1<<7)  /* DACREF bit 7 mask. */
+#define AC_DACREF_7_bp  7  /* DACREF bit 7 position. */
+
+/* AC.INTCTRL  bit masks and bit positions */
+#define AC_CMP_bm  0x01  /* Interrupt Enable bit mask. */
+#define AC_CMP_bp  0  /* Interrupt Enable bit position. */
+#define AC_INTMODE_NORMAL_gm  0x30  /* Interrupt Mode group mask. */
+#define AC_INTMODE_NORMAL_gp  4  /* Interrupt Mode group position. */
+#define AC_INTMODE_NORMAL_0_bm  (1<<4)  /* Interrupt Mode bit 0 mask. */
+#define AC_INTMODE_NORMAL_0_bp  4  /* Interrupt Mode bit 0 position. */
+#define AC_INTMODE_NORMAL_1_bm  (1<<5)  /* Interrupt Mode bit 1 mask. */
+#define AC_INTMODE_NORMAL_1_bp  5  /* Interrupt Mode bit 1 position. */
+#define AC_INTMODE_WINDOW_gm  0x30  /* Interrupt Mode group mask. */
+#define AC_INTMODE_WINDOW_gp  4  /* Interrupt Mode group position. */
+#define AC_INTMODE_WINDOW_0_bm  (1<<4)  /* Interrupt Mode bit 0 mask. */
+#define AC_INTMODE_WINDOW_0_bp  4  /* Interrupt Mode bit 0 position. */
+#define AC_INTMODE_WINDOW_1_bm  (1<<5)  /* Interrupt Mode bit 1 mask. */
+#define AC_INTMODE_WINDOW_1_bp  5  /* Interrupt Mode bit 1 position. */
+
+/* AC.STATUS  bit masks and bit positions */
+#define AC_CMPIF_bm  0x01  /* Analog Comparator Interrupt Flag bit mask. */
+#define AC_CMPIF_bp  0  /* Analog Comparator Interrupt Flag bit position. */
+#define AC_CMPSTATE_bm  0x10  /* Analog Comparator State bit mask. */
+#define AC_CMPSTATE_bp  4  /* Analog Comparator State bit position. */
+#define AC_WINSTATE_gm  0xC0  /* Analog Comparator Window State group mask. */
+#define AC_WINSTATE_gp  6  /* Analog Comparator Window State group position. */
+#define AC_WINSTATE_0_bm  (1<<6)  /* Analog Comparator Window State bit 0 mask. */
+#define AC_WINSTATE_0_bp  6  /* Analog Comparator Window State bit 0 position. */
+#define AC_WINSTATE_1_bm  (1<<7)  /* Analog Comparator Window State bit 1 mask. */
+#define AC_WINSTATE_1_bp  7  /* Analog Comparator Window State bit 1 position. */
+
+
+/* ADC - Analog to Digital Converter */
+/* ADC.CTRLA  bit masks and bit positions */
+#define ADC_ENABLE_bm  0x01  /* ADC Enable bit mask. */
+#define ADC_ENABLE_bp  0  /* ADC Enable bit position. */
+#define ADC_LOWLAT_bm  0x20  /* Low Latency bit mask. */
+#define ADC_LOWLAT_bp  5  /* Low Latency bit position. */
+#define ADC_RUNSTDBY_bm  0x80  /* Run in Standby bit mask. */
+#define ADC_RUNSTDBY_bp  7  /* Run in Standby bit position. */
+
+/* ADC.CTRLB  bit masks and bit positions */
+#define ADC_PRESC_gm  0x0F  /* Prescaler Value group mask. */
+#define ADC_PRESC_gp  0  /* Prescaler Value group position. */
+#define ADC_PRESC_0_bm  (1<<0)  /* Prescaler Value bit 0 mask. */
+#define ADC_PRESC_0_bp  0  /* Prescaler Value bit 0 position. */
+#define ADC_PRESC_1_bm  (1<<1)  /* Prescaler Value bit 1 mask. */
+#define ADC_PRESC_1_bp  1  /* Prescaler Value bit 1 position. */
+#define ADC_PRESC_2_bm  (1<<2)  /* Prescaler Value bit 2 mask. */
+#define ADC_PRESC_2_bp  2  /* Prescaler Value bit 2 position. */
+#define ADC_PRESC_3_bm  (1<<3)  /* Prescaler Value bit 3 mask. */
+#define ADC_PRESC_3_bp  3  /* Prescaler Value bit 3 position. */
+
+/* ADC.CTRLC  bit masks and bit positions */
+#define ADC_REFSEL_gm  0x07  /* Reference select group mask. */
+#define ADC_REFSEL_gp  0  /* Reference select group position. */
+#define ADC_REFSEL_0_bm  (1<<0)  /* Reference select bit 0 mask. */
+#define ADC_REFSEL_0_bp  0  /* Reference select bit 0 position. */
+#define ADC_REFSEL_1_bm  (1<<1)  /* Reference select bit 1 mask. */
+#define ADC_REFSEL_1_bp  1  /* Reference select bit 1 position. */
+#define ADC_REFSEL_2_bm  (1<<2)  /* Reference select bit 2 mask. */
+#define ADC_REFSEL_2_bp  2  /* Reference select bit 2 position. */
+
+/* ADC.CTRLD  bit masks and bit positions */
+#define ADC_WINCM_gm  0x07  /* Window Comparator Mode group mask. */
+#define ADC_WINCM_gp  0  /* Window Comparator Mode group position. */
+#define ADC_WINCM_0_bm  (1<<0)  /* Window Comparator Mode bit 0 mask. */
+#define ADC_WINCM_0_bp  0  /* Window Comparator Mode bit 0 position. */
+#define ADC_WINCM_1_bm  (1<<1)  /* Window Comparator Mode bit 1 mask. */
+#define ADC_WINCM_1_bp  1  /* Window Comparator Mode bit 1 position. */
+#define ADC_WINCM_2_bm  (1<<2)  /* Window Comparator Mode bit 2 mask. */
+#define ADC_WINCM_2_bp  2  /* Window Comparator Mode bit 2 position. */
+#define ADC_WINSRC_bm  0x08  /* Window Mode Source bit mask. */
+#define ADC_WINSRC_bp  3  /* Window Mode Source bit position. */
+
+/* ADC.INTCTRL  bit masks and bit positions */
+#define ADC_RESRDY_bm  0x01  /* Result Ready Interrupt Enable bit mask. */
+#define ADC_RESRDY_bp  0  /* Result Ready Interrupt Enable bit position. */
+#define ADC_SAMPRDY_bm  0x02  /* Sample Ready Interrupt Enable bit mask. */
+#define ADC_SAMPRDY_bp  1  /* Sample Ready Interrupt Enable bit position. */
+#define ADC_WCMP_bm  0x04  /* Window Comparator Interrupt Enable bit mask. */
+#define ADC_WCMP_bp  2  /* Window Comparator Interrupt Enable bit position. */
+#define ADC_RESOVR_bm  0x08  /* Result Overwrite Interrupt Enable bit mask. */
+#define ADC_RESOVR_bp  3  /* Result Overwrite Interrupt Enable bit position. */
+#define ADC_SAMPOVR_bm  0x10  /* Sample Overwrite Interrupt Enable bit mask. */
+#define ADC_SAMPOVR_bp  4  /* Sample Overwrite Interrupt Enable bit position. */
+#define ADC_TRIGOVR_bm  0x20  /* Trigger Overrun Interrupt Enable bit mask. */
+#define ADC_TRIGOVR_bp  5  /* Trigger Overrun Interrupt Enable bit position. */
+
+/* ADC.INTFLAGS  bit masks and bit positions */
+/* ADC_RESRDY  is already defined. */
+/* ADC_SAMPRDY  is already defined. */
+/* ADC_WCMP  is already defined. */
+/* ADC_RESOVR  is already defined. */
+/* ADC_SAMPOVR  is already defined. */
+/* ADC_TRIGOVR  is already defined. */
+
+/* ADC.STATUS  bit masks and bit positions */
+#define ADC_ADCBUSY_bm  0x01  /* ADC Busy bit mask. */
+#define ADC_ADCBUSY_bp  0  /* ADC Busy bit position. */
+
+/* ADC.DBGCTRL  bit masks and bit positions */
+#define ADC_DBGRUN_bm  0x01  /* Run in Debug Mode bit mask. */
+#define ADC_DBGRUN_bp  0  /* Run in Debug Mode bit position. */
+
+/* ADC.CTRLE  bit masks and bit positions */
+#define ADC_SAMPDUR_gm  0xFF  /* Sample Duration group mask. */
+#define ADC_SAMPDUR_gp  0  /* Sample Duration group position. */
+#define ADC_SAMPDUR_0_bm  (1<<0)  /* Sample Duration bit 0 mask. */
+#define ADC_SAMPDUR_0_bp  0  /* Sample Duration bit 0 position. */
+#define ADC_SAMPDUR_1_bm  (1<<1)  /* Sample Duration bit 1 mask. */
+#define ADC_SAMPDUR_1_bp  1  /* Sample Duration bit 1 position. */
+#define ADC_SAMPDUR_2_bm  (1<<2)  /* Sample Duration bit 2 mask. */
+#define ADC_SAMPDUR_2_bp  2  /* Sample Duration bit 2 position. */
+#define ADC_SAMPDUR_3_bm  (1<<3)  /* Sample Duration bit 3 mask. */
+#define ADC_SAMPDUR_3_bp  3  /* Sample Duration bit 3 position. */
+#define ADC_SAMPDUR_4_bm  (1<<4)  /* Sample Duration bit 4 mask. */
+#define ADC_SAMPDUR_4_bp  4  /* Sample Duration bit 4 position. */
+#define ADC_SAMPDUR_5_bm  (1<<5)  /* Sample Duration bit 5 mask. */
+#define ADC_SAMPDUR_5_bp  5  /* Sample Duration bit 5 position. */
+#define ADC_SAMPDUR_6_bm  (1<<6)  /* Sample Duration bit 6 mask. */
+#define ADC_SAMPDUR_6_bp  6  /* Sample Duration bit 6 position. */
+#define ADC_SAMPDUR_7_bm  (1<<7)  /* Sample Duration bit 7 mask. */
+#define ADC_SAMPDUR_7_bp  7  /* Sample Duration bit 7 position. */
+
+/* ADC.CTRLF  bit masks and bit positions */
+#define ADC_SAMPNUM_gm  0x0F  /* Sample numbers group mask. */
+#define ADC_SAMPNUM_gp  0  /* Sample numbers group position. */
+#define ADC_SAMPNUM_0_bm  (1<<0)  /* Sample numbers bit 0 mask. */
+#define ADC_SAMPNUM_0_bp  0  /* Sample numbers bit 0 position. */
+#define ADC_SAMPNUM_1_bm  (1<<1)  /* Sample numbers bit 1 mask. */
+#define ADC_SAMPNUM_1_bp  1  /* Sample numbers bit 1 position. */
+#define ADC_SAMPNUM_2_bm  (1<<2)  /* Sample numbers bit 2 mask. */
+#define ADC_SAMPNUM_2_bp  2  /* Sample numbers bit 2 position. */
+#define ADC_SAMPNUM_3_bm  (1<<3)  /* Sample numbers bit 3 mask. */
+#define ADC_SAMPNUM_3_bp  3  /* Sample numbers bit 3 position. */
+#define ADC_LEFTADJ_bm  0x10  /* Left Adjust bit mask. */
+#define ADC_LEFTADJ_bp  4  /* Left Adjust bit position. */
+#define ADC_FREERUN_bm  0x20  /* Free-Running mode bit mask. */
+#define ADC_FREERUN_bp  5  /* Free-Running mode bit position. */
+#define ADC_CHOPPING_bm  0x40  /* Sign Chopping bit mask. */
+#define ADC_CHOPPING_bp  6  /* Sign Chopping bit position. */
+
+/* ADC.COMMAND  bit masks and bit positions */
+#define ADC_START_gm  0x07  /* Start command group mask. */
+#define ADC_START_gp  0  /* Start command group position. */
+#define ADC_START_0_bm  (1<<0)  /* Start command bit 0 mask. */
+#define ADC_START_0_bp  0  /* Start command bit 0 position. */
+#define ADC_START_1_bm  (1<<1)  /* Start command bit 1 mask. */
+#define ADC_START_1_bp  1  /* Start command bit 1 position. */
+#define ADC_START_2_bm  (1<<2)  /* Start command bit 2 mask. */
+#define ADC_START_2_bp  2  /* Start command bit 2 position. */
+#define ADC_MODE_gm  0x70  /* Mode group mask. */
+#define ADC_MODE_gp  4  /* Mode group position. */
+#define ADC_MODE_0_bm  (1<<4)  /* Mode bit 0 mask. */
+#define ADC_MODE_0_bp  4  /* Mode bit 0 position. */
+#define ADC_MODE_1_bm  (1<<5)  /* Mode bit 1 mask. */
+#define ADC_MODE_1_bp  5  /* Mode bit 1 position. */
+#define ADC_MODE_2_bm  (1<<6)  /* Mode bit 2 mask. */
+#define ADC_MODE_2_bp  6  /* Mode bit 2 position. */
+#define ADC_DIFF_bm  0x80  /* Differential mode bit mask. */
+#define ADC_DIFF_bp  7  /* Differential mode bit position. */
+
+/* ADC.PGACTRL  bit masks and bit positions */
+#define ADC_PGAEN_bm  0x01  /* PGA Enable bit mask. */
+#define ADC_PGAEN_bp  0  /* PGA Enable bit position. */
+#define ADC_PGABIASSEL_gm  0x18  /* PGA BIAS Select group mask. */
+#define ADC_PGABIASSEL_gp  3  /* PGA BIAS Select group position. */
+#define ADC_PGABIASSEL_0_bm  (1<<3)  /* PGA BIAS Select bit 0 mask. */
+#define ADC_PGABIASSEL_0_bp  3  /* PGA BIAS Select bit 0 position. */
+#define ADC_PGABIASSEL_1_bm  (1<<4)  /* PGA BIAS Select bit 1 mask. */
+#define ADC_PGABIASSEL_1_bp  4  /* PGA BIAS Select bit 1 position. */
+#define ADC_GAIN_gm  0xE0  /* Gain group mask. */
+#define ADC_GAIN_gp  5  /* Gain group position. */
+#define ADC_GAIN_0_bm  (1<<5)  /* Gain bit 0 mask. */
+#define ADC_GAIN_0_bp  5  /* Gain bit 0 position. */
+#define ADC_GAIN_1_bm  (1<<6)  /* Gain bit 1 mask. */
+#define ADC_GAIN_1_bp  6  /* Gain bit 1 position. */
+#define ADC_GAIN_2_bm  (1<<7)  /* Gain bit 2 mask. */
+#define ADC_GAIN_2_bp  7  /* Gain bit 2 position. */
+
+/* ADC.MUXPOS  bit masks and bit positions */
+#define ADC_MUXPOS_gm  0x3F  /* Analog Channel Selection Bits group mask. */
+#define ADC_MUXPOS_gp  0  /* Analog Channel Selection Bits group position. */
+#define ADC_MUXPOS_0_bm  (1<<0)  /* Analog Channel Selection Bits bit 0 mask. */
+#define ADC_MUXPOS_0_bp  0  /* Analog Channel Selection Bits bit 0 position. */
+#define ADC_MUXPOS_1_bm  (1<<1)  /* Analog Channel Selection Bits bit 1 mask. */
+#define ADC_MUXPOS_1_bp  1  /* Analog Channel Selection Bits bit 1 position. */
+#define ADC_MUXPOS_2_bm  (1<<2)  /* Analog Channel Selection Bits bit 2 mask. */
+#define ADC_MUXPOS_2_bp  2  /* Analog Channel Selection Bits bit 2 position. */
+#define ADC_MUXPOS_3_bm  (1<<3)  /* Analog Channel Selection Bits bit 3 mask. */
+#define ADC_MUXPOS_3_bp  3  /* Analog Channel Selection Bits bit 3 position. */
+#define ADC_MUXPOS_4_bm  (1<<4)  /* Analog Channel Selection Bits bit 4 mask. */
+#define ADC_MUXPOS_4_bp  4  /* Analog Channel Selection Bits bit 4 position. */
+#define ADC_MUXPOS_5_bm  (1<<5)  /* Analog Channel Selection Bits bit 5 mask. */
+#define ADC_MUXPOS_5_bp  5  /* Analog Channel Selection Bits bit 5 position. */
+#define ADC_VIA_gm  0xC0  /* VIA group mask. */
+#define ADC_VIA_gp  6  /* VIA group position. */
+#define ADC_VIA_0_bm  (1<<6)  /* VIA bit 0 mask. */
+#define ADC_VIA_0_bp  6  /* VIA bit 0 position. */
+#define ADC_VIA_1_bm  (1<<7)  /* VIA bit 1 mask. */
+#define ADC_VIA_1_bp  7  /* VIA bit 1 position. */
+
+/* ADC.MUXNEG  bit masks and bit positions */
+#define ADC_MUXNEG_gm  0x3F  /* Analog Channel Selection Bits group mask. */
+#define ADC_MUXNEG_gp  0  /* Analog Channel Selection Bits group position. */
+#define ADC_MUXNEG_0_bm  (1<<0)  /* Analog Channel Selection Bits bit 0 mask. */
+#define ADC_MUXNEG_0_bp  0  /* Analog Channel Selection Bits bit 0 position. */
+#define ADC_MUXNEG_1_bm  (1<<1)  /* Analog Channel Selection Bits bit 1 mask. */
+#define ADC_MUXNEG_1_bp  1  /* Analog Channel Selection Bits bit 1 position. */
+#define ADC_MUXNEG_2_bm  (1<<2)  /* Analog Channel Selection Bits bit 2 mask. */
+#define ADC_MUXNEG_2_bp  2  /* Analog Channel Selection Bits bit 2 position. */
+#define ADC_MUXNEG_3_bm  (1<<3)  /* Analog Channel Selection Bits bit 3 mask. */
+#define ADC_MUXNEG_3_bp  3  /* Analog Channel Selection Bits bit 3 position. */
+#define ADC_MUXNEG_4_bm  (1<<4)  /* Analog Channel Selection Bits bit 4 mask. */
+#define ADC_MUXNEG_4_bp  4  /* Analog Channel Selection Bits bit 4 position. */
+#define ADC_MUXNEG_5_bm  (1<<5)  /* Analog Channel Selection Bits bit 5 mask. */
+#define ADC_MUXNEG_5_bp  5  /* Analog Channel Selection Bits bit 5 position. */
+/* ADC_VIA  is already defined. */
+
+
+/* BOD - Bod interface */
+/* BOD.CTRLA  bit masks and bit positions */
+#define BOD_SLEEP_gm  0x03  /* Operation in sleep mode group mask. */
+#define BOD_SLEEP_gp  0  /* Operation in sleep mode group position. */
+#define BOD_SLEEP_0_bm  (1<<0)  /* Operation in sleep mode bit 0 mask. */
+#define BOD_SLEEP_0_bp  0  /* Operation in sleep mode bit 0 position. */
+#define BOD_SLEEP_1_bm  (1<<1)  /* Operation in sleep mode bit 1 mask. */
+#define BOD_SLEEP_1_bp  1  /* Operation in sleep mode bit 1 position. */
+#define BOD_ACTIVE_gm  0x0C  /* Operation in active mode group mask. */
+#define BOD_ACTIVE_gp  2  /* Operation in active mode group position. */
+#define BOD_ACTIVE_0_bm  (1<<2)  /* Operation in active mode bit 0 mask. */
+#define BOD_ACTIVE_0_bp  2  /* Operation in active mode bit 0 position. */
+#define BOD_ACTIVE_1_bm  (1<<3)  /* Operation in active mode bit 1 mask. */
+#define BOD_ACTIVE_1_bp  3  /* Operation in active mode bit 1 position. */
+#define BOD_SAMPFREQ_bm  0x10  /* Sample frequency bit mask. */
+#define BOD_SAMPFREQ_bp  4  /* Sample frequency bit position. */
+
+/* BOD.CTRLB  bit masks and bit positions */
+#define BOD_LVL_gm  0x07  /* Bod level group mask. */
+#define BOD_LVL_gp  0  /* Bod level group position. */
+#define BOD_LVL_0_bm  (1<<0)  /* Bod level bit 0 mask. */
+#define BOD_LVL_0_bp  0  /* Bod level bit 0 position. */
+#define BOD_LVL_1_bm  (1<<1)  /* Bod level bit 1 mask. */
+#define BOD_LVL_1_bp  1  /* Bod level bit 1 position. */
+#define BOD_LVL_2_bm  (1<<2)  /* Bod level bit 2 mask. */
+#define BOD_LVL_2_bp  2  /* Bod level bit 2 position. */
+
+/* BOD.VLMCTRLA  bit masks and bit positions */
+#define BOD_VLMLVL_gm  0x03  /* voltage level monitor level group mask. */
+#define BOD_VLMLVL_gp  0  /* voltage level monitor level group position. */
+#define BOD_VLMLVL_0_bm  (1<<0)  /* voltage level monitor level bit 0 mask. */
+#define BOD_VLMLVL_0_bp  0  /* voltage level monitor level bit 0 position. */
+#define BOD_VLMLVL_1_bm  (1<<1)  /* voltage level monitor level bit 1 mask. */
+#define BOD_VLMLVL_1_bp  1  /* voltage level monitor level bit 1 position. */
+
+/* BOD.INTCTRL  bit masks and bit positions */
+#define BOD_VLMIE_bm  0x01  /* voltage level monitor interrrupt enable bit mask. */
+#define BOD_VLMIE_bp  0  /* voltage level monitor interrrupt enable bit position. */
+#define BOD_VLMCFG_gm  0x06  /* Configuration group mask. */
+#define BOD_VLMCFG_gp  1  /* Configuration group position. */
+#define BOD_VLMCFG_0_bm  (1<<1)  /* Configuration bit 0 mask. */
+#define BOD_VLMCFG_0_bp  1  /* Configuration bit 0 position. */
+#define BOD_VLMCFG_1_bm  (1<<2)  /* Configuration bit 1 mask. */
+#define BOD_VLMCFG_1_bp  2  /* Configuration bit 1 position. */
+
+/* BOD.INTFLAGS  bit masks and bit positions */
+#define BOD_VLMIF_bm  0x01  /* Voltage level monitor interrupt flag bit mask. */
+#define BOD_VLMIF_bp  0  /* Voltage level monitor interrupt flag bit position. */
+
+/* BOD.STATUS  bit masks and bit positions */
+#define BOD_VLMS_bm  0x01  /* Voltage level monitor status bit mask. */
+#define BOD_VLMS_bp  0  /* Voltage level monitor status bit position. */
+
+
+/* CCL - Configurable Custom Logic */
+/* CCL.CTRLA  bit masks and bit positions */
+#define CCL_ENABLE_bm  0x01  /* Enable bit mask. */
+#define CCL_ENABLE_bp  0  /* Enable bit position. */
+#define CCL_RUNSTDBY_bm  0x40  /* Run in Standby bit mask. */
+#define CCL_RUNSTDBY_bp  6  /* Run in Standby bit position. */
+
+/* CCL.SEQCTRL0  bit masks and bit positions */
+#define CCL_SEQSEL_gm  0x07  /* Sequential Selection group mask. */
+#define CCL_SEQSEL_gp  0  /* Sequential Selection group position. */
+#define CCL_SEQSEL_0_bm  (1<<0)  /* Sequential Selection bit 0 mask. */
+#define CCL_SEQSEL_0_bp  0  /* Sequential Selection bit 0 position. */
+#define CCL_SEQSEL_1_bm  (1<<1)  /* Sequential Selection bit 1 mask. */
+#define CCL_SEQSEL_1_bp  1  /* Sequential Selection bit 1 position. */
+#define CCL_SEQSEL_2_bm  (1<<2)  /* Sequential Selection bit 2 mask. */
+#define CCL_SEQSEL_2_bp  2  /* Sequential Selection bit 2 position. */
+
+/* CCL.SEQCTRL1  bit masks and bit positions */
+/* CCL_SEQSEL  is already defined. */
+
+/* CCL.INTCTRL0  bit masks and bit positions */
+#define CCL_INTMODE0_gm  0x03  /* Interrupt Mode for LUT0 group mask. */
+#define CCL_INTMODE0_gp  0  /* Interrupt Mode for LUT0 group position. */
+#define CCL_INTMODE0_0_bm  (1<<0)  /* Interrupt Mode for LUT0 bit 0 mask. */
+#define CCL_INTMODE0_0_bp  0  /* Interrupt Mode for LUT0 bit 0 position. */
+#define CCL_INTMODE0_1_bm  (1<<1)  /* Interrupt Mode for LUT0 bit 1 mask. */
+#define CCL_INTMODE0_1_bp  1  /* Interrupt Mode for LUT0 bit 1 position. */
+#define CCL_INTMODE1_gm  0x0C  /* Interrupt Mode for LUT1 group mask. */
+#define CCL_INTMODE1_gp  2  /* Interrupt Mode for LUT1 group position. */
+#define CCL_INTMODE1_0_bm  (1<<2)  /* Interrupt Mode for LUT1 bit 0 mask. */
+#define CCL_INTMODE1_0_bp  2  /* Interrupt Mode for LUT1 bit 0 position. */
+#define CCL_INTMODE1_1_bm  (1<<3)  /* Interrupt Mode for LUT1 bit 1 mask. */
+#define CCL_INTMODE1_1_bp  3  /* Interrupt Mode for LUT1 bit 1 position. */
+#define CCL_INTMODE2_gm  0x30  /* Interrupt Mode for LUT2 group mask. */
+#define CCL_INTMODE2_gp  4  /* Interrupt Mode for LUT2 group position. */
+#define CCL_INTMODE2_0_bm  (1<<4)  /* Interrupt Mode for LUT2 bit 0 mask. */
+#define CCL_INTMODE2_0_bp  4  /* Interrupt Mode for LUT2 bit 0 position. */
+#define CCL_INTMODE2_1_bm  (1<<5)  /* Interrupt Mode for LUT2 bit 1 mask. */
+#define CCL_INTMODE2_1_bp  5  /* Interrupt Mode for LUT2 bit 1 position. */
+#define CCL_INTMODE3_gm  0xC0  /* Interrupt Mode for LUT3 group mask. */
+#define CCL_INTMODE3_gp  6  /* Interrupt Mode for LUT3 group position. */
+#define CCL_INTMODE3_0_bm  (1<<6)  /* Interrupt Mode for LUT3 bit 0 mask. */
+#define CCL_INTMODE3_0_bp  6  /* Interrupt Mode for LUT3 bit 0 position. */
+#define CCL_INTMODE3_1_bm  (1<<7)  /* Interrupt Mode for LUT3 bit 1 mask. */
+#define CCL_INTMODE3_1_bp  7  /* Interrupt Mode for LUT3 bit 1 position. */
+
+/* CCL.INTFLAGS  bit masks and bit positions */
+#define CCL_INT_gm  0x0F  /* Interrupt Flag group mask. */
+#define CCL_INT_gp  0  /* Interrupt Flag group position. */
+#define CCL_INT_0_bm  (1<<0)  /* Interrupt Flag bit 0 mask. */
+#define CCL_INT_0_bp  0  /* Interrupt Flag bit 0 position. */
+#define CCL_INT0_bm  CCL_INT_0_bm  /* This define is deprecated and should not be used */
+#define CCL_INT0_bp  CCL_INT_0_bp  /* This define is deprecated and should not be used */
+#define CCL_INT_1_bm  (1<<1)  /* Interrupt Flag bit 1 mask. */
+#define CCL_INT_1_bp  1  /* Interrupt Flag bit 1 position. */
+#define CCL_INT1_bm  CCL_INT_1_bm  /* This define is deprecated and should not be used */
+#define CCL_INT1_bp  CCL_INT_1_bp  /* This define is deprecated and should not be used */
+#define CCL_INT_2_bm  (1<<2)  /* Interrupt Flag bit 2 mask. */
+#define CCL_INT_2_bp  2  /* Interrupt Flag bit 2 position. */
+#define CCL_INT2_bm  CCL_INT_2_bm  /* This define is deprecated and should not be used */
+#define CCL_INT2_bp  CCL_INT_2_bp  /* This define is deprecated and should not be used */
+#define CCL_INT_3_bm  (1<<3)  /* Interrupt Flag bit 3 mask. */
+#define CCL_INT_3_bp  3  /* Interrupt Flag bit 3 position. */
+#define CCL_INT3_bm  CCL_INT_3_bm  /* This define is deprecated and should not be used */
+#define CCL_INT3_bp  CCL_INT_3_bp  /* This define is deprecated and should not be used */
+
+/* CCL.LUT0CTRLA  bit masks and bit positions */
+/* CCL_ENABLE  is already defined. */
+#define CCL_CLKSRC_gm  0x0E  /* Clock Source Selection group mask. */
+#define CCL_CLKSRC_gp  1  /* Clock Source Selection group position. */
+#define CCL_CLKSRC_0_bm  (1<<1)  /* Clock Source Selection bit 0 mask. */
+#define CCL_CLKSRC_0_bp  1  /* Clock Source Selection bit 0 position. */
+#define CCL_CLKSRC_1_bm  (1<<2)  /* Clock Source Selection bit 1 mask. */
+#define CCL_CLKSRC_1_bp  2  /* Clock Source Selection bit 1 position. */
+#define CCL_CLKSRC_2_bm  (1<<3)  /* Clock Source Selection bit 2 mask. */
+#define CCL_CLKSRC_2_bp  3  /* Clock Source Selection bit 2 position. */
+#define CCL_FILTSEL_gm  0x30  /* Filter Selection group mask. */
+#define CCL_FILTSEL_gp  4  /* Filter Selection group position. */
+#define CCL_FILTSEL_0_bm  (1<<4)  /* Filter Selection bit 0 mask. */
+#define CCL_FILTSEL_0_bp  4  /* Filter Selection bit 0 position. */
+#define CCL_FILTSEL_1_bm  (1<<5)  /* Filter Selection bit 1 mask. */
+#define CCL_FILTSEL_1_bp  5  /* Filter Selection bit 1 position. */
+#define CCL_OUTEN_bm  0x40  /* Output Enable bit mask. */
+#define CCL_OUTEN_bp  6  /* Output Enable bit position. */
+#define CCL_EDGEDET_bm  0x80  /* Edge Detection Enable bit mask. */
+#define CCL_EDGEDET_bp  7  /* Edge Detection Enable bit position. */
+
+/* CCL.LUT0CTRLB  bit masks and bit positions */
+#define CCL_INSEL0_gm  0x0F  /* LUT Input 0 Source Selection group mask. */
+#define CCL_INSEL0_gp  0  /* LUT Input 0 Source Selection group position. */
+#define CCL_INSEL0_0_bm  (1<<0)  /* LUT Input 0 Source Selection bit 0 mask. */
+#define CCL_INSEL0_0_bp  0  /* LUT Input 0 Source Selection bit 0 position. */
+#define CCL_INSEL0_1_bm  (1<<1)  /* LUT Input 0 Source Selection bit 1 mask. */
+#define CCL_INSEL0_1_bp  1  /* LUT Input 0 Source Selection bit 1 position. */
+#define CCL_INSEL0_2_bm  (1<<2)  /* LUT Input 0 Source Selection bit 2 mask. */
+#define CCL_INSEL0_2_bp  2  /* LUT Input 0 Source Selection bit 2 position. */
+#define CCL_INSEL0_3_bm  (1<<3)  /* LUT Input 0 Source Selection bit 3 mask. */
+#define CCL_INSEL0_3_bp  3  /* LUT Input 0 Source Selection bit 3 position. */
+#define CCL_INSEL1_gm  0xF0  /* LUT Input 1 Source Selection group mask. */
+#define CCL_INSEL1_gp  4  /* LUT Input 1 Source Selection group position. */
+#define CCL_INSEL1_0_bm  (1<<4)  /* LUT Input 1 Source Selection bit 0 mask. */
+#define CCL_INSEL1_0_bp  4  /* LUT Input 1 Source Selection bit 0 position. */
+#define CCL_INSEL1_1_bm  (1<<5)  /* LUT Input 1 Source Selection bit 1 mask. */
+#define CCL_INSEL1_1_bp  5  /* LUT Input 1 Source Selection bit 1 position. */
+#define CCL_INSEL1_2_bm  (1<<6)  /* LUT Input 1 Source Selection bit 2 mask. */
+#define CCL_INSEL1_2_bp  6  /* LUT Input 1 Source Selection bit 2 position. */
+#define CCL_INSEL1_3_bm  (1<<7)  /* LUT Input 1 Source Selection bit 3 mask. */
+#define CCL_INSEL1_3_bp  7  /* LUT Input 1 Source Selection bit 3 position. */
+
+/* CCL.LUT0CTRLC  bit masks and bit positions */
+#define CCL_INSEL2_gm  0x0F  /* LUT Input 2 Source Selection group mask. */
+#define CCL_INSEL2_gp  0  /* LUT Input 2 Source Selection group position. */
+#define CCL_INSEL2_0_bm  (1<<0)  /* LUT Input 2 Source Selection bit 0 mask. */
+#define CCL_INSEL2_0_bp  0  /* LUT Input 2 Source Selection bit 0 position. */
+#define CCL_INSEL2_1_bm  (1<<1)  /* LUT Input 2 Source Selection bit 1 mask. */
+#define CCL_INSEL2_1_bp  1  /* LUT Input 2 Source Selection bit 1 position. */
+#define CCL_INSEL2_2_bm  (1<<2)  /* LUT Input 2 Source Selection bit 2 mask. */
+#define CCL_INSEL2_2_bp  2  /* LUT Input 2 Source Selection bit 2 position. */
+#define CCL_INSEL2_3_bm  (1<<3)  /* LUT Input 2 Source Selection bit 3 mask. */
+#define CCL_INSEL2_3_bp  3  /* LUT Input 2 Source Selection bit 3 position. */
+
+/* CCL.TRUTH0  bit masks and bit positions */
+#define CCL_TRUTH_gm  0xFF  /* Truth Table group mask. */
+#define CCL_TRUTH_gp  0  /* Truth Table group position. */
+#define CCL_TRUTH_0_bm  (1<<0)  /* Truth Table bit 0 mask. */
+#define CCL_TRUTH_0_bp  0  /* Truth Table bit 0 position. */
+#define CCL_TRUTH_1_bm  (1<<1)  /* Truth Table bit 1 mask. */
+#define CCL_TRUTH_1_bp  1  /* Truth Table bit 1 position. */
+#define CCL_TRUTH_2_bm  (1<<2)  /* Truth Table bit 2 mask. */
+#define CCL_TRUTH_2_bp  2  /* Truth Table bit 2 position. */
+#define CCL_TRUTH_3_bm  (1<<3)  /* Truth Table bit 3 mask. */
+#define CCL_TRUTH_3_bp  3  /* Truth Table bit 3 position. */
+#define CCL_TRUTH_4_bm  (1<<4)  /* Truth Table bit 4 mask. */
+#define CCL_TRUTH_4_bp  4  /* Truth Table bit 4 position. */
+#define CCL_TRUTH_5_bm  (1<<5)  /* Truth Table bit 5 mask. */
+#define CCL_TRUTH_5_bp  5  /* Truth Table bit 5 position. */
+#define CCL_TRUTH_6_bm  (1<<6)  /* Truth Table bit 6 mask. */
+#define CCL_TRUTH_6_bp  6  /* Truth Table bit 6 position. */
+#define CCL_TRUTH_7_bm  (1<<7)  /* Truth Table bit 7 mask. */
+#define CCL_TRUTH_7_bp  7  /* Truth Table bit 7 position. */
+
+/* CCL.LUT1CTRLA  bit masks and bit positions */
+/* CCL_ENABLE  is already defined. */
+/* CCL_CLKSRC  is already defined. */
+/* CCL_FILTSEL  is already defined. */
+/* CCL_OUTEN  is already defined. */
+/* CCL_EDGEDET  is already defined. */
+
+/* CCL.LUT1CTRLB  bit masks and bit positions */
+/* CCL_INSEL0  is already defined. */
+/* CCL_INSEL1  is already defined. */
+
+/* CCL.LUT1CTRLC  bit masks and bit positions */
+/* CCL_INSEL2  is already defined. */
+
+/* CCL.TRUTH1  bit masks and bit positions */
+/* CCL_TRUTH  is already defined. */
+
+/* CCL.LUT2CTRLA  bit masks and bit positions */
+/* CCL_ENABLE  is already defined. */
+/* CCL_CLKSRC  is already defined. */
+/* CCL_FILTSEL  is already defined. */
+/* CCL_OUTEN  is already defined. */
+/* CCL_EDGEDET  is already defined. */
+
+/* CCL.LUT2CTRLB  bit masks and bit positions */
+/* CCL_INSEL0  is already defined. */
+/* CCL_INSEL1  is already defined. */
+
+/* CCL.LUT2CTRLC  bit masks and bit positions */
+/* CCL_INSEL2  is already defined. */
+
+/* CCL.TRUTH2  bit masks and bit positions */
+/* CCL_TRUTH  is already defined. */
+
+/* CCL.LUT3CTRLA  bit masks and bit positions */
+/* CCL_ENABLE  is already defined. */
+/* CCL_CLKSRC  is already defined. */
+/* CCL_FILTSEL  is already defined. */
+/* CCL_OUTEN  is already defined. */
+/* CCL_EDGEDET  is already defined. */
+
+/* CCL.LUT3CTRLB  bit masks and bit positions */
+/* CCL_INSEL0  is already defined. */
+/* CCL_INSEL1  is already defined. */
+
+/* CCL.LUT3CTRLC  bit masks and bit positions */
+/* CCL_INSEL2  is already defined. */
+
+/* CCL.TRUTH3  bit masks and bit positions */
+/* CCL_TRUTH  is already defined. */
+
+
+/* CLKCTRL - Clock controller */
+/* CLKCTRL.MCLKCTRLA  bit masks and bit positions */
+#define CLKCTRL_CLKSEL_gm  0x07  /* Clock select group mask. */
+#define CLKCTRL_CLKSEL_gp  0  /* Clock select group position. */
+#define CLKCTRL_CLKSEL_0_bm  (1<<0)  /* Clock select bit 0 mask. */
+#define CLKCTRL_CLKSEL_0_bp  0  /* Clock select bit 0 position. */
+#define CLKCTRL_CLKSEL_1_bm  (1<<1)  /* Clock select bit 1 mask. */
+#define CLKCTRL_CLKSEL_1_bp  1  /* Clock select bit 1 position. */
+#define CLKCTRL_CLKSEL_2_bm  (1<<2)  /* Clock select bit 2 mask. */
+#define CLKCTRL_CLKSEL_2_bp  2  /* Clock select bit 2 position. */
+#define CLKCTRL_CLKOUT_bm  0x80  /* System clock out bit mask. */
+#define CLKCTRL_CLKOUT_bp  7  /* System clock out bit position. */
+
+/* CLKCTRL.MCLKCTRLB  bit masks and bit positions */
+#define CLKCTRL_PEN_bm  0x01  /* Prescaler enable bit mask. */
+#define CLKCTRL_PEN_bp  0  /* Prescaler enable bit position. */
+#define CLKCTRL_PDIV_gm  0x1E  /* Prescaler division group mask. */
+#define CLKCTRL_PDIV_gp  1  /* Prescaler division group position. */
+#define CLKCTRL_PDIV_0_bm  (1<<1)  /* Prescaler division bit 0 mask. */
+#define CLKCTRL_PDIV_0_bp  1  /* Prescaler division bit 0 position. */
+#define CLKCTRL_PDIV_1_bm  (1<<2)  /* Prescaler division bit 1 mask. */
+#define CLKCTRL_PDIV_1_bp  2  /* Prescaler division bit 1 position. */
+#define CLKCTRL_PDIV_2_bm  (1<<3)  /* Prescaler division bit 2 mask. */
+#define CLKCTRL_PDIV_2_bp  3  /* Prescaler division bit 2 position. */
+#define CLKCTRL_PDIV_3_bm  (1<<4)  /* Prescaler division bit 3 mask. */
+#define CLKCTRL_PDIV_3_bp  4  /* Prescaler division bit 3 position. */
+
+/* CLKCTRL.MCLKCTRLC  bit masks and bit positions */
+#define CLKCTRL_CFDEN_bm  0x01  /* Clock Failure Detect Enable bit mask. */
+#define CLKCTRL_CFDEN_bp  0  /* Clock Failure Detect Enable bit position. */
+#define CLKCTRL_CFDTST_bm  0x02  /* CFD Test bit mask. */
+#define CLKCTRL_CFDTST_bp  1  /* CFD Test bit position. */
+#define CLKCTRL_CFDSRC_gm  0x0C  /* CFD Source group mask. */
+#define CLKCTRL_CFDSRC_gp  2  /* CFD Source group position. */
+#define CLKCTRL_CFDSRC_0_bm  (1<<2)  /* CFD Source bit 0 mask. */
+#define CLKCTRL_CFDSRC_0_bp  2  /* CFD Source bit 0 position. */
+#define CLKCTRL_CFDSRC_1_bm  (1<<3)  /* CFD Source bit 1 mask. */
+#define CLKCTRL_CFDSRC_1_bp  3  /* CFD Source bit 1 position. */
+
+/* CLKCTRL.MCLKINTCTRL  bit masks and bit positions */
+#define CLKCTRL_CFD_bm  0x01  /* Interrupt Enable bit mask. */
+#define CLKCTRL_CFD_bp  0  /* Interrupt Enable bit position. */
+#define CLKCTRL_INTTYPE_bm  0x80  /* Interrupt Type bit mask. */
+#define CLKCTRL_INTTYPE_bp  7  /* Interrupt Type bit position. */
+
+/* CLKCTRL.MCLKINTFLAGS  bit masks and bit positions */
+/* CLKCTRL_CFD  is already defined. */
+
+/* CLKCTRL.MCLKSTATUS  bit masks and bit positions */
+#define CLKCTRL_SOSC_bm  0x01  /* System Oscillator changing bit mask. */
+#define CLKCTRL_SOSC_bp  0  /* System Oscillator changing bit position. */
+#define CLKCTRL_OSCHFS_bm  0x02  /* High frequency oscillator status bit mask. */
+#define CLKCTRL_OSCHFS_bp  1  /* High frequency oscillator status bit position. */
+#define CLKCTRL_OSC32KS_bm  0x04  /* 32KHz oscillator status bit mask. */
+#define CLKCTRL_OSC32KS_bp  2  /* 32KHz oscillator status bit position. */
+#define CLKCTRL_XOSC32KS_bm  0x08  /* 32.768 kHz Crystal Oscillator status bit mask. */
+#define CLKCTRL_XOSC32KS_bp  3  /* 32.768 kHz Crystal Oscillator status bit position. */
+#define CLKCTRL_EXTS_bm  0x10  /* External Clock status / XOSCHF status bit mask. */
+#define CLKCTRL_EXTS_bp  4  /* External Clock status / XOSCHF status bit position. */
+
+/* CLKCTRL.MCLKTIMEBASE  bit masks and bit positions */
+#define CLKCTRL_TIMEBASE_gm  0x1F  /* Timebase group mask. */
+#define CLKCTRL_TIMEBASE_gp  0  /* Timebase group position. */
+#define CLKCTRL_TIMEBASE_0_bm  (1<<0)  /* Timebase bit 0 mask. */
+#define CLKCTRL_TIMEBASE_0_bp  0  /* Timebase bit 0 position. */
+#define CLKCTRL_TIMEBASE_1_bm  (1<<1)  /* Timebase bit 1 mask. */
+#define CLKCTRL_TIMEBASE_1_bp  1  /* Timebase bit 1 position. */
+#define CLKCTRL_TIMEBASE_2_bm  (1<<2)  /* Timebase bit 2 mask. */
+#define CLKCTRL_TIMEBASE_2_bp  2  /* Timebase bit 2 position. */
+#define CLKCTRL_TIMEBASE_3_bm  (1<<3)  /* Timebase bit 3 mask. */
+#define CLKCTRL_TIMEBASE_3_bp  3  /* Timebase bit 3 position. */
+#define CLKCTRL_TIMEBASE_4_bm  (1<<4)  /* Timebase bit 4 mask. */
+#define CLKCTRL_TIMEBASE_4_bp  4  /* Timebase bit 4 position. */
+
+/* CLKCTRL.OSCHFCTRLA  bit masks and bit positions */
+#define CLKCTRL_AUTOTUNE_gm  0x03  /* Automatic Oscillator Tune group mask. */
+#define CLKCTRL_AUTOTUNE_gp  0  /* Automatic Oscillator Tune group position. */
+#define CLKCTRL_AUTOTUNE_0_bm  (1<<0)  /* Automatic Oscillator Tune bit 0 mask. */
+#define CLKCTRL_AUTOTUNE_0_bp  0  /* Automatic Oscillator Tune bit 0 position. */
+#define CLKCTRL_AUTOTUNE_1_bm  (1<<1)  /* Automatic Oscillator Tune bit 1 mask. */
+#define CLKCTRL_AUTOTUNE_1_bp  1  /* Automatic Oscillator Tune bit 1 position. */
+#define CLKCTRL_RUNSTDBY_bm  0x80  /* Run in standby bit mask. */
+#define CLKCTRL_RUNSTDBY_bp  7  /* Run in standby bit position. */
+
+/* CLKCTRL.OSCHFTUNE  bit masks and bit positions */
+#define CLKCTRL_TUNE_gm  0xFF  /* Oscillator Tune group mask. */
+#define CLKCTRL_TUNE_gp  0  /* Oscillator Tune group position. */
+#define CLKCTRL_TUNE_0_bm  (1<<0)  /* Oscillator Tune bit 0 mask. */
+#define CLKCTRL_TUNE_0_bp  0  /* Oscillator Tune bit 0 position. */
+#define CLKCTRL_TUNE_1_bm  (1<<1)  /* Oscillator Tune bit 1 mask. */
+#define CLKCTRL_TUNE_1_bp  1  /* Oscillator Tune bit 1 position. */
+#define CLKCTRL_TUNE_2_bm  (1<<2)  /* Oscillator Tune bit 2 mask. */
+#define CLKCTRL_TUNE_2_bp  2  /* Oscillator Tune bit 2 position. */
+#define CLKCTRL_TUNE_3_bm  (1<<3)  /* Oscillator Tune bit 3 mask. */
+#define CLKCTRL_TUNE_3_bp  3  /* Oscillator Tune bit 3 position. */
+#define CLKCTRL_TUNE_4_bm  (1<<4)  /* Oscillator Tune bit 4 mask. */
+#define CLKCTRL_TUNE_4_bp  4  /* Oscillator Tune bit 4 position. */
+#define CLKCTRL_TUNE_5_bm  (1<<5)  /* Oscillator Tune bit 5 mask. */
+#define CLKCTRL_TUNE_5_bp  5  /* Oscillator Tune bit 5 position. */
+#define CLKCTRL_TUNE_6_bm  (1<<6)  /* Oscillator Tune bit 6 mask. */
+#define CLKCTRL_TUNE_6_bp  6  /* Oscillator Tune bit 6 position. */
+#define CLKCTRL_TUNE_7_bm  (1<<7)  /* Oscillator Tune bit 7 mask. */
+#define CLKCTRL_TUNE_7_bp  7  /* Oscillator Tune bit 7 position. */
+
+/* CLKCTRL.OSC32KCTRLA  bit masks and bit positions */
+/* CLKCTRL_RUNSTDBY  is already defined. */
+
+/* CLKCTRL.XOSC32KCTRLA  bit masks and bit positions */
+#define CLKCTRL_ENABLE_bm  0x01  /* Enable bit mask. */
+#define CLKCTRL_ENABLE_bp  0  /* Enable bit position. */
+#define CLKCTRL_LPMODE_bm  0x02  /* Low power mode bit mask. */
+#define CLKCTRL_LPMODE_bp  1  /* Low power mode bit position. */
+#define CLKCTRL_SEL_bm  0x04  /* Select bit mask. */
+#define CLKCTRL_SEL_bp  2  /* Select bit position. */
+#define CLKCTRL_CSUT_gm  0x30  /* Crystal startup time group mask. */
+#define CLKCTRL_CSUT_gp  4  /* Crystal startup time group position. */
+#define CLKCTRL_CSUT_0_bm  (1<<4)  /* Crystal startup time bit 0 mask. */
+#define CLKCTRL_CSUT_0_bp  4  /* Crystal startup time bit 0 position. */
+#define CLKCTRL_CSUT_1_bm  (1<<5)  /* Crystal startup time bit 1 mask. */
+#define CLKCTRL_CSUT_1_bp  5  /* Crystal startup time bit 1 position. */
+/* CLKCTRL_RUNSTDBY  is already defined. */
+
+/* CLKCTRL.XOSCHFCTRLA  bit masks and bit positions */
+/* CLKCTRL_ENABLE  is already defined. */
+#define CLKCTRL_SELHF_bm  0x02  /* Source Select bit mask. */
+#define CLKCTRL_SELHF_bp  1  /* Source Select bit position. */
+#define CLKCTRL_CSUTHF_gm  0x30  /* Start-Up Time group mask. */
+#define CLKCTRL_CSUTHF_gp  4  /* Start-Up Time group position. */
+#define CLKCTRL_CSUTHF_0_bm  (1<<4)  /* Start-Up Time bit 0 mask. */
+#define CLKCTRL_CSUTHF_0_bp  4  /* Start-Up Time bit 0 position. */
+#define CLKCTRL_CSUTHF_1_bm  (1<<5)  /* Start-Up Time bit 1 mask. */
+#define CLKCTRL_CSUTHF_1_bp  5  /* Start-Up Time bit 1 position. */
+/* CLKCTRL_RUNSTDBY  is already defined. */
+
+
+/* CPU - CPU */
+/* CPU.CCP  bit masks and bit positions */
+#define CPU_CCP_gm  0xFF  /* CCP signature group mask. */
+#define CPU_CCP_gp  0  /* CCP signature group position. */
+#define CPU_CCP_0_bm  (1<<0)  /* CCP signature bit 0 mask. */
+#define CPU_CCP_0_bp  0  /* CCP signature bit 0 position. */
+#define CPU_CCP_1_bm  (1<<1)  /* CCP signature bit 1 mask. */
+#define CPU_CCP_1_bp  1  /* CCP signature bit 1 position. */
+#define CPU_CCP_2_bm  (1<<2)  /* CCP signature bit 2 mask. */
+#define CPU_CCP_2_bp  2  /* CCP signature bit 2 position. */
+#define CPU_CCP_3_bm  (1<<3)  /* CCP signature bit 3 mask. */
+#define CPU_CCP_3_bp  3  /* CCP signature bit 3 position. */
+#define CPU_CCP_4_bm  (1<<4)  /* CCP signature bit 4 mask. */
+#define CPU_CCP_4_bp  4  /* CCP signature bit 4 position. */
+#define CPU_CCP_5_bm  (1<<5)  /* CCP signature bit 5 mask. */
+#define CPU_CCP_5_bp  5  /* CCP signature bit 5 position. */
+#define CPU_CCP_6_bm  (1<<6)  /* CCP signature bit 6 mask. */
+#define CPU_CCP_6_bp  6  /* CCP signature bit 6 position. */
+#define CPU_CCP_7_bm  (1<<7)  /* CCP signature bit 7 mask. */
+#define CPU_CCP_7_bp  7  /* CCP signature bit 7 position. */
+
+/* CPU.SREG  bit masks and bit positions */
+#define CPU_C_bm  0x01  /* Carry Flag bit mask. */
+#define CPU_C_bp  0  /* Carry Flag bit position. */
+#define CPU_Z_bm  0x02  /* Zero Flag bit mask. */
+#define CPU_Z_bp  1  /* Zero Flag bit position. */
+#define CPU_N_bm  0x04  /* Negative Flag bit mask. */
+#define CPU_N_bp  2  /* Negative Flag bit position. */
+#define CPU_V_bm  0x08  /* Two's Complement Overflow Flag bit mask. */
+#define CPU_V_bp  3  /* Two's Complement Overflow Flag bit position. */
+#define CPU_S_bm  0x10  /* N Exclusive Or V Flag bit mask. */
+#define CPU_S_bp  4  /* N Exclusive Or V Flag bit position. */
+#define CPU_H_bm  0x20  /* Half Carry Flag bit mask. */
+#define CPU_H_bp  5  /* Half Carry Flag bit position. */
+#define CPU_T_bm  0x40  /* Transfer Bit bit mask. */
+#define CPU_T_bp  6  /* Transfer Bit bit position. */
+#define CPU_I_bm  0x80  /* Global Interrupt Enable Flag bit mask. */
+#define CPU_I_bp  7  /* Global Interrupt Enable Flag bit position. */
+
+
+/* CPUINT - Interrupt Controller */
+/* CPUINT.CTRLA  bit masks and bit positions */
+#define CPUINT_LVL0RR_bm  0x01  /* Round-robin Scheduling Enable bit mask. */
+#define CPUINT_LVL0RR_bp  0  /* Round-robin Scheduling Enable bit position. */
+#define CPUINT_CVT_bm  0x20  /* Compact Vector Table bit mask. */
+#define CPUINT_CVT_bp  5  /* Compact Vector Table bit position. */
+#define CPUINT_IVSEL_bm  0x40  /* Interrupt Vector Select bit mask. */
+#define CPUINT_IVSEL_bp  6  /* Interrupt Vector Select bit position. */
+
+/* CPUINT.STATUS  bit masks and bit positions */
+#define CPUINT_LVL0EX_bm  0x01  /* Level 0 Interrupt Executing bit mask. */
+#define CPUINT_LVL0EX_bp  0  /* Level 0 Interrupt Executing bit position. */
+#define CPUINT_LVL1EX_bm  0x02  /* Level 1 Interrupt Executing bit mask. */
+#define CPUINT_LVL1EX_bp  1  /* Level 1 Interrupt Executing bit position. */
+#define CPUINT_NMIEX_bm  0x80  /* Non-maskable Interrupt Executing bit mask. */
+#define CPUINT_NMIEX_bp  7  /* Non-maskable Interrupt Executing bit position. */
+
+/* CPUINT.LVL0PRI  bit masks and bit positions */
+#define CPUINT_LVL0PRI_gm  0xFF  /* Interrupt Level Priority group mask. */
+#define CPUINT_LVL0PRI_gp  0  /* Interrupt Level Priority group position. */
+#define CPUINT_LVL0PRI_0_bm  (1<<0)  /* Interrupt Level Priority bit 0 mask. */
+#define CPUINT_LVL0PRI_0_bp  0  /* Interrupt Level Priority bit 0 position. */
+#define CPUINT_LVL0PRI_1_bm  (1<<1)  /* Interrupt Level Priority bit 1 mask. */
+#define CPUINT_LVL0PRI_1_bp  1  /* Interrupt Level Priority bit 1 position. */
+#define CPUINT_LVL0PRI_2_bm  (1<<2)  /* Interrupt Level Priority bit 2 mask. */
+#define CPUINT_LVL0PRI_2_bp  2  /* Interrupt Level Priority bit 2 position. */
+#define CPUINT_LVL0PRI_3_bm  (1<<3)  /* Interrupt Level Priority bit 3 mask. */
+#define CPUINT_LVL0PRI_3_bp  3  /* Interrupt Level Priority bit 3 position. */
+#define CPUINT_LVL0PRI_4_bm  (1<<4)  /* Interrupt Level Priority bit 4 mask. */
+#define CPUINT_LVL0PRI_4_bp  4  /* Interrupt Level Priority bit 4 position. */
+#define CPUINT_LVL0PRI_5_bm  (1<<5)  /* Interrupt Level Priority bit 5 mask. */
+#define CPUINT_LVL0PRI_5_bp  5  /* Interrupt Level Priority bit 5 position. */
+#define CPUINT_LVL0PRI_6_bm  (1<<6)  /* Interrupt Level Priority bit 6 mask. */
+#define CPUINT_LVL0PRI_6_bp  6  /* Interrupt Level Priority bit 6 position. */
+#define CPUINT_LVL0PRI_7_bm  (1<<7)  /* Interrupt Level Priority bit 7 mask. */
+#define CPUINT_LVL0PRI_7_bp  7  /* Interrupt Level Priority bit 7 position. */
+
+/* CPUINT.LVL1VEC  bit masks and bit positions */
+#define CPUINT_LVL1VEC_gm  0xFF  /* Interrupt Vector with High Priority group mask. */
+#define CPUINT_LVL1VEC_gp  0  /* Interrupt Vector with High Priority group position. */
+#define CPUINT_LVL1VEC_0_bm  (1<<0)  /* Interrupt Vector with High Priority bit 0 mask. */
+#define CPUINT_LVL1VEC_0_bp  0  /* Interrupt Vector with High Priority bit 0 position. */
+#define CPUINT_LVL1VEC_1_bm  (1<<1)  /* Interrupt Vector with High Priority bit 1 mask. */
+#define CPUINT_LVL1VEC_1_bp  1  /* Interrupt Vector with High Priority bit 1 position. */
+#define CPUINT_LVL1VEC_2_bm  (1<<2)  /* Interrupt Vector with High Priority bit 2 mask. */
+#define CPUINT_LVL1VEC_2_bp  2  /* Interrupt Vector with High Priority bit 2 position. */
+#define CPUINT_LVL1VEC_3_bm  (1<<3)  /* Interrupt Vector with High Priority bit 3 mask. */
+#define CPUINT_LVL1VEC_3_bp  3  /* Interrupt Vector with High Priority bit 3 position. */
+#define CPUINT_LVL1VEC_4_bm  (1<<4)  /* Interrupt Vector with High Priority bit 4 mask. */
+#define CPUINT_LVL1VEC_4_bp  4  /* Interrupt Vector with High Priority bit 4 position. */
+#define CPUINT_LVL1VEC_5_bm  (1<<5)  /* Interrupt Vector with High Priority bit 5 mask. */
+#define CPUINT_LVL1VEC_5_bp  5  /* Interrupt Vector with High Priority bit 5 position. */
+#define CPUINT_LVL1VEC_6_bm  (1<<6)  /* Interrupt Vector with High Priority bit 6 mask. */
+#define CPUINT_LVL1VEC_6_bp  6  /* Interrupt Vector with High Priority bit 6 position. */
+#define CPUINT_LVL1VEC_7_bm  (1<<7)  /* Interrupt Vector with High Priority bit 7 mask. */
+#define CPUINT_LVL1VEC_7_bp  7  /* Interrupt Vector with High Priority bit 7 position. */
+
+
+/* CRCSCAN - CRCSCAN */
+/* CRCSCAN.CTRLA  bit masks and bit positions */
+#define CRCSCAN_ENABLE_bm  0x01  /* Enable CRC scan bit mask. */
+#define CRCSCAN_ENABLE_bp  0  /* Enable CRC scan bit position. */
+#define CRCSCAN_NMIEN_bm  0x02  /* Enable NMI Trigger bit mask. */
+#define CRCSCAN_NMIEN_bp  1  /* Enable NMI Trigger bit position. */
+#define CRCSCAN_RESET_bm  0x80  /* Reset CRC scan bit mask. */
+#define CRCSCAN_RESET_bp  7  /* Reset CRC scan bit position. */
+
+/* CRCSCAN.CTRLB  bit masks and bit positions */
+#define CRCSCAN_SRC_gm  0x03  /* CRC Source group mask. */
+#define CRCSCAN_SRC_gp  0  /* CRC Source group position. */
+#define CRCSCAN_SRC_0_bm  (1<<0)  /* CRC Source bit 0 mask. */
+#define CRCSCAN_SRC_0_bp  0  /* CRC Source bit 0 position. */
+#define CRCSCAN_SRC_1_bm  (1<<1)  /* CRC Source bit 1 mask. */
+#define CRCSCAN_SRC_1_bp  1  /* CRC Source bit 1 position. */
+
+/* CRCSCAN.STATUS  bit masks and bit positions */
+#define CRCSCAN_BUSY_bm  0x01  /* CRC Busy bit mask. */
+#define CRCSCAN_BUSY_bp  0  /* CRC Busy bit position. */
+#define CRCSCAN_OK_bm  0x02  /* CRC Ok bit mask. */
+#define CRCSCAN_OK_bp  1  /* CRC Ok bit position. */
+
+
+/* DAC - Digital to Analog Converter */
+/* DAC.CTRLA  bit masks and bit positions */
+#define DAC_ENABLE_bm  0x01  /* DAC Enable bit mask. */
+#define DAC_ENABLE_bp  0  /* DAC Enable bit position. */
+#define DAC_OUTRANGE_gm  0x30  /* Output Buffer Range group mask. */
+#define DAC_OUTRANGE_gp  4  /* Output Buffer Range group position. */
+#define DAC_OUTRANGE_0_bm  (1<<4)  /* Output Buffer Range bit 0 mask. */
+#define DAC_OUTRANGE_0_bp  4  /* Output Buffer Range bit 0 position. */
+#define DAC_OUTRANGE_1_bm  (1<<5)  /* Output Buffer Range bit 1 mask. */
+#define DAC_OUTRANGE_1_bp  5  /* Output Buffer Range bit 1 position. */
+#define DAC_OUTEN_bm  0x40  /* Output Buffer Enable bit mask. */
+#define DAC_OUTEN_bp  6  /* Output Buffer Enable bit position. */
+#define DAC_RUNSTDBY_bm  0x80  /* Run in Standby Mode bit mask. */
+#define DAC_RUNSTDBY_bp  7  /* Run in Standby Mode bit position. */
+
+/* DAC.DATA  bit masks and bit positions */
+#define DAC_DATA_gm  0xFFC0  /* Data group mask. */
+#define DAC_DATA_gp  6  /* Data group position. */
+#define DAC_DATA_0_bm  (1<<6)  /* Data bit 0 mask. */
+#define DAC_DATA_0_bp  6  /* Data bit 0 position. */
+#define DAC_DATA_1_bm  (1<<7)  /* Data bit 1 mask. */
+#define DAC_DATA_1_bp  7  /* Data bit 1 position. */
+#define DAC_DATA_2_bm  (1<<8)  /* Data bit 2 mask. */
+#define DAC_DATA_2_bp  8  /* Data bit 2 position. */
+#define DAC_DATA_3_bm  (1<<9)  /* Data bit 3 mask. */
+#define DAC_DATA_3_bp  9  /* Data bit 3 position. */
+#define DAC_DATA_4_bm  (1<<10)  /* Data bit 4 mask. */
+#define DAC_DATA_4_bp  10  /* Data bit 4 position. */
+#define DAC_DATA_5_bm  (1<<11)  /* Data bit 5 mask. */
+#define DAC_DATA_5_bp  11  /* Data bit 5 position. */
+#define DAC_DATA_6_bm  (1<<12)  /* Data bit 6 mask. */
+#define DAC_DATA_6_bp  12  /* Data bit 6 position. */
+#define DAC_DATA_7_bm  (1<<13)  /* Data bit 7 mask. */
+#define DAC_DATA_7_bp  13  /* Data bit 7 position. */
+#define DAC_DATA_8_bm  (1<<14)  /* Data bit 8 mask. */
+#define DAC_DATA_8_bp  14  /* Data bit 8 position. */
+#define DAC_DATA_9_bm  (1<<15)  /* Data bit 9 mask. */
+#define DAC_DATA_9_bp  15  /* Data bit 9 position. */
+
+
+/* EVSYS - Event System */
+/* EVSYS.SWEVENTA  bit masks and bit positions */
+#define EVSYS_SWEVENTA_gm  0xFF  /* Software event on channel select group mask. */
+#define EVSYS_SWEVENTA_gp  0  /* Software event on channel select group position. */
+#define EVSYS_SWEVENTA_0_bm  (1<<0)  /* Software event on channel select bit 0 mask. */
+#define EVSYS_SWEVENTA_0_bp  0  /* Software event on channel select bit 0 position. */
+#define EVSYS_SWEVENTA_1_bm  (1<<1)  /* Software event on channel select bit 1 mask. */
+#define EVSYS_SWEVENTA_1_bp  1  /* Software event on channel select bit 1 position. */
+#define EVSYS_SWEVENTA_2_bm  (1<<2)  /* Software event on channel select bit 2 mask. */
+#define EVSYS_SWEVENTA_2_bp  2  /* Software event on channel select bit 2 position. */
+#define EVSYS_SWEVENTA_3_bm  (1<<3)  /* Software event on channel select bit 3 mask. */
+#define EVSYS_SWEVENTA_3_bp  3  /* Software event on channel select bit 3 position. */
+#define EVSYS_SWEVENTA_4_bm  (1<<4)  /* Software event on channel select bit 4 mask. */
+#define EVSYS_SWEVENTA_4_bp  4  /* Software event on channel select bit 4 position. */
+#define EVSYS_SWEVENTA_5_bm  (1<<5)  /* Software event on channel select bit 5 mask. */
+#define EVSYS_SWEVENTA_5_bp  5  /* Software event on channel select bit 5 position. */
+#define EVSYS_SWEVENTA_6_bm  (1<<6)  /* Software event on channel select bit 6 mask. */
+#define EVSYS_SWEVENTA_6_bp  6  /* Software event on channel select bit 6 position. */
+#define EVSYS_SWEVENTA_7_bm  (1<<7)  /* Software event on channel select bit 7 mask. */
+#define EVSYS_SWEVENTA_7_bp  7  /* Software event on channel select bit 7 position. */
+
+/* EVSYS.CHANNEL0  bit masks and bit positions */
+#define EVSYS_CHANNEL_gm  0xFF  /* Channel generator select group mask. */
+#define EVSYS_CHANNEL_gp  0  /* Channel generator select group position. */
+#define EVSYS_CHANNEL_0_bm  (1<<0)  /* Channel generator select bit 0 mask. */
+#define EVSYS_CHANNEL_0_bp  0  /* Channel generator select bit 0 position. */
+#define EVSYS_CHANNEL_1_bm  (1<<1)  /* Channel generator select bit 1 mask. */
+#define EVSYS_CHANNEL_1_bp  1  /* Channel generator select bit 1 position. */
+#define EVSYS_CHANNEL_2_bm  (1<<2)  /* Channel generator select bit 2 mask. */
+#define EVSYS_CHANNEL_2_bp  2  /* Channel generator select bit 2 position. */
+#define EVSYS_CHANNEL_3_bm  (1<<3)  /* Channel generator select bit 3 mask. */
+#define EVSYS_CHANNEL_3_bp  3  /* Channel generator select bit 3 position. */
+#define EVSYS_CHANNEL_4_bm  (1<<4)  /* Channel generator select bit 4 mask. */
+#define EVSYS_CHANNEL_4_bp  4  /* Channel generator select bit 4 position. */
+#define EVSYS_CHANNEL_5_bm  (1<<5)  /* Channel generator select bit 5 mask. */
+#define EVSYS_CHANNEL_5_bp  5  /* Channel generator select bit 5 position. */
+#define EVSYS_CHANNEL_6_bm  (1<<6)  /* Channel generator select bit 6 mask. */
+#define EVSYS_CHANNEL_6_bp  6  /* Channel generator select bit 6 position. */
+#define EVSYS_CHANNEL_7_bm  (1<<7)  /* Channel generator select bit 7 mask. */
+#define EVSYS_CHANNEL_7_bp  7  /* Channel generator select bit 7 position. */
+
+/* EVSYS.CHANNEL1  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.CHANNEL2  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.CHANNEL3  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.CHANNEL4  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.CHANNEL5  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.USERCCLLUT0A  bit masks and bit positions */
+#define EVSYS_USER_gm  0xFF  /* User channel select group mask. */
+#define EVSYS_USER_gp  0  /* User channel select group position. */
+#define EVSYS_USER_0_bm  (1<<0)  /* User channel select bit 0 mask. */
+#define EVSYS_USER_0_bp  0  /* User channel select bit 0 position. */
+#define EVSYS_USER_1_bm  (1<<1)  /* User channel select bit 1 mask. */
+#define EVSYS_USER_1_bp  1  /* User channel select bit 1 position. */
+#define EVSYS_USER_2_bm  (1<<2)  /* User channel select bit 2 mask. */
+#define EVSYS_USER_2_bp  2  /* User channel select bit 2 position. */
+#define EVSYS_USER_3_bm  (1<<3)  /* User channel select bit 3 mask. */
+#define EVSYS_USER_3_bp  3  /* User channel select bit 3 position. */
+#define EVSYS_USER_4_bm  (1<<4)  /* User channel select bit 4 mask. */
+#define EVSYS_USER_4_bp  4  /* User channel select bit 4 position. */
+#define EVSYS_USER_5_bm  (1<<5)  /* User channel select bit 5 mask. */
+#define EVSYS_USER_5_bp  5  /* User channel select bit 5 position. */
+#define EVSYS_USER_6_bm  (1<<6)  /* User channel select bit 6 mask. */
+#define EVSYS_USER_6_bp  6  /* User channel select bit 6 position. */
+#define EVSYS_USER_7_bm  (1<<7)  /* User channel select bit 7 mask. */
+#define EVSYS_USER_7_bp  7  /* User channel select bit 7 position. */
+
+/* EVSYS.USERCCLLUT0B  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT1A  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT1B  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT2A  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT2B  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT3A  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT3B  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERADC0START  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTC  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTD  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTF  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERUSART0IRDA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERUSART1IRDA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERUSART2IRDA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCA0CNTA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCA0CNTB  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCA1CNTA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCA1CNTB  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB0CAPT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB0COUNT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB1CAPT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB1COUNT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB2CAPT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB2COUNT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB3CAPT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB3COUNT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+
+/* FUSE - Fuses */
+/* FUSE.WDTCFG  bit masks and bit positions */
+#define FUSE_PERIOD_gm  0x0F  /* Watchdog Timeout Period group mask. */
+#define FUSE_PERIOD_gp  0  /* Watchdog Timeout Period group position. */
+#define FUSE_PERIOD_0_bm  (1<<0)  /* Watchdog Timeout Period bit 0 mask. */
+#define FUSE_PERIOD_0_bp  0  /* Watchdog Timeout Period bit 0 position. */
+#define FUSE_PERIOD_1_bm  (1<<1)  /* Watchdog Timeout Period bit 1 mask. */
+#define FUSE_PERIOD_1_bp  1  /* Watchdog Timeout Period bit 1 position. */
+#define FUSE_PERIOD_2_bm  (1<<2)  /* Watchdog Timeout Period bit 2 mask. */
+#define FUSE_PERIOD_2_bp  2  /* Watchdog Timeout Period bit 2 position. */
+#define FUSE_PERIOD_3_bm  (1<<3)  /* Watchdog Timeout Period bit 3 mask. */
+#define FUSE_PERIOD_3_bp  3  /* Watchdog Timeout Period bit 3 position. */
+#define FUSE_WINDOW_gm  0xF0  /* Watchdog Window Timeout Period group mask. */
+#define FUSE_WINDOW_gp  4  /* Watchdog Window Timeout Period group position. */
+#define FUSE_WINDOW_0_bm  (1<<4)  /* Watchdog Window Timeout Period bit 0 mask. */
+#define FUSE_WINDOW_0_bp  4  /* Watchdog Window Timeout Period bit 0 position. */
+#define FUSE_WINDOW_1_bm  (1<<5)  /* Watchdog Window Timeout Period bit 1 mask. */
+#define FUSE_WINDOW_1_bp  5  /* Watchdog Window Timeout Period bit 1 position. */
+#define FUSE_WINDOW_2_bm  (1<<6)  /* Watchdog Window Timeout Period bit 2 mask. */
+#define FUSE_WINDOW_2_bp  6  /* Watchdog Window Timeout Period bit 2 position. */
+#define FUSE_WINDOW_3_bm  (1<<7)  /* Watchdog Window Timeout Period bit 3 mask. */
+#define FUSE_WINDOW_3_bp  7  /* Watchdog Window Timeout Period bit 3 position. */
+
+/* FUSE.BODCFG  bit masks and bit positions */
+#define FUSE_SLEEP_gm  0x03  /* BOD Operation in Sleep Mode group mask. */
+#define FUSE_SLEEP_gp  0  /* BOD Operation in Sleep Mode group position. */
+#define FUSE_SLEEP_0_bm  (1<<0)  /* BOD Operation in Sleep Mode bit 0 mask. */
+#define FUSE_SLEEP_0_bp  0  /* BOD Operation in Sleep Mode bit 0 position. */
+#define FUSE_SLEEP_1_bm  (1<<1)  /* BOD Operation in Sleep Mode bit 1 mask. */
+#define FUSE_SLEEP_1_bp  1  /* BOD Operation in Sleep Mode bit 1 position. */
+#define FUSE_ACTIVE_gm  0x0C  /* BOD Operation in Active Mode group mask. */
+#define FUSE_ACTIVE_gp  2  /* BOD Operation in Active Mode group position. */
+#define FUSE_ACTIVE_0_bm  (1<<2)  /* BOD Operation in Active Mode bit 0 mask. */
+#define FUSE_ACTIVE_0_bp  2  /* BOD Operation in Active Mode bit 0 position. */
+#define FUSE_ACTIVE_1_bm  (1<<3)  /* BOD Operation in Active Mode bit 1 mask. */
+#define FUSE_ACTIVE_1_bp  3  /* BOD Operation in Active Mode bit 1 position. */
+#define FUSE_SAMPFREQ_bm  0x10  /* BOD Sample Frequency bit mask. */
+#define FUSE_SAMPFREQ_bp  4  /* BOD Sample Frequency bit position. */
+#define FUSE_LVL_gm  0xE0  /* BOD Level group mask. */
+#define FUSE_LVL_gp  5  /* BOD Level group position. */
+#define FUSE_LVL_0_bm  (1<<5)  /* BOD Level bit 0 mask. */
+#define FUSE_LVL_0_bp  5  /* BOD Level bit 0 position. */
+#define FUSE_LVL_1_bm  (1<<6)  /* BOD Level bit 1 mask. */
+#define FUSE_LVL_1_bp  6  /* BOD Level bit 1 position. */
+#define FUSE_LVL_2_bm  (1<<7)  /* BOD Level bit 2 mask. */
+#define FUSE_LVL_2_bp  7  /* BOD Level bit 2 position. */
+
+/* FUSE.OSCCFG  bit masks and bit positions */
+#define FUSE_OSCHFFRQ_bm  0x08  /* High-frequency Oscillator Frequency bit mask. */
+#define FUSE_OSCHFFRQ_bp  3  /* High-frequency Oscillator Frequency bit position. */
+
+/* FUSE.SYSCFG0  bit masks and bit positions */
+#define FUSE_EESAVE_bm  0x01  /* EEPROM Save bit mask. */
+#define FUSE_EESAVE_bp  0  /* EEPROM Save bit position. */
+#define FUSE_RSTPINCFG_bm  0x08  /* Reset Pin Configuration bit mask. */
+#define FUSE_RSTPINCFG_bp  3  /* Reset Pin Configuration bit position. */
+#define FUSE_UPDIPINCFG_bm  0x10  /* UPDI Pin Configuration bit mask. */
+#define FUSE_UPDIPINCFG_bp  4  /* UPDI Pin Configuration bit position. */
+#define FUSE_CRCSEL_bm  0x20  /* CRC Select bit mask. */
+#define FUSE_CRCSEL_bp  5  /* CRC Select bit position. */
+#define FUSE_CRCSRC_gm  0xC0  /* CRC Source group mask. */
+#define FUSE_CRCSRC_gp  6  /* CRC Source group position. */
+#define FUSE_CRCSRC_0_bm  (1<<6)  /* CRC Source bit 0 mask. */
+#define FUSE_CRCSRC_0_bp  6  /* CRC Source bit 0 position. */
+#define FUSE_CRCSRC_1_bm  (1<<7)  /* CRC Source bit 1 mask. */
+#define FUSE_CRCSRC_1_bp  7  /* CRC Source bit 1 position. */
+
+/* FUSE.SYSCFG1  bit masks and bit positions */
+#define FUSE_SUT_gm  0x07  /* Startup Time group mask. */
+#define FUSE_SUT_gp  0  /* Startup Time group position. */
+#define FUSE_SUT_0_bm  (1<<0)  /* Startup Time bit 0 mask. */
+#define FUSE_SUT_0_bp  0  /* Startup Time bit 0 position. */
+#define FUSE_SUT_1_bm  (1<<1)  /* Startup Time bit 1 mask. */
+#define FUSE_SUT_1_bp  1  /* Startup Time bit 1 position. */
+#define FUSE_SUT_2_bm  (1<<2)  /* Startup Time bit 2 mask. */
+#define FUSE_SUT_2_bp  2  /* Startup Time bit 2 position. */
+
+
+
+/* LOCK - Lockbits */
+/* LOCK.KEY  bit masks and bit positions */
+#define LOCK_KEY_gm  0xFFFFFFFF  /* Lock Key group mask. */
+#define LOCK_KEY_gp  0  /* Lock Key group position. */
+#define LOCK_KEY_0_bm  (1<<0)  /* Lock Key bit 0 mask. */
+#define LOCK_KEY_0_bp  0  /* Lock Key bit 0 position. */
+#define LOCK_KEY_1_bm  (1<<1)  /* Lock Key bit 1 mask. */
+#define LOCK_KEY_1_bp  1  /* Lock Key bit 1 position. */
+#define LOCK_KEY_2_bm  (1<<2)  /* Lock Key bit 2 mask. */
+#define LOCK_KEY_2_bp  2  /* Lock Key bit 2 position. */
+#define LOCK_KEY_3_bm  (1<<3)  /* Lock Key bit 3 mask. */
+#define LOCK_KEY_3_bp  3  /* Lock Key bit 3 position. */
+#define LOCK_KEY_4_bm  (1<<4)  /* Lock Key bit 4 mask. */
+#define LOCK_KEY_4_bp  4  /* Lock Key bit 4 position. */
+#define LOCK_KEY_5_bm  (1<<5)  /* Lock Key bit 5 mask. */
+#define LOCK_KEY_5_bp  5  /* Lock Key bit 5 position. */
+#define LOCK_KEY_6_bm  (1<<6)  /* Lock Key bit 6 mask. */
+#define LOCK_KEY_6_bp  6  /* Lock Key bit 6 position. */
+#define LOCK_KEY_7_bm  (1<<7)  /* Lock Key bit 7 mask. */
+#define LOCK_KEY_7_bp  7  /* Lock Key bit 7 position. */
+#define LOCK_KEY_8_bm  (1<<8)  /* Lock Key bit 8 mask. */
+#define LOCK_KEY_8_bp  8  /* Lock Key bit 8 position. */
+#define LOCK_KEY_9_bm  (1<<9)  /* Lock Key bit 9 mask. */
+#define LOCK_KEY_9_bp  9  /* Lock Key bit 9 position. */
+#define LOCK_KEY_10_bm  (1<<10)  /* Lock Key bit 10 mask. */
+#define LOCK_KEY_10_bp  10  /* Lock Key bit 10 position. */
+#define LOCK_KEY_11_bm  (1<<11)  /* Lock Key bit 11 mask. */
+#define LOCK_KEY_11_bp  11  /* Lock Key bit 11 position. */
+#define LOCK_KEY_12_bm  (1<<12)  /* Lock Key bit 12 mask. */
+#define LOCK_KEY_12_bp  12  /* Lock Key bit 12 position. */
+#define LOCK_KEY_13_bm  (1<<13)  /* Lock Key bit 13 mask. */
+#define LOCK_KEY_13_bp  13  /* Lock Key bit 13 position. */
+#define LOCK_KEY_14_bm  (1<<14)  /* Lock Key bit 14 mask. */
+#define LOCK_KEY_14_bp  14  /* Lock Key bit 14 position. */
+#define LOCK_KEY_15_bm  (1<<15)  /* Lock Key bit 15 mask. */
+#define LOCK_KEY_15_bp  15  /* Lock Key bit 15 position. */
+#define LOCK_KEY_16_bm  (1<<16)  /* Lock Key bit 16 mask. */
+#define LOCK_KEY_16_bp  16  /* Lock Key bit 16 position. */
+#define LOCK_KEY_17_bm  (1<<17)  /* Lock Key bit 17 mask. */
+#define LOCK_KEY_17_bp  17  /* Lock Key bit 17 position. */
+#define LOCK_KEY_18_bm  (1<<18)  /* Lock Key bit 18 mask. */
+#define LOCK_KEY_18_bp  18  /* Lock Key bit 18 position. */
+#define LOCK_KEY_19_bm  (1<<19)  /* Lock Key bit 19 mask. */
+#define LOCK_KEY_19_bp  19  /* Lock Key bit 19 position. */
+#define LOCK_KEY_20_bm  (1<<20)  /* Lock Key bit 20 mask. */
+#define LOCK_KEY_20_bp  20  /* Lock Key bit 20 position. */
+#define LOCK_KEY_21_bm  (1<<21)  /* Lock Key bit 21 mask. */
+#define LOCK_KEY_21_bp  21  /* Lock Key bit 21 position. */
+#define LOCK_KEY_22_bm  (1<<22)  /* Lock Key bit 22 mask. */
+#define LOCK_KEY_22_bp  22  /* Lock Key bit 22 position. */
+#define LOCK_KEY_23_bm  (1<<23)  /* Lock Key bit 23 mask. */
+#define LOCK_KEY_23_bp  23  /* Lock Key bit 23 position. */
+#define LOCK_KEY_24_bm  (1<<24)  /* Lock Key bit 24 mask. */
+#define LOCK_KEY_24_bp  24  /* Lock Key bit 24 position. */
+#define LOCK_KEY_25_bm  (1<<25)  /* Lock Key bit 25 mask. */
+#define LOCK_KEY_25_bp  25  /* Lock Key bit 25 position. */
+#define LOCK_KEY_26_bm  (1<<26)  /* Lock Key bit 26 mask. */
+#define LOCK_KEY_26_bp  26  /* Lock Key bit 26 position. */
+#define LOCK_KEY_27_bm  (1<<27)  /* Lock Key bit 27 mask. */
+#define LOCK_KEY_27_bp  27  /* Lock Key bit 27 position. */
+#define LOCK_KEY_28_bm  (1<<28)  /* Lock Key bit 28 mask. */
+#define LOCK_KEY_28_bp  28  /* Lock Key bit 28 position. */
+#define LOCK_KEY_29_bm  (1<<29)  /* Lock Key bit 29 mask. */
+#define LOCK_KEY_29_bp  29  /* Lock Key bit 29 position. */
+#define LOCK_KEY_30_bm  (1<<30)  /* Lock Key bit 30 mask. */
+#define LOCK_KEY_30_bp  30  /* Lock Key bit 30 position. */
+#define LOCK_KEY_31_bm  (1<<31)  /* Lock Key bit 31 mask. */
+#define LOCK_KEY_31_bp  31  /* Lock Key bit 31 position. */
+
+
+/* NVMCTRL - Non-volatile Memory Controller */
+/* NVMCTRL.CTRLA  bit masks and bit positions */
+#define NVMCTRL_CMD_gm  0x7F  /* Command group mask. */
+#define NVMCTRL_CMD_gp  0  /* Command group position. */
+#define NVMCTRL_CMD_0_bm  (1<<0)  /* Command bit 0 mask. */
+#define NVMCTRL_CMD_0_bp  0  /* Command bit 0 position. */
+#define NVMCTRL_CMD_1_bm  (1<<1)  /* Command bit 1 mask. */
+#define NVMCTRL_CMD_1_bp  1  /* Command bit 1 position. */
+#define NVMCTRL_CMD_2_bm  (1<<2)  /* Command bit 2 mask. */
+#define NVMCTRL_CMD_2_bp  2  /* Command bit 2 position. */
+#define NVMCTRL_CMD_3_bm  (1<<3)  /* Command bit 3 mask. */
+#define NVMCTRL_CMD_3_bp  3  /* Command bit 3 position. */
+#define NVMCTRL_CMD_4_bm  (1<<4)  /* Command bit 4 mask. */
+#define NVMCTRL_CMD_4_bp  4  /* Command bit 4 position. */
+#define NVMCTRL_CMD_5_bm  (1<<5)  /* Command bit 5 mask. */
+#define NVMCTRL_CMD_5_bp  5  /* Command bit 5 position. */
+#define NVMCTRL_CMD_6_bm  (1<<6)  /* Command bit 6 mask. */
+#define NVMCTRL_CMD_6_bp  6  /* Command bit 6 position. */
+
+/* NVMCTRL.CTRLB  bit masks and bit positions */
+#define NVMCTRL_APPCODEWP_bm  0x01  /* Application Code Write Protect bit mask. */
+#define NVMCTRL_APPCODEWP_bp  0  /* Application Code Write Protect bit position. */
+#define NVMCTRL_BOOTRP_bm  0x02  /* Boot Read Protect bit mask. */
+#define NVMCTRL_BOOTRP_bp  1  /* Boot Read Protect bit position. */
+#define NVMCTRL_APPDATAWP_bm  0x04  /* Application Data Write Protect bit mask. */
+#define NVMCTRL_APPDATAWP_bp  2  /* Application Data Write Protect bit position. */
+#define NVMCTRL_EEWP_bm  0x08  /* EEPROM Write Protect bit mask. */
+#define NVMCTRL_EEWP_bp  3  /* EEPROM Write Protect bit position. */
+#define NVMCTRL_FLMAP_gm  0x30  /* Flash Mapping in Data space group mask. */
+#define NVMCTRL_FLMAP_gp  4  /* Flash Mapping in Data space group position. */
+#define NVMCTRL_FLMAP_0_bm  (1<<4)  /* Flash Mapping in Data space bit 0 mask. */
+#define NVMCTRL_FLMAP_0_bp  4  /* Flash Mapping in Data space bit 0 position. */
+#define NVMCTRL_FLMAP_1_bm  (1<<5)  /* Flash Mapping in Data space bit 1 mask. */
+#define NVMCTRL_FLMAP_1_bp  5  /* Flash Mapping in Data space bit 1 position. */
+#define NVMCTRL_FLMAPLOCK_bm  0x80  /* Flash Mapping Lock bit mask. */
+#define NVMCTRL_FLMAPLOCK_bp  7  /* Flash Mapping Lock bit position. */
+
+/* NVMCTRL.INTCTRL  bit masks and bit positions */
+#define NVMCTRL_EEREADY_bm  0x01  /* EEPROM Ready bit mask. */
+#define NVMCTRL_EEREADY_bp  0  /* EEPROM Ready bit position. */
+#define NVMCTRL_FLREADY_bm  0x02  /* Flash Ready bit mask. */
+#define NVMCTRL_FLREADY_bp  1  /* Flash Ready bit position. */
+
+/* NVMCTRL.INTFLAGS  bit masks and bit positions */
+/* NVMCTRL_EEREADY  is already defined. */
+/* NVMCTRL_FLREADY  is already defined. */
+
+/* NVMCTRL.STATUS  bit masks and bit positions */
+#define NVMCTRL_EEBUSY_bm  0x01  /* EEPROM busy bit mask. */
+#define NVMCTRL_EEBUSY_bp  0  /* EEPROM busy bit position. */
+#define NVMCTRL_FLBUSY_bm  0x02  /* Flash busy bit mask. */
+#define NVMCTRL_FLBUSY_bp  1  /* Flash busy bit position. */
+#define NVMCTRL_ERROR_gm  0x70  /* Write error group mask. */
+#define NVMCTRL_ERROR_gp  4  /* Write error group position. */
+#define NVMCTRL_ERROR_0_bm  (1<<4)  /* Write error bit 0 mask. */
+#define NVMCTRL_ERROR_0_bp  4  /* Write error bit 0 position. */
+#define NVMCTRL_ERROR_1_bm  (1<<5)  /* Write error bit 1 mask. */
+#define NVMCTRL_ERROR_1_bp  5  /* Write error bit 1 position. */
+#define NVMCTRL_ERROR_2_bm  (1<<6)  /* Write error bit 2 mask. */
+#define NVMCTRL_ERROR_2_bp  6  /* Write error bit 2 position. */
+
+
+/* PORT - I/O Ports */
+/* PORT.INTFLAGS  bit masks and bit positions */
+#define PORT_INT_gm  0xFF  /* Pin Interrupt Flag group mask. */
+#define PORT_INT_gp  0  /* Pin Interrupt Flag group position. */
+#define PORT_INT_0_bm  (1<<0)  /* Pin Interrupt Flag bit 0 mask. */
+#define PORT_INT_0_bp  0  /* Pin Interrupt Flag bit 0 position. */
+#define PORT_INT0_bm  PORT_INT_0_bm  /* This define is deprecated and should not be used */
+#define PORT_INT0_bp  PORT_INT_0_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_1_bm  (1<<1)  /* Pin Interrupt Flag bit 1 mask. */
+#define PORT_INT_1_bp  1  /* Pin Interrupt Flag bit 1 position. */
+#define PORT_INT1_bm  PORT_INT_1_bm  /* This define is deprecated and should not be used */
+#define PORT_INT1_bp  PORT_INT_1_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_2_bm  (1<<2)  /* Pin Interrupt Flag bit 2 mask. */
+#define PORT_INT_2_bp  2  /* Pin Interrupt Flag bit 2 position. */
+#define PORT_INT2_bm  PORT_INT_2_bm  /* This define is deprecated and should not be used */
+#define PORT_INT2_bp  PORT_INT_2_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_3_bm  (1<<3)  /* Pin Interrupt Flag bit 3 mask. */
+#define PORT_INT_3_bp  3  /* Pin Interrupt Flag bit 3 position. */
+#define PORT_INT3_bm  PORT_INT_3_bm  /* This define is deprecated and should not be used */
+#define PORT_INT3_bp  PORT_INT_3_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_4_bm  (1<<4)  /* Pin Interrupt Flag bit 4 mask. */
+#define PORT_INT_4_bp  4  /* Pin Interrupt Flag bit 4 position. */
+#define PORT_INT4_bm  PORT_INT_4_bm  /* This define is deprecated and should not be used */
+#define PORT_INT4_bp  PORT_INT_4_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_5_bm  (1<<5)  /* Pin Interrupt Flag bit 5 mask. */
+#define PORT_INT_5_bp  5  /* Pin Interrupt Flag bit 5 position. */
+#define PORT_INT5_bm  PORT_INT_5_bm  /* This define is deprecated and should not be used */
+#define PORT_INT5_bp  PORT_INT_5_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_6_bm  (1<<6)  /* Pin Interrupt Flag bit 6 mask. */
+#define PORT_INT_6_bp  6  /* Pin Interrupt Flag bit 6 position. */
+#define PORT_INT6_bm  PORT_INT_6_bm  /* This define is deprecated and should not be used */
+#define PORT_INT6_bp  PORT_INT_6_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_7_bm  (1<<7)  /* Pin Interrupt Flag bit 7 mask. */
+#define PORT_INT_7_bp  7  /* Pin Interrupt Flag bit 7 position. */
+#define PORT_INT7_bm  PORT_INT_7_bm  /* This define is deprecated and should not be used */
+#define PORT_INT7_bp  PORT_INT_7_bp  /* This define is deprecated and should not be used */
+
+/* PORT.PORTCTRL  bit masks and bit positions */
+#define PORT_SRL_bm  0x01  /* Slew Rate Limit Enable bit mask. */
+#define PORT_SRL_bp  0  /* Slew Rate Limit Enable bit position. */
+
+/* PORT.PINCONFIG  bit masks and bit positions */
+#define PORT_ISC_gm  0x07  /* Input/Sense Configuration group mask. */
+#define PORT_ISC_gp  0  /* Input/Sense Configuration group position. */
+#define PORT_ISC_0_bm  (1<<0)  /* Input/Sense Configuration bit 0 mask. */
+#define PORT_ISC_0_bp  0  /* Input/Sense Configuration bit 0 position. */
+#define PORT_ISC_1_bm  (1<<1)  /* Input/Sense Configuration bit 1 mask. */
+#define PORT_ISC_1_bp  1  /* Input/Sense Configuration bit 1 position. */
+#define PORT_ISC_2_bm  (1<<2)  /* Input/Sense Configuration bit 2 mask. */
+#define PORT_ISC_2_bp  2  /* Input/Sense Configuration bit 2 position. */
+#define PORT_PULLUPEN_bm  0x08  /* Pullup enable bit mask. */
+#define PORT_PULLUPEN_bp  3  /* Pullup enable bit position. */
+#define PORT_INLVL_bm  0x40  /* Input Level Select bit mask. */
+#define PORT_INLVL_bp  6  /* Input Level Select bit position. */
+#define PORT_INVEN_bm  0x80  /* Inverted I/O Enable bit mask. */
+#define PORT_INVEN_bp  7  /* Inverted I/O Enable bit position. */
+
+/* PORT.PIN0CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN1CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN2CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN3CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN4CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN5CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN6CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN7CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.EVGENCTRL  bit masks and bit positions */
+#define PORT_EVGEN0SEL_gm  0x07  /* Event Generator 0 Select group mask. */
+#define PORT_EVGEN0SEL_gp  0  /* Event Generator 0 Select group position. */
+#define PORT_EVGEN0SEL_0_bm  (1<<0)  /* Event Generator 0 Select bit 0 mask. */
+#define PORT_EVGEN0SEL_0_bp  0  /* Event Generator 0 Select bit 0 position. */
+#define PORT_EVGEN0SEL_1_bm  (1<<1)  /* Event Generator 0 Select bit 1 mask. */
+#define PORT_EVGEN0SEL_1_bp  1  /* Event Generator 0 Select bit 1 position. */
+#define PORT_EVGEN0SEL_2_bm  (1<<2)  /* Event Generator 0 Select bit 2 mask. */
+#define PORT_EVGEN0SEL_2_bp  2  /* Event Generator 0 Select bit 2 position. */
+#define PORT_EVGEN1SEL_gm  0x70  /* Event Generator 1 Select group mask. */
+#define PORT_EVGEN1SEL_gp  4  /* Event Generator 1 Select group position. */
+#define PORT_EVGEN1SEL_0_bm  (1<<4)  /* Event Generator 1 Select bit 0 mask. */
+#define PORT_EVGEN1SEL_0_bp  4  /* Event Generator 1 Select bit 0 position. */
+#define PORT_EVGEN1SEL_1_bm  (1<<5)  /* Event Generator 1 Select bit 1 mask. */
+#define PORT_EVGEN1SEL_1_bp  5  /* Event Generator 1 Select bit 1 position. */
+#define PORT_EVGEN1SEL_2_bm  (1<<6)  /* Event Generator 1 Select bit 2 mask. */
+#define PORT_EVGEN1SEL_2_bp  6  /* Event Generator 1 Select bit 2 position. */
+
+
+/* PORTMUX - Port Multiplexer */
+/* PORTMUX.EVSYSROUTEA  bit masks and bit positions */
+#define PORTMUX_EVOUTA_bm  0x01  /* Event Output A bit mask. */
+#define PORTMUX_EVOUTA_bp  0  /* Event Output A bit position. */
+#define PORTMUX_EVOUTC_bm  0x04  /* Event Output C bit mask. */
+#define PORTMUX_EVOUTC_bp  2  /* Event Output C bit position. */
+#define PORTMUX_EVOUTD_bm  0x08  /* Event Output D bit mask. */
+#define PORTMUX_EVOUTD_bp  3  /* Event Output D bit position. */
+#define PORTMUX_EVOUTF_bm  0x20  /* Event Output F bit mask. */
+#define PORTMUX_EVOUTF_bp  5  /* Event Output F bit position. */
+
+/* PORTMUX.CCLROUTEA  bit masks and bit positions */
+#define PORTMUX_LUT0_bm  0x01  /* CCL Look-Up Table 0 Signals bit mask. */
+#define PORTMUX_LUT0_bp  0  /* CCL Look-Up Table 0 Signals bit position. */
+#define PORTMUX_LUT1_bm  0x02  /* CCL Look-Up Table 1 Signals bit mask. */
+#define PORTMUX_LUT1_bp  1  /* CCL Look-Up Table 1 Signals bit position. */
+#define PORTMUX_LUT2_bm  0x04  /* CCL Look-Up Table 2 Signals bit mask. */
+#define PORTMUX_LUT2_bp  2  /* CCL Look-Up Table 2 Signals bit position. */
+
+/* PORTMUX.USARTROUTEA  bit masks and bit positions */
+#define PORTMUX_USART0_gm  0x07  /* USART0 Routing group mask. */
+#define PORTMUX_USART0_gp  0  /* USART0 Routing group position. */
+#define PORTMUX_USART0_0_bm  (1<<0)  /* USART0 Routing bit 0 mask. */
+#define PORTMUX_USART0_0_bp  0  /* USART0 Routing bit 0 position. */
+#define PORTMUX_USART0_1_bm  (1<<1)  /* USART0 Routing bit 1 mask. */
+#define PORTMUX_USART0_1_bp  1  /* USART0 Routing bit 1 position. */
+#define PORTMUX_USART0_2_bm  (1<<2)  /* USART0 Routing bit 2 mask. */
+#define PORTMUX_USART0_2_bp  2  /* USART0 Routing bit 2 position. */
+#define PORTMUX_USART1_gm  0x18  /* USART1 Routing group mask. */
+#define PORTMUX_USART1_gp  3  /* USART1 Routing group position. */
+#define PORTMUX_USART1_0_bm  (1<<3)  /* USART1 Routing bit 0 mask. */
+#define PORTMUX_USART1_0_bp  3  /* USART1 Routing bit 0 position. */
+#define PORTMUX_USART1_1_bm  (1<<4)  /* USART1 Routing bit 1 mask. */
+#define PORTMUX_USART1_1_bp  4  /* USART1 Routing bit 1 position. */
+
+/* PORTMUX.USARTROUTEB  bit masks and bit positions */
+#define PORTMUX_USART2_gm  0x03  /* USART2 Routing group mask. */
+#define PORTMUX_USART2_gp  0  /* USART2 Routing group position. */
+#define PORTMUX_USART2_0_bm  (1<<0)  /* USART2 Routing bit 0 mask. */
+#define PORTMUX_USART2_0_bp  0  /* USART2 Routing bit 0 position. */
+#define PORTMUX_USART2_1_bm  (1<<1)  /* USART2 Routing bit 1 mask. */
+#define PORTMUX_USART2_1_bp  1  /* USART2 Routing bit 1 position. */
+
+/* PORTMUX.SPIROUTEA  bit masks and bit positions */
+#define PORTMUX_SPI0_gm  0x07  /* SPI0 Signals group mask. */
+#define PORTMUX_SPI0_gp  0  /* SPI0 Signals group position. */
+#define PORTMUX_SPI0_0_bm  (1<<0)  /* SPI0 Signals bit 0 mask. */
+#define PORTMUX_SPI0_0_bp  0  /* SPI0 Signals bit 0 position. */
+#define PORTMUX_SPI0_1_bm  (1<<1)  /* SPI0 Signals bit 1 mask. */
+#define PORTMUX_SPI0_1_bp  1  /* SPI0 Signals bit 1 position. */
+#define PORTMUX_SPI0_2_bm  (1<<2)  /* SPI0 Signals bit 2 mask. */
+#define PORTMUX_SPI0_2_bp  2  /* SPI0 Signals bit 2 position. */
+
+/* PORTMUX.TWIROUTEA  bit masks and bit positions */
+#define PORTMUX_TWI0_gm  0x03  /* TWI0 Signals group mask. */
+#define PORTMUX_TWI0_gp  0  /* TWI0 Signals group position. */
+#define PORTMUX_TWI0_0_bm  (1<<0)  /* TWI0 Signals bit 0 mask. */
+#define PORTMUX_TWI0_0_bp  0  /* TWI0 Signals bit 0 position. */
+#define PORTMUX_TWI0_1_bm  (1<<1)  /* TWI0 Signals bit 1 mask. */
+#define PORTMUX_TWI0_1_bp  1  /* TWI0 Signals bit 1 position. */
+
+/* PORTMUX.TCAROUTEA  bit masks and bit positions */
+#define PORTMUX_TCA0_gm  0x07  /* TCA0 Signals group mask. */
+#define PORTMUX_TCA0_gp  0  /* TCA0 Signals group position. */
+#define PORTMUX_TCA0_0_bm  (1<<0)  /* TCA0 Signals bit 0 mask. */
+#define PORTMUX_TCA0_0_bp  0  /* TCA0 Signals bit 0 position. */
+#define PORTMUX_TCA0_1_bm  (1<<1)  /* TCA0 Signals bit 1 mask. */
+#define PORTMUX_TCA0_1_bp  1  /* TCA0 Signals bit 1 position. */
+#define PORTMUX_TCA0_2_bm  (1<<2)  /* TCA0 Signals bit 2 mask. */
+#define PORTMUX_TCA0_2_bp  2  /* TCA0 Signals bit 2 position. */
+#define PORTMUX_TCA1_gm  0x38  /* TCA1 Signals group mask. */
+#define PORTMUX_TCA1_gp  3  /* TCA1 Signals group position. */
+#define PORTMUX_TCA1_0_bm  (1<<3)  /* TCA1 Signals bit 0 mask. */
+#define PORTMUX_TCA1_0_bp  3  /* TCA1 Signals bit 0 position. */
+#define PORTMUX_TCA1_1_bm  (1<<4)  /* TCA1 Signals bit 1 mask. */
+#define PORTMUX_TCA1_1_bp  4  /* TCA1 Signals bit 1 position. */
+#define PORTMUX_TCA1_2_bm  (1<<5)  /* TCA1 Signals bit 2 mask. */
+#define PORTMUX_TCA1_2_bp  5  /* TCA1 Signals bit 2 position. */
+
+/* PORTMUX.TCBROUTEA  bit masks and bit positions */
+#define PORTMUX_TCB0_bm  0x01  /* TCB0 Output bit mask. */
+#define PORTMUX_TCB0_bp  0  /* TCB0 Output bit position. */
+#define PORTMUX_TCB1_bm  0x02  /* TCB1 Output bit mask. */
+#define PORTMUX_TCB1_bp  1  /* TCB1 Output bit position. */
+#define PORTMUX_TCB2_bm  0x04  /* TCB2 Output bit mask. */
+#define PORTMUX_TCB2_bp  2  /* TCB2 Output bit position. */
+#define PORTMUX_TCB3_bm  0x08  /* TCB3 Output bit mask. */
+#define PORTMUX_TCB3_bp  3  /* TCB3 Output bit position. */
+
+/* PORTMUX.ACROUTEA  bit masks and bit positions */
+#define PORTMUX_AC0_bm  0x01  /* Analog Comparator 0 Output bit mask. */
+#define PORTMUX_AC0_bp  0  /* Analog Comparator 0 Output bit position. */
+#define PORTMUX_AC1_bm  0x02  /* Analog Comparator 1 Output bit mask. */
+#define PORTMUX_AC1_bp  1  /* Analog Comparator 1 Output bit position. */
+
+
+/* RSTCTRL - Reset controller */
+/* RSTCTRL.RSTFR  bit masks and bit positions */
+#define RSTCTRL_PORF_bm  0x01  /* Power on Reset flag bit mask. */
+#define RSTCTRL_PORF_bp  0  /* Power on Reset flag bit position. */
+#define RSTCTRL_BORF_bm  0x02  /* Brown out detector Reset flag bit mask. */
+#define RSTCTRL_BORF_bp  1  /* Brown out detector Reset flag bit position. */
+#define RSTCTRL_EXTRF_bm  0x04  /* External Reset flag bit mask. */
+#define RSTCTRL_EXTRF_bp  2  /* External Reset flag bit position. */
+#define RSTCTRL_WDRF_bm  0x08  /* Watch dog Reset flag bit mask. */
+#define RSTCTRL_WDRF_bp  3  /* Watch dog Reset flag bit position. */
+#define RSTCTRL_SWRF_bm  0x10  /* Software Reset flag bit mask. */
+#define RSTCTRL_SWRF_bp  4  /* Software Reset flag bit position. */
+#define RSTCTRL_UPDIRF_bm  0x20  /* UPDI Reset flag bit mask. */
+#define RSTCTRL_UPDIRF_bp  5  /* UPDI Reset flag bit position. */
+
+/* RSTCTRL.SWRR  bit masks and bit positions */
+#define RSTCTRL_SWRE_bm  0x01  /* Software Reset Enable bit mask. */
+#define RSTCTRL_SWRE_bp  0  /* Software Reset Enable bit position. */
+
+
+/* RTC - Real-Time Counter */
+/* RTC.CTRLA  bit masks and bit positions */
+#define RTC_RTCEN_bm  0x01  /* Enable bit mask. */
+#define RTC_RTCEN_bp  0  /* Enable bit position. */
+#define RTC_CORREN_bm  0x04  /* Correction enable bit mask. */
+#define RTC_CORREN_bp  2  /* Correction enable bit position. */
+#define RTC_PRESCALER_gm  0x78  /* Prescaling Factor group mask. */
+#define RTC_PRESCALER_gp  3  /* Prescaling Factor group position. */
+#define RTC_PRESCALER_0_bm  (1<<3)  /* Prescaling Factor bit 0 mask. */
+#define RTC_PRESCALER_0_bp  3  /* Prescaling Factor bit 0 position. */
+#define RTC_PRESCALER_1_bm  (1<<4)  /* Prescaling Factor bit 1 mask. */
+#define RTC_PRESCALER_1_bp  4  /* Prescaling Factor bit 1 position. */
+#define RTC_PRESCALER_2_bm  (1<<5)  /* Prescaling Factor bit 2 mask. */
+#define RTC_PRESCALER_2_bp  5  /* Prescaling Factor bit 2 position. */
+#define RTC_PRESCALER_3_bm  (1<<6)  /* Prescaling Factor bit 3 mask. */
+#define RTC_PRESCALER_3_bp  6  /* Prescaling Factor bit 3 position. */
+#define RTC_RUNSTDBY_bm  0x80  /* Run In Standby bit mask. */
+#define RTC_RUNSTDBY_bp  7  /* Run In Standby bit position. */
+
+/* RTC.STATUS  bit masks and bit positions */
+#define RTC_CTRLABUSY_bm  0x01  /* CTRLA Synchronization Busy Flag bit mask. */
+#define RTC_CTRLABUSY_bp  0  /* CTRLA Synchronization Busy Flag bit position. */
+#define RTC_CNTBUSY_bm  0x02  /* Count Synchronization Busy Flag bit mask. */
+#define RTC_CNTBUSY_bp  1  /* Count Synchronization Busy Flag bit position. */
+#define RTC_PERBUSY_bm  0x04  /* Period Synchronization Busy Flag bit mask. */
+#define RTC_PERBUSY_bp  2  /* Period Synchronization Busy Flag bit position. */
+#define RTC_CMPBUSY_bm  0x08  /* Comparator Synchronization Busy Flag bit mask. */
+#define RTC_CMPBUSY_bp  3  /* Comparator Synchronization Busy Flag bit position. */
+
+/* RTC.INTCTRL  bit masks and bit positions */
+#define RTC_OVF_bm  0x01  /* Overflow Interrupt enable bit mask. */
+#define RTC_OVF_bp  0  /* Overflow Interrupt enable bit position. */
+#define RTC_CMP_bm  0x02  /* Compare Match Interrupt enable bit mask. */
+#define RTC_CMP_bp  1  /* Compare Match Interrupt enable bit position. */
+
+/* RTC.INTFLAGS  bit masks and bit positions */
+/* RTC_OVF  is already defined. */
+/* RTC_CMP  is already defined. */
+
+/* RTC.DBGCTRL  bit masks and bit positions */
+#define RTC_DBGRUN_bm  0x01  /* Run in debug bit mask. */
+#define RTC_DBGRUN_bp  0  /* Run in debug bit position. */
+
+/* RTC.CALIB  bit masks and bit positions */
+#define RTC_ERROR_gm  0x7F  /* Error Correction Value group mask. */
+#define RTC_ERROR_gp  0  /* Error Correction Value group position. */
+#define RTC_ERROR_0_bm  (1<<0)  /* Error Correction Value bit 0 mask. */
+#define RTC_ERROR_0_bp  0  /* Error Correction Value bit 0 position. */
+#define RTC_ERROR_1_bm  (1<<1)  /* Error Correction Value bit 1 mask. */
+#define RTC_ERROR_1_bp  1  /* Error Correction Value bit 1 position. */
+#define RTC_ERROR_2_bm  (1<<2)  /* Error Correction Value bit 2 mask. */
+#define RTC_ERROR_2_bp  2  /* Error Correction Value bit 2 position. */
+#define RTC_ERROR_3_bm  (1<<3)  /* Error Correction Value bit 3 mask. */
+#define RTC_ERROR_3_bp  3  /* Error Correction Value bit 3 position. */
+#define RTC_ERROR_4_bm  (1<<4)  /* Error Correction Value bit 4 mask. */
+#define RTC_ERROR_4_bp  4  /* Error Correction Value bit 4 position. */
+#define RTC_ERROR_5_bm  (1<<5)  /* Error Correction Value bit 5 mask. */
+#define RTC_ERROR_5_bp  5  /* Error Correction Value bit 5 position. */
+#define RTC_ERROR_6_bm  (1<<6)  /* Error Correction Value bit 6 mask. */
+#define RTC_ERROR_6_bp  6  /* Error Correction Value bit 6 position. */
+#define RTC_SIGN_bm  0x80  /* Error Correction Sign Bit bit mask. */
+#define RTC_SIGN_bp  7  /* Error Correction Sign Bit bit position. */
+
+/* RTC.CLKSEL  bit masks and bit positions */
+#define RTC_CLKSEL_gm  0x03  /* Clock Select group mask. */
+#define RTC_CLKSEL_gp  0  /* Clock Select group position. */
+#define RTC_CLKSEL_0_bm  (1<<0)  /* Clock Select bit 0 mask. */
+#define RTC_CLKSEL_0_bp  0  /* Clock Select bit 0 position. */
+#define RTC_CLKSEL_1_bm  (1<<1)  /* Clock Select bit 1 mask. */
+#define RTC_CLKSEL_1_bp  1  /* Clock Select bit 1 position. */
+
+/* RTC.PITCTRLA  bit masks and bit positions */
+#define RTC_PITEN_bm  0x01  /* Enable bit mask. */
+#define RTC_PITEN_bp  0  /* Enable bit position. */
+#define RTC_PERIOD_gm  0x78  /* Period group mask. */
+#define RTC_PERIOD_gp  3  /* Period group position. */
+#define RTC_PERIOD_0_bm  (1<<3)  /* Period bit 0 mask. */
+#define RTC_PERIOD_0_bp  3  /* Period bit 0 position. */
+#define RTC_PERIOD_1_bm  (1<<4)  /* Period bit 1 mask. */
+#define RTC_PERIOD_1_bp  4  /* Period bit 1 position. */
+#define RTC_PERIOD_2_bm  (1<<5)  /* Period bit 2 mask. */
+#define RTC_PERIOD_2_bp  5  /* Period bit 2 position. */
+#define RTC_PERIOD_3_bm  (1<<6)  /* Period bit 3 mask. */
+#define RTC_PERIOD_3_bp  6  /* Period bit 3 position. */
+
+/* RTC.PITSTATUS  bit masks and bit positions */
+#define RTC_CTRLBUSY_bm  0x01  /* CTRLA Synchronization Busy Flag bit mask. */
+#define RTC_CTRLBUSY_bp  0  /* CTRLA Synchronization Busy Flag bit position. */
+
+/* RTC.PITINTCTRL  bit masks and bit positions */
+#define RTC_PI_bm  0x01  /* Periodic Interrupt bit mask. */
+#define RTC_PI_bp  0  /* Periodic Interrupt bit position. */
+
+/* RTC.PITINTFLAGS  bit masks and bit positions */
+/* RTC_PI  is already defined. */
+
+/* RTC.PITDBGCTRL  bit masks and bit positions */
+/* RTC_DBGRUN  is already defined. */
+
+/* RTC.PITEVGENCTRLA  bit masks and bit positions */
+#define RTC_EVGEN0SEL_gm  0x0F  /* Event Generation 0 Select group mask. */
+#define RTC_EVGEN0SEL_gp  0  /* Event Generation 0 Select group position. */
+#define RTC_EVGEN0SEL_0_bm  (1<<0)  /* Event Generation 0 Select bit 0 mask. */
+#define RTC_EVGEN0SEL_0_bp  0  /* Event Generation 0 Select bit 0 position. */
+#define RTC_EVGEN0SEL_1_bm  (1<<1)  /* Event Generation 0 Select bit 1 mask. */
+#define RTC_EVGEN0SEL_1_bp  1  /* Event Generation 0 Select bit 1 position. */
+#define RTC_EVGEN0SEL_2_bm  (1<<2)  /* Event Generation 0 Select bit 2 mask. */
+#define RTC_EVGEN0SEL_2_bp  2  /* Event Generation 0 Select bit 2 position. */
+#define RTC_EVGEN0SEL_3_bm  (1<<3)  /* Event Generation 0 Select bit 3 mask. */
+#define RTC_EVGEN0SEL_3_bp  3  /* Event Generation 0 Select bit 3 position. */
+#define RTC_EVGEN1SEL_gm  0xF0  /* Event Generation 1 Select group mask. */
+#define RTC_EVGEN1SEL_gp  4  /* Event Generation 1 Select group position. */
+#define RTC_EVGEN1SEL_0_bm  (1<<4)  /* Event Generation 1 Select bit 0 mask. */
+#define RTC_EVGEN1SEL_0_bp  4  /* Event Generation 1 Select bit 0 position. */
+#define RTC_EVGEN1SEL_1_bm  (1<<5)  /* Event Generation 1 Select bit 1 mask. */
+#define RTC_EVGEN1SEL_1_bp  5  /* Event Generation 1 Select bit 1 position. */
+#define RTC_EVGEN1SEL_2_bm  (1<<6)  /* Event Generation 1 Select bit 2 mask. */
+#define RTC_EVGEN1SEL_2_bp  6  /* Event Generation 1 Select bit 2 position. */
+#define RTC_EVGEN1SEL_3_bm  (1<<7)  /* Event Generation 1 Select bit 3 mask. */
+#define RTC_EVGEN1SEL_3_bp  7  /* Event Generation 1 Select bit 3 position. */
+
+
+
+/* SLPCTRL - Sleep Controller */
+/* SLPCTRL.CTRLA  bit masks and bit positions */
+#define SLPCTRL_SEN_bm  0x01  /* Sleep enable bit mask. */
+#define SLPCTRL_SEN_bp  0  /* Sleep enable bit position. */
+#define SLPCTRL_SMODE_gm  0x06  /* Sleep mode group mask. */
+#define SLPCTRL_SMODE_gp  1  /* Sleep mode group position. */
+#define SLPCTRL_SMODE_0_bm  (1<<1)  /* Sleep mode bit 0 mask. */
+#define SLPCTRL_SMODE_0_bp  1  /* Sleep mode bit 0 position. */
+#define SLPCTRL_SMODE_1_bm  (1<<2)  /* Sleep mode bit 1 mask. */
+#define SLPCTRL_SMODE_1_bp  2  /* Sleep mode bit 1 position. */
+
+
+/* SPI - Serial Peripheral Interface */
+/* SPI.CTRLA  bit masks and bit positions */
+#define SPI_ENABLE_bm  0x01  /* Enable Module bit mask. */
+#define SPI_ENABLE_bp  0  /* Enable Module bit position. */
+#define SPI_PRESC_gm  0x06  /* Prescaler group mask. */
+#define SPI_PRESC_gp  1  /* Prescaler group position. */
+#define SPI_PRESC_0_bm  (1<<1)  /* Prescaler bit 0 mask. */
+#define SPI_PRESC_0_bp  1  /* Prescaler bit 0 position. */
+#define SPI_PRESC_1_bm  (1<<2)  /* Prescaler bit 1 mask. */
+#define SPI_PRESC_1_bp  2  /* Prescaler bit 1 position. */
+#define SPI_CLK2X_bm  0x10  /* Enable Double Speed bit mask. */
+#define SPI_CLK2X_bp  4  /* Enable Double Speed bit position. */
+#define SPI_MASTER_bm  0x20  /* Host Operation Enable bit mask. */
+#define SPI_MASTER_bp  5  /* Host Operation Enable bit position. */
+#define SPI_DORD_bm  0x40  /* Data Order Setting bit mask. */
+#define SPI_DORD_bp  6  /* Data Order Setting bit position. */
+
+/* SPI.CTRLB  bit masks and bit positions */
+#define SPI_MODE_gm  0x03  /* SPI Mode group mask. */
+#define SPI_MODE_gp  0  /* SPI Mode group position. */
+#define SPI_MODE_0_bm  (1<<0)  /* SPI Mode bit 0 mask. */
+#define SPI_MODE_0_bp  0  /* SPI Mode bit 0 position. */
+#define SPI_MODE_1_bm  (1<<1)  /* SPI Mode bit 1 mask. */
+#define SPI_MODE_1_bp  1  /* SPI Mode bit 1 position. */
+#define SPI_SSD_bm  0x04  /* SPI Select Disable bit mask. */
+#define SPI_SSD_bp  2  /* SPI Select Disable bit position. */
+#define SPI_BUFWR_bm  0x40  /* Buffer Mode Wait for Receive bit mask. */
+#define SPI_BUFWR_bp  6  /* Buffer Mode Wait for Receive bit position. */
+#define SPI_BUFEN_bm  0x80  /* Buffer Mode Enable bit mask. */
+#define SPI_BUFEN_bp  7  /* Buffer Mode Enable bit position. */
+
+/* SPI.INTCTRL  bit masks and bit positions */
+#define SPI_IE_bm  0x01  /* Interrupt Enable bit mask. */
+#define SPI_IE_bp  0  /* Interrupt Enable bit position. */
+#define SPI_SSIE_bm  0x10  /* SPI Select Trigger Interrupt Enable bit mask. */
+#define SPI_SSIE_bp  4  /* SPI Select Trigger Interrupt Enable bit position. */
+#define SPI_DREIE_bm  0x20  /* Data Register Empty Interrupt Enable bit mask. */
+#define SPI_DREIE_bp  5  /* Data Register Empty Interrupt Enable bit position. */
+#define SPI_TXCIE_bm  0x40  /* Transfer Complete Interrupt Enable bit mask. */
+#define SPI_TXCIE_bp  6  /* Transfer Complete Interrupt Enable bit position. */
+#define SPI_RXCIE_bm  0x80  /* Receive Complete Interrupt Enable bit mask. */
+#define SPI_RXCIE_bp  7  /* Receive Complete Interrupt Enable bit position. */
+
+/* SPI.INTFLAGS  bit masks and bit positions */
+#define SPI_BUFOVF_bm  0x01  /* Buffer Overflow bit mask. */
+#define SPI_BUFOVF_bp  0  /* Buffer Overflow bit position. */
+#define SPI_SSIF_bm  0x10  /* SPI Select Trigger Interrupt Flag bit mask. */
+#define SPI_SSIF_bp  4  /* SPI Select Trigger Interrupt Flag bit position. */
+#define SPI_DREIF_bm  0x20  /* Data Register Empty Interrupt Flag bit mask. */
+#define SPI_DREIF_bp  5  /* Data Register Empty Interrupt Flag bit position. */
+#define SPI_TXCIF_bm  0x40  /* Transfer Complete Interrupt Flag bit mask. */
+#define SPI_TXCIF_bp  6  /* Transfer Complete Interrupt Flag bit position. */
+#define SPI_WRCOL_bm  0x40  /* Write Collision bit mask. */
+#define SPI_WRCOL_bp  6  /* Write Collision bit position. */
+#define SPI_RXCIF_bm  0x80  /* Receive Complete Interrupt Flag bit mask. */
+#define SPI_RXCIF_bp  7  /* Receive Complete Interrupt Flag bit position. */
+#define SPI_IF_bm  0x80  /* Interrupt Flag bit mask. */
+#define SPI_IF_bp  7  /* Interrupt Flag bit position. */
+
+
+/* SYSCFG - System Configuration Registers */
+/* SYSCFG.REVID  bit masks and bit positions */
+#define SYSCFG_MINOR_gm  0x0F  /* Minor Revision group mask. */
+#define SYSCFG_MINOR_gp  0  /* Minor Revision group position. */
+#define SYSCFG_MINOR_0_bm  (1<<0)  /* Minor Revision bit 0 mask. */
+#define SYSCFG_MINOR_0_bp  0  /* Minor Revision bit 0 position. */
+#define SYSCFG_MINOR_1_bm  (1<<1)  /* Minor Revision bit 1 mask. */
+#define SYSCFG_MINOR_1_bp  1  /* Minor Revision bit 1 position. */
+#define SYSCFG_MINOR_2_bm  (1<<2)  /* Minor Revision bit 2 mask. */
+#define SYSCFG_MINOR_2_bp  2  /* Minor Revision bit 2 position. */
+#define SYSCFG_MINOR_3_bm  (1<<3)  /* Minor Revision bit 3 mask. */
+#define SYSCFG_MINOR_3_bp  3  /* Minor Revision bit 3 position. */
+#define SYSCFG_MAJOR_gm  0xF0  /* Major Revision group mask. */
+#define SYSCFG_MAJOR_gp  4  /* Major Revision group position. */
+#define SYSCFG_MAJOR_0_bm  (1<<4)  /* Major Revision bit 0 mask. */
+#define SYSCFG_MAJOR_0_bp  4  /* Major Revision bit 0 position. */
+#define SYSCFG_MAJOR_1_bm  (1<<5)  /* Major Revision bit 1 mask. */
+#define SYSCFG_MAJOR_1_bp  5  /* Major Revision bit 1 position. */
+#define SYSCFG_MAJOR_2_bm  (1<<6)  /* Major Revision bit 2 mask. */
+#define SYSCFG_MAJOR_2_bp  6  /* Major Revision bit 2 position. */
+#define SYSCFG_MAJOR_3_bm  (1<<7)  /* Major Revision bit 3 mask. */
+#define SYSCFG_MAJOR_3_bp  7  /* Major Revision bit 3 position. */
+
+/* SYSCFG.OCDMCTRL  bit masks and bit positions */
+#define SYSCFG_OCDM_gm  0xFF  /* OCD Message group mask. */
+#define SYSCFG_OCDM_gp  0  /* OCD Message group position. */
+#define SYSCFG_OCDM_0_bm  (1<<0)  /* OCD Message bit 0 mask. */
+#define SYSCFG_OCDM_0_bp  0  /* OCD Message bit 0 position. */
+#define SYSCFG_OCDM_1_bm  (1<<1)  /* OCD Message bit 1 mask. */
+#define SYSCFG_OCDM_1_bp  1  /* OCD Message bit 1 position. */
+#define SYSCFG_OCDM_2_bm  (1<<2)  /* OCD Message bit 2 mask. */
+#define SYSCFG_OCDM_2_bp  2  /* OCD Message bit 2 position. */
+#define SYSCFG_OCDM_3_bm  (1<<3)  /* OCD Message bit 3 mask. */
+#define SYSCFG_OCDM_3_bp  3  /* OCD Message bit 3 position. */
+#define SYSCFG_OCDM_4_bm  (1<<4)  /* OCD Message bit 4 mask. */
+#define SYSCFG_OCDM_4_bp  4  /* OCD Message bit 4 position. */
+#define SYSCFG_OCDM_5_bm  (1<<5)  /* OCD Message bit 5 mask. */
+#define SYSCFG_OCDM_5_bp  5  /* OCD Message bit 5 position. */
+#define SYSCFG_OCDM_6_bm  (1<<6)  /* OCD Message bit 6 mask. */
+#define SYSCFG_OCDM_6_bp  6  /* OCD Message bit 6 position. */
+#define SYSCFG_OCDM_7_bm  (1<<7)  /* OCD Message bit 7 mask. */
+#define SYSCFG_OCDM_7_bp  7  /* OCD Message bit 7 position. */
+
+/* SYSCFG.OCDMSTATUS  bit masks and bit positions */
+#define SYSCFG_VALID_bm  0x01  /* OCD Message Valid bit mask. */
+#define SYSCFG_VALID_bp  0  /* OCD Message Valid bit position. */
+
+
+/* TCA - 16-bit Timer/Counter Type A */
+/* TCA_SINGLE.CTRLA  bit masks and bit positions */
+#define TCA_SINGLE_ENABLE_bm  0x01  /* Module Enable bit mask. */
+#define TCA_SINGLE_ENABLE_bp  0  /* Module Enable bit position. */
+#define TCA_SINGLE_CLKSEL_gm  0x0E  /* Clock Selection group mask. */
+#define TCA_SINGLE_CLKSEL_gp  1  /* Clock Selection group position. */
+#define TCA_SINGLE_CLKSEL_0_bm  (1<<1)  /* Clock Selection bit 0 mask. */
+#define TCA_SINGLE_CLKSEL_0_bp  1  /* Clock Selection bit 0 position. */
+#define TCA_SINGLE_CLKSEL_1_bm  (1<<2)  /* Clock Selection bit 1 mask. */
+#define TCA_SINGLE_CLKSEL_1_bp  2  /* Clock Selection bit 1 position. */
+#define TCA_SINGLE_CLKSEL_2_bm  (1<<3)  /* Clock Selection bit 2 mask. */
+#define TCA_SINGLE_CLKSEL_2_bp  3  /* Clock Selection bit 2 position. */
+#define TCA_SINGLE_RUNSTDBY_bm  0x80  /* Run in Standby bit mask. */
+#define TCA_SINGLE_RUNSTDBY_bp  7  /* Run in Standby bit position. */
+
+/* TCA_SINGLE.CTRLB  bit masks and bit positions */
+#define TCA_SINGLE_WGMODE_gm  0x07  /* Waveform generation mode group mask. */
+#define TCA_SINGLE_WGMODE_gp  0  /* Waveform generation mode group position. */
+#define TCA_SINGLE_WGMODE_0_bm  (1<<0)  /* Waveform generation mode bit 0 mask. */
+#define TCA_SINGLE_WGMODE_0_bp  0  /* Waveform generation mode bit 0 position. */
+#define TCA_SINGLE_WGMODE_1_bm  (1<<1)  /* Waveform generation mode bit 1 mask. */
+#define TCA_SINGLE_WGMODE_1_bp  1  /* Waveform generation mode bit 1 position. */
+#define TCA_SINGLE_WGMODE_2_bm  (1<<2)  /* Waveform generation mode bit 2 mask. */
+#define TCA_SINGLE_WGMODE_2_bp  2  /* Waveform generation mode bit 2 position. */
+#define TCA_SINGLE_ALUPD_bm  0x08  /* Auto Lock Update bit mask. */
+#define TCA_SINGLE_ALUPD_bp  3  /* Auto Lock Update bit position. */
+#define TCA_SINGLE_CMP0EN_bm  0x10  /* Compare 0 Enable bit mask. */
+#define TCA_SINGLE_CMP0EN_bp  4  /* Compare 0 Enable bit position. */
+#define TCA_SINGLE_CMP1EN_bm  0x20  /* Compare 1 Enable bit mask. */
+#define TCA_SINGLE_CMP1EN_bp  5  /* Compare 1 Enable bit position. */
+#define TCA_SINGLE_CMP2EN_bm  0x40  /* Compare 2 Enable bit mask. */
+#define TCA_SINGLE_CMP2EN_bp  6  /* Compare 2 Enable bit position. */
+
+/* TCA_SINGLE.CTRLC  bit masks and bit positions */
+#define TCA_SINGLE_CMP0OV_bm  0x01  /* Compare 0 Waveform Output Value bit mask. */
+#define TCA_SINGLE_CMP0OV_bp  0  /* Compare 0 Waveform Output Value bit position. */
+#define TCA_SINGLE_CMP1OV_bm  0x02  /* Compare 1 Waveform Output Value bit mask. */
+#define TCA_SINGLE_CMP1OV_bp  1  /* Compare 1 Waveform Output Value bit position. */
+#define TCA_SINGLE_CMP2OV_bm  0x04  /* Compare 2 Waveform Output Value bit mask. */
+#define TCA_SINGLE_CMP2OV_bp  2  /* Compare 2 Waveform Output Value bit position. */
+
+/* TCA_SINGLE.CTRLD  bit masks and bit positions */
+#define TCA_SINGLE_SPLITM_bm  0x01  /* Split Mode Enable bit mask. */
+#define TCA_SINGLE_SPLITM_bp  0  /* Split Mode Enable bit position. */
+
+/* TCA_SINGLE.CTRLECLR  bit masks and bit positions */
+#define TCA_SINGLE_DIR_bm  0x01  /* Direction bit mask. */
+#define TCA_SINGLE_DIR_bp  0  /* Direction bit position. */
+#define TCA_SINGLE_LUPD_bm  0x02  /* Lock Update bit mask. */
+#define TCA_SINGLE_LUPD_bp  1  /* Lock Update bit position. */
+#define TCA_SINGLE_CMD_gm  0x0C  /* Command group mask. */
+#define TCA_SINGLE_CMD_gp  2  /* Command group position. */
+#define TCA_SINGLE_CMD_0_bm  (1<<2)  /* Command bit 0 mask. */
+#define TCA_SINGLE_CMD_0_bp  2  /* Command bit 0 position. */
+#define TCA_SINGLE_CMD_1_bm  (1<<3)  /* Command bit 1 mask. */
+#define TCA_SINGLE_CMD_1_bp  3  /* Command bit 1 position. */
+
+/* TCA_SINGLE.CTRLESET  bit masks and bit positions */
+/* TCA_SINGLE_DIR  is already defined. */
+/* TCA_SINGLE_LUPD  is already defined. */
+/* TCA_SINGLE_CMD  is already defined. */
+
+/* TCA_SINGLE.CTRLFCLR  bit masks and bit positions */
+#define TCA_SINGLE_PERBV_bm  0x01  /* Period Buffer Valid bit mask. */
+#define TCA_SINGLE_PERBV_bp  0  /* Period Buffer Valid bit position. */
+#define TCA_SINGLE_CMP0BV_bm  0x02  /* Compare 0 Buffer Valid bit mask. */
+#define TCA_SINGLE_CMP0BV_bp  1  /* Compare 0 Buffer Valid bit position. */
+#define TCA_SINGLE_CMP1BV_bm  0x04  /* Compare 1 Buffer Valid bit mask. */
+#define TCA_SINGLE_CMP1BV_bp  2  /* Compare 1 Buffer Valid bit position. */
+#define TCA_SINGLE_CMP2BV_bm  0x08  /* Compare 2 Buffer Valid bit mask. */
+#define TCA_SINGLE_CMP2BV_bp  3  /* Compare 2 Buffer Valid bit position. */
+
+/* TCA_SINGLE.CTRLFSET  bit masks and bit positions */
+/* TCA_SINGLE_PERBV  is already defined. */
+/* TCA_SINGLE_CMP0BV  is already defined. */
+/* TCA_SINGLE_CMP1BV  is already defined. */
+/* TCA_SINGLE_CMP2BV  is already defined. */
+
+/* TCA_SINGLE.EVCTRL  bit masks and bit positions */
+#define TCA_SINGLE_CNTAEI_bm  0x01  /* Count on Event Input A bit mask. */
+#define TCA_SINGLE_CNTAEI_bp  0  /* Count on Event Input A bit position. */
+#define TCA_SINGLE_EVACTA_gm  0x0E  /* Event Action A group mask. */
+#define TCA_SINGLE_EVACTA_gp  1  /* Event Action A group position. */
+#define TCA_SINGLE_EVACTA_0_bm  (1<<1)  /* Event Action A bit 0 mask. */
+#define TCA_SINGLE_EVACTA_0_bp  1  /* Event Action A bit 0 position. */
+#define TCA_SINGLE_EVACTA_1_bm  (1<<2)  /* Event Action A bit 1 mask. */
+#define TCA_SINGLE_EVACTA_1_bp  2  /* Event Action A bit 1 position. */
+#define TCA_SINGLE_EVACTA_2_bm  (1<<3)  /* Event Action A bit 2 mask. */
+#define TCA_SINGLE_EVACTA_2_bp  3  /* Event Action A bit 2 position. */
+#define TCA_SINGLE_CNTBEI_bm  0x10  /* Count on Event Input B bit mask. */
+#define TCA_SINGLE_CNTBEI_bp  4  /* Count on Event Input B bit position. */
+#define TCA_SINGLE_EVACTB_gm  0xE0  /* Event Action B group mask. */
+#define TCA_SINGLE_EVACTB_gp  5  /* Event Action B group position. */
+#define TCA_SINGLE_EVACTB_0_bm  (1<<5)  /* Event Action B bit 0 mask. */
+#define TCA_SINGLE_EVACTB_0_bp  5  /* Event Action B bit 0 position. */
+#define TCA_SINGLE_EVACTB_1_bm  (1<<6)  /* Event Action B bit 1 mask. */
+#define TCA_SINGLE_EVACTB_1_bp  6  /* Event Action B bit 1 position. */
+#define TCA_SINGLE_EVACTB_2_bm  (1<<7)  /* Event Action B bit 2 mask. */
+#define TCA_SINGLE_EVACTB_2_bp  7  /* Event Action B bit 2 position. */
+
+/* TCA_SINGLE.INTCTRL  bit masks and bit positions */
+#define TCA_SINGLE_OVF_bm  0x01  /* Overflow Interrupt bit mask. */
+#define TCA_SINGLE_OVF_bp  0  /* Overflow Interrupt bit position. */
+#define TCA_SINGLE_CMP0_bm  0x10  /* Compare 0 Interrupt bit mask. */
+#define TCA_SINGLE_CMP0_bp  4  /* Compare 0 Interrupt bit position. */
+#define TCA_SINGLE_CMP1_bm  0x20  /* Compare 1 Interrupt bit mask. */
+#define TCA_SINGLE_CMP1_bp  5  /* Compare 1 Interrupt bit position. */
+#define TCA_SINGLE_CMP2_bm  0x40  /* Compare 2 Interrupt bit mask. */
+#define TCA_SINGLE_CMP2_bp  6  /* Compare 2 Interrupt bit position. */
+
+/* TCA_SINGLE.INTFLAGS  bit masks and bit positions */
+/* TCA_SINGLE_OVF  is already defined. */
+/* TCA_SINGLE_CMP0  is already defined. */
+/* TCA_SINGLE_CMP1  is already defined. */
+/* TCA_SINGLE_CMP2  is already defined. */
+
+/* TCA_SINGLE.DBGCTRL  bit masks and bit positions */
+#define TCA_SINGLE_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define TCA_SINGLE_DBGRUN_bp  0  /* Debug Run bit position. */
+
+/* TCA_SPLIT.CTRLA  bit masks and bit positions */
+#define TCA_SPLIT_ENABLE_bm  0x01  /* Module Enable bit mask. */
+#define TCA_SPLIT_ENABLE_bp  0  /* Module Enable bit position. */
+#define TCA_SPLIT_CLKSEL_gm  0x0E  /* Clock Selection group mask. */
+#define TCA_SPLIT_CLKSEL_gp  1  /* Clock Selection group position. */
+#define TCA_SPLIT_CLKSEL_0_bm  (1<<1)  /* Clock Selection bit 0 mask. */
+#define TCA_SPLIT_CLKSEL_0_bp  1  /* Clock Selection bit 0 position. */
+#define TCA_SPLIT_CLKSEL_1_bm  (1<<2)  /* Clock Selection bit 1 mask. */
+#define TCA_SPLIT_CLKSEL_1_bp  2  /* Clock Selection bit 1 position. */
+#define TCA_SPLIT_CLKSEL_2_bm  (1<<3)  /* Clock Selection bit 2 mask. */
+#define TCA_SPLIT_CLKSEL_2_bp  3  /* Clock Selection bit 2 position. */
+#define TCA_SPLIT_RUNSTDBY_bm  0x80  /* Run in Standby bit mask. */
+#define TCA_SPLIT_RUNSTDBY_bp  7  /* Run in Standby bit position. */
+
+/* TCA_SPLIT.CTRLB  bit masks and bit positions */
+#define TCA_SPLIT_LCMP0EN_bm  0x01  /* Low Compare 0 Enable bit mask. */
+#define TCA_SPLIT_LCMP0EN_bp  0  /* Low Compare 0 Enable bit position. */
+#define TCA_SPLIT_LCMP1EN_bm  0x02  /* Low Compare 1 Enable bit mask. */
+#define TCA_SPLIT_LCMP1EN_bp  1  /* Low Compare 1 Enable bit position. */
+#define TCA_SPLIT_LCMP2EN_bm  0x04  /* Low Compare 2 Enable bit mask. */
+#define TCA_SPLIT_LCMP2EN_bp  2  /* Low Compare 2 Enable bit position. */
+#define TCA_SPLIT_HCMP0EN_bm  0x10  /* High Compare 0 Enable bit mask. */
+#define TCA_SPLIT_HCMP0EN_bp  4  /* High Compare 0 Enable bit position. */
+#define TCA_SPLIT_HCMP1EN_bm  0x20  /* High Compare 1 Enable bit mask. */
+#define TCA_SPLIT_HCMP1EN_bp  5  /* High Compare 1 Enable bit position. */
+#define TCA_SPLIT_HCMP2EN_bm  0x40  /* High Compare 2 Enable bit mask. */
+#define TCA_SPLIT_HCMP2EN_bp  6  /* High Compare 2 Enable bit position. */
+
+/* TCA_SPLIT.CTRLC  bit masks and bit positions */
+#define TCA_SPLIT_LCMP0OV_bm  0x01  /* Low Compare 0 Output Value bit mask. */
+#define TCA_SPLIT_LCMP0OV_bp  0  /* Low Compare 0 Output Value bit position. */
+#define TCA_SPLIT_LCMP1OV_bm  0x02  /* Low Compare 1 Output Value bit mask. */
+#define TCA_SPLIT_LCMP1OV_bp  1  /* Low Compare 1 Output Value bit position. */
+#define TCA_SPLIT_LCMP2OV_bm  0x04  /* Low Compare 2 Output Value bit mask. */
+#define TCA_SPLIT_LCMP2OV_bp  2  /* Low Compare 2 Output Value bit position. */
+#define TCA_SPLIT_HCMP0OV_bm  0x10  /* High Compare 0 Output Value bit mask. */
+#define TCA_SPLIT_HCMP0OV_bp  4  /* High Compare 0 Output Value bit position. */
+#define TCA_SPLIT_HCMP1OV_bm  0x20  /* High Compare 1 Output Value bit mask. */
+#define TCA_SPLIT_HCMP1OV_bp  5  /* High Compare 1 Output Value bit position. */
+#define TCA_SPLIT_HCMP2OV_bm  0x40  /* High Compare 2 Output Value bit mask. */
+#define TCA_SPLIT_HCMP2OV_bp  6  /* High Compare 2 Output Value bit position. */
+
+/* TCA_SPLIT.CTRLD  bit masks and bit positions */
+#define TCA_SPLIT_SPLITM_bm  0x01  /* Split Mode Enable bit mask. */
+#define TCA_SPLIT_SPLITM_bp  0  /* Split Mode Enable bit position. */
+
+/* TCA_SPLIT.CTRLECLR  bit masks and bit positions */
+#define TCA_SPLIT_CMDEN_gm  0x03  /* Command Enable group mask. */
+#define TCA_SPLIT_CMDEN_gp  0  /* Command Enable group position. */
+#define TCA_SPLIT_CMDEN_0_bm  (1<<0)  /* Command Enable bit 0 mask. */
+#define TCA_SPLIT_CMDEN_0_bp  0  /* Command Enable bit 0 position. */
+#define TCA_SPLIT_CMDEN_1_bm  (1<<1)  /* Command Enable bit 1 mask. */
+#define TCA_SPLIT_CMDEN_1_bp  1  /* Command Enable bit 1 position. */
+#define TCA_SPLIT_CMD_gm  0x0C  /* Command group mask. */
+#define TCA_SPLIT_CMD_gp  2  /* Command group position. */
+#define TCA_SPLIT_CMD_0_bm  (1<<2)  /* Command bit 0 mask. */
+#define TCA_SPLIT_CMD_0_bp  2  /* Command bit 0 position. */
+#define TCA_SPLIT_CMD_1_bm  (1<<3)  /* Command bit 1 mask. */
+#define TCA_SPLIT_CMD_1_bp  3  /* Command bit 1 position. */
+
+/* TCA_SPLIT.CTRLESET  bit masks and bit positions */
+/* TCA_SPLIT_CMDEN  is already defined. */
+/* TCA_SPLIT_CMD  is already defined. */
+
+/* TCA_SPLIT.INTCTRL  bit masks and bit positions */
+#define TCA_SPLIT_LUNF_bm  0x01  /* Low Underflow Interrupt Enable bit mask. */
+#define TCA_SPLIT_LUNF_bp  0  /* Low Underflow Interrupt Enable bit position. */
+#define TCA_SPLIT_HUNF_bm  0x02  /* High Underflow Interrupt Enable bit mask. */
+#define TCA_SPLIT_HUNF_bp  1  /* High Underflow Interrupt Enable bit position. */
+#define TCA_SPLIT_LCMP0_bm  0x10  /* Low Compare 0 Interrupt Enable bit mask. */
+#define TCA_SPLIT_LCMP0_bp  4  /* Low Compare 0 Interrupt Enable bit position. */
+#define TCA_SPLIT_LCMP1_bm  0x20  /* Low Compare 1 Interrupt Enable bit mask. */
+#define TCA_SPLIT_LCMP1_bp  5  /* Low Compare 1 Interrupt Enable bit position. */
+#define TCA_SPLIT_LCMP2_bm  0x40  /* Low Compare 2 Interrupt Enable bit mask. */
+#define TCA_SPLIT_LCMP2_bp  6  /* Low Compare 2 Interrupt Enable bit position. */
+
+/* TCA_SPLIT.INTFLAGS  bit masks and bit positions */
+/* TCA_SPLIT_LUNF  is already defined. */
+/* TCA_SPLIT_HUNF  is already defined. */
+/* TCA_SPLIT_LCMP0  is already defined. */
+/* TCA_SPLIT_LCMP1  is already defined. */
+/* TCA_SPLIT_LCMP2  is already defined. */
+
+/* TCA_SPLIT.DBGCTRL  bit masks and bit positions */
+#define TCA_SPLIT_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define TCA_SPLIT_DBGRUN_bp  0  /* Debug Run bit position. */
+
+
+/* TCB - 16-bit Timer Type B */
+/* TCB.CTRLA  bit masks and bit positions */
+#define TCB_ENABLE_bm  0x01  /* Enable bit mask. */
+#define TCB_ENABLE_bp  0  /* Enable bit position. */
+#define TCB_CLKSEL_gm  0x0E  /* Clock Select group mask. */
+#define TCB_CLKSEL_gp  1  /* Clock Select group position. */
+#define TCB_CLKSEL_0_bm  (1<<1)  /* Clock Select bit 0 mask. */
+#define TCB_CLKSEL_0_bp  1  /* Clock Select bit 0 position. */
+#define TCB_CLKSEL_1_bm  (1<<2)  /* Clock Select bit 1 mask. */
+#define TCB_CLKSEL_1_bp  2  /* Clock Select bit 1 position. */
+#define TCB_CLKSEL_2_bm  (1<<3)  /* Clock Select bit 2 mask. */
+#define TCB_CLKSEL_2_bp  3  /* Clock Select bit 2 position. */
+#define TCB_SYNCUPD_bm  0x10  /* Synchronize Update bit mask. */
+#define TCB_SYNCUPD_bp  4  /* Synchronize Update bit position. */
+#define TCB_CASCADE_bm  0x20  /* Cascade two timers bit mask. */
+#define TCB_CASCADE_bp  5  /* Cascade two timers bit position. */
+#define TCB_RUNSTDBY_bm  0x40  /* Run Standby bit mask. */
+#define TCB_RUNSTDBY_bp  6  /* Run Standby bit position. */
+
+/* TCB.CTRLB  bit masks and bit positions */
+#define TCB_CNTMODE_gm  0x07  /* Timer Mode group mask. */
+#define TCB_CNTMODE_gp  0  /* Timer Mode group position. */
+#define TCB_CNTMODE_0_bm  (1<<0)  /* Timer Mode bit 0 mask. */
+#define TCB_CNTMODE_0_bp  0  /* Timer Mode bit 0 position. */
+#define TCB_CNTMODE_1_bm  (1<<1)  /* Timer Mode bit 1 mask. */
+#define TCB_CNTMODE_1_bp  1  /* Timer Mode bit 1 position. */
+#define TCB_CNTMODE_2_bm  (1<<2)  /* Timer Mode bit 2 mask. */
+#define TCB_CNTMODE_2_bp  2  /* Timer Mode bit 2 position. */
+#define TCB_CCMPEN_bm  0x10  /* Pin Output Enable bit mask. */
+#define TCB_CCMPEN_bp  4  /* Pin Output Enable bit position. */
+#define TCB_CCMPINIT_bm  0x20  /* Pin Initial State bit mask. */
+#define TCB_CCMPINIT_bp  5  /* Pin Initial State bit position. */
+#define TCB_ASYNC_bm  0x40  /* Asynchronous Enable bit mask. */
+#define TCB_ASYNC_bp  6  /* Asynchronous Enable bit position. */
+
+/* TCB.EVCTRL  bit masks and bit positions */
+#define TCB_CAPTEI_bm  0x01  /* Event Input Enable bit mask. */
+#define TCB_CAPTEI_bp  0  /* Event Input Enable bit position. */
+#define TCB_EDGE_bm  0x10  /* Event Edge bit mask. */
+#define TCB_EDGE_bp  4  /* Event Edge bit position. */
+#define TCB_FILTER_bm  0x40  /* Input Capture Noise Cancellation Filter bit mask. */
+#define TCB_FILTER_bp  6  /* Input Capture Noise Cancellation Filter bit position. */
+
+/* TCB.INTCTRL  bit masks and bit positions */
+#define TCB_CAPT_bm  0x01  /* Capture or Timeout bit mask. */
+#define TCB_CAPT_bp  0  /* Capture or Timeout bit position. */
+#define TCB_OVF_bm  0x02  /* Overflow bit mask. */
+#define TCB_OVF_bp  1  /* Overflow bit position. */
+
+/* TCB.INTFLAGS  bit masks and bit positions */
+/* TCB_CAPT  is already defined. */
+/* TCB_OVF  is already defined. */
+
+/* TCB.STATUS  bit masks and bit positions */
+#define TCB_RUN_bm  0x01  /* Run bit mask. */
+#define TCB_RUN_bp  0  /* Run bit position. */
+
+/* TCB.DBGCTRL  bit masks and bit positions */
+#define TCB_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define TCB_DBGRUN_bp  0  /* Debug Run bit position. */
+
+
+/* TWI - Two-Wire Interface */
+/* TWI.CTRLA  bit masks and bit positions */
+#define TWI_FMEN_bm  0x01  /* Fast-mode Enable bit mask. */
+#define TWI_FMEN_bp  0  /* Fast-mode Enable bit position. */
+#define TWI_FMPEN_bm  0x02  /* Fast-mode Plus Enable bit mask. */
+#define TWI_FMPEN_bp  1  /* Fast-mode Plus Enable bit position. */
+#define TWI_SDAHOLD_gm  0x0C  /* SDA Hold Time group mask. */
+#define TWI_SDAHOLD_gp  2  /* SDA Hold Time group position. */
+#define TWI_SDAHOLD_0_bm  (1<<2)  /* SDA Hold Time bit 0 mask. */
+#define TWI_SDAHOLD_0_bp  2  /* SDA Hold Time bit 0 position. */
+#define TWI_SDAHOLD_1_bm  (1<<3)  /* SDA Hold Time bit 1 mask. */
+#define TWI_SDAHOLD_1_bp  3  /* SDA Hold Time bit 1 position. */
+#define TWI_SDASETUP_bm  0x10  /* SDA Setup Time bit mask. */
+#define TWI_SDASETUP_bp  4  /* SDA Setup Time bit position. */
+#define TWI_INPUTLVL_bm  0x40  /* Input voltage transition level bit mask. */
+#define TWI_INPUTLVL_bp  6  /* Input voltage transition level bit position. */
+
+/* TWI.DUALCTRL  bit masks and bit positions */
+#define TWI_ENABLE_bm  0x01  /* Enable bit mask. */
+#define TWI_ENABLE_bp  0  /* Enable bit position. */
+/* TWI_FMPEN  is already defined. */
+/* TWI_SDAHOLD  is already defined. */
+/* TWI_INPUTLVL  is already defined. */
+
+/* TWI.DBGCTRL  bit masks and bit positions */
+#define TWI_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define TWI_DBGRUN_bp  0  /* Debug Run bit position. */
+
+/* TWI.MCTRLA  bit masks and bit positions */
+/* TWI_ENABLE  is already defined. */
+#define TWI_SMEN_bm  0x02  /* Smart Mode Enable bit mask. */
+#define TWI_SMEN_bp  1  /* Smart Mode Enable bit position. */
+#define TWI_TIMEOUT_gm  0x0C  /* Inactive Bus Time-Out group mask. */
+#define TWI_TIMEOUT_gp  2  /* Inactive Bus Time-Out group position. */
+#define TWI_TIMEOUT_0_bm  (1<<2)  /* Inactive Bus Time-Out bit 0 mask. */
+#define TWI_TIMEOUT_0_bp  2  /* Inactive Bus Time-Out bit 0 position. */
+#define TWI_TIMEOUT_1_bm  (1<<3)  /* Inactive Bus Time-Out bit 1 mask. */
+#define TWI_TIMEOUT_1_bp  3  /* Inactive Bus Time-Out bit 1 position. */
+#define TWI_QCEN_bm  0x10  /* Quick Command Enable bit mask. */
+#define TWI_QCEN_bp  4  /* Quick Command Enable bit position. */
+#define TWI_WIEN_bm  0x40  /* Write Interrupt Enable bit mask. */
+#define TWI_WIEN_bp  6  /* Write Interrupt Enable bit position. */
+#define TWI_RIEN_bm  0x80  /* Read Interrupt Enable bit mask. */
+#define TWI_RIEN_bp  7  /* Read Interrupt Enable bit position. */
+
+/* TWI.MCTRLB  bit masks and bit positions */
+#define TWI_MCMD_gm  0x03  /* Command group mask. */
+#define TWI_MCMD_gp  0  /* Command group position. */
+#define TWI_MCMD_0_bm  (1<<0)  /* Command bit 0 mask. */
+#define TWI_MCMD_0_bp  0  /* Command bit 0 position. */
+#define TWI_MCMD_1_bm  (1<<1)  /* Command bit 1 mask. */
+#define TWI_MCMD_1_bp  1  /* Command bit 1 position. */
+#define TWI_ACKACT_bm  0x04  /* Acknowledge Action bit mask. */
+#define TWI_ACKACT_bp  2  /* Acknowledge Action bit position. */
+#define TWI_FLUSH_bm  0x08  /* Flush bit mask. */
+#define TWI_FLUSH_bp  3  /* Flush bit position. */
+
+/* TWI.MSTATUS  bit masks and bit positions */
+#define TWI_BUSSTATE_gm  0x03  /* Bus State group mask. */
+#define TWI_BUSSTATE_gp  0  /* Bus State group position. */
+#define TWI_BUSSTATE_0_bm  (1<<0)  /* Bus State bit 0 mask. */
+#define TWI_BUSSTATE_0_bp  0  /* Bus State bit 0 position. */
+#define TWI_BUSSTATE_1_bm  (1<<1)  /* Bus State bit 1 mask. */
+#define TWI_BUSSTATE_1_bp  1  /* Bus State bit 1 position. */
+#define TWI_BUSERR_bm  0x04  /* Bus Error bit mask. */
+#define TWI_BUSERR_bp  2  /* Bus Error bit position. */
+#define TWI_ARBLOST_bm  0x08  /* Arbitration Lost bit mask. */
+#define TWI_ARBLOST_bp  3  /* Arbitration Lost bit position. */
+#define TWI_RXACK_bm  0x10  /* Received Acknowledge bit mask. */
+#define TWI_RXACK_bp  4  /* Received Acknowledge bit position. */
+#define TWI_CLKHOLD_bm  0x20  /* Clock Hold bit mask. */
+#define TWI_CLKHOLD_bp  5  /* Clock Hold bit position. */
+#define TWI_WIF_bm  0x40  /* Write Interrupt Flag bit mask. */
+#define TWI_WIF_bp  6  /* Write Interrupt Flag bit position. */
+#define TWI_RIF_bm  0x80  /* Read Interrupt Flag bit mask. */
+#define TWI_RIF_bp  7  /* Read Interrupt Flag bit position. */
+
+/* TWI.MBAUD  bit masks and bit positions */
+#define TWI_BAUD_gm  0xFF  /* Baud Rate group mask. */
+#define TWI_BAUD_gp  0  /* Baud Rate group position. */
+#define TWI_BAUD_0_bm  (1<<0)  /* Baud Rate bit 0 mask. */
+#define TWI_BAUD_0_bp  0  /* Baud Rate bit 0 position. */
+#define TWI_BAUD_1_bm  (1<<1)  /* Baud Rate bit 1 mask. */
+#define TWI_BAUD_1_bp  1  /* Baud Rate bit 1 position. */
+#define TWI_BAUD_2_bm  (1<<2)  /* Baud Rate bit 2 mask. */
+#define TWI_BAUD_2_bp  2  /* Baud Rate bit 2 position. */
+#define TWI_BAUD_3_bm  (1<<3)  /* Baud Rate bit 3 mask. */
+#define TWI_BAUD_3_bp  3  /* Baud Rate bit 3 position. */
+#define TWI_BAUD_4_bm  (1<<4)  /* Baud Rate bit 4 mask. */
+#define TWI_BAUD_4_bp  4  /* Baud Rate bit 4 position. */
+#define TWI_BAUD_5_bm  (1<<5)  /* Baud Rate bit 5 mask. */
+#define TWI_BAUD_5_bp  5  /* Baud Rate bit 5 position. */
+#define TWI_BAUD_6_bm  (1<<6)  /* Baud Rate bit 6 mask. */
+#define TWI_BAUD_6_bp  6  /* Baud Rate bit 6 position. */
+#define TWI_BAUD_7_bm  (1<<7)  /* Baud Rate bit 7 mask. */
+#define TWI_BAUD_7_bp  7  /* Baud Rate bit 7 position. */
+
+/* TWI.MADDR  bit masks and bit positions */
+#define TWI_ADDR_gm  0xFF  /* Address group mask. */
+#define TWI_ADDR_gp  0  /* Address group position. */
+#define TWI_ADDR_0_bm  (1<<0)  /* Address bit 0 mask. */
+#define TWI_ADDR_0_bp  0  /* Address bit 0 position. */
+#define TWI_ADDR_1_bm  (1<<1)  /* Address bit 1 mask. */
+#define TWI_ADDR_1_bp  1  /* Address bit 1 position. */
+#define TWI_ADDR_2_bm  (1<<2)  /* Address bit 2 mask. */
+#define TWI_ADDR_2_bp  2  /* Address bit 2 position. */
+#define TWI_ADDR_3_bm  (1<<3)  /* Address bit 3 mask. */
+#define TWI_ADDR_3_bp  3  /* Address bit 3 position. */
+#define TWI_ADDR_4_bm  (1<<4)  /* Address bit 4 mask. */
+#define TWI_ADDR_4_bp  4  /* Address bit 4 position. */
+#define TWI_ADDR_5_bm  (1<<5)  /* Address bit 5 mask. */
+#define TWI_ADDR_5_bp  5  /* Address bit 5 position. */
+#define TWI_ADDR_6_bm  (1<<6)  /* Address bit 6 mask. */
+#define TWI_ADDR_6_bp  6  /* Address bit 6 position. */
+#define TWI_ADDR_7_bm  (1<<7)  /* Address bit 7 mask. */
+#define TWI_ADDR_7_bp  7  /* Address bit 7 position. */
+
+/* TWI.MDATA  bit masks and bit positions */
+#define TWI_DATA_gm  0xFF  /* Data group mask. */
+#define TWI_DATA_gp  0  /* Data group position. */
+#define TWI_DATA_0_bm  (1<<0)  /* Data bit 0 mask. */
+#define TWI_DATA_0_bp  0  /* Data bit 0 position. */
+#define TWI_DATA_1_bm  (1<<1)  /* Data bit 1 mask. */
+#define TWI_DATA_1_bp  1  /* Data bit 1 position. */
+#define TWI_DATA_2_bm  (1<<2)  /* Data bit 2 mask. */
+#define TWI_DATA_2_bp  2  /* Data bit 2 position. */
+#define TWI_DATA_3_bm  (1<<3)  /* Data bit 3 mask. */
+#define TWI_DATA_3_bp  3  /* Data bit 3 position. */
+#define TWI_DATA_4_bm  (1<<4)  /* Data bit 4 mask. */
+#define TWI_DATA_4_bp  4  /* Data bit 4 position. */
+#define TWI_DATA_5_bm  (1<<5)  /* Data bit 5 mask. */
+#define TWI_DATA_5_bp  5  /* Data bit 5 position. */
+#define TWI_DATA_6_bm  (1<<6)  /* Data bit 6 mask. */
+#define TWI_DATA_6_bp  6  /* Data bit 6 position. */
+#define TWI_DATA_7_bm  (1<<7)  /* Data bit 7 mask. */
+#define TWI_DATA_7_bp  7  /* Data bit 7 position. */
+
+/* TWI.SCTRLA  bit masks and bit positions */
+/* TWI_ENABLE  is already defined. */
+/* TWI_SMEN  is already defined. */
+#define TWI_PMEN_bm  0x04  /* Address Recognition Mode bit mask. */
+#define TWI_PMEN_bp  2  /* Address Recognition Mode bit position. */
+#define TWI_PIEN_bm  0x20  /* Stop Interrupt Enable bit mask. */
+#define TWI_PIEN_bp  5  /* Stop Interrupt Enable bit position. */
+#define TWI_APIEN_bm  0x40  /* Address or Stop Interrupt Enable bit mask. */
+#define TWI_APIEN_bp  6  /* Address or Stop Interrupt Enable bit position. */
+#define TWI_DIEN_bm  0x80  /* Data Interrupt Enable bit mask. */
+#define TWI_DIEN_bp  7  /* Data Interrupt Enable bit position. */
+
+/* TWI.SCTRLB  bit masks and bit positions */
+#define TWI_SCMD_gm  0x03  /* Command group mask. */
+#define TWI_SCMD_gp  0  /* Command group position. */
+#define TWI_SCMD_0_bm  (1<<0)  /* Command bit 0 mask. */
+#define TWI_SCMD_0_bp  0  /* Command bit 0 position. */
+#define TWI_SCMD_1_bm  (1<<1)  /* Command bit 1 mask. */
+#define TWI_SCMD_1_bp  1  /* Command bit 1 position. */
+/* TWI_ACKACT  is already defined. */
+
+/* TWI.SSTATUS  bit masks and bit positions */
+#define TWI_AP_bm  0x01  /* Address or Stop bit mask. */
+#define TWI_AP_bp  0  /* Address or Stop bit position. */
+#define TWI_DIR_bm  0x02  /* Read/Write Direction bit mask. */
+#define TWI_DIR_bp  1  /* Read/Write Direction bit position. */
+/* TWI_BUSERR  is already defined. */
+#define TWI_COLL_bm  0x08  /* Collision bit mask. */
+#define TWI_COLL_bp  3  /* Collision bit position. */
+/* TWI_RXACK  is already defined. */
+/* TWI_CLKHOLD  is already defined. */
+#define TWI_APIF_bm  0x40  /* Address or Stop Interrupt Flag bit mask. */
+#define TWI_APIF_bp  6  /* Address or Stop Interrupt Flag bit position. */
+#define TWI_DIF_bm  0x80  /* Data Interrupt Flag bit mask. */
+#define TWI_DIF_bp  7  /* Data Interrupt Flag bit position. */
+
+/* TWI.SADDR  bit masks and bit positions */
+/* TWI_ADDR  is already defined. */
+
+/* TWI.SDATA  bit masks and bit positions */
+/* TWI_DATA  is already defined. */
+
+/* TWI.SADDRMASK  bit masks and bit positions */
+#define TWI_ADDREN_bm  0x01  /* Address Mask Enable bit mask. */
+#define TWI_ADDREN_bp  0  /* Address Mask Enable bit position. */
+#define TWI_ADDRMASK_gm  0xFE  /* Address Mask group mask. */
+#define TWI_ADDRMASK_gp  1  /* Address Mask group position. */
+#define TWI_ADDRMASK_0_bm  (1<<1)  /* Address Mask bit 0 mask. */
+#define TWI_ADDRMASK_0_bp  1  /* Address Mask bit 0 position. */
+#define TWI_ADDRMASK_1_bm  (1<<2)  /* Address Mask bit 1 mask. */
+#define TWI_ADDRMASK_1_bp  2  /* Address Mask bit 1 position. */
+#define TWI_ADDRMASK_2_bm  (1<<3)  /* Address Mask bit 2 mask. */
+#define TWI_ADDRMASK_2_bp  3  /* Address Mask bit 2 position. */
+#define TWI_ADDRMASK_3_bm  (1<<4)  /* Address Mask bit 3 mask. */
+#define TWI_ADDRMASK_3_bp  4  /* Address Mask bit 3 position. */
+#define TWI_ADDRMASK_4_bm  (1<<5)  /* Address Mask bit 4 mask. */
+#define TWI_ADDRMASK_4_bp  5  /* Address Mask bit 4 position. */
+#define TWI_ADDRMASK_5_bm  (1<<6)  /* Address Mask bit 5 mask. */
+#define TWI_ADDRMASK_5_bp  6  /* Address Mask bit 5 position. */
+#define TWI_ADDRMASK_6_bm  (1<<7)  /* Address Mask bit 6 mask. */
+#define TWI_ADDRMASK_6_bp  7  /* Address Mask bit 6 position. */
+
+
+/* USART - Universal Synchronous and Asynchronous Receiver and Transmitter */
+/* USART.RXDATAL  bit masks and bit positions */
+#define USART_DATA_gm  0xFF  /* RX Data group mask. */
+#define USART_DATA_gp  0  /* RX Data group position. */
+#define USART_DATA_0_bm  (1<<0)  /* RX Data bit 0 mask. */
+#define USART_DATA_0_bp  0  /* RX Data bit 0 position. */
+#define USART_DATA_1_bm  (1<<1)  /* RX Data bit 1 mask. */
+#define USART_DATA_1_bp  1  /* RX Data bit 1 position. */
+#define USART_DATA_2_bm  (1<<2)  /* RX Data bit 2 mask. */
+#define USART_DATA_2_bp  2  /* RX Data bit 2 position. */
+#define USART_DATA_3_bm  (1<<3)  /* RX Data bit 3 mask. */
+#define USART_DATA_3_bp  3  /* RX Data bit 3 position. */
+#define USART_DATA_4_bm  (1<<4)  /* RX Data bit 4 mask. */
+#define USART_DATA_4_bp  4  /* RX Data bit 4 position. */
+#define USART_DATA_5_bm  (1<<5)  /* RX Data bit 5 mask. */
+#define USART_DATA_5_bp  5  /* RX Data bit 5 position. */
+#define USART_DATA_6_bm  (1<<6)  /* RX Data bit 6 mask. */
+#define USART_DATA_6_bp  6  /* RX Data bit 6 position. */
+#define USART_DATA_7_bm  (1<<7)  /* RX Data bit 7 mask. */
+#define USART_DATA_7_bp  7  /* RX Data bit 7 position. */
+
+/* USART.RXDATAH  bit masks and bit positions */
+#define USART_DATA8_bm  0x01  /* Receiver Data Register bit mask. */
+#define USART_DATA8_bp  0  /* Receiver Data Register bit position. */
+#define USART_PERR_bm  0x02  /* Parity Error bit mask. */
+#define USART_PERR_bp  1  /* Parity Error bit position. */
+#define USART_FERR_bm  0x04  /* Frame Error bit mask. */
+#define USART_FERR_bp  2  /* Frame Error bit position. */
+#define USART_BUFOVF_bm  0x40  /* Buffer Overflow bit mask. */
+#define USART_BUFOVF_bp  6  /* Buffer Overflow bit position. */
+#define USART_RXCIF_bm  0x80  /* Receive Complete Interrupt Flag bit mask. */
+#define USART_RXCIF_bp  7  /* Receive Complete Interrupt Flag bit position. */
+
+/* USART.TXDATAL  bit masks and bit positions */
+/* USART_DATA  is already defined. */
+
+/* USART.TXDATAH  bit masks and bit positions */
+/* USART_DATA8  is already defined. */
+
+/* USART.STATUS  bit masks and bit positions */
+#define USART_WFB_bm  0x01  /* Wait For Break bit mask. */
+#define USART_WFB_bp  0  /* Wait For Break bit position. */
+#define USART_BDF_bm  0x02  /* Break Detected Flag bit mask. */
+#define USART_BDF_bp  1  /* Break Detected Flag bit position. */
+#define USART_ISFIF_bm  0x08  /* Inconsistent Sync Field Interrupt Flag bit mask. */
+#define USART_ISFIF_bp  3  /* Inconsistent Sync Field Interrupt Flag bit position. */
+#define USART_RXSIF_bm  0x10  /* Receive Start Interrupt bit mask. */
+#define USART_RXSIF_bp  4  /* Receive Start Interrupt bit position. */
+#define USART_DREIF_bm  0x20  /* Data Register Empty Flag bit mask. */
+#define USART_DREIF_bp  5  /* Data Register Empty Flag bit position. */
+#define USART_TXCIF_bm  0x40  /* Transmit Interrupt Flag bit mask. */
+#define USART_TXCIF_bp  6  /* Transmit Interrupt Flag bit position. */
+/* USART_RXCIF  is already defined. */
+
+/* USART.CTRLA  bit masks and bit positions */
+#define USART_RS485_bm  0x01  /* RS485 Mode internal transmitter bit mask. */
+#define USART_RS485_bp  0  /* RS485 Mode internal transmitter bit position. */
+#define USART_ABEIE_bm  0x04  /* Auto-baud Error Interrupt Enable bit mask. */
+#define USART_ABEIE_bp  2  /* Auto-baud Error Interrupt Enable bit position. */
+#define USART_LBME_bm  0x08  /* Loop-back Mode Enable bit mask. */
+#define USART_LBME_bp  3  /* Loop-back Mode Enable bit position. */
+#define USART_RXSIE_bm  0x10  /* Receiver Start Frame Interrupt Enable bit mask. */
+#define USART_RXSIE_bp  4  /* Receiver Start Frame Interrupt Enable bit position. */
+#define USART_DREIE_bm  0x20  /* Data Register Empty Interrupt Enable bit mask. */
+#define USART_DREIE_bp  5  /* Data Register Empty Interrupt Enable bit position. */
+#define USART_TXCIE_bm  0x40  /* Transmit Complete Interrupt Enable bit mask. */
+#define USART_TXCIE_bp  6  /* Transmit Complete Interrupt Enable bit position. */
+#define USART_RXCIE_bm  0x80  /* Receive Complete Interrupt Enable bit mask. */
+#define USART_RXCIE_bp  7  /* Receive Complete Interrupt Enable bit position. */
+
+/* USART.CTRLB  bit masks and bit positions */
+#define USART_MPCM_bm  0x01  /* Multi-processor Communication Mode bit mask. */
+#define USART_MPCM_bp  0  /* Multi-processor Communication Mode bit position. */
+#define USART_RXMODE_gm  0x06  /* Receiver Mode group mask. */
+#define USART_RXMODE_gp  1  /* Receiver Mode group position. */
+#define USART_RXMODE_0_bm  (1<<1)  /* Receiver Mode bit 0 mask. */
+#define USART_RXMODE_0_bp  1  /* Receiver Mode bit 0 position. */
+#define USART_RXMODE_1_bm  (1<<2)  /* Receiver Mode bit 1 mask. */
+#define USART_RXMODE_1_bp  2  /* Receiver Mode bit 1 position. */
+#define USART_ODME_bm  0x08  /* Open Drain Mode Enable bit mask. */
+#define USART_ODME_bp  3  /* Open Drain Mode Enable bit position. */
+#define USART_SFDEN_bm  0x10  /* Start Frame Detection Enable bit mask. */
+#define USART_SFDEN_bp  4  /* Start Frame Detection Enable bit position. */
+#define USART_TXEN_bm  0x40  /* Transmitter Enable bit mask. */
+#define USART_TXEN_bp  6  /* Transmitter Enable bit position. */
+#define USART_RXEN_bm  0x80  /* Reciever enable bit mask. */
+#define USART_RXEN_bp  7  /* Reciever enable bit position. */
+
+/* USART.CTRLC  bit masks and bit positions */
+#define USART_UCPHA_bm  0x02  /* SPI Host Mode, Clock Phase bit mask. */
+#define USART_UCPHA_bp  1  /* SPI Host Mode, Clock Phase bit position. */
+#define USART_UDORD_bm  0x04  /* SPI Host Mode, Data Order bit mask. */
+#define USART_UDORD_bp  2  /* SPI Host Mode, Data Order bit position. */
+#define USART_CHSIZE_gm  0x07  /* Character Size group mask. */
+#define USART_CHSIZE_gp  0  /* Character Size group position. */
+#define USART_CHSIZE_0_bm  (1<<0)  /* Character Size bit 0 mask. */
+#define USART_CHSIZE_0_bp  0  /* Character Size bit 0 position. */
+#define USART_CHSIZE_1_bm  (1<<1)  /* Character Size bit 1 mask. */
+#define USART_CHSIZE_1_bp  1  /* Character Size bit 1 position. */
+#define USART_CHSIZE_2_bm  (1<<2)  /* Character Size bit 2 mask. */
+#define USART_CHSIZE_2_bp  2  /* Character Size bit 2 position. */
+#define USART_SBMODE_bm  0x08  /* Stop Bit Mode bit mask. */
+#define USART_SBMODE_bp  3  /* Stop Bit Mode bit position. */
+#define USART_PMODE_gm  0x30  /* Parity Mode group mask. */
+#define USART_PMODE_gp  4  /* Parity Mode group position. */
+#define USART_PMODE_0_bm  (1<<4)  /* Parity Mode bit 0 mask. */
+#define USART_PMODE_0_bp  4  /* Parity Mode bit 0 position. */
+#define USART_PMODE_1_bm  (1<<5)  /* Parity Mode bit 1 mask. */
+#define USART_PMODE_1_bp  5  /* Parity Mode bit 1 position. */
+#define USART_CMODE_gm  0xC0  /* Communication Mode group mask. */
+#define USART_CMODE_gp  6  /* Communication Mode group position. */
+#define USART_CMODE_0_bm  (1<<6)  /* Communication Mode bit 0 mask. */
+#define USART_CMODE_0_bp  6  /* Communication Mode bit 0 position. */
+#define USART_CMODE_1_bm  (1<<7)  /* Communication Mode bit 1 mask. */
+#define USART_CMODE_1_bp  7  /* Communication Mode bit 1 position. */
+
+/* USART.CTRLD  bit masks and bit positions */
+#define USART_ABW_gm  0xC0  /* Auto Baud Window group mask. */
+#define USART_ABW_gp  6  /* Auto Baud Window group position. */
+#define USART_ABW_0_bm  (1<<6)  /* Auto Baud Window bit 0 mask. */
+#define USART_ABW_0_bp  6  /* Auto Baud Window bit 0 position. */
+#define USART_ABW_1_bm  (1<<7)  /* Auto Baud Window bit 1 mask. */
+#define USART_ABW_1_bp  7  /* Auto Baud Window bit 1 position. */
+
+/* USART.DBGCTRL  bit masks and bit positions */
+#define USART_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define USART_DBGRUN_bp  0  /* Debug Run bit position. */
+
+/* USART.EVCTRL  bit masks and bit positions */
+#define USART_IREI_bm  0x01  /* IrDA Event Input Enable bit mask. */
+#define USART_IREI_bp  0  /* IrDA Event Input Enable bit position. */
+
+/* USART.TXPLCTRL  bit masks and bit positions */
+#define USART_TXPL_gm  0xFF  /* Transmit pulse length group mask. */
+#define USART_TXPL_gp  0  /* Transmit pulse length group position. */
+#define USART_TXPL_0_bm  (1<<0)  /* Transmit pulse length bit 0 mask. */
+#define USART_TXPL_0_bp  0  /* Transmit pulse length bit 0 position. */
+#define USART_TXPL_1_bm  (1<<1)  /* Transmit pulse length bit 1 mask. */
+#define USART_TXPL_1_bp  1  /* Transmit pulse length bit 1 position. */
+#define USART_TXPL_2_bm  (1<<2)  /* Transmit pulse length bit 2 mask. */
+#define USART_TXPL_2_bp  2  /* Transmit pulse length bit 2 position. */
+#define USART_TXPL_3_bm  (1<<3)  /* Transmit pulse length bit 3 mask. */
+#define USART_TXPL_3_bp  3  /* Transmit pulse length bit 3 position. */
+#define USART_TXPL_4_bm  (1<<4)  /* Transmit pulse length bit 4 mask. */
+#define USART_TXPL_4_bp  4  /* Transmit pulse length bit 4 position. */
+#define USART_TXPL_5_bm  (1<<5)  /* Transmit pulse length bit 5 mask. */
+#define USART_TXPL_5_bp  5  /* Transmit pulse length bit 5 position. */
+#define USART_TXPL_6_bm  (1<<6)  /* Transmit pulse length bit 6 mask. */
+#define USART_TXPL_6_bp  6  /* Transmit pulse length bit 6 position. */
+#define USART_TXPL_7_bm  (1<<7)  /* Transmit pulse length bit 7 mask. */
+#define USART_TXPL_7_bp  7  /* Transmit pulse length bit 7 position. */
+
+/* USART.RXPLCTRL  bit masks and bit positions */
+#define USART_RXPL_gm  0x7F  /* Receiver Pulse Lenght group mask. */
+#define USART_RXPL_gp  0  /* Receiver Pulse Lenght group position. */
+#define USART_RXPL_0_bm  (1<<0)  /* Receiver Pulse Lenght bit 0 mask. */
+#define USART_RXPL_0_bp  0  /* Receiver Pulse Lenght bit 0 position. */
+#define USART_RXPL_1_bm  (1<<1)  /* Receiver Pulse Lenght bit 1 mask. */
+#define USART_RXPL_1_bp  1  /* Receiver Pulse Lenght bit 1 position. */
+#define USART_RXPL_2_bm  (1<<2)  /* Receiver Pulse Lenght bit 2 mask. */
+#define USART_RXPL_2_bp  2  /* Receiver Pulse Lenght bit 2 position. */
+#define USART_RXPL_3_bm  (1<<3)  /* Receiver Pulse Lenght bit 3 mask. */
+#define USART_RXPL_3_bp  3  /* Receiver Pulse Lenght bit 3 position. */
+#define USART_RXPL_4_bm  (1<<4)  /* Receiver Pulse Lenght bit 4 mask. */
+#define USART_RXPL_4_bp  4  /* Receiver Pulse Lenght bit 4 position. */
+#define USART_RXPL_5_bm  (1<<5)  /* Receiver Pulse Lenght bit 5 mask. */
+#define USART_RXPL_5_bp  5  /* Receiver Pulse Lenght bit 5 position. */
+#define USART_RXPL_6_bm  (1<<6)  /* Receiver Pulse Lenght bit 6 mask. */
+#define USART_RXPL_6_bp  6  /* Receiver Pulse Lenght bit 6 position. */
+
+
+
+/* VPORT - Virtual Ports */
+/* VPORT.INTFLAGS  bit masks and bit positions */
+#define VPORT_INT_gm  0xFF  /* Pin Interrupt Flag group mask. */
+#define VPORT_INT_gp  0  /* Pin Interrupt Flag group position. */
+#define VPORT_INT_0_bm  (1<<0)  /* Pin Interrupt Flag bit 0 mask. */
+#define VPORT_INT_0_bp  0  /* Pin Interrupt Flag bit 0 position. */
+#define VPORT_INT_1_bm  (1<<1)  /* Pin Interrupt Flag bit 1 mask. */
+#define VPORT_INT_1_bp  1  /* Pin Interrupt Flag bit 1 position. */
+#define VPORT_INT_2_bm  (1<<2)  /* Pin Interrupt Flag bit 2 mask. */
+#define VPORT_INT_2_bp  2  /* Pin Interrupt Flag bit 2 position. */
+#define VPORT_INT_3_bm  (1<<3)  /* Pin Interrupt Flag bit 3 mask. */
+#define VPORT_INT_3_bp  3  /* Pin Interrupt Flag bit 3 position. */
+#define VPORT_INT_4_bm  (1<<4)  /* Pin Interrupt Flag bit 4 mask. */
+#define VPORT_INT_4_bp  4  /* Pin Interrupt Flag bit 4 position. */
+#define VPORT_INT_5_bm  (1<<5)  /* Pin Interrupt Flag bit 5 mask. */
+#define VPORT_INT_5_bp  5  /* Pin Interrupt Flag bit 5 position. */
+#define VPORT_INT_6_bm  (1<<6)  /* Pin Interrupt Flag bit 6 mask. */
+#define VPORT_INT_6_bp  6  /* Pin Interrupt Flag bit 6 position. */
+#define VPORT_INT_7_bm  (1<<7)  /* Pin Interrupt Flag bit 7 mask. */
+#define VPORT_INT_7_bp  7  /* Pin Interrupt Flag bit 7 position. */
+
+
+/* VREF - Voltage reference */
+/* VREF.DAC0REF  bit masks and bit positions */
+#define VREF_REFSEL_gm  0x07  /* Reference select group mask. */
+#define VREF_REFSEL_gp  0  /* Reference select group position. */
+#define VREF_REFSEL_0_bm  (1<<0)  /* Reference select bit 0 mask. */
+#define VREF_REFSEL_0_bp  0  /* Reference select bit 0 position. */
+#define VREF_REFSEL_1_bm  (1<<1)  /* Reference select bit 1 mask. */
+#define VREF_REFSEL_1_bp  1  /* Reference select bit 1 position. */
+#define VREF_REFSEL_2_bm  (1<<2)  /* Reference select bit 2 mask. */
+#define VREF_REFSEL_2_bp  2  /* Reference select bit 2 position. */
+#define VREF_ALWAYSON_bm  0x80  /* Always on bit mask. */
+#define VREF_ALWAYSON_bp  7  /* Always on bit position. */
+
+/* VREF.ACREF  bit masks and bit positions */
+/* VREF_REFSEL  is already defined. */
+/* VREF_ALWAYSON  is already defined. */
+
+
+/* WDT - Watch-Dog Timer */
+/* WDT.CTRLA  bit masks and bit positions */
+#define WDT_PERIOD_gm  0x0F  /* Period group mask. */
+#define WDT_PERIOD_gp  0  /* Period group position. */
+#define WDT_PERIOD_0_bm  (1<<0)  /* Period bit 0 mask. */
+#define WDT_PERIOD_0_bp  0  /* Period bit 0 position. */
+#define WDT_PERIOD_1_bm  (1<<1)  /* Period bit 1 mask. */
+#define WDT_PERIOD_1_bp  1  /* Period bit 1 position. */
+#define WDT_PERIOD_2_bm  (1<<2)  /* Period bit 2 mask. */
+#define WDT_PERIOD_2_bp  2  /* Period bit 2 position. */
+#define WDT_PERIOD_3_bm  (1<<3)  /* Period bit 3 mask. */
+#define WDT_PERIOD_3_bp  3  /* Period bit 3 position. */
+#define WDT_WINDOW_gm  0xF0  /* Window group mask. */
+#define WDT_WINDOW_gp  4  /* Window group position. */
+#define WDT_WINDOW_0_bm  (1<<4)  /* Window bit 0 mask. */
+#define WDT_WINDOW_0_bp  4  /* Window bit 0 position. */
+#define WDT_WINDOW_1_bm  (1<<5)  /* Window bit 1 mask. */
+#define WDT_WINDOW_1_bp  5  /* Window bit 1 position. */
+#define WDT_WINDOW_2_bm  (1<<6)  /* Window bit 2 mask. */
+#define WDT_WINDOW_2_bp  6  /* Window bit 2 position. */
+#define WDT_WINDOW_3_bm  (1<<7)  /* Window bit 3 mask. */
+#define WDT_WINDOW_3_bp  7  /* Window bit 3 position. */
+
+/* WDT.STATUS  bit masks and bit positions */
+#define WDT_SYNCBUSY_bm  0x01  /* Syncronization busy bit mask. */
+#define WDT_SYNCBUSY_bp  0  /* Syncronization busy bit position. */
+#define WDT_LOCK_bm  0x80  /* Lock enable bit mask. */
+#define WDT_LOCK_bp  7  /* Lock enable bit position. */
+
+
+/* ========== Generic Port Pins ========== */
+#define PIN0_bm 0x01
+#define PIN0_bp 0
+#define PIN1_bm 0x02
+#define PIN1_bp 1
+#define PIN2_bm 0x04
+#define PIN2_bp 2
+#define PIN3_bm 0x08
+#define PIN3_bp 3
+#define PIN4_bm 0x10
+#define PIN4_bp 4
+#define PIN5_bm 0x20
+#define PIN5_bp 5
+#define PIN6_bm 0x40
+#define PIN6_bp 6
+#define PIN7_bm 0x80
+#define PIN7_bp 7
+
+/* ========== Interrupt Vector Definitions ========== */
+/* Vector 0 is the reset vector */
+
+/* NMI interrupt vectors */
+#define NMI_vect_num  1
+#define NMI_vect      _VECTOR(1)  /*  */
+
+/* BOD interrupt vectors */
+#define BOD_VLM_vect_num  2
+#define BOD_VLM_vect      _VECTOR(2)  /*  */
+
+/* CLKCTRL interrupt vectors */
+#define CLKCTRL_CFD_vect_num  3
+#define CLKCTRL_CFD_vect      _VECTOR(3)  /*  */
+
+/* RTC interrupt vectors */
+#define RTC_CNT_vect_num  4
+#define RTC_CNT_vect      _VECTOR(4)  /*  */
+#define RTC_PIT_vect_num  5
+#define RTC_PIT_vect      _VECTOR(5)  /*  */
+
+/* CCL interrupt vectors */
+#define CCL_CCL_vect_num  6
+#define CCL_CCL_vect      _VECTOR(6)  /*  */
+
+/* PORTA interrupt vectors */
+#define PORTA_PORT_vect_num  7
+#define PORTA_PORT_vect      _VECTOR(7)  /*  */
+
+/* TCA0 interrupt vectors */
+#define TCA0_LUNF_vect_num  8
+#define TCA0_LUNF_vect      _VECTOR(8)  /*  */
+#define TCA0_OVF_vect_num  8
+#define TCA0_OVF_vect      _VECTOR(8)  /*  */
+#define TCA0_HUNF_vect_num  9
+#define TCA0_HUNF_vect      _VECTOR(9)  /*  */
+#define TCA0_CMP0_vect_num  10
+#define TCA0_CMP0_vect      _VECTOR(10)  /*  */
+#define TCA0_LCMP0_vect_num  10
+#define TCA0_LCMP0_vect      _VECTOR(10)  /*  */
+#define TCA0_CMP1_vect_num  11
+#define TCA0_CMP1_vect      _VECTOR(11)  /*  */
+#define TCA0_LCMP1_vect_num  11
+#define TCA0_LCMP1_vect      _VECTOR(11)  /*  */
+#define TCA0_CMP2_vect_num  12
+#define TCA0_CMP2_vect      _VECTOR(12)  /*  */
+#define TCA0_LCMP2_vect_num  12
+#define TCA0_LCMP2_vect      _VECTOR(12)  /*  */
+
+/* TCB0 interrupt vectors */
+#define TCB0_INT_vect_num  13
+#define TCB0_INT_vect      _VECTOR(13)  /*  */
+
+/* TCB1 interrupt vectors */
+#define TCB1_INT_vect_num  14
+#define TCB1_INT_vect      _VECTOR(14)  /*  */
+
+/* TWI0 interrupt vectors */
+#define TWI0_TWIS_vect_num  15
+#define TWI0_TWIS_vect      _VECTOR(15)  /*  */
+#define TWI0_TWIM_vect_num  16
+#define TWI0_TWIM_vect      _VECTOR(16)  /*  */
+
+/* SPI0 interrupt vectors */
+#define SPI0_INT_vect_num  17
+#define SPI0_INT_vect      _VECTOR(17)  /*  */
+
+/* USART0 interrupt vectors */
+#define USART0_RXC_vect_num  18
+#define USART0_RXC_vect      _VECTOR(18)  /*  */
+#define USART0_DRE_vect_num  19
+#define USART0_DRE_vect      _VECTOR(19)  /*  */
+#define USART0_TXC_vect_num  20
+#define USART0_TXC_vect      _VECTOR(20)  /*  */
+
+/* PORTD interrupt vectors */
+#define PORTD_PORT_vect_num  21
+#define PORTD_PORT_vect      _VECTOR(21)  /*  */
+
+/* AC0 interrupt vectors */
+#define AC0_AC_vect_num  22
+#define AC0_AC_vect      _VECTOR(22)  /*  */
+
+/* ADC0 interrupt vectors */
+#define ADC0_ERROR_vect_num  23
+#define ADC0_ERROR_vect      _VECTOR(23)  /*  */
+#define ADC0_RESRDY_vect_num  24
+#define ADC0_RESRDY_vect      _VECTOR(24)  /*  */
+#define ADC0_SAMPRDY_vect_num  25
+#define ADC0_SAMPRDY_vect      _VECTOR(25)  /*  */
+
+/* AC1 interrupt vectors */
+#define AC1_AC_vect_num  26
+#define AC1_AC_vect      _VECTOR(26)  /*  */
+
+/* PORTC interrupt vectors */
+#define PORTC_PORT_vect_num  27
+#define PORTC_PORT_vect      _VECTOR(27)  /*  */
+
+/* TCB2 interrupt vectors */
+#define TCB2_INT_vect_num  28
+#define TCB2_INT_vect      _VECTOR(28)  /*  */
+
+/* USART1 interrupt vectors */
+#define USART1_RXC_vect_num  29
+#define USART1_RXC_vect      _VECTOR(29)  /*  */
+#define USART1_DRE_vect_num  30
+#define USART1_DRE_vect      _VECTOR(30)  /*  */
+#define USART1_TXC_vect_num  31
+#define USART1_TXC_vect      _VECTOR(31)  /*  */
+
+/* PORTF interrupt vectors */
+#define PORTF_PORT_vect_num  32
+#define PORTF_PORT_vect      _VECTOR(32)  /*  */
+
+/* NVMCTRL interrupt vectors */
+#define NVMCTRL_EEREADY_vect_num  33
+#define NVMCTRL_EEREADY_vect      _VECTOR(33)  /*  */
+#define NVMCTRL_FLREADY_vect_num  33
+#define NVMCTRL_FLREADY_vect      _VECTOR(33)  /*  */
+#define NVMCTRL_NVMREADY_vect_num  33
+#define NVMCTRL_NVMREADY_vect      _VECTOR(33)  /*  */
+
+/* USART2 interrupt vectors */
+#define USART2_RXC_vect_num  34
+#define USART2_RXC_vect      _VECTOR(34)  /*  */
+#define USART2_DRE_vect_num  35
+#define USART2_DRE_vect      _VECTOR(35)  /*  */
+#define USART2_TXC_vect_num  36
+#define USART2_TXC_vect      _VECTOR(36)  /*  */
+
+#define _VECTOR_SIZE 4 /* Size of individual vector. */
+#define _VECTORS_SIZE (37 * _VECTOR_SIZE)
+
+
+/* ========== Constants ========== */
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define DATAMEM_START     (0x0000)
+#  define DATAMEM_SIZE      (65536)
+#else
+#  define DATAMEM_START     (0x0000U)
+#  define DATAMEM_SIZE      (65536U)
+#endif
+#define DATAMEM_END       (DATAMEM_START + DATAMEM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define IO_START     (0x0000)
+#  define IO_SIZE      (4159)
+#  define IO_PAGE_SIZE (0)
+#else
+#  define IO_START     (0x0000U)
+#  define IO_SIZE      (4159U)
+#  define IO_PAGE_SIZE (0U)
+#endif
+#define IO_END       (IO_START + IO_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define LOCKBITS_START     (0x1040)
+#  define LOCKBITS_SIZE      (4)
+#  define LOCKBITS_PAGE_SIZE (4)
+#else
+#  define LOCKBITS_START     (0x1040U)
+#  define LOCKBITS_SIZE      (4U)
+#  define LOCKBITS_PAGE_SIZE (4U)
+#endif
+#define LOCKBITS_END       (LOCKBITS_START + LOCKBITS_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define FUSES_START     (0x1050)
+#  define FUSES_SIZE      (16)
+#  define FUSES_PAGE_SIZE (8)
+#else
+#  define FUSES_START     (0x1050U)
+#  define FUSES_SIZE      (16U)
+#  define FUSES_PAGE_SIZE (8U)
+#endif
+#define FUSES_END       (FUSES_START + FUSES_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define USER_SIGNATURES_START     (0x1080)
+#  define USER_SIGNATURES_SIZE      (64)
+#  define USER_SIGNATURES_PAGE_SIZE (64)
+#else
+#  define USER_SIGNATURES_START     (0x1080U)
+#  define USER_SIGNATURES_SIZE      (64U)
+#  define USER_SIGNATURES_PAGE_SIZE (64U)
+#endif
+#define USER_SIGNATURES_END       (USER_SIGNATURES_START + USER_SIGNATURES_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define SIGNATURES_START     (0x1100)
+#  define SIGNATURES_SIZE      (3)
+#  define SIGNATURES_PAGE_SIZE (128)
+#else
+#  define SIGNATURES_START     (0x1100U)
+#  define SIGNATURES_SIZE      (3U)
+#  define SIGNATURES_PAGE_SIZE (128U)
+#endif
+#define SIGNATURES_END       (SIGNATURES_START + SIGNATURES_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define PROD_SIGNATURES_START     (0x1103)
+#  define PROD_SIGNATURES_SIZE      (125)
+#  define PROD_SIGNATURES_PAGE_SIZE (128)
+#else
+#  define PROD_SIGNATURES_START     (0x1103U)
+#  define PROD_SIGNATURES_SIZE      (125U)
+#  define PROD_SIGNATURES_PAGE_SIZE (128U)
+#endif
+#define PROD_SIGNATURES_END       (PROD_SIGNATURES_START + PROD_SIGNATURES_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define EEPROM_START     (0x1400)
+#  define EEPROM_SIZE      (512)
+#  define EEPROM_PAGE_SIZE (8)
+#else
+#  define EEPROM_START     (0x1400U)
+#  define EEPROM_SIZE      (512U)
+#  define EEPROM_PAGE_SIZE (8U)
+#endif
+#define EEPROM_END       (EEPROM_START + EEPROM_SIZE - 1)
+
+/* Added MAPPED_EEPROM segment names for avr-libc */
+#define MAPPED_EEPROM_START     (EEPROM_START)
+#define MAPPED_EEPROM_SIZE      (EEPROM_SIZE)
+#define MAPPED_EEPROM_PAGE_SIZE (EEPROM_PAGE_SIZE)
+#define MAPPED_EEPROM_END       (MAPPED_EEPROM_START + MAPPED_EEPROM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define INTERNAL_SRAM_START     (0x7000)
+#  define INTERNAL_SRAM_SIZE      (4096)
+#  define INTERNAL_SRAM_PAGE_SIZE (0)
+#else
+#  define INTERNAL_SRAM_START     (0x7000U)
+#  define INTERNAL_SRAM_SIZE      (4096U)
+#  define INTERNAL_SRAM_PAGE_SIZE (0U)
+#endif
+#define INTERNAL_SRAM_END       (INTERNAL_SRAM_START + INTERNAL_SRAM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define MAPPED_PROGMEM_START     (0x8000)
+#  define MAPPED_PROGMEM_SIZE      (32768)
+#  define MAPPED_PROGMEM_PAGE_SIZE (64)
+#else
+#  define MAPPED_PROGMEM_START     (0x8000U)
+#  define MAPPED_PROGMEM_SIZE      (32768U)
+#  define MAPPED_PROGMEM_PAGE_SIZE (64U)
+#endif
+#define MAPPED_PROGMEM_END       (MAPPED_PROGMEM_START + MAPPED_PROGMEM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define PROGMEM_START     (0x0000)
+#  define PROGMEM_SIZE      (32768)
+#  define PROGMEM_PAGE_SIZE (64)
+#else
+#  define PROGMEM_START     (0x0000U)
+#  define PROGMEM_SIZE      (32768U)
+#  define PROGMEM_PAGE_SIZE (64U)
+#endif
+#define PROGMEM_END       (PROGMEM_START + PROGMEM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define PROGMEM_NRWW_START     (0x0000)
+#  define PROGMEM_NRWW_SIZE      (4096)
+#  define PROGMEM_NRWW_PAGE_SIZE (64)
+#else
+#  define PROGMEM_NRWW_START     (0x0000U)
+#  define PROGMEM_NRWW_SIZE      (4096U)
+#  define PROGMEM_NRWW_PAGE_SIZE (64U)
+#endif
+#define PROGMEM_NRWW_END       (PROGMEM_NRWW_START + PROGMEM_NRWW_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define PROGMEM_RWW_START     (0x1000)
+#  define PROGMEM_RWW_SIZE      (28672)
+#  define PROGMEM_RWW_PAGE_SIZE (64)
+#else
+#  define PROGMEM_RWW_START     (0x1000U)
+#  define PROGMEM_RWW_SIZE      (28672U)
+#  define PROGMEM_RWW_PAGE_SIZE (64U)
+#endif
+#define PROGMEM_RWW_END       (PROGMEM_RWW_START + PROGMEM_RWW_SIZE - 1)
+
+#define FLASHSTART   PROGMEM_START
+#define FLASHEND     PROGMEM_END
+#define RAMSTART     INTERNAL_SRAM_START
+#define RAMSIZE      INTERNAL_SRAM_SIZE
+#define RAMEND       INTERNAL_SRAM_END
+#define E2END        EEPROM_END
+#define E2PAGESIZE   EEPROM_PAGE_SIZE
+
+/* ========== Fuses ========== */
+#define FUSE_MEMORY_SIZE 16
+
+/* Fuse Byte 0 (WDTCFG) */
+#define FUSE_PERIOD0  (unsigned char)_BV(0)  /* Watchdog Timeout Period Bit 0 */
+#define FUSE_PERIOD1  (unsigned char)_BV(1)  /* Watchdog Timeout Period Bit 1 */
+#define FUSE_PERIOD2  (unsigned char)_BV(2)  /* Watchdog Timeout Period Bit 2 */
+#define FUSE_PERIOD3  (unsigned char)_BV(3)  /* Watchdog Timeout Period Bit 3 */
+#define FUSE_WINDOW0  (unsigned char)_BV(4)  /* Watchdog Window Timeout Period Bit 0 */
+#define FUSE_WINDOW1  (unsigned char)_BV(5)  /* Watchdog Window Timeout Period Bit 1 */
+#define FUSE_WINDOW2  (unsigned char)_BV(6)  /* Watchdog Window Timeout Period Bit 2 */
+#define FUSE_WINDOW3  (unsigned char)_BV(7)  /* Watchdog Window Timeout Period Bit 3 */
+#define FUSE0_DEFAULT  (0x0)
+#define FUSE_WDTCFG_DEFAULT  (0x0)
+
+/* Fuse Byte 1 (BODCFG) */
+#define FUSE_SLEEP0  (unsigned char)_BV(0)  /* BOD Operation in Sleep Mode Bit 0 */
+#define FUSE_SLEEP1  (unsigned char)_BV(1)  /* BOD Operation in Sleep Mode Bit 1 */
+#define FUSE_ACTIVE0  (unsigned char)_BV(2)  /* BOD Operation in Active Mode Bit 0 */
+#define FUSE_ACTIVE1  (unsigned char)_BV(3)  /* BOD Operation in Active Mode Bit 1 */
+#define FUSE_SAMPFREQ  (unsigned char)_BV(4)  /* BOD Sample Frequency */
+#define FUSE_LVL0  (unsigned char)_BV(5)  /* BOD Level Bit 0 */
+#define FUSE_LVL1  (unsigned char)_BV(6)  /* BOD Level Bit 1 */
+#define FUSE_LVL2  (unsigned char)_BV(7)  /* BOD Level Bit 2 */
+#define FUSE1_DEFAULT  (0x0)
+#define FUSE_BODCFG_DEFAULT  (0x0)
+
+/* Fuse Byte 2 (OSCCFG) */
+#define FUSE_OSCHFFRQ  (unsigned char)_BV(3)  /* High-frequency Oscillator Frequency */
+#define FUSE2_DEFAULT  (0x0)
+#define FUSE_OSCCFG_DEFAULT  (0x0)
+
+/* Fuse Byte 3 Reserved */
+
+/* Fuse Byte 4 Reserved */
+
+/* Fuse Byte 5 (SYSCFG0) */
+#define FUSE_EESAVE  (unsigned char)_BV(0)  /* EEPROM Save */
+#define FUSE_RSTPINCFG  (unsigned char)_BV(3)  /* Reset Pin Configuration */
+#define FUSE_UPDIPINCFG  (unsigned char)_BV(4)  /* UPDI Pin Configuration */
+#define FUSE_CRCSEL  (unsigned char)_BV(5)  /* CRC Select */
+#define FUSE_CRCSRC0  (unsigned char)_BV(6)  /* CRC Source Bit 0 */
+#define FUSE_CRCSRC1  (unsigned char)_BV(7)  /* CRC Source Bit 1 */
+#define FUSE5_DEFAULT  (0xD0)
+#define FUSE_SYSCFG0_DEFAULT  (0xD0)
+
+/* Fuse Byte 6 (SYSCFG1) */
+#define FUSE_SUT0  (unsigned char)_BV(0)  /* Startup Time Bit 0 */
+#define FUSE_SUT1  (unsigned char)_BV(1)  /* Startup Time Bit 1 */
+#define FUSE_SUT2  (unsigned char)_BV(2)  /* Startup Time Bit 2 */
+#define FUSE6_DEFAULT  (0x7)
+#define FUSE_SYSCFG1_DEFAULT  (0x7)
+
+/* Fuse Byte 7 (CODESIZE) */
+#define FUSE7_DEFAULT  (0x0)
+#define FUSE_CODESIZE_DEFAULT  (0x0)
+
+/* Fuse Byte 8 (BOOTSIZE) */
+#define FUSE8_DEFAULT  (0x0)
+#define FUSE_BOOTSIZE_DEFAULT  (0x0)
+
+/* ========== Lock Bits ========== */
+#define __LOCK_KEY_EXIST
+#ifdef LOCKBITS_DEFAULT
+#undef LOCKBITS_DEFAULT
+#endif //LOCKBITS_DEFAULT
+#define LOCKBITS_DEFAULT  (0x5CC5C55C)
+
+/* ========== Signature ========== */
+#define SIGNATURE_0 0x1E
+#define SIGNATURE_1 0x95
+#define SIGNATURE_2 0x3D
+
+#endif /* #ifdef _AVR_AVR32EA32_H_INCLUDED */
+

--- a/include/avr/ioavr32ea48.h
+++ b/include/avr/ioavr32ea48.h
@@ -1,0 +1,6044 @@
+/*
+ * Copyright (C) 2023, Microchip Technology Inc. and its subsidiaries ("Microchip")
+ * All rights reserved.
+ *
+ * This software is developed by Microchip Technology Inc. and its subsidiaries ("Microchip").
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other
+ *        materials provided with the distribution. Publication is not required when
+ *        this file is used in an embedded application.
+ *
+ *     3. Microchip's name may not be used to endorse or promote products derived from this
+ *        software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY MICROCHIP "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL MICROCHIP BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING BUT NOT LIMITED TO
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWSOEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _AVR_IO_H_
+#  error "Include <avr/io.h> instead of this file."
+#endif
+
+#ifndef _AVR_IOXXX_H_
+#  define _AVR_IOXXX_H_ "ioavr32ea48.h"
+#else
+#  error "Attempt to include more than one <avr/ioXXX.h> file."
+#endif
+
+#ifndef _AVR_AVR32EA48_H_INCLUDED
+#define _AVR_AVR32EA48_H_INCLUDED
+
+/* Ungrouped common registers */
+#define CCP  _SFR_MEM8(0x0034)  /* Configuration Change Protection */
+#define SP  _SFR_MEM16(0x003D)  /* Stack Pointer */
+#define SPL  _SFR_MEM8(0x003D)  /* Stack Pointer Low */
+#define SPH  _SFR_MEM8(0x003E)  /* Stack Pointer High */
+#define SREG  _SFR_MEM8(0x003F)  /* Status Register */
+
+/* C Language Only */
+#if !defined (__ASSEMBLER__)
+
+#include <stdint.h>
+
+typedef volatile uint8_t register8_t;
+typedef volatile uint16_t register16_t;
+typedef volatile uint32_t register32_t;
+
+
+#ifdef _WORDREGISTER
+#undef _WORDREGISTER
+#endif
+#define _WORDREGISTER(regname)   \
+    __extension__ union \
+    { \
+        register16_t regname; \
+        struct \
+        { \
+            register8_t regname ## L; \
+            register8_t regname ## H; \
+        }; \
+    }
+
+#ifdef _DWORDREGISTER
+#undef _DWORDREGISTER
+#endif
+#define _DWORDREGISTER(regname)  \
+    __extension__ union \
+    { \
+        register32_t regname; \
+        struct \
+        { \
+            register8_t regname ## 0; \
+            register8_t regname ## 1; \
+            register8_t regname ## 2; \
+            register8_t regname ## 3; \
+        }; \
+    }
+
+
+/*
+==========================================================================
+IO Module Structures
+==========================================================================
+*/
+
+
+/*
+--------------------------------------------------------------------------
+AC - Analog Comparator
+--------------------------------------------------------------------------
+*/
+
+/* Analog Comparator */
+typedef struct AC_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t MUXCTRL;  /* Mux Control A */
+    register8_t reserved_1[2];
+    register8_t DACREF;  /* DAC Voltage Reference */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t STATUS;  /* Status */
+} AC_t;
+
+/* Hysteresis Mode select */
+typedef enum AC_HYSMODE_enum
+{
+    AC_HYSMODE_NONE_gc = (0x00<<1),  /* No hysteresis */
+    AC_HYSMODE_SMALL_gc = (0x01<<1),  /* Small hysteresis */
+    AC_HYSMODE_MEDIUM_gc = (0x02<<1),  /* Medium hysteresis */
+    AC_HYSMODE_LARGE_gc = (0x03<<1)  /* Large hysteresis */
+} AC_HYSMODE_t;
+
+/* AC Output Initial Value select */
+typedef enum AC_INITVAL_enum
+{
+    AC_INITVAL_LOW_gc = (0x00<<6),  /* Output initialized to 0 */
+    AC_INITVAL_HIGH_gc = (0x01<<6)  /* Output initialized to 1 */
+} AC_INITVAL_t;
+
+/* Interrupt Mode select */
+typedef enum AC_INTMODE_NORMAL_enum
+{
+    AC_INTMODE_NORMAL_BOTHEDGE_gc = (0x00<<4),  /* Positive and negative inputs crosses */
+    AC_INTMODE_NORMAL_NEGEDGE_gc = (0x02<<4),  /* Positive input goes below negative input */
+    AC_INTMODE_NORMAL_POSEDGE_gc = (0x03<<4)  /* Positive input goes above negative input */
+} AC_INTMODE_NORMAL_t;
+
+/* Interrupt Mode select */
+typedef enum AC_INTMODE_WINDOW_enum
+{
+    AC_INTMODE_WINDOW_ABOVE_gc = (0x00<<4),  /* Window interrupt when input above both references */
+    AC_INTMODE_WINDOW_INSIDE_gc = (0x01<<4),  /* Window interrupt when input betweeen references */
+    AC_INTMODE_WINDOW_BELOW_gc = (0x02<<4),  /* Window interrupt when input below both references */
+    AC_INTMODE_WINDOW_OUTSIDE_gc = (0x03<<4)  /* Window interrupt when input outside reference */
+} AC_INTMODE_WINDOW_t;
+
+/* Negative Input MUX Selection */
+typedef enum AC_MUXNEG_enum
+{
+    AC_MUXNEG_AINN0_gc = (0x00<<0),  /* Negative Pin 0 */
+    AC_MUXNEG_AINN1_gc = (0x01<<0),  /* Negative Pin 1 */
+    AC_MUXNEG_AINN2_gc = (0x02<<0),  /* Negative Pin 2 */
+    AC_MUXNEG_AINN3_gc = (0x03<<0),  /* Negative Pin 3 */
+    AC_MUXNEG_DACREF_gc = (0x04<<0)  /* DAC Reference */
+} AC_MUXNEG_t;
+
+/* Positive Input MUX Selection */
+typedef enum AC_MUXPOS_enum
+{
+    AC_MUXPOS_AINP0_gc = (0x00<<3),  /* Positive Pin 0 */
+    AC_MUXPOS_AINP1_gc = (0x01<<3),  /* Positive Pin 1 */
+    AC_MUXPOS_AINP2_gc = (0x02<<3),  /* Positive Pin 2 */
+    AC_MUXPOS_AINP3_gc = (0x03<<3),  /* Positive Pin 3 */
+    AC_MUXPOS_AINP4_gc = (0x04<<3)  /* Positive Pin 4 */
+} AC_MUXPOS_t;
+
+/* Power profile select */
+typedef enum AC_POWER_enum
+{
+    AC_POWER_PROFILE0_gc = (0x00<<3),  /* Power profile 0, Fastest response time, highest consumption */
+    AC_POWER_PROFILE1_gc = (0x01<<3)  /* Power profile 1 */
+} AC_POWER_t;
+
+/* Window selection mode */
+typedef enum AC_WINSEL_enum
+{
+    AC_WINSEL_DISABLED_gc = (0x00<<0),  /* Window function disabled */
+    AC_WINSEL_UPSEL1_gc = (0x01<<0)  /* Select ACn+1 as upper limit in window compare */
+} AC_WINSEL_t;
+
+/* Analog Comparator Window State select */
+typedef enum AC_WINSTATE_enum
+{
+    AC_WINSTATE_ABOVE_gc = (0x00<<6),  /* Above window */
+    AC_WINSTATE_INSIDE_gc = (0x01<<6),  /* Inside window */
+    AC_WINSTATE_BELOW_gc = (0x02<<6)  /* Below window */
+} AC_WINSTATE_t;
+
+/*
+--------------------------------------------------------------------------
+ADC - Analog to Digital Converter
+--------------------------------------------------------------------------
+*/
+
+/* Analog to Digital Converter */
+typedef struct ADC_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    register8_t CTRLD;  /* Control D */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t STATUS;  /* Status register */
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t CTRLE;  /* Control E */
+    register8_t CTRLF;  /* Control F */
+    register8_t COMMAND;  /* Command register */
+    register8_t PGACTRL;  /* PGA Control */
+    register8_t MUXPOS;  /* Positive Input Multiplexer */
+    register8_t MUXNEG;  /* Negative Input Multiplexer */
+    register8_t reserved_1[2];
+    _DWORDREGISTER(RESULT);  /* Result */
+    _WORDREGISTER(SAMPLE);  /* Sample */
+    register8_t reserved_2[2];
+    register8_t TEMP0;  /* Temporary Data 0 */
+    register8_t TEMP1;  /* Temporary Data 1 */
+    register8_t TEMP2;  /* Temporary Data 2 */
+    register8_t reserved_3[1];
+    _WORDREGISTER(WINLT);  /* Window Low Threshold */
+    _WORDREGISTER(WINHT);  /* Window High Threshold */
+    register8_t reserved_4[32];
+} ADC_t;
+
+/* Sign Chopping select */
+typedef enum ADC_CHOPPING_enum
+{
+    ADC_CHOPPING_DISABLE_gc = (0x00<<6),  /* Sign Chopping Disabled */
+    ADC_CHOPPING_ENABLE_gc = (0x01<<6)  /* Sign Chopping Enabled */
+} ADC_CHOPPING_t;
+
+/* Gain select */
+typedef enum ADC_GAIN_enum
+{
+    ADC_GAIN_1X_gc = (0x00<<5),  /* 1x gain */
+    ADC_GAIN_2X_gc = (0x01<<5),  /* 2x gain */
+    ADC_GAIN_4X_gc = (0x02<<5),  /* 4x gain */
+    ADC_GAIN_8X_gc = (0x03<<5),  /* 8x gain */
+    ADC_GAIN_16X_gc = (0x04<<5)  /* 16x gain */
+} ADC_GAIN_t;
+
+/* Mode select */
+typedef enum ADC_MODE_enum
+{
+    ADC_MODE_SINGLE_8BIT_gc = (0x00<<4),  /* Single Conversion with 8-bit resolution */
+    ADC_MODE_SINGLE_12BIT_gc = (0x01<<4),  /* Single Conversion with 12-bit resolution */
+    ADC_MODE_SERIES_gc = (0x02<<4),  /* Series with accumulation, separate trigger for every 12-bit conversion */
+    ADC_MODE_SERIES_SCALING_gc = (0x03<<4),  /* Series with accumulation and scaling, separate trigger for every 12-bit conversion */
+    ADC_MODE_BURST_gc = (0x04<<4),  /* Burst with accumulation, one trigger will run SAMPNUM 12-bit conversions */
+    ADC_MODE_BURST_SCALING_gc = (0x05<<4)  /* Burst with accumulation and scaling, one trigger will run SAMPNUM 12-bit conversions */
+} ADC_MODE_t;
+
+/* Analog Channel Selection Bits */
+typedef enum ADC_MUXNEG_enum
+{
+    ADC_MUXNEG_AIN0_gc = (0x00<<0),  /* ADC input pin 0 */
+    ADC_MUXNEG_AIN1_gc = (0x01<<0),  /* ADC input pin 1 */
+    ADC_MUXNEG_AIN2_gc = (0x02<<0),  /* ADC input pin 2 */
+    ADC_MUXNEG_AIN3_gc = (0x03<<0),  /* ADC input pin 3 */
+    ADC_MUXNEG_AIN4_gc = (0x04<<0),  /* ADC input pin 4 */
+    ADC_MUXNEG_AIN5_gc = (0x05<<0),  /* ADC input pin 5 */
+    ADC_MUXNEG_AIN6_gc = (0x06<<0),  /* ADC input pin 6 */
+    ADC_MUXNEG_AIN7_gc = (0x07<<0),  /* ADC input pin 7 */
+    ADC_MUXNEG_AIN8_gc = (0x08<<0),  /* ADC input pin 8 */
+    ADC_MUXNEG_AIN9_gc = (0x09<<0),  /* ADC input pin 9 */
+    ADC_MUXNEG_AIN10_gc = (0x0A<<0),  /* ADC input pin 10 */
+    ADC_MUXNEG_AIN11_gc = (0x0B<<0),  /* ADC input pin 11 */
+    ADC_MUXNEG_AIN16_gc = (0x10<<0),  /* ADC input pin 16 */
+    ADC_MUXNEG_AIN17_gc = (0x11<<0),  /* ADC input pin 17 */
+    ADC_MUXNEG_AIN18_gc = (0x12<<0),  /* ADC input pin 18 */
+    ADC_MUXNEG_AIN19_gc = (0x13<<0),  /* ADC input pin 19 */
+    ADC_MUXNEG_AIN20_gc = (0x14<<0),  /* ADC input pin 20 */
+    ADC_MUXNEG_AIN21_gc = (0x15<<0),  /* ADC input pin 21 */
+    ADC_MUXNEG_AIN22_gc = (0x16<<0),  /* ADC input pin 22 */
+    ADC_MUXNEG_AIN23_gc = (0x17<<0),  /* ADC input pin 23 */
+    ADC_MUXNEG_AIN24_gc = (0x18<<0),  /* ADC input pin 24 */
+    ADC_MUXNEG_AIN25_gc = (0x19<<0),  /* ADC input pin 25 */
+    ADC_MUXNEG_AIN26_gc = (0x1A<<0),  /* ADC input pin 26 */
+    ADC_MUXNEG_AIN27_gc = (0x1B<<0),  /* ADC input pin 27 */
+    ADC_MUXNEG_AIN28_gc = (0x1C<<0),  /* ADC input pin 28 */
+    ADC_MUXNEG_AIN29_gc = (0x1D<<0),  /* ADC input pin 29 */
+    ADC_MUXNEG_AIN30_gc = (0x1E<<0),  /* ADC input pin 30 */
+    ADC_MUXNEG_AIN31_gc = (0x1F<<0),  /* ADC input pin 31 */
+    ADC_MUXNEG_GND_gc = (0x30<<0),  /* Ground */
+    ADC_MUXNEG_DAC0_gc = (0x38<<0),  /* Digital to Analog Converter 0 */
+    ADC_MUXNEG_DACREF0_gc = (0x39<<0),  /* AC0 DAC reference */
+    ADC_MUXNEG_DACREF1_gc = (0x3A<<0)  /* AC1 DAC reference */
+} ADC_MUXNEG_t;
+
+/* Analog Channel Selection Bits */
+typedef enum ADC_MUXPOS_enum
+{
+    ADC_MUXPOS_AIN0_gc = (0x00<<0),  /* ADC input pin 0 */
+    ADC_MUXPOS_AIN1_gc = (0x01<<0),  /* ADC input pin 1 */
+    ADC_MUXPOS_AIN2_gc = (0x02<<0),  /* ADC input pin 2 */
+    ADC_MUXPOS_AIN3_gc = (0x03<<0),  /* ADC input pin 3 */
+    ADC_MUXPOS_AIN4_gc = (0x04<<0),  /* ADC input pin 4 */
+    ADC_MUXPOS_AIN5_gc = (0x05<<0),  /* ADC input pin 5 */
+    ADC_MUXPOS_AIN6_gc = (0x06<<0),  /* ADC input pin 6 */
+    ADC_MUXPOS_AIN7_gc = (0x07<<0),  /* ADC input pin 7 */
+    ADC_MUXPOS_AIN8_gc = (0x08<<0),  /* ADC input pin 8 */
+    ADC_MUXPOS_AIN9_gc = (0x09<<0),  /* ADC input pin 9 */
+    ADC_MUXPOS_AIN10_gc = (0x0A<<0),  /* ADC input pin 10 */
+    ADC_MUXPOS_AIN11_gc = (0x0B<<0),  /* ADC input pin 11 */
+    ADC_MUXPOS_AIN16_gc = (0x10<<0),  /* ADC input pin 16 */
+    ADC_MUXPOS_AIN17_gc = (0x11<<0),  /* ADC input pin 17 */
+    ADC_MUXPOS_AIN18_gc = (0x12<<0),  /* ADC input pin 18 */
+    ADC_MUXPOS_AIN19_gc = (0x13<<0),  /* ADC input pin 19 */
+    ADC_MUXPOS_AIN20_gc = (0x14<<0),  /* ADC input pin 20 */
+    ADC_MUXPOS_AIN21_gc = (0x15<<0),  /* ADC input pin 21 */
+    ADC_MUXPOS_AIN22_gc = (0x16<<0),  /* ADC input pin 22 */
+    ADC_MUXPOS_AIN23_gc = (0x17<<0),  /* ADC input pin 23 */
+    ADC_MUXPOS_AIN24_gc = (0x18<<0),  /* ADC input pin 24 */
+    ADC_MUXPOS_AIN25_gc = (0x19<<0),  /* ADC input pin 25 */
+    ADC_MUXPOS_AIN26_gc = (0x1A<<0),  /* ADC input pin 26 */
+    ADC_MUXPOS_AIN27_gc = (0x1B<<0),  /* ADC input pin 27 */
+    ADC_MUXPOS_AIN28_gc = (0x1C<<0),  /* ADC input pin 28 */
+    ADC_MUXPOS_AIN29_gc = (0x1D<<0),  /* ADC input pin 29 */
+    ADC_MUXPOS_AIN30_gc = (0x1E<<0),  /* ADC input pin 30 */
+    ADC_MUXPOS_AIN31_gc = (0x1F<<0),  /* ADC input pin 31 */
+    ADC_MUXPOS_GND_gc = (0x30<<0),  /* Ground */
+    ADC_MUXPOS_VDD10_gc = (0x31<<0),  /* VDD Divided by 10 */
+    ADC_MUXPOS_TEMPSENSE_gc = (0x32<<0),  /* Temperature Sensor */
+    ADC_MUXPOS_DAC0_gc = (0x38<<0)  /* Digital to Analog Converter 0 */
+} ADC_MUXPOS_t;
+
+/* PGA BIAS Select */
+typedef enum ADC_PGABIASSEL_enum
+{
+    ADC_PGABIASSEL_100PCT_gc = (0x00<<3),  /* 100% BIAS current. */
+    ADC_PGABIASSEL_75PCT_gc = (0x01<<3),  /* 75% BIAS current. Usable for CLK_ADC<4.5MHz */
+    ADC_PGABIASSEL_50PCT_gc = (0x02<<3),  /* 50% BIAS current. Usable for CLK_ADC<3MHz */
+    ADC_PGABIASSEL_25PCT_gc = (0x03<<3)  /* 25% BIAS current. Usable for CLK_ADC<1.5MHz */
+} ADC_PGABIASSEL_t;
+
+/* Prescaler Value select */
+typedef enum ADC_PRESC_enum
+{
+    ADC_PRESC_DIV2_gc = (0x00<<0),  /* System clock divided by 2 */
+    ADC_PRESC_DIV4_gc = (0x01<<0),  /* System clock divided by 4 */
+    ADC_PRESC_DIV6_gc = (0x02<<0),  /* System clock divided by 6 */
+    ADC_PRESC_DIV8_gc = (0x03<<0),  /* System clock divided by 8 */
+    ADC_PRESC_DIV10_gc = (0x04<<0),  /* System clock divided by 10 */
+    ADC_PRESC_DIV12_gc = (0x05<<0),  /* System clock divided by 12 */
+    ADC_PRESC_DIV14_gc = (0x06<<0),  /* System clock divided by 14 */
+    ADC_PRESC_DIV16_gc = (0x07<<0),  /* System clock divided by 16 */
+    ADC_PRESC_DIV20_gc = (0x08<<0),  /* System clock divided by 20 */
+    ADC_PRESC_DIV24_gc = (0x09<<0),  /* System clock divided by 24 */
+    ADC_PRESC_DIV28_gc = (0x0A<<0),  /* System clock divided by 28 */
+    ADC_PRESC_DIV32_gc = (0x0B<<0),  /* System clock divided by 32 */
+    ADC_PRESC_DIV40_gc = (0x0C<<0),  /* System clock divided by 40 */
+    ADC_PRESC_DIV48_gc = (0x0D<<0),  /* System clock divided by 48 */
+    ADC_PRESC_DIV56_gc = (0x0E<<0),  /* System clock divided by 56 */
+    ADC_PRESC_DIV64_gc = (0x0F<<0)  /* System clock divided by 64 */
+} ADC_PRESC_t;
+
+/* Reference select */
+typedef enum ADC_REFSEL_enum
+{
+    ADC_REFSEL_VDD_gc = (0x00<<0),  /* VDD */
+    ADC_REFSEL_VREFA_gc = (0x02<<0),  /* External Reference */
+    ADC_REFSEL_1V024_gc = (0x04<<0),  /* Internal 1.024V Reference */
+    ADC_REFSEL_2V048_gc = (0x05<<0),  /* Internal 2.048V Reference */
+    ADC_REFSEL_4V096_gc = (0x06<<0),  /* Internal 4.096V Reference */
+    ADC_REFSEL_2V500_gc = (0x07<<0)  /* Internal 2.500V Reference */
+} ADC_REFSEL_t;
+
+/* Sample numbers select */
+typedef enum ADC_SAMPNUM_enum
+{
+    ADC_SAMPNUM_NONE_gc = (0x00<<0),  /* No accumulation */
+    ADC_SAMPNUM_ACC2_gc = (0x01<<0),  /* 2 samples accumulated */
+    ADC_SAMPNUM_ACC4_gc = (0x02<<0),  /* 4 samples accumulated */
+    ADC_SAMPNUM_ACC8_gc = (0x03<<0),  /* 8 samples accumulated */
+    ADC_SAMPNUM_ACC16_gc = (0x04<<0),  /* 16 samples accumulated */
+    ADC_SAMPNUM_ACC32_gc = (0x05<<0),  /* 32 samples accumulated */
+    ADC_SAMPNUM_ACC64_gc = (0x06<<0),  /* 64 samples accumulated */
+    ADC_SAMPNUM_ACC128_gc = (0x07<<0),  /* 128 samples accumulated */
+    ADC_SAMPNUM_ACC256_gc = (0x08<<0),  /* 256 samples accumulated */
+    ADC_SAMPNUM_ACC512_gc = (0x09<<0),  /* 512 samples accumulated */
+    ADC_SAMPNUM_ACC1024_gc = (0x0A<<0)  /* 1024 samples accumulated */
+} ADC_SAMPNUM_t;
+
+/* Start command select */
+typedef enum ADC_START_enum
+{
+    ADC_START_STOP_gc = (0x00<<0),  /* Stop an ongoing conversion */
+    ADC_START_IMMEDIATE_gc = (0x01<<0),  /* Start a conversion immediately. This will be set back to STOP when the first conversion is done, unless Free-Running mode is enabled */
+    ADC_START_MUXPOS_WRITE_gc = (0x02<<0),  /* Start when MUXPOS register is written */
+    ADC_START_MUXNEG_WRITE_gc = (0x03<<0),  /* Start when MUXNEG register is written */
+    ADC_START_EVENT_TRIGGER_gc = (0x04<<0)  /* Start when an event is received */
+} ADC_START_t;
+
+/* VIA select */
+typedef enum ADC_VIA_enum
+{
+    ADC_VIA_DIRECT_gc = (0x00<<6),  /* Inputs connected directly to ADC */
+    ADC_VIA_PGA_gc = (0x01<<6)  /* Inputs connected via PGA */
+} ADC_VIA_t;
+
+/* Window Comparator Mode select */
+typedef enum ADC_WINCM_enum
+{
+    ADC_WINCM_NONE_gc = (0x00<<0),  /* No Window Comparison */
+    ADC_WINCM_BELOW_gc = (0x01<<0),  /* Below Window */
+    ADC_WINCM_ABOVE_gc = (0x02<<0),  /* Above Window */
+    ADC_WINCM_INSIDE_gc = (0x03<<0),  /* Inside Window */
+    ADC_WINCM_OUTSIDE_gc = (0x04<<0)  /* Outside Window */
+} ADC_WINCM_t;
+
+/* Window Mode Source select */
+typedef enum ADC_WINSRC_enum
+{
+    ADC_WINSRC_RESULT_gc = (0x00<<3),  /* Result register used as Window Comparator Source */
+    ADC_WINSRC_SAMPLE_gc = (0x01<<3)  /* Sample register used as Window Comparator Source */
+} ADC_WINSRC_t;
+
+/*
+--------------------------------------------------------------------------
+BOD - Bod interface
+--------------------------------------------------------------------------
+*/
+
+/* Bod interface */
+typedef struct BOD_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t reserved_1[6];
+    register8_t VLMCTRLA;  /* Voltage level monitor Control */
+    register8_t INTCTRL;  /* Voltage level monitor interrupt Control */
+    register8_t INTFLAGS;  /* Voltage level monitor interrupt Flags */
+    register8_t STATUS;  /* Voltage level monitor status */
+    register8_t reserved_2[4];
+} BOD_t;
+
+/* Operation in active mode select */
+typedef enum BOD_ACTIVE_enum
+{
+    BOD_ACTIVE_DISABLE_gc = (0x00<<2),  /* Disabled */
+    BOD_ACTIVE_ENABLED_gc = (0x01<<2),  /* Enabled in continuous mode */
+    BOD_ACTIVE_SAMPLED_gc = (0x02<<2),  /* Enabled in sampled mode */
+    BOD_ACTIVE_ENABLEWAIT_gc = (0x03<<2)  /* Enabled in continuous mode. Execution halted at wake-up until BOD is running */
+} BOD_ACTIVE_t;
+
+/* Bod level select */
+typedef enum BOD_LVL_enum
+{
+    BOD_LVL_BODLEVEL0_gc = (0x00<<0),  /* BOD Disabled during normal operation */
+    BOD_LVL_BODLEVEL1_gc = (0x01<<0),  /* 1.9 V */
+    BOD_LVL_BODLEVEL2_gc = (0x02<<0),  /* 2.7 V */
+    BOD_LVL_BODLEVEL3_gc = (0x03<<0)  /* 4.5 V */
+} BOD_LVL_t;
+
+/* Sample frequency select */
+typedef enum BOD_SAMPFREQ_enum
+{
+    BOD_SAMPFREQ_128HZ_gc = (0x00<<4),  /* Sampling frequency is 128 Hz */
+    BOD_SAMPFREQ_32HZ_gc = (0x01<<4)  /* Sample frequency is 32 Hz */
+} BOD_SAMPFREQ_t;
+
+/* Operation in sleep mode select */
+typedef enum BOD_SLEEP_enum
+{
+    BOD_SLEEP_DISABLE_gc = (0x00<<0),  /* Disabled */
+    BOD_SLEEP_ENABLE_gc = (0x01<<0),  /* Enabled in continuous mode */
+    BOD_SLEEP_SAMPLE_gc = (0x02<<0)  /* Enabled in sampled mode */
+} BOD_SLEEP_t;
+
+/* Configuration select */
+typedef enum BOD_VLMCFG_enum
+{
+    BOD_VLMCFG_FALLING_gc = (0x00<<1),  /* VDD falls below VLM threshold */
+    BOD_VLMCFG_RISING_gc = (0x01<<1),  /* VDD rises above VLM threshold */
+    BOD_VLMCFG_BOTH_gc = (0x02<<1)  /* VDD crosses VLM threshold */
+} BOD_VLMCFG_t;
+
+/* voltage level monitor level select */
+typedef enum BOD_VLMLVL_enum
+{
+    BOD_VLMLVL_OFF_gc = (0x00<<0),  /* VLM Disabled */
+    BOD_VLMLVL_5ABOVE_gc = (0x01<<0),  /* VLM threshold 5% above BOD level */
+    BOD_VLMLVL_15ABOVE_gc = (0x02<<0),  /* VLM threshold 15% above BOD level */
+    BOD_VLMLVL_25ABOVE_gc = (0x03<<0)  /* VLM threshold 25% above BOD level */
+} BOD_VLMLVL_t;
+
+/* Voltage level monitor status select */
+typedef enum BOD_VLMS_enum
+{
+    BOD_VLMS_ABOVE_gc = (0x00<<0),  /* The voltage is above the VLM threshold level */
+    BOD_VLMS_BELOW_gc = (0x01<<0)  /* The voltage is below the VLM threshold level */
+} BOD_VLMS_t;
+
+/*
+--------------------------------------------------------------------------
+CCL - Configurable Custom Logic
+--------------------------------------------------------------------------
+*/
+
+/* Configurable Custom Logic */
+typedef struct CCL_struct
+{
+    register8_t CTRLA;  /* Control Register A */
+    register8_t SEQCTRL0;  /* Sequential Control 0 */
+    register8_t SEQCTRL1;  /* Sequential Control 1 */
+    register8_t reserved_1[2];
+    register8_t INTCTRL0;  /* Interrupt Control 0 */
+    register8_t reserved_2[1];
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t LUT0CTRLA;  /* LUT 0 Control A */
+    register8_t LUT0CTRLB;  /* LUT 0 Control B */
+    register8_t LUT0CTRLC;  /* LUT 0 Control C */
+    register8_t TRUTH0;  /* Truth 0 */
+    register8_t LUT1CTRLA;  /* LUT 1 Control A */
+    register8_t LUT1CTRLB;  /* LUT 1 Control B */
+    register8_t LUT1CTRLC;  /* LUT 1 Control C */
+    register8_t TRUTH1;  /* Truth 1 */
+    register8_t LUT2CTRLA;  /* LUT 2 Control A */
+    register8_t LUT2CTRLB;  /* LUT 2 Control B */
+    register8_t LUT2CTRLC;  /* LUT 2 Control C */
+    register8_t TRUTH2;  /* Truth 2 */
+    register8_t LUT3CTRLA;  /* LUT 3 Control A */
+    register8_t LUT3CTRLB;  /* LUT 3 Control B */
+    register8_t LUT3CTRLC;  /* LUT 3 Control C */
+    register8_t TRUTH3;  /* Truth 3 */
+    register8_t reserved_3[40];
+} CCL_t;
+
+/* Clock Source Selection */
+typedef enum CCL_CLKSRC_enum
+{
+    CCL_CLKSRC_CLKPER_gc = (0x00<<1),  /* Peripheral Clock */
+    CCL_CLKSRC_IN2_gc = (0x01<<1),  /* INSEL2 selection */
+    CCL_CLKSRC_OSCHF_gc = (0x04<<1),  /* Internal High Frequency oscillator */
+    CCL_CLKSRC_OSC32K_gc = (0x05<<1),  /* Internal 32.768 kHz oscillator */
+    CCL_CLKSRC_OSC1K_gc = (0x06<<1)  /* Internal 32.768 kHz oscillator divided by 32 */
+} CCL_CLKSRC_t;
+
+/* Edge Detection Enable select */
+typedef enum CCL_EDGEDET_enum
+{
+    CCL_EDGEDET_DIS_gc = (0x00<<7),  /* Edge detector is disabled */
+    CCL_EDGEDET_EN_gc = (0x01<<7)  /* Edge detector is enabled */
+} CCL_EDGEDET_t;
+
+/* Filter Selection */
+typedef enum CCL_FILTSEL_enum
+{
+    CCL_FILTSEL_DISABLE_gc = (0x00<<4),  /* Filter disabled */
+    CCL_FILTSEL_SYNCH_gc = (0x01<<4),  /* Synchronizer enabled */
+    CCL_FILTSEL_FILTER_gc = (0x02<<4)  /* Filter enabled */
+} CCL_FILTSEL_t;
+
+/* LUT Input 0 Source Selection */
+typedef enum CCL_INSEL0_enum
+{
+    CCL_INSEL0_MASK_gc = (0x00<<0),  /* Masked input */
+    CCL_INSEL0_FEEDBACK_gc = (0x01<<0),  /* Feedback input */
+    CCL_INSEL0_LINK_gc = (0x02<<0),  /* Output from LUT[n+1] as input source */
+    CCL_INSEL0_EVENTA_gc = (0x03<<0),  /* Event A as input source */
+    CCL_INSEL0_EVENTB_gc = (0x04<<0),  /* Event B as input source */
+    CCL_INSEL0_IO_gc = (0x05<<0),  /* IN0 input source */
+    CCL_INSEL0_AC0_gc = (0x06<<0),  /* AC0 output input source */
+    CCL_INSEL0_USART0_gc = (0x07<<0),  /* USART0 TxD input source */
+    CCL_INSEL0_SPI0_gc = (0x08<<0),  /* SPI0 MISO input source */
+    CCL_INSEL0_TCA0_gc = (0x09<<0),  /* TCA0 WO0 input source */
+    CCL_INSEL0_TCA1_gc = (0x0A<<0),  /* TCA1 WO0 input source */
+    CCL_INSEL0_TCB0_gc = (0x0B<<0)  /* TCB0 WO input source */
+} CCL_INSEL0_t;
+
+/* LUT Input 1 Source Selection */
+typedef enum CCL_INSEL1_enum
+{
+    CCL_INSEL1_MASK_gc = (0x00<<4),  /* Masked input */
+    CCL_INSEL1_FEEDBACK_gc = (0x01<<4),  /* Feedback input */
+    CCL_INSEL1_LINK_gc = (0x02<<4),  /* Output from LUT[n+1] as input source */
+    CCL_INSEL1_EVENTA_gc = (0x03<<4),  /* Event A as input source */
+    CCL_INSEL1_EVENTB_gc = (0x04<<4),  /* Event B as input source */
+    CCL_INSEL1_IO_gc = (0x05<<4),  /* IN0 input source */
+    CCL_INSEL1_AC1_gc = (0x06<<4),  /* AC1 output input source */
+    CCL_INSEL1_USART1_gc = (0x07<<4),  /* USART1 TxD input source */
+    CCL_INSEL1_SPI0_gc = (0x08<<4),  /* SPI0 MISO input source */
+    CCL_INSEL1_TCA0_gc = (0x09<<4),  /* TCA0 WO1 input source */
+    CCL_INSEL1_TCA1_gc = (0x0A<<4),  /* TCA1 WO1 input source */
+    CCL_INSEL1_TCB1_gc = (0x0B<<4)  /* TCB1 WO input source */
+} CCL_INSEL1_t;
+
+/* LUT Input 2 Source Selection */
+typedef enum CCL_INSEL2_enum
+{
+    CCL_INSEL2_MASK_gc = (0x00<<0),  /* Masked input */
+    CCL_INSEL2_FEEDBACK_gc = (0x01<<0),  /* Feedback input */
+    CCL_INSEL2_LINK_gc = (0x02<<0),  /* Output from LUT[n+1] as input source */
+    CCL_INSEL2_EVENTA_gc = (0x03<<0),  /* Event A as input source */
+    CCL_INSEL2_EVENTB_gc = (0x04<<0),  /* Event B as input source */
+    CCL_INSEL2_IO_gc = (0x05<<0),  /* IN0 input source */
+    CCL_INSEL2_AC1_gc = (0x06<<0),  /* AC1 output input source */
+    CCL_INSEL2_USART2_gc = (0x07<<0),  /* USART2 TxD input source */
+    CCL_INSEL2_SPI0_gc = (0x08<<0),  /* SPI0 MISO input source */
+    CCL_INSEL2_TCA0_gc = (0x09<<0),  /* TCA0 WO2 input source */
+    CCL_INSEL2_TCA1_gc = (0x0A<<0),  /* TCA1 WO2 input source */
+    CCL_INSEL2_TCB2_gc = (0x0B<<0)  /* TCB2 WO input source */
+} CCL_INSEL2_t;
+
+/* Interrupt Mode for LUT0 select */
+typedef enum CCL_INTMODE0_enum
+{
+    CCL_INTMODE0_INTDISABLE_gc = (0x00<<0),  /* Interrupt disabled */
+    CCL_INTMODE0_RISING_gc = (0x01<<0),  /* Sense rising edge */
+    CCL_INTMODE0_FALLING_gc = (0x02<<0),  /* Sense falling edge */
+    CCL_INTMODE0_BOTH_gc = (0x03<<0)  /* Sense both edges */
+} CCL_INTMODE0_t;
+
+/* Interrupt Mode for LUT1 select */
+typedef enum CCL_INTMODE1_enum
+{
+    CCL_INTMODE1_INTDISABLE_gc = (0x00<<2),  /* Interrupt disabled */
+    CCL_INTMODE1_RISING_gc = (0x01<<2),  /* Sense rising edge */
+    CCL_INTMODE1_FALLING_gc = (0x02<<2),  /* Sense falling edge */
+    CCL_INTMODE1_BOTH_gc = (0x03<<2)  /* Sense both edges */
+} CCL_INTMODE1_t;
+
+/* Interrupt Mode for LUT2 select */
+typedef enum CCL_INTMODE2_enum
+{
+    CCL_INTMODE2_INTDISABLE_gc = (0x00<<4),  /* Interrupt disabled */
+    CCL_INTMODE2_RISING_gc = (0x01<<4),  /* Sense rising edge */
+    CCL_INTMODE2_FALLING_gc = (0x02<<4),  /* Sense falling edge */
+    CCL_INTMODE2_BOTH_gc = (0x03<<4)  /* Sense both edges */
+} CCL_INTMODE2_t;
+
+/* Interrupt Mode for LUT3 select */
+typedef enum CCL_INTMODE3_enum
+{
+    CCL_INTMODE3_INTDISABLE_gc = (0x00<<6),  /* Interrupt disabled */
+    CCL_INTMODE3_RISING_gc = (0x01<<6),  /* Sense rising edge */
+    CCL_INTMODE3_FALLING_gc = (0x02<<6),  /* Sense falling edge */
+    CCL_INTMODE3_BOTH_gc = (0x03<<6)  /* Sense both edges */
+} CCL_INTMODE3_t;
+
+/* Sequential Selection */
+typedef enum CCL_SEQSEL_enum
+{
+    CCL_SEQSEL_DISABLE_gc = (0x00<<0),  /* Sequential logic disabled */
+    CCL_SEQSEL_DFF_gc = (0x01<<0),  /* D FlipFlop */
+    CCL_SEQSEL_JK_gc = (0x02<<0),  /* JK FlipFlop */
+    CCL_SEQSEL_LATCH_gc = (0x03<<0),  /* D Latch */
+    CCL_SEQSEL_RS_gc = (0x04<<0)  /* RS Latch */
+} CCL_SEQSEL_t;
+
+/*
+--------------------------------------------------------------------------
+CLKCTRL - Clock controller
+--------------------------------------------------------------------------
+*/
+
+/* Clock controller */
+typedef struct CLKCTRL_struct
+{
+    register8_t MCLKCTRLA;  /* MCLK Control A */
+    register8_t MCLKCTRLB;  /* MCLK Control B */
+    register8_t MCLKCTRLC;  /* MCLK Control C */
+    register8_t MCLKINTCTRL;  /* MCLK Interrupt Control */
+    register8_t MCLKINTFLAGS;  /* MCLK Interrupt Flags */
+    register8_t MCLKSTATUS;  /* MCLK Status */
+    register8_t MCLKTIMEBASE;  /* MCLK Timebase */
+    register8_t reserved_1[1];
+    register8_t OSCHFCTRLA;  /* OSCHF Control A */
+    register8_t OSCHFTUNE;  /* OSCHF Tune */
+    register8_t reserved_2[14];
+    register8_t OSC32KCTRLA;  /* OSC32K Control A */
+    register8_t reserved_3[3];
+    register8_t XOSC32KCTRLA;  /* XOSC32K Control A */
+    register8_t reserved_4[3];
+    register8_t XOSCHFCTRLA;  /* XOSCHF Control A */
+} CLKCTRL_t;
+
+/* Automatic Oscillator Tune select */
+typedef enum CLKCTRL_AUTOTUNE_enum
+{
+    CLKCTRL_AUTOTUNE_OFF_gc = (0x00<<0),  /* Disabled */
+    CLKCTRL_AUTOTUNE_XOSC32K_gc = (0x01<<0)  /* Tune against 32.768 kHz Crystal Oscillator */
+} CLKCTRL_AUTOTUNE_t;
+
+/* CFD Source select */
+typedef enum CLKCTRL_CFDSRC_enum
+{
+    CLKCTRL_CFDSRC_CLKMAIN_gc = (0x00<<2),  /* Main Clock */
+    CLKCTRL_CFDSRC_XOSCHF_gc = (0x01<<2),  /* High Frequency Crystal Oscillator */
+    CLKCTRL_CFDSRC_XOSC32K_gc = (0x02<<2)  /* 32.768 kHz Crystal Oscillator */
+} CLKCTRL_CFDSRC_t;
+
+/* Clock select */
+typedef enum CLKCTRL_CLKSEL_enum
+{
+    CLKCTRL_CLKSEL_OSCHF_gc = (0x00<<0),  /* Internal high-frequency oscillator */
+    CLKCTRL_CLKSEL_OSC32K_gc = (0x01<<0),  /* Internal 32.768 kHz oscillator */
+    CLKCTRL_CLKSEL_XOSC32K_gc = (0x02<<0),  /* 32.768 kHz crystal oscillator */
+    CLKCTRL_CLKSEL_EXTCLK_gc = (0x03<<0)  /* External clock */
+} CLKCTRL_CLKSEL_t;
+
+/* Crystal startup time select */
+typedef enum CLKCTRL_CSUT_enum
+{
+    CLKCTRL_CSUT_1K_gc = (0x00<<4),  /* 1k cycles */
+    CLKCTRL_CSUT_16K_gc = (0x01<<4),  /* 16k cycles */
+    CLKCTRL_CSUT_32K_gc = (0x02<<4),  /* 32k cycles */
+    CLKCTRL_CSUT_64K_gc = (0x03<<4)  /* 64k cycles */
+} CLKCTRL_CSUT_t;
+
+/* Start-Up Time select */
+typedef enum CLKCTRL_CSUTHF_enum
+{
+    CLKCTRL_CSUTHF_256CYC_gc = (0x00<<4),  /* 256 XOSCHF Cycles */
+    CLKCTRL_CSUTHF_1KCYC_gc = (0x01<<4),  /* 1K XOSCHF Cycles */
+    CLKCTRL_CSUTHF_4KCYC_gc = (0x02<<4)  /* 4K XOSCHF Cycles */
+} CLKCTRL_CSUTHF_t;
+
+/* Interrupt Type select */
+typedef enum CLKCTRL_INTTYPE_enum
+{
+    CLKCTRL_INTTYPE_INT_gc = (0x00<<7),  /* Regular interrupt */
+    CLKCTRL_INTTYPE_NMI_gc = (0x01<<7)  /* Non-maskable interrupt */
+} CLKCTRL_INTTYPE_t;
+
+/* Prescaler division select */
+typedef enum CLKCTRL_PDIV_enum
+{
+    CLKCTRL_PDIV_DIV2_gc = (0x00<<1),  /* Divide by 2 */
+    CLKCTRL_PDIV_DIV4_gc = (0x01<<1),  /* Divide by 4 */
+    CLKCTRL_PDIV_DIV8_gc = (0x02<<1),  /* Divide by 8 */
+    CLKCTRL_PDIV_DIV16_gc = (0x03<<1),  /* Divide by 16 */
+    CLKCTRL_PDIV_DIV32_gc = (0x04<<1),  /* Divide by 32 */
+    CLKCTRL_PDIV_DIV64_gc = (0x05<<1),  /* Divide by 64 */
+    CLKCTRL_PDIV_DIV6_gc = (0x08<<1),  /* Divide by 6 */
+    CLKCTRL_PDIV_DIV10_gc = (0x09<<1),  /* Divide by 10 */
+    CLKCTRL_PDIV_DIV12_gc = (0x0A<<1),  /* Divide by 12 */
+    CLKCTRL_PDIV_DIV24_gc = (0x0B<<1),  /* Divide by 24 */
+    CLKCTRL_PDIV_DIV48_gc = (0x0C<<1)  /* Divide by 48 */
+} CLKCTRL_PDIV_t;
+
+/* Source Select */
+typedef enum CLKCTRL_SELHF_enum
+{
+    CLKCTRL_SELHF_CRYSTAL_gc = (0x00<<1),  /* External Crystal */
+    CLKCTRL_SELHF_EXTCLK_gc = (0x01<<1)  /* Extenal Clock on XTALHF1 pin */
+} CLKCTRL_SELHF_t;
+
+/*
+--------------------------------------------------------------------------
+CPU - CPU
+--------------------------------------------------------------------------
+*/
+
+#define CORE_VERSION  V4S
+
+/* CCP signature select */
+typedef enum CCP_enum
+{
+    CCP_SPM_gc = (0x9D<<0),  /* SPM Instruction Protection */
+    CCP_IOREG_gc = (0xD8<<0)  /* IO Register Protection */
+} CCP_t;
+
+/*
+--------------------------------------------------------------------------
+CPUINT - Interrupt Controller
+--------------------------------------------------------------------------
+*/
+
+/* Interrupt Controller */
+typedef struct CPUINT_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t STATUS;  /* Status */
+    register8_t LVL0PRI;  /* Interrupt Level 0 Priority */
+    register8_t LVL1VEC;  /* Interrupt Level 1 Priority Vector */
+} CPUINT_t;
+
+
+/*
+--------------------------------------------------------------------------
+CRCSCAN - CRCSCAN
+--------------------------------------------------------------------------
+*/
+
+/* CRCSCAN */
+typedef struct CRCSCAN_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t STATUS;  /* Status */
+    register8_t reserved_1[13];
+} CRCSCAN_t;
+
+/* CRC Source select */
+typedef enum CRCSCAN_SRC_enum
+{
+    CRCSCAN_SRC_FLASH_gc = (0x00<<0),  /* CRC on entire flash */
+    CRCSCAN_SRC_APPLICATION_gc = (0x01<<0),  /* CRC on boot and appl section of flash */
+    CRCSCAN_SRC_BOOT_gc = (0x02<<0)  /* CRC on boot section of flash */
+} CRCSCAN_SRC_t;
+
+/*
+--------------------------------------------------------------------------
+DAC - Digital to Analog Converter
+--------------------------------------------------------------------------
+*/
+
+/* Digital to Analog Converter */
+typedef struct DAC_struct
+{
+    register8_t CTRLA;  /* Control Register A */
+    register8_t reserved_1[1];
+    _WORDREGISTER(DATA);  /* DATA Register */
+    register8_t reserved_2[12];
+} DAC_t;
+
+/* Output Buffer Range select */
+typedef enum DAC_OUTRANGE_enum
+{
+    DAC_OUTRANGE_AUTO_gc = (0x00<<4),  /* Output buffer automatically choose best range */
+    DAC_OUTRANGE_LOW_gc = (0x02<<4),  /* Output buffer configured to low range */
+    DAC_OUTRANGE_HIGH_gc = (0x03<<4)  /* Output buffer configured to high range */
+} DAC_OUTRANGE_t;
+
+/*
+--------------------------------------------------------------------------
+EVSYS - Event System
+--------------------------------------------------------------------------
+*/
+
+/* Event System */
+typedef struct EVSYS_struct
+{
+    register8_t SWEVENTA;  /* Software Event A */
+    register8_t reserved_1[15];
+    register8_t CHANNEL0;  /* Multiplexer Channel 0 */
+    register8_t CHANNEL1;  /* Multiplexer Channel 1 */
+    register8_t CHANNEL2;  /* Multiplexer Channel 2 */
+    register8_t CHANNEL3;  /* Multiplexer Channel 3 */
+    register8_t CHANNEL4;  /* Multiplexer Channel 4 */
+    register8_t CHANNEL5;  /* Multiplexer Channel 5 */
+    register8_t reserved_2[10];
+    register8_t USERCCLLUT0A;  /* CCL0 Event A */
+    register8_t USERCCLLUT0B;  /* CCL0 Event B */
+    register8_t USERCCLLUT1A;  /* CCL1 Event A */
+    register8_t USERCCLLUT1B;  /* CCL1 Event B */
+    register8_t USERCCLLUT2A;  /* CCL2 Event A */
+    register8_t USERCCLLUT2B;  /* CCL2 Event B */
+    register8_t USERCCLLUT3A;  /* CCL3 Event A */
+    register8_t USERCCLLUT3B;  /* CCL3 Event B */
+    register8_t USERADC0START;  /* ADC0 */
+    register8_t USEREVSYSEVOUTA;  /* EVOUTA */
+    register8_t USEREVSYSEVOUTB;  /* EVOUTB */
+    register8_t USEREVSYSEVOUTC;  /* EVOUTC */
+    register8_t USEREVSYSEVOUTD;  /* EVOUTD */
+    register8_t USEREVSYSEVOUTE;  /* EVOUTE */
+    register8_t USEREVSYSEVOUTF;  /* EVOUTF */
+    register8_t USERUSART0IRDA;  /* USART0 */
+    register8_t USERUSART1IRDA;  /* USART1 */
+    register8_t USERUSART2IRDA;  /* USART2 */
+    register8_t USERTCA0CNTA;  /* TCA0 Event A */
+    register8_t USERTCA0CNTB;  /* TCA0 Event B */
+    register8_t USERTCA1CNTA;  /* TCA1 Event A */
+    register8_t USERTCA1CNTB;  /* TCA1 Event B */
+    register8_t USERTCB0CAPT;  /* TCB0 Event A */
+    register8_t USERTCB0COUNT;  /* TCB0 Event B */
+    register8_t USERTCB1CAPT;  /* TCB1 Event A */
+    register8_t USERTCB1COUNT;  /* TCB1 Event B */
+    register8_t USERTCB2CAPT;  /* TCB2 Event A */
+    register8_t USERTCB2COUNT;  /* TCB2 Event B */
+    register8_t USERTCB3CAPT;  /* TCB3 Event A */
+    register8_t USERTCB3COUNT;  /* TCB3 Event B */
+    register8_t reserved_3[2];
+} EVSYS_t;
+
+/* Channel generator select */
+typedef enum EVSYS_CHANNEL_enum
+{
+    EVSYS_CHANNEL_OFF_gc = (0x00<<0),  /* Off */
+    EVSYS_CHANNEL_UPDI_SYNCH_gc = (0x01<<0),  /* UPDI SYNCH character */
+    EVSYS_CHANNEL_RTC_OVF_gc = (0x06<<0),  /* Real Time Counter overflow */
+    EVSYS_CHANNEL_RTC_CMP_gc = (0x07<<0),  /* Real Time Counter compare */
+    EVSYS_CHANNEL_RTC_PITEV0_gc = (0x08<<0),  /* Periodic Interrupt Timer Event 0 */
+    EVSYS_CHANNEL_RTC_PITEV1_gc = (0x09<<0),  /* Periodic Interrupt Timer Event 1 */
+    EVSYS_CHANNEL_CCL_LUT0_gc = (0x10<<0),  /* Configurable Custom Logic LUT0 */
+    EVSYS_CHANNEL_CCL_LUT1_gc = (0x11<<0),  /* Configurable Custom Logic LUT1 */
+    EVSYS_CHANNEL_CCL_LUT2_gc = (0x12<<0),  /* Configurable Custom Logic LUT2 */
+    EVSYS_CHANNEL_CCL_LUT3_gc = (0x13<<0),  /* Configurable Custom Logic LUT3 */
+    EVSYS_CHANNEL_AC0_OUT_gc = (0x20<<0),  /* Analog Comparator 0 out */
+    EVSYS_CHANNEL_AC1_OUT_gc = (0x21<<0),  /* Analog Comparator 1 out */
+    EVSYS_CHANNEL_ADC0_RES_gc = (0x24<<0),  /* ADC 0 Result Ready */
+    EVSYS_CHANNEL_ADC0_SAMP_gc = (0x25<<0),  /* ADC 0 Sample Ready */
+    EVSYS_CHANNEL_ADC0_WCMP_gc = (0x26<<0),  /* ADC 0 Window Compare */
+    EVSYS_CHANNEL_PORTA_EV0_gc = (0x40<<0),  /* Port A Event 0 */
+    EVSYS_CHANNEL_PORTA_EV1_gc = (0x41<<0),  /* Port A Event 1 */
+    EVSYS_CHANNEL_PORTB_EV0_gc = (0x42<<0),  /* Port B Event 0 */
+    EVSYS_CHANNEL_PORTB_EV1_gc = (0x43<<0),  /* Port B Event 1 */
+    EVSYS_CHANNEL_PORTC_EV0_gc = (0x44<<0),  /* Port C Event 0 */
+    EVSYS_CHANNEL_PORTC_EV1_gc = (0x45<<0),  /* Port C Event 1 */
+    EVSYS_CHANNEL_PORTD_EV0_gc = (0x46<<0),  /* Port D Event 0 */
+    EVSYS_CHANNEL_PORTD_EV1_gc = (0x47<<0),  /* Port D Event 1 */
+    EVSYS_CHANNEL_PORTE_EV0_gc = (0x48<<0),  /* Port E Event 0 */
+    EVSYS_CHANNEL_PORTE_EV1_gc = (0x49<<0),  /* Port E Event 1 */
+    EVSYS_CHANNEL_PORTF_EV0_gc = (0x4A<<0),  /* Port F Event 0 */
+    EVSYS_CHANNEL_PORTF_EV1_gc = (0x4B<<0),  /* Port F Event 1 */
+    EVSYS_CHANNEL_USART0_XCK_gc = (0x60<<0),  /* USART 0 XCK */
+    EVSYS_CHANNEL_USART1_XCK_gc = (0x61<<0),  /* USART 1 XCK */
+    EVSYS_CHANNEL_USART2_XCK_gc = (0x62<<0),  /* USART 2 XCK */
+    EVSYS_CHANNEL_SPI0_SCK_gc = (0x68<<0),  /* SPI 0 SCK */
+    EVSYS_CHANNEL_TCA0_OVF_LUNF_gc = (0x80<<0),  /* Timer/Counter A0 overflow / low byte timer underflow */
+    EVSYS_CHANNEL_TCA0_HUNF_gc = (0x81<<0),  /* Timer/Counter A0 high byte timer underflow */
+    EVSYS_CHANNEL_TCA0_CMP0_LCMP0_gc = (0x84<<0),  /* Timer/Counter A0 compare 0 / low byte timer compare 0 */
+    EVSYS_CHANNEL_TCA0_CMP1_LCMP1_gc = (0x85<<0),  /* Timer/Counter A0 compare 1 / low byte timer compare 1 */
+    EVSYS_CHANNEL_TCA0_CMP2_LCMP2_gc = (0x86<<0),  /* Timer/Counter A0 compare 2 / low byte timer compare 2 */
+    EVSYS_CHANNEL_TCA1_OVF_LUNF_gc = (0x88<<0),  /* Timer/Counter A1 overflow / low byte timer underflow */
+    EVSYS_CHANNEL_TCA1_HUNF_gc = (0x89<<0),  /* Timer/Counter A1 high byte timer underflow */
+    EVSYS_CHANNEL_TCA1_CMP0_LCMP0_gc = (0x8C<<0),  /* Timer/Counter A1 compare 0 / low byte timer compare 0 */
+    EVSYS_CHANNEL_TCA1_CMP1_LCMP1_gc = (0x8D<<0),  /* Timer/Counter A1 compare 1 / low byte timer compare 1 */
+    EVSYS_CHANNEL_TCA1_CMP2_LCMP2_gc = (0x8E<<0),  /* Timer/Counter A1 compare 2 / low byte timer compare 2 */
+    EVSYS_CHANNEL_TCB0_CAPT_gc = (0xA0<<0),  /* Timer/Counter B0 capture */
+    EVSYS_CHANNEL_TCB0_OVF_gc = (0xA1<<0),  /* Timer/Counter B0 overflow */
+    EVSYS_CHANNEL_TCB1_CAPT_gc = (0xA2<<0),  /* Timer/Counter B1 capture */
+    EVSYS_CHANNEL_TCB1_OVF_gc = (0xA3<<0),  /* Timer/Counter B1 overflow */
+    EVSYS_CHANNEL_TCB2_CAPT_gc = (0xA4<<0),  /* Timer/Counter B2 capture */
+    EVSYS_CHANNEL_TCB2_OVF_gc = (0xA5<<0),  /* Timer/Counter B2 overflow */
+    EVSYS_CHANNEL_TCB3_CAPT_gc = (0xA6<<0),  /* Timer/Counter B3 capture */
+    EVSYS_CHANNEL_TCB3_OVF_gc = (0xA7<<0)  /* Timer/Counter B3 overflow */
+} EVSYS_CHANNEL_t;
+
+/* Software event on channel select */
+typedef enum EVSYS_SWEVENTA_enum
+{
+    EVSYS_SWEVENTA_CH0_gc = (0x01<<0),  /* Software event on channel 0 */
+    EVSYS_SWEVENTA_CH1_gc = (0x02<<0),  /* Software event on channel 1 */
+    EVSYS_SWEVENTA_CH2_gc = (0x04<<0),  /* Software event on channel 2 */
+    EVSYS_SWEVENTA_CH3_gc = (0x08<<0),  /* Software event on channel 3 */
+    EVSYS_SWEVENTA_CH4_gc = (0x10<<0),  /* Software event on channel 4 */
+    EVSYS_SWEVENTA_CH5_gc = (0x20<<0),  /* Software event on channel 5 */
+    EVSYS_SWEVENTA_CH6_gc = (0x40<<0),  /* Software event on channel 6 */
+    EVSYS_SWEVENTA_CH7_gc = (0x80<<0)  /* Software event on channel 7 */
+} EVSYS_SWEVENTA_t;
+
+/* User channel select */
+typedef enum EVSYS_USER_enum
+{
+    EVSYS_USER_OFF_gc = (0x00<<0),  /* Off, No Eventsys Channel connected */
+    EVSYS_USER_CHANNEL0_gc = (0x01<<0),  /* Connect user to event channel 0 */
+    EVSYS_USER_CHANNEL1_gc = (0x02<<0),  /* Connect user to event channel 1 */
+    EVSYS_USER_CHANNEL2_gc = (0x03<<0),  /* Connect user to event channel 2 */
+    EVSYS_USER_CHANNEL3_gc = (0x04<<0),  /* Connect user to event channel 3 */
+    EVSYS_USER_CHANNEL4_gc = (0x05<<0),  /* Connect user to event channel 4 */
+    EVSYS_USER_CHANNEL5_gc = (0x06<<0)  /* Connect user to event channel 5 */
+} EVSYS_USER_t;
+
+/*
+--------------------------------------------------------------------------
+FUSE - Fuses
+--------------------------------------------------------------------------
+*/
+
+/* Fuses */
+typedef struct FUSE_struct
+{
+    register8_t WDTCFG;  /* Watchdog Configuration */
+    register8_t BODCFG;  /* BOD Configuration */
+    register8_t OSCCFG;  /* Oscillator Configuration */
+    register8_t reserved_1[2];
+    register8_t SYSCFG0;  /* System Configuration 0 */
+    register8_t SYSCFG1;  /* System Configuration 1 */
+    register8_t CODESIZE;  /* Code Section Size */
+    register8_t BOOTSIZE;  /* Boot Section Size */
+} FUSE_t;
+
+/* avr-libc typedef for avr/fuse.h */
+typedef FUSE_t NVM_FUSES_t;
+
+/* BOD Operation in Active Mode select */
+typedef enum ACTIVE_enum
+{
+    ACTIVE_DISABLE_gc = (0x00<<2),  /* Disabled */
+    ACTIVE_ENABLED_gc = (0x01<<2),  /* Enabled in continuous mode */
+    ACTIVE_SAMPLED_gc = (0x02<<2),  /* Enabled in sampled mode */
+    ACTIVE_ENABLEWAIT_gc = (0x03<<2)  /* Enabled in continuous mode. Execution halted at wake-up until BOD is running */
+} ACTIVE_t;
+
+/* CRC Select */
+typedef enum CRCSEL_enum
+{
+    CRCSEL_CRC16_gc = (0x00<<5),  /* Enable CRC16 */
+    CRCSEL_CRC32_gc = (0x01<<5)  /* Enable CRC32 */
+} CRCSEL_t;
+
+/* CRC Source select */
+typedef enum CRCSRC_enum
+{
+    CRCSRC_FLASH_gc = (0x00<<6),  /* CRC of full Flash (boot, application code and application data) */
+    CRCSRC_BOOT_gc = (0x01<<6),  /* CRC of boot section */
+    CRCSRC_BOOTAPP_gc = (0x02<<6),  /* CRC of application code and boot sections */
+    CRCSRC_NOCRC_gc = (0x03<<6)  /* No CRC */
+} CRCSRC_t;
+
+/* EEPROM Save select */
+typedef enum EESAVE_enum
+{
+    EESAVE_DISABLE_gc = (0x00<<0),  /* EEPROM content is erased during chip erase */
+    EESAVE_ENABLE_gc = (0x01<<0)  /* EEPROM content is preserved during chip erase */
+} EESAVE_t;
+
+/* BOD Level select */
+typedef enum LVL_enum
+{
+    LVL_BODLEVEL0_gc = (0x00<<5),  /* BOD Disabled during normal operation */
+    LVL_BODLEVEL1_gc = (0x01<<5),  /* 1.9 V */
+    LVL_BODLEVEL2_gc = (0x02<<5),  /* 2.7 V */
+    LVL_BODLEVEL3_gc = (0x03<<5)  /* 4.5 V */
+} LVL_t;
+
+/* High-frequency Oscillator Frequency select */
+typedef enum OSCHFFRQ_enum
+{
+    OSCHFFRQ_20M_gc = (0x00<<3),  /* OSCHF running at 20 MHz */
+    OSCHFFRQ_16M_gc = (0x01<<3)  /* OSCHF running at 16 MHz */
+} OSCHFFRQ_t;
+
+/* Watchdog Timeout Period select */
+typedef enum PERIOD_enum
+{
+    PERIOD_OFF_gc = (0x00<<0),  /* Watch-Dog timer Off */
+    PERIOD_8CLK_gc = (0x01<<0),  /* 8 cycles (8ms) */
+    PERIOD_16CLK_gc = (0x02<<0),  /* 16 cycles (16ms) */
+    PERIOD_32CLK_gc = (0x03<<0),  /* 32 cycles (32ms) */
+    PERIOD_64CLK_gc = (0x04<<0),  /* 64 cycles (64ms) */
+    PERIOD_128CLK_gc = (0x05<<0),  /* 128 cycles (0.128s) */
+    PERIOD_256CLK_gc = (0x06<<0),  /* 256 cycles (0.256s) */
+    PERIOD_512CLK_gc = (0x07<<0),  /* 512 cycles (0.512s) */
+    PERIOD_1KCLK_gc = (0x08<<0),  /* 1K cycles (1.0s) */
+    PERIOD_2KCLK_gc = (0x09<<0),  /* 2K cycles (2.0s) */
+    PERIOD_4KCLK_gc = (0x0A<<0),  /* 4K cycles (4.0s) */
+    PERIOD_8KCLK_gc = (0x0B<<0)  /* 8K cycles (8.0s) */
+} PERIOD_t;
+
+/* Reset Pin Configuration select */
+typedef enum RSTPINCFG_enum
+{
+    RSTPINCFG_NONE_gc = (0x00<<3),  /* No External Reset */
+    RSTPINCFG_RESET_gc = (0x01<<3)  /* PF6 configured as RESET pin */
+} RSTPINCFG_t;
+
+/* BOD Sample Frequency select */
+typedef enum SAMPFREQ_enum
+{
+    SAMPFREQ_128HZ_gc = (0x00<<4),  /* Sampling frequency is 128 Hz */
+    SAMPFREQ_32HZ_gc = (0x01<<4)  /* Sample frequency is 32 Hz */
+} SAMPFREQ_t;
+
+/* BOD Operation in Sleep Mode select */
+typedef enum SLEEP_enum
+{
+    SLEEP_DISABLE_gc = (0x00<<0),  /* Disabled */
+    SLEEP_ENABLE_gc = (0x01<<0),  /* Enabled in continuous mode */
+    SLEEP_SAMPLE_gc = (0x02<<0)  /* Enabled in sampled mode */
+} SLEEP_t;
+
+/* Startup Time select */
+typedef enum SUT_enum
+{
+    SUT_0MS_gc = (0x00<<0),  /* 0 ms */
+    SUT_1MS_gc = (0x01<<0),  /* 1 ms */
+    SUT_2MS_gc = (0x02<<0),  /* 2 ms */
+    SUT_4MS_gc = (0x03<<0),  /* 4 ms */
+    SUT_8MS_gc = (0x04<<0),  /* 8 ms */
+    SUT_16MS_gc = (0x05<<0),  /* 16 ms */
+    SUT_32MS_gc = (0x06<<0),  /* 32 ms */
+    SUT_64MS_gc = (0x07<<0)  /* 64 ms */
+} SUT_t;
+
+/* UPDI Pin Configuration select */
+typedef enum UPDIPINCFG_enum
+{
+    UPDIPINCFG_GPIO_gc = (0x00<<4),  /* PF7 Configured as GPIO pin */
+    UPDIPINCFG_UPDI_gc = (0x01<<4)  /* PF7 Configured as UPDI pin */
+} UPDIPINCFG_t;
+
+/* Watchdog Window Timeout Period select */
+typedef enum WINDOW_enum
+{
+    WINDOW_OFF_gc = (0x00<<4),  /* Window mode off */
+    WINDOW_8CLK_gc = (0x01<<4),  /* 8 cycles (8ms) */
+    WINDOW_16CLK_gc = (0x02<<4),  /* 16 cycles (16ms) */
+    WINDOW_32CLK_gc = (0x03<<4),  /* 32 cycles (32ms) */
+    WINDOW_64CLK_gc = (0x04<<4),  /* 64 cycles (64ms) */
+    WINDOW_128CLK_gc = (0x05<<4),  /* 128 cycles (0.128s) */
+    WINDOW_256CLK_gc = (0x06<<4),  /* 256 cycles (0.256s) */
+    WINDOW_512CLK_gc = (0x07<<4),  /* 512 cycles (0.512s) */
+    WINDOW_1KCLK_gc = (0x08<<4),  /* 1K cycles (1.0s) */
+    WINDOW_2KCLK_gc = (0x09<<4),  /* 2K cycles (2.0s) */
+    WINDOW_4KCLK_gc = (0x0A<<4),  /* 4K cycles (4.0s) */
+    WINDOW_8KCLK_gc = (0x0B<<4)  /* 8K cycles (8.0s) */
+} WINDOW_t;
+
+/*
+--------------------------------------------------------------------------
+GPR - General Purpose Registers
+--------------------------------------------------------------------------
+*/
+
+/* General Purpose Registers */
+typedef struct GPR_struct
+{
+    register8_t GPR0;  /* General Purpose Register 0 */
+    register8_t GPR1;  /* General Purpose Register 1 */
+    register8_t GPR2;  /* General Purpose Register 2 */
+    register8_t GPR3;  /* General Purpose Register 3 */
+} GPR_t;
+
+
+/*
+--------------------------------------------------------------------------
+LOCK - Lockbits
+--------------------------------------------------------------------------
+*/
+
+/* Lockbits */
+typedef struct LOCK_struct
+{
+    _DWORDREGISTER(KEY);  /* Lock Key Bits */
+} LOCK_t;
+
+/* Lock Key select */
+typedef enum LOCK_KEY_enum
+{
+    LOCK_KEY_NOLOCK_gc = (0x5CC5C55C<<0),  /* No locks */
+    LOCK_KEY_RWLOCK_gc = (0xA33A3AA3<<0)  /* Read and write lock */
+} LOCK_KEY_t;
+
+/*
+--------------------------------------------------------------------------
+NVMCTRL - Non-volatile Memory Controller
+--------------------------------------------------------------------------
+*/
+
+/* Non-volatile Memory Controller */
+typedef struct NVMCTRL_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t reserved_1[2];
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t STATUS;  /* Status */
+    register8_t reserved_2[1];
+    _WORDREGISTER(DATA);  /* Data */
+    register8_t reserved_3[2];
+    _DWORDREGISTER(ADDR);  /* Address */
+    register8_t reserved_4[48];
+} NVMCTRL_t;
+
+/* Command select */
+typedef enum NVMCTRL_CMD_enum
+{
+    NVMCTRL_CMD_NOCMD_gc = (0x00<<0),  /* No Command */
+    NVMCTRL_CMD_NOOP_gc = (0x01<<0),  /* No Operation */
+    NVMCTRL_CMD_FLPW_gc = (0x04<<0),  /* Flash Page Write */
+    NVMCTRL_CMD_FLPERW_gc = (0x05<<0),  /* Flash Page Erase and Write */
+    NVMCTRL_CMD_FLPER_gc = (0x08<<0),  /* Flash Page Erase */
+    NVMCTRL_CMD_FLMPER2_gc = (0x09<<0),  /* Flash 2-page erase enable */
+    NVMCTRL_CMD_FLMPER4_gc = (0x0A<<0),  /* Flash 4-page erase enable */
+    NVMCTRL_CMD_FLMPER8_gc = (0x0B<<0),  /* Flash 8-page erase enable */
+    NVMCTRL_CMD_FLMPER16_gc = (0x0C<<0),  /* Flash 16-page erase enable */
+    NVMCTRL_CMD_FLMPER32_gc = (0x0D<<0),  /* Flash 32-page erase enable */
+    NVMCTRL_CMD_FLPBCLR_gc = (0x0F<<0),  /* Flash Page Buffer Clear */
+    NVMCTRL_CMD_EEPW_gc = (0x14<<0),  /* EEPROM Page Write */
+    NVMCTRL_CMD_EEPERW_gc = (0x15<<0),  /* EEPROM Page Erase and Write */
+    NVMCTRL_CMD_EEPER_gc = (0x17<<0),  /* EEPROM Page Erase */
+    NVMCTRL_CMD_EEPBCLR_gc = (0x1F<<0),  /* EEPROM Page Buffer Clear */
+    NVMCTRL_CMD_CHER_gc = (0x20<<0),  /* Chip Erase Command (UPDI only) */
+    NVMCTRL_CMD_EECHER_gc = (0x30<<0)  /* EEPROM Erase Command (UPDI only) */
+} NVMCTRL_CMD_t;
+
+/* Write error select */
+typedef enum NVMCTRL_ERROR_enum
+{
+    NVMCTRL_ERROR_NOERROR_gc = (0x00<<4),  /* No Error */
+    NVMCTRL_ERROR_WRITEPROTECT_gc = (0x02<<4),  /* Attempt to program write protected area */
+    NVMCTRL_ERROR_CMDCOLLISION_gc = (0x03<<4),  /* Selecting new write command while write command already seleted */
+    NVMCTRL_ERROR_WRONGSECTION_gc = (0x04<<4)  /* Address cannot be written with selected command */
+} NVMCTRL_ERROR_t;
+
+/* Flash Mapping in Data space select */
+typedef enum NVMCTRL_FLMAP_enum
+{
+    NVMCTRL_FLMAP_SECTION0_gc = (0x00<<4),  /* Flash section 0, 0 - 32KB */
+    NVMCTRL_FLMAP_SECTION1_gc = (0x01<<4),  /* Flash section 1, 32 - 64KB */
+    NVMCTRL_FLMAP_SECTION2_gc = (0x02<<4),  /* Flash section 2, 64 - 96KB */
+    NVMCTRL_FLMAP_SECTION3_gc = (0x03<<4)  /* Flash section 3, 96 - 128KB */
+} NVMCTRL_FLMAP_t;
+
+/*
+--------------------------------------------------------------------------
+PORT - I/O Ports
+--------------------------------------------------------------------------
+*/
+
+/* I/O Ports */
+typedef struct PORT_struct
+{
+    register8_t DIR;  /* Data Direction */
+    register8_t DIRSET;  /* Data Direction Set */
+    register8_t DIRCLR;  /* Data Direction Clear */
+    register8_t DIRTGL;  /* Data Direction Toggle */
+    register8_t OUT;  /* Output Value */
+    register8_t OUTSET;  /* Output Value Set */
+    register8_t OUTCLR;  /* Output Value Clear */
+    register8_t OUTTGL;  /* Output Value Toggle */
+    register8_t IN;  /* Input Value */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t PORTCTRL;  /* Port Control */
+    register8_t PINCONFIG;  /* Pin Control Config */
+    register8_t PINCTRLUPD;  /* Pin Control Update */
+    register8_t PINCTRLSET;  /* Pin Control Set */
+    register8_t PINCTRLCLR;  /* Pin Control Clear */
+    register8_t reserved_1[1];
+    register8_t PIN0CTRL;  /* Pin 0 Control */
+    register8_t PIN1CTRL;  /* Pin 1 Control */
+    register8_t PIN2CTRL;  /* Pin 2 Control */
+    register8_t PIN3CTRL;  /* Pin 3 Control */
+    register8_t PIN4CTRL;  /* Pin 4 Control */
+    register8_t PIN5CTRL;  /* Pin 5 Control */
+    register8_t PIN6CTRL;  /* Pin 6 Control */
+    register8_t PIN7CTRL;  /* Pin 7 Control */
+    register8_t EVGENCTRL;  /* Event Generation Control */
+    register8_t reserved_2[7];
+} PORT_t;
+
+/* Event Generator 0 Select */
+typedef enum PORT_EVGEN0SEL_enum
+{
+    PORT_EVGEN0SEL_PIN0_gc = (0x00<<0),  /* Pin 0 used as event generator */
+    PORT_EVGEN0SEL_PIN1_gc = (0x01<<0),  /* Pin 1 used as event generator */
+    PORT_EVGEN0SEL_PIN2_gc = (0x02<<0),  /* Pin 2 used as event generator */
+    PORT_EVGEN0SEL_PIN3_gc = (0x03<<0),  /* Pin 3 used as event generator */
+    PORT_EVGEN0SEL_PIN4_gc = (0x04<<0),  /* Pin 4 used as event generator */
+    PORT_EVGEN0SEL_PIN5_gc = (0x05<<0),  /* Pin 5 used as event generator */
+    PORT_EVGEN0SEL_PIN6_gc = (0x06<<0),  /* Pin 6 used as event generator */
+    PORT_EVGEN0SEL_PIN7_gc = (0x07<<0)  /* Pin 7 used as event generator */
+} PORT_EVGEN0SEL_t;
+
+/* Event Generator 1 Select */
+typedef enum PORT_EVGEN1SEL_enum
+{
+    PORT_EVGEN1SEL_PIN0_gc = (0x00<<4),  /* Pin 0 used as event generator */
+    PORT_EVGEN1SEL_PIN1_gc = (0x01<<4),  /* Pin 1 used as event generator */
+    PORT_EVGEN1SEL_PIN2_gc = (0x02<<4),  /* Pin 2 used as event generator */
+    PORT_EVGEN1SEL_PIN3_gc = (0x03<<4),  /* Pin 3 used as event generator */
+    PORT_EVGEN1SEL_PIN4_gc = (0x04<<4),  /* Pin 4 used as event generator */
+    PORT_EVGEN1SEL_PIN5_gc = (0x05<<4),  /* Pin 5 used as event generator */
+    PORT_EVGEN1SEL_PIN6_gc = (0x06<<4),  /* Pin 6 used as event generator */
+    PORT_EVGEN1SEL_PIN7_gc = (0x07<<4)  /* Pin 7 used as event generator */
+} PORT_EVGEN1SEL_t;
+
+/* Input Level Select */
+typedef enum PORT_INLVL_enum
+{
+    PORT_INLVL_ST_gc = (0x00<<6),  /* Schmitt-Trigger input level */
+    PORT_INLVL_TTL_gc = (0x01<<6)  /* TTL Input level */
+} PORT_INLVL_t;
+
+/* Input/Sense Configuration select */
+typedef enum PORT_ISC_enum
+{
+    PORT_ISC_INTDISABLE_gc = (0x00<<0),  /* Interrupt disabled but input buffer enabled */
+    PORT_ISC_BOTHEDGES_gc = (0x01<<0),  /* Sense Both Edges */
+    PORT_ISC_RISING_gc = (0x02<<0),  /* Sense Rising Edge */
+    PORT_ISC_FALLING_gc = (0x03<<0),  /* Sense Falling Edge */
+    PORT_ISC_INPUT_DISABLE_gc = (0x04<<0),  /* Digital Input Buffer disabled */
+    PORT_ISC_LEVEL_gc = (0x05<<0)  /* Sense low Level */
+} PORT_ISC_t;
+
+/*
+--------------------------------------------------------------------------
+PORTMUX - Port Multiplexer
+--------------------------------------------------------------------------
+*/
+
+/* Port Multiplexer */
+typedef struct PORTMUX_struct
+{
+    register8_t EVSYSROUTEA;  /* EVSYS route A */
+    register8_t CCLROUTEA;  /* CCL route A */
+    register8_t USARTROUTEA;  /* USART route A */
+    register8_t USARTROUTEB;  /* USART route B */
+    register8_t reserved_1[1];
+    register8_t SPIROUTEA;  /* SPI route A */
+    register8_t TWIROUTEA;  /* TWI route A */
+    register8_t TCAROUTEA;  /* TCA route A */
+    register8_t TCBROUTEA;  /* TCB route A */
+    register8_t reserved_2[1];
+    register8_t ACROUTEA;  /* AC route A */
+    register8_t reserved_3[21];
+} PORTMUX_t;
+
+/* Analog Comparator 0 Output select */
+typedef enum PORTMUX_AC0_enum
+{
+    PORTMUX_AC0_DEFAULT_gc = (0x00<<0),  /* OUT: PA7 */
+    PORTMUX_AC0_ALT1_gc = (0x01<<0)  /* OUT: PC6 */
+} PORTMUX_AC0_t;
+
+/* Analog Comparator 1 Output select */
+typedef enum PORTMUX_AC1_enum
+{
+    PORTMUX_AC1_DEFAULT_gc = (0x00<<1),  /* OUT: PA7 */
+    PORTMUX_AC1_ALT1_gc = (0x01<<1)  /* OUT: PC6 */
+} PORTMUX_AC1_t;
+
+/* Event Output A select */
+typedef enum PORTMUX_EVOUTA_enum
+{
+    PORTMUX_EVOUTA_DEFAULT_gc = (0x00<<0),  /* EVOUTA: PA2 */
+    PORTMUX_EVOUTA_ALT1_gc = (0x01<<0)  /* EVOUTA: PA7 */
+} PORTMUX_EVOUTA_t;
+
+/* Event Output B select */
+typedef enum PORTMUX_EVOUTB_enum
+{
+    PORTMUX_EVOUTB_DEFAULT_gc = (0x00<<1)  /* EVOUTB: PB2 */
+} PORTMUX_EVOUTB_t;
+
+/* Event Output C select */
+typedef enum PORTMUX_EVOUTC_enum
+{
+    PORTMUX_EVOUTC_DEFAULT_gc = (0x00<<2),  /* EVOUTC: PC2 */
+    PORTMUX_EVOUTC_ALT1_gc = (0x01<<2)  /* EVOUTC: PC7 */
+} PORTMUX_EVOUTC_t;
+
+/* Event Output D select */
+typedef enum PORTMUX_EVOUTD_enum
+{
+    PORTMUX_EVOUTD_DEFAULT_gc = (0x00<<3),  /* EVOUTD: PD2 */
+    PORTMUX_EVOUTD_ALT1_gc = (0x01<<3)  /* EVOUTD: PD7 */
+} PORTMUX_EVOUTD_t;
+
+/* Event Output E select */
+typedef enum PORTMUX_EVOUTE_enum
+{
+    PORTMUX_EVOUTE_DEFAULT_gc = (0x00<<4)  /* EVOUTE: PE2 */
+} PORTMUX_EVOUTE_t;
+
+/* Event Output F select */
+typedef enum PORTMUX_EVOUTF_enum
+{
+    PORTMUX_EVOUTF_DEFAULT_gc = (0x00<<5),  /* EVOUTF: PF2 */
+    PORTMUX_EVOUTF_ALT1_gc = (0x01<<5)  /* EVOUTF: PF7 */
+} PORTMUX_EVOUTF_t;
+
+/* CCL Look-Up Table 0 Signals select */
+typedef enum PORTMUX_LUT0_enum
+{
+    PORTMUX_LUT0_DEFAULT_gc = (0x00<<0),  /* In: PA0, PA1, PA2, Out: PA3 */
+    PORTMUX_LUT0_ALT1_gc = (0x01<<0)  /* In: PA0, PA1, PA2, Out: PA6 */
+} PORTMUX_LUT0_t;
+
+/* CCL Look-Up Table 1 Signals select */
+typedef enum PORTMUX_LUT1_enum
+{
+    PORTMUX_LUT1_DEFAULT_gc = (0x00<<1),  /* In: PC0, PC1, PC2, Out: PC3 */
+    PORTMUX_LUT1_ALT1_gc = (0x01<<1)  /* In: PC0, PC1, PC2, Out: PC6 */
+} PORTMUX_LUT1_t;
+
+/* CCL Look-Up Table 2 Signals select */
+typedef enum PORTMUX_LUT2_enum
+{
+    PORTMUX_LUT2_DEFAULT_gc = (0x00<<2),  /* In: PD0, PD1, PD2, Out: PD3 */
+    PORTMUX_LUT2_ALT1_gc = (0x01<<2)  /* In: PD0, PD1, PD2, Out: PD6 */
+} PORTMUX_LUT2_t;
+
+/* SPI0 Signals select */
+typedef enum PORTMUX_SPI0_enum
+{
+    PORTMUX_SPI0_DEFAULT_gc = (0x00<<0),  /* MOSI: PA4, MISO: PA5, SCK: PA6, SS: PA7 */
+    PORTMUX_SPI0_ALT1_gc = (0x01<<0),  /* MOSI: PE0, MISO: PE1, SCK: PE2, SS: PE3 */
+    PORTMUX_SPI0_ALT3_gc = (0x03<<0),  /* MOSI: PA0, MISO: PA1, SCK: PC0, SS: PC1 */
+    PORTMUX_SPI0_ALT4_gc = (0x04<<0),  /* MOSI: PD4, MISO: PD5, SCK: PD6, SS: PD7 */
+    PORTMUX_SPI0_ALT5_gc = (0x05<<0),  /* MOSI: PC0, MISO: PC1, SCK: PC2, SS: PC3 */
+    PORTMUX_SPI0_ALT6_gc = (0x06<<0),  /* MOSI: PC1, MISO: PC2, SCK: PC3, SS: PF7 */
+    PORTMUX_SPI0_NONE_gc = (0x07<<0)  /* Not connected to any pins, SS set to 1 */
+} PORTMUX_SPI0_t;
+
+/* TCA0 Signals select */
+typedef enum PORTMUX_TCA0_enum
+{
+    PORTMUX_TCA0_PORTA_gc = (0x00<<0),  /* WOn: PA0, PA1, PA2, PA3, PA4, PA5 */
+    PORTMUX_TCA0_PORTB_gc = (0x01<<0),  /* WOn: PB0, PB1, PB2, PB3, PB4, PB5 */
+    PORTMUX_TCA0_PORTC_gc = (0x02<<0),  /* WOn: PC0, PC1, PC2, PC3, PC4, PC5 */
+    PORTMUX_TCA0_PORTD_gc = (0x03<<0),  /* WOn: PD0, PD1, PD2, PD3, PD4, PD5 */
+    PORTMUX_TCA0_PORTE_gc = (0x04<<0),  /* WOn: PE0, PE1, PE2, PE3, -, - */
+    PORTMUX_TCA0_PORTF_gc = (0x05<<0)  /* WOn: PF0, PF1, PF2, PF3, PF4, PF5 */
+} PORTMUX_TCA0_t;
+
+/* TCA1 Signals select */
+typedef enum PORTMUX_TCA1_enum
+{
+    PORTMUX_TCA1_PORTB_gc = (0x00<<3),  /* WOn: PB0, PB1, PB2, PB3, PB4, PB5 */
+    PORTMUX_TCA1_PORTC_gc = (0x01<<3),  /* WOn: PC4, PC5, PC6, -, -, - */
+    PORTMUX_TCA1_PORTA_gc = (0x04<<3),  /* WOn: PA4, PA5, PA6, -, -, - */
+    PORTMUX_TCA1_PORTD_gc = (0x05<<3)  /* WOn: PD4, PD5, PD6, -, -, - */
+} PORTMUX_TCA1_t;
+
+/* TCB0 Output select */
+typedef enum PORTMUX_TCB0_enum
+{
+    PORTMUX_TCB0_DEFAULT_gc = (0x00<<0),  /* WO: PA2 */
+    PORTMUX_TCB0_ALT1_gc = (0x01<<0)  /* WO: PF4 */
+} PORTMUX_TCB0_t;
+
+/* TCB1 Output select */
+typedef enum PORTMUX_TCB1_enum
+{
+    PORTMUX_TCB1_DEFAULT_gc = (0x00<<1),  /* WO: PA3 */
+    PORTMUX_TCB1_ALT1_gc = (0x01<<1)  /* WO: PF5 */
+} PORTMUX_TCB1_t;
+
+/* TCB2 Output select */
+typedef enum PORTMUX_TCB2_enum
+{
+    PORTMUX_TCB2_DEFAULT_gc = (0x00<<2),  /* WO: PC0 */
+    PORTMUX_TCB2_ALT1_gc = (0x01<<2)  /* WO: PB4 */
+} PORTMUX_TCB2_t;
+
+/* TCB3 Output select */
+typedef enum PORTMUX_TCB3_enum
+{
+    PORTMUX_TCB3_DEFAULT_gc = (0x00<<3),  /* WO: PB5 */
+    PORTMUX_TCB3_ALT1_gc = (0x01<<3)  /* WO: PC1 */
+} PORTMUX_TCB3_t;
+
+/* TWI0 Signals select */
+typedef enum PORTMUX_TWI0_enum
+{
+    PORTMUX_TWI0_DEFAULT_gc = (0x00<<0),  /* SDA: PA2, SCL: PA3. Dual mode: SDA: PC2, SCL: PC3 */
+    PORTMUX_TWI0_ALT1_gc = (0x01<<0),  /* SDA: PA2, SCL: PA3. Dual mode: SDA: PC6, SCL: PC7 */
+    PORTMUX_TWI0_ALT2_gc = (0x02<<0),  /* SDA: PC2, SCL: PC3. Dual mode: SDA: PC6, SCL: PC7 */
+    PORTMUX_TWI0_ALT3_gc = (0x03<<0)  /* SDA: PA0, SCL: PA1. Dual mode: SDA: PC2, SCL: PC3 */
+} PORTMUX_TWI0_t;
+
+/* USART0 Routing select */
+typedef enum PORTMUX_USART0_enum
+{
+    PORTMUX_USART0_DEFAULT_gc = (0x00<<0),  /* TxD: PA0, RxD: PA1, XCK: PA2, XDIR: PA3 */
+    PORTMUX_USART0_ALT1_gc = (0x01<<0),  /* TxD: PA4, RxD: PA5, XCK: PA6, XDIR: PA7 */
+    PORTMUX_USART0_ALT2_gc = (0x02<<0),  /* TxD: PA2, RxD: PA3, XCK: -, XDIR: - */
+    PORTMUX_USART0_ALT3_gc = (0x03<<0),  /* TxD: PD4, RxD: PD5, XCK: PD6, XDIR: PD7 */
+    PORTMUX_USART0_ALT4_gc = (0x04<<0),  /* TxD: PC1, RxD: PC2, XCK: PC3, XDIR: - */
+    PORTMUX_USART0_NONE_gc = (0x05<<0)  /* Not connected to any pins */
+} PORTMUX_USART0_t;
+
+/* USART1 Routing select */
+typedef enum PORTMUX_USART1_enum
+{
+    PORTMUX_USART1_DEFAULT_gc = (0x00<<3),  /* TxD: PC0, RxD: PC1, XCK: PC2, XDIR: PC3 */
+    PORTMUX_USART1_ALT1_gc = (0x01<<3),  /* TxD: PC4, RxD: PC5, XCK: PC6, XDIR: PC7 */
+    PORTMUX_USART1_ALT2_gc = (0x02<<3),  /* TxD: PD6, RxD: PD7, XCK: -, XDIR: - */
+    PORTMUX_USART1_NONE_gc = (0x03<<3)  /* Not connected to any pins */
+} PORTMUX_USART1_t;
+
+/* USART2 Routing select */
+typedef enum PORTMUX_USART2_enum
+{
+    PORTMUX_USART2_DEFAULT_gc = (0x00<<0),  /* TxD: PF0, RxD: PF1, XCK: PF2, XDIR: PF3 */
+    PORTMUX_USART2_ALT1_gc = (0x01<<0),  /* TxD: PF4, RxD: PF5, XCK: - , XDIR: - */
+    PORTMUX_USART2_NONE_gc = (0x03<<0)  /* Not connected to any pins */
+} PORTMUX_USART2_t;
+
+/*
+--------------------------------------------------------------------------
+RSTCTRL - Reset controller
+--------------------------------------------------------------------------
+*/
+
+/* Reset controller */
+typedef struct RSTCTRL_struct
+{
+    register8_t RSTFR;  /* Reset Flags */
+    register8_t SWRR;  /* Software Reset */
+    register8_t reserved_1[14];
+} RSTCTRL_t;
+
+
+/*
+--------------------------------------------------------------------------
+RTC - Real-Time Counter
+--------------------------------------------------------------------------
+*/
+
+/* Real-Time Counter */
+typedef struct RTC_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t STATUS;  /* Status */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t TEMP;  /* Temporary */
+    register8_t DBGCTRL;  /* Debug control */
+    register8_t CALIB;  /* Calibration */
+    register8_t CLKSEL;  /* Clock Select */
+    _WORDREGISTER(CNT);  /* Counter */
+    _WORDREGISTER(PER);  /* Period */
+    _WORDREGISTER(CMP);  /* Compare */
+    register8_t reserved_1[2];
+    register8_t PITCTRLA;  /* PIT Control A */
+    register8_t PITSTATUS;  /* PIT Status */
+    register8_t PITINTCTRL;  /* PIT Interrupt Control */
+    register8_t PITINTFLAGS;  /* PIT Interrupt Flags */
+    register8_t reserved_2[1];
+    register8_t PITDBGCTRL;  /* PIT Debug control */
+    register8_t PITEVGENCTRLA;  /* PIT Event Generation Control A */
+    register8_t reserved_3[9];
+} RTC_t;
+
+/* Clock Select */
+typedef enum RTC_CLKSEL_enum
+{
+    RTC_CLKSEL_OSC32K_gc = (0x00<<0),  /* Internal 32.768 kHz Oscillator */
+    RTC_CLKSEL_OSC1K_gc = (0x01<<0),  /* Internal 32.768 kHz Oscillator Divided by 32 */
+    RTC_CLKSEL_XOSC32K_gc = (0x02<<0),  /* 32.768 kHz Crystal Oscillator */
+    RTC_CLKSEL_EXTCLK_gc = (0x03<<0)  /* External Clock */
+} RTC_CLKSEL_t;
+
+/* Event Generation 0 Select */
+typedef enum RTC_EVGEN0SEL_enum
+{
+    RTC_EVGEN0SEL_OFF_gc = (0x00<<0),  /* No Event Generated */
+    RTC_EVGEN0SEL_DIV4_gc = (0x01<<0),  /* CLK_RTC divided by 4 */
+    RTC_EVGEN0SEL_DIV8_gc = (0x02<<0),  /* CLK_RTC divided by 8 */
+    RTC_EVGEN0SEL_DIV16_gc = (0x03<<0),  /* CLK_RTC divided by 16 */
+    RTC_EVGEN0SEL_DIV32_gc = (0x04<<0),  /* CLK_RTC divided by 32 */
+    RTC_EVGEN0SEL_DIV64_gc = (0x05<<0),  /* CLK_RTC divided by 64 */
+    RTC_EVGEN0SEL_DIV128_gc = (0x06<<0),  /* CLK_RTC divided by 128 */
+    RTC_EVGEN0SEL_DIV256_gc = (0x07<<0),  /* CLK_RTC divided by 256 */
+    RTC_EVGEN0SEL_DIV512_gc = (0x08<<0),  /* CLK_RTC divided by 512 */
+    RTC_EVGEN0SEL_DIV1024_gc = (0x09<<0),  /* CLK_RTC divided by 1024 */
+    RTC_EVGEN0SEL_DIV2048_gc = (0x0A<<0),  /* CLK_RTC divided by 2048 */
+    RTC_EVGEN0SEL_DIV4096_gc = (0x0B<<0),  /* CLK_RTC divided by 4096 */
+    RTC_EVGEN0SEL_DIV8192_gc = (0x0C<<0),  /* CLK_RTC divided by 8192 */
+    RTC_EVGEN0SEL_DIV16384_gc = (0x0D<<0),  /* CLK_RTC divided by 16384 */
+    RTC_EVGEN0SEL_DIV32768_gc = (0x0E<<0)  /* CLK_RTC divided by 32768 */
+} RTC_EVGEN0SEL_t;
+
+/* Event Generation 1 Select */
+typedef enum RTC_EVGEN1SEL_enum
+{
+    RTC_EVGEN1SEL_OFF_gc = (0x00<<4),  /* No Event Generated */
+    RTC_EVGEN1SEL_DIV4_gc = (0x01<<4),  /* CLK_RTC divided by 4 */
+    RTC_EVGEN1SEL_DIV8_gc = (0x02<<4),  /* CLK_RTC divided by 8 */
+    RTC_EVGEN1SEL_DIV16_gc = (0x03<<4),  /* CLK_RTC divided by 16 */
+    RTC_EVGEN1SEL_DIV32_gc = (0x04<<4),  /* CLK_RTC divided by 32 */
+    RTC_EVGEN1SEL_DIV64_gc = (0x05<<4),  /* CLK_RTC divided by 64 */
+    RTC_EVGEN1SEL_DIV128_gc = (0x06<<4),  /* CLK_RTC divided by 128 */
+    RTC_EVGEN1SEL_DIV256_gc = (0x07<<4),  /* CLK_RTC divided by 256 */
+    RTC_EVGEN1SEL_DIV512_gc = (0x08<<4),  /* CLK_RTC divided by 512 */
+    RTC_EVGEN1SEL_DIV1024_gc = (0x09<<4),  /* CLK_RTC divided by 1024 */
+    RTC_EVGEN1SEL_DIV2048_gc = (0x0A<<4),  /* CLK_RTC divided by 2048 */
+    RTC_EVGEN1SEL_DIV4096_gc = (0x0B<<4),  /* CLK_RTC divided by 4096 */
+    RTC_EVGEN1SEL_DIV8192_gc = (0x0C<<4),  /* CLK_RTC divided by 8192 */
+    RTC_EVGEN1SEL_DIV16384_gc = (0x0D<<4),  /* CLK_RTC divided by 16384 */
+    RTC_EVGEN1SEL_DIV32768_gc = (0x0E<<4)  /* CLK_RTC divided by 32768 */
+} RTC_EVGEN1SEL_t;
+
+/* Period select */
+typedef enum RTC_PERIOD_enum
+{
+    RTC_PERIOD_OFF_gc = (0x00<<3),  /* Off */
+    RTC_PERIOD_CYC4_gc = (0x01<<3),  /* RTC Clock Cycles 4 */
+    RTC_PERIOD_CYC8_gc = (0x02<<3),  /* RTC Clock Cycles 8 */
+    RTC_PERIOD_CYC16_gc = (0x03<<3),  /* RTC Clock Cycles 16 */
+    RTC_PERIOD_CYC32_gc = (0x04<<3),  /* RTC Clock Cycles 32 */
+    RTC_PERIOD_CYC64_gc = (0x05<<3),  /* RTC Clock Cycles 64 */
+    RTC_PERIOD_CYC128_gc = (0x06<<3),  /* RTC Clock Cycles 128 */
+    RTC_PERIOD_CYC256_gc = (0x07<<3),  /* RTC Clock Cycles 256 */
+    RTC_PERIOD_CYC512_gc = (0x08<<3),  /* RTC Clock Cycles 512 */
+    RTC_PERIOD_CYC1024_gc = (0x09<<3),  /* RTC Clock Cycles 1024 */
+    RTC_PERIOD_CYC2048_gc = (0x0A<<3),  /* RTC Clock Cycles 2048 */
+    RTC_PERIOD_CYC4096_gc = (0x0B<<3),  /* RTC Clock Cycles 4096 */
+    RTC_PERIOD_CYC8192_gc = (0x0C<<3),  /* RTC Clock Cycles 8192 */
+    RTC_PERIOD_CYC16384_gc = (0x0D<<3),  /* RTC Clock Cycles 16384 */
+    RTC_PERIOD_CYC32768_gc = (0x0E<<3)  /* RTC Clock Cycles 32768 */
+} RTC_PERIOD_t;
+
+/* Prescaling Factor select */
+typedef enum RTC_PRESCALER_enum
+{
+    RTC_PRESCALER_DIV1_gc = (0x00<<3),  /* RTC Clock / 1 */
+    RTC_PRESCALER_DIV2_gc = (0x01<<3),  /* RTC Clock / 2 */
+    RTC_PRESCALER_DIV4_gc = (0x02<<3),  /* RTC Clock / 4 */
+    RTC_PRESCALER_DIV8_gc = (0x03<<3),  /* RTC Clock / 8 */
+    RTC_PRESCALER_DIV16_gc = (0x04<<3),  /* RTC Clock / 16 */
+    RTC_PRESCALER_DIV32_gc = (0x05<<3),  /* RTC Clock / 32 */
+    RTC_PRESCALER_DIV64_gc = (0x06<<3),  /* RTC Clock / 64 */
+    RTC_PRESCALER_DIV128_gc = (0x07<<3),  /* RTC Clock / 128 */
+    RTC_PRESCALER_DIV256_gc = (0x08<<3),  /* RTC Clock / 256 */
+    RTC_PRESCALER_DIV512_gc = (0x09<<3),  /* RTC Clock / 512 */
+    RTC_PRESCALER_DIV1024_gc = (0x0A<<3),  /* RTC Clock / 1024 */
+    RTC_PRESCALER_DIV2048_gc = (0x0B<<3),  /* RTC Clock / 2048 */
+    RTC_PRESCALER_DIV4096_gc = (0x0C<<3),  /* RTC Clock / 4096 */
+    RTC_PRESCALER_DIV8192_gc = (0x0D<<3),  /* RTC Clock / 8192 */
+    RTC_PRESCALER_DIV16384_gc = (0x0E<<3),  /* RTC Clock / 16384 */
+    RTC_PRESCALER_DIV32768_gc = (0x0F<<3)  /* RTC Clock / 32768 */
+} RTC_PRESCALER_t;
+
+/*
+--------------------------------------------------------------------------
+SIGROW - Signature row
+--------------------------------------------------------------------------
+*/
+
+/* Signature row */
+typedef struct SIGROW_struct
+{
+    register8_t DEVICEID0;  /* Device ID Byte 0 */
+    register8_t DEVICEID1;  /* Device ID Byte 1 */
+    register8_t DEVICEID2;  /* Device ID Byte 2 */
+    register8_t reserved_1[1];
+    _WORDREGISTER(TEMPSENSE0);  /* Temperature Calibration 0 */
+    _WORDREGISTER(TEMPSENSE1);  /* Temperature Calibration 1 */
+    register8_t reserved_2[8];
+    register8_t SERNUM0;  /* Serial Number Byte 0 */
+    register8_t SERNUM1;  /* Serial Number Byte 1 */
+    register8_t SERNUM2;  /* Serial Number Byte 2 */
+    register8_t SERNUM3;  /* Serial Number Byte 3 */
+    register8_t SERNUM4;  /* Serial Number Byte 4 */
+    register8_t SERNUM5;  /* Serial Number Byte 5 */
+    register8_t SERNUM6;  /* Serial Number Byte 6 */
+    register8_t SERNUM7;  /* Serial Number Byte 7 */
+    register8_t SERNUM8;  /* Serial Number Byte 8 */
+    register8_t SERNUM9;  /* Serial Number Byte 9 */
+    register8_t SERNUM10;  /* Serial Number Byte 10 */
+    register8_t SERNUM11;  /* Serial Number Byte 11 */
+    register8_t SERNUM12;  /* Serial Number Byte 12 */
+    register8_t SERNUM13;  /* Serial Number Byte 13 */
+    register8_t SERNUM14;  /* Serial Number Byte 14 */
+    register8_t SERNUM15;  /* Serial Number Byte 15 */
+    register8_t reserved_3[32];
+} SIGROW_t;
+
+
+/*
+--------------------------------------------------------------------------
+SLPCTRL - Sleep Controller
+--------------------------------------------------------------------------
+*/
+
+/* Sleep Controller */
+typedef struct SLPCTRL_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t reserved_1[1];
+} SLPCTRL_t;
+
+/* Sleep mode select */
+typedef enum SLPCTRL_SMODE_enum
+{
+    SLPCTRL_SMODE_IDLE_gc = (0x00<<1),  /* Idle mode */
+    SLPCTRL_SMODE_STDBY_gc = (0x01<<1),  /* Standby Mode */
+    SLPCTRL_SMODE_PDOWN_gc = (0x02<<1)  /* Power-down Mode */
+} SLPCTRL_SMODE_t;
+
+#define SLEEP_MODE_IDLE (0x00<<1)
+#define SLEEP_MODE_STANDBY (0x01<<1)
+#define SLEEP_MODE_PWR_DOWN (0x02<<1)
+/*
+--------------------------------------------------------------------------
+SPI - Serial Peripheral Interface
+--------------------------------------------------------------------------
+*/
+
+/* Serial Peripheral Interface */
+typedef struct SPI_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t DATA;  /* Data */
+    register8_t reserved_1[3];
+} SPI_t;
+
+/* SPI Mode select */
+typedef enum SPI_MODE_enum
+{
+    SPI_MODE_0_gc = (0x00<<0),  /* SPI Mode 0 */
+    SPI_MODE_1_gc = (0x01<<0),  /* SPI Mode 1 */
+    SPI_MODE_2_gc = (0x02<<0),  /* SPI Mode 2 */
+    SPI_MODE_3_gc = (0x03<<0)  /* SPI Mode 3 */
+} SPI_MODE_t;
+
+/* Prescaler select */
+typedef enum SPI_PRESC_enum
+{
+    SPI_PRESC_DIV4_gc = (0x00<<1),  /* CLK_PER / 4 */
+    SPI_PRESC_DIV16_gc = (0x01<<1),  /* CLK_PER / 16 */
+    SPI_PRESC_DIV64_gc = (0x02<<1),  /* CLK_PER / 64 */
+    SPI_PRESC_DIV128_gc = (0x03<<1)  /* CLK_PER / 128 */
+} SPI_PRESC_t;
+
+/*
+--------------------------------------------------------------------------
+SYSCFG - System Configuration Registers
+--------------------------------------------------------------------------
+*/
+
+/* System Configuration Registers */
+typedef struct SYSCFG_struct
+{
+    register8_t reserved_1[1];
+    register8_t REVID;  /* Revision ID */
+    register8_t reserved_2[2];
+    register8_t OCDMCTRL;  /* OCD Message Control */
+    register8_t OCDMSTATUS;  /* OCD Message Status */
+    register8_t reserved_3[26];
+} SYSCFG_t;
+
+
+/*
+--------------------------------------------------------------------------
+TCA - 16-bit Timer/Counter Type A
+--------------------------------------------------------------------------
+*/
+
+/* 16-bit Timer/Counter Type A - Single Mode */
+typedef struct TCA_SINGLE_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    register8_t CTRLD;  /* Control D */
+    register8_t CTRLECLR;  /* Control E Clear */
+    register8_t CTRLESET;  /* Control E Set */
+    register8_t CTRLFCLR;  /* Control F Clear */
+    register8_t CTRLFSET;  /* Control F Set */
+    register8_t reserved_1[1];
+    register8_t EVCTRL;  /* Event Control */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t reserved_2[2];
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t TEMP;  /* Temporary data for 16-bit Access */
+    register8_t reserved_3[16];
+    _WORDREGISTER(CNT);  /* Count */
+    register8_t reserved_4[4];
+    _WORDREGISTER(PER);  /* Period */
+    _WORDREGISTER(CMP0);  /* Compare 0 */
+    _WORDREGISTER(CMP1);  /* Compare 1 */
+    _WORDREGISTER(CMP2);  /* Compare 2 */
+    register8_t reserved_5[8];
+    _WORDREGISTER(PERBUF);  /* Period Buffer */
+    _WORDREGISTER(CMP0BUF);  /* Compare 0 Buffer */
+    _WORDREGISTER(CMP1BUF);  /* Compare 1 Buffer */
+    _WORDREGISTER(CMP2BUF);  /* Compare 2 Buffer */
+    register8_t reserved_6[2];
+} TCA_SINGLE_t;
+
+/* 16-bit Timer/Counter Type A - Split Mode */
+typedef struct TCA_SPLIT_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    register8_t CTRLD;  /* Control D */
+    register8_t CTRLECLR;  /* Control E Clear */
+    register8_t CTRLESET;  /* Control E Set */
+    register8_t reserved_1[4];
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t reserved_2[2];
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t reserved_3[17];
+    register8_t LCNT;  /* Low Count */
+    register8_t HCNT;  /* High Count */
+    register8_t reserved_4[4];
+    register8_t LPER;  /* Low Period */
+    register8_t HPER;  /* High Period */
+    register8_t LCMP0;  /* Low Compare */
+    register8_t HCMP0;  /* High Compare */
+    register8_t LCMP1;  /* Low Compare */
+    register8_t HCMP1;  /* High Compare */
+    register8_t LCMP2;  /* Low Compare */
+    register8_t HCMP2;  /* High Compare */
+    register8_t reserved_5[18];
+} TCA_SPLIT_t;
+
+/* 16-bit Timer/Counter Type A */
+typedef union TCA_union
+{
+    TCA_SINGLE_t SINGLE;  /* Single Mode */
+    TCA_SPLIT_t SPLIT;  /* Split Mode */
+} TCA_t;
+
+/* Clock Selection */
+typedef enum TCA_SINGLE_CLKSEL_enum
+{
+    TCA_SINGLE_CLKSEL_DIV1_gc = (0x00<<1),  /* CLK_PER */
+    TCA_SINGLE_CLKSEL_DIV2_gc = (0x01<<1),  /* CLK_PER / 2 */
+    TCA_SINGLE_CLKSEL_DIV4_gc = (0x02<<1),  /* CLK_PER / 4 */
+    TCA_SINGLE_CLKSEL_DIV8_gc = (0x03<<1),  /* CLK_PER / 8 */
+    TCA_SINGLE_CLKSEL_DIV16_gc = (0x04<<1),  /* CLK_PER / 16 */
+    TCA_SINGLE_CLKSEL_DIV64_gc = (0x05<<1),  /* CLK_PER / 64 */
+    TCA_SINGLE_CLKSEL_DIV256_gc = (0x06<<1),  /* CLK_PER / 256 */
+    TCA_SINGLE_CLKSEL_DIV1024_gc = (0x07<<1)  /* CLK_PER / 1024 */
+} TCA_SINGLE_CLKSEL_t;
+
+/* Command select */
+typedef enum TCA_SINGLE_CMD_enum
+{
+    TCA_SINGLE_CMD_NONE_gc = (0x00<<2),  /* No Command */
+    TCA_SINGLE_CMD_UPDATE_gc = (0x01<<2),  /* Force Update */
+    TCA_SINGLE_CMD_RESTART_gc = (0x02<<2),  /* Force Restart */
+    TCA_SINGLE_CMD_RESET_gc = (0x03<<2)  /* Force Hard Reset */
+} TCA_SINGLE_CMD_t;
+
+/* Direction select */
+typedef enum TCA_SINGLE_DIR_enum
+{
+    TCA_SINGLE_DIR_UP_gc = (0x00<<0),  /* Count up */
+    TCA_SINGLE_DIR_DOWN_gc = (0x01<<0)  /* Count down */
+} TCA_SINGLE_DIR_t;
+
+/* Event Action A select */
+typedef enum TCA_SINGLE_EVACTA_enum
+{
+    TCA_SINGLE_EVACTA_CNT_POSEDGE_gc = (0x00<<1),  /* Count on positive edge event */
+    TCA_SINGLE_EVACTA_CNT_ANYEDGE_gc = (0x01<<1),  /* Count on any edge event */
+    TCA_SINGLE_EVACTA_CNT_HIGHLVL_gc = (0x02<<1),  /* Count on prescaled clock while event line is 1. */
+    TCA_SINGLE_EVACTA_UPDOWN_gc = (0x03<<1)  /* Count on prescaled clock. Event controls count direction. Up-count when event line is 0, down-count when event line is 1. */
+} TCA_SINGLE_EVACTA_t;
+
+/* Event Action B select */
+typedef enum TCA_SINGLE_EVACTB_enum
+{
+    TCA_SINGLE_EVACTB_NONE_gc = (0x00<<5),  /* No Action */
+    TCA_SINGLE_EVACTB_UPDOWN_gc = (0x03<<5),  /* Count on prescaled clock. Event controls count direction. Up-count when event line is 0, down-count when event line is 1. */
+    TCA_SINGLE_EVACTB_RESTART_POSEDGE_gc = (0x04<<5),  /* Restart counter at positive edge event */
+    TCA_SINGLE_EVACTB_RESTART_ANYEDGE_gc = (0x05<<5),  /* Restart counter on any edge event */
+    TCA_SINGLE_EVACTB_RESTART_HIGHLVL_gc = (0x06<<5)  /* Restart counter while event line is 1. */
+} TCA_SINGLE_EVACTB_t;
+
+/* Waveform generation mode select */
+typedef enum TCA_SINGLE_WGMODE_enum
+{
+    TCA_SINGLE_WGMODE_NORMAL_gc = (0x00<<0),  /* Normal Mode */
+    TCA_SINGLE_WGMODE_FRQ_gc = (0x01<<0),  /* Frequency Generation Mode */
+    TCA_SINGLE_WGMODE_SINGLESLOPE_gc = (0x03<<0),  /* Single Slope PWM */
+    TCA_SINGLE_WGMODE_DSTOP_gc = (0x05<<0),  /* Dual Slope PWM, overflow on TOP */
+    TCA_SINGLE_WGMODE_DSBOTH_gc = (0x06<<0),  /* Dual Slope PWM, overflow on TOP and BOTTOM */
+    TCA_SINGLE_WGMODE_DSBOTTOM_gc = (0x07<<0)  /* Dual Slope PWM, overflow on BOTTOM */
+} TCA_SINGLE_WGMODE_t;
+
+/* Clock Selection */
+typedef enum TCA_SPLIT_CLKSEL_enum
+{
+    TCA_SPLIT_CLKSEL_DIV1_gc = (0x00<<1),  /* CLK_PER */
+    TCA_SPLIT_CLKSEL_DIV2_gc = (0x01<<1),  /* CLK_PER / 2 */
+    TCA_SPLIT_CLKSEL_DIV4_gc = (0x02<<1),  /* CLK_PER / 4 */
+    TCA_SPLIT_CLKSEL_DIV8_gc = (0x03<<1),  /* CLK_PER / 8 */
+    TCA_SPLIT_CLKSEL_DIV16_gc = (0x04<<1),  /* CLK_PER / 16 */
+    TCA_SPLIT_CLKSEL_DIV64_gc = (0x05<<1),  /* CLK_PER / 64 */
+    TCA_SPLIT_CLKSEL_DIV256_gc = (0x06<<1),  /* CLK_PER / 256 */
+    TCA_SPLIT_CLKSEL_DIV1024_gc = (0x07<<1)  /* CLK_PER / 1024 */
+} TCA_SPLIT_CLKSEL_t;
+
+/* Command select */
+typedef enum TCA_SPLIT_CMD_enum
+{
+    TCA_SPLIT_CMD_NONE_gc = (0x00<<2),  /* No Command */
+    TCA_SPLIT_CMD_UPDATE_gc = (0x01<<2),  /* Force Update */
+    TCA_SPLIT_CMD_RESTART_gc = (0x02<<2),  /* Force Restart */
+    TCA_SPLIT_CMD_RESET_gc = (0x03<<2)  /* Force Hard Reset */
+} TCA_SPLIT_CMD_t;
+
+/* Command Enable select */
+typedef enum TCA_SPLIT_CMDEN_enum
+{
+    TCA_SPLIT_CMDEN_NONE_gc = (0x00<<0),  /* None */
+    TCA_SPLIT_CMDEN_BOTH_gc = (0x03<<0)  /* Both low byte and high byte counter */
+} TCA_SPLIT_CMDEN_t;
+
+/*
+--------------------------------------------------------------------------
+TCB - 16-bit Timer Type B
+--------------------------------------------------------------------------
+*/
+
+/* 16-bit Timer Type B */
+typedef struct TCB_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control Register B */
+    register8_t reserved_1[2];
+    register8_t EVCTRL;  /* Event Control */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t STATUS;  /* Status */
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t TEMP;  /* Temporary Value */
+    _WORDREGISTER(CNT);  /* Count */
+    _WORDREGISTER(CCMP);  /* Compare or Capture */
+    register8_t reserved_2[2];
+} TCB_t;
+
+/* Clock Select */
+typedef enum TCB_CLKSEL_enum
+{
+    TCB_CLKSEL_DIV1_gc = (0x00<<1),  /* CLK_PER */
+    TCB_CLKSEL_DIV2_gc = (0x01<<1),  /* CLK_PER/2 */
+    TCB_CLKSEL_TCA0_gc = (0x02<<1),  /* Use CLK_TCA from TCA0 */
+    TCB_CLKSEL_TCA1_gc = (0x03<<1),  /* Use CLK_TCA from TCA1 */
+    TCB_CLKSEL_EVENT_gc = (0x07<<1)  /* Count on event edge */
+} TCB_CLKSEL_t;
+
+/* Timer Mode select */
+typedef enum TCB_CNTMODE_enum
+{
+    TCB_CNTMODE_INT_gc = (0x00<<0),  /* Periodic Interrupt */
+    TCB_CNTMODE_TIMEOUT_gc = (0x01<<0),  /* Periodic Timeout */
+    TCB_CNTMODE_CAPT_gc = (0x02<<0),  /* Input Capture Event */
+    TCB_CNTMODE_FRQ_gc = (0x03<<0),  /* Input Capture Frequency measurement */
+    TCB_CNTMODE_PW_gc = (0x04<<0),  /* Input Capture Pulse-Width measurement */
+    TCB_CNTMODE_FRQPW_gc = (0x05<<0),  /* Input Capture Frequency and Pulse-Width measurement */
+    TCB_CNTMODE_SINGLE_gc = (0x06<<0),  /* Single Shot */
+    TCB_CNTMODE_PWM8_gc = (0x07<<0)  /* 8-bit PWM */
+} TCB_CNTMODE_t;
+
+/*
+--------------------------------------------------------------------------
+TWI - Two-Wire Interface
+--------------------------------------------------------------------------
+*/
+
+/* Two-Wire Interface */
+typedef struct TWI_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t DUALCTRL;  /* Dual Mode Control */
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t MCTRLA;  /* Host Control A */
+    register8_t MCTRLB;  /* Host Control B */
+    register8_t MSTATUS;  /* Host STATUS */
+    register8_t MBAUD;  /* Host Baud Rate */
+    register8_t MADDR;  /* Host Address */
+    register8_t MDATA;  /* Host Data */
+    register8_t SCTRLA;  /* Client Control A */
+    register8_t SCTRLB;  /* Client Control B */
+    register8_t SSTATUS;  /* Client Status */
+    register8_t SADDR;  /* Client Address */
+    register8_t SDATA;  /* Client Data */
+    register8_t SADDRMASK;  /* Client Address Mask */
+    register8_t reserved_1[1];
+} TWI_t;
+
+/* Acknowledge Action select */
+typedef enum TWI_ACKACT_enum
+{
+    TWI_ACKACT_ACK_gc = (0x00<<2),  /* Send ACK */
+    TWI_ACKACT_NACK_gc = (0x01<<2)  /* Send NACK */
+} TWI_ACKACT_t;
+
+/* Address or Stop select */
+typedef enum TWI_AP_enum
+{
+    TWI_AP_STOP_gc = (0x00<<0),  /* A Stop condition generated the interrupt on APIF flag */
+    TWI_AP_ADR_gc = (0x01<<0)  /* Address detection generated the interrupt on APIF flag */
+} TWI_AP_t;
+
+/* Bus State select */
+typedef enum TWI_BUSSTATE_enum
+{
+    TWI_BUSSTATE_UNKNOWN_gc = (0x00<<0),  /* Unknown bus state */
+    TWI_BUSSTATE_IDLE_gc = (0x01<<0),  /* Bus is idle */
+    TWI_BUSSTATE_OWNER_gc = (0x02<<0),  /* This TWI controls the bus */
+    TWI_BUSSTATE_BUSY_gc = (0x03<<0)  /* The bus is busy */
+} TWI_BUSSTATE_t;
+
+/* Debug Run select */
+typedef enum TWI_DBGRUN_enum
+{
+    TWI_DBGRUN_HALT_gc = (0x00<<0),  /* The peripheral is halted in Break Debug mode and ignores events */
+    TWI_DBGRUN_RUN_gc = (0x01<<0)  /* The peripheral will continue to run in Break Debug mode when the CPU is halted */
+} TWI_DBGRUN_t;
+
+/* Fast-mode Enable select */
+typedef enum TWI_FMEN_enum
+{
+    TWI_FMEN_OFF_gc = (0x00<<0),  /* SCL duty cycle operating according to Sm specification */
+    TWI_FMEN_ON_gc = (0x01<<0)  /* SCL duty cycle operating according to Fm specification */
+} TWI_FMEN_t;
+
+/* Fast-mode Plus Enable select */
+typedef enum TWI_FMPEN_enum
+{
+    TWI_FMPEN_OFF_gc = (0x00<<1),  /* Operating in Standard-mode or Fast-mode */
+    TWI_FMPEN_ON_gc = (0x01<<1)  /* Operating in Fast-mode Plus */
+} TWI_FMPEN_t;
+
+/* Input voltage transition level select */
+typedef enum TWI_INPUTLVL_enum
+{
+    TWI_INPUTLVL_I2C_gc = (0x00<<6),  /* I2C input voltage transition level */
+    TWI_INPUTLVL_SMBUS_gc = (0x01<<6)  /* SMBus 3.0 input voltage transition level */
+} TWI_INPUTLVL_t;
+
+/* Command select */
+typedef enum TWI_MCMD_enum
+{
+    TWI_MCMD_NOACT_gc = (0x00<<0),  /* No action */
+    TWI_MCMD_REPSTART_gc = (0x01<<0),  /* Execute Acknowledge Action followed by repeated Start. */
+    TWI_MCMD_RECVTRANS_gc = (0x02<<0),  /* Execute Acknowledge Action followed by a byte read/write operation. Read/write is defined by DIR. */
+    TWI_MCMD_STOP_gc = (0x03<<0)  /* Execute Acknowledge Action followed by issuing a Stop condition. */
+} TWI_MCMD_t;
+
+/* Command select */
+typedef enum TWI_SCMD_enum
+{
+    TWI_SCMD_NOACT_gc = (0x00<<0),  /* No Action */
+    TWI_SCMD_COMPTRANS_gc = (0x02<<0),  /* Complete transaction */
+    TWI_SCMD_RESPONSE_gc = (0x03<<0)  /* Used in response to an interrupt */
+} TWI_SCMD_t;
+
+/* SDA Hold Time select */
+typedef enum TWI_SDAHOLD_enum
+{
+    TWI_SDAHOLD_OFF_gc = (0x00<<2),  /* No SDA Hold Delay */
+    TWI_SDAHOLD_50NS_gc = (0x01<<2),  /* Short SDA hold time */
+    TWI_SDAHOLD_300NS_gc = (0x02<<2),  /* Meets SMBUS 2.0 specification under typical conditions */
+    TWI_SDAHOLD_500NS_gc = (0x03<<2)  /* Meets SMBUS 2.0 specificaiton across all corners */
+} TWI_SDAHOLD_t;
+
+/* SDA Setup Time select */
+typedef enum TWI_SDASETUP_enum
+{
+    TWI_SDASETUP_4CYC_gc = (0x00<<4),  /* SDA setup time is four clock cycles */
+    TWI_SDASETUP_8CYC_gc = (0x01<<4)  /* SDA setup time is eight clock cycle */
+} TWI_SDASETUP_t;
+
+/* Inactive Bus Time-Out select */
+typedef enum TWI_TIMEOUT_enum
+{
+    TWI_TIMEOUT_DISABLED_gc = (0x00<<2),  /* Bus time-out disabled. I2C. */
+    TWI_TIMEOUT_50US_gc = (0x01<<2),  /* 50us - SMBus */
+    TWI_TIMEOUT_100US_gc = (0x02<<2),  /* 100us */
+    TWI_TIMEOUT_200US_gc = (0x03<<2)  /* 200us */
+} TWI_TIMEOUT_t;
+
+/*
+--------------------------------------------------------------------------
+USART - Universal Synchronous and Asynchronous Receiver and Transmitter
+--------------------------------------------------------------------------
+*/
+
+/* Universal Synchronous and Asynchronous Receiver and Transmitter */
+typedef struct USART_struct
+{
+    register8_t RXDATAL;  /* Receive Data Low Byte */
+    register8_t RXDATAH;  /* Receive Data High Byte */
+    register8_t TXDATAL;  /* Transmit Data Low Byte */
+    register8_t TXDATAH;  /* Transmit Data High Byte */
+    register8_t STATUS;  /* Status */
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    _WORDREGISTER(BAUD);  /* Baud Rate */
+    register8_t CTRLD;  /* Control D */
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t EVCTRL;  /* Event Control */
+    register8_t TXPLCTRL;  /* IRCOM Transmitter Pulse Length Control */
+    register8_t RXPLCTRL;  /* IRCOM Receiver Pulse Length Control */
+    register8_t reserved_1[1];
+} USART_t;
+
+/* Auto Baud Window select */
+typedef enum USART_ABW_enum
+{
+    USART_ABW_WDW0_gc = (0x00<<6),  /* 18% tolerance */
+    USART_ABW_WDW1_gc = (0x01<<6),  /* 15% tolerance */
+    USART_ABW_WDW2_gc = (0x02<<6),  /* 21% tolerance */
+    USART_ABW_WDW3_gc = (0x03<<6)  /* 25% tolerance */
+} USART_ABW_t;
+
+/* Character Size select */
+typedef enum USART_CHSIZE_enum
+{
+    USART_CHSIZE_5BIT_gc = (0x00<<0),  /* Character size: 5 bit */
+    USART_CHSIZE_6BIT_gc = (0x01<<0),  /* Character size: 6 bit */
+    USART_CHSIZE_7BIT_gc = (0x02<<0),  /* Character size: 7 bit */
+    USART_CHSIZE_8BIT_gc = (0x03<<0),  /* Character size: 8 bit */
+    USART_CHSIZE_9BITL_gc = (0x06<<0),  /* Character size: 9 bit read low byte first */
+    USART_CHSIZE_9BITH_gc = (0x07<<0)  /* Character size: 9 bit read high byte first */
+} USART_CHSIZE_t;
+
+/* Communication Mode select */
+typedef enum USART_CMODE_enum
+{
+    USART_CMODE_ASYNCHRONOUS_gc = (0x00<<6),  /* Asynchronous Mode */
+    USART_CMODE_SYNCHRONOUS_gc = (0x01<<6),  /* Synchronous Mode */
+    USART_CMODE_IRCOM_gc = (0x02<<6),  /* Infrared Communication */
+    USART_CMODE_MSPI_gc = (0x03<<6)  /* SPI Host Mode */
+} USART_CMODE_t;
+
+/* Parity Mode select */
+typedef enum USART_PMODE_enum
+{
+    USART_PMODE_DISABLED_gc = (0x00<<4),  /* No Parity */
+    USART_PMODE_EVEN_gc = (0x02<<4),  /* Even Parity */
+    USART_PMODE_ODD_gc = (0x03<<4)  /* Odd Parity */
+} USART_PMODE_t;
+
+/* RS485 Mode internal transmitter select */
+typedef enum USART_RS485_enum
+{
+    USART_RS485_DISABLE_gc = (0x00<<0),  /* RS485 Mode disabled */
+    USART_RS485_ENABLE_gc = (0x01<<0)  /* RS485 Mode enabled */
+} USART_RS485_t;
+
+/* Receiver Mode select */
+typedef enum USART_RXMODE_enum
+{
+    USART_RXMODE_NORMAL_gc = (0x00<<1),  /* Normal mode */
+    USART_RXMODE_CLK2X_gc = (0x01<<1),  /* CLK2x mode */
+    USART_RXMODE_GENAUTO_gc = (0x02<<1),  /* Generic autobaud mode */
+    USART_RXMODE_LINAUTO_gc = (0x03<<1)  /* LIN constrained autobaud mode */
+} USART_RXMODE_t;
+
+/* Stop Bit Mode select */
+typedef enum USART_SBMODE_enum
+{
+    USART_SBMODE_1BIT_gc = (0x00<<3),  /* 1 stop bit */
+    USART_SBMODE_2BIT_gc = (0x01<<3)  /* 2 stop bits */
+} USART_SBMODE_t;
+
+/*
+--------------------------------------------------------------------------
+USERROW - User Row
+--------------------------------------------------------------------------
+*/
+
+/* User Row */
+typedef struct USERROW_struct
+{
+    register8_t USERROW0;  /* User Row Byte 0 */
+    register8_t USERROW1;  /* User Row Byte 1 */
+    register8_t USERROW2;  /* User Row Byte 2 */
+    register8_t USERROW3;  /* User Row Byte 3 */
+    register8_t USERROW4;  /* User Row Byte 4 */
+    register8_t USERROW5;  /* User Row Byte 5 */
+    register8_t USERROW6;  /* User Row Byte 6 */
+    register8_t USERROW7;  /* User Row Byte 7 */
+    register8_t USERROW8;  /* User Row Byte 8 */
+    register8_t USERROW9;  /* User Row Byte 9 */
+    register8_t USERROW10;  /* User Row Byte 10 */
+    register8_t USERROW11;  /* User Row Byte 11 */
+    register8_t USERROW12;  /* User Row Byte 12 */
+    register8_t USERROW13;  /* User Row Byte 13 */
+    register8_t USERROW14;  /* User Row Byte 14 */
+    register8_t USERROW15;  /* User Row Byte 15 */
+    register8_t USERROW16;  /* User Row Byte 16 */
+    register8_t USERROW17;  /* User Row Byte 17 */
+    register8_t USERROW18;  /* User Row Byte 18 */
+    register8_t USERROW19;  /* User Row Byte 19 */
+    register8_t USERROW20;  /* User Row Byte 20 */
+    register8_t USERROW21;  /* User Row Byte 21 */
+    register8_t USERROW22;  /* User Row Byte 22 */
+    register8_t USERROW23;  /* User Row Byte 23 */
+    register8_t USERROW24;  /* User Row Byte 24 */
+    register8_t USERROW25;  /* User Row Byte 25 */
+    register8_t USERROW26;  /* User Row Byte 26 */
+    register8_t USERROW27;  /* User Row Byte 27 */
+    register8_t USERROW28;  /* User Row Byte 28 */
+    register8_t USERROW29;  /* User Row Byte 29 */
+    register8_t USERROW30;  /* User Row Byte 30 */
+    register8_t USERROW31;  /* User Row Byte 31 */
+    register8_t USERROW32;  /* User Row Byte 32 */
+    register8_t USERROW33;  /* User Row Byte 33 */
+    register8_t USERROW34;  /* User Row Byte 34 */
+    register8_t USERROW35;  /* User Row Byte 35 */
+    register8_t USERROW36;  /* User Row Byte 36 */
+    register8_t USERROW37;  /* User Row Byte 37 */
+    register8_t USERROW38;  /* User Row Byte 38 */
+    register8_t USERROW39;  /* User Row Byte 39 */
+    register8_t USERROW40;  /* User Row Byte 40 */
+    register8_t USERROW41;  /* User Row Byte 41 */
+    register8_t USERROW42;  /* User Row Byte 42 */
+    register8_t USERROW43;  /* User Row Byte 43 */
+    register8_t USERROW44;  /* User Row Byte 44 */
+    register8_t USERROW45;  /* User Row Byte 45 */
+    register8_t USERROW46;  /* User Row Byte 46 */
+    register8_t USERROW47;  /* User Row Byte 47 */
+    register8_t USERROW48;  /* User Row Byte 48 */
+    register8_t USERROW49;  /* User Row Byte 49 */
+    register8_t USERROW50;  /* User Row Byte 50 */
+    register8_t USERROW51;  /* User Row Byte 51 */
+    register8_t USERROW52;  /* User Row Byte 52 */
+    register8_t USERROW53;  /* User Row Byte 53 */
+    register8_t USERROW54;  /* User Row Byte 54 */
+    register8_t USERROW55;  /* User Row Byte 55 */
+    register8_t USERROW56;  /* User Row Byte 56 */
+    register8_t USERROW57;  /* User Row Byte 57 */
+    register8_t USERROW58;  /* User Row Byte 58 */
+    register8_t USERROW59;  /* User Row Byte 59 */
+    register8_t USERROW60;  /* User Row Byte 60 */
+    register8_t USERROW61;  /* User Row Byte 61 */
+    register8_t USERROW62;  /* User Row Byte 62 */
+    register8_t USERROW63;  /* User Row Byte 63 */
+} USERROW_t;
+
+
+/*
+--------------------------------------------------------------------------
+VPORT - Virtual Ports
+--------------------------------------------------------------------------
+*/
+
+/* Virtual Ports */
+typedef struct VPORT_struct
+{
+    register8_t DIR;  /* Data Direction */
+    register8_t OUT;  /* Output Value */
+    register8_t IN;  /* Input Value */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+} VPORT_t;
+
+
+/*
+--------------------------------------------------------------------------
+VREF - Voltage reference
+--------------------------------------------------------------------------
+*/
+
+/* Voltage reference */
+typedef struct VREF_struct
+{
+    register8_t reserved_1[2];
+    register8_t DAC0REF;  /* DAC0 Reference */
+    register8_t reserved_2[1];
+    register8_t ACREF;  /* AC Reference */
+} VREF_t;
+
+/* Reference select */
+typedef enum VREF_REFSEL_enum
+{
+    VREF_REFSEL_1V024_gc = (0x00<<0),  /* Internal 1.024V reference */
+    VREF_REFSEL_2V048_gc = (0x01<<0),  /* Internal 2.048V reference */
+    VREF_REFSEL_4V096_gc = (0x02<<0),  /* Internal 4.096V reference */
+    VREF_REFSEL_2V500_gc = (0x03<<0),  /* Internal 2.500V reference */
+    VREF_REFSEL_VDD_gc = (0x05<<0),  /* VDD as reference */
+    VREF_REFSEL_VREFA_gc = (0x06<<0)  /* External reference on VREFA pin */
+} VREF_REFSEL_t;
+
+/*
+--------------------------------------------------------------------------
+WDT - Watch-Dog Timer
+--------------------------------------------------------------------------
+*/
+
+/* Watch-Dog Timer */
+typedef struct WDT_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t STATUS;  /* Status */
+    register8_t reserved_1[14];
+} WDT_t;
+
+/* Period select */
+typedef enum WDT_PERIOD_enum
+{
+    WDT_PERIOD_OFF_gc = (0x00<<0),  /* Off */
+    WDT_PERIOD_8CLK_gc = (0x01<<0),  /* 8 cycles (8ms) */
+    WDT_PERIOD_16CLK_gc = (0x02<<0),  /* 16 cycles (16ms) */
+    WDT_PERIOD_32CLK_gc = (0x03<<0),  /* 32 cycles (32ms) */
+    WDT_PERIOD_64CLK_gc = (0x04<<0),  /* 64 cycles (64ms) */
+    WDT_PERIOD_128CLK_gc = (0x05<<0),  /* 128 cycles (0.128s) */
+    WDT_PERIOD_256CLK_gc = (0x06<<0),  /* 256 cycles (0.256s) */
+    WDT_PERIOD_512CLK_gc = (0x07<<0),  /* 512 cycles (0.512s) */
+    WDT_PERIOD_1KCLK_gc = (0x08<<0),  /* 1K cycles (1.0s) */
+    WDT_PERIOD_2KCLK_gc = (0x09<<0),  /* 2K cycles (2.0s) */
+    WDT_PERIOD_4KCLK_gc = (0x0A<<0),  /* 4K cycles (4.1s) */
+    WDT_PERIOD_8KCLK_gc = (0x0B<<0)  /* 8K cycles (8.2s) */
+} WDT_PERIOD_t;
+
+/* Window select */
+typedef enum WDT_WINDOW_enum
+{
+    WDT_WINDOW_OFF_gc = (0x00<<4),  /* Off */
+    WDT_WINDOW_8CLK_gc = (0x01<<4),  /* 8 cycles (8ms) */
+    WDT_WINDOW_16CLK_gc = (0x02<<4),  /* 16 cycles (16ms) */
+    WDT_WINDOW_32CLK_gc = (0x03<<4),  /* 32 cycles (32ms) */
+    WDT_WINDOW_64CLK_gc = (0x04<<4),  /* 64 cycles (64ms) */
+    WDT_WINDOW_128CLK_gc = (0x05<<4),  /* 128 cycles (0.128s) */
+    WDT_WINDOW_256CLK_gc = (0x06<<4),  /* 256 cycles (0.256s) */
+    WDT_WINDOW_512CLK_gc = (0x07<<4),  /* 512 cycles (0.512s) */
+    WDT_WINDOW_1KCLK_gc = (0x08<<4),  /* 1K cycles (1.0s) */
+    WDT_WINDOW_2KCLK_gc = (0x09<<4),  /* 2K cycles (2.0s) */
+    WDT_WINDOW_4KCLK_gc = (0x0A<<4),  /* 4K cycles (4.1s) */
+    WDT_WINDOW_8KCLK_gc = (0x0B<<4)  /* 8K cycles (8.2s) */
+} WDT_WINDOW_t;
+/*
+==========================================================================
+IO Module Instances. Mapped to memory.
+==========================================================================
+*/
+
+#define VPORTA              (*(VPORT_t *) 0x0000) /* Virtual Ports */
+#define VPORTB              (*(VPORT_t *) 0x0004) /* Virtual Ports */
+#define VPORTC              (*(VPORT_t *) 0x0008) /* Virtual Ports */
+#define VPORTD              (*(VPORT_t *) 0x000C) /* Virtual Ports */
+#define VPORTE              (*(VPORT_t *) 0x0010) /* Virtual Ports */
+#define VPORTF              (*(VPORT_t *) 0x0014) /* Virtual Ports */
+#define GPR                   (*(GPR_t *) 0x001C) /* General Purpose Registers */
+#define RSTCTRL           (*(RSTCTRL_t *) 0x0040) /* Reset controller */
+#define SLPCTRL           (*(SLPCTRL_t *) 0x0050) /* Sleep Controller */
+#define CLKCTRL           (*(CLKCTRL_t *) 0x0060) /* Clock controller */
+#define BOD                   (*(BOD_t *) 0x00A0) /* Bod interface */
+#define VREF                 (*(VREF_t *) 0x00B0) /* Voltage reference */
+#define WDT                   (*(WDT_t *) 0x0100) /* Watch-Dog Timer */
+#define CPUINT             (*(CPUINT_t *) 0x0110) /* Interrupt Controller */
+#define CRCSCAN           (*(CRCSCAN_t *) 0x0120) /* CRCSCAN */
+#define RTC                   (*(RTC_t *) 0x0140) /* Real-Time Counter */
+#define CCL                   (*(CCL_t *) 0x01C0) /* Configurable Custom Logic */
+#define EVSYS               (*(EVSYS_t *) 0x0200) /* Event System */
+#define PORTA                (*(PORT_t *) 0x0400) /* I/O Ports */
+#define PORTB                (*(PORT_t *) 0x0420) /* I/O Ports */
+#define PORTC                (*(PORT_t *) 0x0440) /* I/O Ports */
+#define PORTD                (*(PORT_t *) 0x0460) /* I/O Ports */
+#define PORTE                (*(PORT_t *) 0x0480) /* I/O Ports */
+#define PORTF                (*(PORT_t *) 0x04A0) /* I/O Ports */
+#define PORTMUX           (*(PORTMUX_t *) 0x05E0) /* Port Multiplexer */
+#define ADC0                  (*(ADC_t *) 0x0600) /* Analog to Digital Converter */
+#define AC0                    (*(AC_t *) 0x0680) /* Analog Comparator */
+#define AC1                    (*(AC_t *) 0x0688) /* Analog Comparator */
+#define DAC0                  (*(DAC_t *) 0x06A0) /* Digital to Analog Converter */
+#define USART0              (*(USART_t *) 0x0800) /* Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define USART1              (*(USART_t *) 0x0820) /* Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define USART2              (*(USART_t *) 0x0840) /* Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define TWI0                  (*(TWI_t *) 0x0900) /* Two-Wire Interface */
+#define SPI0                  (*(SPI_t *) 0x0940) /* Serial Peripheral Interface */
+#define TCA0                  (*(TCA_t *) 0x0A00) /* 16-bit Timer/Counter Type A */
+#define TCA1                  (*(TCA_t *) 0x0A40) /* 16-bit Timer/Counter Type A */
+#define TCB0                  (*(TCB_t *) 0x0B00) /* 16-bit Timer Type B */
+#define TCB1                  (*(TCB_t *) 0x0B10) /* 16-bit Timer Type B */
+#define TCB2                  (*(TCB_t *) 0x0B20) /* 16-bit Timer Type B */
+#define TCB3                  (*(TCB_t *) 0x0B30) /* 16-bit Timer Type B */
+#define SYSCFG             (*(SYSCFG_t *) 0x0F00) /* System Configuration Registers */
+#define NVMCTRL           (*(NVMCTRL_t *) 0x1000) /* Non-volatile Memory Controller */
+#define LOCK                 (*(LOCK_t *) 0x1040) /* Lockbits */
+#define FUSE                 (*(FUSE_t *) 0x1050) /* Fuses */
+#define USERROW           (*(USERROW_t *) 0x1080) /* User Row */
+#define SIGROW             (*(SIGROW_t *) 0x1100) /* Signature row */
+
+#endif /* !defined (__ASSEMBLER__) */
+
+
+/* ========== Flattened fully qualified IO register names ========== */
+
+
+/* VPORT (VPORTA) - Virtual Ports */
+#define VPORTA_DIR  _SFR_MEM8(0x0000)
+#define VPORTA_OUT  _SFR_MEM8(0x0001)
+#define VPORTA_IN  _SFR_MEM8(0x0002)
+#define VPORTA_INTFLAGS  _SFR_MEM8(0x0003)
+
+
+/* VPORT (VPORTB) - Virtual Ports */
+#define VPORTB_DIR  _SFR_MEM8(0x0004)
+#define VPORTB_OUT  _SFR_MEM8(0x0005)
+#define VPORTB_IN  _SFR_MEM8(0x0006)
+#define VPORTB_INTFLAGS  _SFR_MEM8(0x0007)
+
+
+/* VPORT (VPORTC) - Virtual Ports */
+#define VPORTC_DIR  _SFR_MEM8(0x0008)
+#define VPORTC_OUT  _SFR_MEM8(0x0009)
+#define VPORTC_IN  _SFR_MEM8(0x000A)
+#define VPORTC_INTFLAGS  _SFR_MEM8(0x000B)
+
+
+/* VPORT (VPORTD) - Virtual Ports */
+#define VPORTD_DIR  _SFR_MEM8(0x000C)
+#define VPORTD_OUT  _SFR_MEM8(0x000D)
+#define VPORTD_IN  _SFR_MEM8(0x000E)
+#define VPORTD_INTFLAGS  _SFR_MEM8(0x000F)
+
+
+/* VPORT (VPORTE) - Virtual Ports */
+#define VPORTE_DIR  _SFR_MEM8(0x0010)
+#define VPORTE_OUT  _SFR_MEM8(0x0011)
+#define VPORTE_IN  _SFR_MEM8(0x0012)
+#define VPORTE_INTFLAGS  _SFR_MEM8(0x0013)
+
+
+/* VPORT (VPORTF) - Virtual Ports */
+#define VPORTF_DIR  _SFR_MEM8(0x0014)
+#define VPORTF_OUT  _SFR_MEM8(0x0015)
+#define VPORTF_IN  _SFR_MEM8(0x0016)
+#define VPORTF_INTFLAGS  _SFR_MEM8(0x0017)
+
+
+/* GPR - General Purpose Registers */
+#define GPR_GPR0  _SFR_MEM8(0x001C)
+#define GPR_GPR1  _SFR_MEM8(0x001D)
+#define GPR_GPR2  _SFR_MEM8(0x001E)
+#define GPR_GPR3  _SFR_MEM8(0x001F)
+
+
+/* CPU - CPU */
+#define CPU_CCP  _SFR_MEM8(0x0034)
+#define CPU_SP  _SFR_MEM16(0x003D)
+#define CPU_SPL  _SFR_MEM8(0x003D)
+#define CPU_SPH  _SFR_MEM8(0x003E)
+#define CPU_SREG  _SFR_MEM8(0x003F)
+
+
+/* RSTCTRL - Reset controller */
+#define RSTCTRL_RSTFR  _SFR_MEM8(0x0040)
+#define RSTCTRL_SWRR  _SFR_MEM8(0x0041)
+
+
+/* SLPCTRL - Sleep Controller */
+#define SLPCTRL_CTRLA  _SFR_MEM8(0x0050)
+
+
+/* CLKCTRL - Clock controller */
+#define CLKCTRL_MCLKCTRLA  _SFR_MEM8(0x0060)
+#define CLKCTRL_MCLKCTRLB  _SFR_MEM8(0x0061)
+#define CLKCTRL_MCLKCTRLC  _SFR_MEM8(0x0062)
+#define CLKCTRL_MCLKINTCTRL  _SFR_MEM8(0x0063)
+#define CLKCTRL_MCLKINTFLAGS  _SFR_MEM8(0x0064)
+#define CLKCTRL_MCLKSTATUS  _SFR_MEM8(0x0065)
+#define CLKCTRL_MCLKTIMEBASE  _SFR_MEM8(0x0066)
+#define CLKCTRL_OSCHFCTRLA  _SFR_MEM8(0x0068)
+#define CLKCTRL_OSCHFTUNE  _SFR_MEM8(0x0069)
+#define CLKCTRL_OSC32KCTRLA  _SFR_MEM8(0x0078)
+#define CLKCTRL_XOSC32KCTRLA  _SFR_MEM8(0x007C)
+#define CLKCTRL_XOSCHFCTRLA  _SFR_MEM8(0x0080)
+
+
+/* BOD - Bod interface */
+#define BOD_CTRLA  _SFR_MEM8(0x00A0)
+#define BOD_CTRLB  _SFR_MEM8(0x00A1)
+#define BOD_VLMCTRLA  _SFR_MEM8(0x00A8)
+#define BOD_INTCTRL  _SFR_MEM8(0x00A9)
+#define BOD_INTFLAGS  _SFR_MEM8(0x00AA)
+#define BOD_STATUS  _SFR_MEM8(0x00AB)
+
+
+/* VREF - Voltage reference */
+#define VREF_DAC0REF  _SFR_MEM8(0x00B2)
+#define VREF_ACREF  _SFR_MEM8(0x00B4)
+
+
+/* WDT - Watch-Dog Timer */
+#define WDT_CTRLA  _SFR_MEM8(0x0100)
+#define WDT_STATUS  _SFR_MEM8(0x0101)
+
+
+/* CPUINT - Interrupt Controller */
+#define CPUINT_CTRLA  _SFR_MEM8(0x0110)
+#define CPUINT_STATUS  _SFR_MEM8(0x0111)
+#define CPUINT_LVL0PRI  _SFR_MEM8(0x0112)
+#define CPUINT_LVL1VEC  _SFR_MEM8(0x0113)
+
+
+/* CRCSCAN - CRCSCAN */
+#define CRCSCAN_CTRLA  _SFR_MEM8(0x0120)
+#define CRCSCAN_CTRLB  _SFR_MEM8(0x0121)
+#define CRCSCAN_STATUS  _SFR_MEM8(0x0122)
+
+
+/* RTC - Real-Time Counter */
+#define RTC_CTRLA  _SFR_MEM8(0x0140)
+#define RTC_STATUS  _SFR_MEM8(0x0141)
+#define RTC_INTCTRL  _SFR_MEM8(0x0142)
+#define RTC_INTFLAGS  _SFR_MEM8(0x0143)
+#define RTC_TEMP  _SFR_MEM8(0x0144)
+#define RTC_DBGCTRL  _SFR_MEM8(0x0145)
+#define RTC_CALIB  _SFR_MEM8(0x0146)
+#define RTC_CLKSEL  _SFR_MEM8(0x0147)
+#define RTC_CNT  _SFR_MEM16(0x0148)
+#define RTC_CNTL  _SFR_MEM8(0x0148)
+#define RTC_CNTH  _SFR_MEM8(0x0149)
+#define RTC_PER  _SFR_MEM16(0x014A)
+#define RTC_PERL  _SFR_MEM8(0x014A)
+#define RTC_PERH  _SFR_MEM8(0x014B)
+#define RTC_CMP  _SFR_MEM16(0x014C)
+#define RTC_CMPL  _SFR_MEM8(0x014C)
+#define RTC_CMPH  _SFR_MEM8(0x014D)
+#define RTC_PITCTRLA  _SFR_MEM8(0x0150)
+#define RTC_PITSTATUS  _SFR_MEM8(0x0151)
+#define RTC_PITINTCTRL  _SFR_MEM8(0x0152)
+#define RTC_PITINTFLAGS  _SFR_MEM8(0x0153)
+#define RTC_PITDBGCTRL  _SFR_MEM8(0x0155)
+#define RTC_PITEVGENCTRLA  _SFR_MEM8(0x0156)
+
+
+/* CCL - Configurable Custom Logic */
+#define CCL_CTRLA  _SFR_MEM8(0x01C0)
+#define CCL_SEQCTRL0  _SFR_MEM8(0x01C1)
+#define CCL_SEQCTRL1  _SFR_MEM8(0x01C2)
+#define CCL_INTCTRL0  _SFR_MEM8(0x01C5)
+#define CCL_INTFLAGS  _SFR_MEM8(0x01C7)
+#define CCL_LUT0CTRLA  _SFR_MEM8(0x01C8)
+#define CCL_LUT0CTRLB  _SFR_MEM8(0x01C9)
+#define CCL_LUT0CTRLC  _SFR_MEM8(0x01CA)
+#define CCL_TRUTH0  _SFR_MEM8(0x01CB)
+#define CCL_LUT1CTRLA  _SFR_MEM8(0x01CC)
+#define CCL_LUT1CTRLB  _SFR_MEM8(0x01CD)
+#define CCL_LUT1CTRLC  _SFR_MEM8(0x01CE)
+#define CCL_TRUTH1  _SFR_MEM8(0x01CF)
+#define CCL_LUT2CTRLA  _SFR_MEM8(0x01D0)
+#define CCL_LUT2CTRLB  _SFR_MEM8(0x01D1)
+#define CCL_LUT2CTRLC  _SFR_MEM8(0x01D2)
+#define CCL_TRUTH2  _SFR_MEM8(0x01D3)
+#define CCL_LUT3CTRLA  _SFR_MEM8(0x01D4)
+#define CCL_LUT3CTRLB  _SFR_MEM8(0x01D5)
+#define CCL_LUT3CTRLC  _SFR_MEM8(0x01D6)
+#define CCL_TRUTH3  _SFR_MEM8(0x01D7)
+
+
+/* EVSYS - Event System */
+#define EVSYS_SWEVENTA  _SFR_MEM8(0x0200)
+#define EVSYS_CHANNEL0  _SFR_MEM8(0x0210)
+#define EVSYS_CHANNEL1  _SFR_MEM8(0x0211)
+#define EVSYS_CHANNEL2  _SFR_MEM8(0x0212)
+#define EVSYS_CHANNEL3  _SFR_MEM8(0x0213)
+#define EVSYS_CHANNEL4  _SFR_MEM8(0x0214)
+#define EVSYS_CHANNEL5  _SFR_MEM8(0x0215)
+#define EVSYS_USERCCLLUT0A  _SFR_MEM8(0x0220)
+#define EVSYS_USERCCLLUT0B  _SFR_MEM8(0x0221)
+#define EVSYS_USERCCLLUT1A  _SFR_MEM8(0x0222)
+#define EVSYS_USERCCLLUT1B  _SFR_MEM8(0x0223)
+#define EVSYS_USERCCLLUT2A  _SFR_MEM8(0x0224)
+#define EVSYS_USERCCLLUT2B  _SFR_MEM8(0x0225)
+#define EVSYS_USERCCLLUT3A  _SFR_MEM8(0x0226)
+#define EVSYS_USERCCLLUT3B  _SFR_MEM8(0x0227)
+#define EVSYS_USERADC0START  _SFR_MEM8(0x0228)
+#define EVSYS_USEREVSYSEVOUTA  _SFR_MEM8(0x0229)
+#define EVSYS_USEREVSYSEVOUTB  _SFR_MEM8(0x022A)
+#define EVSYS_USEREVSYSEVOUTC  _SFR_MEM8(0x022B)
+#define EVSYS_USEREVSYSEVOUTD  _SFR_MEM8(0x022C)
+#define EVSYS_USEREVSYSEVOUTE  _SFR_MEM8(0x022D)
+#define EVSYS_USEREVSYSEVOUTF  _SFR_MEM8(0x022E)
+#define EVSYS_USERUSART0IRDA  _SFR_MEM8(0x022F)
+#define EVSYS_USERUSART1IRDA  _SFR_MEM8(0x0230)
+#define EVSYS_USERUSART2IRDA  _SFR_MEM8(0x0231)
+#define EVSYS_USERTCA0CNTA  _SFR_MEM8(0x0232)
+#define EVSYS_USERTCA0CNTB  _SFR_MEM8(0x0233)
+#define EVSYS_USERTCA1CNTA  _SFR_MEM8(0x0234)
+#define EVSYS_USERTCA1CNTB  _SFR_MEM8(0x0235)
+#define EVSYS_USERTCB0CAPT  _SFR_MEM8(0x0236)
+#define EVSYS_USERTCB0COUNT  _SFR_MEM8(0x0237)
+#define EVSYS_USERTCB1CAPT  _SFR_MEM8(0x0238)
+#define EVSYS_USERTCB1COUNT  _SFR_MEM8(0x0239)
+#define EVSYS_USERTCB2CAPT  _SFR_MEM8(0x023A)
+#define EVSYS_USERTCB2COUNT  _SFR_MEM8(0x023B)
+#define EVSYS_USERTCB3CAPT  _SFR_MEM8(0x023C)
+#define EVSYS_USERTCB3COUNT  _SFR_MEM8(0x023D)
+
+
+/* PORT (PORTA) - I/O Ports */
+#define PORTA_DIR  _SFR_MEM8(0x0400)
+#define PORTA_DIRSET  _SFR_MEM8(0x0401)
+#define PORTA_DIRCLR  _SFR_MEM8(0x0402)
+#define PORTA_DIRTGL  _SFR_MEM8(0x0403)
+#define PORTA_OUT  _SFR_MEM8(0x0404)
+#define PORTA_OUTSET  _SFR_MEM8(0x0405)
+#define PORTA_OUTCLR  _SFR_MEM8(0x0406)
+#define PORTA_OUTTGL  _SFR_MEM8(0x0407)
+#define PORTA_IN  _SFR_MEM8(0x0408)
+#define PORTA_INTFLAGS  _SFR_MEM8(0x0409)
+#define PORTA_PORTCTRL  _SFR_MEM8(0x040A)
+#define PORTA_PINCONFIG  _SFR_MEM8(0x040B)
+#define PORTA_PINCTRLUPD  _SFR_MEM8(0x040C)
+#define PORTA_PINCTRLSET  _SFR_MEM8(0x040D)
+#define PORTA_PINCTRLCLR  _SFR_MEM8(0x040E)
+#define PORTA_PIN0CTRL  _SFR_MEM8(0x0410)
+#define PORTA_PIN1CTRL  _SFR_MEM8(0x0411)
+#define PORTA_PIN2CTRL  _SFR_MEM8(0x0412)
+#define PORTA_PIN3CTRL  _SFR_MEM8(0x0413)
+#define PORTA_PIN4CTRL  _SFR_MEM8(0x0414)
+#define PORTA_PIN5CTRL  _SFR_MEM8(0x0415)
+#define PORTA_PIN6CTRL  _SFR_MEM8(0x0416)
+#define PORTA_PIN7CTRL  _SFR_MEM8(0x0417)
+#define PORTA_EVGENCTRL  _SFR_MEM8(0x0418)
+
+
+/* PORT (PORTB) - I/O Ports */
+#define PORTB_DIR  _SFR_MEM8(0x0420)
+#define PORTB_DIRSET  _SFR_MEM8(0x0421)
+#define PORTB_DIRCLR  _SFR_MEM8(0x0422)
+#define PORTB_DIRTGL  _SFR_MEM8(0x0423)
+#define PORTB_OUT  _SFR_MEM8(0x0424)
+#define PORTB_OUTSET  _SFR_MEM8(0x0425)
+#define PORTB_OUTCLR  _SFR_MEM8(0x0426)
+#define PORTB_OUTTGL  _SFR_MEM8(0x0427)
+#define PORTB_IN  _SFR_MEM8(0x0428)
+#define PORTB_INTFLAGS  _SFR_MEM8(0x0429)
+#define PORTB_PORTCTRL  _SFR_MEM8(0x042A)
+#define PORTB_PINCONFIG  _SFR_MEM8(0x042B)
+#define PORTB_PINCTRLUPD  _SFR_MEM8(0x042C)
+#define PORTB_PINCTRLSET  _SFR_MEM8(0x042D)
+#define PORTB_PINCTRLCLR  _SFR_MEM8(0x042E)
+#define PORTB_PIN0CTRL  _SFR_MEM8(0x0430)
+#define PORTB_PIN1CTRL  _SFR_MEM8(0x0431)
+#define PORTB_PIN2CTRL  _SFR_MEM8(0x0432)
+#define PORTB_PIN3CTRL  _SFR_MEM8(0x0433)
+#define PORTB_PIN4CTRL  _SFR_MEM8(0x0434)
+#define PORTB_PIN5CTRL  _SFR_MEM8(0x0435)
+#define PORTB_PIN6CTRL  _SFR_MEM8(0x0436)
+#define PORTB_PIN7CTRL  _SFR_MEM8(0x0437)
+#define PORTB_EVGENCTRL  _SFR_MEM8(0x0438)
+
+
+/* PORT (PORTC) - I/O Ports */
+#define PORTC_DIR  _SFR_MEM8(0x0440)
+#define PORTC_DIRSET  _SFR_MEM8(0x0441)
+#define PORTC_DIRCLR  _SFR_MEM8(0x0442)
+#define PORTC_DIRTGL  _SFR_MEM8(0x0443)
+#define PORTC_OUT  _SFR_MEM8(0x0444)
+#define PORTC_OUTSET  _SFR_MEM8(0x0445)
+#define PORTC_OUTCLR  _SFR_MEM8(0x0446)
+#define PORTC_OUTTGL  _SFR_MEM8(0x0447)
+#define PORTC_IN  _SFR_MEM8(0x0448)
+#define PORTC_INTFLAGS  _SFR_MEM8(0x0449)
+#define PORTC_PORTCTRL  _SFR_MEM8(0x044A)
+#define PORTC_PINCONFIG  _SFR_MEM8(0x044B)
+#define PORTC_PINCTRLUPD  _SFR_MEM8(0x044C)
+#define PORTC_PINCTRLSET  _SFR_MEM8(0x044D)
+#define PORTC_PINCTRLCLR  _SFR_MEM8(0x044E)
+#define PORTC_PIN0CTRL  _SFR_MEM8(0x0450)
+#define PORTC_PIN1CTRL  _SFR_MEM8(0x0451)
+#define PORTC_PIN2CTRL  _SFR_MEM8(0x0452)
+#define PORTC_PIN3CTRL  _SFR_MEM8(0x0453)
+#define PORTC_PIN4CTRL  _SFR_MEM8(0x0454)
+#define PORTC_PIN5CTRL  _SFR_MEM8(0x0455)
+#define PORTC_PIN6CTRL  _SFR_MEM8(0x0456)
+#define PORTC_PIN7CTRL  _SFR_MEM8(0x0457)
+#define PORTC_EVGENCTRL  _SFR_MEM8(0x0458)
+
+
+/* PORT (PORTD) - I/O Ports */
+#define PORTD_DIR  _SFR_MEM8(0x0460)
+#define PORTD_DIRSET  _SFR_MEM8(0x0461)
+#define PORTD_DIRCLR  _SFR_MEM8(0x0462)
+#define PORTD_DIRTGL  _SFR_MEM8(0x0463)
+#define PORTD_OUT  _SFR_MEM8(0x0464)
+#define PORTD_OUTSET  _SFR_MEM8(0x0465)
+#define PORTD_OUTCLR  _SFR_MEM8(0x0466)
+#define PORTD_OUTTGL  _SFR_MEM8(0x0467)
+#define PORTD_IN  _SFR_MEM8(0x0468)
+#define PORTD_INTFLAGS  _SFR_MEM8(0x0469)
+#define PORTD_PORTCTRL  _SFR_MEM8(0x046A)
+#define PORTD_PINCONFIG  _SFR_MEM8(0x046B)
+#define PORTD_PINCTRLUPD  _SFR_MEM8(0x046C)
+#define PORTD_PINCTRLSET  _SFR_MEM8(0x046D)
+#define PORTD_PINCTRLCLR  _SFR_MEM8(0x046E)
+#define PORTD_PIN0CTRL  _SFR_MEM8(0x0470)
+#define PORTD_PIN1CTRL  _SFR_MEM8(0x0471)
+#define PORTD_PIN2CTRL  _SFR_MEM8(0x0472)
+#define PORTD_PIN3CTRL  _SFR_MEM8(0x0473)
+#define PORTD_PIN4CTRL  _SFR_MEM8(0x0474)
+#define PORTD_PIN5CTRL  _SFR_MEM8(0x0475)
+#define PORTD_PIN6CTRL  _SFR_MEM8(0x0476)
+#define PORTD_PIN7CTRL  _SFR_MEM8(0x0477)
+#define PORTD_EVGENCTRL  _SFR_MEM8(0x0478)
+
+
+/* PORT (PORTE) - I/O Ports */
+#define PORTE_DIR  _SFR_MEM8(0x0480)
+#define PORTE_DIRSET  _SFR_MEM8(0x0481)
+#define PORTE_DIRCLR  _SFR_MEM8(0x0482)
+#define PORTE_DIRTGL  _SFR_MEM8(0x0483)
+#define PORTE_OUT  _SFR_MEM8(0x0484)
+#define PORTE_OUTSET  _SFR_MEM8(0x0485)
+#define PORTE_OUTCLR  _SFR_MEM8(0x0486)
+#define PORTE_OUTTGL  _SFR_MEM8(0x0487)
+#define PORTE_IN  _SFR_MEM8(0x0488)
+#define PORTE_INTFLAGS  _SFR_MEM8(0x0489)
+#define PORTE_PORTCTRL  _SFR_MEM8(0x048A)
+#define PORTE_PINCONFIG  _SFR_MEM8(0x048B)
+#define PORTE_PINCTRLUPD  _SFR_MEM8(0x048C)
+#define PORTE_PINCTRLSET  _SFR_MEM8(0x048D)
+#define PORTE_PINCTRLCLR  _SFR_MEM8(0x048E)
+#define PORTE_PIN0CTRL  _SFR_MEM8(0x0490)
+#define PORTE_PIN1CTRL  _SFR_MEM8(0x0491)
+#define PORTE_PIN2CTRL  _SFR_MEM8(0x0492)
+#define PORTE_PIN3CTRL  _SFR_MEM8(0x0493)
+#define PORTE_PIN4CTRL  _SFR_MEM8(0x0494)
+#define PORTE_PIN5CTRL  _SFR_MEM8(0x0495)
+#define PORTE_PIN6CTRL  _SFR_MEM8(0x0496)
+#define PORTE_PIN7CTRL  _SFR_MEM8(0x0497)
+#define PORTE_EVGENCTRL  _SFR_MEM8(0x0498)
+
+
+/* PORT (PORTF) - I/O Ports */
+#define PORTF_DIR  _SFR_MEM8(0x04A0)
+#define PORTF_DIRSET  _SFR_MEM8(0x04A1)
+#define PORTF_DIRCLR  _SFR_MEM8(0x04A2)
+#define PORTF_DIRTGL  _SFR_MEM8(0x04A3)
+#define PORTF_OUT  _SFR_MEM8(0x04A4)
+#define PORTF_OUTSET  _SFR_MEM8(0x04A5)
+#define PORTF_OUTCLR  _SFR_MEM8(0x04A6)
+#define PORTF_OUTTGL  _SFR_MEM8(0x04A7)
+#define PORTF_IN  _SFR_MEM8(0x04A8)
+#define PORTF_INTFLAGS  _SFR_MEM8(0x04A9)
+#define PORTF_PORTCTRL  _SFR_MEM8(0x04AA)
+#define PORTF_PINCONFIG  _SFR_MEM8(0x04AB)
+#define PORTF_PINCTRLUPD  _SFR_MEM8(0x04AC)
+#define PORTF_PINCTRLSET  _SFR_MEM8(0x04AD)
+#define PORTF_PINCTRLCLR  _SFR_MEM8(0x04AE)
+#define PORTF_PIN0CTRL  _SFR_MEM8(0x04B0)
+#define PORTF_PIN1CTRL  _SFR_MEM8(0x04B1)
+#define PORTF_PIN2CTRL  _SFR_MEM8(0x04B2)
+#define PORTF_PIN3CTRL  _SFR_MEM8(0x04B3)
+#define PORTF_PIN4CTRL  _SFR_MEM8(0x04B4)
+#define PORTF_PIN5CTRL  _SFR_MEM8(0x04B5)
+#define PORTF_PIN6CTRL  _SFR_MEM8(0x04B6)
+#define PORTF_PIN7CTRL  _SFR_MEM8(0x04B7)
+#define PORTF_EVGENCTRL  _SFR_MEM8(0x04B8)
+
+
+/* PORTMUX - Port Multiplexer */
+#define PORTMUX_EVSYSROUTEA  _SFR_MEM8(0x05E0)
+#define PORTMUX_CCLROUTEA  _SFR_MEM8(0x05E1)
+#define PORTMUX_USARTROUTEA  _SFR_MEM8(0x05E2)
+#define PORTMUX_USARTROUTEB  _SFR_MEM8(0x05E3)
+#define PORTMUX_SPIROUTEA  _SFR_MEM8(0x05E5)
+#define PORTMUX_TWIROUTEA  _SFR_MEM8(0x05E6)
+#define PORTMUX_TCAROUTEA  _SFR_MEM8(0x05E7)
+#define PORTMUX_TCBROUTEA  _SFR_MEM8(0x05E8)
+#define PORTMUX_ACROUTEA  _SFR_MEM8(0x05EA)
+
+
+/* ADC (ADC0) - Analog to Digital Converter */
+#define ADC0_CTRLA  _SFR_MEM8(0x0600)
+#define ADC0_CTRLB  _SFR_MEM8(0x0601)
+#define ADC0_CTRLC  _SFR_MEM8(0x0602)
+#define ADC0_CTRLD  _SFR_MEM8(0x0603)
+#define ADC0_INTCTRL  _SFR_MEM8(0x0604)
+#define ADC0_INTFLAGS  _SFR_MEM8(0x0605)
+#define ADC0_STATUS  _SFR_MEM8(0x0606)
+#define ADC0_DBGCTRL  _SFR_MEM8(0x0607)
+#define ADC0_CTRLE  _SFR_MEM8(0x0608)
+#define ADC0_CTRLF  _SFR_MEM8(0x0609)
+#define ADC0_COMMAND  _SFR_MEM8(0x060A)
+#define ADC0_PGACTRL  _SFR_MEM8(0x060B)
+#define ADC0_MUXPOS  _SFR_MEM8(0x060C)
+#define ADC0_MUXNEG  _SFR_MEM8(0x060D)
+#define ADC0_RESULT  _SFR_MEM32(0x0610)
+#define ADC0_RESULT0  _SFR_MEM8(0x0610)
+#define ADC0_RESULT1  _SFR_MEM8(0x0611)
+#define ADC0_RESULT2  _SFR_MEM8(0x0612)
+#define ADC0_RESULT3  _SFR_MEM8(0x0613)
+#define ADC0_SAMPLE  _SFR_MEM16(0x0614)
+#define ADC0_SAMPLEL  _SFR_MEM8(0x0614)
+#define ADC0_SAMPLEH  _SFR_MEM8(0x0615)
+#define ADC0_TEMP0  _SFR_MEM8(0x0618)
+#define ADC0_TEMP1  _SFR_MEM8(0x0619)
+#define ADC0_TEMP2  _SFR_MEM8(0x061A)
+#define ADC0_WINLT  _SFR_MEM16(0x061C)
+#define ADC0_WINLTL  _SFR_MEM8(0x061C)
+#define ADC0_WINLTH  _SFR_MEM8(0x061D)
+#define ADC0_WINHT  _SFR_MEM16(0x061E)
+#define ADC0_WINHTL  _SFR_MEM8(0x061E)
+#define ADC0_WINHTH  _SFR_MEM8(0x061F)
+
+
+/* AC (AC0) - Analog Comparator */
+#define AC0_CTRLA  _SFR_MEM8(0x0680)
+#define AC0_CTRLB  _SFR_MEM8(0x0681)
+#define AC0_MUXCTRL  _SFR_MEM8(0x0682)
+#define AC0_DACREF  _SFR_MEM8(0x0685)
+#define AC0_INTCTRL  _SFR_MEM8(0x0686)
+#define AC0_STATUS  _SFR_MEM8(0x0687)
+
+
+/* AC (AC1) - Analog Comparator */
+#define AC1_CTRLA  _SFR_MEM8(0x0688)
+#define AC1_CTRLB  _SFR_MEM8(0x0689)
+#define AC1_MUXCTRL  _SFR_MEM8(0x068A)
+#define AC1_DACREF  _SFR_MEM8(0x068D)
+#define AC1_INTCTRL  _SFR_MEM8(0x068E)
+#define AC1_STATUS  _SFR_MEM8(0x068F)
+
+
+/* DAC (DAC0) - Digital to Analog Converter */
+#define DAC0_CTRLA  _SFR_MEM8(0x06A0)
+#define DAC0_DATA  _SFR_MEM16(0x06A2)
+#define DAC0_DATAL  _SFR_MEM8(0x06A2)
+#define DAC0_DATAH  _SFR_MEM8(0x06A3)
+
+
+/* USART (USART0) - Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define USART0_RXDATAL  _SFR_MEM8(0x0800)
+#define USART0_RXDATAH  _SFR_MEM8(0x0801)
+#define USART0_TXDATAL  _SFR_MEM8(0x0802)
+#define USART0_TXDATAH  _SFR_MEM8(0x0803)
+#define USART0_STATUS  _SFR_MEM8(0x0804)
+#define USART0_CTRLA  _SFR_MEM8(0x0805)
+#define USART0_CTRLB  _SFR_MEM8(0x0806)
+#define USART0_CTRLC  _SFR_MEM8(0x0807)
+#define USART0_BAUD  _SFR_MEM16(0x0808)
+#define USART0_BAUDL  _SFR_MEM8(0x0808)
+#define USART0_BAUDH  _SFR_MEM8(0x0809)
+#define USART0_CTRLD  _SFR_MEM8(0x080A)
+#define USART0_DBGCTRL  _SFR_MEM8(0x080B)
+#define USART0_EVCTRL  _SFR_MEM8(0x080C)
+#define USART0_TXPLCTRL  _SFR_MEM8(0x080D)
+#define USART0_RXPLCTRL  _SFR_MEM8(0x080E)
+
+
+/* USART (USART1) - Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define USART1_RXDATAL  _SFR_MEM8(0x0820)
+#define USART1_RXDATAH  _SFR_MEM8(0x0821)
+#define USART1_TXDATAL  _SFR_MEM8(0x0822)
+#define USART1_TXDATAH  _SFR_MEM8(0x0823)
+#define USART1_STATUS  _SFR_MEM8(0x0824)
+#define USART1_CTRLA  _SFR_MEM8(0x0825)
+#define USART1_CTRLB  _SFR_MEM8(0x0826)
+#define USART1_CTRLC  _SFR_MEM8(0x0827)
+#define USART1_BAUD  _SFR_MEM16(0x0828)
+#define USART1_BAUDL  _SFR_MEM8(0x0828)
+#define USART1_BAUDH  _SFR_MEM8(0x0829)
+#define USART1_CTRLD  _SFR_MEM8(0x082A)
+#define USART1_DBGCTRL  _SFR_MEM8(0x082B)
+#define USART1_EVCTRL  _SFR_MEM8(0x082C)
+#define USART1_TXPLCTRL  _SFR_MEM8(0x082D)
+#define USART1_RXPLCTRL  _SFR_MEM8(0x082E)
+
+
+/* USART (USART2) - Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define USART2_RXDATAL  _SFR_MEM8(0x0840)
+#define USART2_RXDATAH  _SFR_MEM8(0x0841)
+#define USART2_TXDATAL  _SFR_MEM8(0x0842)
+#define USART2_TXDATAH  _SFR_MEM8(0x0843)
+#define USART2_STATUS  _SFR_MEM8(0x0844)
+#define USART2_CTRLA  _SFR_MEM8(0x0845)
+#define USART2_CTRLB  _SFR_MEM8(0x0846)
+#define USART2_CTRLC  _SFR_MEM8(0x0847)
+#define USART2_BAUD  _SFR_MEM16(0x0848)
+#define USART2_BAUDL  _SFR_MEM8(0x0848)
+#define USART2_BAUDH  _SFR_MEM8(0x0849)
+#define USART2_CTRLD  _SFR_MEM8(0x084A)
+#define USART2_DBGCTRL  _SFR_MEM8(0x084B)
+#define USART2_EVCTRL  _SFR_MEM8(0x084C)
+#define USART2_TXPLCTRL  _SFR_MEM8(0x084D)
+#define USART2_RXPLCTRL  _SFR_MEM8(0x084E)
+
+
+/* TWI (TWI0) - Two-Wire Interface */
+#define TWI0_CTRLA  _SFR_MEM8(0x0900)
+#define TWI0_DUALCTRL  _SFR_MEM8(0x0901)
+#define TWI0_DBGCTRL  _SFR_MEM8(0x0902)
+#define TWI0_MCTRLA  _SFR_MEM8(0x0903)
+#define TWI0_MCTRLB  _SFR_MEM8(0x0904)
+#define TWI0_MSTATUS  _SFR_MEM8(0x0905)
+#define TWI0_MBAUD  _SFR_MEM8(0x0906)
+#define TWI0_MADDR  _SFR_MEM8(0x0907)
+#define TWI0_MDATA  _SFR_MEM8(0x0908)
+#define TWI0_SCTRLA  _SFR_MEM8(0x0909)
+#define TWI0_SCTRLB  _SFR_MEM8(0x090A)
+#define TWI0_SSTATUS  _SFR_MEM8(0x090B)
+#define TWI0_SADDR  _SFR_MEM8(0x090C)
+#define TWI0_SDATA  _SFR_MEM8(0x090D)
+#define TWI0_SADDRMASK  _SFR_MEM8(0x090E)
+
+
+/* SPI (SPI0) - Serial Peripheral Interface */
+#define SPI0_CTRLA  _SFR_MEM8(0x0940)
+#define SPI0_CTRLB  _SFR_MEM8(0x0941)
+#define SPI0_INTCTRL  _SFR_MEM8(0x0942)
+#define SPI0_INTFLAGS  _SFR_MEM8(0x0943)
+#define SPI0_DATA  _SFR_MEM8(0x0944)
+
+
+/* TCA (TCA0) - 16-bit Timer/Counter Type A - Single Mode */
+#define TCA0_SINGLE_CTRLA  _SFR_MEM8(0x0A00)
+#define TCA0_SINGLE_CTRLB  _SFR_MEM8(0x0A01)
+#define TCA0_SINGLE_CTRLC  _SFR_MEM8(0x0A02)
+#define TCA0_SINGLE_CTRLD  _SFR_MEM8(0x0A03)
+#define TCA0_SINGLE_CTRLECLR  _SFR_MEM8(0x0A04)
+#define TCA0_SINGLE_CTRLESET  _SFR_MEM8(0x0A05)
+#define TCA0_SINGLE_CTRLFCLR  _SFR_MEM8(0x0A06)
+#define TCA0_SINGLE_CTRLFSET  _SFR_MEM8(0x0A07)
+#define TCA0_SINGLE_EVCTRL  _SFR_MEM8(0x0A09)
+#define TCA0_SINGLE_INTCTRL  _SFR_MEM8(0x0A0A)
+#define TCA0_SINGLE_INTFLAGS  _SFR_MEM8(0x0A0B)
+#define TCA0_SINGLE_DBGCTRL  _SFR_MEM8(0x0A0E)
+#define TCA0_SINGLE_TEMP  _SFR_MEM8(0x0A0F)
+#define TCA0_SINGLE_CNT  _SFR_MEM16(0x0A20)
+#define TCA0_SINGLE_CNTL  _SFR_MEM8(0x0A20)
+#define TCA0_SINGLE_CNTH  _SFR_MEM8(0x0A21)
+#define TCA0_SINGLE_PER  _SFR_MEM16(0x0A26)
+#define TCA0_SINGLE_PERL  _SFR_MEM8(0x0A26)
+#define TCA0_SINGLE_PERH  _SFR_MEM8(0x0A27)
+#define TCA0_SINGLE_CMP0  _SFR_MEM16(0x0A28)
+#define TCA0_SINGLE_CMP0L  _SFR_MEM8(0x0A28)
+#define TCA0_SINGLE_CMP0H  _SFR_MEM8(0x0A29)
+#define TCA0_SINGLE_CMP1  _SFR_MEM16(0x0A2A)
+#define TCA0_SINGLE_CMP1L  _SFR_MEM8(0x0A2A)
+#define TCA0_SINGLE_CMP1H  _SFR_MEM8(0x0A2B)
+#define TCA0_SINGLE_CMP2  _SFR_MEM16(0x0A2C)
+#define TCA0_SINGLE_CMP2L  _SFR_MEM8(0x0A2C)
+#define TCA0_SINGLE_CMP2H  _SFR_MEM8(0x0A2D)
+#define TCA0_SINGLE_PERBUF  _SFR_MEM16(0x0A36)
+#define TCA0_SINGLE_PERBUFL  _SFR_MEM8(0x0A36)
+#define TCA0_SINGLE_PERBUFH  _SFR_MEM8(0x0A37)
+#define TCA0_SINGLE_CMP0BUF  _SFR_MEM16(0x0A38)
+#define TCA0_SINGLE_CMP0BUFL  _SFR_MEM8(0x0A38)
+#define TCA0_SINGLE_CMP0BUFH  _SFR_MEM8(0x0A39)
+#define TCA0_SINGLE_CMP1BUF  _SFR_MEM16(0x0A3A)
+#define TCA0_SINGLE_CMP1BUFL  _SFR_MEM8(0x0A3A)
+#define TCA0_SINGLE_CMP1BUFH  _SFR_MEM8(0x0A3B)
+#define TCA0_SINGLE_CMP2BUF  _SFR_MEM16(0x0A3C)
+#define TCA0_SINGLE_CMP2BUFL  _SFR_MEM8(0x0A3C)
+#define TCA0_SINGLE_CMP2BUFH  _SFR_MEM8(0x0A3D)
+
+
+/* TCA (TCA0) - 16-bit Timer/Counter Type A - Split Mode */
+#define TCA0_SPLIT_CTRLA  _SFR_MEM8(0x0A00)
+#define TCA0_SPLIT_CTRLB  _SFR_MEM8(0x0A01)
+#define TCA0_SPLIT_CTRLC  _SFR_MEM8(0x0A02)
+#define TCA0_SPLIT_CTRLD  _SFR_MEM8(0x0A03)
+#define TCA0_SPLIT_CTRLECLR  _SFR_MEM8(0x0A04)
+#define TCA0_SPLIT_CTRLESET  _SFR_MEM8(0x0A05)
+#define TCA0_SPLIT_INTCTRL  _SFR_MEM8(0x0A0A)
+#define TCA0_SPLIT_INTFLAGS  _SFR_MEM8(0x0A0B)
+#define TCA0_SPLIT_DBGCTRL  _SFR_MEM8(0x0A0E)
+#define TCA0_SPLIT_LCNT  _SFR_MEM8(0x0A20)
+#define TCA0_SPLIT_HCNT  _SFR_MEM8(0x0A21)
+#define TCA0_SPLIT_LPER  _SFR_MEM8(0x0A26)
+#define TCA0_SPLIT_HPER  _SFR_MEM8(0x0A27)
+#define TCA0_SPLIT_LCMP0  _SFR_MEM8(0x0A28)
+#define TCA0_SPLIT_HCMP0  _SFR_MEM8(0x0A29)
+#define TCA0_SPLIT_LCMP1  _SFR_MEM8(0x0A2A)
+#define TCA0_SPLIT_HCMP1  _SFR_MEM8(0x0A2B)
+#define TCA0_SPLIT_LCMP2  _SFR_MEM8(0x0A2C)
+#define TCA0_SPLIT_HCMP2  _SFR_MEM8(0x0A2D)
+
+
+/* TCA (TCA1) - 16-bit Timer/Counter Type A - Single Mode */
+#define TCA1_SINGLE_CTRLA  _SFR_MEM8(0x0A40)
+#define TCA1_SINGLE_CTRLB  _SFR_MEM8(0x0A41)
+#define TCA1_SINGLE_CTRLC  _SFR_MEM8(0x0A42)
+#define TCA1_SINGLE_CTRLD  _SFR_MEM8(0x0A43)
+#define TCA1_SINGLE_CTRLECLR  _SFR_MEM8(0x0A44)
+#define TCA1_SINGLE_CTRLESET  _SFR_MEM8(0x0A45)
+#define TCA1_SINGLE_CTRLFCLR  _SFR_MEM8(0x0A46)
+#define TCA1_SINGLE_CTRLFSET  _SFR_MEM8(0x0A47)
+#define TCA1_SINGLE_EVCTRL  _SFR_MEM8(0x0A49)
+#define TCA1_SINGLE_INTCTRL  _SFR_MEM8(0x0A4A)
+#define TCA1_SINGLE_INTFLAGS  _SFR_MEM8(0x0A4B)
+#define TCA1_SINGLE_DBGCTRL  _SFR_MEM8(0x0A4E)
+#define TCA1_SINGLE_TEMP  _SFR_MEM8(0x0A4F)
+#define TCA1_SINGLE_CNT  _SFR_MEM16(0x0A60)
+#define TCA1_SINGLE_CNTL  _SFR_MEM8(0x0A60)
+#define TCA1_SINGLE_CNTH  _SFR_MEM8(0x0A61)
+#define TCA1_SINGLE_PER  _SFR_MEM16(0x0A66)
+#define TCA1_SINGLE_PERL  _SFR_MEM8(0x0A66)
+#define TCA1_SINGLE_PERH  _SFR_MEM8(0x0A67)
+#define TCA1_SINGLE_CMP0  _SFR_MEM16(0x0A68)
+#define TCA1_SINGLE_CMP0L  _SFR_MEM8(0x0A68)
+#define TCA1_SINGLE_CMP0H  _SFR_MEM8(0x0A69)
+#define TCA1_SINGLE_CMP1  _SFR_MEM16(0x0A6A)
+#define TCA1_SINGLE_CMP1L  _SFR_MEM8(0x0A6A)
+#define TCA1_SINGLE_CMP1H  _SFR_MEM8(0x0A6B)
+#define TCA1_SINGLE_CMP2  _SFR_MEM16(0x0A6C)
+#define TCA1_SINGLE_CMP2L  _SFR_MEM8(0x0A6C)
+#define TCA1_SINGLE_CMP2H  _SFR_MEM8(0x0A6D)
+#define TCA1_SINGLE_PERBUF  _SFR_MEM16(0x0A76)
+#define TCA1_SINGLE_PERBUFL  _SFR_MEM8(0x0A76)
+#define TCA1_SINGLE_PERBUFH  _SFR_MEM8(0x0A77)
+#define TCA1_SINGLE_CMP0BUF  _SFR_MEM16(0x0A78)
+#define TCA1_SINGLE_CMP0BUFL  _SFR_MEM8(0x0A78)
+#define TCA1_SINGLE_CMP0BUFH  _SFR_MEM8(0x0A79)
+#define TCA1_SINGLE_CMP1BUF  _SFR_MEM16(0x0A7A)
+#define TCA1_SINGLE_CMP1BUFL  _SFR_MEM8(0x0A7A)
+#define TCA1_SINGLE_CMP1BUFH  _SFR_MEM8(0x0A7B)
+#define TCA1_SINGLE_CMP2BUF  _SFR_MEM16(0x0A7C)
+#define TCA1_SINGLE_CMP2BUFL  _SFR_MEM8(0x0A7C)
+#define TCA1_SINGLE_CMP2BUFH  _SFR_MEM8(0x0A7D)
+
+
+/* TCA (TCA1) - 16-bit Timer/Counter Type A - Split Mode */
+#define TCA1_SPLIT_CTRLA  _SFR_MEM8(0x0A40)
+#define TCA1_SPLIT_CTRLB  _SFR_MEM8(0x0A41)
+#define TCA1_SPLIT_CTRLC  _SFR_MEM8(0x0A42)
+#define TCA1_SPLIT_CTRLD  _SFR_MEM8(0x0A43)
+#define TCA1_SPLIT_CTRLECLR  _SFR_MEM8(0x0A44)
+#define TCA1_SPLIT_CTRLESET  _SFR_MEM8(0x0A45)
+#define TCA1_SPLIT_INTCTRL  _SFR_MEM8(0x0A4A)
+#define TCA1_SPLIT_INTFLAGS  _SFR_MEM8(0x0A4B)
+#define TCA1_SPLIT_DBGCTRL  _SFR_MEM8(0x0A4E)
+#define TCA1_SPLIT_LCNT  _SFR_MEM8(0x0A60)
+#define TCA1_SPLIT_HCNT  _SFR_MEM8(0x0A61)
+#define TCA1_SPLIT_LPER  _SFR_MEM8(0x0A66)
+#define TCA1_SPLIT_HPER  _SFR_MEM8(0x0A67)
+#define TCA1_SPLIT_LCMP0  _SFR_MEM8(0x0A68)
+#define TCA1_SPLIT_HCMP0  _SFR_MEM8(0x0A69)
+#define TCA1_SPLIT_LCMP1  _SFR_MEM8(0x0A6A)
+#define TCA1_SPLIT_HCMP1  _SFR_MEM8(0x0A6B)
+#define TCA1_SPLIT_LCMP2  _SFR_MEM8(0x0A6C)
+#define TCA1_SPLIT_HCMP2  _SFR_MEM8(0x0A6D)
+
+
+/* TCB (TCB0) - 16-bit Timer Type B */
+#define TCB0_CTRLA  _SFR_MEM8(0x0B00)
+#define TCB0_CTRLB  _SFR_MEM8(0x0B01)
+#define TCB0_EVCTRL  _SFR_MEM8(0x0B04)
+#define TCB0_INTCTRL  _SFR_MEM8(0x0B05)
+#define TCB0_INTFLAGS  _SFR_MEM8(0x0B06)
+#define TCB0_STATUS  _SFR_MEM8(0x0B07)
+#define TCB0_DBGCTRL  _SFR_MEM8(0x0B08)
+#define TCB0_TEMP  _SFR_MEM8(0x0B09)
+#define TCB0_CNT  _SFR_MEM16(0x0B0A)
+#define TCB0_CNTL  _SFR_MEM8(0x0B0A)
+#define TCB0_CNTH  _SFR_MEM8(0x0B0B)
+#define TCB0_CCMP  _SFR_MEM16(0x0B0C)
+#define TCB0_CCMPL  _SFR_MEM8(0x0B0C)
+#define TCB0_CCMPH  _SFR_MEM8(0x0B0D)
+
+
+/* TCB (TCB1) - 16-bit Timer Type B */
+#define TCB1_CTRLA  _SFR_MEM8(0x0B10)
+#define TCB1_CTRLB  _SFR_MEM8(0x0B11)
+#define TCB1_EVCTRL  _SFR_MEM8(0x0B14)
+#define TCB1_INTCTRL  _SFR_MEM8(0x0B15)
+#define TCB1_INTFLAGS  _SFR_MEM8(0x0B16)
+#define TCB1_STATUS  _SFR_MEM8(0x0B17)
+#define TCB1_DBGCTRL  _SFR_MEM8(0x0B18)
+#define TCB1_TEMP  _SFR_MEM8(0x0B19)
+#define TCB1_CNT  _SFR_MEM16(0x0B1A)
+#define TCB1_CNTL  _SFR_MEM8(0x0B1A)
+#define TCB1_CNTH  _SFR_MEM8(0x0B1B)
+#define TCB1_CCMP  _SFR_MEM16(0x0B1C)
+#define TCB1_CCMPL  _SFR_MEM8(0x0B1C)
+#define TCB1_CCMPH  _SFR_MEM8(0x0B1D)
+
+
+/* TCB (TCB2) - 16-bit Timer Type B */
+#define TCB2_CTRLA  _SFR_MEM8(0x0B20)
+#define TCB2_CTRLB  _SFR_MEM8(0x0B21)
+#define TCB2_EVCTRL  _SFR_MEM8(0x0B24)
+#define TCB2_INTCTRL  _SFR_MEM8(0x0B25)
+#define TCB2_INTFLAGS  _SFR_MEM8(0x0B26)
+#define TCB2_STATUS  _SFR_MEM8(0x0B27)
+#define TCB2_DBGCTRL  _SFR_MEM8(0x0B28)
+#define TCB2_TEMP  _SFR_MEM8(0x0B29)
+#define TCB2_CNT  _SFR_MEM16(0x0B2A)
+#define TCB2_CNTL  _SFR_MEM8(0x0B2A)
+#define TCB2_CNTH  _SFR_MEM8(0x0B2B)
+#define TCB2_CCMP  _SFR_MEM16(0x0B2C)
+#define TCB2_CCMPL  _SFR_MEM8(0x0B2C)
+#define TCB2_CCMPH  _SFR_MEM8(0x0B2D)
+
+
+/* TCB (TCB3) - 16-bit Timer Type B */
+#define TCB3_CTRLA  _SFR_MEM8(0x0B30)
+#define TCB3_CTRLB  _SFR_MEM8(0x0B31)
+#define TCB3_EVCTRL  _SFR_MEM8(0x0B34)
+#define TCB3_INTCTRL  _SFR_MEM8(0x0B35)
+#define TCB3_INTFLAGS  _SFR_MEM8(0x0B36)
+#define TCB3_STATUS  _SFR_MEM8(0x0B37)
+#define TCB3_DBGCTRL  _SFR_MEM8(0x0B38)
+#define TCB3_TEMP  _SFR_MEM8(0x0B39)
+#define TCB3_CNT  _SFR_MEM16(0x0B3A)
+#define TCB3_CNTL  _SFR_MEM8(0x0B3A)
+#define TCB3_CNTH  _SFR_MEM8(0x0B3B)
+#define TCB3_CCMP  _SFR_MEM16(0x0B3C)
+#define TCB3_CCMPL  _SFR_MEM8(0x0B3C)
+#define TCB3_CCMPH  _SFR_MEM8(0x0B3D)
+
+
+/* SYSCFG - System Configuration Registers */
+#define SYSCFG_REVID  _SFR_MEM8(0x0F01)
+#define SYSCFG_OCDMCTRL  _SFR_MEM8(0x0F04)
+#define SYSCFG_OCDMSTATUS  _SFR_MEM8(0x0F05)
+
+
+/* NVMCTRL - Non-volatile Memory Controller */
+#define NVMCTRL_CTRLA  _SFR_MEM8(0x1000)
+#define NVMCTRL_CTRLB  _SFR_MEM8(0x1001)
+#define NVMCTRL_INTCTRL  _SFR_MEM8(0x1004)
+#define NVMCTRL_INTFLAGS  _SFR_MEM8(0x1005)
+#define NVMCTRL_STATUS  _SFR_MEM8(0x1006)
+#define NVMCTRL_DATA  _SFR_MEM16(0x1008)
+#define NVMCTRL_DATAL  _SFR_MEM8(0x1008)
+#define NVMCTRL_DATAH  _SFR_MEM8(0x1009)
+#define NVMCTRL_ADDR  _SFR_MEM32(0x100C)
+#define NVMCTRL_ADDR0  _SFR_MEM8(0x100C)
+#define NVMCTRL_ADDR1  _SFR_MEM8(0x100D)
+#define NVMCTRL_ADDR2  _SFR_MEM8(0x100E)
+#define NVMCTRL_ADDR3  _SFR_MEM8(0x100F)
+
+
+/* LOCK - Lockbits */
+#define LOCK_KEY  _SFR_MEM32(0x1040)
+#define LOCK_KEY0  _SFR_MEM8(0x1040)
+#define LOCK_KEY1  _SFR_MEM8(0x1041)
+#define LOCK_KEY2  _SFR_MEM8(0x1042)
+#define LOCK_KEY3  _SFR_MEM8(0x1043)
+
+
+/* FUSE - Fuses */
+#define FUSE_WDTCFG  _SFR_MEM8(0x1050)
+#define FUSE_BODCFG  _SFR_MEM8(0x1051)
+#define FUSE_OSCCFG  _SFR_MEM8(0x1052)
+#define FUSE_SYSCFG0  _SFR_MEM8(0x1055)
+#define FUSE_SYSCFG1  _SFR_MEM8(0x1056)
+#define FUSE_CODESIZE  _SFR_MEM8(0x1057)
+#define FUSE_BOOTSIZE  _SFR_MEM8(0x1058)
+
+
+/* USERROW - User Row */
+#define USERROW_USERROW0  _SFR_MEM8(0x1080)
+#define USERROW_USERROW1  _SFR_MEM8(0x1081)
+#define USERROW_USERROW2  _SFR_MEM8(0x1082)
+#define USERROW_USERROW3  _SFR_MEM8(0x1083)
+#define USERROW_USERROW4  _SFR_MEM8(0x1084)
+#define USERROW_USERROW5  _SFR_MEM8(0x1085)
+#define USERROW_USERROW6  _SFR_MEM8(0x1086)
+#define USERROW_USERROW7  _SFR_MEM8(0x1087)
+#define USERROW_USERROW8  _SFR_MEM8(0x1088)
+#define USERROW_USERROW9  _SFR_MEM8(0x1089)
+#define USERROW_USERROW10  _SFR_MEM8(0x108A)
+#define USERROW_USERROW11  _SFR_MEM8(0x108B)
+#define USERROW_USERROW12  _SFR_MEM8(0x108C)
+#define USERROW_USERROW13  _SFR_MEM8(0x108D)
+#define USERROW_USERROW14  _SFR_MEM8(0x108E)
+#define USERROW_USERROW15  _SFR_MEM8(0x108F)
+#define USERROW_USERROW16  _SFR_MEM8(0x1090)
+#define USERROW_USERROW17  _SFR_MEM8(0x1091)
+#define USERROW_USERROW18  _SFR_MEM8(0x1092)
+#define USERROW_USERROW19  _SFR_MEM8(0x1093)
+#define USERROW_USERROW20  _SFR_MEM8(0x1094)
+#define USERROW_USERROW21  _SFR_MEM8(0x1095)
+#define USERROW_USERROW22  _SFR_MEM8(0x1096)
+#define USERROW_USERROW23  _SFR_MEM8(0x1097)
+#define USERROW_USERROW24  _SFR_MEM8(0x1098)
+#define USERROW_USERROW25  _SFR_MEM8(0x1099)
+#define USERROW_USERROW26  _SFR_MEM8(0x109A)
+#define USERROW_USERROW27  _SFR_MEM8(0x109B)
+#define USERROW_USERROW28  _SFR_MEM8(0x109C)
+#define USERROW_USERROW29  _SFR_MEM8(0x109D)
+#define USERROW_USERROW30  _SFR_MEM8(0x109E)
+#define USERROW_USERROW31  _SFR_MEM8(0x109F)
+#define USERROW_USERROW32  _SFR_MEM8(0x10A0)
+#define USERROW_USERROW33  _SFR_MEM8(0x10A1)
+#define USERROW_USERROW34  _SFR_MEM8(0x10A2)
+#define USERROW_USERROW35  _SFR_MEM8(0x10A3)
+#define USERROW_USERROW36  _SFR_MEM8(0x10A4)
+#define USERROW_USERROW37  _SFR_MEM8(0x10A5)
+#define USERROW_USERROW38  _SFR_MEM8(0x10A6)
+#define USERROW_USERROW39  _SFR_MEM8(0x10A7)
+#define USERROW_USERROW40  _SFR_MEM8(0x10A8)
+#define USERROW_USERROW41  _SFR_MEM8(0x10A9)
+#define USERROW_USERROW42  _SFR_MEM8(0x10AA)
+#define USERROW_USERROW43  _SFR_MEM8(0x10AB)
+#define USERROW_USERROW44  _SFR_MEM8(0x10AC)
+#define USERROW_USERROW45  _SFR_MEM8(0x10AD)
+#define USERROW_USERROW46  _SFR_MEM8(0x10AE)
+#define USERROW_USERROW47  _SFR_MEM8(0x10AF)
+#define USERROW_USERROW48  _SFR_MEM8(0x10B0)
+#define USERROW_USERROW49  _SFR_MEM8(0x10B1)
+#define USERROW_USERROW50  _SFR_MEM8(0x10B2)
+#define USERROW_USERROW51  _SFR_MEM8(0x10B3)
+#define USERROW_USERROW52  _SFR_MEM8(0x10B4)
+#define USERROW_USERROW53  _SFR_MEM8(0x10B5)
+#define USERROW_USERROW54  _SFR_MEM8(0x10B6)
+#define USERROW_USERROW55  _SFR_MEM8(0x10B7)
+#define USERROW_USERROW56  _SFR_MEM8(0x10B8)
+#define USERROW_USERROW57  _SFR_MEM8(0x10B9)
+#define USERROW_USERROW58  _SFR_MEM8(0x10BA)
+#define USERROW_USERROW59  _SFR_MEM8(0x10BB)
+#define USERROW_USERROW60  _SFR_MEM8(0x10BC)
+#define USERROW_USERROW61  _SFR_MEM8(0x10BD)
+#define USERROW_USERROW62  _SFR_MEM8(0x10BE)
+#define USERROW_USERROW63  _SFR_MEM8(0x10BF)
+
+
+/* SIGROW - Signature row */
+#define SIGROW_DEVICEID0  _SFR_MEM8(0x1100)
+#define SIGROW_DEVICEID1  _SFR_MEM8(0x1101)
+#define SIGROW_DEVICEID2  _SFR_MEM8(0x1102)
+#define SIGROW_TEMPSENSE0  _SFR_MEM16(0x1104)
+#define SIGROW_TEMPSENSE0L  _SFR_MEM8(0x1104)
+#define SIGROW_TEMPSENSE0H  _SFR_MEM8(0x1105)
+#define SIGROW_TEMPSENSE1  _SFR_MEM16(0x1106)
+#define SIGROW_TEMPSENSE1L  _SFR_MEM8(0x1106)
+#define SIGROW_TEMPSENSE1H  _SFR_MEM8(0x1107)
+#define SIGROW_SERNUM0  _SFR_MEM8(0x1110)
+#define SIGROW_SERNUM1  _SFR_MEM8(0x1111)
+#define SIGROW_SERNUM2  _SFR_MEM8(0x1112)
+#define SIGROW_SERNUM3  _SFR_MEM8(0x1113)
+#define SIGROW_SERNUM4  _SFR_MEM8(0x1114)
+#define SIGROW_SERNUM5  _SFR_MEM8(0x1115)
+#define SIGROW_SERNUM6  _SFR_MEM8(0x1116)
+#define SIGROW_SERNUM7  _SFR_MEM8(0x1117)
+#define SIGROW_SERNUM8  _SFR_MEM8(0x1118)
+#define SIGROW_SERNUM9  _SFR_MEM8(0x1119)
+#define SIGROW_SERNUM10  _SFR_MEM8(0x111A)
+#define SIGROW_SERNUM11  _SFR_MEM8(0x111B)
+#define SIGROW_SERNUM12  _SFR_MEM8(0x111C)
+#define SIGROW_SERNUM13  _SFR_MEM8(0x111D)
+#define SIGROW_SERNUM14  _SFR_MEM8(0x111E)
+#define SIGROW_SERNUM15  _SFR_MEM8(0x111F)
+
+
+
+/*================== Bitfield Definitions ================== */
+
+/* AC - Analog Comparator */
+/* AC.CTRLA  bit masks and bit positions */
+#define AC_ENABLE_bm  0x01  /* Enable bit mask. */
+#define AC_ENABLE_bp  0  /* Enable bit position. */
+#define AC_HYSMODE_gm  0x06  /* Hysteresis Mode group mask. */
+#define AC_HYSMODE_gp  1  /* Hysteresis Mode group position. */
+#define AC_HYSMODE_0_bm  (1<<1)  /* Hysteresis Mode bit 0 mask. */
+#define AC_HYSMODE_0_bp  1  /* Hysteresis Mode bit 0 position. */
+#define AC_HYSMODE_1_bm  (1<<2)  /* Hysteresis Mode bit 1 mask. */
+#define AC_HYSMODE_1_bp  2  /* Hysteresis Mode bit 1 position. */
+#define AC_POWER_gm  0x18  /* Power profile group mask. */
+#define AC_POWER_gp  3  /* Power profile group position. */
+#define AC_POWER_0_bm  (1<<3)  /* Power profile bit 0 mask. */
+#define AC_POWER_0_bp  3  /* Power profile bit 0 position. */
+#define AC_POWER_1_bm  (1<<4)  /* Power profile bit 1 mask. */
+#define AC_POWER_1_bp  4  /* Power profile bit 1 position. */
+#define AC_OUTEN_bm  0x40  /* Output Pad Enable bit mask. */
+#define AC_OUTEN_bp  6  /* Output Pad Enable bit position. */
+#define AC_RUNSTDBY_bm  0x80  /* Run in Standby Mode bit mask. */
+#define AC_RUNSTDBY_bp  7  /* Run in Standby Mode bit position. */
+
+/* AC.CTRLB  bit masks and bit positions */
+#define AC_WINSEL_gm  0x03  /* Window selection mode group mask. */
+#define AC_WINSEL_gp  0  /* Window selection mode group position. */
+#define AC_WINSEL_0_bm  (1<<0)  /* Window selection mode bit 0 mask. */
+#define AC_WINSEL_0_bp  0  /* Window selection mode bit 0 position. */
+#define AC_WINSEL_1_bm  (1<<1)  /* Window selection mode bit 1 mask. */
+#define AC_WINSEL_1_bp  1  /* Window selection mode bit 1 position. */
+
+/* AC.MUXCTRL  bit masks and bit positions */
+#define AC_MUXNEG_gm  0x07  /* Negative Input MUX Selection group mask. */
+#define AC_MUXNEG_gp  0  /* Negative Input MUX Selection group position. */
+#define AC_MUXNEG_0_bm  (1<<0)  /* Negative Input MUX Selection bit 0 mask. */
+#define AC_MUXNEG_0_bp  0  /* Negative Input MUX Selection bit 0 position. */
+#define AC_MUXNEG_1_bm  (1<<1)  /* Negative Input MUX Selection bit 1 mask. */
+#define AC_MUXNEG_1_bp  1  /* Negative Input MUX Selection bit 1 position. */
+#define AC_MUXNEG_2_bm  (1<<2)  /* Negative Input MUX Selection bit 2 mask. */
+#define AC_MUXNEG_2_bp  2  /* Negative Input MUX Selection bit 2 position. */
+#define AC_MUXPOS_gm  0x38  /* Positive Input MUX Selection group mask. */
+#define AC_MUXPOS_gp  3  /* Positive Input MUX Selection group position. */
+#define AC_MUXPOS_0_bm  (1<<3)  /* Positive Input MUX Selection bit 0 mask. */
+#define AC_MUXPOS_0_bp  3  /* Positive Input MUX Selection bit 0 position. */
+#define AC_MUXPOS_1_bm  (1<<4)  /* Positive Input MUX Selection bit 1 mask. */
+#define AC_MUXPOS_1_bp  4  /* Positive Input MUX Selection bit 1 position. */
+#define AC_MUXPOS_2_bm  (1<<5)  /* Positive Input MUX Selection bit 2 mask. */
+#define AC_MUXPOS_2_bp  5  /* Positive Input MUX Selection bit 2 position. */
+#define AC_INITVAL_bm  0x40  /* AC Output Initial Value bit mask. */
+#define AC_INITVAL_bp  6  /* AC Output Initial Value bit position. */
+#define AC_INVERT_bm  0x80  /* Invert AC Output bit mask. */
+#define AC_INVERT_bp  7  /* Invert AC Output bit position. */
+
+/* AC.DACREF  bit masks and bit positions */
+#define AC_DACREF_gm  0xFF  /* DACREF group mask. */
+#define AC_DACREF_gp  0  /* DACREF group position. */
+#define AC_DACREF_0_bm  (1<<0)  /* DACREF bit 0 mask. */
+#define AC_DACREF_0_bp  0  /* DACREF bit 0 position. */
+#define AC_DACREF_1_bm  (1<<1)  /* DACREF bit 1 mask. */
+#define AC_DACREF_1_bp  1  /* DACREF bit 1 position. */
+#define AC_DACREF_2_bm  (1<<2)  /* DACREF bit 2 mask. */
+#define AC_DACREF_2_bp  2  /* DACREF bit 2 position. */
+#define AC_DACREF_3_bm  (1<<3)  /* DACREF bit 3 mask. */
+#define AC_DACREF_3_bp  3  /* DACREF bit 3 position. */
+#define AC_DACREF_4_bm  (1<<4)  /* DACREF bit 4 mask. */
+#define AC_DACREF_4_bp  4  /* DACREF bit 4 position. */
+#define AC_DACREF_5_bm  (1<<5)  /* DACREF bit 5 mask. */
+#define AC_DACREF_5_bp  5  /* DACREF bit 5 position. */
+#define AC_DACREF_6_bm  (1<<6)  /* DACREF bit 6 mask. */
+#define AC_DACREF_6_bp  6  /* DACREF bit 6 position. */
+#define AC_DACREF_7_bm  (1<<7)  /* DACREF bit 7 mask. */
+#define AC_DACREF_7_bp  7  /* DACREF bit 7 position. */
+
+/* AC.INTCTRL  bit masks and bit positions */
+#define AC_CMP_bm  0x01  /* Interrupt Enable bit mask. */
+#define AC_CMP_bp  0  /* Interrupt Enable bit position. */
+#define AC_INTMODE_NORMAL_gm  0x30  /* Interrupt Mode group mask. */
+#define AC_INTMODE_NORMAL_gp  4  /* Interrupt Mode group position. */
+#define AC_INTMODE_NORMAL_0_bm  (1<<4)  /* Interrupt Mode bit 0 mask. */
+#define AC_INTMODE_NORMAL_0_bp  4  /* Interrupt Mode bit 0 position. */
+#define AC_INTMODE_NORMAL_1_bm  (1<<5)  /* Interrupt Mode bit 1 mask. */
+#define AC_INTMODE_NORMAL_1_bp  5  /* Interrupt Mode bit 1 position. */
+#define AC_INTMODE_WINDOW_gm  0x30  /* Interrupt Mode group mask. */
+#define AC_INTMODE_WINDOW_gp  4  /* Interrupt Mode group position. */
+#define AC_INTMODE_WINDOW_0_bm  (1<<4)  /* Interrupt Mode bit 0 mask. */
+#define AC_INTMODE_WINDOW_0_bp  4  /* Interrupt Mode bit 0 position. */
+#define AC_INTMODE_WINDOW_1_bm  (1<<5)  /* Interrupt Mode bit 1 mask. */
+#define AC_INTMODE_WINDOW_1_bp  5  /* Interrupt Mode bit 1 position. */
+
+/* AC.STATUS  bit masks and bit positions */
+#define AC_CMPIF_bm  0x01  /* Analog Comparator Interrupt Flag bit mask. */
+#define AC_CMPIF_bp  0  /* Analog Comparator Interrupt Flag bit position. */
+#define AC_CMPSTATE_bm  0x10  /* Analog Comparator State bit mask. */
+#define AC_CMPSTATE_bp  4  /* Analog Comparator State bit position. */
+#define AC_WINSTATE_gm  0xC0  /* Analog Comparator Window State group mask. */
+#define AC_WINSTATE_gp  6  /* Analog Comparator Window State group position. */
+#define AC_WINSTATE_0_bm  (1<<6)  /* Analog Comparator Window State bit 0 mask. */
+#define AC_WINSTATE_0_bp  6  /* Analog Comparator Window State bit 0 position. */
+#define AC_WINSTATE_1_bm  (1<<7)  /* Analog Comparator Window State bit 1 mask. */
+#define AC_WINSTATE_1_bp  7  /* Analog Comparator Window State bit 1 position. */
+
+
+/* ADC - Analog to Digital Converter */
+/* ADC.CTRLA  bit masks and bit positions */
+#define ADC_ENABLE_bm  0x01  /* ADC Enable bit mask. */
+#define ADC_ENABLE_bp  0  /* ADC Enable bit position. */
+#define ADC_LOWLAT_bm  0x20  /* Low Latency bit mask. */
+#define ADC_LOWLAT_bp  5  /* Low Latency bit position. */
+#define ADC_RUNSTDBY_bm  0x80  /* Run in Standby bit mask. */
+#define ADC_RUNSTDBY_bp  7  /* Run in Standby bit position. */
+
+/* ADC.CTRLB  bit masks and bit positions */
+#define ADC_PRESC_gm  0x0F  /* Prescaler Value group mask. */
+#define ADC_PRESC_gp  0  /* Prescaler Value group position. */
+#define ADC_PRESC_0_bm  (1<<0)  /* Prescaler Value bit 0 mask. */
+#define ADC_PRESC_0_bp  0  /* Prescaler Value bit 0 position. */
+#define ADC_PRESC_1_bm  (1<<1)  /* Prescaler Value bit 1 mask. */
+#define ADC_PRESC_1_bp  1  /* Prescaler Value bit 1 position. */
+#define ADC_PRESC_2_bm  (1<<2)  /* Prescaler Value bit 2 mask. */
+#define ADC_PRESC_2_bp  2  /* Prescaler Value bit 2 position. */
+#define ADC_PRESC_3_bm  (1<<3)  /* Prescaler Value bit 3 mask. */
+#define ADC_PRESC_3_bp  3  /* Prescaler Value bit 3 position. */
+
+/* ADC.CTRLC  bit masks and bit positions */
+#define ADC_REFSEL_gm  0x07  /* Reference select group mask. */
+#define ADC_REFSEL_gp  0  /* Reference select group position. */
+#define ADC_REFSEL_0_bm  (1<<0)  /* Reference select bit 0 mask. */
+#define ADC_REFSEL_0_bp  0  /* Reference select bit 0 position. */
+#define ADC_REFSEL_1_bm  (1<<1)  /* Reference select bit 1 mask. */
+#define ADC_REFSEL_1_bp  1  /* Reference select bit 1 position. */
+#define ADC_REFSEL_2_bm  (1<<2)  /* Reference select bit 2 mask. */
+#define ADC_REFSEL_2_bp  2  /* Reference select bit 2 position. */
+
+/* ADC.CTRLD  bit masks and bit positions */
+#define ADC_WINCM_gm  0x07  /* Window Comparator Mode group mask. */
+#define ADC_WINCM_gp  0  /* Window Comparator Mode group position. */
+#define ADC_WINCM_0_bm  (1<<0)  /* Window Comparator Mode bit 0 mask. */
+#define ADC_WINCM_0_bp  0  /* Window Comparator Mode bit 0 position. */
+#define ADC_WINCM_1_bm  (1<<1)  /* Window Comparator Mode bit 1 mask. */
+#define ADC_WINCM_1_bp  1  /* Window Comparator Mode bit 1 position. */
+#define ADC_WINCM_2_bm  (1<<2)  /* Window Comparator Mode bit 2 mask. */
+#define ADC_WINCM_2_bp  2  /* Window Comparator Mode bit 2 position. */
+#define ADC_WINSRC_bm  0x08  /* Window Mode Source bit mask. */
+#define ADC_WINSRC_bp  3  /* Window Mode Source bit position. */
+
+/* ADC.INTCTRL  bit masks and bit positions */
+#define ADC_RESRDY_bm  0x01  /* Result Ready Interrupt Enable bit mask. */
+#define ADC_RESRDY_bp  0  /* Result Ready Interrupt Enable bit position. */
+#define ADC_SAMPRDY_bm  0x02  /* Sample Ready Interrupt Enable bit mask. */
+#define ADC_SAMPRDY_bp  1  /* Sample Ready Interrupt Enable bit position. */
+#define ADC_WCMP_bm  0x04  /* Window Comparator Interrupt Enable bit mask. */
+#define ADC_WCMP_bp  2  /* Window Comparator Interrupt Enable bit position. */
+#define ADC_RESOVR_bm  0x08  /* Result Overwrite Interrupt Enable bit mask. */
+#define ADC_RESOVR_bp  3  /* Result Overwrite Interrupt Enable bit position. */
+#define ADC_SAMPOVR_bm  0x10  /* Sample Overwrite Interrupt Enable bit mask. */
+#define ADC_SAMPOVR_bp  4  /* Sample Overwrite Interrupt Enable bit position. */
+#define ADC_TRIGOVR_bm  0x20  /* Trigger Overrun Interrupt Enable bit mask. */
+#define ADC_TRIGOVR_bp  5  /* Trigger Overrun Interrupt Enable bit position. */
+
+/* ADC.INTFLAGS  bit masks and bit positions */
+/* ADC_RESRDY  is already defined. */
+/* ADC_SAMPRDY  is already defined. */
+/* ADC_WCMP  is already defined. */
+/* ADC_RESOVR  is already defined. */
+/* ADC_SAMPOVR  is already defined. */
+/* ADC_TRIGOVR  is already defined. */
+
+/* ADC.STATUS  bit masks and bit positions */
+#define ADC_ADCBUSY_bm  0x01  /* ADC Busy bit mask. */
+#define ADC_ADCBUSY_bp  0  /* ADC Busy bit position. */
+
+/* ADC.DBGCTRL  bit masks and bit positions */
+#define ADC_DBGRUN_bm  0x01  /* Run in Debug Mode bit mask. */
+#define ADC_DBGRUN_bp  0  /* Run in Debug Mode bit position. */
+
+/* ADC.CTRLE  bit masks and bit positions */
+#define ADC_SAMPDUR_gm  0xFF  /* Sample Duration group mask. */
+#define ADC_SAMPDUR_gp  0  /* Sample Duration group position. */
+#define ADC_SAMPDUR_0_bm  (1<<0)  /* Sample Duration bit 0 mask. */
+#define ADC_SAMPDUR_0_bp  0  /* Sample Duration bit 0 position. */
+#define ADC_SAMPDUR_1_bm  (1<<1)  /* Sample Duration bit 1 mask. */
+#define ADC_SAMPDUR_1_bp  1  /* Sample Duration bit 1 position. */
+#define ADC_SAMPDUR_2_bm  (1<<2)  /* Sample Duration bit 2 mask. */
+#define ADC_SAMPDUR_2_bp  2  /* Sample Duration bit 2 position. */
+#define ADC_SAMPDUR_3_bm  (1<<3)  /* Sample Duration bit 3 mask. */
+#define ADC_SAMPDUR_3_bp  3  /* Sample Duration bit 3 position. */
+#define ADC_SAMPDUR_4_bm  (1<<4)  /* Sample Duration bit 4 mask. */
+#define ADC_SAMPDUR_4_bp  4  /* Sample Duration bit 4 position. */
+#define ADC_SAMPDUR_5_bm  (1<<5)  /* Sample Duration bit 5 mask. */
+#define ADC_SAMPDUR_5_bp  5  /* Sample Duration bit 5 position. */
+#define ADC_SAMPDUR_6_bm  (1<<6)  /* Sample Duration bit 6 mask. */
+#define ADC_SAMPDUR_6_bp  6  /* Sample Duration bit 6 position. */
+#define ADC_SAMPDUR_7_bm  (1<<7)  /* Sample Duration bit 7 mask. */
+#define ADC_SAMPDUR_7_bp  7  /* Sample Duration bit 7 position. */
+
+/* ADC.CTRLF  bit masks and bit positions */
+#define ADC_SAMPNUM_gm  0x0F  /* Sample numbers group mask. */
+#define ADC_SAMPNUM_gp  0  /* Sample numbers group position. */
+#define ADC_SAMPNUM_0_bm  (1<<0)  /* Sample numbers bit 0 mask. */
+#define ADC_SAMPNUM_0_bp  0  /* Sample numbers bit 0 position. */
+#define ADC_SAMPNUM_1_bm  (1<<1)  /* Sample numbers bit 1 mask. */
+#define ADC_SAMPNUM_1_bp  1  /* Sample numbers bit 1 position. */
+#define ADC_SAMPNUM_2_bm  (1<<2)  /* Sample numbers bit 2 mask. */
+#define ADC_SAMPNUM_2_bp  2  /* Sample numbers bit 2 position. */
+#define ADC_SAMPNUM_3_bm  (1<<3)  /* Sample numbers bit 3 mask. */
+#define ADC_SAMPNUM_3_bp  3  /* Sample numbers bit 3 position. */
+#define ADC_LEFTADJ_bm  0x10  /* Left Adjust bit mask. */
+#define ADC_LEFTADJ_bp  4  /* Left Adjust bit position. */
+#define ADC_FREERUN_bm  0x20  /* Free-Running mode bit mask. */
+#define ADC_FREERUN_bp  5  /* Free-Running mode bit position. */
+#define ADC_CHOPPING_bm  0x40  /* Sign Chopping bit mask. */
+#define ADC_CHOPPING_bp  6  /* Sign Chopping bit position. */
+
+/* ADC.COMMAND  bit masks and bit positions */
+#define ADC_START_gm  0x07  /* Start command group mask. */
+#define ADC_START_gp  0  /* Start command group position. */
+#define ADC_START_0_bm  (1<<0)  /* Start command bit 0 mask. */
+#define ADC_START_0_bp  0  /* Start command bit 0 position. */
+#define ADC_START_1_bm  (1<<1)  /* Start command bit 1 mask. */
+#define ADC_START_1_bp  1  /* Start command bit 1 position. */
+#define ADC_START_2_bm  (1<<2)  /* Start command bit 2 mask. */
+#define ADC_START_2_bp  2  /* Start command bit 2 position. */
+#define ADC_MODE_gm  0x70  /* Mode group mask. */
+#define ADC_MODE_gp  4  /* Mode group position. */
+#define ADC_MODE_0_bm  (1<<4)  /* Mode bit 0 mask. */
+#define ADC_MODE_0_bp  4  /* Mode bit 0 position. */
+#define ADC_MODE_1_bm  (1<<5)  /* Mode bit 1 mask. */
+#define ADC_MODE_1_bp  5  /* Mode bit 1 position. */
+#define ADC_MODE_2_bm  (1<<6)  /* Mode bit 2 mask. */
+#define ADC_MODE_2_bp  6  /* Mode bit 2 position. */
+#define ADC_DIFF_bm  0x80  /* Differential mode bit mask. */
+#define ADC_DIFF_bp  7  /* Differential mode bit position. */
+
+/* ADC.PGACTRL  bit masks and bit positions */
+#define ADC_PGAEN_bm  0x01  /* PGA Enable bit mask. */
+#define ADC_PGAEN_bp  0  /* PGA Enable bit position. */
+#define ADC_PGABIASSEL_gm  0x18  /* PGA BIAS Select group mask. */
+#define ADC_PGABIASSEL_gp  3  /* PGA BIAS Select group position. */
+#define ADC_PGABIASSEL_0_bm  (1<<3)  /* PGA BIAS Select bit 0 mask. */
+#define ADC_PGABIASSEL_0_bp  3  /* PGA BIAS Select bit 0 position. */
+#define ADC_PGABIASSEL_1_bm  (1<<4)  /* PGA BIAS Select bit 1 mask. */
+#define ADC_PGABIASSEL_1_bp  4  /* PGA BIAS Select bit 1 position. */
+#define ADC_GAIN_gm  0xE0  /* Gain group mask. */
+#define ADC_GAIN_gp  5  /* Gain group position. */
+#define ADC_GAIN_0_bm  (1<<5)  /* Gain bit 0 mask. */
+#define ADC_GAIN_0_bp  5  /* Gain bit 0 position. */
+#define ADC_GAIN_1_bm  (1<<6)  /* Gain bit 1 mask. */
+#define ADC_GAIN_1_bp  6  /* Gain bit 1 position. */
+#define ADC_GAIN_2_bm  (1<<7)  /* Gain bit 2 mask. */
+#define ADC_GAIN_2_bp  7  /* Gain bit 2 position. */
+
+/* ADC.MUXPOS  bit masks and bit positions */
+#define ADC_MUXPOS_gm  0x3F  /* Analog Channel Selection Bits group mask. */
+#define ADC_MUXPOS_gp  0  /* Analog Channel Selection Bits group position. */
+#define ADC_MUXPOS_0_bm  (1<<0)  /* Analog Channel Selection Bits bit 0 mask. */
+#define ADC_MUXPOS_0_bp  0  /* Analog Channel Selection Bits bit 0 position. */
+#define ADC_MUXPOS_1_bm  (1<<1)  /* Analog Channel Selection Bits bit 1 mask. */
+#define ADC_MUXPOS_1_bp  1  /* Analog Channel Selection Bits bit 1 position. */
+#define ADC_MUXPOS_2_bm  (1<<2)  /* Analog Channel Selection Bits bit 2 mask. */
+#define ADC_MUXPOS_2_bp  2  /* Analog Channel Selection Bits bit 2 position. */
+#define ADC_MUXPOS_3_bm  (1<<3)  /* Analog Channel Selection Bits bit 3 mask. */
+#define ADC_MUXPOS_3_bp  3  /* Analog Channel Selection Bits bit 3 position. */
+#define ADC_MUXPOS_4_bm  (1<<4)  /* Analog Channel Selection Bits bit 4 mask. */
+#define ADC_MUXPOS_4_bp  4  /* Analog Channel Selection Bits bit 4 position. */
+#define ADC_MUXPOS_5_bm  (1<<5)  /* Analog Channel Selection Bits bit 5 mask. */
+#define ADC_MUXPOS_5_bp  5  /* Analog Channel Selection Bits bit 5 position. */
+#define ADC_VIA_gm  0xC0  /* VIA group mask. */
+#define ADC_VIA_gp  6  /* VIA group position. */
+#define ADC_VIA_0_bm  (1<<6)  /* VIA bit 0 mask. */
+#define ADC_VIA_0_bp  6  /* VIA bit 0 position. */
+#define ADC_VIA_1_bm  (1<<7)  /* VIA bit 1 mask. */
+#define ADC_VIA_1_bp  7  /* VIA bit 1 position. */
+
+/* ADC.MUXNEG  bit masks and bit positions */
+#define ADC_MUXNEG_gm  0x3F  /* Analog Channel Selection Bits group mask. */
+#define ADC_MUXNEG_gp  0  /* Analog Channel Selection Bits group position. */
+#define ADC_MUXNEG_0_bm  (1<<0)  /* Analog Channel Selection Bits bit 0 mask. */
+#define ADC_MUXNEG_0_bp  0  /* Analog Channel Selection Bits bit 0 position. */
+#define ADC_MUXNEG_1_bm  (1<<1)  /* Analog Channel Selection Bits bit 1 mask. */
+#define ADC_MUXNEG_1_bp  1  /* Analog Channel Selection Bits bit 1 position. */
+#define ADC_MUXNEG_2_bm  (1<<2)  /* Analog Channel Selection Bits bit 2 mask. */
+#define ADC_MUXNEG_2_bp  2  /* Analog Channel Selection Bits bit 2 position. */
+#define ADC_MUXNEG_3_bm  (1<<3)  /* Analog Channel Selection Bits bit 3 mask. */
+#define ADC_MUXNEG_3_bp  3  /* Analog Channel Selection Bits bit 3 position. */
+#define ADC_MUXNEG_4_bm  (1<<4)  /* Analog Channel Selection Bits bit 4 mask. */
+#define ADC_MUXNEG_4_bp  4  /* Analog Channel Selection Bits bit 4 position. */
+#define ADC_MUXNEG_5_bm  (1<<5)  /* Analog Channel Selection Bits bit 5 mask. */
+#define ADC_MUXNEG_5_bp  5  /* Analog Channel Selection Bits bit 5 position. */
+/* ADC_VIA  is already defined. */
+
+
+/* BOD - Bod interface */
+/* BOD.CTRLA  bit masks and bit positions */
+#define BOD_SLEEP_gm  0x03  /* Operation in sleep mode group mask. */
+#define BOD_SLEEP_gp  0  /* Operation in sleep mode group position. */
+#define BOD_SLEEP_0_bm  (1<<0)  /* Operation in sleep mode bit 0 mask. */
+#define BOD_SLEEP_0_bp  0  /* Operation in sleep mode bit 0 position. */
+#define BOD_SLEEP_1_bm  (1<<1)  /* Operation in sleep mode bit 1 mask. */
+#define BOD_SLEEP_1_bp  1  /* Operation in sleep mode bit 1 position. */
+#define BOD_ACTIVE_gm  0x0C  /* Operation in active mode group mask. */
+#define BOD_ACTIVE_gp  2  /* Operation in active mode group position. */
+#define BOD_ACTIVE_0_bm  (1<<2)  /* Operation in active mode bit 0 mask. */
+#define BOD_ACTIVE_0_bp  2  /* Operation in active mode bit 0 position. */
+#define BOD_ACTIVE_1_bm  (1<<3)  /* Operation in active mode bit 1 mask. */
+#define BOD_ACTIVE_1_bp  3  /* Operation in active mode bit 1 position. */
+#define BOD_SAMPFREQ_bm  0x10  /* Sample frequency bit mask. */
+#define BOD_SAMPFREQ_bp  4  /* Sample frequency bit position. */
+
+/* BOD.CTRLB  bit masks and bit positions */
+#define BOD_LVL_gm  0x07  /* Bod level group mask. */
+#define BOD_LVL_gp  0  /* Bod level group position. */
+#define BOD_LVL_0_bm  (1<<0)  /* Bod level bit 0 mask. */
+#define BOD_LVL_0_bp  0  /* Bod level bit 0 position. */
+#define BOD_LVL_1_bm  (1<<1)  /* Bod level bit 1 mask. */
+#define BOD_LVL_1_bp  1  /* Bod level bit 1 position. */
+#define BOD_LVL_2_bm  (1<<2)  /* Bod level bit 2 mask. */
+#define BOD_LVL_2_bp  2  /* Bod level bit 2 position. */
+
+/* BOD.VLMCTRLA  bit masks and bit positions */
+#define BOD_VLMLVL_gm  0x03  /* voltage level monitor level group mask. */
+#define BOD_VLMLVL_gp  0  /* voltage level monitor level group position. */
+#define BOD_VLMLVL_0_bm  (1<<0)  /* voltage level monitor level bit 0 mask. */
+#define BOD_VLMLVL_0_bp  0  /* voltage level monitor level bit 0 position. */
+#define BOD_VLMLVL_1_bm  (1<<1)  /* voltage level monitor level bit 1 mask. */
+#define BOD_VLMLVL_1_bp  1  /* voltage level monitor level bit 1 position. */
+
+/* BOD.INTCTRL  bit masks and bit positions */
+#define BOD_VLMIE_bm  0x01  /* voltage level monitor interrrupt enable bit mask. */
+#define BOD_VLMIE_bp  0  /* voltage level monitor interrrupt enable bit position. */
+#define BOD_VLMCFG_gm  0x06  /* Configuration group mask. */
+#define BOD_VLMCFG_gp  1  /* Configuration group position. */
+#define BOD_VLMCFG_0_bm  (1<<1)  /* Configuration bit 0 mask. */
+#define BOD_VLMCFG_0_bp  1  /* Configuration bit 0 position. */
+#define BOD_VLMCFG_1_bm  (1<<2)  /* Configuration bit 1 mask. */
+#define BOD_VLMCFG_1_bp  2  /* Configuration bit 1 position. */
+
+/* BOD.INTFLAGS  bit masks and bit positions */
+#define BOD_VLMIF_bm  0x01  /* Voltage level monitor interrupt flag bit mask. */
+#define BOD_VLMIF_bp  0  /* Voltage level monitor interrupt flag bit position. */
+
+/* BOD.STATUS  bit masks and bit positions */
+#define BOD_VLMS_bm  0x01  /* Voltage level monitor status bit mask. */
+#define BOD_VLMS_bp  0  /* Voltage level monitor status bit position. */
+
+
+/* CCL - Configurable Custom Logic */
+/* CCL.CTRLA  bit masks and bit positions */
+#define CCL_ENABLE_bm  0x01  /* Enable bit mask. */
+#define CCL_ENABLE_bp  0  /* Enable bit position. */
+#define CCL_RUNSTDBY_bm  0x40  /* Run in Standby bit mask. */
+#define CCL_RUNSTDBY_bp  6  /* Run in Standby bit position. */
+
+/* CCL.SEQCTRL0  bit masks and bit positions */
+#define CCL_SEQSEL_gm  0x07  /* Sequential Selection group mask. */
+#define CCL_SEQSEL_gp  0  /* Sequential Selection group position. */
+#define CCL_SEQSEL_0_bm  (1<<0)  /* Sequential Selection bit 0 mask. */
+#define CCL_SEQSEL_0_bp  0  /* Sequential Selection bit 0 position. */
+#define CCL_SEQSEL_1_bm  (1<<1)  /* Sequential Selection bit 1 mask. */
+#define CCL_SEQSEL_1_bp  1  /* Sequential Selection bit 1 position. */
+#define CCL_SEQSEL_2_bm  (1<<2)  /* Sequential Selection bit 2 mask. */
+#define CCL_SEQSEL_2_bp  2  /* Sequential Selection bit 2 position. */
+
+/* CCL.SEQCTRL1  bit masks and bit positions */
+/* CCL_SEQSEL  is already defined. */
+
+/* CCL.INTCTRL0  bit masks and bit positions */
+#define CCL_INTMODE0_gm  0x03  /* Interrupt Mode for LUT0 group mask. */
+#define CCL_INTMODE0_gp  0  /* Interrupt Mode for LUT0 group position. */
+#define CCL_INTMODE0_0_bm  (1<<0)  /* Interrupt Mode for LUT0 bit 0 mask. */
+#define CCL_INTMODE0_0_bp  0  /* Interrupt Mode for LUT0 bit 0 position. */
+#define CCL_INTMODE0_1_bm  (1<<1)  /* Interrupt Mode for LUT0 bit 1 mask. */
+#define CCL_INTMODE0_1_bp  1  /* Interrupt Mode for LUT0 bit 1 position. */
+#define CCL_INTMODE1_gm  0x0C  /* Interrupt Mode for LUT1 group mask. */
+#define CCL_INTMODE1_gp  2  /* Interrupt Mode for LUT1 group position. */
+#define CCL_INTMODE1_0_bm  (1<<2)  /* Interrupt Mode for LUT1 bit 0 mask. */
+#define CCL_INTMODE1_0_bp  2  /* Interrupt Mode for LUT1 bit 0 position. */
+#define CCL_INTMODE1_1_bm  (1<<3)  /* Interrupt Mode for LUT1 bit 1 mask. */
+#define CCL_INTMODE1_1_bp  3  /* Interrupt Mode for LUT1 bit 1 position. */
+#define CCL_INTMODE2_gm  0x30  /* Interrupt Mode for LUT2 group mask. */
+#define CCL_INTMODE2_gp  4  /* Interrupt Mode for LUT2 group position. */
+#define CCL_INTMODE2_0_bm  (1<<4)  /* Interrupt Mode for LUT2 bit 0 mask. */
+#define CCL_INTMODE2_0_bp  4  /* Interrupt Mode for LUT2 bit 0 position. */
+#define CCL_INTMODE2_1_bm  (1<<5)  /* Interrupt Mode for LUT2 bit 1 mask. */
+#define CCL_INTMODE2_1_bp  5  /* Interrupt Mode for LUT2 bit 1 position. */
+#define CCL_INTMODE3_gm  0xC0  /* Interrupt Mode for LUT3 group mask. */
+#define CCL_INTMODE3_gp  6  /* Interrupt Mode for LUT3 group position. */
+#define CCL_INTMODE3_0_bm  (1<<6)  /* Interrupt Mode for LUT3 bit 0 mask. */
+#define CCL_INTMODE3_0_bp  6  /* Interrupt Mode for LUT3 bit 0 position. */
+#define CCL_INTMODE3_1_bm  (1<<7)  /* Interrupt Mode for LUT3 bit 1 mask. */
+#define CCL_INTMODE3_1_bp  7  /* Interrupt Mode for LUT3 bit 1 position. */
+
+/* CCL.INTFLAGS  bit masks and bit positions */
+#define CCL_INT_gm  0x0F  /* Interrupt Flag group mask. */
+#define CCL_INT_gp  0  /* Interrupt Flag group position. */
+#define CCL_INT_0_bm  (1<<0)  /* Interrupt Flag bit 0 mask. */
+#define CCL_INT_0_bp  0  /* Interrupt Flag bit 0 position. */
+#define CCL_INT0_bm  CCL_INT_0_bm  /* This define is deprecated and should not be used */
+#define CCL_INT0_bp  CCL_INT_0_bp  /* This define is deprecated and should not be used */
+#define CCL_INT_1_bm  (1<<1)  /* Interrupt Flag bit 1 mask. */
+#define CCL_INT_1_bp  1  /* Interrupt Flag bit 1 position. */
+#define CCL_INT1_bm  CCL_INT_1_bm  /* This define is deprecated and should not be used */
+#define CCL_INT1_bp  CCL_INT_1_bp  /* This define is deprecated and should not be used */
+#define CCL_INT_2_bm  (1<<2)  /* Interrupt Flag bit 2 mask. */
+#define CCL_INT_2_bp  2  /* Interrupt Flag bit 2 position. */
+#define CCL_INT2_bm  CCL_INT_2_bm  /* This define is deprecated and should not be used */
+#define CCL_INT2_bp  CCL_INT_2_bp  /* This define is deprecated and should not be used */
+#define CCL_INT_3_bm  (1<<3)  /* Interrupt Flag bit 3 mask. */
+#define CCL_INT_3_bp  3  /* Interrupt Flag bit 3 position. */
+#define CCL_INT3_bm  CCL_INT_3_bm  /* This define is deprecated and should not be used */
+#define CCL_INT3_bp  CCL_INT_3_bp  /* This define is deprecated and should not be used */
+
+/* CCL.LUT0CTRLA  bit masks and bit positions */
+/* CCL_ENABLE  is already defined. */
+#define CCL_CLKSRC_gm  0x0E  /* Clock Source Selection group mask. */
+#define CCL_CLKSRC_gp  1  /* Clock Source Selection group position. */
+#define CCL_CLKSRC_0_bm  (1<<1)  /* Clock Source Selection bit 0 mask. */
+#define CCL_CLKSRC_0_bp  1  /* Clock Source Selection bit 0 position. */
+#define CCL_CLKSRC_1_bm  (1<<2)  /* Clock Source Selection bit 1 mask. */
+#define CCL_CLKSRC_1_bp  2  /* Clock Source Selection bit 1 position. */
+#define CCL_CLKSRC_2_bm  (1<<3)  /* Clock Source Selection bit 2 mask. */
+#define CCL_CLKSRC_2_bp  3  /* Clock Source Selection bit 2 position. */
+#define CCL_FILTSEL_gm  0x30  /* Filter Selection group mask. */
+#define CCL_FILTSEL_gp  4  /* Filter Selection group position. */
+#define CCL_FILTSEL_0_bm  (1<<4)  /* Filter Selection bit 0 mask. */
+#define CCL_FILTSEL_0_bp  4  /* Filter Selection bit 0 position. */
+#define CCL_FILTSEL_1_bm  (1<<5)  /* Filter Selection bit 1 mask. */
+#define CCL_FILTSEL_1_bp  5  /* Filter Selection bit 1 position. */
+#define CCL_OUTEN_bm  0x40  /* Output Enable bit mask. */
+#define CCL_OUTEN_bp  6  /* Output Enable bit position. */
+#define CCL_EDGEDET_bm  0x80  /* Edge Detection Enable bit mask. */
+#define CCL_EDGEDET_bp  7  /* Edge Detection Enable bit position. */
+
+/* CCL.LUT0CTRLB  bit masks and bit positions */
+#define CCL_INSEL0_gm  0x0F  /* LUT Input 0 Source Selection group mask. */
+#define CCL_INSEL0_gp  0  /* LUT Input 0 Source Selection group position. */
+#define CCL_INSEL0_0_bm  (1<<0)  /* LUT Input 0 Source Selection bit 0 mask. */
+#define CCL_INSEL0_0_bp  0  /* LUT Input 0 Source Selection bit 0 position. */
+#define CCL_INSEL0_1_bm  (1<<1)  /* LUT Input 0 Source Selection bit 1 mask. */
+#define CCL_INSEL0_1_bp  1  /* LUT Input 0 Source Selection bit 1 position. */
+#define CCL_INSEL0_2_bm  (1<<2)  /* LUT Input 0 Source Selection bit 2 mask. */
+#define CCL_INSEL0_2_bp  2  /* LUT Input 0 Source Selection bit 2 position. */
+#define CCL_INSEL0_3_bm  (1<<3)  /* LUT Input 0 Source Selection bit 3 mask. */
+#define CCL_INSEL0_3_bp  3  /* LUT Input 0 Source Selection bit 3 position. */
+#define CCL_INSEL1_gm  0xF0  /* LUT Input 1 Source Selection group mask. */
+#define CCL_INSEL1_gp  4  /* LUT Input 1 Source Selection group position. */
+#define CCL_INSEL1_0_bm  (1<<4)  /* LUT Input 1 Source Selection bit 0 mask. */
+#define CCL_INSEL1_0_bp  4  /* LUT Input 1 Source Selection bit 0 position. */
+#define CCL_INSEL1_1_bm  (1<<5)  /* LUT Input 1 Source Selection bit 1 mask. */
+#define CCL_INSEL1_1_bp  5  /* LUT Input 1 Source Selection bit 1 position. */
+#define CCL_INSEL1_2_bm  (1<<6)  /* LUT Input 1 Source Selection bit 2 mask. */
+#define CCL_INSEL1_2_bp  6  /* LUT Input 1 Source Selection bit 2 position. */
+#define CCL_INSEL1_3_bm  (1<<7)  /* LUT Input 1 Source Selection bit 3 mask. */
+#define CCL_INSEL1_3_bp  7  /* LUT Input 1 Source Selection bit 3 position. */
+
+/* CCL.LUT0CTRLC  bit masks and bit positions */
+#define CCL_INSEL2_gm  0x0F  /* LUT Input 2 Source Selection group mask. */
+#define CCL_INSEL2_gp  0  /* LUT Input 2 Source Selection group position. */
+#define CCL_INSEL2_0_bm  (1<<0)  /* LUT Input 2 Source Selection bit 0 mask. */
+#define CCL_INSEL2_0_bp  0  /* LUT Input 2 Source Selection bit 0 position. */
+#define CCL_INSEL2_1_bm  (1<<1)  /* LUT Input 2 Source Selection bit 1 mask. */
+#define CCL_INSEL2_1_bp  1  /* LUT Input 2 Source Selection bit 1 position. */
+#define CCL_INSEL2_2_bm  (1<<2)  /* LUT Input 2 Source Selection bit 2 mask. */
+#define CCL_INSEL2_2_bp  2  /* LUT Input 2 Source Selection bit 2 position. */
+#define CCL_INSEL2_3_bm  (1<<3)  /* LUT Input 2 Source Selection bit 3 mask. */
+#define CCL_INSEL2_3_bp  3  /* LUT Input 2 Source Selection bit 3 position. */
+
+/* CCL.TRUTH0  bit masks and bit positions */
+#define CCL_TRUTH_gm  0xFF  /* Truth Table group mask. */
+#define CCL_TRUTH_gp  0  /* Truth Table group position. */
+#define CCL_TRUTH_0_bm  (1<<0)  /* Truth Table bit 0 mask. */
+#define CCL_TRUTH_0_bp  0  /* Truth Table bit 0 position. */
+#define CCL_TRUTH_1_bm  (1<<1)  /* Truth Table bit 1 mask. */
+#define CCL_TRUTH_1_bp  1  /* Truth Table bit 1 position. */
+#define CCL_TRUTH_2_bm  (1<<2)  /* Truth Table bit 2 mask. */
+#define CCL_TRUTH_2_bp  2  /* Truth Table bit 2 position. */
+#define CCL_TRUTH_3_bm  (1<<3)  /* Truth Table bit 3 mask. */
+#define CCL_TRUTH_3_bp  3  /* Truth Table bit 3 position. */
+#define CCL_TRUTH_4_bm  (1<<4)  /* Truth Table bit 4 mask. */
+#define CCL_TRUTH_4_bp  4  /* Truth Table bit 4 position. */
+#define CCL_TRUTH_5_bm  (1<<5)  /* Truth Table bit 5 mask. */
+#define CCL_TRUTH_5_bp  5  /* Truth Table bit 5 position. */
+#define CCL_TRUTH_6_bm  (1<<6)  /* Truth Table bit 6 mask. */
+#define CCL_TRUTH_6_bp  6  /* Truth Table bit 6 position. */
+#define CCL_TRUTH_7_bm  (1<<7)  /* Truth Table bit 7 mask. */
+#define CCL_TRUTH_7_bp  7  /* Truth Table bit 7 position. */
+
+/* CCL.LUT1CTRLA  bit masks and bit positions */
+/* CCL_ENABLE  is already defined. */
+/* CCL_CLKSRC  is already defined. */
+/* CCL_FILTSEL  is already defined. */
+/* CCL_OUTEN  is already defined. */
+/* CCL_EDGEDET  is already defined. */
+
+/* CCL.LUT1CTRLB  bit masks and bit positions */
+/* CCL_INSEL0  is already defined. */
+/* CCL_INSEL1  is already defined. */
+
+/* CCL.LUT1CTRLC  bit masks and bit positions */
+/* CCL_INSEL2  is already defined. */
+
+/* CCL.TRUTH1  bit masks and bit positions */
+/* CCL_TRUTH  is already defined. */
+
+/* CCL.LUT2CTRLA  bit masks and bit positions */
+/* CCL_ENABLE  is already defined. */
+/* CCL_CLKSRC  is already defined. */
+/* CCL_FILTSEL  is already defined. */
+/* CCL_OUTEN  is already defined. */
+/* CCL_EDGEDET  is already defined. */
+
+/* CCL.LUT2CTRLB  bit masks and bit positions */
+/* CCL_INSEL0  is already defined. */
+/* CCL_INSEL1  is already defined. */
+
+/* CCL.LUT2CTRLC  bit masks and bit positions */
+/* CCL_INSEL2  is already defined. */
+
+/* CCL.TRUTH2  bit masks and bit positions */
+/* CCL_TRUTH  is already defined. */
+
+/* CCL.LUT3CTRLA  bit masks and bit positions */
+/* CCL_ENABLE  is already defined. */
+/* CCL_CLKSRC  is already defined. */
+/* CCL_FILTSEL  is already defined. */
+/* CCL_OUTEN  is already defined. */
+/* CCL_EDGEDET  is already defined. */
+
+/* CCL.LUT3CTRLB  bit masks and bit positions */
+/* CCL_INSEL0  is already defined. */
+/* CCL_INSEL1  is already defined. */
+
+/* CCL.LUT3CTRLC  bit masks and bit positions */
+/* CCL_INSEL2  is already defined. */
+
+/* CCL.TRUTH3  bit masks and bit positions */
+/* CCL_TRUTH  is already defined. */
+
+
+/* CLKCTRL - Clock controller */
+/* CLKCTRL.MCLKCTRLA  bit masks and bit positions */
+#define CLKCTRL_CLKSEL_gm  0x07  /* Clock select group mask. */
+#define CLKCTRL_CLKSEL_gp  0  /* Clock select group position. */
+#define CLKCTRL_CLKSEL_0_bm  (1<<0)  /* Clock select bit 0 mask. */
+#define CLKCTRL_CLKSEL_0_bp  0  /* Clock select bit 0 position. */
+#define CLKCTRL_CLKSEL_1_bm  (1<<1)  /* Clock select bit 1 mask. */
+#define CLKCTRL_CLKSEL_1_bp  1  /* Clock select bit 1 position. */
+#define CLKCTRL_CLKSEL_2_bm  (1<<2)  /* Clock select bit 2 mask. */
+#define CLKCTRL_CLKSEL_2_bp  2  /* Clock select bit 2 position. */
+#define CLKCTRL_CLKOUT_bm  0x80  /* System clock out bit mask. */
+#define CLKCTRL_CLKOUT_bp  7  /* System clock out bit position. */
+
+/* CLKCTRL.MCLKCTRLB  bit masks and bit positions */
+#define CLKCTRL_PEN_bm  0x01  /* Prescaler enable bit mask. */
+#define CLKCTRL_PEN_bp  0  /* Prescaler enable bit position. */
+#define CLKCTRL_PDIV_gm  0x1E  /* Prescaler division group mask. */
+#define CLKCTRL_PDIV_gp  1  /* Prescaler division group position. */
+#define CLKCTRL_PDIV_0_bm  (1<<1)  /* Prescaler division bit 0 mask. */
+#define CLKCTRL_PDIV_0_bp  1  /* Prescaler division bit 0 position. */
+#define CLKCTRL_PDIV_1_bm  (1<<2)  /* Prescaler division bit 1 mask. */
+#define CLKCTRL_PDIV_1_bp  2  /* Prescaler division bit 1 position. */
+#define CLKCTRL_PDIV_2_bm  (1<<3)  /* Prescaler division bit 2 mask. */
+#define CLKCTRL_PDIV_2_bp  3  /* Prescaler division bit 2 position. */
+#define CLKCTRL_PDIV_3_bm  (1<<4)  /* Prescaler division bit 3 mask. */
+#define CLKCTRL_PDIV_3_bp  4  /* Prescaler division bit 3 position. */
+
+/* CLKCTRL.MCLKCTRLC  bit masks and bit positions */
+#define CLKCTRL_CFDEN_bm  0x01  /* Clock Failure Detect Enable bit mask. */
+#define CLKCTRL_CFDEN_bp  0  /* Clock Failure Detect Enable bit position. */
+#define CLKCTRL_CFDTST_bm  0x02  /* CFD Test bit mask. */
+#define CLKCTRL_CFDTST_bp  1  /* CFD Test bit position. */
+#define CLKCTRL_CFDSRC_gm  0x0C  /* CFD Source group mask. */
+#define CLKCTRL_CFDSRC_gp  2  /* CFD Source group position. */
+#define CLKCTRL_CFDSRC_0_bm  (1<<2)  /* CFD Source bit 0 mask. */
+#define CLKCTRL_CFDSRC_0_bp  2  /* CFD Source bit 0 position. */
+#define CLKCTRL_CFDSRC_1_bm  (1<<3)  /* CFD Source bit 1 mask. */
+#define CLKCTRL_CFDSRC_1_bp  3  /* CFD Source bit 1 position. */
+
+/* CLKCTRL.MCLKINTCTRL  bit masks and bit positions */
+#define CLKCTRL_CFD_bm  0x01  /* Interrupt Enable bit mask. */
+#define CLKCTRL_CFD_bp  0  /* Interrupt Enable bit position. */
+#define CLKCTRL_INTTYPE_bm  0x80  /* Interrupt Type bit mask. */
+#define CLKCTRL_INTTYPE_bp  7  /* Interrupt Type bit position. */
+
+/* CLKCTRL.MCLKINTFLAGS  bit masks and bit positions */
+/* CLKCTRL_CFD  is already defined. */
+
+/* CLKCTRL.MCLKSTATUS  bit masks and bit positions */
+#define CLKCTRL_SOSC_bm  0x01  /* System Oscillator changing bit mask. */
+#define CLKCTRL_SOSC_bp  0  /* System Oscillator changing bit position. */
+#define CLKCTRL_OSCHFS_bm  0x02  /* High frequency oscillator status bit mask. */
+#define CLKCTRL_OSCHFS_bp  1  /* High frequency oscillator status bit position. */
+#define CLKCTRL_OSC32KS_bm  0x04  /* 32KHz oscillator status bit mask. */
+#define CLKCTRL_OSC32KS_bp  2  /* 32KHz oscillator status bit position. */
+#define CLKCTRL_XOSC32KS_bm  0x08  /* 32.768 kHz Crystal Oscillator status bit mask. */
+#define CLKCTRL_XOSC32KS_bp  3  /* 32.768 kHz Crystal Oscillator status bit position. */
+#define CLKCTRL_EXTS_bm  0x10  /* External Clock status / XOSCHF status bit mask. */
+#define CLKCTRL_EXTS_bp  4  /* External Clock status / XOSCHF status bit position. */
+
+/* CLKCTRL.MCLKTIMEBASE  bit masks and bit positions */
+#define CLKCTRL_TIMEBASE_gm  0x1F  /* Timebase group mask. */
+#define CLKCTRL_TIMEBASE_gp  0  /* Timebase group position. */
+#define CLKCTRL_TIMEBASE_0_bm  (1<<0)  /* Timebase bit 0 mask. */
+#define CLKCTRL_TIMEBASE_0_bp  0  /* Timebase bit 0 position. */
+#define CLKCTRL_TIMEBASE_1_bm  (1<<1)  /* Timebase bit 1 mask. */
+#define CLKCTRL_TIMEBASE_1_bp  1  /* Timebase bit 1 position. */
+#define CLKCTRL_TIMEBASE_2_bm  (1<<2)  /* Timebase bit 2 mask. */
+#define CLKCTRL_TIMEBASE_2_bp  2  /* Timebase bit 2 position. */
+#define CLKCTRL_TIMEBASE_3_bm  (1<<3)  /* Timebase bit 3 mask. */
+#define CLKCTRL_TIMEBASE_3_bp  3  /* Timebase bit 3 position. */
+#define CLKCTRL_TIMEBASE_4_bm  (1<<4)  /* Timebase bit 4 mask. */
+#define CLKCTRL_TIMEBASE_4_bp  4  /* Timebase bit 4 position. */
+
+/* CLKCTRL.OSCHFCTRLA  bit masks and bit positions */
+#define CLKCTRL_AUTOTUNE_gm  0x03  /* Automatic Oscillator Tune group mask. */
+#define CLKCTRL_AUTOTUNE_gp  0  /* Automatic Oscillator Tune group position. */
+#define CLKCTRL_AUTOTUNE_0_bm  (1<<0)  /* Automatic Oscillator Tune bit 0 mask. */
+#define CLKCTRL_AUTOTUNE_0_bp  0  /* Automatic Oscillator Tune bit 0 position. */
+#define CLKCTRL_AUTOTUNE_1_bm  (1<<1)  /* Automatic Oscillator Tune bit 1 mask. */
+#define CLKCTRL_AUTOTUNE_1_bp  1  /* Automatic Oscillator Tune bit 1 position. */
+#define CLKCTRL_RUNSTDBY_bm  0x80  /* Run in standby bit mask. */
+#define CLKCTRL_RUNSTDBY_bp  7  /* Run in standby bit position. */
+
+/* CLKCTRL.OSCHFTUNE  bit masks and bit positions */
+#define CLKCTRL_TUNE_gm  0xFF  /* Oscillator Tune group mask. */
+#define CLKCTRL_TUNE_gp  0  /* Oscillator Tune group position. */
+#define CLKCTRL_TUNE_0_bm  (1<<0)  /* Oscillator Tune bit 0 mask. */
+#define CLKCTRL_TUNE_0_bp  0  /* Oscillator Tune bit 0 position. */
+#define CLKCTRL_TUNE_1_bm  (1<<1)  /* Oscillator Tune bit 1 mask. */
+#define CLKCTRL_TUNE_1_bp  1  /* Oscillator Tune bit 1 position. */
+#define CLKCTRL_TUNE_2_bm  (1<<2)  /* Oscillator Tune bit 2 mask. */
+#define CLKCTRL_TUNE_2_bp  2  /* Oscillator Tune bit 2 position. */
+#define CLKCTRL_TUNE_3_bm  (1<<3)  /* Oscillator Tune bit 3 mask. */
+#define CLKCTRL_TUNE_3_bp  3  /* Oscillator Tune bit 3 position. */
+#define CLKCTRL_TUNE_4_bm  (1<<4)  /* Oscillator Tune bit 4 mask. */
+#define CLKCTRL_TUNE_4_bp  4  /* Oscillator Tune bit 4 position. */
+#define CLKCTRL_TUNE_5_bm  (1<<5)  /* Oscillator Tune bit 5 mask. */
+#define CLKCTRL_TUNE_5_bp  5  /* Oscillator Tune bit 5 position. */
+#define CLKCTRL_TUNE_6_bm  (1<<6)  /* Oscillator Tune bit 6 mask. */
+#define CLKCTRL_TUNE_6_bp  6  /* Oscillator Tune bit 6 position. */
+#define CLKCTRL_TUNE_7_bm  (1<<7)  /* Oscillator Tune bit 7 mask. */
+#define CLKCTRL_TUNE_7_bp  7  /* Oscillator Tune bit 7 position. */
+
+/* CLKCTRL.OSC32KCTRLA  bit masks and bit positions */
+/* CLKCTRL_RUNSTDBY  is already defined. */
+
+/* CLKCTRL.XOSC32KCTRLA  bit masks and bit positions */
+#define CLKCTRL_ENABLE_bm  0x01  /* Enable bit mask. */
+#define CLKCTRL_ENABLE_bp  0  /* Enable bit position. */
+#define CLKCTRL_LPMODE_bm  0x02  /* Low power mode bit mask. */
+#define CLKCTRL_LPMODE_bp  1  /* Low power mode bit position. */
+#define CLKCTRL_SEL_bm  0x04  /* Select bit mask. */
+#define CLKCTRL_SEL_bp  2  /* Select bit position. */
+#define CLKCTRL_CSUT_gm  0x30  /* Crystal startup time group mask. */
+#define CLKCTRL_CSUT_gp  4  /* Crystal startup time group position. */
+#define CLKCTRL_CSUT_0_bm  (1<<4)  /* Crystal startup time bit 0 mask. */
+#define CLKCTRL_CSUT_0_bp  4  /* Crystal startup time bit 0 position. */
+#define CLKCTRL_CSUT_1_bm  (1<<5)  /* Crystal startup time bit 1 mask. */
+#define CLKCTRL_CSUT_1_bp  5  /* Crystal startup time bit 1 position. */
+/* CLKCTRL_RUNSTDBY  is already defined. */
+
+/* CLKCTRL.XOSCHFCTRLA  bit masks and bit positions */
+/* CLKCTRL_ENABLE  is already defined. */
+#define CLKCTRL_SELHF_bm  0x02  /* Source Select bit mask. */
+#define CLKCTRL_SELHF_bp  1  /* Source Select bit position. */
+#define CLKCTRL_CSUTHF_gm  0x30  /* Start-Up Time group mask. */
+#define CLKCTRL_CSUTHF_gp  4  /* Start-Up Time group position. */
+#define CLKCTRL_CSUTHF_0_bm  (1<<4)  /* Start-Up Time bit 0 mask. */
+#define CLKCTRL_CSUTHF_0_bp  4  /* Start-Up Time bit 0 position. */
+#define CLKCTRL_CSUTHF_1_bm  (1<<5)  /* Start-Up Time bit 1 mask. */
+#define CLKCTRL_CSUTHF_1_bp  5  /* Start-Up Time bit 1 position. */
+/* CLKCTRL_RUNSTDBY  is already defined. */
+
+
+/* CPU - CPU */
+/* CPU.CCP  bit masks and bit positions */
+#define CPU_CCP_gm  0xFF  /* CCP signature group mask. */
+#define CPU_CCP_gp  0  /* CCP signature group position. */
+#define CPU_CCP_0_bm  (1<<0)  /* CCP signature bit 0 mask. */
+#define CPU_CCP_0_bp  0  /* CCP signature bit 0 position. */
+#define CPU_CCP_1_bm  (1<<1)  /* CCP signature bit 1 mask. */
+#define CPU_CCP_1_bp  1  /* CCP signature bit 1 position. */
+#define CPU_CCP_2_bm  (1<<2)  /* CCP signature bit 2 mask. */
+#define CPU_CCP_2_bp  2  /* CCP signature bit 2 position. */
+#define CPU_CCP_3_bm  (1<<3)  /* CCP signature bit 3 mask. */
+#define CPU_CCP_3_bp  3  /* CCP signature bit 3 position. */
+#define CPU_CCP_4_bm  (1<<4)  /* CCP signature bit 4 mask. */
+#define CPU_CCP_4_bp  4  /* CCP signature bit 4 position. */
+#define CPU_CCP_5_bm  (1<<5)  /* CCP signature bit 5 mask. */
+#define CPU_CCP_5_bp  5  /* CCP signature bit 5 position. */
+#define CPU_CCP_6_bm  (1<<6)  /* CCP signature bit 6 mask. */
+#define CPU_CCP_6_bp  6  /* CCP signature bit 6 position. */
+#define CPU_CCP_7_bm  (1<<7)  /* CCP signature bit 7 mask. */
+#define CPU_CCP_7_bp  7  /* CCP signature bit 7 position. */
+
+/* CPU.SREG  bit masks and bit positions */
+#define CPU_C_bm  0x01  /* Carry Flag bit mask. */
+#define CPU_C_bp  0  /* Carry Flag bit position. */
+#define CPU_Z_bm  0x02  /* Zero Flag bit mask. */
+#define CPU_Z_bp  1  /* Zero Flag bit position. */
+#define CPU_N_bm  0x04  /* Negative Flag bit mask. */
+#define CPU_N_bp  2  /* Negative Flag bit position. */
+#define CPU_V_bm  0x08  /* Two's Complement Overflow Flag bit mask. */
+#define CPU_V_bp  3  /* Two's Complement Overflow Flag bit position. */
+#define CPU_S_bm  0x10  /* N Exclusive Or V Flag bit mask. */
+#define CPU_S_bp  4  /* N Exclusive Or V Flag bit position. */
+#define CPU_H_bm  0x20  /* Half Carry Flag bit mask. */
+#define CPU_H_bp  5  /* Half Carry Flag bit position. */
+#define CPU_T_bm  0x40  /* Transfer Bit bit mask. */
+#define CPU_T_bp  6  /* Transfer Bit bit position. */
+#define CPU_I_bm  0x80  /* Global Interrupt Enable Flag bit mask. */
+#define CPU_I_bp  7  /* Global Interrupt Enable Flag bit position. */
+
+
+/* CPUINT - Interrupt Controller */
+/* CPUINT.CTRLA  bit masks and bit positions */
+#define CPUINT_LVL0RR_bm  0x01  /* Round-robin Scheduling Enable bit mask. */
+#define CPUINT_LVL0RR_bp  0  /* Round-robin Scheduling Enable bit position. */
+#define CPUINT_CVT_bm  0x20  /* Compact Vector Table bit mask. */
+#define CPUINT_CVT_bp  5  /* Compact Vector Table bit position. */
+#define CPUINT_IVSEL_bm  0x40  /* Interrupt Vector Select bit mask. */
+#define CPUINT_IVSEL_bp  6  /* Interrupt Vector Select bit position. */
+
+/* CPUINT.STATUS  bit masks and bit positions */
+#define CPUINT_LVL0EX_bm  0x01  /* Level 0 Interrupt Executing bit mask. */
+#define CPUINT_LVL0EX_bp  0  /* Level 0 Interrupt Executing bit position. */
+#define CPUINT_LVL1EX_bm  0x02  /* Level 1 Interrupt Executing bit mask. */
+#define CPUINT_LVL1EX_bp  1  /* Level 1 Interrupt Executing bit position. */
+#define CPUINT_NMIEX_bm  0x80  /* Non-maskable Interrupt Executing bit mask. */
+#define CPUINT_NMIEX_bp  7  /* Non-maskable Interrupt Executing bit position. */
+
+/* CPUINT.LVL0PRI  bit masks and bit positions */
+#define CPUINT_LVL0PRI_gm  0xFF  /* Interrupt Level Priority group mask. */
+#define CPUINT_LVL0PRI_gp  0  /* Interrupt Level Priority group position. */
+#define CPUINT_LVL0PRI_0_bm  (1<<0)  /* Interrupt Level Priority bit 0 mask. */
+#define CPUINT_LVL0PRI_0_bp  0  /* Interrupt Level Priority bit 0 position. */
+#define CPUINT_LVL0PRI_1_bm  (1<<1)  /* Interrupt Level Priority bit 1 mask. */
+#define CPUINT_LVL0PRI_1_bp  1  /* Interrupt Level Priority bit 1 position. */
+#define CPUINT_LVL0PRI_2_bm  (1<<2)  /* Interrupt Level Priority bit 2 mask. */
+#define CPUINT_LVL0PRI_2_bp  2  /* Interrupt Level Priority bit 2 position. */
+#define CPUINT_LVL0PRI_3_bm  (1<<3)  /* Interrupt Level Priority bit 3 mask. */
+#define CPUINT_LVL0PRI_3_bp  3  /* Interrupt Level Priority bit 3 position. */
+#define CPUINT_LVL0PRI_4_bm  (1<<4)  /* Interrupt Level Priority bit 4 mask. */
+#define CPUINT_LVL0PRI_4_bp  4  /* Interrupt Level Priority bit 4 position. */
+#define CPUINT_LVL0PRI_5_bm  (1<<5)  /* Interrupt Level Priority bit 5 mask. */
+#define CPUINT_LVL0PRI_5_bp  5  /* Interrupt Level Priority bit 5 position. */
+#define CPUINT_LVL0PRI_6_bm  (1<<6)  /* Interrupt Level Priority bit 6 mask. */
+#define CPUINT_LVL0PRI_6_bp  6  /* Interrupt Level Priority bit 6 position. */
+#define CPUINT_LVL0PRI_7_bm  (1<<7)  /* Interrupt Level Priority bit 7 mask. */
+#define CPUINT_LVL0PRI_7_bp  7  /* Interrupt Level Priority bit 7 position. */
+
+/* CPUINT.LVL1VEC  bit masks and bit positions */
+#define CPUINT_LVL1VEC_gm  0xFF  /* Interrupt Vector with High Priority group mask. */
+#define CPUINT_LVL1VEC_gp  0  /* Interrupt Vector with High Priority group position. */
+#define CPUINT_LVL1VEC_0_bm  (1<<0)  /* Interrupt Vector with High Priority bit 0 mask. */
+#define CPUINT_LVL1VEC_0_bp  0  /* Interrupt Vector with High Priority bit 0 position. */
+#define CPUINT_LVL1VEC_1_bm  (1<<1)  /* Interrupt Vector with High Priority bit 1 mask. */
+#define CPUINT_LVL1VEC_1_bp  1  /* Interrupt Vector with High Priority bit 1 position. */
+#define CPUINT_LVL1VEC_2_bm  (1<<2)  /* Interrupt Vector with High Priority bit 2 mask. */
+#define CPUINT_LVL1VEC_2_bp  2  /* Interrupt Vector with High Priority bit 2 position. */
+#define CPUINT_LVL1VEC_3_bm  (1<<3)  /* Interrupt Vector with High Priority bit 3 mask. */
+#define CPUINT_LVL1VEC_3_bp  3  /* Interrupt Vector with High Priority bit 3 position. */
+#define CPUINT_LVL1VEC_4_bm  (1<<4)  /* Interrupt Vector with High Priority bit 4 mask. */
+#define CPUINT_LVL1VEC_4_bp  4  /* Interrupt Vector with High Priority bit 4 position. */
+#define CPUINT_LVL1VEC_5_bm  (1<<5)  /* Interrupt Vector with High Priority bit 5 mask. */
+#define CPUINT_LVL1VEC_5_bp  5  /* Interrupt Vector with High Priority bit 5 position. */
+#define CPUINT_LVL1VEC_6_bm  (1<<6)  /* Interrupt Vector with High Priority bit 6 mask. */
+#define CPUINT_LVL1VEC_6_bp  6  /* Interrupt Vector with High Priority bit 6 position. */
+#define CPUINT_LVL1VEC_7_bm  (1<<7)  /* Interrupt Vector with High Priority bit 7 mask. */
+#define CPUINT_LVL1VEC_7_bp  7  /* Interrupt Vector with High Priority bit 7 position. */
+
+
+/* CRCSCAN - CRCSCAN */
+/* CRCSCAN.CTRLA  bit masks and bit positions */
+#define CRCSCAN_ENABLE_bm  0x01  /* Enable CRC scan bit mask. */
+#define CRCSCAN_ENABLE_bp  0  /* Enable CRC scan bit position. */
+#define CRCSCAN_NMIEN_bm  0x02  /* Enable NMI Trigger bit mask. */
+#define CRCSCAN_NMIEN_bp  1  /* Enable NMI Trigger bit position. */
+#define CRCSCAN_RESET_bm  0x80  /* Reset CRC scan bit mask. */
+#define CRCSCAN_RESET_bp  7  /* Reset CRC scan bit position. */
+
+/* CRCSCAN.CTRLB  bit masks and bit positions */
+#define CRCSCAN_SRC_gm  0x03  /* CRC Source group mask. */
+#define CRCSCAN_SRC_gp  0  /* CRC Source group position. */
+#define CRCSCAN_SRC_0_bm  (1<<0)  /* CRC Source bit 0 mask. */
+#define CRCSCAN_SRC_0_bp  0  /* CRC Source bit 0 position. */
+#define CRCSCAN_SRC_1_bm  (1<<1)  /* CRC Source bit 1 mask. */
+#define CRCSCAN_SRC_1_bp  1  /* CRC Source bit 1 position. */
+
+/* CRCSCAN.STATUS  bit masks and bit positions */
+#define CRCSCAN_BUSY_bm  0x01  /* CRC Busy bit mask. */
+#define CRCSCAN_BUSY_bp  0  /* CRC Busy bit position. */
+#define CRCSCAN_OK_bm  0x02  /* CRC Ok bit mask. */
+#define CRCSCAN_OK_bp  1  /* CRC Ok bit position. */
+
+
+/* DAC - Digital to Analog Converter */
+/* DAC.CTRLA  bit masks and bit positions */
+#define DAC_ENABLE_bm  0x01  /* DAC Enable bit mask. */
+#define DAC_ENABLE_bp  0  /* DAC Enable bit position. */
+#define DAC_OUTRANGE_gm  0x30  /* Output Buffer Range group mask. */
+#define DAC_OUTRANGE_gp  4  /* Output Buffer Range group position. */
+#define DAC_OUTRANGE_0_bm  (1<<4)  /* Output Buffer Range bit 0 mask. */
+#define DAC_OUTRANGE_0_bp  4  /* Output Buffer Range bit 0 position. */
+#define DAC_OUTRANGE_1_bm  (1<<5)  /* Output Buffer Range bit 1 mask. */
+#define DAC_OUTRANGE_1_bp  5  /* Output Buffer Range bit 1 position. */
+#define DAC_OUTEN_bm  0x40  /* Output Buffer Enable bit mask. */
+#define DAC_OUTEN_bp  6  /* Output Buffer Enable bit position. */
+#define DAC_RUNSTDBY_bm  0x80  /* Run in Standby Mode bit mask. */
+#define DAC_RUNSTDBY_bp  7  /* Run in Standby Mode bit position. */
+
+/* DAC.DATA  bit masks and bit positions */
+#define DAC_DATA_gm  0xFFC0  /* Data group mask. */
+#define DAC_DATA_gp  6  /* Data group position. */
+#define DAC_DATA_0_bm  (1<<6)  /* Data bit 0 mask. */
+#define DAC_DATA_0_bp  6  /* Data bit 0 position. */
+#define DAC_DATA_1_bm  (1<<7)  /* Data bit 1 mask. */
+#define DAC_DATA_1_bp  7  /* Data bit 1 position. */
+#define DAC_DATA_2_bm  (1<<8)  /* Data bit 2 mask. */
+#define DAC_DATA_2_bp  8  /* Data bit 2 position. */
+#define DAC_DATA_3_bm  (1<<9)  /* Data bit 3 mask. */
+#define DAC_DATA_3_bp  9  /* Data bit 3 position. */
+#define DAC_DATA_4_bm  (1<<10)  /* Data bit 4 mask. */
+#define DAC_DATA_4_bp  10  /* Data bit 4 position. */
+#define DAC_DATA_5_bm  (1<<11)  /* Data bit 5 mask. */
+#define DAC_DATA_5_bp  11  /* Data bit 5 position. */
+#define DAC_DATA_6_bm  (1<<12)  /* Data bit 6 mask. */
+#define DAC_DATA_6_bp  12  /* Data bit 6 position. */
+#define DAC_DATA_7_bm  (1<<13)  /* Data bit 7 mask. */
+#define DAC_DATA_7_bp  13  /* Data bit 7 position. */
+#define DAC_DATA_8_bm  (1<<14)  /* Data bit 8 mask. */
+#define DAC_DATA_8_bp  14  /* Data bit 8 position. */
+#define DAC_DATA_9_bm  (1<<15)  /* Data bit 9 mask. */
+#define DAC_DATA_9_bp  15  /* Data bit 9 position. */
+
+
+/* EVSYS - Event System */
+/* EVSYS.SWEVENTA  bit masks and bit positions */
+#define EVSYS_SWEVENTA_gm  0xFF  /* Software event on channel select group mask. */
+#define EVSYS_SWEVENTA_gp  0  /* Software event on channel select group position. */
+#define EVSYS_SWEVENTA_0_bm  (1<<0)  /* Software event on channel select bit 0 mask. */
+#define EVSYS_SWEVENTA_0_bp  0  /* Software event on channel select bit 0 position. */
+#define EVSYS_SWEVENTA_1_bm  (1<<1)  /* Software event on channel select bit 1 mask. */
+#define EVSYS_SWEVENTA_1_bp  1  /* Software event on channel select bit 1 position. */
+#define EVSYS_SWEVENTA_2_bm  (1<<2)  /* Software event on channel select bit 2 mask. */
+#define EVSYS_SWEVENTA_2_bp  2  /* Software event on channel select bit 2 position. */
+#define EVSYS_SWEVENTA_3_bm  (1<<3)  /* Software event on channel select bit 3 mask. */
+#define EVSYS_SWEVENTA_3_bp  3  /* Software event on channel select bit 3 position. */
+#define EVSYS_SWEVENTA_4_bm  (1<<4)  /* Software event on channel select bit 4 mask. */
+#define EVSYS_SWEVENTA_4_bp  4  /* Software event on channel select bit 4 position. */
+#define EVSYS_SWEVENTA_5_bm  (1<<5)  /* Software event on channel select bit 5 mask. */
+#define EVSYS_SWEVENTA_5_bp  5  /* Software event on channel select bit 5 position. */
+#define EVSYS_SWEVENTA_6_bm  (1<<6)  /* Software event on channel select bit 6 mask. */
+#define EVSYS_SWEVENTA_6_bp  6  /* Software event on channel select bit 6 position. */
+#define EVSYS_SWEVENTA_7_bm  (1<<7)  /* Software event on channel select bit 7 mask. */
+#define EVSYS_SWEVENTA_7_bp  7  /* Software event on channel select bit 7 position. */
+
+/* EVSYS.CHANNEL0  bit masks and bit positions */
+#define EVSYS_CHANNEL_gm  0xFF  /* Channel generator select group mask. */
+#define EVSYS_CHANNEL_gp  0  /* Channel generator select group position. */
+#define EVSYS_CHANNEL_0_bm  (1<<0)  /* Channel generator select bit 0 mask. */
+#define EVSYS_CHANNEL_0_bp  0  /* Channel generator select bit 0 position. */
+#define EVSYS_CHANNEL_1_bm  (1<<1)  /* Channel generator select bit 1 mask. */
+#define EVSYS_CHANNEL_1_bp  1  /* Channel generator select bit 1 position. */
+#define EVSYS_CHANNEL_2_bm  (1<<2)  /* Channel generator select bit 2 mask. */
+#define EVSYS_CHANNEL_2_bp  2  /* Channel generator select bit 2 position. */
+#define EVSYS_CHANNEL_3_bm  (1<<3)  /* Channel generator select bit 3 mask. */
+#define EVSYS_CHANNEL_3_bp  3  /* Channel generator select bit 3 position. */
+#define EVSYS_CHANNEL_4_bm  (1<<4)  /* Channel generator select bit 4 mask. */
+#define EVSYS_CHANNEL_4_bp  4  /* Channel generator select bit 4 position. */
+#define EVSYS_CHANNEL_5_bm  (1<<5)  /* Channel generator select bit 5 mask. */
+#define EVSYS_CHANNEL_5_bp  5  /* Channel generator select bit 5 position. */
+#define EVSYS_CHANNEL_6_bm  (1<<6)  /* Channel generator select bit 6 mask. */
+#define EVSYS_CHANNEL_6_bp  6  /* Channel generator select bit 6 position. */
+#define EVSYS_CHANNEL_7_bm  (1<<7)  /* Channel generator select bit 7 mask. */
+#define EVSYS_CHANNEL_7_bp  7  /* Channel generator select bit 7 position. */
+
+/* EVSYS.CHANNEL1  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.CHANNEL2  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.CHANNEL3  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.CHANNEL4  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.CHANNEL5  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.USERCCLLUT0A  bit masks and bit positions */
+#define EVSYS_USER_gm  0xFF  /* User channel select group mask. */
+#define EVSYS_USER_gp  0  /* User channel select group position. */
+#define EVSYS_USER_0_bm  (1<<0)  /* User channel select bit 0 mask. */
+#define EVSYS_USER_0_bp  0  /* User channel select bit 0 position. */
+#define EVSYS_USER_1_bm  (1<<1)  /* User channel select bit 1 mask. */
+#define EVSYS_USER_1_bp  1  /* User channel select bit 1 position. */
+#define EVSYS_USER_2_bm  (1<<2)  /* User channel select bit 2 mask. */
+#define EVSYS_USER_2_bp  2  /* User channel select bit 2 position. */
+#define EVSYS_USER_3_bm  (1<<3)  /* User channel select bit 3 mask. */
+#define EVSYS_USER_3_bp  3  /* User channel select bit 3 position. */
+#define EVSYS_USER_4_bm  (1<<4)  /* User channel select bit 4 mask. */
+#define EVSYS_USER_4_bp  4  /* User channel select bit 4 position. */
+#define EVSYS_USER_5_bm  (1<<5)  /* User channel select bit 5 mask. */
+#define EVSYS_USER_5_bp  5  /* User channel select bit 5 position. */
+#define EVSYS_USER_6_bm  (1<<6)  /* User channel select bit 6 mask. */
+#define EVSYS_USER_6_bp  6  /* User channel select bit 6 position. */
+#define EVSYS_USER_7_bm  (1<<7)  /* User channel select bit 7 mask. */
+#define EVSYS_USER_7_bp  7  /* User channel select bit 7 position. */
+
+/* EVSYS.USERCCLLUT0B  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT1A  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT1B  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT2A  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT2B  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT3A  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT3B  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERADC0START  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTB  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTC  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTD  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTE  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTF  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERUSART0IRDA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERUSART1IRDA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERUSART2IRDA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCA0CNTA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCA0CNTB  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCA1CNTA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCA1CNTB  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB0CAPT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB0COUNT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB1CAPT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB1COUNT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB2CAPT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB2COUNT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB3CAPT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB3COUNT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+
+/* FUSE - Fuses */
+/* FUSE.WDTCFG  bit masks and bit positions */
+#define FUSE_PERIOD_gm  0x0F  /* Watchdog Timeout Period group mask. */
+#define FUSE_PERIOD_gp  0  /* Watchdog Timeout Period group position. */
+#define FUSE_PERIOD_0_bm  (1<<0)  /* Watchdog Timeout Period bit 0 mask. */
+#define FUSE_PERIOD_0_bp  0  /* Watchdog Timeout Period bit 0 position. */
+#define FUSE_PERIOD_1_bm  (1<<1)  /* Watchdog Timeout Period bit 1 mask. */
+#define FUSE_PERIOD_1_bp  1  /* Watchdog Timeout Period bit 1 position. */
+#define FUSE_PERIOD_2_bm  (1<<2)  /* Watchdog Timeout Period bit 2 mask. */
+#define FUSE_PERIOD_2_bp  2  /* Watchdog Timeout Period bit 2 position. */
+#define FUSE_PERIOD_3_bm  (1<<3)  /* Watchdog Timeout Period bit 3 mask. */
+#define FUSE_PERIOD_3_bp  3  /* Watchdog Timeout Period bit 3 position. */
+#define FUSE_WINDOW_gm  0xF0  /* Watchdog Window Timeout Period group mask. */
+#define FUSE_WINDOW_gp  4  /* Watchdog Window Timeout Period group position. */
+#define FUSE_WINDOW_0_bm  (1<<4)  /* Watchdog Window Timeout Period bit 0 mask. */
+#define FUSE_WINDOW_0_bp  4  /* Watchdog Window Timeout Period bit 0 position. */
+#define FUSE_WINDOW_1_bm  (1<<5)  /* Watchdog Window Timeout Period bit 1 mask. */
+#define FUSE_WINDOW_1_bp  5  /* Watchdog Window Timeout Period bit 1 position. */
+#define FUSE_WINDOW_2_bm  (1<<6)  /* Watchdog Window Timeout Period bit 2 mask. */
+#define FUSE_WINDOW_2_bp  6  /* Watchdog Window Timeout Period bit 2 position. */
+#define FUSE_WINDOW_3_bm  (1<<7)  /* Watchdog Window Timeout Period bit 3 mask. */
+#define FUSE_WINDOW_3_bp  7  /* Watchdog Window Timeout Period bit 3 position. */
+
+/* FUSE.BODCFG  bit masks and bit positions */
+#define FUSE_SLEEP_gm  0x03  /* BOD Operation in Sleep Mode group mask. */
+#define FUSE_SLEEP_gp  0  /* BOD Operation in Sleep Mode group position. */
+#define FUSE_SLEEP_0_bm  (1<<0)  /* BOD Operation in Sleep Mode bit 0 mask. */
+#define FUSE_SLEEP_0_bp  0  /* BOD Operation in Sleep Mode bit 0 position. */
+#define FUSE_SLEEP_1_bm  (1<<1)  /* BOD Operation in Sleep Mode bit 1 mask. */
+#define FUSE_SLEEP_1_bp  1  /* BOD Operation in Sleep Mode bit 1 position. */
+#define FUSE_ACTIVE_gm  0x0C  /* BOD Operation in Active Mode group mask. */
+#define FUSE_ACTIVE_gp  2  /* BOD Operation in Active Mode group position. */
+#define FUSE_ACTIVE_0_bm  (1<<2)  /* BOD Operation in Active Mode bit 0 mask. */
+#define FUSE_ACTIVE_0_bp  2  /* BOD Operation in Active Mode bit 0 position. */
+#define FUSE_ACTIVE_1_bm  (1<<3)  /* BOD Operation in Active Mode bit 1 mask. */
+#define FUSE_ACTIVE_1_bp  3  /* BOD Operation in Active Mode bit 1 position. */
+#define FUSE_SAMPFREQ_bm  0x10  /* BOD Sample Frequency bit mask. */
+#define FUSE_SAMPFREQ_bp  4  /* BOD Sample Frequency bit position. */
+#define FUSE_LVL_gm  0xE0  /* BOD Level group mask. */
+#define FUSE_LVL_gp  5  /* BOD Level group position. */
+#define FUSE_LVL_0_bm  (1<<5)  /* BOD Level bit 0 mask. */
+#define FUSE_LVL_0_bp  5  /* BOD Level bit 0 position. */
+#define FUSE_LVL_1_bm  (1<<6)  /* BOD Level bit 1 mask. */
+#define FUSE_LVL_1_bp  6  /* BOD Level bit 1 position. */
+#define FUSE_LVL_2_bm  (1<<7)  /* BOD Level bit 2 mask. */
+#define FUSE_LVL_2_bp  7  /* BOD Level bit 2 position. */
+
+/* FUSE.OSCCFG  bit masks and bit positions */
+#define FUSE_OSCHFFRQ_bm  0x08  /* High-frequency Oscillator Frequency bit mask. */
+#define FUSE_OSCHFFRQ_bp  3  /* High-frequency Oscillator Frequency bit position. */
+
+/* FUSE.SYSCFG0  bit masks and bit positions */
+#define FUSE_EESAVE_bm  0x01  /* EEPROM Save bit mask. */
+#define FUSE_EESAVE_bp  0  /* EEPROM Save bit position. */
+#define FUSE_RSTPINCFG_bm  0x08  /* Reset Pin Configuration bit mask. */
+#define FUSE_RSTPINCFG_bp  3  /* Reset Pin Configuration bit position. */
+#define FUSE_UPDIPINCFG_bm  0x10  /* UPDI Pin Configuration bit mask. */
+#define FUSE_UPDIPINCFG_bp  4  /* UPDI Pin Configuration bit position. */
+#define FUSE_CRCSEL_bm  0x20  /* CRC Select bit mask. */
+#define FUSE_CRCSEL_bp  5  /* CRC Select bit position. */
+#define FUSE_CRCSRC_gm  0xC0  /* CRC Source group mask. */
+#define FUSE_CRCSRC_gp  6  /* CRC Source group position. */
+#define FUSE_CRCSRC_0_bm  (1<<6)  /* CRC Source bit 0 mask. */
+#define FUSE_CRCSRC_0_bp  6  /* CRC Source bit 0 position. */
+#define FUSE_CRCSRC_1_bm  (1<<7)  /* CRC Source bit 1 mask. */
+#define FUSE_CRCSRC_1_bp  7  /* CRC Source bit 1 position. */
+
+/* FUSE.SYSCFG1  bit masks and bit positions */
+#define FUSE_SUT_gm  0x07  /* Startup Time group mask. */
+#define FUSE_SUT_gp  0  /* Startup Time group position. */
+#define FUSE_SUT_0_bm  (1<<0)  /* Startup Time bit 0 mask. */
+#define FUSE_SUT_0_bp  0  /* Startup Time bit 0 position. */
+#define FUSE_SUT_1_bm  (1<<1)  /* Startup Time bit 1 mask. */
+#define FUSE_SUT_1_bp  1  /* Startup Time bit 1 position. */
+#define FUSE_SUT_2_bm  (1<<2)  /* Startup Time bit 2 mask. */
+#define FUSE_SUT_2_bp  2  /* Startup Time bit 2 position. */
+
+
+
+/* LOCK - Lockbits */
+/* LOCK.KEY  bit masks and bit positions */
+#define LOCK_KEY_gm  0xFFFFFFFF  /* Lock Key group mask. */
+#define LOCK_KEY_gp  0  /* Lock Key group position. */
+#define LOCK_KEY_0_bm  (1<<0)  /* Lock Key bit 0 mask. */
+#define LOCK_KEY_0_bp  0  /* Lock Key bit 0 position. */
+#define LOCK_KEY_1_bm  (1<<1)  /* Lock Key bit 1 mask. */
+#define LOCK_KEY_1_bp  1  /* Lock Key bit 1 position. */
+#define LOCK_KEY_2_bm  (1<<2)  /* Lock Key bit 2 mask. */
+#define LOCK_KEY_2_bp  2  /* Lock Key bit 2 position. */
+#define LOCK_KEY_3_bm  (1<<3)  /* Lock Key bit 3 mask. */
+#define LOCK_KEY_3_bp  3  /* Lock Key bit 3 position. */
+#define LOCK_KEY_4_bm  (1<<4)  /* Lock Key bit 4 mask. */
+#define LOCK_KEY_4_bp  4  /* Lock Key bit 4 position. */
+#define LOCK_KEY_5_bm  (1<<5)  /* Lock Key bit 5 mask. */
+#define LOCK_KEY_5_bp  5  /* Lock Key bit 5 position. */
+#define LOCK_KEY_6_bm  (1<<6)  /* Lock Key bit 6 mask. */
+#define LOCK_KEY_6_bp  6  /* Lock Key bit 6 position. */
+#define LOCK_KEY_7_bm  (1<<7)  /* Lock Key bit 7 mask. */
+#define LOCK_KEY_7_bp  7  /* Lock Key bit 7 position. */
+#define LOCK_KEY_8_bm  (1<<8)  /* Lock Key bit 8 mask. */
+#define LOCK_KEY_8_bp  8  /* Lock Key bit 8 position. */
+#define LOCK_KEY_9_bm  (1<<9)  /* Lock Key bit 9 mask. */
+#define LOCK_KEY_9_bp  9  /* Lock Key bit 9 position. */
+#define LOCK_KEY_10_bm  (1<<10)  /* Lock Key bit 10 mask. */
+#define LOCK_KEY_10_bp  10  /* Lock Key bit 10 position. */
+#define LOCK_KEY_11_bm  (1<<11)  /* Lock Key bit 11 mask. */
+#define LOCK_KEY_11_bp  11  /* Lock Key bit 11 position. */
+#define LOCK_KEY_12_bm  (1<<12)  /* Lock Key bit 12 mask. */
+#define LOCK_KEY_12_bp  12  /* Lock Key bit 12 position. */
+#define LOCK_KEY_13_bm  (1<<13)  /* Lock Key bit 13 mask. */
+#define LOCK_KEY_13_bp  13  /* Lock Key bit 13 position. */
+#define LOCK_KEY_14_bm  (1<<14)  /* Lock Key bit 14 mask. */
+#define LOCK_KEY_14_bp  14  /* Lock Key bit 14 position. */
+#define LOCK_KEY_15_bm  (1<<15)  /* Lock Key bit 15 mask. */
+#define LOCK_KEY_15_bp  15  /* Lock Key bit 15 position. */
+#define LOCK_KEY_16_bm  (1<<16)  /* Lock Key bit 16 mask. */
+#define LOCK_KEY_16_bp  16  /* Lock Key bit 16 position. */
+#define LOCK_KEY_17_bm  (1<<17)  /* Lock Key bit 17 mask. */
+#define LOCK_KEY_17_bp  17  /* Lock Key bit 17 position. */
+#define LOCK_KEY_18_bm  (1<<18)  /* Lock Key bit 18 mask. */
+#define LOCK_KEY_18_bp  18  /* Lock Key bit 18 position. */
+#define LOCK_KEY_19_bm  (1<<19)  /* Lock Key bit 19 mask. */
+#define LOCK_KEY_19_bp  19  /* Lock Key bit 19 position. */
+#define LOCK_KEY_20_bm  (1<<20)  /* Lock Key bit 20 mask. */
+#define LOCK_KEY_20_bp  20  /* Lock Key bit 20 position. */
+#define LOCK_KEY_21_bm  (1<<21)  /* Lock Key bit 21 mask. */
+#define LOCK_KEY_21_bp  21  /* Lock Key bit 21 position. */
+#define LOCK_KEY_22_bm  (1<<22)  /* Lock Key bit 22 mask. */
+#define LOCK_KEY_22_bp  22  /* Lock Key bit 22 position. */
+#define LOCK_KEY_23_bm  (1<<23)  /* Lock Key bit 23 mask. */
+#define LOCK_KEY_23_bp  23  /* Lock Key bit 23 position. */
+#define LOCK_KEY_24_bm  (1<<24)  /* Lock Key bit 24 mask. */
+#define LOCK_KEY_24_bp  24  /* Lock Key bit 24 position. */
+#define LOCK_KEY_25_bm  (1<<25)  /* Lock Key bit 25 mask. */
+#define LOCK_KEY_25_bp  25  /* Lock Key bit 25 position. */
+#define LOCK_KEY_26_bm  (1<<26)  /* Lock Key bit 26 mask. */
+#define LOCK_KEY_26_bp  26  /* Lock Key bit 26 position. */
+#define LOCK_KEY_27_bm  (1<<27)  /* Lock Key bit 27 mask. */
+#define LOCK_KEY_27_bp  27  /* Lock Key bit 27 position. */
+#define LOCK_KEY_28_bm  (1<<28)  /* Lock Key bit 28 mask. */
+#define LOCK_KEY_28_bp  28  /* Lock Key bit 28 position. */
+#define LOCK_KEY_29_bm  (1<<29)  /* Lock Key bit 29 mask. */
+#define LOCK_KEY_29_bp  29  /* Lock Key bit 29 position. */
+#define LOCK_KEY_30_bm  (1<<30)  /* Lock Key bit 30 mask. */
+#define LOCK_KEY_30_bp  30  /* Lock Key bit 30 position. */
+#define LOCK_KEY_31_bm  (1<<31)  /* Lock Key bit 31 mask. */
+#define LOCK_KEY_31_bp  31  /* Lock Key bit 31 position. */
+
+
+/* NVMCTRL - Non-volatile Memory Controller */
+/* NVMCTRL.CTRLA  bit masks and bit positions */
+#define NVMCTRL_CMD_gm  0x7F  /* Command group mask. */
+#define NVMCTRL_CMD_gp  0  /* Command group position. */
+#define NVMCTRL_CMD_0_bm  (1<<0)  /* Command bit 0 mask. */
+#define NVMCTRL_CMD_0_bp  0  /* Command bit 0 position. */
+#define NVMCTRL_CMD_1_bm  (1<<1)  /* Command bit 1 mask. */
+#define NVMCTRL_CMD_1_bp  1  /* Command bit 1 position. */
+#define NVMCTRL_CMD_2_bm  (1<<2)  /* Command bit 2 mask. */
+#define NVMCTRL_CMD_2_bp  2  /* Command bit 2 position. */
+#define NVMCTRL_CMD_3_bm  (1<<3)  /* Command bit 3 mask. */
+#define NVMCTRL_CMD_3_bp  3  /* Command bit 3 position. */
+#define NVMCTRL_CMD_4_bm  (1<<4)  /* Command bit 4 mask. */
+#define NVMCTRL_CMD_4_bp  4  /* Command bit 4 position. */
+#define NVMCTRL_CMD_5_bm  (1<<5)  /* Command bit 5 mask. */
+#define NVMCTRL_CMD_5_bp  5  /* Command bit 5 position. */
+#define NVMCTRL_CMD_6_bm  (1<<6)  /* Command bit 6 mask. */
+#define NVMCTRL_CMD_6_bp  6  /* Command bit 6 position. */
+
+/* NVMCTRL.CTRLB  bit masks and bit positions */
+#define NVMCTRL_APPCODEWP_bm  0x01  /* Application Code Write Protect bit mask. */
+#define NVMCTRL_APPCODEWP_bp  0  /* Application Code Write Protect bit position. */
+#define NVMCTRL_BOOTRP_bm  0x02  /* Boot Read Protect bit mask. */
+#define NVMCTRL_BOOTRP_bp  1  /* Boot Read Protect bit position. */
+#define NVMCTRL_APPDATAWP_bm  0x04  /* Application Data Write Protect bit mask. */
+#define NVMCTRL_APPDATAWP_bp  2  /* Application Data Write Protect bit position. */
+#define NVMCTRL_EEWP_bm  0x08  /* EEPROM Write Protect bit mask. */
+#define NVMCTRL_EEWP_bp  3  /* EEPROM Write Protect bit position. */
+#define NVMCTRL_FLMAP_gm  0x30  /* Flash Mapping in Data space group mask. */
+#define NVMCTRL_FLMAP_gp  4  /* Flash Mapping in Data space group position. */
+#define NVMCTRL_FLMAP_0_bm  (1<<4)  /* Flash Mapping in Data space bit 0 mask. */
+#define NVMCTRL_FLMAP_0_bp  4  /* Flash Mapping in Data space bit 0 position. */
+#define NVMCTRL_FLMAP_1_bm  (1<<5)  /* Flash Mapping in Data space bit 1 mask. */
+#define NVMCTRL_FLMAP_1_bp  5  /* Flash Mapping in Data space bit 1 position. */
+#define NVMCTRL_FLMAPLOCK_bm  0x80  /* Flash Mapping Lock bit mask. */
+#define NVMCTRL_FLMAPLOCK_bp  7  /* Flash Mapping Lock bit position. */
+
+/* NVMCTRL.INTCTRL  bit masks and bit positions */
+#define NVMCTRL_EEREADY_bm  0x01  /* EEPROM Ready bit mask. */
+#define NVMCTRL_EEREADY_bp  0  /* EEPROM Ready bit position. */
+#define NVMCTRL_FLREADY_bm  0x02  /* Flash Ready bit mask. */
+#define NVMCTRL_FLREADY_bp  1  /* Flash Ready bit position. */
+
+/* NVMCTRL.INTFLAGS  bit masks and bit positions */
+/* NVMCTRL_EEREADY  is already defined. */
+/* NVMCTRL_FLREADY  is already defined. */
+
+/* NVMCTRL.STATUS  bit masks and bit positions */
+#define NVMCTRL_EEBUSY_bm  0x01  /* EEPROM busy bit mask. */
+#define NVMCTRL_EEBUSY_bp  0  /* EEPROM busy bit position. */
+#define NVMCTRL_FLBUSY_bm  0x02  /* Flash busy bit mask. */
+#define NVMCTRL_FLBUSY_bp  1  /* Flash busy bit position. */
+#define NVMCTRL_ERROR_gm  0x70  /* Write error group mask. */
+#define NVMCTRL_ERROR_gp  4  /* Write error group position. */
+#define NVMCTRL_ERROR_0_bm  (1<<4)  /* Write error bit 0 mask. */
+#define NVMCTRL_ERROR_0_bp  4  /* Write error bit 0 position. */
+#define NVMCTRL_ERROR_1_bm  (1<<5)  /* Write error bit 1 mask. */
+#define NVMCTRL_ERROR_1_bp  5  /* Write error bit 1 position. */
+#define NVMCTRL_ERROR_2_bm  (1<<6)  /* Write error bit 2 mask. */
+#define NVMCTRL_ERROR_2_bp  6  /* Write error bit 2 position. */
+
+
+/* PORT - I/O Ports */
+/* PORT.INTFLAGS  bit masks and bit positions */
+#define PORT_INT_gm  0xFF  /* Pin Interrupt Flag group mask. */
+#define PORT_INT_gp  0  /* Pin Interrupt Flag group position. */
+#define PORT_INT_0_bm  (1<<0)  /* Pin Interrupt Flag bit 0 mask. */
+#define PORT_INT_0_bp  0  /* Pin Interrupt Flag bit 0 position. */
+#define PORT_INT0_bm  PORT_INT_0_bm  /* This define is deprecated and should not be used */
+#define PORT_INT0_bp  PORT_INT_0_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_1_bm  (1<<1)  /* Pin Interrupt Flag bit 1 mask. */
+#define PORT_INT_1_bp  1  /* Pin Interrupt Flag bit 1 position. */
+#define PORT_INT1_bm  PORT_INT_1_bm  /* This define is deprecated and should not be used */
+#define PORT_INT1_bp  PORT_INT_1_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_2_bm  (1<<2)  /* Pin Interrupt Flag bit 2 mask. */
+#define PORT_INT_2_bp  2  /* Pin Interrupt Flag bit 2 position. */
+#define PORT_INT2_bm  PORT_INT_2_bm  /* This define is deprecated and should not be used */
+#define PORT_INT2_bp  PORT_INT_2_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_3_bm  (1<<3)  /* Pin Interrupt Flag bit 3 mask. */
+#define PORT_INT_3_bp  3  /* Pin Interrupt Flag bit 3 position. */
+#define PORT_INT3_bm  PORT_INT_3_bm  /* This define is deprecated and should not be used */
+#define PORT_INT3_bp  PORT_INT_3_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_4_bm  (1<<4)  /* Pin Interrupt Flag bit 4 mask. */
+#define PORT_INT_4_bp  4  /* Pin Interrupt Flag bit 4 position. */
+#define PORT_INT4_bm  PORT_INT_4_bm  /* This define is deprecated and should not be used */
+#define PORT_INT4_bp  PORT_INT_4_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_5_bm  (1<<5)  /* Pin Interrupt Flag bit 5 mask. */
+#define PORT_INT_5_bp  5  /* Pin Interrupt Flag bit 5 position. */
+#define PORT_INT5_bm  PORT_INT_5_bm  /* This define is deprecated and should not be used */
+#define PORT_INT5_bp  PORT_INT_5_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_6_bm  (1<<6)  /* Pin Interrupt Flag bit 6 mask. */
+#define PORT_INT_6_bp  6  /* Pin Interrupt Flag bit 6 position. */
+#define PORT_INT6_bm  PORT_INT_6_bm  /* This define is deprecated and should not be used */
+#define PORT_INT6_bp  PORT_INT_6_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_7_bm  (1<<7)  /* Pin Interrupt Flag bit 7 mask. */
+#define PORT_INT_7_bp  7  /* Pin Interrupt Flag bit 7 position. */
+#define PORT_INT7_bm  PORT_INT_7_bm  /* This define is deprecated and should not be used */
+#define PORT_INT7_bp  PORT_INT_7_bp  /* This define is deprecated and should not be used */
+
+/* PORT.PORTCTRL  bit masks and bit positions */
+#define PORT_SRL_bm  0x01  /* Slew Rate Limit Enable bit mask. */
+#define PORT_SRL_bp  0  /* Slew Rate Limit Enable bit position. */
+
+/* PORT.PINCONFIG  bit masks and bit positions */
+#define PORT_ISC_gm  0x07  /* Input/Sense Configuration group mask. */
+#define PORT_ISC_gp  0  /* Input/Sense Configuration group position. */
+#define PORT_ISC_0_bm  (1<<0)  /* Input/Sense Configuration bit 0 mask. */
+#define PORT_ISC_0_bp  0  /* Input/Sense Configuration bit 0 position. */
+#define PORT_ISC_1_bm  (1<<1)  /* Input/Sense Configuration bit 1 mask. */
+#define PORT_ISC_1_bp  1  /* Input/Sense Configuration bit 1 position. */
+#define PORT_ISC_2_bm  (1<<2)  /* Input/Sense Configuration bit 2 mask. */
+#define PORT_ISC_2_bp  2  /* Input/Sense Configuration bit 2 position. */
+#define PORT_PULLUPEN_bm  0x08  /* Pullup enable bit mask. */
+#define PORT_PULLUPEN_bp  3  /* Pullup enable bit position. */
+#define PORT_INLVL_bm  0x40  /* Input Level Select bit mask. */
+#define PORT_INLVL_bp  6  /* Input Level Select bit position. */
+#define PORT_INVEN_bm  0x80  /* Inverted I/O Enable bit mask. */
+#define PORT_INVEN_bp  7  /* Inverted I/O Enable bit position. */
+
+/* PORT.PIN0CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN1CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN2CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN3CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN4CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN5CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN6CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN7CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.EVGENCTRL  bit masks and bit positions */
+#define PORT_EVGEN0SEL_gm  0x07  /* Event Generator 0 Select group mask. */
+#define PORT_EVGEN0SEL_gp  0  /* Event Generator 0 Select group position. */
+#define PORT_EVGEN0SEL_0_bm  (1<<0)  /* Event Generator 0 Select bit 0 mask. */
+#define PORT_EVGEN0SEL_0_bp  0  /* Event Generator 0 Select bit 0 position. */
+#define PORT_EVGEN0SEL_1_bm  (1<<1)  /* Event Generator 0 Select bit 1 mask. */
+#define PORT_EVGEN0SEL_1_bp  1  /* Event Generator 0 Select bit 1 position. */
+#define PORT_EVGEN0SEL_2_bm  (1<<2)  /* Event Generator 0 Select bit 2 mask. */
+#define PORT_EVGEN0SEL_2_bp  2  /* Event Generator 0 Select bit 2 position. */
+#define PORT_EVGEN1SEL_gm  0x70  /* Event Generator 1 Select group mask. */
+#define PORT_EVGEN1SEL_gp  4  /* Event Generator 1 Select group position. */
+#define PORT_EVGEN1SEL_0_bm  (1<<4)  /* Event Generator 1 Select bit 0 mask. */
+#define PORT_EVGEN1SEL_0_bp  4  /* Event Generator 1 Select bit 0 position. */
+#define PORT_EVGEN1SEL_1_bm  (1<<5)  /* Event Generator 1 Select bit 1 mask. */
+#define PORT_EVGEN1SEL_1_bp  5  /* Event Generator 1 Select bit 1 position. */
+#define PORT_EVGEN1SEL_2_bm  (1<<6)  /* Event Generator 1 Select bit 2 mask. */
+#define PORT_EVGEN1SEL_2_bp  6  /* Event Generator 1 Select bit 2 position. */
+
+
+/* PORTMUX - Port Multiplexer */
+/* PORTMUX.EVSYSROUTEA  bit masks and bit positions */
+#define PORTMUX_EVOUTA_bm  0x01  /* Event Output A bit mask. */
+#define PORTMUX_EVOUTA_bp  0  /* Event Output A bit position. */
+#define PORTMUX_EVOUTB_bm  0x02  /* Event Output B bit mask. */
+#define PORTMUX_EVOUTB_bp  1  /* Event Output B bit position. */
+#define PORTMUX_EVOUTC_bm  0x04  /* Event Output C bit mask. */
+#define PORTMUX_EVOUTC_bp  2  /* Event Output C bit position. */
+#define PORTMUX_EVOUTD_bm  0x08  /* Event Output D bit mask. */
+#define PORTMUX_EVOUTD_bp  3  /* Event Output D bit position. */
+#define PORTMUX_EVOUTE_bm  0x10  /* Event Output E bit mask. */
+#define PORTMUX_EVOUTE_bp  4  /* Event Output E bit position. */
+#define PORTMUX_EVOUTF_bm  0x20  /* Event Output F bit mask. */
+#define PORTMUX_EVOUTF_bp  5  /* Event Output F bit position. */
+
+/* PORTMUX.CCLROUTEA  bit masks and bit positions */
+#define PORTMUX_LUT0_bm  0x01  /* CCL Look-Up Table 0 Signals bit mask. */
+#define PORTMUX_LUT0_bp  0  /* CCL Look-Up Table 0 Signals bit position. */
+#define PORTMUX_LUT1_bm  0x02  /* CCL Look-Up Table 1 Signals bit mask. */
+#define PORTMUX_LUT1_bp  1  /* CCL Look-Up Table 1 Signals bit position. */
+#define PORTMUX_LUT2_bm  0x04  /* CCL Look-Up Table 2 Signals bit mask. */
+#define PORTMUX_LUT2_bp  2  /* CCL Look-Up Table 2 Signals bit position. */
+
+/* PORTMUX.USARTROUTEA  bit masks and bit positions */
+#define PORTMUX_USART0_gm  0x07  /* USART0 Routing group mask. */
+#define PORTMUX_USART0_gp  0  /* USART0 Routing group position. */
+#define PORTMUX_USART0_0_bm  (1<<0)  /* USART0 Routing bit 0 mask. */
+#define PORTMUX_USART0_0_bp  0  /* USART0 Routing bit 0 position. */
+#define PORTMUX_USART0_1_bm  (1<<1)  /* USART0 Routing bit 1 mask. */
+#define PORTMUX_USART0_1_bp  1  /* USART0 Routing bit 1 position. */
+#define PORTMUX_USART0_2_bm  (1<<2)  /* USART0 Routing bit 2 mask. */
+#define PORTMUX_USART0_2_bp  2  /* USART0 Routing bit 2 position. */
+#define PORTMUX_USART1_gm  0x18  /* USART1 Routing group mask. */
+#define PORTMUX_USART1_gp  3  /* USART1 Routing group position. */
+#define PORTMUX_USART1_0_bm  (1<<3)  /* USART1 Routing bit 0 mask. */
+#define PORTMUX_USART1_0_bp  3  /* USART1 Routing bit 0 position. */
+#define PORTMUX_USART1_1_bm  (1<<4)  /* USART1 Routing bit 1 mask. */
+#define PORTMUX_USART1_1_bp  4  /* USART1 Routing bit 1 position. */
+
+/* PORTMUX.USARTROUTEB  bit masks and bit positions */
+#define PORTMUX_USART2_gm  0x03  /* USART2 Routing group mask. */
+#define PORTMUX_USART2_gp  0  /* USART2 Routing group position. */
+#define PORTMUX_USART2_0_bm  (1<<0)  /* USART2 Routing bit 0 mask. */
+#define PORTMUX_USART2_0_bp  0  /* USART2 Routing bit 0 position. */
+#define PORTMUX_USART2_1_bm  (1<<1)  /* USART2 Routing bit 1 mask. */
+#define PORTMUX_USART2_1_bp  1  /* USART2 Routing bit 1 position. */
+
+/* PORTMUX.SPIROUTEA  bit masks and bit positions */
+#define PORTMUX_SPI0_gm  0x07  /* SPI0 Signals group mask. */
+#define PORTMUX_SPI0_gp  0  /* SPI0 Signals group position. */
+#define PORTMUX_SPI0_0_bm  (1<<0)  /* SPI0 Signals bit 0 mask. */
+#define PORTMUX_SPI0_0_bp  0  /* SPI0 Signals bit 0 position. */
+#define PORTMUX_SPI0_1_bm  (1<<1)  /* SPI0 Signals bit 1 mask. */
+#define PORTMUX_SPI0_1_bp  1  /* SPI0 Signals bit 1 position. */
+#define PORTMUX_SPI0_2_bm  (1<<2)  /* SPI0 Signals bit 2 mask. */
+#define PORTMUX_SPI0_2_bp  2  /* SPI0 Signals bit 2 position. */
+
+/* PORTMUX.TWIROUTEA  bit masks and bit positions */
+#define PORTMUX_TWI0_gm  0x03  /* TWI0 Signals group mask. */
+#define PORTMUX_TWI0_gp  0  /* TWI0 Signals group position. */
+#define PORTMUX_TWI0_0_bm  (1<<0)  /* TWI0 Signals bit 0 mask. */
+#define PORTMUX_TWI0_0_bp  0  /* TWI0 Signals bit 0 position. */
+#define PORTMUX_TWI0_1_bm  (1<<1)  /* TWI0 Signals bit 1 mask. */
+#define PORTMUX_TWI0_1_bp  1  /* TWI0 Signals bit 1 position. */
+
+/* PORTMUX.TCAROUTEA  bit masks and bit positions */
+#define PORTMUX_TCA0_gm  0x07  /* TCA0 Signals group mask. */
+#define PORTMUX_TCA0_gp  0  /* TCA0 Signals group position. */
+#define PORTMUX_TCA0_0_bm  (1<<0)  /* TCA0 Signals bit 0 mask. */
+#define PORTMUX_TCA0_0_bp  0  /* TCA0 Signals bit 0 position. */
+#define PORTMUX_TCA0_1_bm  (1<<1)  /* TCA0 Signals bit 1 mask. */
+#define PORTMUX_TCA0_1_bp  1  /* TCA0 Signals bit 1 position. */
+#define PORTMUX_TCA0_2_bm  (1<<2)  /* TCA0 Signals bit 2 mask. */
+#define PORTMUX_TCA0_2_bp  2  /* TCA0 Signals bit 2 position. */
+#define PORTMUX_TCA1_gm  0x38  /* TCA1 Signals group mask. */
+#define PORTMUX_TCA1_gp  3  /* TCA1 Signals group position. */
+#define PORTMUX_TCA1_0_bm  (1<<3)  /* TCA1 Signals bit 0 mask. */
+#define PORTMUX_TCA1_0_bp  3  /* TCA1 Signals bit 0 position. */
+#define PORTMUX_TCA1_1_bm  (1<<4)  /* TCA1 Signals bit 1 mask. */
+#define PORTMUX_TCA1_1_bp  4  /* TCA1 Signals bit 1 position. */
+#define PORTMUX_TCA1_2_bm  (1<<5)  /* TCA1 Signals bit 2 mask. */
+#define PORTMUX_TCA1_2_bp  5  /* TCA1 Signals bit 2 position. */
+
+/* PORTMUX.TCBROUTEA  bit masks and bit positions */
+#define PORTMUX_TCB0_bm  0x01  /* TCB0 Output bit mask. */
+#define PORTMUX_TCB0_bp  0  /* TCB0 Output bit position. */
+#define PORTMUX_TCB1_bm  0x02  /* TCB1 Output bit mask. */
+#define PORTMUX_TCB1_bp  1  /* TCB1 Output bit position. */
+#define PORTMUX_TCB2_bm  0x04  /* TCB2 Output bit mask. */
+#define PORTMUX_TCB2_bp  2  /* TCB2 Output bit position. */
+#define PORTMUX_TCB3_bm  0x08  /* TCB3 Output bit mask. */
+#define PORTMUX_TCB3_bp  3  /* TCB3 Output bit position. */
+
+/* PORTMUX.ACROUTEA  bit masks and bit positions */
+#define PORTMUX_AC0_bm  0x01  /* Analog Comparator 0 Output bit mask. */
+#define PORTMUX_AC0_bp  0  /* Analog Comparator 0 Output bit position. */
+#define PORTMUX_AC1_bm  0x02  /* Analog Comparator 1 Output bit mask. */
+#define PORTMUX_AC1_bp  1  /* Analog Comparator 1 Output bit position. */
+
+
+/* RSTCTRL - Reset controller */
+/* RSTCTRL.RSTFR  bit masks and bit positions */
+#define RSTCTRL_PORF_bm  0x01  /* Power on Reset flag bit mask. */
+#define RSTCTRL_PORF_bp  0  /* Power on Reset flag bit position. */
+#define RSTCTRL_BORF_bm  0x02  /* Brown out detector Reset flag bit mask. */
+#define RSTCTRL_BORF_bp  1  /* Brown out detector Reset flag bit position. */
+#define RSTCTRL_EXTRF_bm  0x04  /* External Reset flag bit mask. */
+#define RSTCTRL_EXTRF_bp  2  /* External Reset flag bit position. */
+#define RSTCTRL_WDRF_bm  0x08  /* Watch dog Reset flag bit mask. */
+#define RSTCTRL_WDRF_bp  3  /* Watch dog Reset flag bit position. */
+#define RSTCTRL_SWRF_bm  0x10  /* Software Reset flag bit mask. */
+#define RSTCTRL_SWRF_bp  4  /* Software Reset flag bit position. */
+#define RSTCTRL_UPDIRF_bm  0x20  /* UPDI Reset flag bit mask. */
+#define RSTCTRL_UPDIRF_bp  5  /* UPDI Reset flag bit position. */
+
+/* RSTCTRL.SWRR  bit masks and bit positions */
+#define RSTCTRL_SWRE_bm  0x01  /* Software Reset Enable bit mask. */
+#define RSTCTRL_SWRE_bp  0  /* Software Reset Enable bit position. */
+
+
+/* RTC - Real-Time Counter */
+/* RTC.CTRLA  bit masks and bit positions */
+#define RTC_RTCEN_bm  0x01  /* Enable bit mask. */
+#define RTC_RTCEN_bp  0  /* Enable bit position. */
+#define RTC_CORREN_bm  0x04  /* Correction enable bit mask. */
+#define RTC_CORREN_bp  2  /* Correction enable bit position. */
+#define RTC_PRESCALER_gm  0x78  /* Prescaling Factor group mask. */
+#define RTC_PRESCALER_gp  3  /* Prescaling Factor group position. */
+#define RTC_PRESCALER_0_bm  (1<<3)  /* Prescaling Factor bit 0 mask. */
+#define RTC_PRESCALER_0_bp  3  /* Prescaling Factor bit 0 position. */
+#define RTC_PRESCALER_1_bm  (1<<4)  /* Prescaling Factor bit 1 mask. */
+#define RTC_PRESCALER_1_bp  4  /* Prescaling Factor bit 1 position. */
+#define RTC_PRESCALER_2_bm  (1<<5)  /* Prescaling Factor bit 2 mask. */
+#define RTC_PRESCALER_2_bp  5  /* Prescaling Factor bit 2 position. */
+#define RTC_PRESCALER_3_bm  (1<<6)  /* Prescaling Factor bit 3 mask. */
+#define RTC_PRESCALER_3_bp  6  /* Prescaling Factor bit 3 position. */
+#define RTC_RUNSTDBY_bm  0x80  /* Run In Standby bit mask. */
+#define RTC_RUNSTDBY_bp  7  /* Run In Standby bit position. */
+
+/* RTC.STATUS  bit masks and bit positions */
+#define RTC_CTRLABUSY_bm  0x01  /* CTRLA Synchronization Busy Flag bit mask. */
+#define RTC_CTRLABUSY_bp  0  /* CTRLA Synchronization Busy Flag bit position. */
+#define RTC_CNTBUSY_bm  0x02  /* Count Synchronization Busy Flag bit mask. */
+#define RTC_CNTBUSY_bp  1  /* Count Synchronization Busy Flag bit position. */
+#define RTC_PERBUSY_bm  0x04  /* Period Synchronization Busy Flag bit mask. */
+#define RTC_PERBUSY_bp  2  /* Period Synchronization Busy Flag bit position. */
+#define RTC_CMPBUSY_bm  0x08  /* Comparator Synchronization Busy Flag bit mask. */
+#define RTC_CMPBUSY_bp  3  /* Comparator Synchronization Busy Flag bit position. */
+
+/* RTC.INTCTRL  bit masks and bit positions */
+#define RTC_OVF_bm  0x01  /* Overflow Interrupt enable bit mask. */
+#define RTC_OVF_bp  0  /* Overflow Interrupt enable bit position. */
+#define RTC_CMP_bm  0x02  /* Compare Match Interrupt enable bit mask. */
+#define RTC_CMP_bp  1  /* Compare Match Interrupt enable bit position. */
+
+/* RTC.INTFLAGS  bit masks and bit positions */
+/* RTC_OVF  is already defined. */
+/* RTC_CMP  is already defined. */
+
+/* RTC.DBGCTRL  bit masks and bit positions */
+#define RTC_DBGRUN_bm  0x01  /* Run in debug bit mask. */
+#define RTC_DBGRUN_bp  0  /* Run in debug bit position. */
+
+/* RTC.CALIB  bit masks and bit positions */
+#define RTC_ERROR_gm  0x7F  /* Error Correction Value group mask. */
+#define RTC_ERROR_gp  0  /* Error Correction Value group position. */
+#define RTC_ERROR_0_bm  (1<<0)  /* Error Correction Value bit 0 mask. */
+#define RTC_ERROR_0_bp  0  /* Error Correction Value bit 0 position. */
+#define RTC_ERROR_1_bm  (1<<1)  /* Error Correction Value bit 1 mask. */
+#define RTC_ERROR_1_bp  1  /* Error Correction Value bit 1 position. */
+#define RTC_ERROR_2_bm  (1<<2)  /* Error Correction Value bit 2 mask. */
+#define RTC_ERROR_2_bp  2  /* Error Correction Value bit 2 position. */
+#define RTC_ERROR_3_bm  (1<<3)  /* Error Correction Value bit 3 mask. */
+#define RTC_ERROR_3_bp  3  /* Error Correction Value bit 3 position. */
+#define RTC_ERROR_4_bm  (1<<4)  /* Error Correction Value bit 4 mask. */
+#define RTC_ERROR_4_bp  4  /* Error Correction Value bit 4 position. */
+#define RTC_ERROR_5_bm  (1<<5)  /* Error Correction Value bit 5 mask. */
+#define RTC_ERROR_5_bp  5  /* Error Correction Value bit 5 position. */
+#define RTC_ERROR_6_bm  (1<<6)  /* Error Correction Value bit 6 mask. */
+#define RTC_ERROR_6_bp  6  /* Error Correction Value bit 6 position. */
+#define RTC_SIGN_bm  0x80  /* Error Correction Sign Bit bit mask. */
+#define RTC_SIGN_bp  7  /* Error Correction Sign Bit bit position. */
+
+/* RTC.CLKSEL  bit masks and bit positions */
+#define RTC_CLKSEL_gm  0x03  /* Clock Select group mask. */
+#define RTC_CLKSEL_gp  0  /* Clock Select group position. */
+#define RTC_CLKSEL_0_bm  (1<<0)  /* Clock Select bit 0 mask. */
+#define RTC_CLKSEL_0_bp  0  /* Clock Select bit 0 position. */
+#define RTC_CLKSEL_1_bm  (1<<1)  /* Clock Select bit 1 mask. */
+#define RTC_CLKSEL_1_bp  1  /* Clock Select bit 1 position. */
+
+/* RTC.PITCTRLA  bit masks and bit positions */
+#define RTC_PITEN_bm  0x01  /* Enable bit mask. */
+#define RTC_PITEN_bp  0  /* Enable bit position. */
+#define RTC_PERIOD_gm  0x78  /* Period group mask. */
+#define RTC_PERIOD_gp  3  /* Period group position. */
+#define RTC_PERIOD_0_bm  (1<<3)  /* Period bit 0 mask. */
+#define RTC_PERIOD_0_bp  3  /* Period bit 0 position. */
+#define RTC_PERIOD_1_bm  (1<<4)  /* Period bit 1 mask. */
+#define RTC_PERIOD_1_bp  4  /* Period bit 1 position. */
+#define RTC_PERIOD_2_bm  (1<<5)  /* Period bit 2 mask. */
+#define RTC_PERIOD_2_bp  5  /* Period bit 2 position. */
+#define RTC_PERIOD_3_bm  (1<<6)  /* Period bit 3 mask. */
+#define RTC_PERIOD_3_bp  6  /* Period bit 3 position. */
+
+/* RTC.PITSTATUS  bit masks and bit positions */
+#define RTC_CTRLBUSY_bm  0x01  /* CTRLA Synchronization Busy Flag bit mask. */
+#define RTC_CTRLBUSY_bp  0  /* CTRLA Synchronization Busy Flag bit position. */
+
+/* RTC.PITINTCTRL  bit masks and bit positions */
+#define RTC_PI_bm  0x01  /* Periodic Interrupt bit mask. */
+#define RTC_PI_bp  0  /* Periodic Interrupt bit position. */
+
+/* RTC.PITINTFLAGS  bit masks and bit positions */
+/* RTC_PI  is already defined. */
+
+/* RTC.PITDBGCTRL  bit masks and bit positions */
+/* RTC_DBGRUN  is already defined. */
+
+/* RTC.PITEVGENCTRLA  bit masks and bit positions */
+#define RTC_EVGEN0SEL_gm  0x0F  /* Event Generation 0 Select group mask. */
+#define RTC_EVGEN0SEL_gp  0  /* Event Generation 0 Select group position. */
+#define RTC_EVGEN0SEL_0_bm  (1<<0)  /* Event Generation 0 Select bit 0 mask. */
+#define RTC_EVGEN0SEL_0_bp  0  /* Event Generation 0 Select bit 0 position. */
+#define RTC_EVGEN0SEL_1_bm  (1<<1)  /* Event Generation 0 Select bit 1 mask. */
+#define RTC_EVGEN0SEL_1_bp  1  /* Event Generation 0 Select bit 1 position. */
+#define RTC_EVGEN0SEL_2_bm  (1<<2)  /* Event Generation 0 Select bit 2 mask. */
+#define RTC_EVGEN0SEL_2_bp  2  /* Event Generation 0 Select bit 2 position. */
+#define RTC_EVGEN0SEL_3_bm  (1<<3)  /* Event Generation 0 Select bit 3 mask. */
+#define RTC_EVGEN0SEL_3_bp  3  /* Event Generation 0 Select bit 3 position. */
+#define RTC_EVGEN1SEL_gm  0xF0  /* Event Generation 1 Select group mask. */
+#define RTC_EVGEN1SEL_gp  4  /* Event Generation 1 Select group position. */
+#define RTC_EVGEN1SEL_0_bm  (1<<4)  /* Event Generation 1 Select bit 0 mask. */
+#define RTC_EVGEN1SEL_0_bp  4  /* Event Generation 1 Select bit 0 position. */
+#define RTC_EVGEN1SEL_1_bm  (1<<5)  /* Event Generation 1 Select bit 1 mask. */
+#define RTC_EVGEN1SEL_1_bp  5  /* Event Generation 1 Select bit 1 position. */
+#define RTC_EVGEN1SEL_2_bm  (1<<6)  /* Event Generation 1 Select bit 2 mask. */
+#define RTC_EVGEN1SEL_2_bp  6  /* Event Generation 1 Select bit 2 position. */
+#define RTC_EVGEN1SEL_3_bm  (1<<7)  /* Event Generation 1 Select bit 3 mask. */
+#define RTC_EVGEN1SEL_3_bp  7  /* Event Generation 1 Select bit 3 position. */
+
+
+
+/* SLPCTRL - Sleep Controller */
+/* SLPCTRL.CTRLA  bit masks and bit positions */
+#define SLPCTRL_SEN_bm  0x01  /* Sleep enable bit mask. */
+#define SLPCTRL_SEN_bp  0  /* Sleep enable bit position. */
+#define SLPCTRL_SMODE_gm  0x06  /* Sleep mode group mask. */
+#define SLPCTRL_SMODE_gp  1  /* Sleep mode group position. */
+#define SLPCTRL_SMODE_0_bm  (1<<1)  /* Sleep mode bit 0 mask. */
+#define SLPCTRL_SMODE_0_bp  1  /* Sleep mode bit 0 position. */
+#define SLPCTRL_SMODE_1_bm  (1<<2)  /* Sleep mode bit 1 mask. */
+#define SLPCTRL_SMODE_1_bp  2  /* Sleep mode bit 1 position. */
+
+
+/* SPI - Serial Peripheral Interface */
+/* SPI.CTRLA  bit masks and bit positions */
+#define SPI_ENABLE_bm  0x01  /* Enable Module bit mask. */
+#define SPI_ENABLE_bp  0  /* Enable Module bit position. */
+#define SPI_PRESC_gm  0x06  /* Prescaler group mask. */
+#define SPI_PRESC_gp  1  /* Prescaler group position. */
+#define SPI_PRESC_0_bm  (1<<1)  /* Prescaler bit 0 mask. */
+#define SPI_PRESC_0_bp  1  /* Prescaler bit 0 position. */
+#define SPI_PRESC_1_bm  (1<<2)  /* Prescaler bit 1 mask. */
+#define SPI_PRESC_1_bp  2  /* Prescaler bit 1 position. */
+#define SPI_CLK2X_bm  0x10  /* Enable Double Speed bit mask. */
+#define SPI_CLK2X_bp  4  /* Enable Double Speed bit position. */
+#define SPI_MASTER_bm  0x20  /* Host Operation Enable bit mask. */
+#define SPI_MASTER_bp  5  /* Host Operation Enable bit position. */
+#define SPI_DORD_bm  0x40  /* Data Order Setting bit mask. */
+#define SPI_DORD_bp  6  /* Data Order Setting bit position. */
+
+/* SPI.CTRLB  bit masks and bit positions */
+#define SPI_MODE_gm  0x03  /* SPI Mode group mask. */
+#define SPI_MODE_gp  0  /* SPI Mode group position. */
+#define SPI_MODE_0_bm  (1<<0)  /* SPI Mode bit 0 mask. */
+#define SPI_MODE_0_bp  0  /* SPI Mode bit 0 position. */
+#define SPI_MODE_1_bm  (1<<1)  /* SPI Mode bit 1 mask. */
+#define SPI_MODE_1_bp  1  /* SPI Mode bit 1 position. */
+#define SPI_SSD_bm  0x04  /* SPI Select Disable bit mask. */
+#define SPI_SSD_bp  2  /* SPI Select Disable bit position. */
+#define SPI_BUFWR_bm  0x40  /* Buffer Mode Wait for Receive bit mask. */
+#define SPI_BUFWR_bp  6  /* Buffer Mode Wait for Receive bit position. */
+#define SPI_BUFEN_bm  0x80  /* Buffer Mode Enable bit mask. */
+#define SPI_BUFEN_bp  7  /* Buffer Mode Enable bit position. */
+
+/* SPI.INTCTRL  bit masks and bit positions */
+#define SPI_IE_bm  0x01  /* Interrupt Enable bit mask. */
+#define SPI_IE_bp  0  /* Interrupt Enable bit position. */
+#define SPI_SSIE_bm  0x10  /* SPI Select Trigger Interrupt Enable bit mask. */
+#define SPI_SSIE_bp  4  /* SPI Select Trigger Interrupt Enable bit position. */
+#define SPI_DREIE_bm  0x20  /* Data Register Empty Interrupt Enable bit mask. */
+#define SPI_DREIE_bp  5  /* Data Register Empty Interrupt Enable bit position. */
+#define SPI_TXCIE_bm  0x40  /* Transfer Complete Interrupt Enable bit mask. */
+#define SPI_TXCIE_bp  6  /* Transfer Complete Interrupt Enable bit position. */
+#define SPI_RXCIE_bm  0x80  /* Receive Complete Interrupt Enable bit mask. */
+#define SPI_RXCIE_bp  7  /* Receive Complete Interrupt Enable bit position. */
+
+/* SPI.INTFLAGS  bit masks and bit positions */
+#define SPI_BUFOVF_bm  0x01  /* Buffer Overflow bit mask. */
+#define SPI_BUFOVF_bp  0  /* Buffer Overflow bit position. */
+#define SPI_SSIF_bm  0x10  /* SPI Select Trigger Interrupt Flag bit mask. */
+#define SPI_SSIF_bp  4  /* SPI Select Trigger Interrupt Flag bit position. */
+#define SPI_DREIF_bm  0x20  /* Data Register Empty Interrupt Flag bit mask. */
+#define SPI_DREIF_bp  5  /* Data Register Empty Interrupt Flag bit position. */
+#define SPI_TXCIF_bm  0x40  /* Transfer Complete Interrupt Flag bit mask. */
+#define SPI_TXCIF_bp  6  /* Transfer Complete Interrupt Flag bit position. */
+#define SPI_WRCOL_bm  0x40  /* Write Collision bit mask. */
+#define SPI_WRCOL_bp  6  /* Write Collision bit position. */
+#define SPI_RXCIF_bm  0x80  /* Receive Complete Interrupt Flag bit mask. */
+#define SPI_RXCIF_bp  7  /* Receive Complete Interrupt Flag bit position. */
+#define SPI_IF_bm  0x80  /* Interrupt Flag bit mask. */
+#define SPI_IF_bp  7  /* Interrupt Flag bit position. */
+
+
+/* SYSCFG - System Configuration Registers */
+/* SYSCFG.REVID  bit masks and bit positions */
+#define SYSCFG_MINOR_gm  0x0F  /* Minor Revision group mask. */
+#define SYSCFG_MINOR_gp  0  /* Minor Revision group position. */
+#define SYSCFG_MINOR_0_bm  (1<<0)  /* Minor Revision bit 0 mask. */
+#define SYSCFG_MINOR_0_bp  0  /* Minor Revision bit 0 position. */
+#define SYSCFG_MINOR_1_bm  (1<<1)  /* Minor Revision bit 1 mask. */
+#define SYSCFG_MINOR_1_bp  1  /* Minor Revision bit 1 position. */
+#define SYSCFG_MINOR_2_bm  (1<<2)  /* Minor Revision bit 2 mask. */
+#define SYSCFG_MINOR_2_bp  2  /* Minor Revision bit 2 position. */
+#define SYSCFG_MINOR_3_bm  (1<<3)  /* Minor Revision bit 3 mask. */
+#define SYSCFG_MINOR_3_bp  3  /* Minor Revision bit 3 position. */
+#define SYSCFG_MAJOR_gm  0xF0  /* Major Revision group mask. */
+#define SYSCFG_MAJOR_gp  4  /* Major Revision group position. */
+#define SYSCFG_MAJOR_0_bm  (1<<4)  /* Major Revision bit 0 mask. */
+#define SYSCFG_MAJOR_0_bp  4  /* Major Revision bit 0 position. */
+#define SYSCFG_MAJOR_1_bm  (1<<5)  /* Major Revision bit 1 mask. */
+#define SYSCFG_MAJOR_1_bp  5  /* Major Revision bit 1 position. */
+#define SYSCFG_MAJOR_2_bm  (1<<6)  /* Major Revision bit 2 mask. */
+#define SYSCFG_MAJOR_2_bp  6  /* Major Revision bit 2 position. */
+#define SYSCFG_MAJOR_3_bm  (1<<7)  /* Major Revision bit 3 mask. */
+#define SYSCFG_MAJOR_3_bp  7  /* Major Revision bit 3 position. */
+
+/* SYSCFG.OCDMCTRL  bit masks and bit positions */
+#define SYSCFG_OCDM_gm  0xFF  /* OCD Message group mask. */
+#define SYSCFG_OCDM_gp  0  /* OCD Message group position. */
+#define SYSCFG_OCDM_0_bm  (1<<0)  /* OCD Message bit 0 mask. */
+#define SYSCFG_OCDM_0_bp  0  /* OCD Message bit 0 position. */
+#define SYSCFG_OCDM_1_bm  (1<<1)  /* OCD Message bit 1 mask. */
+#define SYSCFG_OCDM_1_bp  1  /* OCD Message bit 1 position. */
+#define SYSCFG_OCDM_2_bm  (1<<2)  /* OCD Message bit 2 mask. */
+#define SYSCFG_OCDM_2_bp  2  /* OCD Message bit 2 position. */
+#define SYSCFG_OCDM_3_bm  (1<<3)  /* OCD Message bit 3 mask. */
+#define SYSCFG_OCDM_3_bp  3  /* OCD Message bit 3 position. */
+#define SYSCFG_OCDM_4_bm  (1<<4)  /* OCD Message bit 4 mask. */
+#define SYSCFG_OCDM_4_bp  4  /* OCD Message bit 4 position. */
+#define SYSCFG_OCDM_5_bm  (1<<5)  /* OCD Message bit 5 mask. */
+#define SYSCFG_OCDM_5_bp  5  /* OCD Message bit 5 position. */
+#define SYSCFG_OCDM_6_bm  (1<<6)  /* OCD Message bit 6 mask. */
+#define SYSCFG_OCDM_6_bp  6  /* OCD Message bit 6 position. */
+#define SYSCFG_OCDM_7_bm  (1<<7)  /* OCD Message bit 7 mask. */
+#define SYSCFG_OCDM_7_bp  7  /* OCD Message bit 7 position. */
+
+/* SYSCFG.OCDMSTATUS  bit masks and bit positions */
+#define SYSCFG_VALID_bm  0x01  /* OCD Message Valid bit mask. */
+#define SYSCFG_VALID_bp  0  /* OCD Message Valid bit position. */
+
+
+/* TCA - 16-bit Timer/Counter Type A */
+/* TCA_SINGLE.CTRLA  bit masks and bit positions */
+#define TCA_SINGLE_ENABLE_bm  0x01  /* Module Enable bit mask. */
+#define TCA_SINGLE_ENABLE_bp  0  /* Module Enable bit position. */
+#define TCA_SINGLE_CLKSEL_gm  0x0E  /* Clock Selection group mask. */
+#define TCA_SINGLE_CLKSEL_gp  1  /* Clock Selection group position. */
+#define TCA_SINGLE_CLKSEL_0_bm  (1<<1)  /* Clock Selection bit 0 mask. */
+#define TCA_SINGLE_CLKSEL_0_bp  1  /* Clock Selection bit 0 position. */
+#define TCA_SINGLE_CLKSEL_1_bm  (1<<2)  /* Clock Selection bit 1 mask. */
+#define TCA_SINGLE_CLKSEL_1_bp  2  /* Clock Selection bit 1 position. */
+#define TCA_SINGLE_CLKSEL_2_bm  (1<<3)  /* Clock Selection bit 2 mask. */
+#define TCA_SINGLE_CLKSEL_2_bp  3  /* Clock Selection bit 2 position. */
+#define TCA_SINGLE_RUNSTDBY_bm  0x80  /* Run in Standby bit mask. */
+#define TCA_SINGLE_RUNSTDBY_bp  7  /* Run in Standby bit position. */
+
+/* TCA_SINGLE.CTRLB  bit masks and bit positions */
+#define TCA_SINGLE_WGMODE_gm  0x07  /* Waveform generation mode group mask. */
+#define TCA_SINGLE_WGMODE_gp  0  /* Waveform generation mode group position. */
+#define TCA_SINGLE_WGMODE_0_bm  (1<<0)  /* Waveform generation mode bit 0 mask. */
+#define TCA_SINGLE_WGMODE_0_bp  0  /* Waveform generation mode bit 0 position. */
+#define TCA_SINGLE_WGMODE_1_bm  (1<<1)  /* Waveform generation mode bit 1 mask. */
+#define TCA_SINGLE_WGMODE_1_bp  1  /* Waveform generation mode bit 1 position. */
+#define TCA_SINGLE_WGMODE_2_bm  (1<<2)  /* Waveform generation mode bit 2 mask. */
+#define TCA_SINGLE_WGMODE_2_bp  2  /* Waveform generation mode bit 2 position. */
+#define TCA_SINGLE_ALUPD_bm  0x08  /* Auto Lock Update bit mask. */
+#define TCA_SINGLE_ALUPD_bp  3  /* Auto Lock Update bit position. */
+#define TCA_SINGLE_CMP0EN_bm  0x10  /* Compare 0 Enable bit mask. */
+#define TCA_SINGLE_CMP0EN_bp  4  /* Compare 0 Enable bit position. */
+#define TCA_SINGLE_CMP1EN_bm  0x20  /* Compare 1 Enable bit mask. */
+#define TCA_SINGLE_CMP1EN_bp  5  /* Compare 1 Enable bit position. */
+#define TCA_SINGLE_CMP2EN_bm  0x40  /* Compare 2 Enable bit mask. */
+#define TCA_SINGLE_CMP2EN_bp  6  /* Compare 2 Enable bit position. */
+
+/* TCA_SINGLE.CTRLC  bit masks and bit positions */
+#define TCA_SINGLE_CMP0OV_bm  0x01  /* Compare 0 Waveform Output Value bit mask. */
+#define TCA_SINGLE_CMP0OV_bp  0  /* Compare 0 Waveform Output Value bit position. */
+#define TCA_SINGLE_CMP1OV_bm  0x02  /* Compare 1 Waveform Output Value bit mask. */
+#define TCA_SINGLE_CMP1OV_bp  1  /* Compare 1 Waveform Output Value bit position. */
+#define TCA_SINGLE_CMP2OV_bm  0x04  /* Compare 2 Waveform Output Value bit mask. */
+#define TCA_SINGLE_CMP2OV_bp  2  /* Compare 2 Waveform Output Value bit position. */
+
+/* TCA_SINGLE.CTRLD  bit masks and bit positions */
+#define TCA_SINGLE_SPLITM_bm  0x01  /* Split Mode Enable bit mask. */
+#define TCA_SINGLE_SPLITM_bp  0  /* Split Mode Enable bit position. */
+
+/* TCA_SINGLE.CTRLECLR  bit masks and bit positions */
+#define TCA_SINGLE_DIR_bm  0x01  /* Direction bit mask. */
+#define TCA_SINGLE_DIR_bp  0  /* Direction bit position. */
+#define TCA_SINGLE_LUPD_bm  0x02  /* Lock Update bit mask. */
+#define TCA_SINGLE_LUPD_bp  1  /* Lock Update bit position. */
+#define TCA_SINGLE_CMD_gm  0x0C  /* Command group mask. */
+#define TCA_SINGLE_CMD_gp  2  /* Command group position. */
+#define TCA_SINGLE_CMD_0_bm  (1<<2)  /* Command bit 0 mask. */
+#define TCA_SINGLE_CMD_0_bp  2  /* Command bit 0 position. */
+#define TCA_SINGLE_CMD_1_bm  (1<<3)  /* Command bit 1 mask. */
+#define TCA_SINGLE_CMD_1_bp  3  /* Command bit 1 position. */
+
+/* TCA_SINGLE.CTRLESET  bit masks and bit positions */
+/* TCA_SINGLE_DIR  is already defined. */
+/* TCA_SINGLE_LUPD  is already defined. */
+/* TCA_SINGLE_CMD  is already defined. */
+
+/* TCA_SINGLE.CTRLFCLR  bit masks and bit positions */
+#define TCA_SINGLE_PERBV_bm  0x01  /* Period Buffer Valid bit mask. */
+#define TCA_SINGLE_PERBV_bp  0  /* Period Buffer Valid bit position. */
+#define TCA_SINGLE_CMP0BV_bm  0x02  /* Compare 0 Buffer Valid bit mask. */
+#define TCA_SINGLE_CMP0BV_bp  1  /* Compare 0 Buffer Valid bit position. */
+#define TCA_SINGLE_CMP1BV_bm  0x04  /* Compare 1 Buffer Valid bit mask. */
+#define TCA_SINGLE_CMP1BV_bp  2  /* Compare 1 Buffer Valid bit position. */
+#define TCA_SINGLE_CMP2BV_bm  0x08  /* Compare 2 Buffer Valid bit mask. */
+#define TCA_SINGLE_CMP2BV_bp  3  /* Compare 2 Buffer Valid bit position. */
+
+/* TCA_SINGLE.CTRLFSET  bit masks and bit positions */
+/* TCA_SINGLE_PERBV  is already defined. */
+/* TCA_SINGLE_CMP0BV  is already defined. */
+/* TCA_SINGLE_CMP1BV  is already defined. */
+/* TCA_SINGLE_CMP2BV  is already defined. */
+
+/* TCA_SINGLE.EVCTRL  bit masks and bit positions */
+#define TCA_SINGLE_CNTAEI_bm  0x01  /* Count on Event Input A bit mask. */
+#define TCA_SINGLE_CNTAEI_bp  0  /* Count on Event Input A bit position. */
+#define TCA_SINGLE_EVACTA_gm  0x0E  /* Event Action A group mask. */
+#define TCA_SINGLE_EVACTA_gp  1  /* Event Action A group position. */
+#define TCA_SINGLE_EVACTA_0_bm  (1<<1)  /* Event Action A bit 0 mask. */
+#define TCA_SINGLE_EVACTA_0_bp  1  /* Event Action A bit 0 position. */
+#define TCA_SINGLE_EVACTA_1_bm  (1<<2)  /* Event Action A bit 1 mask. */
+#define TCA_SINGLE_EVACTA_1_bp  2  /* Event Action A bit 1 position. */
+#define TCA_SINGLE_EVACTA_2_bm  (1<<3)  /* Event Action A bit 2 mask. */
+#define TCA_SINGLE_EVACTA_2_bp  3  /* Event Action A bit 2 position. */
+#define TCA_SINGLE_CNTBEI_bm  0x10  /* Count on Event Input B bit mask. */
+#define TCA_SINGLE_CNTBEI_bp  4  /* Count on Event Input B bit position. */
+#define TCA_SINGLE_EVACTB_gm  0xE0  /* Event Action B group mask. */
+#define TCA_SINGLE_EVACTB_gp  5  /* Event Action B group position. */
+#define TCA_SINGLE_EVACTB_0_bm  (1<<5)  /* Event Action B bit 0 mask. */
+#define TCA_SINGLE_EVACTB_0_bp  5  /* Event Action B bit 0 position. */
+#define TCA_SINGLE_EVACTB_1_bm  (1<<6)  /* Event Action B bit 1 mask. */
+#define TCA_SINGLE_EVACTB_1_bp  6  /* Event Action B bit 1 position. */
+#define TCA_SINGLE_EVACTB_2_bm  (1<<7)  /* Event Action B bit 2 mask. */
+#define TCA_SINGLE_EVACTB_2_bp  7  /* Event Action B bit 2 position. */
+
+/* TCA_SINGLE.INTCTRL  bit masks and bit positions */
+#define TCA_SINGLE_OVF_bm  0x01  /* Overflow Interrupt bit mask. */
+#define TCA_SINGLE_OVF_bp  0  /* Overflow Interrupt bit position. */
+#define TCA_SINGLE_CMP0_bm  0x10  /* Compare 0 Interrupt bit mask. */
+#define TCA_SINGLE_CMP0_bp  4  /* Compare 0 Interrupt bit position. */
+#define TCA_SINGLE_CMP1_bm  0x20  /* Compare 1 Interrupt bit mask. */
+#define TCA_SINGLE_CMP1_bp  5  /* Compare 1 Interrupt bit position. */
+#define TCA_SINGLE_CMP2_bm  0x40  /* Compare 2 Interrupt bit mask. */
+#define TCA_SINGLE_CMP2_bp  6  /* Compare 2 Interrupt bit position. */
+
+/* TCA_SINGLE.INTFLAGS  bit masks and bit positions */
+/* TCA_SINGLE_OVF  is already defined. */
+/* TCA_SINGLE_CMP0  is already defined. */
+/* TCA_SINGLE_CMP1  is already defined. */
+/* TCA_SINGLE_CMP2  is already defined. */
+
+/* TCA_SINGLE.DBGCTRL  bit masks and bit positions */
+#define TCA_SINGLE_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define TCA_SINGLE_DBGRUN_bp  0  /* Debug Run bit position. */
+
+/* TCA_SPLIT.CTRLA  bit masks and bit positions */
+#define TCA_SPLIT_ENABLE_bm  0x01  /* Module Enable bit mask. */
+#define TCA_SPLIT_ENABLE_bp  0  /* Module Enable bit position. */
+#define TCA_SPLIT_CLKSEL_gm  0x0E  /* Clock Selection group mask. */
+#define TCA_SPLIT_CLKSEL_gp  1  /* Clock Selection group position. */
+#define TCA_SPLIT_CLKSEL_0_bm  (1<<1)  /* Clock Selection bit 0 mask. */
+#define TCA_SPLIT_CLKSEL_0_bp  1  /* Clock Selection bit 0 position. */
+#define TCA_SPLIT_CLKSEL_1_bm  (1<<2)  /* Clock Selection bit 1 mask. */
+#define TCA_SPLIT_CLKSEL_1_bp  2  /* Clock Selection bit 1 position. */
+#define TCA_SPLIT_CLKSEL_2_bm  (1<<3)  /* Clock Selection bit 2 mask. */
+#define TCA_SPLIT_CLKSEL_2_bp  3  /* Clock Selection bit 2 position. */
+#define TCA_SPLIT_RUNSTDBY_bm  0x80  /* Run in Standby bit mask. */
+#define TCA_SPLIT_RUNSTDBY_bp  7  /* Run in Standby bit position. */
+
+/* TCA_SPLIT.CTRLB  bit masks and bit positions */
+#define TCA_SPLIT_LCMP0EN_bm  0x01  /* Low Compare 0 Enable bit mask. */
+#define TCA_SPLIT_LCMP0EN_bp  0  /* Low Compare 0 Enable bit position. */
+#define TCA_SPLIT_LCMP1EN_bm  0x02  /* Low Compare 1 Enable bit mask. */
+#define TCA_SPLIT_LCMP1EN_bp  1  /* Low Compare 1 Enable bit position. */
+#define TCA_SPLIT_LCMP2EN_bm  0x04  /* Low Compare 2 Enable bit mask. */
+#define TCA_SPLIT_LCMP2EN_bp  2  /* Low Compare 2 Enable bit position. */
+#define TCA_SPLIT_HCMP0EN_bm  0x10  /* High Compare 0 Enable bit mask. */
+#define TCA_SPLIT_HCMP0EN_bp  4  /* High Compare 0 Enable bit position. */
+#define TCA_SPLIT_HCMP1EN_bm  0x20  /* High Compare 1 Enable bit mask. */
+#define TCA_SPLIT_HCMP1EN_bp  5  /* High Compare 1 Enable bit position. */
+#define TCA_SPLIT_HCMP2EN_bm  0x40  /* High Compare 2 Enable bit mask. */
+#define TCA_SPLIT_HCMP2EN_bp  6  /* High Compare 2 Enable bit position. */
+
+/* TCA_SPLIT.CTRLC  bit masks and bit positions */
+#define TCA_SPLIT_LCMP0OV_bm  0x01  /* Low Compare 0 Output Value bit mask. */
+#define TCA_SPLIT_LCMP0OV_bp  0  /* Low Compare 0 Output Value bit position. */
+#define TCA_SPLIT_LCMP1OV_bm  0x02  /* Low Compare 1 Output Value bit mask. */
+#define TCA_SPLIT_LCMP1OV_bp  1  /* Low Compare 1 Output Value bit position. */
+#define TCA_SPLIT_LCMP2OV_bm  0x04  /* Low Compare 2 Output Value bit mask. */
+#define TCA_SPLIT_LCMP2OV_bp  2  /* Low Compare 2 Output Value bit position. */
+#define TCA_SPLIT_HCMP0OV_bm  0x10  /* High Compare 0 Output Value bit mask. */
+#define TCA_SPLIT_HCMP0OV_bp  4  /* High Compare 0 Output Value bit position. */
+#define TCA_SPLIT_HCMP1OV_bm  0x20  /* High Compare 1 Output Value bit mask. */
+#define TCA_SPLIT_HCMP1OV_bp  5  /* High Compare 1 Output Value bit position. */
+#define TCA_SPLIT_HCMP2OV_bm  0x40  /* High Compare 2 Output Value bit mask. */
+#define TCA_SPLIT_HCMP2OV_bp  6  /* High Compare 2 Output Value bit position. */
+
+/* TCA_SPLIT.CTRLD  bit masks and bit positions */
+#define TCA_SPLIT_SPLITM_bm  0x01  /* Split Mode Enable bit mask. */
+#define TCA_SPLIT_SPLITM_bp  0  /* Split Mode Enable bit position. */
+
+/* TCA_SPLIT.CTRLECLR  bit masks and bit positions */
+#define TCA_SPLIT_CMDEN_gm  0x03  /* Command Enable group mask. */
+#define TCA_SPLIT_CMDEN_gp  0  /* Command Enable group position. */
+#define TCA_SPLIT_CMDEN_0_bm  (1<<0)  /* Command Enable bit 0 mask. */
+#define TCA_SPLIT_CMDEN_0_bp  0  /* Command Enable bit 0 position. */
+#define TCA_SPLIT_CMDEN_1_bm  (1<<1)  /* Command Enable bit 1 mask. */
+#define TCA_SPLIT_CMDEN_1_bp  1  /* Command Enable bit 1 position. */
+#define TCA_SPLIT_CMD_gm  0x0C  /* Command group mask. */
+#define TCA_SPLIT_CMD_gp  2  /* Command group position. */
+#define TCA_SPLIT_CMD_0_bm  (1<<2)  /* Command bit 0 mask. */
+#define TCA_SPLIT_CMD_0_bp  2  /* Command bit 0 position. */
+#define TCA_SPLIT_CMD_1_bm  (1<<3)  /* Command bit 1 mask. */
+#define TCA_SPLIT_CMD_1_bp  3  /* Command bit 1 position. */
+
+/* TCA_SPLIT.CTRLESET  bit masks and bit positions */
+/* TCA_SPLIT_CMDEN  is already defined. */
+/* TCA_SPLIT_CMD  is already defined. */
+
+/* TCA_SPLIT.INTCTRL  bit masks and bit positions */
+#define TCA_SPLIT_LUNF_bm  0x01  /* Low Underflow Interrupt Enable bit mask. */
+#define TCA_SPLIT_LUNF_bp  0  /* Low Underflow Interrupt Enable bit position. */
+#define TCA_SPLIT_HUNF_bm  0x02  /* High Underflow Interrupt Enable bit mask. */
+#define TCA_SPLIT_HUNF_bp  1  /* High Underflow Interrupt Enable bit position. */
+#define TCA_SPLIT_LCMP0_bm  0x10  /* Low Compare 0 Interrupt Enable bit mask. */
+#define TCA_SPLIT_LCMP0_bp  4  /* Low Compare 0 Interrupt Enable bit position. */
+#define TCA_SPLIT_LCMP1_bm  0x20  /* Low Compare 1 Interrupt Enable bit mask. */
+#define TCA_SPLIT_LCMP1_bp  5  /* Low Compare 1 Interrupt Enable bit position. */
+#define TCA_SPLIT_LCMP2_bm  0x40  /* Low Compare 2 Interrupt Enable bit mask. */
+#define TCA_SPLIT_LCMP2_bp  6  /* Low Compare 2 Interrupt Enable bit position. */
+
+/* TCA_SPLIT.INTFLAGS  bit masks and bit positions */
+/* TCA_SPLIT_LUNF  is already defined. */
+/* TCA_SPLIT_HUNF  is already defined. */
+/* TCA_SPLIT_LCMP0  is already defined. */
+/* TCA_SPLIT_LCMP1  is already defined. */
+/* TCA_SPLIT_LCMP2  is already defined. */
+
+/* TCA_SPLIT.DBGCTRL  bit masks and bit positions */
+#define TCA_SPLIT_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define TCA_SPLIT_DBGRUN_bp  0  /* Debug Run bit position. */
+
+
+/* TCB - 16-bit Timer Type B */
+/* TCB.CTRLA  bit masks and bit positions */
+#define TCB_ENABLE_bm  0x01  /* Enable bit mask. */
+#define TCB_ENABLE_bp  0  /* Enable bit position. */
+#define TCB_CLKSEL_gm  0x0E  /* Clock Select group mask. */
+#define TCB_CLKSEL_gp  1  /* Clock Select group position. */
+#define TCB_CLKSEL_0_bm  (1<<1)  /* Clock Select bit 0 mask. */
+#define TCB_CLKSEL_0_bp  1  /* Clock Select bit 0 position. */
+#define TCB_CLKSEL_1_bm  (1<<2)  /* Clock Select bit 1 mask. */
+#define TCB_CLKSEL_1_bp  2  /* Clock Select bit 1 position. */
+#define TCB_CLKSEL_2_bm  (1<<3)  /* Clock Select bit 2 mask. */
+#define TCB_CLKSEL_2_bp  3  /* Clock Select bit 2 position. */
+#define TCB_SYNCUPD_bm  0x10  /* Synchronize Update bit mask. */
+#define TCB_SYNCUPD_bp  4  /* Synchronize Update bit position. */
+#define TCB_CASCADE_bm  0x20  /* Cascade two timers bit mask. */
+#define TCB_CASCADE_bp  5  /* Cascade two timers bit position. */
+#define TCB_RUNSTDBY_bm  0x40  /* Run Standby bit mask. */
+#define TCB_RUNSTDBY_bp  6  /* Run Standby bit position. */
+
+/* TCB.CTRLB  bit masks and bit positions */
+#define TCB_CNTMODE_gm  0x07  /* Timer Mode group mask. */
+#define TCB_CNTMODE_gp  0  /* Timer Mode group position. */
+#define TCB_CNTMODE_0_bm  (1<<0)  /* Timer Mode bit 0 mask. */
+#define TCB_CNTMODE_0_bp  0  /* Timer Mode bit 0 position. */
+#define TCB_CNTMODE_1_bm  (1<<1)  /* Timer Mode bit 1 mask. */
+#define TCB_CNTMODE_1_bp  1  /* Timer Mode bit 1 position. */
+#define TCB_CNTMODE_2_bm  (1<<2)  /* Timer Mode bit 2 mask. */
+#define TCB_CNTMODE_2_bp  2  /* Timer Mode bit 2 position. */
+#define TCB_CCMPEN_bm  0x10  /* Pin Output Enable bit mask. */
+#define TCB_CCMPEN_bp  4  /* Pin Output Enable bit position. */
+#define TCB_CCMPINIT_bm  0x20  /* Pin Initial State bit mask. */
+#define TCB_CCMPINIT_bp  5  /* Pin Initial State bit position. */
+#define TCB_ASYNC_bm  0x40  /* Asynchronous Enable bit mask. */
+#define TCB_ASYNC_bp  6  /* Asynchronous Enable bit position. */
+
+/* TCB.EVCTRL  bit masks and bit positions */
+#define TCB_CAPTEI_bm  0x01  /* Event Input Enable bit mask. */
+#define TCB_CAPTEI_bp  0  /* Event Input Enable bit position. */
+#define TCB_EDGE_bm  0x10  /* Event Edge bit mask. */
+#define TCB_EDGE_bp  4  /* Event Edge bit position. */
+#define TCB_FILTER_bm  0x40  /* Input Capture Noise Cancellation Filter bit mask. */
+#define TCB_FILTER_bp  6  /* Input Capture Noise Cancellation Filter bit position. */
+
+/* TCB.INTCTRL  bit masks and bit positions */
+#define TCB_CAPT_bm  0x01  /* Capture or Timeout bit mask. */
+#define TCB_CAPT_bp  0  /* Capture or Timeout bit position. */
+#define TCB_OVF_bm  0x02  /* Overflow bit mask. */
+#define TCB_OVF_bp  1  /* Overflow bit position. */
+
+/* TCB.INTFLAGS  bit masks and bit positions */
+/* TCB_CAPT  is already defined. */
+/* TCB_OVF  is already defined. */
+
+/* TCB.STATUS  bit masks and bit positions */
+#define TCB_RUN_bm  0x01  /* Run bit mask. */
+#define TCB_RUN_bp  0  /* Run bit position. */
+
+/* TCB.DBGCTRL  bit masks and bit positions */
+#define TCB_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define TCB_DBGRUN_bp  0  /* Debug Run bit position. */
+
+
+/* TWI - Two-Wire Interface */
+/* TWI.CTRLA  bit masks and bit positions */
+#define TWI_FMEN_bm  0x01  /* Fast-mode Enable bit mask. */
+#define TWI_FMEN_bp  0  /* Fast-mode Enable bit position. */
+#define TWI_FMPEN_bm  0x02  /* Fast-mode Plus Enable bit mask. */
+#define TWI_FMPEN_bp  1  /* Fast-mode Plus Enable bit position. */
+#define TWI_SDAHOLD_gm  0x0C  /* SDA Hold Time group mask. */
+#define TWI_SDAHOLD_gp  2  /* SDA Hold Time group position. */
+#define TWI_SDAHOLD_0_bm  (1<<2)  /* SDA Hold Time bit 0 mask. */
+#define TWI_SDAHOLD_0_bp  2  /* SDA Hold Time bit 0 position. */
+#define TWI_SDAHOLD_1_bm  (1<<3)  /* SDA Hold Time bit 1 mask. */
+#define TWI_SDAHOLD_1_bp  3  /* SDA Hold Time bit 1 position. */
+#define TWI_SDASETUP_bm  0x10  /* SDA Setup Time bit mask. */
+#define TWI_SDASETUP_bp  4  /* SDA Setup Time bit position. */
+#define TWI_INPUTLVL_bm  0x40  /* Input voltage transition level bit mask. */
+#define TWI_INPUTLVL_bp  6  /* Input voltage transition level bit position. */
+
+/* TWI.DUALCTRL  bit masks and bit positions */
+#define TWI_ENABLE_bm  0x01  /* Enable bit mask. */
+#define TWI_ENABLE_bp  0  /* Enable bit position. */
+/* TWI_FMPEN  is already defined. */
+/* TWI_SDAHOLD  is already defined. */
+/* TWI_INPUTLVL  is already defined. */
+
+/* TWI.DBGCTRL  bit masks and bit positions */
+#define TWI_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define TWI_DBGRUN_bp  0  /* Debug Run bit position. */
+
+/* TWI.MCTRLA  bit masks and bit positions */
+/* TWI_ENABLE  is already defined. */
+#define TWI_SMEN_bm  0x02  /* Smart Mode Enable bit mask. */
+#define TWI_SMEN_bp  1  /* Smart Mode Enable bit position. */
+#define TWI_TIMEOUT_gm  0x0C  /* Inactive Bus Time-Out group mask. */
+#define TWI_TIMEOUT_gp  2  /* Inactive Bus Time-Out group position. */
+#define TWI_TIMEOUT_0_bm  (1<<2)  /* Inactive Bus Time-Out bit 0 mask. */
+#define TWI_TIMEOUT_0_bp  2  /* Inactive Bus Time-Out bit 0 position. */
+#define TWI_TIMEOUT_1_bm  (1<<3)  /* Inactive Bus Time-Out bit 1 mask. */
+#define TWI_TIMEOUT_1_bp  3  /* Inactive Bus Time-Out bit 1 position. */
+#define TWI_QCEN_bm  0x10  /* Quick Command Enable bit mask. */
+#define TWI_QCEN_bp  4  /* Quick Command Enable bit position. */
+#define TWI_WIEN_bm  0x40  /* Write Interrupt Enable bit mask. */
+#define TWI_WIEN_bp  6  /* Write Interrupt Enable bit position. */
+#define TWI_RIEN_bm  0x80  /* Read Interrupt Enable bit mask. */
+#define TWI_RIEN_bp  7  /* Read Interrupt Enable bit position. */
+
+/* TWI.MCTRLB  bit masks and bit positions */
+#define TWI_MCMD_gm  0x03  /* Command group mask. */
+#define TWI_MCMD_gp  0  /* Command group position. */
+#define TWI_MCMD_0_bm  (1<<0)  /* Command bit 0 mask. */
+#define TWI_MCMD_0_bp  0  /* Command bit 0 position. */
+#define TWI_MCMD_1_bm  (1<<1)  /* Command bit 1 mask. */
+#define TWI_MCMD_1_bp  1  /* Command bit 1 position. */
+#define TWI_ACKACT_bm  0x04  /* Acknowledge Action bit mask. */
+#define TWI_ACKACT_bp  2  /* Acknowledge Action bit position. */
+#define TWI_FLUSH_bm  0x08  /* Flush bit mask. */
+#define TWI_FLUSH_bp  3  /* Flush bit position. */
+
+/* TWI.MSTATUS  bit masks and bit positions */
+#define TWI_BUSSTATE_gm  0x03  /* Bus State group mask. */
+#define TWI_BUSSTATE_gp  0  /* Bus State group position. */
+#define TWI_BUSSTATE_0_bm  (1<<0)  /* Bus State bit 0 mask. */
+#define TWI_BUSSTATE_0_bp  0  /* Bus State bit 0 position. */
+#define TWI_BUSSTATE_1_bm  (1<<1)  /* Bus State bit 1 mask. */
+#define TWI_BUSSTATE_1_bp  1  /* Bus State bit 1 position. */
+#define TWI_BUSERR_bm  0x04  /* Bus Error bit mask. */
+#define TWI_BUSERR_bp  2  /* Bus Error bit position. */
+#define TWI_ARBLOST_bm  0x08  /* Arbitration Lost bit mask. */
+#define TWI_ARBLOST_bp  3  /* Arbitration Lost bit position. */
+#define TWI_RXACK_bm  0x10  /* Received Acknowledge bit mask. */
+#define TWI_RXACK_bp  4  /* Received Acknowledge bit position. */
+#define TWI_CLKHOLD_bm  0x20  /* Clock Hold bit mask. */
+#define TWI_CLKHOLD_bp  5  /* Clock Hold bit position. */
+#define TWI_WIF_bm  0x40  /* Write Interrupt Flag bit mask. */
+#define TWI_WIF_bp  6  /* Write Interrupt Flag bit position. */
+#define TWI_RIF_bm  0x80  /* Read Interrupt Flag bit mask. */
+#define TWI_RIF_bp  7  /* Read Interrupt Flag bit position. */
+
+/* TWI.MBAUD  bit masks and bit positions */
+#define TWI_BAUD_gm  0xFF  /* Baud Rate group mask. */
+#define TWI_BAUD_gp  0  /* Baud Rate group position. */
+#define TWI_BAUD_0_bm  (1<<0)  /* Baud Rate bit 0 mask. */
+#define TWI_BAUD_0_bp  0  /* Baud Rate bit 0 position. */
+#define TWI_BAUD_1_bm  (1<<1)  /* Baud Rate bit 1 mask. */
+#define TWI_BAUD_1_bp  1  /* Baud Rate bit 1 position. */
+#define TWI_BAUD_2_bm  (1<<2)  /* Baud Rate bit 2 mask. */
+#define TWI_BAUD_2_bp  2  /* Baud Rate bit 2 position. */
+#define TWI_BAUD_3_bm  (1<<3)  /* Baud Rate bit 3 mask. */
+#define TWI_BAUD_3_bp  3  /* Baud Rate bit 3 position. */
+#define TWI_BAUD_4_bm  (1<<4)  /* Baud Rate bit 4 mask. */
+#define TWI_BAUD_4_bp  4  /* Baud Rate bit 4 position. */
+#define TWI_BAUD_5_bm  (1<<5)  /* Baud Rate bit 5 mask. */
+#define TWI_BAUD_5_bp  5  /* Baud Rate bit 5 position. */
+#define TWI_BAUD_6_bm  (1<<6)  /* Baud Rate bit 6 mask. */
+#define TWI_BAUD_6_bp  6  /* Baud Rate bit 6 position. */
+#define TWI_BAUD_7_bm  (1<<7)  /* Baud Rate bit 7 mask. */
+#define TWI_BAUD_7_bp  7  /* Baud Rate bit 7 position. */
+
+/* TWI.MADDR  bit masks and bit positions */
+#define TWI_ADDR_gm  0xFF  /* Address group mask. */
+#define TWI_ADDR_gp  0  /* Address group position. */
+#define TWI_ADDR_0_bm  (1<<0)  /* Address bit 0 mask. */
+#define TWI_ADDR_0_bp  0  /* Address bit 0 position. */
+#define TWI_ADDR_1_bm  (1<<1)  /* Address bit 1 mask. */
+#define TWI_ADDR_1_bp  1  /* Address bit 1 position. */
+#define TWI_ADDR_2_bm  (1<<2)  /* Address bit 2 mask. */
+#define TWI_ADDR_2_bp  2  /* Address bit 2 position. */
+#define TWI_ADDR_3_bm  (1<<3)  /* Address bit 3 mask. */
+#define TWI_ADDR_3_bp  3  /* Address bit 3 position. */
+#define TWI_ADDR_4_bm  (1<<4)  /* Address bit 4 mask. */
+#define TWI_ADDR_4_bp  4  /* Address bit 4 position. */
+#define TWI_ADDR_5_bm  (1<<5)  /* Address bit 5 mask. */
+#define TWI_ADDR_5_bp  5  /* Address bit 5 position. */
+#define TWI_ADDR_6_bm  (1<<6)  /* Address bit 6 mask. */
+#define TWI_ADDR_6_bp  6  /* Address bit 6 position. */
+#define TWI_ADDR_7_bm  (1<<7)  /* Address bit 7 mask. */
+#define TWI_ADDR_7_bp  7  /* Address bit 7 position. */
+
+/* TWI.MDATA  bit masks and bit positions */
+#define TWI_DATA_gm  0xFF  /* Data group mask. */
+#define TWI_DATA_gp  0  /* Data group position. */
+#define TWI_DATA_0_bm  (1<<0)  /* Data bit 0 mask. */
+#define TWI_DATA_0_bp  0  /* Data bit 0 position. */
+#define TWI_DATA_1_bm  (1<<1)  /* Data bit 1 mask. */
+#define TWI_DATA_1_bp  1  /* Data bit 1 position. */
+#define TWI_DATA_2_bm  (1<<2)  /* Data bit 2 mask. */
+#define TWI_DATA_2_bp  2  /* Data bit 2 position. */
+#define TWI_DATA_3_bm  (1<<3)  /* Data bit 3 mask. */
+#define TWI_DATA_3_bp  3  /* Data bit 3 position. */
+#define TWI_DATA_4_bm  (1<<4)  /* Data bit 4 mask. */
+#define TWI_DATA_4_bp  4  /* Data bit 4 position. */
+#define TWI_DATA_5_bm  (1<<5)  /* Data bit 5 mask. */
+#define TWI_DATA_5_bp  5  /* Data bit 5 position. */
+#define TWI_DATA_6_bm  (1<<6)  /* Data bit 6 mask. */
+#define TWI_DATA_6_bp  6  /* Data bit 6 position. */
+#define TWI_DATA_7_bm  (1<<7)  /* Data bit 7 mask. */
+#define TWI_DATA_7_bp  7  /* Data bit 7 position. */
+
+/* TWI.SCTRLA  bit masks and bit positions */
+/* TWI_ENABLE  is already defined. */
+/* TWI_SMEN  is already defined. */
+#define TWI_PMEN_bm  0x04  /* Address Recognition Mode bit mask. */
+#define TWI_PMEN_bp  2  /* Address Recognition Mode bit position. */
+#define TWI_PIEN_bm  0x20  /* Stop Interrupt Enable bit mask. */
+#define TWI_PIEN_bp  5  /* Stop Interrupt Enable bit position. */
+#define TWI_APIEN_bm  0x40  /* Address or Stop Interrupt Enable bit mask. */
+#define TWI_APIEN_bp  6  /* Address or Stop Interrupt Enable bit position. */
+#define TWI_DIEN_bm  0x80  /* Data Interrupt Enable bit mask. */
+#define TWI_DIEN_bp  7  /* Data Interrupt Enable bit position. */
+
+/* TWI.SCTRLB  bit masks and bit positions */
+#define TWI_SCMD_gm  0x03  /* Command group mask. */
+#define TWI_SCMD_gp  0  /* Command group position. */
+#define TWI_SCMD_0_bm  (1<<0)  /* Command bit 0 mask. */
+#define TWI_SCMD_0_bp  0  /* Command bit 0 position. */
+#define TWI_SCMD_1_bm  (1<<1)  /* Command bit 1 mask. */
+#define TWI_SCMD_1_bp  1  /* Command bit 1 position. */
+/* TWI_ACKACT  is already defined. */
+
+/* TWI.SSTATUS  bit masks and bit positions */
+#define TWI_AP_bm  0x01  /* Address or Stop bit mask. */
+#define TWI_AP_bp  0  /* Address or Stop bit position. */
+#define TWI_DIR_bm  0x02  /* Read/Write Direction bit mask. */
+#define TWI_DIR_bp  1  /* Read/Write Direction bit position. */
+/* TWI_BUSERR  is already defined. */
+#define TWI_COLL_bm  0x08  /* Collision bit mask. */
+#define TWI_COLL_bp  3  /* Collision bit position. */
+/* TWI_RXACK  is already defined. */
+/* TWI_CLKHOLD  is already defined. */
+#define TWI_APIF_bm  0x40  /* Address or Stop Interrupt Flag bit mask. */
+#define TWI_APIF_bp  6  /* Address or Stop Interrupt Flag bit position. */
+#define TWI_DIF_bm  0x80  /* Data Interrupt Flag bit mask. */
+#define TWI_DIF_bp  7  /* Data Interrupt Flag bit position. */
+
+/* TWI.SADDR  bit masks and bit positions */
+/* TWI_ADDR  is already defined. */
+
+/* TWI.SDATA  bit masks and bit positions */
+/* TWI_DATA  is already defined. */
+
+/* TWI.SADDRMASK  bit masks and bit positions */
+#define TWI_ADDREN_bm  0x01  /* Address Mask Enable bit mask. */
+#define TWI_ADDREN_bp  0  /* Address Mask Enable bit position. */
+#define TWI_ADDRMASK_gm  0xFE  /* Address Mask group mask. */
+#define TWI_ADDRMASK_gp  1  /* Address Mask group position. */
+#define TWI_ADDRMASK_0_bm  (1<<1)  /* Address Mask bit 0 mask. */
+#define TWI_ADDRMASK_0_bp  1  /* Address Mask bit 0 position. */
+#define TWI_ADDRMASK_1_bm  (1<<2)  /* Address Mask bit 1 mask. */
+#define TWI_ADDRMASK_1_bp  2  /* Address Mask bit 1 position. */
+#define TWI_ADDRMASK_2_bm  (1<<3)  /* Address Mask bit 2 mask. */
+#define TWI_ADDRMASK_2_bp  3  /* Address Mask bit 2 position. */
+#define TWI_ADDRMASK_3_bm  (1<<4)  /* Address Mask bit 3 mask. */
+#define TWI_ADDRMASK_3_bp  4  /* Address Mask bit 3 position. */
+#define TWI_ADDRMASK_4_bm  (1<<5)  /* Address Mask bit 4 mask. */
+#define TWI_ADDRMASK_4_bp  5  /* Address Mask bit 4 position. */
+#define TWI_ADDRMASK_5_bm  (1<<6)  /* Address Mask bit 5 mask. */
+#define TWI_ADDRMASK_5_bp  6  /* Address Mask bit 5 position. */
+#define TWI_ADDRMASK_6_bm  (1<<7)  /* Address Mask bit 6 mask. */
+#define TWI_ADDRMASK_6_bp  7  /* Address Mask bit 6 position. */
+
+
+/* USART - Universal Synchronous and Asynchronous Receiver and Transmitter */
+/* USART.RXDATAL  bit masks and bit positions */
+#define USART_DATA_gm  0xFF  /* RX Data group mask. */
+#define USART_DATA_gp  0  /* RX Data group position. */
+#define USART_DATA_0_bm  (1<<0)  /* RX Data bit 0 mask. */
+#define USART_DATA_0_bp  0  /* RX Data bit 0 position. */
+#define USART_DATA_1_bm  (1<<1)  /* RX Data bit 1 mask. */
+#define USART_DATA_1_bp  1  /* RX Data bit 1 position. */
+#define USART_DATA_2_bm  (1<<2)  /* RX Data bit 2 mask. */
+#define USART_DATA_2_bp  2  /* RX Data bit 2 position. */
+#define USART_DATA_3_bm  (1<<3)  /* RX Data bit 3 mask. */
+#define USART_DATA_3_bp  3  /* RX Data bit 3 position. */
+#define USART_DATA_4_bm  (1<<4)  /* RX Data bit 4 mask. */
+#define USART_DATA_4_bp  4  /* RX Data bit 4 position. */
+#define USART_DATA_5_bm  (1<<5)  /* RX Data bit 5 mask. */
+#define USART_DATA_5_bp  5  /* RX Data bit 5 position. */
+#define USART_DATA_6_bm  (1<<6)  /* RX Data bit 6 mask. */
+#define USART_DATA_6_bp  6  /* RX Data bit 6 position. */
+#define USART_DATA_7_bm  (1<<7)  /* RX Data bit 7 mask. */
+#define USART_DATA_7_bp  7  /* RX Data bit 7 position. */
+
+/* USART.RXDATAH  bit masks and bit positions */
+#define USART_DATA8_bm  0x01  /* Receiver Data Register bit mask. */
+#define USART_DATA8_bp  0  /* Receiver Data Register bit position. */
+#define USART_PERR_bm  0x02  /* Parity Error bit mask. */
+#define USART_PERR_bp  1  /* Parity Error bit position. */
+#define USART_FERR_bm  0x04  /* Frame Error bit mask. */
+#define USART_FERR_bp  2  /* Frame Error bit position. */
+#define USART_BUFOVF_bm  0x40  /* Buffer Overflow bit mask. */
+#define USART_BUFOVF_bp  6  /* Buffer Overflow bit position. */
+#define USART_RXCIF_bm  0x80  /* Receive Complete Interrupt Flag bit mask. */
+#define USART_RXCIF_bp  7  /* Receive Complete Interrupt Flag bit position. */
+
+/* USART.TXDATAL  bit masks and bit positions */
+/* USART_DATA  is already defined. */
+
+/* USART.TXDATAH  bit masks and bit positions */
+/* USART_DATA8  is already defined. */
+
+/* USART.STATUS  bit masks and bit positions */
+#define USART_WFB_bm  0x01  /* Wait For Break bit mask. */
+#define USART_WFB_bp  0  /* Wait For Break bit position. */
+#define USART_BDF_bm  0x02  /* Break Detected Flag bit mask. */
+#define USART_BDF_bp  1  /* Break Detected Flag bit position. */
+#define USART_ISFIF_bm  0x08  /* Inconsistent Sync Field Interrupt Flag bit mask. */
+#define USART_ISFIF_bp  3  /* Inconsistent Sync Field Interrupt Flag bit position. */
+#define USART_RXSIF_bm  0x10  /* Receive Start Interrupt bit mask. */
+#define USART_RXSIF_bp  4  /* Receive Start Interrupt bit position. */
+#define USART_DREIF_bm  0x20  /* Data Register Empty Flag bit mask. */
+#define USART_DREIF_bp  5  /* Data Register Empty Flag bit position. */
+#define USART_TXCIF_bm  0x40  /* Transmit Interrupt Flag bit mask. */
+#define USART_TXCIF_bp  6  /* Transmit Interrupt Flag bit position. */
+/* USART_RXCIF  is already defined. */
+
+/* USART.CTRLA  bit masks and bit positions */
+#define USART_RS485_bm  0x01  /* RS485 Mode internal transmitter bit mask. */
+#define USART_RS485_bp  0  /* RS485 Mode internal transmitter bit position. */
+#define USART_ABEIE_bm  0x04  /* Auto-baud Error Interrupt Enable bit mask. */
+#define USART_ABEIE_bp  2  /* Auto-baud Error Interrupt Enable bit position. */
+#define USART_LBME_bm  0x08  /* Loop-back Mode Enable bit mask. */
+#define USART_LBME_bp  3  /* Loop-back Mode Enable bit position. */
+#define USART_RXSIE_bm  0x10  /* Receiver Start Frame Interrupt Enable bit mask. */
+#define USART_RXSIE_bp  4  /* Receiver Start Frame Interrupt Enable bit position. */
+#define USART_DREIE_bm  0x20  /* Data Register Empty Interrupt Enable bit mask. */
+#define USART_DREIE_bp  5  /* Data Register Empty Interrupt Enable bit position. */
+#define USART_TXCIE_bm  0x40  /* Transmit Complete Interrupt Enable bit mask. */
+#define USART_TXCIE_bp  6  /* Transmit Complete Interrupt Enable bit position. */
+#define USART_RXCIE_bm  0x80  /* Receive Complete Interrupt Enable bit mask. */
+#define USART_RXCIE_bp  7  /* Receive Complete Interrupt Enable bit position. */
+
+/* USART.CTRLB  bit masks and bit positions */
+#define USART_MPCM_bm  0x01  /* Multi-processor Communication Mode bit mask. */
+#define USART_MPCM_bp  0  /* Multi-processor Communication Mode bit position. */
+#define USART_RXMODE_gm  0x06  /* Receiver Mode group mask. */
+#define USART_RXMODE_gp  1  /* Receiver Mode group position. */
+#define USART_RXMODE_0_bm  (1<<1)  /* Receiver Mode bit 0 mask. */
+#define USART_RXMODE_0_bp  1  /* Receiver Mode bit 0 position. */
+#define USART_RXMODE_1_bm  (1<<2)  /* Receiver Mode bit 1 mask. */
+#define USART_RXMODE_1_bp  2  /* Receiver Mode bit 1 position. */
+#define USART_ODME_bm  0x08  /* Open Drain Mode Enable bit mask. */
+#define USART_ODME_bp  3  /* Open Drain Mode Enable bit position. */
+#define USART_SFDEN_bm  0x10  /* Start Frame Detection Enable bit mask. */
+#define USART_SFDEN_bp  4  /* Start Frame Detection Enable bit position. */
+#define USART_TXEN_bm  0x40  /* Transmitter Enable bit mask. */
+#define USART_TXEN_bp  6  /* Transmitter Enable bit position. */
+#define USART_RXEN_bm  0x80  /* Reciever enable bit mask. */
+#define USART_RXEN_bp  7  /* Reciever enable bit position. */
+
+/* USART.CTRLC  bit masks and bit positions */
+#define USART_UCPHA_bm  0x02  /* SPI Host Mode, Clock Phase bit mask. */
+#define USART_UCPHA_bp  1  /* SPI Host Mode, Clock Phase bit position. */
+#define USART_UDORD_bm  0x04  /* SPI Host Mode, Data Order bit mask. */
+#define USART_UDORD_bp  2  /* SPI Host Mode, Data Order bit position. */
+#define USART_CHSIZE_gm  0x07  /* Character Size group mask. */
+#define USART_CHSIZE_gp  0  /* Character Size group position. */
+#define USART_CHSIZE_0_bm  (1<<0)  /* Character Size bit 0 mask. */
+#define USART_CHSIZE_0_bp  0  /* Character Size bit 0 position. */
+#define USART_CHSIZE_1_bm  (1<<1)  /* Character Size bit 1 mask. */
+#define USART_CHSIZE_1_bp  1  /* Character Size bit 1 position. */
+#define USART_CHSIZE_2_bm  (1<<2)  /* Character Size bit 2 mask. */
+#define USART_CHSIZE_2_bp  2  /* Character Size bit 2 position. */
+#define USART_SBMODE_bm  0x08  /* Stop Bit Mode bit mask. */
+#define USART_SBMODE_bp  3  /* Stop Bit Mode bit position. */
+#define USART_PMODE_gm  0x30  /* Parity Mode group mask. */
+#define USART_PMODE_gp  4  /* Parity Mode group position. */
+#define USART_PMODE_0_bm  (1<<4)  /* Parity Mode bit 0 mask. */
+#define USART_PMODE_0_bp  4  /* Parity Mode bit 0 position. */
+#define USART_PMODE_1_bm  (1<<5)  /* Parity Mode bit 1 mask. */
+#define USART_PMODE_1_bp  5  /* Parity Mode bit 1 position. */
+#define USART_CMODE_gm  0xC0  /* Communication Mode group mask. */
+#define USART_CMODE_gp  6  /* Communication Mode group position. */
+#define USART_CMODE_0_bm  (1<<6)  /* Communication Mode bit 0 mask. */
+#define USART_CMODE_0_bp  6  /* Communication Mode bit 0 position. */
+#define USART_CMODE_1_bm  (1<<7)  /* Communication Mode bit 1 mask. */
+#define USART_CMODE_1_bp  7  /* Communication Mode bit 1 position. */
+
+/* USART.CTRLD  bit masks and bit positions */
+#define USART_ABW_gm  0xC0  /* Auto Baud Window group mask. */
+#define USART_ABW_gp  6  /* Auto Baud Window group position. */
+#define USART_ABW_0_bm  (1<<6)  /* Auto Baud Window bit 0 mask. */
+#define USART_ABW_0_bp  6  /* Auto Baud Window bit 0 position. */
+#define USART_ABW_1_bm  (1<<7)  /* Auto Baud Window bit 1 mask. */
+#define USART_ABW_1_bp  7  /* Auto Baud Window bit 1 position. */
+
+/* USART.DBGCTRL  bit masks and bit positions */
+#define USART_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define USART_DBGRUN_bp  0  /* Debug Run bit position. */
+
+/* USART.EVCTRL  bit masks and bit positions */
+#define USART_IREI_bm  0x01  /* IrDA Event Input Enable bit mask. */
+#define USART_IREI_bp  0  /* IrDA Event Input Enable bit position. */
+
+/* USART.TXPLCTRL  bit masks and bit positions */
+#define USART_TXPL_gm  0xFF  /* Transmit pulse length group mask. */
+#define USART_TXPL_gp  0  /* Transmit pulse length group position. */
+#define USART_TXPL_0_bm  (1<<0)  /* Transmit pulse length bit 0 mask. */
+#define USART_TXPL_0_bp  0  /* Transmit pulse length bit 0 position. */
+#define USART_TXPL_1_bm  (1<<1)  /* Transmit pulse length bit 1 mask. */
+#define USART_TXPL_1_bp  1  /* Transmit pulse length bit 1 position. */
+#define USART_TXPL_2_bm  (1<<2)  /* Transmit pulse length bit 2 mask. */
+#define USART_TXPL_2_bp  2  /* Transmit pulse length bit 2 position. */
+#define USART_TXPL_3_bm  (1<<3)  /* Transmit pulse length bit 3 mask. */
+#define USART_TXPL_3_bp  3  /* Transmit pulse length bit 3 position. */
+#define USART_TXPL_4_bm  (1<<4)  /* Transmit pulse length bit 4 mask. */
+#define USART_TXPL_4_bp  4  /* Transmit pulse length bit 4 position. */
+#define USART_TXPL_5_bm  (1<<5)  /* Transmit pulse length bit 5 mask. */
+#define USART_TXPL_5_bp  5  /* Transmit pulse length bit 5 position. */
+#define USART_TXPL_6_bm  (1<<6)  /* Transmit pulse length bit 6 mask. */
+#define USART_TXPL_6_bp  6  /* Transmit pulse length bit 6 position. */
+#define USART_TXPL_7_bm  (1<<7)  /* Transmit pulse length bit 7 mask. */
+#define USART_TXPL_7_bp  7  /* Transmit pulse length bit 7 position. */
+
+/* USART.RXPLCTRL  bit masks and bit positions */
+#define USART_RXPL_gm  0x7F  /* Receiver Pulse Lenght group mask. */
+#define USART_RXPL_gp  0  /* Receiver Pulse Lenght group position. */
+#define USART_RXPL_0_bm  (1<<0)  /* Receiver Pulse Lenght bit 0 mask. */
+#define USART_RXPL_0_bp  0  /* Receiver Pulse Lenght bit 0 position. */
+#define USART_RXPL_1_bm  (1<<1)  /* Receiver Pulse Lenght bit 1 mask. */
+#define USART_RXPL_1_bp  1  /* Receiver Pulse Lenght bit 1 position. */
+#define USART_RXPL_2_bm  (1<<2)  /* Receiver Pulse Lenght bit 2 mask. */
+#define USART_RXPL_2_bp  2  /* Receiver Pulse Lenght bit 2 position. */
+#define USART_RXPL_3_bm  (1<<3)  /* Receiver Pulse Lenght bit 3 mask. */
+#define USART_RXPL_3_bp  3  /* Receiver Pulse Lenght bit 3 position. */
+#define USART_RXPL_4_bm  (1<<4)  /* Receiver Pulse Lenght bit 4 mask. */
+#define USART_RXPL_4_bp  4  /* Receiver Pulse Lenght bit 4 position. */
+#define USART_RXPL_5_bm  (1<<5)  /* Receiver Pulse Lenght bit 5 mask. */
+#define USART_RXPL_5_bp  5  /* Receiver Pulse Lenght bit 5 position. */
+#define USART_RXPL_6_bm  (1<<6)  /* Receiver Pulse Lenght bit 6 mask. */
+#define USART_RXPL_6_bp  6  /* Receiver Pulse Lenght bit 6 position. */
+
+
+
+/* VPORT - Virtual Ports */
+/* VPORT.INTFLAGS  bit masks and bit positions */
+#define VPORT_INT_gm  0xFF  /* Pin Interrupt Flag group mask. */
+#define VPORT_INT_gp  0  /* Pin Interrupt Flag group position. */
+#define VPORT_INT_0_bm  (1<<0)  /* Pin Interrupt Flag bit 0 mask. */
+#define VPORT_INT_0_bp  0  /* Pin Interrupt Flag bit 0 position. */
+#define VPORT_INT_1_bm  (1<<1)  /* Pin Interrupt Flag bit 1 mask. */
+#define VPORT_INT_1_bp  1  /* Pin Interrupt Flag bit 1 position. */
+#define VPORT_INT_2_bm  (1<<2)  /* Pin Interrupt Flag bit 2 mask. */
+#define VPORT_INT_2_bp  2  /* Pin Interrupt Flag bit 2 position. */
+#define VPORT_INT_3_bm  (1<<3)  /* Pin Interrupt Flag bit 3 mask. */
+#define VPORT_INT_3_bp  3  /* Pin Interrupt Flag bit 3 position. */
+#define VPORT_INT_4_bm  (1<<4)  /* Pin Interrupt Flag bit 4 mask. */
+#define VPORT_INT_4_bp  4  /* Pin Interrupt Flag bit 4 position. */
+#define VPORT_INT_5_bm  (1<<5)  /* Pin Interrupt Flag bit 5 mask. */
+#define VPORT_INT_5_bp  5  /* Pin Interrupt Flag bit 5 position. */
+#define VPORT_INT_6_bm  (1<<6)  /* Pin Interrupt Flag bit 6 mask. */
+#define VPORT_INT_6_bp  6  /* Pin Interrupt Flag bit 6 position. */
+#define VPORT_INT_7_bm  (1<<7)  /* Pin Interrupt Flag bit 7 mask. */
+#define VPORT_INT_7_bp  7  /* Pin Interrupt Flag bit 7 position. */
+
+
+/* VREF - Voltage reference */
+/* VREF.DAC0REF  bit masks and bit positions */
+#define VREF_REFSEL_gm  0x07  /* Reference select group mask. */
+#define VREF_REFSEL_gp  0  /* Reference select group position. */
+#define VREF_REFSEL_0_bm  (1<<0)  /* Reference select bit 0 mask. */
+#define VREF_REFSEL_0_bp  0  /* Reference select bit 0 position. */
+#define VREF_REFSEL_1_bm  (1<<1)  /* Reference select bit 1 mask. */
+#define VREF_REFSEL_1_bp  1  /* Reference select bit 1 position. */
+#define VREF_REFSEL_2_bm  (1<<2)  /* Reference select bit 2 mask. */
+#define VREF_REFSEL_2_bp  2  /* Reference select bit 2 position. */
+#define VREF_ALWAYSON_bm  0x80  /* Always on bit mask. */
+#define VREF_ALWAYSON_bp  7  /* Always on bit position. */
+
+/* VREF.ACREF  bit masks and bit positions */
+/* VREF_REFSEL  is already defined. */
+/* VREF_ALWAYSON  is already defined. */
+
+
+/* WDT - Watch-Dog Timer */
+/* WDT.CTRLA  bit masks and bit positions */
+#define WDT_PERIOD_gm  0x0F  /* Period group mask. */
+#define WDT_PERIOD_gp  0  /* Period group position. */
+#define WDT_PERIOD_0_bm  (1<<0)  /* Period bit 0 mask. */
+#define WDT_PERIOD_0_bp  0  /* Period bit 0 position. */
+#define WDT_PERIOD_1_bm  (1<<1)  /* Period bit 1 mask. */
+#define WDT_PERIOD_1_bp  1  /* Period bit 1 position. */
+#define WDT_PERIOD_2_bm  (1<<2)  /* Period bit 2 mask. */
+#define WDT_PERIOD_2_bp  2  /* Period bit 2 position. */
+#define WDT_PERIOD_3_bm  (1<<3)  /* Period bit 3 mask. */
+#define WDT_PERIOD_3_bp  3  /* Period bit 3 position. */
+#define WDT_WINDOW_gm  0xF0  /* Window group mask. */
+#define WDT_WINDOW_gp  4  /* Window group position. */
+#define WDT_WINDOW_0_bm  (1<<4)  /* Window bit 0 mask. */
+#define WDT_WINDOW_0_bp  4  /* Window bit 0 position. */
+#define WDT_WINDOW_1_bm  (1<<5)  /* Window bit 1 mask. */
+#define WDT_WINDOW_1_bp  5  /* Window bit 1 position. */
+#define WDT_WINDOW_2_bm  (1<<6)  /* Window bit 2 mask. */
+#define WDT_WINDOW_2_bp  6  /* Window bit 2 position. */
+#define WDT_WINDOW_3_bm  (1<<7)  /* Window bit 3 mask. */
+#define WDT_WINDOW_3_bp  7  /* Window bit 3 position. */
+
+/* WDT.STATUS  bit masks and bit positions */
+#define WDT_SYNCBUSY_bm  0x01  /* Syncronization busy bit mask. */
+#define WDT_SYNCBUSY_bp  0  /* Syncronization busy bit position. */
+#define WDT_LOCK_bm  0x80  /* Lock enable bit mask. */
+#define WDT_LOCK_bp  7  /* Lock enable bit position. */
+
+
+/* ========== Generic Port Pins ========== */
+#define PIN0_bm 0x01
+#define PIN0_bp 0
+#define PIN1_bm 0x02
+#define PIN1_bp 1
+#define PIN2_bm 0x04
+#define PIN2_bp 2
+#define PIN3_bm 0x08
+#define PIN3_bp 3
+#define PIN4_bm 0x10
+#define PIN4_bp 4
+#define PIN5_bm 0x20
+#define PIN5_bp 5
+#define PIN6_bm 0x40
+#define PIN6_bp 6
+#define PIN7_bm 0x80
+#define PIN7_bp 7
+
+/* ========== Interrupt Vector Definitions ========== */
+/* Vector 0 is the reset vector */
+
+/* NMI interrupt vectors */
+#define NMI_vect_num  1
+#define NMI_vect      _VECTOR(1)  /*  */
+
+/* BOD interrupt vectors */
+#define BOD_VLM_vect_num  2
+#define BOD_VLM_vect      _VECTOR(2)  /*  */
+
+/* CLKCTRL interrupt vectors */
+#define CLKCTRL_CFD_vect_num  3
+#define CLKCTRL_CFD_vect      _VECTOR(3)  /*  */
+
+/* RTC interrupt vectors */
+#define RTC_CNT_vect_num  4
+#define RTC_CNT_vect      _VECTOR(4)  /*  */
+#define RTC_PIT_vect_num  5
+#define RTC_PIT_vect      _VECTOR(5)  /*  */
+
+/* CCL interrupt vectors */
+#define CCL_CCL_vect_num  6
+#define CCL_CCL_vect      _VECTOR(6)  /*  */
+
+/* PORTA interrupt vectors */
+#define PORTA_PORT_vect_num  7
+#define PORTA_PORT_vect      _VECTOR(7)  /*  */
+
+/* TCA0 interrupt vectors */
+#define TCA0_LUNF_vect_num  8
+#define TCA0_LUNF_vect      _VECTOR(8)  /*  */
+#define TCA0_OVF_vect_num  8
+#define TCA0_OVF_vect      _VECTOR(8)  /*  */
+#define TCA0_HUNF_vect_num  9
+#define TCA0_HUNF_vect      _VECTOR(9)  /*  */
+#define TCA0_CMP0_vect_num  10
+#define TCA0_CMP0_vect      _VECTOR(10)  /*  */
+#define TCA0_LCMP0_vect_num  10
+#define TCA0_LCMP0_vect      _VECTOR(10)  /*  */
+#define TCA0_CMP1_vect_num  11
+#define TCA0_CMP1_vect      _VECTOR(11)  /*  */
+#define TCA0_LCMP1_vect_num  11
+#define TCA0_LCMP1_vect      _VECTOR(11)  /*  */
+#define TCA0_CMP2_vect_num  12
+#define TCA0_CMP2_vect      _VECTOR(12)  /*  */
+#define TCA0_LCMP2_vect_num  12
+#define TCA0_LCMP2_vect      _VECTOR(12)  /*  */
+
+/* TCB0 interrupt vectors */
+#define TCB0_INT_vect_num  13
+#define TCB0_INT_vect      _VECTOR(13)  /*  */
+
+/* TCB1 interrupt vectors */
+#define TCB1_INT_vect_num  14
+#define TCB1_INT_vect      _VECTOR(14)  /*  */
+
+/* TWI0 interrupt vectors */
+#define TWI0_TWIS_vect_num  15
+#define TWI0_TWIS_vect      _VECTOR(15)  /*  */
+#define TWI0_TWIM_vect_num  16
+#define TWI0_TWIM_vect      _VECTOR(16)  /*  */
+
+/* SPI0 interrupt vectors */
+#define SPI0_INT_vect_num  17
+#define SPI0_INT_vect      _VECTOR(17)  /*  */
+
+/* USART0 interrupt vectors */
+#define USART0_RXC_vect_num  18
+#define USART0_RXC_vect      _VECTOR(18)  /*  */
+#define USART0_DRE_vect_num  19
+#define USART0_DRE_vect      _VECTOR(19)  /*  */
+#define USART0_TXC_vect_num  20
+#define USART0_TXC_vect      _VECTOR(20)  /*  */
+
+/* PORTD interrupt vectors */
+#define PORTD_PORT_vect_num  21
+#define PORTD_PORT_vect      _VECTOR(21)  /*  */
+
+/* AC0 interrupt vectors */
+#define AC0_AC_vect_num  22
+#define AC0_AC_vect      _VECTOR(22)  /*  */
+
+/* ADC0 interrupt vectors */
+#define ADC0_ERROR_vect_num  23
+#define ADC0_ERROR_vect      _VECTOR(23)  /*  */
+#define ADC0_RESRDY_vect_num  24
+#define ADC0_RESRDY_vect      _VECTOR(24)  /*  */
+#define ADC0_SAMPRDY_vect_num  25
+#define ADC0_SAMPRDY_vect      _VECTOR(25)  /*  */
+
+/* AC1 interrupt vectors */
+#define AC1_AC_vect_num  26
+#define AC1_AC_vect      _VECTOR(26)  /*  */
+
+/* PORTC interrupt vectors */
+#define PORTC_PORT_vect_num  27
+#define PORTC_PORT_vect      _VECTOR(27)  /*  */
+
+/* TCB2 interrupt vectors */
+#define TCB2_INT_vect_num  28
+#define TCB2_INT_vect      _VECTOR(28)  /*  */
+
+/* USART1 interrupt vectors */
+#define USART1_RXC_vect_num  29
+#define USART1_RXC_vect      _VECTOR(29)  /*  */
+#define USART1_DRE_vect_num  30
+#define USART1_DRE_vect      _VECTOR(30)  /*  */
+#define USART1_TXC_vect_num  31
+#define USART1_TXC_vect      _VECTOR(31)  /*  */
+
+/* PORTF interrupt vectors */
+#define PORTF_PORT_vect_num  32
+#define PORTF_PORT_vect      _VECTOR(32)  /*  */
+
+/* NVMCTRL interrupt vectors */
+#define NVMCTRL_EEREADY_vect_num  33
+#define NVMCTRL_EEREADY_vect      _VECTOR(33)  /*  */
+#define NVMCTRL_FLREADY_vect_num  33
+#define NVMCTRL_FLREADY_vect      _VECTOR(33)  /*  */
+#define NVMCTRL_NVMREADY_vect_num  33
+#define NVMCTRL_NVMREADY_vect      _VECTOR(33)  /*  */
+
+/* USART2 interrupt vectors */
+#define USART2_RXC_vect_num  34
+#define USART2_RXC_vect      _VECTOR(34)  /*  */
+#define USART2_DRE_vect_num  35
+#define USART2_DRE_vect      _VECTOR(35)  /*  */
+#define USART2_TXC_vect_num  36
+#define USART2_TXC_vect      _VECTOR(36)  /*  */
+
+/* TCB3 interrupt vectors */
+#define TCB3_INT_vect_num  37
+#define TCB3_INT_vect      _VECTOR(37)  /*  */
+
+/* TCA1 interrupt vectors */
+#define TCA1_LUNF_vect_num  38
+#define TCA1_LUNF_vect      _VECTOR(38)  /*  */
+#define TCA1_OVF_vect_num  38
+#define TCA1_OVF_vect      _VECTOR(38)  /*  */
+#define TCA1_HUNF_vect_num  39
+#define TCA1_HUNF_vect      _VECTOR(39)  /*  */
+#define TCA1_CMP0_vect_num  40
+#define TCA1_CMP0_vect      _VECTOR(40)  /*  */
+#define TCA1_LCMP0_vect_num  40
+#define TCA1_LCMP0_vect      _VECTOR(40)  /*  */
+#define TCA1_CMP1_vect_num  41
+#define TCA1_CMP1_vect      _VECTOR(41)  /*  */
+#define TCA1_LCMP1_vect_num  41
+#define TCA1_LCMP1_vect      _VECTOR(41)  /*  */
+#define TCA1_CMP2_vect_num  42
+#define TCA1_CMP2_vect      _VECTOR(42)  /*  */
+#define TCA1_LCMP2_vect_num  42
+#define TCA1_LCMP2_vect      _VECTOR(42)  /*  */
+
+/* PORTE interrupt vectors */
+#define PORTE_PORT_vect_num  43
+#define PORTE_PORT_vect      _VECTOR(43)  /*  */
+
+/* PORTB interrupt vectors */
+#define PORTB_PORT_vect_num  44
+#define PORTB_PORT_vect      _VECTOR(44)  /*  */
+
+#define _VECTOR_SIZE 4 /* Size of individual vector. */
+#define _VECTORS_SIZE (45 * _VECTOR_SIZE)
+
+
+/* ========== Constants ========== */
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define DATAMEM_START     (0x0000)
+#  define DATAMEM_SIZE      (65536)
+#else
+#  define DATAMEM_START     (0x0000U)
+#  define DATAMEM_SIZE      (65536U)
+#endif
+#define DATAMEM_END       (DATAMEM_START + DATAMEM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define IO_START     (0x0000)
+#  define IO_SIZE      (4159)
+#  define IO_PAGE_SIZE (0)
+#else
+#  define IO_START     (0x0000U)
+#  define IO_SIZE      (4159U)
+#  define IO_PAGE_SIZE (0U)
+#endif
+#define IO_END       (IO_START + IO_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define LOCKBITS_START     (0x1040)
+#  define LOCKBITS_SIZE      (4)
+#  define LOCKBITS_PAGE_SIZE (4)
+#else
+#  define LOCKBITS_START     (0x1040U)
+#  define LOCKBITS_SIZE      (4U)
+#  define LOCKBITS_PAGE_SIZE (4U)
+#endif
+#define LOCKBITS_END       (LOCKBITS_START + LOCKBITS_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define FUSES_START     (0x1050)
+#  define FUSES_SIZE      (16)
+#  define FUSES_PAGE_SIZE (8)
+#else
+#  define FUSES_START     (0x1050U)
+#  define FUSES_SIZE      (16U)
+#  define FUSES_PAGE_SIZE (8U)
+#endif
+#define FUSES_END       (FUSES_START + FUSES_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define USER_SIGNATURES_START     (0x1080)
+#  define USER_SIGNATURES_SIZE      (64)
+#  define USER_SIGNATURES_PAGE_SIZE (64)
+#else
+#  define USER_SIGNATURES_START     (0x1080U)
+#  define USER_SIGNATURES_SIZE      (64U)
+#  define USER_SIGNATURES_PAGE_SIZE (64U)
+#endif
+#define USER_SIGNATURES_END       (USER_SIGNATURES_START + USER_SIGNATURES_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define SIGNATURES_START     (0x1100)
+#  define SIGNATURES_SIZE      (3)
+#  define SIGNATURES_PAGE_SIZE (128)
+#else
+#  define SIGNATURES_START     (0x1100U)
+#  define SIGNATURES_SIZE      (3U)
+#  define SIGNATURES_PAGE_SIZE (128U)
+#endif
+#define SIGNATURES_END       (SIGNATURES_START + SIGNATURES_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define PROD_SIGNATURES_START     (0x1103)
+#  define PROD_SIGNATURES_SIZE      (125)
+#  define PROD_SIGNATURES_PAGE_SIZE (128)
+#else
+#  define PROD_SIGNATURES_START     (0x1103U)
+#  define PROD_SIGNATURES_SIZE      (125U)
+#  define PROD_SIGNATURES_PAGE_SIZE (128U)
+#endif
+#define PROD_SIGNATURES_END       (PROD_SIGNATURES_START + PROD_SIGNATURES_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define EEPROM_START     (0x1400)
+#  define EEPROM_SIZE      (512)
+#  define EEPROM_PAGE_SIZE (8)
+#else
+#  define EEPROM_START     (0x1400U)
+#  define EEPROM_SIZE      (512U)
+#  define EEPROM_PAGE_SIZE (8U)
+#endif
+#define EEPROM_END       (EEPROM_START + EEPROM_SIZE - 1)
+
+/* Added MAPPED_EEPROM segment names for avr-libc */
+#define MAPPED_EEPROM_START     (EEPROM_START)
+#define MAPPED_EEPROM_SIZE      (EEPROM_SIZE)
+#define MAPPED_EEPROM_PAGE_SIZE (EEPROM_PAGE_SIZE)
+#define MAPPED_EEPROM_END       (MAPPED_EEPROM_START + MAPPED_EEPROM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define INTERNAL_SRAM_START     (0x7000)
+#  define INTERNAL_SRAM_SIZE      (4096)
+#  define INTERNAL_SRAM_PAGE_SIZE (0)
+#else
+#  define INTERNAL_SRAM_START     (0x7000U)
+#  define INTERNAL_SRAM_SIZE      (4096U)
+#  define INTERNAL_SRAM_PAGE_SIZE (0U)
+#endif
+#define INTERNAL_SRAM_END       (INTERNAL_SRAM_START + INTERNAL_SRAM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define MAPPED_PROGMEM_START     (0x8000)
+#  define MAPPED_PROGMEM_SIZE      (32768)
+#  define MAPPED_PROGMEM_PAGE_SIZE (64)
+#else
+#  define MAPPED_PROGMEM_START     (0x8000U)
+#  define MAPPED_PROGMEM_SIZE      (32768U)
+#  define MAPPED_PROGMEM_PAGE_SIZE (64U)
+#endif
+#define MAPPED_PROGMEM_END       (MAPPED_PROGMEM_START + MAPPED_PROGMEM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define PROGMEM_START     (0x0000)
+#  define PROGMEM_SIZE      (32768)
+#  define PROGMEM_PAGE_SIZE (64)
+#else
+#  define PROGMEM_START     (0x0000U)
+#  define PROGMEM_SIZE      (32768U)
+#  define PROGMEM_PAGE_SIZE (64U)
+#endif
+#define PROGMEM_END       (PROGMEM_START + PROGMEM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define PROGMEM_NRWW_START     (0x0000)
+#  define PROGMEM_NRWW_SIZE      (4096)
+#  define PROGMEM_NRWW_PAGE_SIZE (64)
+#else
+#  define PROGMEM_NRWW_START     (0x0000U)
+#  define PROGMEM_NRWW_SIZE      (4096U)
+#  define PROGMEM_NRWW_PAGE_SIZE (64U)
+#endif
+#define PROGMEM_NRWW_END       (PROGMEM_NRWW_START + PROGMEM_NRWW_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define PROGMEM_RWW_START     (0x1000)
+#  define PROGMEM_RWW_SIZE      (28672)
+#  define PROGMEM_RWW_PAGE_SIZE (64)
+#else
+#  define PROGMEM_RWW_START     (0x1000U)
+#  define PROGMEM_RWW_SIZE      (28672U)
+#  define PROGMEM_RWW_PAGE_SIZE (64U)
+#endif
+#define PROGMEM_RWW_END       (PROGMEM_RWW_START + PROGMEM_RWW_SIZE - 1)
+
+#define FLASHSTART   PROGMEM_START
+#define FLASHEND     PROGMEM_END
+#define RAMSTART     INTERNAL_SRAM_START
+#define RAMSIZE      INTERNAL_SRAM_SIZE
+#define RAMEND       INTERNAL_SRAM_END
+#define E2END        EEPROM_END
+#define E2PAGESIZE   EEPROM_PAGE_SIZE
+
+/* ========== Fuses ========== */
+#define FUSE_MEMORY_SIZE 16
+
+/* Fuse Byte 0 (WDTCFG) */
+#define FUSE_PERIOD0  (unsigned char)_BV(0)  /* Watchdog Timeout Period Bit 0 */
+#define FUSE_PERIOD1  (unsigned char)_BV(1)  /* Watchdog Timeout Period Bit 1 */
+#define FUSE_PERIOD2  (unsigned char)_BV(2)  /* Watchdog Timeout Period Bit 2 */
+#define FUSE_PERIOD3  (unsigned char)_BV(3)  /* Watchdog Timeout Period Bit 3 */
+#define FUSE_WINDOW0  (unsigned char)_BV(4)  /* Watchdog Window Timeout Period Bit 0 */
+#define FUSE_WINDOW1  (unsigned char)_BV(5)  /* Watchdog Window Timeout Period Bit 1 */
+#define FUSE_WINDOW2  (unsigned char)_BV(6)  /* Watchdog Window Timeout Period Bit 2 */
+#define FUSE_WINDOW3  (unsigned char)_BV(7)  /* Watchdog Window Timeout Period Bit 3 */
+#define FUSE0_DEFAULT  (0x0)
+#define FUSE_WDTCFG_DEFAULT  (0x0)
+
+/* Fuse Byte 1 (BODCFG) */
+#define FUSE_SLEEP0  (unsigned char)_BV(0)  /* BOD Operation in Sleep Mode Bit 0 */
+#define FUSE_SLEEP1  (unsigned char)_BV(1)  /* BOD Operation in Sleep Mode Bit 1 */
+#define FUSE_ACTIVE0  (unsigned char)_BV(2)  /* BOD Operation in Active Mode Bit 0 */
+#define FUSE_ACTIVE1  (unsigned char)_BV(3)  /* BOD Operation in Active Mode Bit 1 */
+#define FUSE_SAMPFREQ  (unsigned char)_BV(4)  /* BOD Sample Frequency */
+#define FUSE_LVL0  (unsigned char)_BV(5)  /* BOD Level Bit 0 */
+#define FUSE_LVL1  (unsigned char)_BV(6)  /* BOD Level Bit 1 */
+#define FUSE_LVL2  (unsigned char)_BV(7)  /* BOD Level Bit 2 */
+#define FUSE1_DEFAULT  (0x0)
+#define FUSE_BODCFG_DEFAULT  (0x0)
+
+/* Fuse Byte 2 (OSCCFG) */
+#define FUSE_OSCHFFRQ  (unsigned char)_BV(3)  /* High-frequency Oscillator Frequency */
+#define FUSE2_DEFAULT  (0x0)
+#define FUSE_OSCCFG_DEFAULT  (0x0)
+
+/* Fuse Byte 3 Reserved */
+
+/* Fuse Byte 4 Reserved */
+
+/* Fuse Byte 5 (SYSCFG0) */
+#define FUSE_EESAVE  (unsigned char)_BV(0)  /* EEPROM Save */
+#define FUSE_RSTPINCFG  (unsigned char)_BV(3)  /* Reset Pin Configuration */
+#define FUSE_UPDIPINCFG  (unsigned char)_BV(4)  /* UPDI Pin Configuration */
+#define FUSE_CRCSEL  (unsigned char)_BV(5)  /* CRC Select */
+#define FUSE_CRCSRC0  (unsigned char)_BV(6)  /* CRC Source Bit 0 */
+#define FUSE_CRCSRC1  (unsigned char)_BV(7)  /* CRC Source Bit 1 */
+#define FUSE5_DEFAULT  (0xD0)
+#define FUSE_SYSCFG0_DEFAULT  (0xD0)
+
+/* Fuse Byte 6 (SYSCFG1) */
+#define FUSE_SUT0  (unsigned char)_BV(0)  /* Startup Time Bit 0 */
+#define FUSE_SUT1  (unsigned char)_BV(1)  /* Startup Time Bit 1 */
+#define FUSE_SUT2  (unsigned char)_BV(2)  /* Startup Time Bit 2 */
+#define FUSE6_DEFAULT  (0x7)
+#define FUSE_SYSCFG1_DEFAULT  (0x7)
+
+/* Fuse Byte 7 (CODESIZE) */
+#define FUSE7_DEFAULT  (0x0)
+#define FUSE_CODESIZE_DEFAULT  (0x0)
+
+/* Fuse Byte 8 (BOOTSIZE) */
+#define FUSE8_DEFAULT  (0x0)
+#define FUSE_BOOTSIZE_DEFAULT  (0x0)
+
+/* ========== Lock Bits ========== */
+#define __LOCK_KEY_EXIST
+#ifdef LOCKBITS_DEFAULT
+#undef LOCKBITS_DEFAULT
+#endif //LOCKBITS_DEFAULT
+#define LOCKBITS_DEFAULT  (0x5CC5C55C)
+
+/* ========== Signature ========== */
+#define SIGNATURE_0 0x1E
+#define SIGNATURE_1 0x95
+#define SIGNATURE_2 0x3C
+
+#endif /* #ifdef _AVR_AVR32EA48_H_INCLUDED */
+

--- a/include/avr/ioavr64ea28.h
+++ b/include/avr/ioavr64ea28.h
@@ -1,0 +1,5800 @@
+/*
+ * Copyright (C) 2023, Microchip Technology Inc. and its subsidiaries ("Microchip")
+ * All rights reserved.
+ *
+ * This software is developed by Microchip Technology Inc. and its subsidiaries ("Microchip").
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other
+ *        materials provided with the distribution. Publication is not required when
+ *        this file is used in an embedded application.
+ *
+ *     3. Microchip's name may not be used to endorse or promote products derived from this
+ *        software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY MICROCHIP "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL MICROCHIP BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING BUT NOT LIMITED TO
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWSOEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _AVR_IO_H_
+#  error "Include <avr/io.h> instead of this file."
+#endif
+
+#ifndef _AVR_IOXXX_H_
+#  define _AVR_IOXXX_H_ "ioavr64ea28.h"
+#else
+#  error "Attempt to include more than one <avr/ioXXX.h> file."
+#endif
+
+#ifndef _AVR_AVR64EA28_H_INCLUDED
+#define _AVR_AVR64EA28_H_INCLUDED
+
+/* Ungrouped common registers */
+#define CCP  _SFR_MEM8(0x0034)  /* Configuration Change Protection */
+#define SP  _SFR_MEM16(0x003D)  /* Stack Pointer */
+#define SPL  _SFR_MEM8(0x003D)  /* Stack Pointer Low */
+#define SPH  _SFR_MEM8(0x003E)  /* Stack Pointer High */
+#define SREG  _SFR_MEM8(0x003F)  /* Status Register */
+
+/* C Language Only */
+#if !defined (__ASSEMBLER__)
+
+#include <stdint.h>
+
+typedef volatile uint8_t register8_t;
+typedef volatile uint16_t register16_t;
+typedef volatile uint32_t register32_t;
+
+
+#ifdef _WORDREGISTER
+#undef _WORDREGISTER
+#endif
+#define _WORDREGISTER(regname)   \
+    __extension__ union \
+    { \
+        register16_t regname; \
+        struct \
+        { \
+            register8_t regname ## L; \
+            register8_t regname ## H; \
+        }; \
+    }
+
+#ifdef _DWORDREGISTER
+#undef _DWORDREGISTER
+#endif
+#define _DWORDREGISTER(regname)  \
+    __extension__ union \
+    { \
+        register32_t regname; \
+        struct \
+        { \
+            register8_t regname ## 0; \
+            register8_t regname ## 1; \
+            register8_t regname ## 2; \
+            register8_t regname ## 3; \
+        }; \
+    }
+
+
+/*
+==========================================================================
+IO Module Structures
+==========================================================================
+*/
+
+
+/*
+--------------------------------------------------------------------------
+AC - Analog Comparator
+--------------------------------------------------------------------------
+*/
+
+/* Analog Comparator */
+typedef struct AC_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t MUXCTRL;  /* Mux Control A */
+    register8_t reserved_1[2];
+    register8_t DACREF;  /* DAC Voltage Reference */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t STATUS;  /* Status */
+} AC_t;
+
+/* Hysteresis Mode select */
+typedef enum AC_HYSMODE_enum
+{
+    AC_HYSMODE_NONE_gc = (0x00<<1),  /* No hysteresis */
+    AC_HYSMODE_SMALL_gc = (0x01<<1),  /* Small hysteresis */
+    AC_HYSMODE_MEDIUM_gc = (0x02<<1),  /* Medium hysteresis */
+    AC_HYSMODE_LARGE_gc = (0x03<<1)  /* Large hysteresis */
+} AC_HYSMODE_t;
+
+/* AC Output Initial Value select */
+typedef enum AC_INITVAL_enum
+{
+    AC_INITVAL_LOW_gc = (0x00<<6),  /* Output initialized to 0 */
+    AC_INITVAL_HIGH_gc = (0x01<<6)  /* Output initialized to 1 */
+} AC_INITVAL_t;
+
+/* Interrupt Mode select */
+typedef enum AC_INTMODE_NORMAL_enum
+{
+    AC_INTMODE_NORMAL_BOTHEDGE_gc = (0x00<<4),  /* Positive and negative inputs crosses */
+    AC_INTMODE_NORMAL_NEGEDGE_gc = (0x02<<4),  /* Positive input goes below negative input */
+    AC_INTMODE_NORMAL_POSEDGE_gc = (0x03<<4)  /* Positive input goes above negative input */
+} AC_INTMODE_NORMAL_t;
+
+/* Interrupt Mode select */
+typedef enum AC_INTMODE_WINDOW_enum
+{
+    AC_INTMODE_WINDOW_ABOVE_gc = (0x00<<4),  /* Window interrupt when input above both references */
+    AC_INTMODE_WINDOW_INSIDE_gc = (0x01<<4),  /* Window interrupt when input betweeen references */
+    AC_INTMODE_WINDOW_BELOW_gc = (0x02<<4),  /* Window interrupt when input below both references */
+    AC_INTMODE_WINDOW_OUTSIDE_gc = (0x03<<4)  /* Window interrupt when input outside reference */
+} AC_INTMODE_WINDOW_t;
+
+/* Negative Input MUX Selection */
+typedef enum AC_MUXNEG_enum
+{
+    AC_MUXNEG_AINN0_gc = (0x00<<0),  /* Negative Pin 0 */
+    AC_MUXNEG_AINN1_gc = (0x01<<0),  /* Negative Pin 1 */
+    AC_MUXNEG_AINN2_gc = (0x02<<0),  /* Negative Pin 2 */
+    AC_MUXNEG_AINN3_gc = (0x03<<0),  /* Negative Pin 3 */
+    AC_MUXNEG_DACREF_gc = (0x04<<0)  /* DAC Reference */
+} AC_MUXNEG_t;
+
+/* Positive Input MUX Selection */
+typedef enum AC_MUXPOS_enum
+{
+    AC_MUXPOS_AINP0_gc = (0x00<<3),  /* Positive Pin 0 */
+    AC_MUXPOS_AINP1_gc = (0x01<<3),  /* Positive Pin 1 */
+    AC_MUXPOS_AINP2_gc = (0x02<<3),  /* Positive Pin 2 */
+    AC_MUXPOS_AINP3_gc = (0x03<<3),  /* Positive Pin 3 */
+    AC_MUXPOS_AINP4_gc = (0x04<<3)  /* Positive Pin 4 */
+} AC_MUXPOS_t;
+
+/* Power profile select */
+typedef enum AC_POWER_enum
+{
+    AC_POWER_PROFILE0_gc = (0x00<<3),  /* Power profile 0, Fastest response time, highest consumption */
+    AC_POWER_PROFILE1_gc = (0x01<<3)  /* Power profile 1 */
+} AC_POWER_t;
+
+/* Window selection mode */
+typedef enum AC_WINSEL_enum
+{
+    AC_WINSEL_DISABLED_gc = (0x00<<0),  /* Window function disabled */
+    AC_WINSEL_UPSEL1_gc = (0x01<<0)  /* Select ACn+1 as upper limit in window compare */
+} AC_WINSEL_t;
+
+/* Analog Comparator Window State select */
+typedef enum AC_WINSTATE_enum
+{
+    AC_WINSTATE_ABOVE_gc = (0x00<<6),  /* Above window */
+    AC_WINSTATE_INSIDE_gc = (0x01<<6),  /* Inside window */
+    AC_WINSTATE_BELOW_gc = (0x02<<6)  /* Below window */
+} AC_WINSTATE_t;
+
+/*
+--------------------------------------------------------------------------
+ADC - Analog to Digital Converter
+--------------------------------------------------------------------------
+*/
+
+/* Analog to Digital Converter */
+typedef struct ADC_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    register8_t CTRLD;  /* Control D */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t STATUS;  /* Status register */
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t CTRLE;  /* Control E */
+    register8_t CTRLF;  /* Control F */
+    register8_t COMMAND;  /* Command register */
+    register8_t PGACTRL;  /* PGA Control */
+    register8_t MUXPOS;  /* Positive Input Multiplexer */
+    register8_t MUXNEG;  /* Negative Input Multiplexer */
+    register8_t reserved_1[2];
+    _DWORDREGISTER(RESULT);  /* Result */
+    _WORDREGISTER(SAMPLE);  /* Sample */
+    register8_t reserved_2[2];
+    register8_t TEMP0;  /* Temporary Data 0 */
+    register8_t TEMP1;  /* Temporary Data 1 */
+    register8_t TEMP2;  /* Temporary Data 2 */
+    register8_t reserved_3[1];
+    _WORDREGISTER(WINLT);  /* Window Low Threshold */
+    _WORDREGISTER(WINHT);  /* Window High Threshold */
+    register8_t reserved_4[32];
+} ADC_t;
+
+/* Sign Chopping select */
+typedef enum ADC_CHOPPING_enum
+{
+    ADC_CHOPPING_DISABLE_gc = (0x00<<6),  /* Sign Chopping Disabled */
+    ADC_CHOPPING_ENABLE_gc = (0x01<<6)  /* Sign Chopping Enabled */
+} ADC_CHOPPING_t;
+
+/* Gain select */
+typedef enum ADC_GAIN_enum
+{
+    ADC_GAIN_1X_gc = (0x00<<5),  /* 1x gain */
+    ADC_GAIN_2X_gc = (0x01<<5),  /* 2x gain */
+    ADC_GAIN_4X_gc = (0x02<<5),  /* 4x gain */
+    ADC_GAIN_8X_gc = (0x03<<5),  /* 8x gain */
+    ADC_GAIN_16X_gc = (0x04<<5)  /* 16x gain */
+} ADC_GAIN_t;
+
+/* Mode select */
+typedef enum ADC_MODE_enum
+{
+    ADC_MODE_SINGLE_8BIT_gc = (0x00<<4),  /* Single Conversion with 8-bit resolution */
+    ADC_MODE_SINGLE_12BIT_gc = (0x01<<4),  /* Single Conversion with 12-bit resolution */
+    ADC_MODE_SERIES_gc = (0x02<<4),  /* Series with accumulation, separate trigger for every 12-bit conversion */
+    ADC_MODE_SERIES_SCALING_gc = (0x03<<4),  /* Series with accumulation and scaling, separate trigger for every 12-bit conversion */
+    ADC_MODE_BURST_gc = (0x04<<4),  /* Burst with accumulation, one trigger will run SAMPNUM 12-bit conversions */
+    ADC_MODE_BURST_SCALING_gc = (0x05<<4)  /* Burst with accumulation and scaling, one trigger will run SAMPNUM 12-bit conversions */
+} ADC_MODE_t;
+
+/* Analog Channel Selection Bits */
+typedef enum ADC_MUXNEG_enum
+{
+    ADC_MUXNEG_AIN0_gc = (0x00<<0),  /* ADC input pin 0 */
+    ADC_MUXNEG_AIN1_gc = (0x01<<0),  /* ADC input pin 1 */
+    ADC_MUXNEG_AIN2_gc = (0x02<<0),  /* ADC input pin 2 */
+    ADC_MUXNEG_AIN3_gc = (0x03<<0),  /* ADC input pin 3 */
+    ADC_MUXNEG_AIN4_gc = (0x04<<0),  /* ADC input pin 4 */
+    ADC_MUXNEG_AIN5_gc = (0x05<<0),  /* ADC input pin 5 */
+    ADC_MUXNEG_AIN6_gc = (0x06<<0),  /* ADC input pin 6 */
+    ADC_MUXNEG_AIN7_gc = (0x07<<0),  /* ADC input pin 7 */
+    ADC_MUXNEG_AIN16_gc = (0x10<<0),  /* ADC input pin 16 */
+    ADC_MUXNEG_AIN17_gc = (0x11<<0),  /* ADC input pin 17 */
+    ADC_MUXNEG_AIN22_gc = (0x16<<0),  /* ADC input pin 22 */
+    ADC_MUXNEG_AIN23_gc = (0x17<<0),  /* ADC input pin 23 */
+    ADC_MUXNEG_AIN24_gc = (0x18<<0),  /* ADC input pin 24 */
+    ADC_MUXNEG_AIN25_gc = (0x19<<0),  /* ADC input pin 25 */
+    ADC_MUXNEG_AIN26_gc = (0x1A<<0),  /* ADC input pin 26 */
+    ADC_MUXNEG_AIN27_gc = (0x1B<<0),  /* ADC input pin 27 */
+    ADC_MUXNEG_AIN28_gc = (0x1C<<0),  /* ADC input pin 28 */
+    ADC_MUXNEG_AIN29_gc = (0x1D<<0),  /* ADC input pin 29 */
+    ADC_MUXNEG_AIN30_gc = (0x1E<<0),  /* ADC input pin 30 */
+    ADC_MUXNEG_AIN31_gc = (0x1F<<0),  /* ADC input pin 31 */
+    ADC_MUXNEG_GND_gc = (0x30<<0),  /* Ground */
+    ADC_MUXNEG_DAC0_gc = (0x38<<0),  /* Digital to Analog Converter 0 */
+    ADC_MUXNEG_DACREF0_gc = (0x39<<0),  /* AC0 DAC reference */
+    ADC_MUXNEG_DACREF1_gc = (0x3A<<0)  /* AC1 DAC reference */
+} ADC_MUXNEG_t;
+
+/* Analog Channel Selection Bits */
+typedef enum ADC_MUXPOS_enum
+{
+    ADC_MUXPOS_AIN0_gc = (0x00<<0),  /* ADC input pin 0 */
+    ADC_MUXPOS_AIN1_gc = (0x01<<0),  /* ADC input pin 1 */
+    ADC_MUXPOS_AIN2_gc = (0x02<<0),  /* ADC input pin 2 */
+    ADC_MUXPOS_AIN3_gc = (0x03<<0),  /* ADC input pin 3 */
+    ADC_MUXPOS_AIN4_gc = (0x04<<0),  /* ADC input pin 4 */
+    ADC_MUXPOS_AIN5_gc = (0x05<<0),  /* ADC input pin 5 */
+    ADC_MUXPOS_AIN6_gc = (0x06<<0),  /* ADC input pin 6 */
+    ADC_MUXPOS_AIN7_gc = (0x07<<0),  /* ADC input pin 7 */
+    ADC_MUXPOS_AIN16_gc = (0x10<<0),  /* ADC input pin 16 */
+    ADC_MUXPOS_AIN17_gc = (0x11<<0),  /* ADC input pin 17 */
+    ADC_MUXPOS_AIN22_gc = (0x16<<0),  /* ADC input pin 22 */
+    ADC_MUXPOS_AIN23_gc = (0x17<<0),  /* ADC input pin 23 */
+    ADC_MUXPOS_AIN24_gc = (0x18<<0),  /* ADC input pin 24 */
+    ADC_MUXPOS_AIN25_gc = (0x19<<0),  /* ADC input pin 25 */
+    ADC_MUXPOS_AIN26_gc = (0x1A<<0),  /* ADC input pin 26 */
+    ADC_MUXPOS_AIN27_gc = (0x1B<<0),  /* ADC input pin 27 */
+    ADC_MUXPOS_AIN28_gc = (0x1C<<0),  /* ADC input pin 28 */
+    ADC_MUXPOS_AIN29_gc = (0x1D<<0),  /* ADC input pin 29 */
+    ADC_MUXPOS_AIN30_gc = (0x1E<<0),  /* ADC input pin 30 */
+    ADC_MUXPOS_AIN31_gc = (0x1F<<0),  /* ADC input pin 31 */
+    ADC_MUXPOS_GND_gc = (0x30<<0),  /* Ground */
+    ADC_MUXPOS_VDD10_gc = (0x31<<0),  /* VDD Divided by 10 */
+    ADC_MUXPOS_TEMPSENSE_gc = (0x32<<0),  /* Temperature Sensor */
+    ADC_MUXPOS_DAC0_gc = (0x38<<0)  /* Digital to Analog Converter 0 */
+} ADC_MUXPOS_t;
+
+/* PGA BIAS Select */
+typedef enum ADC_PGABIASSEL_enum
+{
+    ADC_PGABIASSEL_100PCT_gc = (0x00<<3),  /* 100% BIAS current. */
+    ADC_PGABIASSEL_75PCT_gc = (0x01<<3),  /* 75% BIAS current. Usable for CLK_ADC<4.5MHz */
+    ADC_PGABIASSEL_50PCT_gc = (0x02<<3),  /* 50% BIAS current. Usable for CLK_ADC<3MHz */
+    ADC_PGABIASSEL_25PCT_gc = (0x03<<3)  /* 25% BIAS current. Usable for CLK_ADC<1.5MHz */
+} ADC_PGABIASSEL_t;
+
+/* Prescaler Value select */
+typedef enum ADC_PRESC_enum
+{
+    ADC_PRESC_DIV2_gc = (0x00<<0),  /* System clock divided by 2 */
+    ADC_PRESC_DIV4_gc = (0x01<<0),  /* System clock divided by 4 */
+    ADC_PRESC_DIV6_gc = (0x02<<0),  /* System clock divided by 6 */
+    ADC_PRESC_DIV8_gc = (0x03<<0),  /* System clock divided by 8 */
+    ADC_PRESC_DIV10_gc = (0x04<<0),  /* System clock divided by 10 */
+    ADC_PRESC_DIV12_gc = (0x05<<0),  /* System clock divided by 12 */
+    ADC_PRESC_DIV14_gc = (0x06<<0),  /* System clock divided by 14 */
+    ADC_PRESC_DIV16_gc = (0x07<<0),  /* System clock divided by 16 */
+    ADC_PRESC_DIV20_gc = (0x08<<0),  /* System clock divided by 20 */
+    ADC_PRESC_DIV24_gc = (0x09<<0),  /* System clock divided by 24 */
+    ADC_PRESC_DIV28_gc = (0x0A<<0),  /* System clock divided by 28 */
+    ADC_PRESC_DIV32_gc = (0x0B<<0),  /* System clock divided by 32 */
+    ADC_PRESC_DIV40_gc = (0x0C<<0),  /* System clock divided by 40 */
+    ADC_PRESC_DIV48_gc = (0x0D<<0),  /* System clock divided by 48 */
+    ADC_PRESC_DIV56_gc = (0x0E<<0),  /* System clock divided by 56 */
+    ADC_PRESC_DIV64_gc = (0x0F<<0)  /* System clock divided by 64 */
+} ADC_PRESC_t;
+
+/* Reference select */
+typedef enum ADC_REFSEL_enum
+{
+    ADC_REFSEL_VDD_gc = (0x00<<0),  /* VDD */
+    ADC_REFSEL_VREFA_gc = (0x02<<0),  /* External Reference */
+    ADC_REFSEL_1V024_gc = (0x04<<0),  /* Internal 1.024V Reference */
+    ADC_REFSEL_2V048_gc = (0x05<<0),  /* Internal 2.048V Reference */
+    ADC_REFSEL_4V096_gc = (0x06<<0),  /* Internal 4.096V Reference */
+    ADC_REFSEL_2V500_gc = (0x07<<0)  /* Internal 2.500V Reference */
+} ADC_REFSEL_t;
+
+/* Sample numbers select */
+typedef enum ADC_SAMPNUM_enum
+{
+    ADC_SAMPNUM_NONE_gc = (0x00<<0),  /* No accumulation */
+    ADC_SAMPNUM_ACC2_gc = (0x01<<0),  /* 2 samples accumulated */
+    ADC_SAMPNUM_ACC4_gc = (0x02<<0),  /* 4 samples accumulated */
+    ADC_SAMPNUM_ACC8_gc = (0x03<<0),  /* 8 samples accumulated */
+    ADC_SAMPNUM_ACC16_gc = (0x04<<0),  /* 16 samples accumulated */
+    ADC_SAMPNUM_ACC32_gc = (0x05<<0),  /* 32 samples accumulated */
+    ADC_SAMPNUM_ACC64_gc = (0x06<<0),  /* 64 samples accumulated */
+    ADC_SAMPNUM_ACC128_gc = (0x07<<0),  /* 128 samples accumulated */
+    ADC_SAMPNUM_ACC256_gc = (0x08<<0),  /* 256 samples accumulated */
+    ADC_SAMPNUM_ACC512_gc = (0x09<<0),  /* 512 samples accumulated */
+    ADC_SAMPNUM_ACC1024_gc = (0x0A<<0)  /* 1024 samples accumulated */
+} ADC_SAMPNUM_t;
+
+/* Start command select */
+typedef enum ADC_START_enum
+{
+    ADC_START_STOP_gc = (0x00<<0),  /* Stop an ongoing conversion */
+    ADC_START_IMMEDIATE_gc = (0x01<<0),  /* Start a conversion immediately. This will be set back to STOP when the first conversion is done, unless Free-Running mode is enabled */
+    ADC_START_MUXPOS_WRITE_gc = (0x02<<0),  /* Start when MUXPOS register is written */
+    ADC_START_MUXNEG_WRITE_gc = (0x03<<0),  /* Start when MUXNEG register is written */
+    ADC_START_EVENT_TRIGGER_gc = (0x04<<0)  /* Start when an event is received */
+} ADC_START_t;
+
+/* VIA select */
+typedef enum ADC_VIA_enum
+{
+    ADC_VIA_DIRECT_gc = (0x00<<6),  /* Inputs connected directly to ADC */
+    ADC_VIA_PGA_gc = (0x01<<6)  /* Inputs connected via PGA */
+} ADC_VIA_t;
+
+/* Window Comparator Mode select */
+typedef enum ADC_WINCM_enum
+{
+    ADC_WINCM_NONE_gc = (0x00<<0),  /* No Window Comparison */
+    ADC_WINCM_BELOW_gc = (0x01<<0),  /* Below Window */
+    ADC_WINCM_ABOVE_gc = (0x02<<0),  /* Above Window */
+    ADC_WINCM_INSIDE_gc = (0x03<<0),  /* Inside Window */
+    ADC_WINCM_OUTSIDE_gc = (0x04<<0)  /* Outside Window */
+} ADC_WINCM_t;
+
+/* Window Mode Source select */
+typedef enum ADC_WINSRC_enum
+{
+    ADC_WINSRC_RESULT_gc = (0x00<<3),  /* Result register used as Window Comparator Source */
+    ADC_WINSRC_SAMPLE_gc = (0x01<<3)  /* Sample register used as Window Comparator Source */
+} ADC_WINSRC_t;
+
+/*
+--------------------------------------------------------------------------
+BOD - Bod interface
+--------------------------------------------------------------------------
+*/
+
+/* Bod interface */
+typedef struct BOD_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t reserved_1[6];
+    register8_t VLMCTRLA;  /* Voltage level monitor Control */
+    register8_t INTCTRL;  /* Voltage level monitor interrupt Control */
+    register8_t INTFLAGS;  /* Voltage level monitor interrupt Flags */
+    register8_t STATUS;  /* Voltage level monitor status */
+    register8_t reserved_2[4];
+} BOD_t;
+
+/* Operation in active mode select */
+typedef enum BOD_ACTIVE_enum
+{
+    BOD_ACTIVE_DISABLE_gc = (0x00<<2),  /* Disabled */
+    BOD_ACTIVE_ENABLED_gc = (0x01<<2),  /* Enabled in continuous mode */
+    BOD_ACTIVE_SAMPLED_gc = (0x02<<2),  /* Enabled in sampled mode */
+    BOD_ACTIVE_ENABLEWAIT_gc = (0x03<<2)  /* Enabled in continuous mode. Execution halted at wake-up until BOD is running */
+} BOD_ACTIVE_t;
+
+/* Bod level select */
+typedef enum BOD_LVL_enum
+{
+    BOD_LVL_BODLEVEL0_gc = (0x00<<0),  /* BOD Disabled during normal operation */
+    BOD_LVL_BODLEVEL1_gc = (0x01<<0),  /* 1.9 V */
+    BOD_LVL_BODLEVEL2_gc = (0x02<<0),  /* 2.7 V */
+    BOD_LVL_BODLEVEL3_gc = (0x03<<0)  /* 4.5 V */
+} BOD_LVL_t;
+
+/* Sample frequency select */
+typedef enum BOD_SAMPFREQ_enum
+{
+    BOD_SAMPFREQ_128HZ_gc = (0x00<<4),  /* Sampling frequency is 128 Hz */
+    BOD_SAMPFREQ_32HZ_gc = (0x01<<4)  /* Sample frequency is 32 Hz */
+} BOD_SAMPFREQ_t;
+
+/* Operation in sleep mode select */
+typedef enum BOD_SLEEP_enum
+{
+    BOD_SLEEP_DISABLE_gc = (0x00<<0),  /* Disabled */
+    BOD_SLEEP_ENABLE_gc = (0x01<<0),  /* Enabled in continuous mode */
+    BOD_SLEEP_SAMPLE_gc = (0x02<<0)  /* Enabled in sampled mode */
+} BOD_SLEEP_t;
+
+/* Configuration select */
+typedef enum BOD_VLMCFG_enum
+{
+    BOD_VLMCFG_FALLING_gc = (0x00<<1),  /* VDD falls below VLM threshold */
+    BOD_VLMCFG_RISING_gc = (0x01<<1),  /* VDD rises above VLM threshold */
+    BOD_VLMCFG_BOTH_gc = (0x02<<1)  /* VDD crosses VLM threshold */
+} BOD_VLMCFG_t;
+
+/* voltage level monitor level select */
+typedef enum BOD_VLMLVL_enum
+{
+    BOD_VLMLVL_OFF_gc = (0x00<<0),  /* VLM Disabled */
+    BOD_VLMLVL_5ABOVE_gc = (0x01<<0),  /* VLM threshold 5% above BOD level */
+    BOD_VLMLVL_15ABOVE_gc = (0x02<<0),  /* VLM threshold 15% above BOD level */
+    BOD_VLMLVL_25ABOVE_gc = (0x03<<0)  /* VLM threshold 25% above BOD level */
+} BOD_VLMLVL_t;
+
+/* Voltage level monitor status select */
+typedef enum BOD_VLMS_enum
+{
+    BOD_VLMS_ABOVE_gc = (0x00<<0),  /* The voltage is above the VLM threshold level */
+    BOD_VLMS_BELOW_gc = (0x01<<0)  /* The voltage is below the VLM threshold level */
+} BOD_VLMS_t;
+
+/*
+--------------------------------------------------------------------------
+CCL - Configurable Custom Logic
+--------------------------------------------------------------------------
+*/
+
+/* Configurable Custom Logic */
+typedef struct CCL_struct
+{
+    register8_t CTRLA;  /* Control Register A */
+    register8_t SEQCTRL0;  /* Sequential Control 0 */
+    register8_t SEQCTRL1;  /* Sequential Control 1 */
+    register8_t reserved_1[2];
+    register8_t INTCTRL0;  /* Interrupt Control 0 */
+    register8_t reserved_2[1];
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t LUT0CTRLA;  /* LUT 0 Control A */
+    register8_t LUT0CTRLB;  /* LUT 0 Control B */
+    register8_t LUT0CTRLC;  /* LUT 0 Control C */
+    register8_t TRUTH0;  /* Truth 0 */
+    register8_t LUT1CTRLA;  /* LUT 1 Control A */
+    register8_t LUT1CTRLB;  /* LUT 1 Control B */
+    register8_t LUT1CTRLC;  /* LUT 1 Control C */
+    register8_t TRUTH1;  /* Truth 1 */
+    register8_t LUT2CTRLA;  /* LUT 2 Control A */
+    register8_t LUT2CTRLB;  /* LUT 2 Control B */
+    register8_t LUT2CTRLC;  /* LUT 2 Control C */
+    register8_t TRUTH2;  /* Truth 2 */
+    register8_t LUT3CTRLA;  /* LUT 3 Control A */
+    register8_t LUT3CTRLB;  /* LUT 3 Control B */
+    register8_t LUT3CTRLC;  /* LUT 3 Control C */
+    register8_t TRUTH3;  /* Truth 3 */
+    register8_t reserved_3[40];
+} CCL_t;
+
+/* Clock Source Selection */
+typedef enum CCL_CLKSRC_enum
+{
+    CCL_CLKSRC_CLKPER_gc = (0x00<<1),  /* Peripheral Clock */
+    CCL_CLKSRC_IN2_gc = (0x01<<1),  /* INSEL2 selection */
+    CCL_CLKSRC_OSCHF_gc = (0x04<<1),  /* Internal High Frequency oscillator */
+    CCL_CLKSRC_OSC32K_gc = (0x05<<1),  /* Internal 32.768 kHz oscillator */
+    CCL_CLKSRC_OSC1K_gc = (0x06<<1)  /* Internal 32.768 kHz oscillator divided by 32 */
+} CCL_CLKSRC_t;
+
+/* Edge Detection Enable select */
+typedef enum CCL_EDGEDET_enum
+{
+    CCL_EDGEDET_DIS_gc = (0x00<<7),  /* Edge detector is disabled */
+    CCL_EDGEDET_EN_gc = (0x01<<7)  /* Edge detector is enabled */
+} CCL_EDGEDET_t;
+
+/* Filter Selection */
+typedef enum CCL_FILTSEL_enum
+{
+    CCL_FILTSEL_DISABLE_gc = (0x00<<4),  /* Filter disabled */
+    CCL_FILTSEL_SYNCH_gc = (0x01<<4),  /* Synchronizer enabled */
+    CCL_FILTSEL_FILTER_gc = (0x02<<4)  /* Filter enabled */
+} CCL_FILTSEL_t;
+
+/* LUT Input 0 Source Selection */
+typedef enum CCL_INSEL0_enum
+{
+    CCL_INSEL0_MASK_gc = (0x00<<0),  /* Masked input */
+    CCL_INSEL0_FEEDBACK_gc = (0x01<<0),  /* Feedback input */
+    CCL_INSEL0_LINK_gc = (0x02<<0),  /* Output from LUT[n+1] as input source */
+    CCL_INSEL0_EVENTA_gc = (0x03<<0),  /* Event A as input source */
+    CCL_INSEL0_EVENTB_gc = (0x04<<0),  /* Event B as input source */
+    CCL_INSEL0_IO_gc = (0x05<<0),  /* IN0 input source */
+    CCL_INSEL0_AC0_gc = (0x06<<0),  /* AC0 output input source */
+    CCL_INSEL0_USART0_gc = (0x07<<0),  /* USART0 TxD input source */
+    CCL_INSEL0_SPI0_gc = (0x08<<0),  /* SPI0 MISO input source */
+    CCL_INSEL0_TCA0_gc = (0x09<<0),  /* TCA0 WO0 input source */
+    CCL_INSEL0_TCA1_gc = (0x0A<<0),  /* TCA1 WO0 input source */
+    CCL_INSEL0_TCB0_gc = (0x0B<<0)  /* TCB0 WO input source */
+} CCL_INSEL0_t;
+
+/* LUT Input 1 Source Selection */
+typedef enum CCL_INSEL1_enum
+{
+    CCL_INSEL1_MASK_gc = (0x00<<4),  /* Masked input */
+    CCL_INSEL1_FEEDBACK_gc = (0x01<<4),  /* Feedback input */
+    CCL_INSEL1_LINK_gc = (0x02<<4),  /* Output from LUT[n+1] as input source */
+    CCL_INSEL1_EVENTA_gc = (0x03<<4),  /* Event A as input source */
+    CCL_INSEL1_EVENTB_gc = (0x04<<4),  /* Event B as input source */
+    CCL_INSEL1_IO_gc = (0x05<<4),  /* IN0 input source */
+    CCL_INSEL1_AC1_gc = (0x06<<4),  /* AC1 output input source */
+    CCL_INSEL1_USART1_gc = (0x07<<4),  /* USART1 TxD input source */
+    CCL_INSEL1_SPI0_gc = (0x08<<4),  /* SPI0 MISO input source */
+    CCL_INSEL1_TCA0_gc = (0x09<<4),  /* TCA0 WO1 input source */
+    CCL_INSEL1_TCA1_gc = (0x0A<<4),  /* TCA1 WO1 input source */
+    CCL_INSEL1_TCB1_gc = (0x0B<<4)  /* TCB1 WO input source */
+} CCL_INSEL1_t;
+
+/* LUT Input 2 Source Selection */
+typedef enum CCL_INSEL2_enum
+{
+    CCL_INSEL2_MASK_gc = (0x00<<0),  /* Masked input */
+    CCL_INSEL2_FEEDBACK_gc = (0x01<<0),  /* Feedback input */
+    CCL_INSEL2_LINK_gc = (0x02<<0),  /* Output from LUT[n+1] as input source */
+    CCL_INSEL2_EVENTA_gc = (0x03<<0),  /* Event A as input source */
+    CCL_INSEL2_EVENTB_gc = (0x04<<0),  /* Event B as input source */
+    CCL_INSEL2_IO_gc = (0x05<<0),  /* IN0 input source */
+    CCL_INSEL2_AC1_gc = (0x06<<0),  /* AC1 output input source */
+    CCL_INSEL2_USART2_gc = (0x07<<0),  /* USART2 TxD input source */
+    CCL_INSEL2_SPI0_gc = (0x08<<0),  /* SPI0 MISO input source */
+    CCL_INSEL2_TCA0_gc = (0x09<<0),  /* TCA0 WO2 input source */
+    CCL_INSEL2_TCA1_gc = (0x0A<<0),  /* TCA1 WO2 input source */
+    CCL_INSEL2_TCB2_gc = (0x0B<<0)  /* TCB2 WO input source */
+} CCL_INSEL2_t;
+
+/* Interrupt Mode for LUT0 select */
+typedef enum CCL_INTMODE0_enum
+{
+    CCL_INTMODE0_INTDISABLE_gc = (0x00<<0),  /* Interrupt disabled */
+    CCL_INTMODE0_RISING_gc = (0x01<<0),  /* Sense rising edge */
+    CCL_INTMODE0_FALLING_gc = (0x02<<0),  /* Sense falling edge */
+    CCL_INTMODE0_BOTH_gc = (0x03<<0)  /* Sense both edges */
+} CCL_INTMODE0_t;
+
+/* Interrupt Mode for LUT1 select */
+typedef enum CCL_INTMODE1_enum
+{
+    CCL_INTMODE1_INTDISABLE_gc = (0x00<<2),  /* Interrupt disabled */
+    CCL_INTMODE1_RISING_gc = (0x01<<2),  /* Sense rising edge */
+    CCL_INTMODE1_FALLING_gc = (0x02<<2),  /* Sense falling edge */
+    CCL_INTMODE1_BOTH_gc = (0x03<<2)  /* Sense both edges */
+} CCL_INTMODE1_t;
+
+/* Interrupt Mode for LUT2 select */
+typedef enum CCL_INTMODE2_enum
+{
+    CCL_INTMODE2_INTDISABLE_gc = (0x00<<4),  /* Interrupt disabled */
+    CCL_INTMODE2_RISING_gc = (0x01<<4),  /* Sense rising edge */
+    CCL_INTMODE2_FALLING_gc = (0x02<<4),  /* Sense falling edge */
+    CCL_INTMODE2_BOTH_gc = (0x03<<4)  /* Sense both edges */
+} CCL_INTMODE2_t;
+
+/* Interrupt Mode for LUT3 select */
+typedef enum CCL_INTMODE3_enum
+{
+    CCL_INTMODE3_INTDISABLE_gc = (0x00<<6),  /* Interrupt disabled */
+    CCL_INTMODE3_RISING_gc = (0x01<<6),  /* Sense rising edge */
+    CCL_INTMODE3_FALLING_gc = (0x02<<6),  /* Sense falling edge */
+    CCL_INTMODE3_BOTH_gc = (0x03<<6)  /* Sense both edges */
+} CCL_INTMODE3_t;
+
+/* Sequential Selection */
+typedef enum CCL_SEQSEL_enum
+{
+    CCL_SEQSEL_DISABLE_gc = (0x00<<0),  /* Sequential logic disabled */
+    CCL_SEQSEL_DFF_gc = (0x01<<0),  /* D FlipFlop */
+    CCL_SEQSEL_JK_gc = (0x02<<0),  /* JK FlipFlop */
+    CCL_SEQSEL_LATCH_gc = (0x03<<0),  /* D Latch */
+    CCL_SEQSEL_RS_gc = (0x04<<0)  /* RS Latch */
+} CCL_SEQSEL_t;
+
+/*
+--------------------------------------------------------------------------
+CLKCTRL - Clock controller
+--------------------------------------------------------------------------
+*/
+
+/* Clock controller */
+typedef struct CLKCTRL_struct
+{
+    register8_t MCLKCTRLA;  /* MCLK Control A */
+    register8_t MCLKCTRLB;  /* MCLK Control B */
+    register8_t MCLKCTRLC;  /* MCLK Control C */
+    register8_t MCLKINTCTRL;  /* MCLK Interrupt Control */
+    register8_t MCLKINTFLAGS;  /* MCLK Interrupt Flags */
+    register8_t MCLKSTATUS;  /* MCLK Status */
+    register8_t MCLKTIMEBASE;  /* MCLK Timebase */
+    register8_t reserved_1[1];
+    register8_t OSCHFCTRLA;  /* OSCHF Control A */
+    register8_t OSCHFTUNE;  /* OSCHF Tune */
+    register8_t reserved_2[14];
+    register8_t OSC32KCTRLA;  /* OSC32K Control A */
+    register8_t reserved_3[3];
+    register8_t XOSC32KCTRLA;  /* XOSC32K Control A */
+    register8_t reserved_4[3];
+    register8_t XOSCHFCTRLA;  /* XOSCHF Control A */
+} CLKCTRL_t;
+
+/* Automatic Oscillator Tune select */
+typedef enum CLKCTRL_AUTOTUNE_enum
+{
+    CLKCTRL_AUTOTUNE_OFF_gc = (0x00<<0),  /* Disabled */
+    CLKCTRL_AUTOTUNE_XOSC32K_gc = (0x01<<0)  /* Tune against 32.768 kHz Crystal Oscillator */
+} CLKCTRL_AUTOTUNE_t;
+
+/* CFD Source select */
+typedef enum CLKCTRL_CFDSRC_enum
+{
+    CLKCTRL_CFDSRC_CLKMAIN_gc = (0x00<<2),  /* Main Clock */
+    CLKCTRL_CFDSRC_XOSCHF_gc = (0x01<<2),  /* High Frequency Crystal Oscillator */
+    CLKCTRL_CFDSRC_XOSC32K_gc = (0x02<<2)  /* 32.768 kHz Crystal Oscillator */
+} CLKCTRL_CFDSRC_t;
+
+/* Clock select */
+typedef enum CLKCTRL_CLKSEL_enum
+{
+    CLKCTRL_CLKSEL_OSCHF_gc = (0x00<<0),  /* Internal high-frequency oscillator */
+    CLKCTRL_CLKSEL_OSC32K_gc = (0x01<<0),  /* Internal 32.768 kHz oscillator */
+    CLKCTRL_CLKSEL_XOSC32K_gc = (0x02<<0),  /* 32.768 kHz crystal oscillator */
+    CLKCTRL_CLKSEL_EXTCLK_gc = (0x03<<0)  /* External clock */
+} CLKCTRL_CLKSEL_t;
+
+/* Crystal startup time select */
+typedef enum CLKCTRL_CSUT_enum
+{
+    CLKCTRL_CSUT_1K_gc = (0x00<<4),  /* 1k cycles */
+    CLKCTRL_CSUT_16K_gc = (0x01<<4),  /* 16k cycles */
+    CLKCTRL_CSUT_32K_gc = (0x02<<4),  /* 32k cycles */
+    CLKCTRL_CSUT_64K_gc = (0x03<<4)  /* 64k cycles */
+} CLKCTRL_CSUT_t;
+
+/* Start-Up Time select */
+typedef enum CLKCTRL_CSUTHF_enum
+{
+    CLKCTRL_CSUTHF_256CYC_gc = (0x00<<4),  /* 256 XOSCHF Cycles */
+    CLKCTRL_CSUTHF_1KCYC_gc = (0x01<<4),  /* 1K XOSCHF Cycles */
+    CLKCTRL_CSUTHF_4KCYC_gc = (0x02<<4)  /* 4K XOSCHF Cycles */
+} CLKCTRL_CSUTHF_t;
+
+/* Interrupt Type select */
+typedef enum CLKCTRL_INTTYPE_enum
+{
+    CLKCTRL_INTTYPE_INT_gc = (0x00<<7),  /* Regular interrupt */
+    CLKCTRL_INTTYPE_NMI_gc = (0x01<<7)  /* Non-maskable interrupt */
+} CLKCTRL_INTTYPE_t;
+
+/* Prescaler division select */
+typedef enum CLKCTRL_PDIV_enum
+{
+    CLKCTRL_PDIV_DIV2_gc = (0x00<<1),  /* Divide by 2 */
+    CLKCTRL_PDIV_DIV4_gc = (0x01<<1),  /* Divide by 4 */
+    CLKCTRL_PDIV_DIV8_gc = (0x02<<1),  /* Divide by 8 */
+    CLKCTRL_PDIV_DIV16_gc = (0x03<<1),  /* Divide by 16 */
+    CLKCTRL_PDIV_DIV32_gc = (0x04<<1),  /* Divide by 32 */
+    CLKCTRL_PDIV_DIV64_gc = (0x05<<1),  /* Divide by 64 */
+    CLKCTRL_PDIV_DIV6_gc = (0x08<<1),  /* Divide by 6 */
+    CLKCTRL_PDIV_DIV10_gc = (0x09<<1),  /* Divide by 10 */
+    CLKCTRL_PDIV_DIV12_gc = (0x0A<<1),  /* Divide by 12 */
+    CLKCTRL_PDIV_DIV24_gc = (0x0B<<1),  /* Divide by 24 */
+    CLKCTRL_PDIV_DIV48_gc = (0x0C<<1)  /* Divide by 48 */
+} CLKCTRL_PDIV_t;
+
+/* Source Select */
+typedef enum CLKCTRL_SELHF_enum
+{
+    CLKCTRL_SELHF_CRYSTAL_gc = (0x00<<1),  /* External Crystal */
+    CLKCTRL_SELHF_EXTCLK_gc = (0x01<<1)  /* Extenal Clock on XTALHF1 pin */
+} CLKCTRL_SELHF_t;
+
+/*
+--------------------------------------------------------------------------
+CPU - CPU
+--------------------------------------------------------------------------
+*/
+
+#define CORE_VERSION  V4S
+
+/* CCP signature select */
+typedef enum CCP_enum
+{
+    CCP_SPM_gc = (0x9D<<0),  /* SPM Instruction Protection */
+    CCP_IOREG_gc = (0xD8<<0)  /* IO Register Protection */
+} CCP_t;
+
+/*
+--------------------------------------------------------------------------
+CPUINT - Interrupt Controller
+--------------------------------------------------------------------------
+*/
+
+/* Interrupt Controller */
+typedef struct CPUINT_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t STATUS;  /* Status */
+    register8_t LVL0PRI;  /* Interrupt Level 0 Priority */
+    register8_t LVL1VEC;  /* Interrupt Level 1 Priority Vector */
+} CPUINT_t;
+
+
+/*
+--------------------------------------------------------------------------
+CRCSCAN - CRCSCAN
+--------------------------------------------------------------------------
+*/
+
+/* CRCSCAN */
+typedef struct CRCSCAN_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t STATUS;  /* Status */
+    register8_t reserved_1[13];
+} CRCSCAN_t;
+
+/* CRC Source select */
+typedef enum CRCSCAN_SRC_enum
+{
+    CRCSCAN_SRC_FLASH_gc = (0x00<<0),  /* CRC on entire flash */
+    CRCSCAN_SRC_APPLICATION_gc = (0x01<<0),  /* CRC on boot and appl section of flash */
+    CRCSCAN_SRC_BOOT_gc = (0x02<<0)  /* CRC on boot section of flash */
+} CRCSCAN_SRC_t;
+
+/*
+--------------------------------------------------------------------------
+DAC - Digital to Analog Converter
+--------------------------------------------------------------------------
+*/
+
+/* Digital to Analog Converter */
+typedef struct DAC_struct
+{
+    register8_t CTRLA;  /* Control Register A */
+    register8_t reserved_1[1];
+    _WORDREGISTER(DATA);  /* DATA Register */
+    register8_t reserved_2[12];
+} DAC_t;
+
+/* Output Buffer Range select */
+typedef enum DAC_OUTRANGE_enum
+{
+    DAC_OUTRANGE_AUTO_gc = (0x00<<4),  /* Output buffer automatically choose best range */
+    DAC_OUTRANGE_LOW_gc = (0x02<<4),  /* Output buffer configured to low range */
+    DAC_OUTRANGE_HIGH_gc = (0x03<<4)  /* Output buffer configured to high range */
+} DAC_OUTRANGE_t;
+
+/*
+--------------------------------------------------------------------------
+EVSYS - Event System
+--------------------------------------------------------------------------
+*/
+
+/* Event System */
+typedef struct EVSYS_struct
+{
+    register8_t SWEVENTA;  /* Software Event A */
+    register8_t reserved_1[15];
+    register8_t CHANNEL0;  /* Multiplexer Channel 0 */
+    register8_t CHANNEL1;  /* Multiplexer Channel 1 */
+    register8_t CHANNEL2;  /* Multiplexer Channel 2 */
+    register8_t CHANNEL3;  /* Multiplexer Channel 3 */
+    register8_t CHANNEL4;  /* Multiplexer Channel 4 */
+    register8_t CHANNEL5;  /* Multiplexer Channel 5 */
+    register8_t reserved_2[10];
+    register8_t USERCCLLUT0A;  /* CCL0 Event A */
+    register8_t USERCCLLUT0B;  /* CCL0 Event B */
+    register8_t USERCCLLUT1A;  /* CCL1 Event A */
+    register8_t USERCCLLUT1B;  /* CCL1 Event B */
+    register8_t USERCCLLUT2A;  /* CCL2 Event A */
+    register8_t USERCCLLUT2B;  /* CCL2 Event B */
+    register8_t USERCCLLUT3A;  /* CCL3 Event A */
+    register8_t USERCCLLUT3B;  /* CCL3 Event B */
+    register8_t USERADC0START;  /* ADC0 */
+    register8_t USEREVSYSEVOUTA;  /* EVOUTA */
+    register8_t reserved_3[1];
+    register8_t USEREVSYSEVOUTC;  /* EVOUTC */
+    register8_t USEREVSYSEVOUTD;  /* EVOUTD */
+    register8_t reserved_4[1];
+    register8_t USEREVSYSEVOUTF;  /* EVOUTF */
+    register8_t USERUSART0IRDA;  /* USART0 */
+    register8_t USERUSART1IRDA;  /* USART1 */
+    register8_t USERUSART2IRDA;  /* USART2 */
+    register8_t USERTCA0CNTA;  /* TCA0 Event A */
+    register8_t USERTCA0CNTB;  /* TCA0 Event B */
+    register8_t USERTCA1CNTA;  /* TCA1 Event A */
+    register8_t USERTCA1CNTB;  /* TCA1 Event B */
+    register8_t USERTCB0CAPT;  /* TCB0 Event A */
+    register8_t USERTCB0COUNT;  /* TCB0 Event B */
+    register8_t USERTCB1CAPT;  /* TCB1 Event A */
+    register8_t USERTCB1COUNT;  /* TCB1 Event B */
+    register8_t USERTCB2CAPT;  /* TCB2 Event A */
+    register8_t USERTCB2COUNT;  /* TCB2 Event B */
+    register8_t USERTCB3CAPT;  /* TCB3 Event A */
+    register8_t USERTCB3COUNT;  /* TCB3 Event B */
+    register8_t reserved_5[2];
+} EVSYS_t;
+
+/* Channel generator select */
+typedef enum EVSYS_CHANNEL_enum
+{
+    EVSYS_CHANNEL_OFF_gc = (0x00<<0),  /* Off */
+    EVSYS_CHANNEL_UPDI_SYNCH_gc = (0x01<<0),  /* UPDI SYNCH character */
+    EVSYS_CHANNEL_RTC_OVF_gc = (0x06<<0),  /* Real Time Counter overflow */
+    EVSYS_CHANNEL_RTC_CMP_gc = (0x07<<0),  /* Real Time Counter compare */
+    EVSYS_CHANNEL_RTC_PITEV0_gc = (0x08<<0),  /* Periodic Interrupt Timer Event 0 */
+    EVSYS_CHANNEL_RTC_PITEV1_gc = (0x09<<0),  /* Periodic Interrupt Timer Event 1 */
+    EVSYS_CHANNEL_CCL_LUT0_gc = (0x10<<0),  /* Configurable Custom Logic LUT0 */
+    EVSYS_CHANNEL_CCL_LUT1_gc = (0x11<<0),  /* Configurable Custom Logic LUT1 */
+    EVSYS_CHANNEL_CCL_LUT2_gc = (0x12<<0),  /* Configurable Custom Logic LUT2 */
+    EVSYS_CHANNEL_CCL_LUT3_gc = (0x13<<0),  /* Configurable Custom Logic LUT3 */
+    EVSYS_CHANNEL_AC0_OUT_gc = (0x20<<0),  /* Analog Comparator 0 out */
+    EVSYS_CHANNEL_AC1_OUT_gc = (0x21<<0),  /* Analog Comparator 1 out */
+    EVSYS_CHANNEL_ADC0_RES_gc = (0x24<<0),  /* ADC 0 Result Ready */
+    EVSYS_CHANNEL_ADC0_SAMP_gc = (0x25<<0),  /* ADC 0 Sample Ready */
+    EVSYS_CHANNEL_ADC0_WCMP_gc = (0x26<<0),  /* ADC 0 Window Compare */
+    EVSYS_CHANNEL_PORTA_EV0_gc = (0x40<<0),  /* Port A Event 0 */
+    EVSYS_CHANNEL_PORTA_EV1_gc = (0x41<<0),  /* Port A Event 1 */
+    EVSYS_CHANNEL_PORTC_EV0_gc = (0x44<<0),  /* Port C Event 0 */
+    EVSYS_CHANNEL_PORTC_EV1_gc = (0x45<<0),  /* Port C Event 1 */
+    EVSYS_CHANNEL_PORTD_EV0_gc = (0x46<<0),  /* Port D Event 0 */
+    EVSYS_CHANNEL_PORTD_EV1_gc = (0x47<<0),  /* Port D Event 1 */
+    EVSYS_CHANNEL_PORTF_EV0_gc = (0x4A<<0),  /* Port F Event 0 */
+    EVSYS_CHANNEL_PORTF_EV1_gc = (0x4B<<0),  /* Port F Event 1 */
+    EVSYS_CHANNEL_USART0_XCK_gc = (0x60<<0),  /* USART 0 XCK */
+    EVSYS_CHANNEL_USART1_XCK_gc = (0x61<<0),  /* USART 1 XCK */
+    EVSYS_CHANNEL_USART2_XCK_gc = (0x62<<0),  /* USART 2 XCK */
+    EVSYS_CHANNEL_SPI0_SCK_gc = (0x68<<0),  /* SPI 0 SCK */
+    EVSYS_CHANNEL_TCA0_OVF_LUNF_gc = (0x80<<0),  /* Timer/Counter A0 overflow / low byte timer underflow */
+    EVSYS_CHANNEL_TCA0_HUNF_gc = (0x81<<0),  /* Timer/Counter A0 high byte timer underflow */
+    EVSYS_CHANNEL_TCA0_CMP0_LCMP0_gc = (0x84<<0),  /* Timer/Counter A0 compare 0 / low byte timer compare 0 */
+    EVSYS_CHANNEL_TCA0_CMP1_LCMP1_gc = (0x85<<0),  /* Timer/Counter A0 compare 1 / low byte timer compare 1 */
+    EVSYS_CHANNEL_TCA0_CMP2_LCMP2_gc = (0x86<<0),  /* Timer/Counter A0 compare 2 / low byte timer compare 2 */
+    EVSYS_CHANNEL_TCA1_OVF_LUNF_gc = (0x88<<0),  /* Timer/Counter A1 overflow / low byte timer underflow */
+    EVSYS_CHANNEL_TCA1_HUNF_gc = (0x89<<0),  /* Timer/Counter A1 high byte timer underflow */
+    EVSYS_CHANNEL_TCA1_CMP0_LCMP0_gc = (0x8C<<0),  /* Timer/Counter A1 compare 0 / low byte timer compare 0 */
+    EVSYS_CHANNEL_TCA1_CMP1_LCMP1_gc = (0x8D<<0),  /* Timer/Counter A1 compare 1 / low byte timer compare 1 */
+    EVSYS_CHANNEL_TCA1_CMP2_LCMP2_gc = (0x8E<<0),  /* Timer/Counter A1 compare 2 / low byte timer compare 2 */
+    EVSYS_CHANNEL_TCB0_CAPT_gc = (0xA0<<0),  /* Timer/Counter B0 capture */
+    EVSYS_CHANNEL_TCB0_OVF_gc = (0xA1<<0),  /* Timer/Counter B0 overflow */
+    EVSYS_CHANNEL_TCB1_CAPT_gc = (0xA2<<0),  /* Timer/Counter B1 capture */
+    EVSYS_CHANNEL_TCB1_OVF_gc = (0xA3<<0),  /* Timer/Counter B1 overflow */
+    EVSYS_CHANNEL_TCB2_CAPT_gc = (0xA4<<0),  /* Timer/Counter B2 capture */
+    EVSYS_CHANNEL_TCB2_OVF_gc = (0xA5<<0),  /* Timer/Counter B2 overflow */
+    EVSYS_CHANNEL_TCB3_CAPT_gc = (0xA6<<0),  /* Timer/Counter B3 capture */
+    EVSYS_CHANNEL_TCB3_OVF_gc = (0xA7<<0)  /* Timer/Counter B3 overflow */
+} EVSYS_CHANNEL_t;
+
+/* Software event on channel select */
+typedef enum EVSYS_SWEVENTA_enum
+{
+    EVSYS_SWEVENTA_CH0_gc = (0x01<<0),  /* Software event on channel 0 */
+    EVSYS_SWEVENTA_CH1_gc = (0x02<<0),  /* Software event on channel 1 */
+    EVSYS_SWEVENTA_CH2_gc = (0x04<<0),  /* Software event on channel 2 */
+    EVSYS_SWEVENTA_CH3_gc = (0x08<<0),  /* Software event on channel 3 */
+    EVSYS_SWEVENTA_CH4_gc = (0x10<<0),  /* Software event on channel 4 */
+    EVSYS_SWEVENTA_CH5_gc = (0x20<<0),  /* Software event on channel 5 */
+    EVSYS_SWEVENTA_CH6_gc = (0x40<<0),  /* Software event on channel 6 */
+    EVSYS_SWEVENTA_CH7_gc = (0x80<<0)  /* Software event on channel 7 */
+} EVSYS_SWEVENTA_t;
+
+/* User channel select */
+typedef enum EVSYS_USER_enum
+{
+    EVSYS_USER_OFF_gc = (0x00<<0),  /* Off, No Eventsys Channel connected */
+    EVSYS_USER_CHANNEL0_gc = (0x01<<0),  /* Connect user to event channel 0 */
+    EVSYS_USER_CHANNEL1_gc = (0x02<<0),  /* Connect user to event channel 1 */
+    EVSYS_USER_CHANNEL2_gc = (0x03<<0),  /* Connect user to event channel 2 */
+    EVSYS_USER_CHANNEL3_gc = (0x04<<0),  /* Connect user to event channel 3 */
+    EVSYS_USER_CHANNEL4_gc = (0x05<<0),  /* Connect user to event channel 4 */
+    EVSYS_USER_CHANNEL5_gc = (0x06<<0)  /* Connect user to event channel 5 */
+} EVSYS_USER_t;
+
+/*
+--------------------------------------------------------------------------
+FUSE - Fuses
+--------------------------------------------------------------------------
+*/
+
+/* Fuses */
+typedef struct FUSE_struct
+{
+    register8_t WDTCFG;  /* Watchdog Configuration */
+    register8_t BODCFG;  /* BOD Configuration */
+    register8_t OSCCFG;  /* Oscillator Configuration */
+    register8_t reserved_1[2];
+    register8_t SYSCFG0;  /* System Configuration 0 */
+    register8_t SYSCFG1;  /* System Configuration 1 */
+    register8_t CODESIZE;  /* Code Section Size */
+    register8_t BOOTSIZE;  /* Boot Section Size */
+} FUSE_t;
+
+/* avr-libc typedef for avr/fuse.h */
+typedef FUSE_t NVM_FUSES_t;
+
+/* BOD Operation in Active Mode select */
+typedef enum ACTIVE_enum
+{
+    ACTIVE_DISABLE_gc = (0x00<<2),  /* Disabled */
+    ACTIVE_ENABLED_gc = (0x01<<2),  /* Enabled in continuous mode */
+    ACTIVE_SAMPLED_gc = (0x02<<2),  /* Enabled in sampled mode */
+    ACTIVE_ENABLEWAIT_gc = (0x03<<2)  /* Enabled in continuous mode. Execution halted at wake-up until BOD is running */
+} ACTIVE_t;
+
+/* CRC Select */
+typedef enum CRCSEL_enum
+{
+    CRCSEL_CRC16_gc = (0x00<<5),  /* Enable CRC16 */
+    CRCSEL_CRC32_gc = (0x01<<5)  /* Enable CRC32 */
+} CRCSEL_t;
+
+/* CRC Source select */
+typedef enum CRCSRC_enum
+{
+    CRCSRC_FLASH_gc = (0x00<<6),  /* CRC of full Flash (boot, application code and application data) */
+    CRCSRC_BOOT_gc = (0x01<<6),  /* CRC of boot section */
+    CRCSRC_BOOTAPP_gc = (0x02<<6),  /* CRC of application code and boot sections */
+    CRCSRC_NOCRC_gc = (0x03<<6)  /* No CRC */
+} CRCSRC_t;
+
+/* EEPROM Save select */
+typedef enum EESAVE_enum
+{
+    EESAVE_DISABLE_gc = (0x00<<0),  /* EEPROM content is erased during chip erase */
+    EESAVE_ENABLE_gc = (0x01<<0)  /* EEPROM content is preserved during chip erase */
+} EESAVE_t;
+
+/* BOD Level select */
+typedef enum LVL_enum
+{
+    LVL_BODLEVEL0_gc = (0x00<<5),  /* BOD Disabled during normal operation */
+    LVL_BODLEVEL1_gc = (0x01<<5),  /* 1.9 V */
+    LVL_BODLEVEL2_gc = (0x02<<5),  /* 2.7 V */
+    LVL_BODLEVEL3_gc = (0x03<<5)  /* 4.5 V */
+} LVL_t;
+
+/* High-frequency Oscillator Frequency select */
+typedef enum OSCHFFRQ_enum
+{
+    OSCHFFRQ_20M_gc = (0x00<<3),  /* OSCHF running at 20 MHz */
+    OSCHFFRQ_16M_gc = (0x01<<3)  /* OSCHF running at 16 MHz */
+} OSCHFFRQ_t;
+
+/* Watchdog Timeout Period select */
+typedef enum PERIOD_enum
+{
+    PERIOD_OFF_gc = (0x00<<0),  /* Watch-Dog timer Off */
+    PERIOD_8CLK_gc = (0x01<<0),  /* 8 cycles (8ms) */
+    PERIOD_16CLK_gc = (0x02<<0),  /* 16 cycles (16ms) */
+    PERIOD_32CLK_gc = (0x03<<0),  /* 32 cycles (32ms) */
+    PERIOD_64CLK_gc = (0x04<<0),  /* 64 cycles (64ms) */
+    PERIOD_128CLK_gc = (0x05<<0),  /* 128 cycles (0.128s) */
+    PERIOD_256CLK_gc = (0x06<<0),  /* 256 cycles (0.256s) */
+    PERIOD_512CLK_gc = (0x07<<0),  /* 512 cycles (0.512s) */
+    PERIOD_1KCLK_gc = (0x08<<0),  /* 1K cycles (1.0s) */
+    PERIOD_2KCLK_gc = (0x09<<0),  /* 2K cycles (2.0s) */
+    PERIOD_4KCLK_gc = (0x0A<<0),  /* 4K cycles (4.0s) */
+    PERIOD_8KCLK_gc = (0x0B<<0)  /* 8K cycles (8.0s) */
+} PERIOD_t;
+
+/* Reset Pin Configuration select */
+typedef enum RSTPINCFG_enum
+{
+    RSTPINCFG_NONE_gc = (0x00<<3),  /* No External Reset */
+    RSTPINCFG_RESET_gc = (0x01<<3)  /* PF6 configured as RESET pin */
+} RSTPINCFG_t;
+
+/* BOD Sample Frequency select */
+typedef enum SAMPFREQ_enum
+{
+    SAMPFREQ_128HZ_gc = (0x00<<4),  /* Sampling frequency is 128 Hz */
+    SAMPFREQ_32HZ_gc = (0x01<<4)  /* Sample frequency is 32 Hz */
+} SAMPFREQ_t;
+
+/* BOD Operation in Sleep Mode select */
+typedef enum SLEEP_enum
+{
+    SLEEP_DISABLE_gc = (0x00<<0),  /* Disabled */
+    SLEEP_ENABLE_gc = (0x01<<0),  /* Enabled in continuous mode */
+    SLEEP_SAMPLE_gc = (0x02<<0)  /* Enabled in sampled mode */
+} SLEEP_t;
+
+/* Startup Time select */
+typedef enum SUT_enum
+{
+    SUT_0MS_gc = (0x00<<0),  /* 0 ms */
+    SUT_1MS_gc = (0x01<<0),  /* 1 ms */
+    SUT_2MS_gc = (0x02<<0),  /* 2 ms */
+    SUT_4MS_gc = (0x03<<0),  /* 4 ms */
+    SUT_8MS_gc = (0x04<<0),  /* 8 ms */
+    SUT_16MS_gc = (0x05<<0),  /* 16 ms */
+    SUT_32MS_gc = (0x06<<0),  /* 32 ms */
+    SUT_64MS_gc = (0x07<<0)  /* 64 ms */
+} SUT_t;
+
+/* UPDI Pin Configuration select */
+typedef enum UPDIPINCFG_enum
+{
+    UPDIPINCFG_GPIO_gc = (0x00<<4),  /* PF7 Configured as GPIO pin */
+    UPDIPINCFG_UPDI_gc = (0x01<<4)  /* PF7 Configured as UPDI pin */
+} UPDIPINCFG_t;
+
+/* Watchdog Window Timeout Period select */
+typedef enum WINDOW_enum
+{
+    WINDOW_OFF_gc = (0x00<<4),  /* Window mode off */
+    WINDOW_8CLK_gc = (0x01<<4),  /* 8 cycles (8ms) */
+    WINDOW_16CLK_gc = (0x02<<4),  /* 16 cycles (16ms) */
+    WINDOW_32CLK_gc = (0x03<<4),  /* 32 cycles (32ms) */
+    WINDOW_64CLK_gc = (0x04<<4),  /* 64 cycles (64ms) */
+    WINDOW_128CLK_gc = (0x05<<4),  /* 128 cycles (0.128s) */
+    WINDOW_256CLK_gc = (0x06<<4),  /* 256 cycles (0.256s) */
+    WINDOW_512CLK_gc = (0x07<<4),  /* 512 cycles (0.512s) */
+    WINDOW_1KCLK_gc = (0x08<<4),  /* 1K cycles (1.0s) */
+    WINDOW_2KCLK_gc = (0x09<<4),  /* 2K cycles (2.0s) */
+    WINDOW_4KCLK_gc = (0x0A<<4),  /* 4K cycles (4.0s) */
+    WINDOW_8KCLK_gc = (0x0B<<4)  /* 8K cycles (8.0s) */
+} WINDOW_t;
+
+/*
+--------------------------------------------------------------------------
+GPR - General Purpose Registers
+--------------------------------------------------------------------------
+*/
+
+/* General Purpose Registers */
+typedef struct GPR_struct
+{
+    register8_t GPR0;  /* General Purpose Register 0 */
+    register8_t GPR1;  /* General Purpose Register 1 */
+    register8_t GPR2;  /* General Purpose Register 2 */
+    register8_t GPR3;  /* General Purpose Register 3 */
+} GPR_t;
+
+
+/*
+--------------------------------------------------------------------------
+LOCK - Lockbits
+--------------------------------------------------------------------------
+*/
+
+/* Lockbits */
+typedef struct LOCK_struct
+{
+    _DWORDREGISTER(KEY);  /* Lock Key Bits */
+} LOCK_t;
+
+/* Lock Key select */
+typedef enum LOCK_KEY_enum
+{
+    LOCK_KEY_NOLOCK_gc = (0x5CC5C55C<<0),  /* No locks */
+    LOCK_KEY_RWLOCK_gc = (0xA33A3AA3<<0)  /* Read and write lock */
+} LOCK_KEY_t;
+
+/*
+--------------------------------------------------------------------------
+NVMCTRL - Non-volatile Memory Controller
+--------------------------------------------------------------------------
+*/
+
+/* Non-volatile Memory Controller */
+typedef struct NVMCTRL_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t reserved_1[2];
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t STATUS;  /* Status */
+    register8_t reserved_2[1];
+    _WORDREGISTER(DATA);  /* Data */
+    register8_t reserved_3[2];
+    _DWORDREGISTER(ADDR);  /* Address */
+    register8_t reserved_4[48];
+} NVMCTRL_t;
+
+/* Command select */
+typedef enum NVMCTRL_CMD_enum
+{
+    NVMCTRL_CMD_NOCMD_gc = (0x00<<0),  /* No Command */
+    NVMCTRL_CMD_NOOP_gc = (0x01<<0),  /* No Operation */
+    NVMCTRL_CMD_FLPW_gc = (0x04<<0),  /* Flash Page Write */
+    NVMCTRL_CMD_FLPERW_gc = (0x05<<0),  /* Flash Page Erase and Write */
+    NVMCTRL_CMD_FLPER_gc = (0x08<<0),  /* Flash Page Erase */
+    NVMCTRL_CMD_FLMPER2_gc = (0x09<<0),  /* Flash 2-page erase enable */
+    NVMCTRL_CMD_FLMPER4_gc = (0x0A<<0),  /* Flash 4-page erase enable */
+    NVMCTRL_CMD_FLMPER8_gc = (0x0B<<0),  /* Flash 8-page erase enable */
+    NVMCTRL_CMD_FLMPER16_gc = (0x0C<<0),  /* Flash 16-page erase enable */
+    NVMCTRL_CMD_FLMPER32_gc = (0x0D<<0),  /* Flash 32-page erase enable */
+    NVMCTRL_CMD_FLPBCLR_gc = (0x0F<<0),  /* Flash Page Buffer Clear */
+    NVMCTRL_CMD_EEPW_gc = (0x14<<0),  /* EEPROM Page Write */
+    NVMCTRL_CMD_EEPERW_gc = (0x15<<0),  /* EEPROM Page Erase and Write */
+    NVMCTRL_CMD_EEPER_gc = (0x17<<0),  /* EEPROM Page Erase */
+    NVMCTRL_CMD_EEPBCLR_gc = (0x1F<<0),  /* EEPROM Page Buffer Clear */
+    NVMCTRL_CMD_CHER_gc = (0x20<<0),  /* Chip Erase Command (UPDI only) */
+    NVMCTRL_CMD_EECHER_gc = (0x30<<0)  /* EEPROM Erase Command (UPDI only) */
+} NVMCTRL_CMD_t;
+
+/* Write error select */
+typedef enum NVMCTRL_ERROR_enum
+{
+    NVMCTRL_ERROR_NOERROR_gc = (0x00<<4),  /* No Error */
+    NVMCTRL_ERROR_WRITEPROTECT_gc = (0x02<<4),  /* Attempt to program write protected area */
+    NVMCTRL_ERROR_CMDCOLLISION_gc = (0x03<<4),  /* Selecting new write command while write command already seleted */
+    NVMCTRL_ERROR_WRONGSECTION_gc = (0x04<<4)  /* Address cannot be written with selected command */
+} NVMCTRL_ERROR_t;
+
+/* Flash Mapping in Data space select */
+typedef enum NVMCTRL_FLMAP_enum
+{
+    NVMCTRL_FLMAP_SECTION0_gc = (0x00<<4),  /* Flash section 0, 0 - 32KB */
+    NVMCTRL_FLMAP_SECTION1_gc = (0x01<<4),  /* Flash section 1, 32 - 64KB */
+    NVMCTRL_FLMAP_SECTION2_gc = (0x02<<4),  /* Flash section 2, 64 - 96KB */
+    NVMCTRL_FLMAP_SECTION3_gc = (0x03<<4)  /* Flash section 3, 96 - 128KB */
+} NVMCTRL_FLMAP_t;
+
+/*
+--------------------------------------------------------------------------
+PORT - I/O Ports
+--------------------------------------------------------------------------
+*/
+
+/* I/O Ports */
+typedef struct PORT_struct
+{
+    register8_t DIR;  /* Data Direction */
+    register8_t DIRSET;  /* Data Direction Set */
+    register8_t DIRCLR;  /* Data Direction Clear */
+    register8_t DIRTGL;  /* Data Direction Toggle */
+    register8_t OUT;  /* Output Value */
+    register8_t OUTSET;  /* Output Value Set */
+    register8_t OUTCLR;  /* Output Value Clear */
+    register8_t OUTTGL;  /* Output Value Toggle */
+    register8_t IN;  /* Input Value */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t PORTCTRL;  /* Port Control */
+    register8_t PINCONFIG;  /* Pin Control Config */
+    register8_t PINCTRLUPD;  /* Pin Control Update */
+    register8_t PINCTRLSET;  /* Pin Control Set */
+    register8_t PINCTRLCLR;  /* Pin Control Clear */
+    register8_t reserved_1[1];
+    register8_t PIN0CTRL;  /* Pin 0 Control */
+    register8_t PIN1CTRL;  /* Pin 1 Control */
+    register8_t PIN2CTRL;  /* Pin 2 Control */
+    register8_t PIN3CTRL;  /* Pin 3 Control */
+    register8_t PIN4CTRL;  /* Pin 4 Control */
+    register8_t PIN5CTRL;  /* Pin 5 Control */
+    register8_t PIN6CTRL;  /* Pin 6 Control */
+    register8_t PIN7CTRL;  /* Pin 7 Control */
+    register8_t EVGENCTRL;  /* Event Generation Control */
+    register8_t reserved_2[7];
+} PORT_t;
+
+/* Event Generator 0 Select */
+typedef enum PORT_EVGEN0SEL_enum
+{
+    PORT_EVGEN0SEL_PIN0_gc = (0x00<<0),  /* Pin 0 used as event generator */
+    PORT_EVGEN0SEL_PIN1_gc = (0x01<<0),  /* Pin 1 used as event generator */
+    PORT_EVGEN0SEL_PIN2_gc = (0x02<<0),  /* Pin 2 used as event generator */
+    PORT_EVGEN0SEL_PIN3_gc = (0x03<<0),  /* Pin 3 used as event generator */
+    PORT_EVGEN0SEL_PIN4_gc = (0x04<<0),  /* Pin 4 used as event generator */
+    PORT_EVGEN0SEL_PIN5_gc = (0x05<<0),  /* Pin 5 used as event generator */
+    PORT_EVGEN0SEL_PIN6_gc = (0x06<<0),  /* Pin 6 used as event generator */
+    PORT_EVGEN0SEL_PIN7_gc = (0x07<<0)  /* Pin 7 used as event generator */
+} PORT_EVGEN0SEL_t;
+
+/* Event Generator 1 Select */
+typedef enum PORT_EVGEN1SEL_enum
+{
+    PORT_EVGEN1SEL_PIN0_gc = (0x00<<4),  /* Pin 0 used as event generator */
+    PORT_EVGEN1SEL_PIN1_gc = (0x01<<4),  /* Pin 1 used as event generator */
+    PORT_EVGEN1SEL_PIN2_gc = (0x02<<4),  /* Pin 2 used as event generator */
+    PORT_EVGEN1SEL_PIN3_gc = (0x03<<4),  /* Pin 3 used as event generator */
+    PORT_EVGEN1SEL_PIN4_gc = (0x04<<4),  /* Pin 4 used as event generator */
+    PORT_EVGEN1SEL_PIN5_gc = (0x05<<4),  /* Pin 5 used as event generator */
+    PORT_EVGEN1SEL_PIN6_gc = (0x06<<4),  /* Pin 6 used as event generator */
+    PORT_EVGEN1SEL_PIN7_gc = (0x07<<4)  /* Pin 7 used as event generator */
+} PORT_EVGEN1SEL_t;
+
+/* Input Level Select */
+typedef enum PORT_INLVL_enum
+{
+    PORT_INLVL_ST_gc = (0x00<<6),  /* Schmitt-Trigger input level */
+    PORT_INLVL_TTL_gc = (0x01<<6)  /* TTL Input level */
+} PORT_INLVL_t;
+
+/* Input/Sense Configuration select */
+typedef enum PORT_ISC_enum
+{
+    PORT_ISC_INTDISABLE_gc = (0x00<<0),  /* Interrupt disabled but input buffer enabled */
+    PORT_ISC_BOTHEDGES_gc = (0x01<<0),  /* Sense Both Edges */
+    PORT_ISC_RISING_gc = (0x02<<0),  /* Sense Rising Edge */
+    PORT_ISC_FALLING_gc = (0x03<<0),  /* Sense Falling Edge */
+    PORT_ISC_INPUT_DISABLE_gc = (0x04<<0),  /* Digital Input Buffer disabled */
+    PORT_ISC_LEVEL_gc = (0x05<<0)  /* Sense low Level */
+} PORT_ISC_t;
+
+/*
+--------------------------------------------------------------------------
+PORTMUX - Port Multiplexer
+--------------------------------------------------------------------------
+*/
+
+/* Port Multiplexer */
+typedef struct PORTMUX_struct
+{
+    register8_t EVSYSROUTEA;  /* EVSYS route A */
+    register8_t CCLROUTEA;  /* CCL route A */
+    register8_t USARTROUTEA;  /* USART route A */
+    register8_t USARTROUTEB;  /* USART route B */
+    register8_t reserved_1[1];
+    register8_t SPIROUTEA;  /* SPI route A */
+    register8_t TWIROUTEA;  /* TWI route A */
+    register8_t TCAROUTEA;  /* TCA route A */
+    register8_t TCBROUTEA;  /* TCB route A */
+    register8_t reserved_2[1];
+    register8_t ACROUTEA;  /* AC route A */
+    register8_t reserved_3[21];
+} PORTMUX_t;
+
+/* Analog Comparator 0 Output select */
+typedef enum PORTMUX_AC0_enum
+{
+    PORTMUX_AC0_DEFAULT_gc = (0x00<<0)  /* OUT: PA7 */
+} PORTMUX_AC0_t;
+
+/* Analog Comparator 1 Output select */
+typedef enum PORTMUX_AC1_enum
+{
+    PORTMUX_AC1_DEFAULT_gc = (0x00<<1)  /* OUT: PA7 */
+} PORTMUX_AC1_t;
+
+/* Event Output A select */
+typedef enum PORTMUX_EVOUTA_enum
+{
+    PORTMUX_EVOUTA_DEFAULT_gc = (0x00<<0),  /* EVOUTA: PA2 */
+    PORTMUX_EVOUTA_ALT1_gc = (0x01<<0)  /* EVOUTA: PA7 */
+} PORTMUX_EVOUTA_t;
+
+/* Event Output C select */
+typedef enum PORTMUX_EVOUTC_enum
+{
+    PORTMUX_EVOUTC_DEFAULT_gc = (0x00<<2)  /* EVOUTC: PC2 */
+} PORTMUX_EVOUTC_t;
+
+/* Event Output D select */
+typedef enum PORTMUX_EVOUTD_enum
+{
+    PORTMUX_EVOUTD_DEFAULT_gc = (0x00<<3),  /* EVOUTD: PD2 */
+    PORTMUX_EVOUTD_ALT1_gc = (0x01<<3)  /* EVOUTD: PD7 */
+} PORTMUX_EVOUTD_t;
+
+/* Event Output F select */
+typedef enum PORTMUX_EVOUTF_enum
+{
+    PORTMUX_EVOUTF_DEFAULT_gc = (0x00<<5),  /* Not connected to any pins */
+    PORTMUX_EVOUTF_ALT1_gc = (0x01<<5)  /* EVOUTF: PF7 */
+} PORTMUX_EVOUTF_t;
+
+/* CCL Look-Up Table 0 Signals select */
+typedef enum PORTMUX_LUT0_enum
+{
+    PORTMUX_LUT0_DEFAULT_gc = (0x00<<0),  /* In: PA0, PA1, PA2, Out: PA3 */
+    PORTMUX_LUT0_ALT1_gc = (0x01<<0)  /* In: PA0, PA1, PA2, Out: PA6 */
+} PORTMUX_LUT0_t;
+
+/* CCL Look-Up Table 1 Signals select */
+typedef enum PORTMUX_LUT1_enum
+{
+    PORTMUX_LUT1_DEFAULT_gc = (0x00<<1),  /* In: PC0, PC1, PC2, Out: PC3 */
+    PORTMUX_LUT1_ALT1_gc = (0x01<<1)  /* In: PC0, PC1, PC2, Out: - */
+} PORTMUX_LUT1_t;
+
+/* CCL Look-Up Table 2 Signals select */
+typedef enum PORTMUX_LUT2_enum
+{
+    PORTMUX_LUT2_DEFAULT_gc = (0x00<<2),  /* In: PD0, PD1, PD2, Out: PD3 */
+    PORTMUX_LUT2_ALT1_gc = (0x01<<2)  /* In: PD0, PD1, PD2, Out: PD6 */
+} PORTMUX_LUT2_t;
+
+/* SPI0 Signals select */
+typedef enum PORTMUX_SPI0_enum
+{
+    PORTMUX_SPI0_DEFAULT_gc = (0x00<<0),  /* MOSI: PA4, MISO: PA5, SCK: PA6, SS: PA7 */
+    PORTMUX_SPI0_ALT3_gc = (0x03<<0),  /* MOSI: PA0, MISO: PA1, SCK: PC0, SS: PC1 */
+    PORTMUX_SPI0_ALT4_gc = (0x04<<0),  /* MOSI: PD4, MISO: PD5, SCK: PD6, SS: PD7 */
+    PORTMUX_SPI0_ALT5_gc = (0x05<<0),  /* MOSI: PC0, MISO: PC1, SCK: PC2, SS: PC3 */
+    PORTMUX_SPI0_ALT6_gc = (0x06<<0),  /* MOSI: PC1, MISO: PC2, SCK: PC3, SS: PF7 */
+    PORTMUX_SPI0_NONE_gc = (0x07<<0)  /* Not connected to any pins, SS set to 1 */
+} PORTMUX_SPI0_t;
+
+/* TCA0 Signals select */
+typedef enum PORTMUX_TCA0_enum
+{
+    PORTMUX_TCA0_PORTA_gc = (0x00<<0),  /* WOn: PA0, PA1, PA2, PA3, PA4, PA5 */
+    PORTMUX_TCA0_PORTC_gc = (0x02<<0),  /* WOn: PC0, PC1, PC2, PC3, -, - */
+    PORTMUX_TCA0_PORTD_gc = (0x03<<0),  /* WOn: PD0, PD1, PD2, PD3, PD4, PD5 */
+    PORTMUX_TCA0_PORTF_gc = (0x05<<0)  /* WOn: PF0, PF1, -, -, -, - */
+} PORTMUX_TCA0_t;
+
+/* TCA1 Signals select */
+typedef enum PORTMUX_TCA1_enum
+{
+    PORTMUX_TCA1_PORTB_gc = (0x00<<3),  /* Not connected to any pins */
+    PORTMUX_TCA1_PORTA_gc = (0x04<<3),  /* WOn: PA4, PA5, PA6, -, -, - */
+    PORTMUX_TCA1_PORTD_gc = (0x05<<3)  /* WOn: PD4, PD5, PD6, -, -, - */
+} PORTMUX_TCA1_t;
+
+/* TCB0 Output select */
+typedef enum PORTMUX_TCB0_enum
+{
+    PORTMUX_TCB0_DEFAULT_gc = (0x00<<0)  /* WO: PA2 */
+} PORTMUX_TCB0_t;
+
+/* TCB1 Output select */
+typedef enum PORTMUX_TCB1_enum
+{
+    PORTMUX_TCB1_DEFAULT_gc = (0x00<<1)  /* WO: PA3 */
+} PORTMUX_TCB1_t;
+
+/* TCB2 Output select */
+typedef enum PORTMUX_TCB2_enum
+{
+    PORTMUX_TCB2_DEFAULT_gc = (0x00<<2)  /* WO: PC0 */
+} PORTMUX_TCB2_t;
+
+/* TCB3 Output select */
+typedef enum PORTMUX_TCB3_enum
+{
+    PORTMUX_TCB3_DEFAULT_gc = (0x00<<3),  /* Not connected to any pins */
+    PORTMUX_TCB3_ALT1_gc = (0x01<<3)  /* WO: PC1 */
+} PORTMUX_TCB3_t;
+
+/* TWI0 Signals select */
+typedef enum PORTMUX_TWI0_enum
+{
+    PORTMUX_TWI0_DEFAULT_gc = (0x00<<0),  /* SDA: PA2, SCL: PA3. Dual mode: SDA: PC2, SCL: PC3 */
+    PORTMUX_TWI0_ALT1_gc = (0x01<<0),  /* SDA: PA2, SCL: PA3. Dual mode: SDA: -, SCL: - */
+    PORTMUX_TWI0_ALT2_gc = (0x02<<0),  /* SDA: PC2, SCL: PC3. Dual mode: SDA: -, SCL: - */
+    PORTMUX_TWI0_ALT3_gc = (0x03<<0)  /* SDA: PA0, SCL: PA1. Dual mode: SDA: PC2, SCL: PC3 */
+} PORTMUX_TWI0_t;
+
+/* USART0 Routing select */
+typedef enum PORTMUX_USART0_enum
+{
+    PORTMUX_USART0_DEFAULT_gc = (0x00<<0),  /* TxD: PA0, RxD: PA1, XCK: PA2, XDIR: PA3 */
+    PORTMUX_USART0_ALT1_gc = (0x01<<0),  /* TxD: PA4, RxD: PA5, XCK: PA6, XDIR: PA7 */
+    PORTMUX_USART0_ALT2_gc = (0x02<<0),  /* TxD: PA2, RxD: PA3, XCK: -, XDIR: - */
+    PORTMUX_USART0_ALT3_gc = (0x03<<0),  /* TxD: PD4, RxD: PD5, XCK: PD6, XDIR: PD7 */
+    PORTMUX_USART0_ALT4_gc = (0x04<<0),  /* TxD: PC1, RxD: PC2, XCK: PC3, XDIR: - */
+    PORTMUX_USART0_NONE_gc = (0x05<<0)  /* Not connected to any pins */
+} PORTMUX_USART0_t;
+
+/* USART1 Routing select */
+typedef enum PORTMUX_USART1_enum
+{
+    PORTMUX_USART1_DEFAULT_gc = (0x00<<3),  /* TxD: PC0, RxD: PC1, XCK: PC2, XDIR: PC3 */
+    PORTMUX_USART1_ALT2_gc = (0x02<<3),  /* TxD: PD6, RxD: PD7, XCK: -, XDIR: - */
+    PORTMUX_USART1_NONE_gc = (0x03<<3)  /* Not connected to any pins */
+} PORTMUX_USART1_t;
+
+/* USART2 Routing select */
+typedef enum PORTMUX_USART2_enum
+{
+    PORTMUX_USART2_DEFAULT_gc = (0x00<<0),  /* TxD: PF0, RxD: PF1, XCK: -, XDIR: - */
+    PORTMUX_USART2_NONE_gc = (0x03<<0)  /* Not connected to any pins */
+} PORTMUX_USART2_t;
+
+/*
+--------------------------------------------------------------------------
+RSTCTRL - Reset controller
+--------------------------------------------------------------------------
+*/
+
+/* Reset controller */
+typedef struct RSTCTRL_struct
+{
+    register8_t RSTFR;  /* Reset Flags */
+    register8_t SWRR;  /* Software Reset */
+    register8_t reserved_1[14];
+} RSTCTRL_t;
+
+
+/*
+--------------------------------------------------------------------------
+RTC - Real-Time Counter
+--------------------------------------------------------------------------
+*/
+
+/* Real-Time Counter */
+typedef struct RTC_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t STATUS;  /* Status */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t TEMP;  /* Temporary */
+    register8_t DBGCTRL;  /* Debug control */
+    register8_t CALIB;  /* Calibration */
+    register8_t CLKSEL;  /* Clock Select */
+    _WORDREGISTER(CNT);  /* Counter */
+    _WORDREGISTER(PER);  /* Period */
+    _WORDREGISTER(CMP);  /* Compare */
+    register8_t reserved_1[2];
+    register8_t PITCTRLA;  /* PIT Control A */
+    register8_t PITSTATUS;  /* PIT Status */
+    register8_t PITINTCTRL;  /* PIT Interrupt Control */
+    register8_t PITINTFLAGS;  /* PIT Interrupt Flags */
+    register8_t reserved_2[1];
+    register8_t PITDBGCTRL;  /* PIT Debug control */
+    register8_t PITEVGENCTRLA;  /* PIT Event Generation Control A */
+    register8_t reserved_3[9];
+} RTC_t;
+
+/* Clock Select */
+typedef enum RTC_CLKSEL_enum
+{
+    RTC_CLKSEL_OSC32K_gc = (0x00<<0),  /* Internal 32.768 kHz Oscillator */
+    RTC_CLKSEL_OSC1K_gc = (0x01<<0),  /* Internal 32.768 kHz Oscillator Divided by 32 */
+    RTC_CLKSEL_XOSC32K_gc = (0x02<<0),  /* 32.768 kHz Crystal Oscillator */
+    RTC_CLKSEL_EXTCLK_gc = (0x03<<0)  /* External Clock */
+} RTC_CLKSEL_t;
+
+/* Event Generation 0 Select */
+typedef enum RTC_EVGEN0SEL_enum
+{
+    RTC_EVGEN0SEL_OFF_gc = (0x00<<0),  /* No Event Generated */
+    RTC_EVGEN0SEL_DIV4_gc = (0x01<<0),  /* CLK_RTC divided by 4 */
+    RTC_EVGEN0SEL_DIV8_gc = (0x02<<0),  /* CLK_RTC divided by 8 */
+    RTC_EVGEN0SEL_DIV16_gc = (0x03<<0),  /* CLK_RTC divided by 16 */
+    RTC_EVGEN0SEL_DIV32_gc = (0x04<<0),  /* CLK_RTC divided by 32 */
+    RTC_EVGEN0SEL_DIV64_gc = (0x05<<0),  /* CLK_RTC divided by 64 */
+    RTC_EVGEN0SEL_DIV128_gc = (0x06<<0),  /* CLK_RTC divided by 128 */
+    RTC_EVGEN0SEL_DIV256_gc = (0x07<<0),  /* CLK_RTC divided by 256 */
+    RTC_EVGEN0SEL_DIV512_gc = (0x08<<0),  /* CLK_RTC divided by 512 */
+    RTC_EVGEN0SEL_DIV1024_gc = (0x09<<0),  /* CLK_RTC divided by 1024 */
+    RTC_EVGEN0SEL_DIV2048_gc = (0x0A<<0),  /* CLK_RTC divided by 2048 */
+    RTC_EVGEN0SEL_DIV4096_gc = (0x0B<<0),  /* CLK_RTC divided by 4096 */
+    RTC_EVGEN0SEL_DIV8192_gc = (0x0C<<0),  /* CLK_RTC divided by 8192 */
+    RTC_EVGEN0SEL_DIV16384_gc = (0x0D<<0),  /* CLK_RTC divided by 16384 */
+    RTC_EVGEN0SEL_DIV32768_gc = (0x0E<<0)  /* CLK_RTC divided by 32768 */
+} RTC_EVGEN0SEL_t;
+
+/* Event Generation 1 Select */
+typedef enum RTC_EVGEN1SEL_enum
+{
+    RTC_EVGEN1SEL_OFF_gc = (0x00<<4),  /* No Event Generated */
+    RTC_EVGEN1SEL_DIV4_gc = (0x01<<4),  /* CLK_RTC divided by 4 */
+    RTC_EVGEN1SEL_DIV8_gc = (0x02<<4),  /* CLK_RTC divided by 8 */
+    RTC_EVGEN1SEL_DIV16_gc = (0x03<<4),  /* CLK_RTC divided by 16 */
+    RTC_EVGEN1SEL_DIV32_gc = (0x04<<4),  /* CLK_RTC divided by 32 */
+    RTC_EVGEN1SEL_DIV64_gc = (0x05<<4),  /* CLK_RTC divided by 64 */
+    RTC_EVGEN1SEL_DIV128_gc = (0x06<<4),  /* CLK_RTC divided by 128 */
+    RTC_EVGEN1SEL_DIV256_gc = (0x07<<4),  /* CLK_RTC divided by 256 */
+    RTC_EVGEN1SEL_DIV512_gc = (0x08<<4),  /* CLK_RTC divided by 512 */
+    RTC_EVGEN1SEL_DIV1024_gc = (0x09<<4),  /* CLK_RTC divided by 1024 */
+    RTC_EVGEN1SEL_DIV2048_gc = (0x0A<<4),  /* CLK_RTC divided by 2048 */
+    RTC_EVGEN1SEL_DIV4096_gc = (0x0B<<4),  /* CLK_RTC divided by 4096 */
+    RTC_EVGEN1SEL_DIV8192_gc = (0x0C<<4),  /* CLK_RTC divided by 8192 */
+    RTC_EVGEN1SEL_DIV16384_gc = (0x0D<<4),  /* CLK_RTC divided by 16384 */
+    RTC_EVGEN1SEL_DIV32768_gc = (0x0E<<4)  /* CLK_RTC divided by 32768 */
+} RTC_EVGEN1SEL_t;
+
+/* Period select */
+typedef enum RTC_PERIOD_enum
+{
+    RTC_PERIOD_OFF_gc = (0x00<<3),  /* Off */
+    RTC_PERIOD_CYC4_gc = (0x01<<3),  /* RTC Clock Cycles 4 */
+    RTC_PERIOD_CYC8_gc = (0x02<<3),  /* RTC Clock Cycles 8 */
+    RTC_PERIOD_CYC16_gc = (0x03<<3),  /* RTC Clock Cycles 16 */
+    RTC_PERIOD_CYC32_gc = (0x04<<3),  /* RTC Clock Cycles 32 */
+    RTC_PERIOD_CYC64_gc = (0x05<<3),  /* RTC Clock Cycles 64 */
+    RTC_PERIOD_CYC128_gc = (0x06<<3),  /* RTC Clock Cycles 128 */
+    RTC_PERIOD_CYC256_gc = (0x07<<3),  /* RTC Clock Cycles 256 */
+    RTC_PERIOD_CYC512_gc = (0x08<<3),  /* RTC Clock Cycles 512 */
+    RTC_PERIOD_CYC1024_gc = (0x09<<3),  /* RTC Clock Cycles 1024 */
+    RTC_PERIOD_CYC2048_gc = (0x0A<<3),  /* RTC Clock Cycles 2048 */
+    RTC_PERIOD_CYC4096_gc = (0x0B<<3),  /* RTC Clock Cycles 4096 */
+    RTC_PERIOD_CYC8192_gc = (0x0C<<3),  /* RTC Clock Cycles 8192 */
+    RTC_PERIOD_CYC16384_gc = (0x0D<<3),  /* RTC Clock Cycles 16384 */
+    RTC_PERIOD_CYC32768_gc = (0x0E<<3)  /* RTC Clock Cycles 32768 */
+} RTC_PERIOD_t;
+
+/* Prescaling Factor select */
+typedef enum RTC_PRESCALER_enum
+{
+    RTC_PRESCALER_DIV1_gc = (0x00<<3),  /* RTC Clock / 1 */
+    RTC_PRESCALER_DIV2_gc = (0x01<<3),  /* RTC Clock / 2 */
+    RTC_PRESCALER_DIV4_gc = (0x02<<3),  /* RTC Clock / 4 */
+    RTC_PRESCALER_DIV8_gc = (0x03<<3),  /* RTC Clock / 8 */
+    RTC_PRESCALER_DIV16_gc = (0x04<<3),  /* RTC Clock / 16 */
+    RTC_PRESCALER_DIV32_gc = (0x05<<3),  /* RTC Clock / 32 */
+    RTC_PRESCALER_DIV64_gc = (0x06<<3),  /* RTC Clock / 64 */
+    RTC_PRESCALER_DIV128_gc = (0x07<<3),  /* RTC Clock / 128 */
+    RTC_PRESCALER_DIV256_gc = (0x08<<3),  /* RTC Clock / 256 */
+    RTC_PRESCALER_DIV512_gc = (0x09<<3),  /* RTC Clock / 512 */
+    RTC_PRESCALER_DIV1024_gc = (0x0A<<3),  /* RTC Clock / 1024 */
+    RTC_PRESCALER_DIV2048_gc = (0x0B<<3),  /* RTC Clock / 2048 */
+    RTC_PRESCALER_DIV4096_gc = (0x0C<<3),  /* RTC Clock / 4096 */
+    RTC_PRESCALER_DIV8192_gc = (0x0D<<3),  /* RTC Clock / 8192 */
+    RTC_PRESCALER_DIV16384_gc = (0x0E<<3),  /* RTC Clock / 16384 */
+    RTC_PRESCALER_DIV32768_gc = (0x0F<<3)  /* RTC Clock / 32768 */
+} RTC_PRESCALER_t;
+
+/*
+--------------------------------------------------------------------------
+SIGROW - Signature row
+--------------------------------------------------------------------------
+*/
+
+/* Signature row */
+typedef struct SIGROW_struct
+{
+    register8_t DEVICEID0;  /* Device ID Byte 0 */
+    register8_t DEVICEID1;  /* Device ID Byte 1 */
+    register8_t DEVICEID2;  /* Device ID Byte 2 */
+    register8_t reserved_1[1];
+    _WORDREGISTER(TEMPSENSE0);  /* Temperature Calibration 0 */
+    _WORDREGISTER(TEMPSENSE1);  /* Temperature Calibration 1 */
+    register8_t reserved_2[8];
+    register8_t SERNUM0;  /* Serial Number Byte 0 */
+    register8_t SERNUM1;  /* Serial Number Byte 1 */
+    register8_t SERNUM2;  /* Serial Number Byte 2 */
+    register8_t SERNUM3;  /* Serial Number Byte 3 */
+    register8_t SERNUM4;  /* Serial Number Byte 4 */
+    register8_t SERNUM5;  /* Serial Number Byte 5 */
+    register8_t SERNUM6;  /* Serial Number Byte 6 */
+    register8_t SERNUM7;  /* Serial Number Byte 7 */
+    register8_t SERNUM8;  /* Serial Number Byte 8 */
+    register8_t SERNUM9;  /* Serial Number Byte 9 */
+    register8_t SERNUM10;  /* Serial Number Byte 10 */
+    register8_t SERNUM11;  /* Serial Number Byte 11 */
+    register8_t SERNUM12;  /* Serial Number Byte 12 */
+    register8_t SERNUM13;  /* Serial Number Byte 13 */
+    register8_t SERNUM14;  /* Serial Number Byte 14 */
+    register8_t SERNUM15;  /* Serial Number Byte 15 */
+    register8_t reserved_3[32];
+} SIGROW_t;
+
+
+/*
+--------------------------------------------------------------------------
+SLPCTRL - Sleep Controller
+--------------------------------------------------------------------------
+*/
+
+/* Sleep Controller */
+typedef struct SLPCTRL_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t reserved_1[1];
+} SLPCTRL_t;
+
+/* Sleep mode select */
+typedef enum SLPCTRL_SMODE_enum
+{
+    SLPCTRL_SMODE_IDLE_gc = (0x00<<1),  /* Idle mode */
+    SLPCTRL_SMODE_STDBY_gc = (0x01<<1),  /* Standby Mode */
+    SLPCTRL_SMODE_PDOWN_gc = (0x02<<1)  /* Power-down Mode */
+} SLPCTRL_SMODE_t;
+
+#define SLEEP_MODE_IDLE (0x00<<1)
+#define SLEEP_MODE_STANDBY (0x01<<1)
+#define SLEEP_MODE_PWR_DOWN (0x02<<1)
+/*
+--------------------------------------------------------------------------
+SPI - Serial Peripheral Interface
+--------------------------------------------------------------------------
+*/
+
+/* Serial Peripheral Interface */
+typedef struct SPI_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t DATA;  /* Data */
+    register8_t reserved_1[3];
+} SPI_t;
+
+/* SPI Mode select */
+typedef enum SPI_MODE_enum
+{
+    SPI_MODE_0_gc = (0x00<<0),  /* SPI Mode 0 */
+    SPI_MODE_1_gc = (0x01<<0),  /* SPI Mode 1 */
+    SPI_MODE_2_gc = (0x02<<0),  /* SPI Mode 2 */
+    SPI_MODE_3_gc = (0x03<<0)  /* SPI Mode 3 */
+} SPI_MODE_t;
+
+/* Prescaler select */
+typedef enum SPI_PRESC_enum
+{
+    SPI_PRESC_DIV4_gc = (0x00<<1),  /* CLK_PER / 4 */
+    SPI_PRESC_DIV16_gc = (0x01<<1),  /* CLK_PER / 16 */
+    SPI_PRESC_DIV64_gc = (0x02<<1),  /* CLK_PER / 64 */
+    SPI_PRESC_DIV128_gc = (0x03<<1)  /* CLK_PER / 128 */
+} SPI_PRESC_t;
+
+/*
+--------------------------------------------------------------------------
+SYSCFG - System Configuration Registers
+--------------------------------------------------------------------------
+*/
+
+/* System Configuration Registers */
+typedef struct SYSCFG_struct
+{
+    register8_t reserved_1[1];
+    register8_t REVID;  /* Revision ID */
+    register8_t reserved_2[2];
+    register8_t OCDMCTRL;  /* OCD Message Control */
+    register8_t OCDMSTATUS;  /* OCD Message Status */
+    register8_t reserved_3[26];
+} SYSCFG_t;
+
+
+/*
+--------------------------------------------------------------------------
+TCA - 16-bit Timer/Counter Type A
+--------------------------------------------------------------------------
+*/
+
+/* 16-bit Timer/Counter Type A - Single Mode */
+typedef struct TCA_SINGLE_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    register8_t CTRLD;  /* Control D */
+    register8_t CTRLECLR;  /* Control E Clear */
+    register8_t CTRLESET;  /* Control E Set */
+    register8_t CTRLFCLR;  /* Control F Clear */
+    register8_t CTRLFSET;  /* Control F Set */
+    register8_t reserved_1[1];
+    register8_t EVCTRL;  /* Event Control */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t reserved_2[2];
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t TEMP;  /* Temporary data for 16-bit Access */
+    register8_t reserved_3[16];
+    _WORDREGISTER(CNT);  /* Count */
+    register8_t reserved_4[4];
+    _WORDREGISTER(PER);  /* Period */
+    _WORDREGISTER(CMP0);  /* Compare 0 */
+    _WORDREGISTER(CMP1);  /* Compare 1 */
+    _WORDREGISTER(CMP2);  /* Compare 2 */
+    register8_t reserved_5[8];
+    _WORDREGISTER(PERBUF);  /* Period Buffer */
+    _WORDREGISTER(CMP0BUF);  /* Compare 0 Buffer */
+    _WORDREGISTER(CMP1BUF);  /* Compare 1 Buffer */
+    _WORDREGISTER(CMP2BUF);  /* Compare 2 Buffer */
+    register8_t reserved_6[2];
+} TCA_SINGLE_t;
+
+/* 16-bit Timer/Counter Type A - Split Mode */
+typedef struct TCA_SPLIT_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    register8_t CTRLD;  /* Control D */
+    register8_t CTRLECLR;  /* Control E Clear */
+    register8_t CTRLESET;  /* Control E Set */
+    register8_t reserved_1[4];
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t reserved_2[2];
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t reserved_3[17];
+    register8_t LCNT;  /* Low Count */
+    register8_t HCNT;  /* High Count */
+    register8_t reserved_4[4];
+    register8_t LPER;  /* Low Period */
+    register8_t HPER;  /* High Period */
+    register8_t LCMP0;  /* Low Compare */
+    register8_t HCMP0;  /* High Compare */
+    register8_t LCMP1;  /* Low Compare */
+    register8_t HCMP1;  /* High Compare */
+    register8_t LCMP2;  /* Low Compare */
+    register8_t HCMP2;  /* High Compare */
+    register8_t reserved_5[18];
+} TCA_SPLIT_t;
+
+/* 16-bit Timer/Counter Type A */
+typedef union TCA_union
+{
+    TCA_SINGLE_t SINGLE;  /* Single Mode */
+    TCA_SPLIT_t SPLIT;  /* Split Mode */
+} TCA_t;
+
+/* Clock Selection */
+typedef enum TCA_SINGLE_CLKSEL_enum
+{
+    TCA_SINGLE_CLKSEL_DIV1_gc = (0x00<<1),  /* CLK_PER */
+    TCA_SINGLE_CLKSEL_DIV2_gc = (0x01<<1),  /* CLK_PER / 2 */
+    TCA_SINGLE_CLKSEL_DIV4_gc = (0x02<<1),  /* CLK_PER / 4 */
+    TCA_SINGLE_CLKSEL_DIV8_gc = (0x03<<1),  /* CLK_PER / 8 */
+    TCA_SINGLE_CLKSEL_DIV16_gc = (0x04<<1),  /* CLK_PER / 16 */
+    TCA_SINGLE_CLKSEL_DIV64_gc = (0x05<<1),  /* CLK_PER / 64 */
+    TCA_SINGLE_CLKSEL_DIV256_gc = (0x06<<1),  /* CLK_PER / 256 */
+    TCA_SINGLE_CLKSEL_DIV1024_gc = (0x07<<1)  /* CLK_PER / 1024 */
+} TCA_SINGLE_CLKSEL_t;
+
+/* Command select */
+typedef enum TCA_SINGLE_CMD_enum
+{
+    TCA_SINGLE_CMD_NONE_gc = (0x00<<2),  /* No Command */
+    TCA_SINGLE_CMD_UPDATE_gc = (0x01<<2),  /* Force Update */
+    TCA_SINGLE_CMD_RESTART_gc = (0x02<<2),  /* Force Restart */
+    TCA_SINGLE_CMD_RESET_gc = (0x03<<2)  /* Force Hard Reset */
+} TCA_SINGLE_CMD_t;
+
+/* Direction select */
+typedef enum TCA_SINGLE_DIR_enum
+{
+    TCA_SINGLE_DIR_UP_gc = (0x00<<0),  /* Count up */
+    TCA_SINGLE_DIR_DOWN_gc = (0x01<<0)  /* Count down */
+} TCA_SINGLE_DIR_t;
+
+/* Event Action A select */
+typedef enum TCA_SINGLE_EVACTA_enum
+{
+    TCA_SINGLE_EVACTA_CNT_POSEDGE_gc = (0x00<<1),  /* Count on positive edge event */
+    TCA_SINGLE_EVACTA_CNT_ANYEDGE_gc = (0x01<<1),  /* Count on any edge event */
+    TCA_SINGLE_EVACTA_CNT_HIGHLVL_gc = (0x02<<1),  /* Count on prescaled clock while event line is 1. */
+    TCA_SINGLE_EVACTA_UPDOWN_gc = (0x03<<1)  /* Count on prescaled clock. Event controls count direction. Up-count when event line is 0, down-count when event line is 1. */
+} TCA_SINGLE_EVACTA_t;
+
+/* Event Action B select */
+typedef enum TCA_SINGLE_EVACTB_enum
+{
+    TCA_SINGLE_EVACTB_NONE_gc = (0x00<<5),  /* No Action */
+    TCA_SINGLE_EVACTB_UPDOWN_gc = (0x03<<5),  /* Count on prescaled clock. Event controls count direction. Up-count when event line is 0, down-count when event line is 1. */
+    TCA_SINGLE_EVACTB_RESTART_POSEDGE_gc = (0x04<<5),  /* Restart counter at positive edge event */
+    TCA_SINGLE_EVACTB_RESTART_ANYEDGE_gc = (0x05<<5),  /* Restart counter on any edge event */
+    TCA_SINGLE_EVACTB_RESTART_HIGHLVL_gc = (0x06<<5)  /* Restart counter while event line is 1. */
+} TCA_SINGLE_EVACTB_t;
+
+/* Waveform generation mode select */
+typedef enum TCA_SINGLE_WGMODE_enum
+{
+    TCA_SINGLE_WGMODE_NORMAL_gc = (0x00<<0),  /* Normal Mode */
+    TCA_SINGLE_WGMODE_FRQ_gc = (0x01<<0),  /* Frequency Generation Mode */
+    TCA_SINGLE_WGMODE_SINGLESLOPE_gc = (0x03<<0),  /* Single Slope PWM */
+    TCA_SINGLE_WGMODE_DSTOP_gc = (0x05<<0),  /* Dual Slope PWM, overflow on TOP */
+    TCA_SINGLE_WGMODE_DSBOTH_gc = (0x06<<0),  /* Dual Slope PWM, overflow on TOP and BOTTOM */
+    TCA_SINGLE_WGMODE_DSBOTTOM_gc = (0x07<<0)  /* Dual Slope PWM, overflow on BOTTOM */
+} TCA_SINGLE_WGMODE_t;
+
+/* Clock Selection */
+typedef enum TCA_SPLIT_CLKSEL_enum
+{
+    TCA_SPLIT_CLKSEL_DIV1_gc = (0x00<<1),  /* CLK_PER */
+    TCA_SPLIT_CLKSEL_DIV2_gc = (0x01<<1),  /* CLK_PER / 2 */
+    TCA_SPLIT_CLKSEL_DIV4_gc = (0x02<<1),  /* CLK_PER / 4 */
+    TCA_SPLIT_CLKSEL_DIV8_gc = (0x03<<1),  /* CLK_PER / 8 */
+    TCA_SPLIT_CLKSEL_DIV16_gc = (0x04<<1),  /* CLK_PER / 16 */
+    TCA_SPLIT_CLKSEL_DIV64_gc = (0x05<<1),  /* CLK_PER / 64 */
+    TCA_SPLIT_CLKSEL_DIV256_gc = (0x06<<1),  /* CLK_PER / 256 */
+    TCA_SPLIT_CLKSEL_DIV1024_gc = (0x07<<1)  /* CLK_PER / 1024 */
+} TCA_SPLIT_CLKSEL_t;
+
+/* Command select */
+typedef enum TCA_SPLIT_CMD_enum
+{
+    TCA_SPLIT_CMD_NONE_gc = (0x00<<2),  /* No Command */
+    TCA_SPLIT_CMD_UPDATE_gc = (0x01<<2),  /* Force Update */
+    TCA_SPLIT_CMD_RESTART_gc = (0x02<<2),  /* Force Restart */
+    TCA_SPLIT_CMD_RESET_gc = (0x03<<2)  /* Force Hard Reset */
+} TCA_SPLIT_CMD_t;
+
+/* Command Enable select */
+typedef enum TCA_SPLIT_CMDEN_enum
+{
+    TCA_SPLIT_CMDEN_NONE_gc = (0x00<<0),  /* None */
+    TCA_SPLIT_CMDEN_BOTH_gc = (0x03<<0)  /* Both low byte and high byte counter */
+} TCA_SPLIT_CMDEN_t;
+
+/*
+--------------------------------------------------------------------------
+TCB - 16-bit Timer Type B
+--------------------------------------------------------------------------
+*/
+
+/* 16-bit Timer Type B */
+typedef struct TCB_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control Register B */
+    register8_t reserved_1[2];
+    register8_t EVCTRL;  /* Event Control */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t STATUS;  /* Status */
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t TEMP;  /* Temporary Value */
+    _WORDREGISTER(CNT);  /* Count */
+    _WORDREGISTER(CCMP);  /* Compare or Capture */
+    register8_t reserved_2[2];
+} TCB_t;
+
+/* Clock Select */
+typedef enum TCB_CLKSEL_enum
+{
+    TCB_CLKSEL_DIV1_gc = (0x00<<1),  /* CLK_PER */
+    TCB_CLKSEL_DIV2_gc = (0x01<<1),  /* CLK_PER/2 */
+    TCB_CLKSEL_TCA0_gc = (0x02<<1),  /* Use CLK_TCA from TCA0 */
+    TCB_CLKSEL_TCA1_gc = (0x03<<1),  /* Use CLK_TCA from TCA1 */
+    TCB_CLKSEL_EVENT_gc = (0x07<<1)  /* Count on event edge */
+} TCB_CLKSEL_t;
+
+/* Timer Mode select */
+typedef enum TCB_CNTMODE_enum
+{
+    TCB_CNTMODE_INT_gc = (0x00<<0),  /* Periodic Interrupt */
+    TCB_CNTMODE_TIMEOUT_gc = (0x01<<0),  /* Periodic Timeout */
+    TCB_CNTMODE_CAPT_gc = (0x02<<0),  /* Input Capture Event */
+    TCB_CNTMODE_FRQ_gc = (0x03<<0),  /* Input Capture Frequency measurement */
+    TCB_CNTMODE_PW_gc = (0x04<<0),  /* Input Capture Pulse-Width measurement */
+    TCB_CNTMODE_FRQPW_gc = (0x05<<0),  /* Input Capture Frequency and Pulse-Width measurement */
+    TCB_CNTMODE_SINGLE_gc = (0x06<<0),  /* Single Shot */
+    TCB_CNTMODE_PWM8_gc = (0x07<<0)  /* 8-bit PWM */
+} TCB_CNTMODE_t;
+
+/*
+--------------------------------------------------------------------------
+TWI - Two-Wire Interface
+--------------------------------------------------------------------------
+*/
+
+/* Two-Wire Interface */
+typedef struct TWI_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t DUALCTRL;  /* Dual Mode Control */
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t MCTRLA;  /* Host Control A */
+    register8_t MCTRLB;  /* Host Control B */
+    register8_t MSTATUS;  /* Host STATUS */
+    register8_t MBAUD;  /* Host Baud Rate */
+    register8_t MADDR;  /* Host Address */
+    register8_t MDATA;  /* Host Data */
+    register8_t SCTRLA;  /* Client Control A */
+    register8_t SCTRLB;  /* Client Control B */
+    register8_t SSTATUS;  /* Client Status */
+    register8_t SADDR;  /* Client Address */
+    register8_t SDATA;  /* Client Data */
+    register8_t SADDRMASK;  /* Client Address Mask */
+    register8_t reserved_1[1];
+} TWI_t;
+
+/* Acknowledge Action select */
+typedef enum TWI_ACKACT_enum
+{
+    TWI_ACKACT_ACK_gc = (0x00<<2),  /* Send ACK */
+    TWI_ACKACT_NACK_gc = (0x01<<2)  /* Send NACK */
+} TWI_ACKACT_t;
+
+/* Address or Stop select */
+typedef enum TWI_AP_enum
+{
+    TWI_AP_STOP_gc = (0x00<<0),  /* A Stop condition generated the interrupt on APIF flag */
+    TWI_AP_ADR_gc = (0x01<<0)  /* Address detection generated the interrupt on APIF flag */
+} TWI_AP_t;
+
+/* Bus State select */
+typedef enum TWI_BUSSTATE_enum
+{
+    TWI_BUSSTATE_UNKNOWN_gc = (0x00<<0),  /* Unknown bus state */
+    TWI_BUSSTATE_IDLE_gc = (0x01<<0),  /* Bus is idle */
+    TWI_BUSSTATE_OWNER_gc = (0x02<<0),  /* This TWI controls the bus */
+    TWI_BUSSTATE_BUSY_gc = (0x03<<0)  /* The bus is busy */
+} TWI_BUSSTATE_t;
+
+/* Debug Run select */
+typedef enum TWI_DBGRUN_enum
+{
+    TWI_DBGRUN_HALT_gc = (0x00<<0),  /* The peripheral is halted in Break Debug mode and ignores events */
+    TWI_DBGRUN_RUN_gc = (0x01<<0)  /* The peripheral will continue to run in Break Debug mode when the CPU is halted */
+} TWI_DBGRUN_t;
+
+/* Fast-mode Enable select */
+typedef enum TWI_FMEN_enum
+{
+    TWI_FMEN_OFF_gc = (0x00<<0),  /* SCL duty cycle operating according to Sm specification */
+    TWI_FMEN_ON_gc = (0x01<<0)  /* SCL duty cycle operating according to Fm specification */
+} TWI_FMEN_t;
+
+/* Fast-mode Plus Enable select */
+typedef enum TWI_FMPEN_enum
+{
+    TWI_FMPEN_OFF_gc = (0x00<<1),  /* Operating in Standard-mode or Fast-mode */
+    TWI_FMPEN_ON_gc = (0x01<<1)  /* Operating in Fast-mode Plus */
+} TWI_FMPEN_t;
+
+/* Input voltage transition level select */
+typedef enum TWI_INPUTLVL_enum
+{
+    TWI_INPUTLVL_I2C_gc = (0x00<<6),  /* I2C input voltage transition level */
+    TWI_INPUTLVL_SMBUS_gc = (0x01<<6)  /* SMBus 3.0 input voltage transition level */
+} TWI_INPUTLVL_t;
+
+/* Command select */
+typedef enum TWI_MCMD_enum
+{
+    TWI_MCMD_NOACT_gc = (0x00<<0),  /* No action */
+    TWI_MCMD_REPSTART_gc = (0x01<<0),  /* Execute Acknowledge Action followed by repeated Start. */
+    TWI_MCMD_RECVTRANS_gc = (0x02<<0),  /* Execute Acknowledge Action followed by a byte read/write operation. Read/write is defined by DIR. */
+    TWI_MCMD_STOP_gc = (0x03<<0)  /* Execute Acknowledge Action followed by issuing a Stop condition. */
+} TWI_MCMD_t;
+
+/* Command select */
+typedef enum TWI_SCMD_enum
+{
+    TWI_SCMD_NOACT_gc = (0x00<<0),  /* No Action */
+    TWI_SCMD_COMPTRANS_gc = (0x02<<0),  /* Complete transaction */
+    TWI_SCMD_RESPONSE_gc = (0x03<<0)  /* Used in response to an interrupt */
+} TWI_SCMD_t;
+
+/* SDA Hold Time select */
+typedef enum TWI_SDAHOLD_enum
+{
+    TWI_SDAHOLD_OFF_gc = (0x00<<2),  /* No SDA Hold Delay */
+    TWI_SDAHOLD_50NS_gc = (0x01<<2),  /* Short SDA hold time */
+    TWI_SDAHOLD_300NS_gc = (0x02<<2),  /* Meets SMBUS 2.0 specification under typical conditions */
+    TWI_SDAHOLD_500NS_gc = (0x03<<2)  /* Meets SMBUS 2.0 specificaiton across all corners */
+} TWI_SDAHOLD_t;
+
+/* SDA Setup Time select */
+typedef enum TWI_SDASETUP_enum
+{
+    TWI_SDASETUP_4CYC_gc = (0x00<<4),  /* SDA setup time is four clock cycles */
+    TWI_SDASETUP_8CYC_gc = (0x01<<4)  /* SDA setup time is eight clock cycle */
+} TWI_SDASETUP_t;
+
+/* Inactive Bus Time-Out select */
+typedef enum TWI_TIMEOUT_enum
+{
+    TWI_TIMEOUT_DISABLED_gc = (0x00<<2),  /* Bus time-out disabled. I2C. */
+    TWI_TIMEOUT_50US_gc = (0x01<<2),  /* 50us - SMBus */
+    TWI_TIMEOUT_100US_gc = (0x02<<2),  /* 100us */
+    TWI_TIMEOUT_200US_gc = (0x03<<2)  /* 200us */
+} TWI_TIMEOUT_t;
+
+/*
+--------------------------------------------------------------------------
+USART - Universal Synchronous and Asynchronous Receiver and Transmitter
+--------------------------------------------------------------------------
+*/
+
+/* Universal Synchronous and Asynchronous Receiver and Transmitter */
+typedef struct USART_struct
+{
+    register8_t RXDATAL;  /* Receive Data Low Byte */
+    register8_t RXDATAH;  /* Receive Data High Byte */
+    register8_t TXDATAL;  /* Transmit Data Low Byte */
+    register8_t TXDATAH;  /* Transmit Data High Byte */
+    register8_t STATUS;  /* Status */
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    _WORDREGISTER(BAUD);  /* Baud Rate */
+    register8_t CTRLD;  /* Control D */
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t EVCTRL;  /* Event Control */
+    register8_t TXPLCTRL;  /* IRCOM Transmitter Pulse Length Control */
+    register8_t RXPLCTRL;  /* IRCOM Receiver Pulse Length Control */
+    register8_t reserved_1[1];
+} USART_t;
+
+/* Auto Baud Window select */
+typedef enum USART_ABW_enum
+{
+    USART_ABW_WDW0_gc = (0x00<<6),  /* 18% tolerance */
+    USART_ABW_WDW1_gc = (0x01<<6),  /* 15% tolerance */
+    USART_ABW_WDW2_gc = (0x02<<6),  /* 21% tolerance */
+    USART_ABW_WDW3_gc = (0x03<<6)  /* 25% tolerance */
+} USART_ABW_t;
+
+/* Character Size select */
+typedef enum USART_CHSIZE_enum
+{
+    USART_CHSIZE_5BIT_gc = (0x00<<0),  /* Character size: 5 bit */
+    USART_CHSIZE_6BIT_gc = (0x01<<0),  /* Character size: 6 bit */
+    USART_CHSIZE_7BIT_gc = (0x02<<0),  /* Character size: 7 bit */
+    USART_CHSIZE_8BIT_gc = (0x03<<0),  /* Character size: 8 bit */
+    USART_CHSIZE_9BITL_gc = (0x06<<0),  /* Character size: 9 bit read low byte first */
+    USART_CHSIZE_9BITH_gc = (0x07<<0)  /* Character size: 9 bit read high byte first */
+} USART_CHSIZE_t;
+
+/* Communication Mode select */
+typedef enum USART_CMODE_enum
+{
+    USART_CMODE_ASYNCHRONOUS_gc = (0x00<<6),  /* Asynchronous Mode */
+    USART_CMODE_SYNCHRONOUS_gc = (0x01<<6),  /* Synchronous Mode */
+    USART_CMODE_IRCOM_gc = (0x02<<6),  /* Infrared Communication */
+    USART_CMODE_MSPI_gc = (0x03<<6)  /* SPI Host Mode */
+} USART_CMODE_t;
+
+/* Parity Mode select */
+typedef enum USART_PMODE_enum
+{
+    USART_PMODE_DISABLED_gc = (0x00<<4),  /* No Parity */
+    USART_PMODE_EVEN_gc = (0x02<<4),  /* Even Parity */
+    USART_PMODE_ODD_gc = (0x03<<4)  /* Odd Parity */
+} USART_PMODE_t;
+
+/* RS485 Mode internal transmitter select */
+typedef enum USART_RS485_enum
+{
+    USART_RS485_DISABLE_gc = (0x00<<0),  /* RS485 Mode disabled */
+    USART_RS485_ENABLE_gc = (0x01<<0)  /* RS485 Mode enabled */
+} USART_RS485_t;
+
+/* Receiver Mode select */
+typedef enum USART_RXMODE_enum
+{
+    USART_RXMODE_NORMAL_gc = (0x00<<1),  /* Normal mode */
+    USART_RXMODE_CLK2X_gc = (0x01<<1),  /* CLK2x mode */
+    USART_RXMODE_GENAUTO_gc = (0x02<<1),  /* Generic autobaud mode */
+    USART_RXMODE_LINAUTO_gc = (0x03<<1)  /* LIN constrained autobaud mode */
+} USART_RXMODE_t;
+
+/* Stop Bit Mode select */
+typedef enum USART_SBMODE_enum
+{
+    USART_SBMODE_1BIT_gc = (0x00<<3),  /* 1 stop bit */
+    USART_SBMODE_2BIT_gc = (0x01<<3)  /* 2 stop bits */
+} USART_SBMODE_t;
+
+/*
+--------------------------------------------------------------------------
+USERROW - User Row
+--------------------------------------------------------------------------
+*/
+
+/* User Row */
+typedef struct USERROW_struct
+{
+    register8_t USERROW0;  /* User Row Byte 0 */
+    register8_t USERROW1;  /* User Row Byte 1 */
+    register8_t USERROW2;  /* User Row Byte 2 */
+    register8_t USERROW3;  /* User Row Byte 3 */
+    register8_t USERROW4;  /* User Row Byte 4 */
+    register8_t USERROW5;  /* User Row Byte 5 */
+    register8_t USERROW6;  /* User Row Byte 6 */
+    register8_t USERROW7;  /* User Row Byte 7 */
+    register8_t USERROW8;  /* User Row Byte 8 */
+    register8_t USERROW9;  /* User Row Byte 9 */
+    register8_t USERROW10;  /* User Row Byte 10 */
+    register8_t USERROW11;  /* User Row Byte 11 */
+    register8_t USERROW12;  /* User Row Byte 12 */
+    register8_t USERROW13;  /* User Row Byte 13 */
+    register8_t USERROW14;  /* User Row Byte 14 */
+    register8_t USERROW15;  /* User Row Byte 15 */
+    register8_t USERROW16;  /* User Row Byte 16 */
+    register8_t USERROW17;  /* User Row Byte 17 */
+    register8_t USERROW18;  /* User Row Byte 18 */
+    register8_t USERROW19;  /* User Row Byte 19 */
+    register8_t USERROW20;  /* User Row Byte 20 */
+    register8_t USERROW21;  /* User Row Byte 21 */
+    register8_t USERROW22;  /* User Row Byte 22 */
+    register8_t USERROW23;  /* User Row Byte 23 */
+    register8_t USERROW24;  /* User Row Byte 24 */
+    register8_t USERROW25;  /* User Row Byte 25 */
+    register8_t USERROW26;  /* User Row Byte 26 */
+    register8_t USERROW27;  /* User Row Byte 27 */
+    register8_t USERROW28;  /* User Row Byte 28 */
+    register8_t USERROW29;  /* User Row Byte 29 */
+    register8_t USERROW30;  /* User Row Byte 30 */
+    register8_t USERROW31;  /* User Row Byte 31 */
+    register8_t USERROW32;  /* User Row Byte 32 */
+    register8_t USERROW33;  /* User Row Byte 33 */
+    register8_t USERROW34;  /* User Row Byte 34 */
+    register8_t USERROW35;  /* User Row Byte 35 */
+    register8_t USERROW36;  /* User Row Byte 36 */
+    register8_t USERROW37;  /* User Row Byte 37 */
+    register8_t USERROW38;  /* User Row Byte 38 */
+    register8_t USERROW39;  /* User Row Byte 39 */
+    register8_t USERROW40;  /* User Row Byte 40 */
+    register8_t USERROW41;  /* User Row Byte 41 */
+    register8_t USERROW42;  /* User Row Byte 42 */
+    register8_t USERROW43;  /* User Row Byte 43 */
+    register8_t USERROW44;  /* User Row Byte 44 */
+    register8_t USERROW45;  /* User Row Byte 45 */
+    register8_t USERROW46;  /* User Row Byte 46 */
+    register8_t USERROW47;  /* User Row Byte 47 */
+    register8_t USERROW48;  /* User Row Byte 48 */
+    register8_t USERROW49;  /* User Row Byte 49 */
+    register8_t USERROW50;  /* User Row Byte 50 */
+    register8_t USERROW51;  /* User Row Byte 51 */
+    register8_t USERROW52;  /* User Row Byte 52 */
+    register8_t USERROW53;  /* User Row Byte 53 */
+    register8_t USERROW54;  /* User Row Byte 54 */
+    register8_t USERROW55;  /* User Row Byte 55 */
+    register8_t USERROW56;  /* User Row Byte 56 */
+    register8_t USERROW57;  /* User Row Byte 57 */
+    register8_t USERROW58;  /* User Row Byte 58 */
+    register8_t USERROW59;  /* User Row Byte 59 */
+    register8_t USERROW60;  /* User Row Byte 60 */
+    register8_t USERROW61;  /* User Row Byte 61 */
+    register8_t USERROW62;  /* User Row Byte 62 */
+    register8_t USERROW63;  /* User Row Byte 63 */
+} USERROW_t;
+
+
+/*
+--------------------------------------------------------------------------
+VPORT - Virtual Ports
+--------------------------------------------------------------------------
+*/
+
+/* Virtual Ports */
+typedef struct VPORT_struct
+{
+    register8_t DIR;  /* Data Direction */
+    register8_t OUT;  /* Output Value */
+    register8_t IN;  /* Input Value */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+} VPORT_t;
+
+
+/*
+--------------------------------------------------------------------------
+VREF - Voltage reference
+--------------------------------------------------------------------------
+*/
+
+/* Voltage reference */
+typedef struct VREF_struct
+{
+    register8_t reserved_1[2];
+    register8_t DAC0REF;  /* DAC0 Reference */
+    register8_t reserved_2[1];
+    register8_t ACREF;  /* AC Reference */
+} VREF_t;
+
+/* Reference select */
+typedef enum VREF_REFSEL_enum
+{
+    VREF_REFSEL_1V024_gc = (0x00<<0),  /* Internal 1.024V reference */
+    VREF_REFSEL_2V048_gc = (0x01<<0),  /* Internal 2.048V reference */
+    VREF_REFSEL_4V096_gc = (0x02<<0),  /* Internal 4.096V reference */
+    VREF_REFSEL_2V500_gc = (0x03<<0),  /* Internal 2.500V reference */
+    VREF_REFSEL_VDD_gc = (0x05<<0),  /* VDD as reference */
+    VREF_REFSEL_VREFA_gc = (0x06<<0)  /* External reference on VREFA pin */
+} VREF_REFSEL_t;
+
+/*
+--------------------------------------------------------------------------
+WDT - Watch-Dog Timer
+--------------------------------------------------------------------------
+*/
+
+/* Watch-Dog Timer */
+typedef struct WDT_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t STATUS;  /* Status */
+    register8_t reserved_1[14];
+} WDT_t;
+
+/* Period select */
+typedef enum WDT_PERIOD_enum
+{
+    WDT_PERIOD_OFF_gc = (0x00<<0),  /* Off */
+    WDT_PERIOD_8CLK_gc = (0x01<<0),  /* 8 cycles (8ms) */
+    WDT_PERIOD_16CLK_gc = (0x02<<0),  /* 16 cycles (16ms) */
+    WDT_PERIOD_32CLK_gc = (0x03<<0),  /* 32 cycles (32ms) */
+    WDT_PERIOD_64CLK_gc = (0x04<<0),  /* 64 cycles (64ms) */
+    WDT_PERIOD_128CLK_gc = (0x05<<0),  /* 128 cycles (0.128s) */
+    WDT_PERIOD_256CLK_gc = (0x06<<0),  /* 256 cycles (0.256s) */
+    WDT_PERIOD_512CLK_gc = (0x07<<0),  /* 512 cycles (0.512s) */
+    WDT_PERIOD_1KCLK_gc = (0x08<<0),  /* 1K cycles (1.0s) */
+    WDT_PERIOD_2KCLK_gc = (0x09<<0),  /* 2K cycles (2.0s) */
+    WDT_PERIOD_4KCLK_gc = (0x0A<<0),  /* 4K cycles (4.1s) */
+    WDT_PERIOD_8KCLK_gc = (0x0B<<0)  /* 8K cycles (8.2s) */
+} WDT_PERIOD_t;
+
+/* Window select */
+typedef enum WDT_WINDOW_enum
+{
+    WDT_WINDOW_OFF_gc = (0x00<<4),  /* Off */
+    WDT_WINDOW_8CLK_gc = (0x01<<4),  /* 8 cycles (8ms) */
+    WDT_WINDOW_16CLK_gc = (0x02<<4),  /* 16 cycles (16ms) */
+    WDT_WINDOW_32CLK_gc = (0x03<<4),  /* 32 cycles (32ms) */
+    WDT_WINDOW_64CLK_gc = (0x04<<4),  /* 64 cycles (64ms) */
+    WDT_WINDOW_128CLK_gc = (0x05<<4),  /* 128 cycles (0.128s) */
+    WDT_WINDOW_256CLK_gc = (0x06<<4),  /* 256 cycles (0.256s) */
+    WDT_WINDOW_512CLK_gc = (0x07<<4),  /* 512 cycles (0.512s) */
+    WDT_WINDOW_1KCLK_gc = (0x08<<4),  /* 1K cycles (1.0s) */
+    WDT_WINDOW_2KCLK_gc = (0x09<<4),  /* 2K cycles (2.0s) */
+    WDT_WINDOW_4KCLK_gc = (0x0A<<4),  /* 4K cycles (4.1s) */
+    WDT_WINDOW_8KCLK_gc = (0x0B<<4)  /* 8K cycles (8.2s) */
+} WDT_WINDOW_t;
+/*
+==========================================================================
+IO Module Instances. Mapped to memory.
+==========================================================================
+*/
+
+#define VPORTA              (*(VPORT_t *) 0x0000) /* Virtual Ports */
+#define VPORTC              (*(VPORT_t *) 0x0008) /* Virtual Ports */
+#define VPORTD              (*(VPORT_t *) 0x000C) /* Virtual Ports */
+#define VPORTF              (*(VPORT_t *) 0x0014) /* Virtual Ports */
+#define GPR                   (*(GPR_t *) 0x001C) /* General Purpose Registers */
+#define RSTCTRL           (*(RSTCTRL_t *) 0x0040) /* Reset controller */
+#define SLPCTRL           (*(SLPCTRL_t *) 0x0050) /* Sleep Controller */
+#define CLKCTRL           (*(CLKCTRL_t *) 0x0060) /* Clock controller */
+#define BOD                   (*(BOD_t *) 0x00A0) /* Bod interface */
+#define VREF                 (*(VREF_t *) 0x00B0) /* Voltage reference */
+#define WDT                   (*(WDT_t *) 0x0100) /* Watch-Dog Timer */
+#define CPUINT             (*(CPUINT_t *) 0x0110) /* Interrupt Controller */
+#define CRCSCAN           (*(CRCSCAN_t *) 0x0120) /* CRCSCAN */
+#define RTC                   (*(RTC_t *) 0x0140) /* Real-Time Counter */
+#define CCL                   (*(CCL_t *) 0x01C0) /* Configurable Custom Logic */
+#define EVSYS               (*(EVSYS_t *) 0x0200) /* Event System */
+#define PORTA                (*(PORT_t *) 0x0400) /* I/O Ports */
+#define PORTC                (*(PORT_t *) 0x0440) /* I/O Ports */
+#define PORTD                (*(PORT_t *) 0x0460) /* I/O Ports */
+#define PORTF                (*(PORT_t *) 0x04A0) /* I/O Ports */
+#define PORTMUX           (*(PORTMUX_t *) 0x05E0) /* Port Multiplexer */
+#define ADC0                  (*(ADC_t *) 0x0600) /* Analog to Digital Converter */
+#define AC0                    (*(AC_t *) 0x0680) /* Analog Comparator */
+#define AC1                    (*(AC_t *) 0x0688) /* Analog Comparator */
+#define DAC0                  (*(DAC_t *) 0x06A0) /* Digital to Analog Converter */
+#define USART0              (*(USART_t *) 0x0800) /* Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define USART1              (*(USART_t *) 0x0820) /* Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define USART2              (*(USART_t *) 0x0840) /* Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define TWI0                  (*(TWI_t *) 0x0900) /* Two-Wire Interface */
+#define SPI0                  (*(SPI_t *) 0x0940) /* Serial Peripheral Interface */
+#define TCA0                  (*(TCA_t *) 0x0A00) /* 16-bit Timer/Counter Type A */
+#define TCB0                  (*(TCB_t *) 0x0B00) /* 16-bit Timer Type B */
+#define TCB1                  (*(TCB_t *) 0x0B10) /* 16-bit Timer Type B */
+#define TCB2                  (*(TCB_t *) 0x0B20) /* 16-bit Timer Type B */
+#define SYSCFG             (*(SYSCFG_t *) 0x0F00) /* System Configuration Registers */
+#define NVMCTRL           (*(NVMCTRL_t *) 0x1000) /* Non-volatile Memory Controller */
+#define LOCK                 (*(LOCK_t *) 0x1040) /* Lockbits */
+#define FUSE                 (*(FUSE_t *) 0x1050) /* Fuses */
+#define USERROW           (*(USERROW_t *) 0x1080) /* User Row */
+#define SIGROW             (*(SIGROW_t *) 0x1100) /* Signature row */
+
+#endif /* !defined (__ASSEMBLER__) */
+
+
+/* ========== Flattened fully qualified IO register names ========== */
+
+
+/* VPORT (VPORTA) - Virtual Ports */
+#define VPORTA_DIR  _SFR_MEM8(0x0000)
+#define VPORTA_OUT  _SFR_MEM8(0x0001)
+#define VPORTA_IN  _SFR_MEM8(0x0002)
+#define VPORTA_INTFLAGS  _SFR_MEM8(0x0003)
+
+
+/* VPORT (VPORTC) - Virtual Ports */
+#define VPORTC_DIR  _SFR_MEM8(0x0008)
+#define VPORTC_OUT  _SFR_MEM8(0x0009)
+#define VPORTC_IN  _SFR_MEM8(0x000A)
+#define VPORTC_INTFLAGS  _SFR_MEM8(0x000B)
+
+
+/* VPORT (VPORTD) - Virtual Ports */
+#define VPORTD_DIR  _SFR_MEM8(0x000C)
+#define VPORTD_OUT  _SFR_MEM8(0x000D)
+#define VPORTD_IN  _SFR_MEM8(0x000E)
+#define VPORTD_INTFLAGS  _SFR_MEM8(0x000F)
+
+
+/* VPORT (VPORTF) - Virtual Ports */
+#define VPORTF_DIR  _SFR_MEM8(0x0014)
+#define VPORTF_OUT  _SFR_MEM8(0x0015)
+#define VPORTF_IN  _SFR_MEM8(0x0016)
+#define VPORTF_INTFLAGS  _SFR_MEM8(0x0017)
+
+
+/* GPR - General Purpose Registers */
+#define GPR_GPR0  _SFR_MEM8(0x001C)
+#define GPR_GPR1  _SFR_MEM8(0x001D)
+#define GPR_GPR2  _SFR_MEM8(0x001E)
+#define GPR_GPR3  _SFR_MEM8(0x001F)
+
+
+/* CPU - CPU */
+#define CPU_CCP  _SFR_MEM8(0x0034)
+#define CPU_SP  _SFR_MEM16(0x003D)
+#define CPU_SPL  _SFR_MEM8(0x003D)
+#define CPU_SPH  _SFR_MEM8(0x003E)
+#define CPU_SREG  _SFR_MEM8(0x003F)
+
+
+/* RSTCTRL - Reset controller */
+#define RSTCTRL_RSTFR  _SFR_MEM8(0x0040)
+#define RSTCTRL_SWRR  _SFR_MEM8(0x0041)
+
+
+/* SLPCTRL - Sleep Controller */
+#define SLPCTRL_CTRLA  _SFR_MEM8(0x0050)
+
+
+/* CLKCTRL - Clock controller */
+#define CLKCTRL_MCLKCTRLA  _SFR_MEM8(0x0060)
+#define CLKCTRL_MCLKCTRLB  _SFR_MEM8(0x0061)
+#define CLKCTRL_MCLKCTRLC  _SFR_MEM8(0x0062)
+#define CLKCTRL_MCLKINTCTRL  _SFR_MEM8(0x0063)
+#define CLKCTRL_MCLKINTFLAGS  _SFR_MEM8(0x0064)
+#define CLKCTRL_MCLKSTATUS  _SFR_MEM8(0x0065)
+#define CLKCTRL_MCLKTIMEBASE  _SFR_MEM8(0x0066)
+#define CLKCTRL_OSCHFCTRLA  _SFR_MEM8(0x0068)
+#define CLKCTRL_OSCHFTUNE  _SFR_MEM8(0x0069)
+#define CLKCTRL_OSC32KCTRLA  _SFR_MEM8(0x0078)
+#define CLKCTRL_XOSC32KCTRLA  _SFR_MEM8(0x007C)
+#define CLKCTRL_XOSCHFCTRLA  _SFR_MEM8(0x0080)
+
+
+/* BOD - Bod interface */
+#define BOD_CTRLA  _SFR_MEM8(0x00A0)
+#define BOD_CTRLB  _SFR_MEM8(0x00A1)
+#define BOD_VLMCTRLA  _SFR_MEM8(0x00A8)
+#define BOD_INTCTRL  _SFR_MEM8(0x00A9)
+#define BOD_INTFLAGS  _SFR_MEM8(0x00AA)
+#define BOD_STATUS  _SFR_MEM8(0x00AB)
+
+
+/* VREF - Voltage reference */
+#define VREF_DAC0REF  _SFR_MEM8(0x00B2)
+#define VREF_ACREF  _SFR_MEM8(0x00B4)
+
+
+/* WDT - Watch-Dog Timer */
+#define WDT_CTRLA  _SFR_MEM8(0x0100)
+#define WDT_STATUS  _SFR_MEM8(0x0101)
+
+
+/* CPUINT - Interrupt Controller */
+#define CPUINT_CTRLA  _SFR_MEM8(0x0110)
+#define CPUINT_STATUS  _SFR_MEM8(0x0111)
+#define CPUINT_LVL0PRI  _SFR_MEM8(0x0112)
+#define CPUINT_LVL1VEC  _SFR_MEM8(0x0113)
+
+
+/* CRCSCAN - CRCSCAN */
+#define CRCSCAN_CTRLA  _SFR_MEM8(0x0120)
+#define CRCSCAN_CTRLB  _SFR_MEM8(0x0121)
+#define CRCSCAN_STATUS  _SFR_MEM8(0x0122)
+
+
+/* RTC - Real-Time Counter */
+#define RTC_CTRLA  _SFR_MEM8(0x0140)
+#define RTC_STATUS  _SFR_MEM8(0x0141)
+#define RTC_INTCTRL  _SFR_MEM8(0x0142)
+#define RTC_INTFLAGS  _SFR_MEM8(0x0143)
+#define RTC_TEMP  _SFR_MEM8(0x0144)
+#define RTC_DBGCTRL  _SFR_MEM8(0x0145)
+#define RTC_CALIB  _SFR_MEM8(0x0146)
+#define RTC_CLKSEL  _SFR_MEM8(0x0147)
+#define RTC_CNT  _SFR_MEM16(0x0148)
+#define RTC_CNTL  _SFR_MEM8(0x0148)
+#define RTC_CNTH  _SFR_MEM8(0x0149)
+#define RTC_PER  _SFR_MEM16(0x014A)
+#define RTC_PERL  _SFR_MEM8(0x014A)
+#define RTC_PERH  _SFR_MEM8(0x014B)
+#define RTC_CMP  _SFR_MEM16(0x014C)
+#define RTC_CMPL  _SFR_MEM8(0x014C)
+#define RTC_CMPH  _SFR_MEM8(0x014D)
+#define RTC_PITCTRLA  _SFR_MEM8(0x0150)
+#define RTC_PITSTATUS  _SFR_MEM8(0x0151)
+#define RTC_PITINTCTRL  _SFR_MEM8(0x0152)
+#define RTC_PITINTFLAGS  _SFR_MEM8(0x0153)
+#define RTC_PITDBGCTRL  _SFR_MEM8(0x0155)
+#define RTC_PITEVGENCTRLA  _SFR_MEM8(0x0156)
+
+
+/* CCL - Configurable Custom Logic */
+#define CCL_CTRLA  _SFR_MEM8(0x01C0)
+#define CCL_SEQCTRL0  _SFR_MEM8(0x01C1)
+#define CCL_SEQCTRL1  _SFR_MEM8(0x01C2)
+#define CCL_INTCTRL0  _SFR_MEM8(0x01C5)
+#define CCL_INTFLAGS  _SFR_MEM8(0x01C7)
+#define CCL_LUT0CTRLA  _SFR_MEM8(0x01C8)
+#define CCL_LUT0CTRLB  _SFR_MEM8(0x01C9)
+#define CCL_LUT0CTRLC  _SFR_MEM8(0x01CA)
+#define CCL_TRUTH0  _SFR_MEM8(0x01CB)
+#define CCL_LUT1CTRLA  _SFR_MEM8(0x01CC)
+#define CCL_LUT1CTRLB  _SFR_MEM8(0x01CD)
+#define CCL_LUT1CTRLC  _SFR_MEM8(0x01CE)
+#define CCL_TRUTH1  _SFR_MEM8(0x01CF)
+#define CCL_LUT2CTRLA  _SFR_MEM8(0x01D0)
+#define CCL_LUT2CTRLB  _SFR_MEM8(0x01D1)
+#define CCL_LUT2CTRLC  _SFR_MEM8(0x01D2)
+#define CCL_TRUTH2  _SFR_MEM8(0x01D3)
+#define CCL_LUT3CTRLA  _SFR_MEM8(0x01D4)
+#define CCL_LUT3CTRLB  _SFR_MEM8(0x01D5)
+#define CCL_LUT3CTRLC  _SFR_MEM8(0x01D6)
+#define CCL_TRUTH3  _SFR_MEM8(0x01D7)
+
+
+/* EVSYS - Event System */
+#define EVSYS_SWEVENTA  _SFR_MEM8(0x0200)
+#define EVSYS_CHANNEL0  _SFR_MEM8(0x0210)
+#define EVSYS_CHANNEL1  _SFR_MEM8(0x0211)
+#define EVSYS_CHANNEL2  _SFR_MEM8(0x0212)
+#define EVSYS_CHANNEL3  _SFR_MEM8(0x0213)
+#define EVSYS_CHANNEL4  _SFR_MEM8(0x0214)
+#define EVSYS_CHANNEL5  _SFR_MEM8(0x0215)
+#define EVSYS_USERCCLLUT0A  _SFR_MEM8(0x0220)
+#define EVSYS_USERCCLLUT0B  _SFR_MEM8(0x0221)
+#define EVSYS_USERCCLLUT1A  _SFR_MEM8(0x0222)
+#define EVSYS_USERCCLLUT1B  _SFR_MEM8(0x0223)
+#define EVSYS_USERCCLLUT2A  _SFR_MEM8(0x0224)
+#define EVSYS_USERCCLLUT2B  _SFR_MEM8(0x0225)
+#define EVSYS_USERCCLLUT3A  _SFR_MEM8(0x0226)
+#define EVSYS_USERCCLLUT3B  _SFR_MEM8(0x0227)
+#define EVSYS_USERADC0START  _SFR_MEM8(0x0228)
+#define EVSYS_USEREVSYSEVOUTA  _SFR_MEM8(0x0229)
+#define EVSYS_USEREVSYSEVOUTC  _SFR_MEM8(0x022B)
+#define EVSYS_USEREVSYSEVOUTD  _SFR_MEM8(0x022C)
+#define EVSYS_USEREVSYSEVOUTF  _SFR_MEM8(0x022E)
+#define EVSYS_USERUSART0IRDA  _SFR_MEM8(0x022F)
+#define EVSYS_USERUSART1IRDA  _SFR_MEM8(0x0230)
+#define EVSYS_USERUSART2IRDA  _SFR_MEM8(0x0231)
+#define EVSYS_USERTCA0CNTA  _SFR_MEM8(0x0232)
+#define EVSYS_USERTCA0CNTB  _SFR_MEM8(0x0233)
+#define EVSYS_USERTCA1CNTA  _SFR_MEM8(0x0234)
+#define EVSYS_USERTCA1CNTB  _SFR_MEM8(0x0235)
+#define EVSYS_USERTCB0CAPT  _SFR_MEM8(0x0236)
+#define EVSYS_USERTCB0COUNT  _SFR_MEM8(0x0237)
+#define EVSYS_USERTCB1CAPT  _SFR_MEM8(0x0238)
+#define EVSYS_USERTCB1COUNT  _SFR_MEM8(0x0239)
+#define EVSYS_USERTCB2CAPT  _SFR_MEM8(0x023A)
+#define EVSYS_USERTCB2COUNT  _SFR_MEM8(0x023B)
+#define EVSYS_USERTCB3CAPT  _SFR_MEM8(0x023C)
+#define EVSYS_USERTCB3COUNT  _SFR_MEM8(0x023D)
+
+
+/* PORT (PORTA) - I/O Ports */
+#define PORTA_DIR  _SFR_MEM8(0x0400)
+#define PORTA_DIRSET  _SFR_MEM8(0x0401)
+#define PORTA_DIRCLR  _SFR_MEM8(0x0402)
+#define PORTA_DIRTGL  _SFR_MEM8(0x0403)
+#define PORTA_OUT  _SFR_MEM8(0x0404)
+#define PORTA_OUTSET  _SFR_MEM8(0x0405)
+#define PORTA_OUTCLR  _SFR_MEM8(0x0406)
+#define PORTA_OUTTGL  _SFR_MEM8(0x0407)
+#define PORTA_IN  _SFR_MEM8(0x0408)
+#define PORTA_INTFLAGS  _SFR_MEM8(0x0409)
+#define PORTA_PORTCTRL  _SFR_MEM8(0x040A)
+#define PORTA_PINCONFIG  _SFR_MEM8(0x040B)
+#define PORTA_PINCTRLUPD  _SFR_MEM8(0x040C)
+#define PORTA_PINCTRLSET  _SFR_MEM8(0x040D)
+#define PORTA_PINCTRLCLR  _SFR_MEM8(0x040E)
+#define PORTA_PIN0CTRL  _SFR_MEM8(0x0410)
+#define PORTA_PIN1CTRL  _SFR_MEM8(0x0411)
+#define PORTA_PIN2CTRL  _SFR_MEM8(0x0412)
+#define PORTA_PIN3CTRL  _SFR_MEM8(0x0413)
+#define PORTA_PIN4CTRL  _SFR_MEM8(0x0414)
+#define PORTA_PIN5CTRL  _SFR_MEM8(0x0415)
+#define PORTA_PIN6CTRL  _SFR_MEM8(0x0416)
+#define PORTA_PIN7CTRL  _SFR_MEM8(0x0417)
+#define PORTA_EVGENCTRL  _SFR_MEM8(0x0418)
+
+
+/* PORT (PORTC) - I/O Ports */
+#define PORTC_DIR  _SFR_MEM8(0x0440)
+#define PORTC_DIRSET  _SFR_MEM8(0x0441)
+#define PORTC_DIRCLR  _SFR_MEM8(0x0442)
+#define PORTC_DIRTGL  _SFR_MEM8(0x0443)
+#define PORTC_OUT  _SFR_MEM8(0x0444)
+#define PORTC_OUTSET  _SFR_MEM8(0x0445)
+#define PORTC_OUTCLR  _SFR_MEM8(0x0446)
+#define PORTC_OUTTGL  _SFR_MEM8(0x0447)
+#define PORTC_IN  _SFR_MEM8(0x0448)
+#define PORTC_INTFLAGS  _SFR_MEM8(0x0449)
+#define PORTC_PORTCTRL  _SFR_MEM8(0x044A)
+#define PORTC_PINCONFIG  _SFR_MEM8(0x044B)
+#define PORTC_PINCTRLUPD  _SFR_MEM8(0x044C)
+#define PORTC_PINCTRLSET  _SFR_MEM8(0x044D)
+#define PORTC_PINCTRLCLR  _SFR_MEM8(0x044E)
+#define PORTC_PIN0CTRL  _SFR_MEM8(0x0450)
+#define PORTC_PIN1CTRL  _SFR_MEM8(0x0451)
+#define PORTC_PIN2CTRL  _SFR_MEM8(0x0452)
+#define PORTC_PIN3CTRL  _SFR_MEM8(0x0453)
+#define PORTC_PIN4CTRL  _SFR_MEM8(0x0454)
+#define PORTC_PIN5CTRL  _SFR_MEM8(0x0455)
+#define PORTC_PIN6CTRL  _SFR_MEM8(0x0456)
+#define PORTC_PIN7CTRL  _SFR_MEM8(0x0457)
+#define PORTC_EVGENCTRL  _SFR_MEM8(0x0458)
+
+
+/* PORT (PORTD) - I/O Ports */
+#define PORTD_DIR  _SFR_MEM8(0x0460)
+#define PORTD_DIRSET  _SFR_MEM8(0x0461)
+#define PORTD_DIRCLR  _SFR_MEM8(0x0462)
+#define PORTD_DIRTGL  _SFR_MEM8(0x0463)
+#define PORTD_OUT  _SFR_MEM8(0x0464)
+#define PORTD_OUTSET  _SFR_MEM8(0x0465)
+#define PORTD_OUTCLR  _SFR_MEM8(0x0466)
+#define PORTD_OUTTGL  _SFR_MEM8(0x0467)
+#define PORTD_IN  _SFR_MEM8(0x0468)
+#define PORTD_INTFLAGS  _SFR_MEM8(0x0469)
+#define PORTD_PORTCTRL  _SFR_MEM8(0x046A)
+#define PORTD_PINCONFIG  _SFR_MEM8(0x046B)
+#define PORTD_PINCTRLUPD  _SFR_MEM8(0x046C)
+#define PORTD_PINCTRLSET  _SFR_MEM8(0x046D)
+#define PORTD_PINCTRLCLR  _SFR_MEM8(0x046E)
+#define PORTD_PIN0CTRL  _SFR_MEM8(0x0470)
+#define PORTD_PIN1CTRL  _SFR_MEM8(0x0471)
+#define PORTD_PIN2CTRL  _SFR_MEM8(0x0472)
+#define PORTD_PIN3CTRL  _SFR_MEM8(0x0473)
+#define PORTD_PIN4CTRL  _SFR_MEM8(0x0474)
+#define PORTD_PIN5CTRL  _SFR_MEM8(0x0475)
+#define PORTD_PIN6CTRL  _SFR_MEM8(0x0476)
+#define PORTD_PIN7CTRL  _SFR_MEM8(0x0477)
+#define PORTD_EVGENCTRL  _SFR_MEM8(0x0478)
+
+
+/* PORT (PORTF) - I/O Ports */
+#define PORTF_DIR  _SFR_MEM8(0x04A0)
+#define PORTF_DIRSET  _SFR_MEM8(0x04A1)
+#define PORTF_DIRCLR  _SFR_MEM8(0x04A2)
+#define PORTF_DIRTGL  _SFR_MEM8(0x04A3)
+#define PORTF_OUT  _SFR_MEM8(0x04A4)
+#define PORTF_OUTSET  _SFR_MEM8(0x04A5)
+#define PORTF_OUTCLR  _SFR_MEM8(0x04A6)
+#define PORTF_OUTTGL  _SFR_MEM8(0x04A7)
+#define PORTF_IN  _SFR_MEM8(0x04A8)
+#define PORTF_INTFLAGS  _SFR_MEM8(0x04A9)
+#define PORTF_PORTCTRL  _SFR_MEM8(0x04AA)
+#define PORTF_PINCONFIG  _SFR_MEM8(0x04AB)
+#define PORTF_PINCTRLUPD  _SFR_MEM8(0x04AC)
+#define PORTF_PINCTRLSET  _SFR_MEM8(0x04AD)
+#define PORTF_PINCTRLCLR  _SFR_MEM8(0x04AE)
+#define PORTF_PIN0CTRL  _SFR_MEM8(0x04B0)
+#define PORTF_PIN1CTRL  _SFR_MEM8(0x04B1)
+#define PORTF_PIN2CTRL  _SFR_MEM8(0x04B2)
+#define PORTF_PIN3CTRL  _SFR_MEM8(0x04B3)
+#define PORTF_PIN4CTRL  _SFR_MEM8(0x04B4)
+#define PORTF_PIN5CTRL  _SFR_MEM8(0x04B5)
+#define PORTF_PIN6CTRL  _SFR_MEM8(0x04B6)
+#define PORTF_PIN7CTRL  _SFR_MEM8(0x04B7)
+#define PORTF_EVGENCTRL  _SFR_MEM8(0x04B8)
+
+
+/* PORTMUX - Port Multiplexer */
+#define PORTMUX_EVSYSROUTEA  _SFR_MEM8(0x05E0)
+#define PORTMUX_CCLROUTEA  _SFR_MEM8(0x05E1)
+#define PORTMUX_USARTROUTEA  _SFR_MEM8(0x05E2)
+#define PORTMUX_USARTROUTEB  _SFR_MEM8(0x05E3)
+#define PORTMUX_SPIROUTEA  _SFR_MEM8(0x05E5)
+#define PORTMUX_TWIROUTEA  _SFR_MEM8(0x05E6)
+#define PORTMUX_TCAROUTEA  _SFR_MEM8(0x05E7)
+#define PORTMUX_TCBROUTEA  _SFR_MEM8(0x05E8)
+#define PORTMUX_ACROUTEA  _SFR_MEM8(0x05EA)
+
+
+/* ADC (ADC0) - Analog to Digital Converter */
+#define ADC0_CTRLA  _SFR_MEM8(0x0600)
+#define ADC0_CTRLB  _SFR_MEM8(0x0601)
+#define ADC0_CTRLC  _SFR_MEM8(0x0602)
+#define ADC0_CTRLD  _SFR_MEM8(0x0603)
+#define ADC0_INTCTRL  _SFR_MEM8(0x0604)
+#define ADC0_INTFLAGS  _SFR_MEM8(0x0605)
+#define ADC0_STATUS  _SFR_MEM8(0x0606)
+#define ADC0_DBGCTRL  _SFR_MEM8(0x0607)
+#define ADC0_CTRLE  _SFR_MEM8(0x0608)
+#define ADC0_CTRLF  _SFR_MEM8(0x0609)
+#define ADC0_COMMAND  _SFR_MEM8(0x060A)
+#define ADC0_PGACTRL  _SFR_MEM8(0x060B)
+#define ADC0_MUXPOS  _SFR_MEM8(0x060C)
+#define ADC0_MUXNEG  _SFR_MEM8(0x060D)
+#define ADC0_RESULT  _SFR_MEM32(0x0610)
+#define ADC0_RESULT0  _SFR_MEM8(0x0610)
+#define ADC0_RESULT1  _SFR_MEM8(0x0611)
+#define ADC0_RESULT2  _SFR_MEM8(0x0612)
+#define ADC0_RESULT3  _SFR_MEM8(0x0613)
+#define ADC0_SAMPLE  _SFR_MEM16(0x0614)
+#define ADC0_SAMPLEL  _SFR_MEM8(0x0614)
+#define ADC0_SAMPLEH  _SFR_MEM8(0x0615)
+#define ADC0_TEMP0  _SFR_MEM8(0x0618)
+#define ADC0_TEMP1  _SFR_MEM8(0x0619)
+#define ADC0_TEMP2  _SFR_MEM8(0x061A)
+#define ADC0_WINLT  _SFR_MEM16(0x061C)
+#define ADC0_WINLTL  _SFR_MEM8(0x061C)
+#define ADC0_WINLTH  _SFR_MEM8(0x061D)
+#define ADC0_WINHT  _SFR_MEM16(0x061E)
+#define ADC0_WINHTL  _SFR_MEM8(0x061E)
+#define ADC0_WINHTH  _SFR_MEM8(0x061F)
+
+
+/* AC (AC0) - Analog Comparator */
+#define AC0_CTRLA  _SFR_MEM8(0x0680)
+#define AC0_CTRLB  _SFR_MEM8(0x0681)
+#define AC0_MUXCTRL  _SFR_MEM8(0x0682)
+#define AC0_DACREF  _SFR_MEM8(0x0685)
+#define AC0_INTCTRL  _SFR_MEM8(0x0686)
+#define AC0_STATUS  _SFR_MEM8(0x0687)
+
+
+/* AC (AC1) - Analog Comparator */
+#define AC1_CTRLA  _SFR_MEM8(0x0688)
+#define AC1_CTRLB  _SFR_MEM8(0x0689)
+#define AC1_MUXCTRL  _SFR_MEM8(0x068A)
+#define AC1_DACREF  _SFR_MEM8(0x068D)
+#define AC1_INTCTRL  _SFR_MEM8(0x068E)
+#define AC1_STATUS  _SFR_MEM8(0x068F)
+
+
+/* DAC (DAC0) - Digital to Analog Converter */
+#define DAC0_CTRLA  _SFR_MEM8(0x06A0)
+#define DAC0_DATA  _SFR_MEM16(0x06A2)
+#define DAC0_DATAL  _SFR_MEM8(0x06A2)
+#define DAC0_DATAH  _SFR_MEM8(0x06A3)
+
+
+/* USART (USART0) - Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define USART0_RXDATAL  _SFR_MEM8(0x0800)
+#define USART0_RXDATAH  _SFR_MEM8(0x0801)
+#define USART0_TXDATAL  _SFR_MEM8(0x0802)
+#define USART0_TXDATAH  _SFR_MEM8(0x0803)
+#define USART0_STATUS  _SFR_MEM8(0x0804)
+#define USART0_CTRLA  _SFR_MEM8(0x0805)
+#define USART0_CTRLB  _SFR_MEM8(0x0806)
+#define USART0_CTRLC  _SFR_MEM8(0x0807)
+#define USART0_BAUD  _SFR_MEM16(0x0808)
+#define USART0_BAUDL  _SFR_MEM8(0x0808)
+#define USART0_BAUDH  _SFR_MEM8(0x0809)
+#define USART0_CTRLD  _SFR_MEM8(0x080A)
+#define USART0_DBGCTRL  _SFR_MEM8(0x080B)
+#define USART0_EVCTRL  _SFR_MEM8(0x080C)
+#define USART0_TXPLCTRL  _SFR_MEM8(0x080D)
+#define USART0_RXPLCTRL  _SFR_MEM8(0x080E)
+
+
+/* USART (USART1) - Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define USART1_RXDATAL  _SFR_MEM8(0x0820)
+#define USART1_RXDATAH  _SFR_MEM8(0x0821)
+#define USART1_TXDATAL  _SFR_MEM8(0x0822)
+#define USART1_TXDATAH  _SFR_MEM8(0x0823)
+#define USART1_STATUS  _SFR_MEM8(0x0824)
+#define USART1_CTRLA  _SFR_MEM8(0x0825)
+#define USART1_CTRLB  _SFR_MEM8(0x0826)
+#define USART1_CTRLC  _SFR_MEM8(0x0827)
+#define USART1_BAUD  _SFR_MEM16(0x0828)
+#define USART1_BAUDL  _SFR_MEM8(0x0828)
+#define USART1_BAUDH  _SFR_MEM8(0x0829)
+#define USART1_CTRLD  _SFR_MEM8(0x082A)
+#define USART1_DBGCTRL  _SFR_MEM8(0x082B)
+#define USART1_EVCTRL  _SFR_MEM8(0x082C)
+#define USART1_TXPLCTRL  _SFR_MEM8(0x082D)
+#define USART1_RXPLCTRL  _SFR_MEM8(0x082E)
+
+
+/* USART (USART2) - Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define USART2_RXDATAL  _SFR_MEM8(0x0840)
+#define USART2_RXDATAH  _SFR_MEM8(0x0841)
+#define USART2_TXDATAL  _SFR_MEM8(0x0842)
+#define USART2_TXDATAH  _SFR_MEM8(0x0843)
+#define USART2_STATUS  _SFR_MEM8(0x0844)
+#define USART2_CTRLA  _SFR_MEM8(0x0845)
+#define USART2_CTRLB  _SFR_MEM8(0x0846)
+#define USART2_CTRLC  _SFR_MEM8(0x0847)
+#define USART2_BAUD  _SFR_MEM16(0x0848)
+#define USART2_BAUDL  _SFR_MEM8(0x0848)
+#define USART2_BAUDH  _SFR_MEM8(0x0849)
+#define USART2_CTRLD  _SFR_MEM8(0x084A)
+#define USART2_DBGCTRL  _SFR_MEM8(0x084B)
+#define USART2_EVCTRL  _SFR_MEM8(0x084C)
+#define USART2_TXPLCTRL  _SFR_MEM8(0x084D)
+#define USART2_RXPLCTRL  _SFR_MEM8(0x084E)
+
+
+/* TWI (TWI0) - Two-Wire Interface */
+#define TWI0_CTRLA  _SFR_MEM8(0x0900)
+#define TWI0_DUALCTRL  _SFR_MEM8(0x0901)
+#define TWI0_DBGCTRL  _SFR_MEM8(0x0902)
+#define TWI0_MCTRLA  _SFR_MEM8(0x0903)
+#define TWI0_MCTRLB  _SFR_MEM8(0x0904)
+#define TWI0_MSTATUS  _SFR_MEM8(0x0905)
+#define TWI0_MBAUD  _SFR_MEM8(0x0906)
+#define TWI0_MADDR  _SFR_MEM8(0x0907)
+#define TWI0_MDATA  _SFR_MEM8(0x0908)
+#define TWI0_SCTRLA  _SFR_MEM8(0x0909)
+#define TWI0_SCTRLB  _SFR_MEM8(0x090A)
+#define TWI0_SSTATUS  _SFR_MEM8(0x090B)
+#define TWI0_SADDR  _SFR_MEM8(0x090C)
+#define TWI0_SDATA  _SFR_MEM8(0x090D)
+#define TWI0_SADDRMASK  _SFR_MEM8(0x090E)
+
+
+/* SPI (SPI0) - Serial Peripheral Interface */
+#define SPI0_CTRLA  _SFR_MEM8(0x0940)
+#define SPI0_CTRLB  _SFR_MEM8(0x0941)
+#define SPI0_INTCTRL  _SFR_MEM8(0x0942)
+#define SPI0_INTFLAGS  _SFR_MEM8(0x0943)
+#define SPI0_DATA  _SFR_MEM8(0x0944)
+
+
+/* TCA (TCA0) - 16-bit Timer/Counter Type A - Single Mode */
+#define TCA0_SINGLE_CTRLA  _SFR_MEM8(0x0A00)
+#define TCA0_SINGLE_CTRLB  _SFR_MEM8(0x0A01)
+#define TCA0_SINGLE_CTRLC  _SFR_MEM8(0x0A02)
+#define TCA0_SINGLE_CTRLD  _SFR_MEM8(0x0A03)
+#define TCA0_SINGLE_CTRLECLR  _SFR_MEM8(0x0A04)
+#define TCA0_SINGLE_CTRLESET  _SFR_MEM8(0x0A05)
+#define TCA0_SINGLE_CTRLFCLR  _SFR_MEM8(0x0A06)
+#define TCA0_SINGLE_CTRLFSET  _SFR_MEM8(0x0A07)
+#define TCA0_SINGLE_EVCTRL  _SFR_MEM8(0x0A09)
+#define TCA0_SINGLE_INTCTRL  _SFR_MEM8(0x0A0A)
+#define TCA0_SINGLE_INTFLAGS  _SFR_MEM8(0x0A0B)
+#define TCA0_SINGLE_DBGCTRL  _SFR_MEM8(0x0A0E)
+#define TCA0_SINGLE_TEMP  _SFR_MEM8(0x0A0F)
+#define TCA0_SINGLE_CNT  _SFR_MEM16(0x0A20)
+#define TCA0_SINGLE_CNTL  _SFR_MEM8(0x0A20)
+#define TCA0_SINGLE_CNTH  _SFR_MEM8(0x0A21)
+#define TCA0_SINGLE_PER  _SFR_MEM16(0x0A26)
+#define TCA0_SINGLE_PERL  _SFR_MEM8(0x0A26)
+#define TCA0_SINGLE_PERH  _SFR_MEM8(0x0A27)
+#define TCA0_SINGLE_CMP0  _SFR_MEM16(0x0A28)
+#define TCA0_SINGLE_CMP0L  _SFR_MEM8(0x0A28)
+#define TCA0_SINGLE_CMP0H  _SFR_MEM8(0x0A29)
+#define TCA0_SINGLE_CMP1  _SFR_MEM16(0x0A2A)
+#define TCA0_SINGLE_CMP1L  _SFR_MEM8(0x0A2A)
+#define TCA0_SINGLE_CMP1H  _SFR_MEM8(0x0A2B)
+#define TCA0_SINGLE_CMP2  _SFR_MEM16(0x0A2C)
+#define TCA0_SINGLE_CMP2L  _SFR_MEM8(0x0A2C)
+#define TCA0_SINGLE_CMP2H  _SFR_MEM8(0x0A2D)
+#define TCA0_SINGLE_PERBUF  _SFR_MEM16(0x0A36)
+#define TCA0_SINGLE_PERBUFL  _SFR_MEM8(0x0A36)
+#define TCA0_SINGLE_PERBUFH  _SFR_MEM8(0x0A37)
+#define TCA0_SINGLE_CMP0BUF  _SFR_MEM16(0x0A38)
+#define TCA0_SINGLE_CMP0BUFL  _SFR_MEM8(0x0A38)
+#define TCA0_SINGLE_CMP0BUFH  _SFR_MEM8(0x0A39)
+#define TCA0_SINGLE_CMP1BUF  _SFR_MEM16(0x0A3A)
+#define TCA0_SINGLE_CMP1BUFL  _SFR_MEM8(0x0A3A)
+#define TCA0_SINGLE_CMP1BUFH  _SFR_MEM8(0x0A3B)
+#define TCA0_SINGLE_CMP2BUF  _SFR_MEM16(0x0A3C)
+#define TCA0_SINGLE_CMP2BUFL  _SFR_MEM8(0x0A3C)
+#define TCA0_SINGLE_CMP2BUFH  _SFR_MEM8(0x0A3D)
+
+
+/* TCA (TCA0) - 16-bit Timer/Counter Type A - Split Mode */
+#define TCA0_SPLIT_CTRLA  _SFR_MEM8(0x0A00)
+#define TCA0_SPLIT_CTRLB  _SFR_MEM8(0x0A01)
+#define TCA0_SPLIT_CTRLC  _SFR_MEM8(0x0A02)
+#define TCA0_SPLIT_CTRLD  _SFR_MEM8(0x0A03)
+#define TCA0_SPLIT_CTRLECLR  _SFR_MEM8(0x0A04)
+#define TCA0_SPLIT_CTRLESET  _SFR_MEM8(0x0A05)
+#define TCA0_SPLIT_INTCTRL  _SFR_MEM8(0x0A0A)
+#define TCA0_SPLIT_INTFLAGS  _SFR_MEM8(0x0A0B)
+#define TCA0_SPLIT_DBGCTRL  _SFR_MEM8(0x0A0E)
+#define TCA0_SPLIT_LCNT  _SFR_MEM8(0x0A20)
+#define TCA0_SPLIT_HCNT  _SFR_MEM8(0x0A21)
+#define TCA0_SPLIT_LPER  _SFR_MEM8(0x0A26)
+#define TCA0_SPLIT_HPER  _SFR_MEM8(0x0A27)
+#define TCA0_SPLIT_LCMP0  _SFR_MEM8(0x0A28)
+#define TCA0_SPLIT_HCMP0  _SFR_MEM8(0x0A29)
+#define TCA0_SPLIT_LCMP1  _SFR_MEM8(0x0A2A)
+#define TCA0_SPLIT_HCMP1  _SFR_MEM8(0x0A2B)
+#define TCA0_SPLIT_LCMP2  _SFR_MEM8(0x0A2C)
+#define TCA0_SPLIT_HCMP2  _SFR_MEM8(0x0A2D)
+
+
+/* TCB (TCB0) - 16-bit Timer Type B */
+#define TCB0_CTRLA  _SFR_MEM8(0x0B00)
+#define TCB0_CTRLB  _SFR_MEM8(0x0B01)
+#define TCB0_EVCTRL  _SFR_MEM8(0x0B04)
+#define TCB0_INTCTRL  _SFR_MEM8(0x0B05)
+#define TCB0_INTFLAGS  _SFR_MEM8(0x0B06)
+#define TCB0_STATUS  _SFR_MEM8(0x0B07)
+#define TCB0_DBGCTRL  _SFR_MEM8(0x0B08)
+#define TCB0_TEMP  _SFR_MEM8(0x0B09)
+#define TCB0_CNT  _SFR_MEM16(0x0B0A)
+#define TCB0_CNTL  _SFR_MEM8(0x0B0A)
+#define TCB0_CNTH  _SFR_MEM8(0x0B0B)
+#define TCB0_CCMP  _SFR_MEM16(0x0B0C)
+#define TCB0_CCMPL  _SFR_MEM8(0x0B0C)
+#define TCB0_CCMPH  _SFR_MEM8(0x0B0D)
+
+
+/* TCB (TCB1) - 16-bit Timer Type B */
+#define TCB1_CTRLA  _SFR_MEM8(0x0B10)
+#define TCB1_CTRLB  _SFR_MEM8(0x0B11)
+#define TCB1_EVCTRL  _SFR_MEM8(0x0B14)
+#define TCB1_INTCTRL  _SFR_MEM8(0x0B15)
+#define TCB1_INTFLAGS  _SFR_MEM8(0x0B16)
+#define TCB1_STATUS  _SFR_MEM8(0x0B17)
+#define TCB1_DBGCTRL  _SFR_MEM8(0x0B18)
+#define TCB1_TEMP  _SFR_MEM8(0x0B19)
+#define TCB1_CNT  _SFR_MEM16(0x0B1A)
+#define TCB1_CNTL  _SFR_MEM8(0x0B1A)
+#define TCB1_CNTH  _SFR_MEM8(0x0B1B)
+#define TCB1_CCMP  _SFR_MEM16(0x0B1C)
+#define TCB1_CCMPL  _SFR_MEM8(0x0B1C)
+#define TCB1_CCMPH  _SFR_MEM8(0x0B1D)
+
+
+/* TCB (TCB2) - 16-bit Timer Type B */
+#define TCB2_CTRLA  _SFR_MEM8(0x0B20)
+#define TCB2_CTRLB  _SFR_MEM8(0x0B21)
+#define TCB2_EVCTRL  _SFR_MEM8(0x0B24)
+#define TCB2_INTCTRL  _SFR_MEM8(0x0B25)
+#define TCB2_INTFLAGS  _SFR_MEM8(0x0B26)
+#define TCB2_STATUS  _SFR_MEM8(0x0B27)
+#define TCB2_DBGCTRL  _SFR_MEM8(0x0B28)
+#define TCB2_TEMP  _SFR_MEM8(0x0B29)
+#define TCB2_CNT  _SFR_MEM16(0x0B2A)
+#define TCB2_CNTL  _SFR_MEM8(0x0B2A)
+#define TCB2_CNTH  _SFR_MEM8(0x0B2B)
+#define TCB2_CCMP  _SFR_MEM16(0x0B2C)
+#define TCB2_CCMPL  _SFR_MEM8(0x0B2C)
+#define TCB2_CCMPH  _SFR_MEM8(0x0B2D)
+
+
+/* SYSCFG - System Configuration Registers */
+#define SYSCFG_REVID  _SFR_MEM8(0x0F01)
+#define SYSCFG_OCDMCTRL  _SFR_MEM8(0x0F04)
+#define SYSCFG_OCDMSTATUS  _SFR_MEM8(0x0F05)
+
+
+/* NVMCTRL - Non-volatile Memory Controller */
+#define NVMCTRL_CTRLA  _SFR_MEM8(0x1000)
+#define NVMCTRL_CTRLB  _SFR_MEM8(0x1001)
+#define NVMCTRL_INTCTRL  _SFR_MEM8(0x1004)
+#define NVMCTRL_INTFLAGS  _SFR_MEM8(0x1005)
+#define NVMCTRL_STATUS  _SFR_MEM8(0x1006)
+#define NVMCTRL_DATA  _SFR_MEM16(0x1008)
+#define NVMCTRL_DATAL  _SFR_MEM8(0x1008)
+#define NVMCTRL_DATAH  _SFR_MEM8(0x1009)
+#define NVMCTRL_ADDR  _SFR_MEM32(0x100C)
+#define NVMCTRL_ADDR0  _SFR_MEM8(0x100C)
+#define NVMCTRL_ADDR1  _SFR_MEM8(0x100D)
+#define NVMCTRL_ADDR2  _SFR_MEM8(0x100E)
+#define NVMCTRL_ADDR3  _SFR_MEM8(0x100F)
+
+
+/* LOCK - Lockbits */
+#define LOCK_KEY  _SFR_MEM32(0x1040)
+#define LOCK_KEY0  _SFR_MEM8(0x1040)
+#define LOCK_KEY1  _SFR_MEM8(0x1041)
+#define LOCK_KEY2  _SFR_MEM8(0x1042)
+#define LOCK_KEY3  _SFR_MEM8(0x1043)
+
+
+/* FUSE - Fuses */
+#define FUSE_WDTCFG  _SFR_MEM8(0x1050)
+#define FUSE_BODCFG  _SFR_MEM8(0x1051)
+#define FUSE_OSCCFG  _SFR_MEM8(0x1052)
+#define FUSE_SYSCFG0  _SFR_MEM8(0x1055)
+#define FUSE_SYSCFG1  _SFR_MEM8(0x1056)
+#define FUSE_CODESIZE  _SFR_MEM8(0x1057)
+#define FUSE_BOOTSIZE  _SFR_MEM8(0x1058)
+
+
+/* USERROW - User Row */
+#define USERROW_USERROW0  _SFR_MEM8(0x1080)
+#define USERROW_USERROW1  _SFR_MEM8(0x1081)
+#define USERROW_USERROW2  _SFR_MEM8(0x1082)
+#define USERROW_USERROW3  _SFR_MEM8(0x1083)
+#define USERROW_USERROW4  _SFR_MEM8(0x1084)
+#define USERROW_USERROW5  _SFR_MEM8(0x1085)
+#define USERROW_USERROW6  _SFR_MEM8(0x1086)
+#define USERROW_USERROW7  _SFR_MEM8(0x1087)
+#define USERROW_USERROW8  _SFR_MEM8(0x1088)
+#define USERROW_USERROW9  _SFR_MEM8(0x1089)
+#define USERROW_USERROW10  _SFR_MEM8(0x108A)
+#define USERROW_USERROW11  _SFR_MEM8(0x108B)
+#define USERROW_USERROW12  _SFR_MEM8(0x108C)
+#define USERROW_USERROW13  _SFR_MEM8(0x108D)
+#define USERROW_USERROW14  _SFR_MEM8(0x108E)
+#define USERROW_USERROW15  _SFR_MEM8(0x108F)
+#define USERROW_USERROW16  _SFR_MEM8(0x1090)
+#define USERROW_USERROW17  _SFR_MEM8(0x1091)
+#define USERROW_USERROW18  _SFR_MEM8(0x1092)
+#define USERROW_USERROW19  _SFR_MEM8(0x1093)
+#define USERROW_USERROW20  _SFR_MEM8(0x1094)
+#define USERROW_USERROW21  _SFR_MEM8(0x1095)
+#define USERROW_USERROW22  _SFR_MEM8(0x1096)
+#define USERROW_USERROW23  _SFR_MEM8(0x1097)
+#define USERROW_USERROW24  _SFR_MEM8(0x1098)
+#define USERROW_USERROW25  _SFR_MEM8(0x1099)
+#define USERROW_USERROW26  _SFR_MEM8(0x109A)
+#define USERROW_USERROW27  _SFR_MEM8(0x109B)
+#define USERROW_USERROW28  _SFR_MEM8(0x109C)
+#define USERROW_USERROW29  _SFR_MEM8(0x109D)
+#define USERROW_USERROW30  _SFR_MEM8(0x109E)
+#define USERROW_USERROW31  _SFR_MEM8(0x109F)
+#define USERROW_USERROW32  _SFR_MEM8(0x10A0)
+#define USERROW_USERROW33  _SFR_MEM8(0x10A1)
+#define USERROW_USERROW34  _SFR_MEM8(0x10A2)
+#define USERROW_USERROW35  _SFR_MEM8(0x10A3)
+#define USERROW_USERROW36  _SFR_MEM8(0x10A4)
+#define USERROW_USERROW37  _SFR_MEM8(0x10A5)
+#define USERROW_USERROW38  _SFR_MEM8(0x10A6)
+#define USERROW_USERROW39  _SFR_MEM8(0x10A7)
+#define USERROW_USERROW40  _SFR_MEM8(0x10A8)
+#define USERROW_USERROW41  _SFR_MEM8(0x10A9)
+#define USERROW_USERROW42  _SFR_MEM8(0x10AA)
+#define USERROW_USERROW43  _SFR_MEM8(0x10AB)
+#define USERROW_USERROW44  _SFR_MEM8(0x10AC)
+#define USERROW_USERROW45  _SFR_MEM8(0x10AD)
+#define USERROW_USERROW46  _SFR_MEM8(0x10AE)
+#define USERROW_USERROW47  _SFR_MEM8(0x10AF)
+#define USERROW_USERROW48  _SFR_MEM8(0x10B0)
+#define USERROW_USERROW49  _SFR_MEM8(0x10B1)
+#define USERROW_USERROW50  _SFR_MEM8(0x10B2)
+#define USERROW_USERROW51  _SFR_MEM8(0x10B3)
+#define USERROW_USERROW52  _SFR_MEM8(0x10B4)
+#define USERROW_USERROW53  _SFR_MEM8(0x10B5)
+#define USERROW_USERROW54  _SFR_MEM8(0x10B6)
+#define USERROW_USERROW55  _SFR_MEM8(0x10B7)
+#define USERROW_USERROW56  _SFR_MEM8(0x10B8)
+#define USERROW_USERROW57  _SFR_MEM8(0x10B9)
+#define USERROW_USERROW58  _SFR_MEM8(0x10BA)
+#define USERROW_USERROW59  _SFR_MEM8(0x10BB)
+#define USERROW_USERROW60  _SFR_MEM8(0x10BC)
+#define USERROW_USERROW61  _SFR_MEM8(0x10BD)
+#define USERROW_USERROW62  _SFR_MEM8(0x10BE)
+#define USERROW_USERROW63  _SFR_MEM8(0x10BF)
+
+
+/* SIGROW - Signature row */
+#define SIGROW_DEVICEID0  _SFR_MEM8(0x1100)
+#define SIGROW_DEVICEID1  _SFR_MEM8(0x1101)
+#define SIGROW_DEVICEID2  _SFR_MEM8(0x1102)
+#define SIGROW_TEMPSENSE0  _SFR_MEM16(0x1104)
+#define SIGROW_TEMPSENSE0L  _SFR_MEM8(0x1104)
+#define SIGROW_TEMPSENSE0H  _SFR_MEM8(0x1105)
+#define SIGROW_TEMPSENSE1  _SFR_MEM16(0x1106)
+#define SIGROW_TEMPSENSE1L  _SFR_MEM8(0x1106)
+#define SIGROW_TEMPSENSE1H  _SFR_MEM8(0x1107)
+#define SIGROW_SERNUM0  _SFR_MEM8(0x1110)
+#define SIGROW_SERNUM1  _SFR_MEM8(0x1111)
+#define SIGROW_SERNUM2  _SFR_MEM8(0x1112)
+#define SIGROW_SERNUM3  _SFR_MEM8(0x1113)
+#define SIGROW_SERNUM4  _SFR_MEM8(0x1114)
+#define SIGROW_SERNUM5  _SFR_MEM8(0x1115)
+#define SIGROW_SERNUM6  _SFR_MEM8(0x1116)
+#define SIGROW_SERNUM7  _SFR_MEM8(0x1117)
+#define SIGROW_SERNUM8  _SFR_MEM8(0x1118)
+#define SIGROW_SERNUM9  _SFR_MEM8(0x1119)
+#define SIGROW_SERNUM10  _SFR_MEM8(0x111A)
+#define SIGROW_SERNUM11  _SFR_MEM8(0x111B)
+#define SIGROW_SERNUM12  _SFR_MEM8(0x111C)
+#define SIGROW_SERNUM13  _SFR_MEM8(0x111D)
+#define SIGROW_SERNUM14  _SFR_MEM8(0x111E)
+#define SIGROW_SERNUM15  _SFR_MEM8(0x111F)
+
+
+
+/*================== Bitfield Definitions ================== */
+
+/* AC - Analog Comparator */
+/* AC.CTRLA  bit masks and bit positions */
+#define AC_ENABLE_bm  0x01  /* Enable bit mask. */
+#define AC_ENABLE_bp  0  /* Enable bit position. */
+#define AC_HYSMODE_gm  0x06  /* Hysteresis Mode group mask. */
+#define AC_HYSMODE_gp  1  /* Hysteresis Mode group position. */
+#define AC_HYSMODE_0_bm  (1<<1)  /* Hysteresis Mode bit 0 mask. */
+#define AC_HYSMODE_0_bp  1  /* Hysteresis Mode bit 0 position. */
+#define AC_HYSMODE_1_bm  (1<<2)  /* Hysteresis Mode bit 1 mask. */
+#define AC_HYSMODE_1_bp  2  /* Hysteresis Mode bit 1 position. */
+#define AC_POWER_gm  0x18  /* Power profile group mask. */
+#define AC_POWER_gp  3  /* Power profile group position. */
+#define AC_POWER_0_bm  (1<<3)  /* Power profile bit 0 mask. */
+#define AC_POWER_0_bp  3  /* Power profile bit 0 position. */
+#define AC_POWER_1_bm  (1<<4)  /* Power profile bit 1 mask. */
+#define AC_POWER_1_bp  4  /* Power profile bit 1 position. */
+#define AC_OUTEN_bm  0x40  /* Output Pad Enable bit mask. */
+#define AC_OUTEN_bp  6  /* Output Pad Enable bit position. */
+#define AC_RUNSTDBY_bm  0x80  /* Run in Standby Mode bit mask. */
+#define AC_RUNSTDBY_bp  7  /* Run in Standby Mode bit position. */
+
+/* AC.CTRLB  bit masks and bit positions */
+#define AC_WINSEL_gm  0x03  /* Window selection mode group mask. */
+#define AC_WINSEL_gp  0  /* Window selection mode group position. */
+#define AC_WINSEL_0_bm  (1<<0)  /* Window selection mode bit 0 mask. */
+#define AC_WINSEL_0_bp  0  /* Window selection mode bit 0 position. */
+#define AC_WINSEL_1_bm  (1<<1)  /* Window selection mode bit 1 mask. */
+#define AC_WINSEL_1_bp  1  /* Window selection mode bit 1 position. */
+
+/* AC.MUXCTRL  bit masks and bit positions */
+#define AC_MUXNEG_gm  0x07  /* Negative Input MUX Selection group mask. */
+#define AC_MUXNEG_gp  0  /* Negative Input MUX Selection group position. */
+#define AC_MUXNEG_0_bm  (1<<0)  /* Negative Input MUX Selection bit 0 mask. */
+#define AC_MUXNEG_0_bp  0  /* Negative Input MUX Selection bit 0 position. */
+#define AC_MUXNEG_1_bm  (1<<1)  /* Negative Input MUX Selection bit 1 mask. */
+#define AC_MUXNEG_1_bp  1  /* Negative Input MUX Selection bit 1 position. */
+#define AC_MUXNEG_2_bm  (1<<2)  /* Negative Input MUX Selection bit 2 mask. */
+#define AC_MUXNEG_2_bp  2  /* Negative Input MUX Selection bit 2 position. */
+#define AC_MUXPOS_gm  0x38  /* Positive Input MUX Selection group mask. */
+#define AC_MUXPOS_gp  3  /* Positive Input MUX Selection group position. */
+#define AC_MUXPOS_0_bm  (1<<3)  /* Positive Input MUX Selection bit 0 mask. */
+#define AC_MUXPOS_0_bp  3  /* Positive Input MUX Selection bit 0 position. */
+#define AC_MUXPOS_1_bm  (1<<4)  /* Positive Input MUX Selection bit 1 mask. */
+#define AC_MUXPOS_1_bp  4  /* Positive Input MUX Selection bit 1 position. */
+#define AC_MUXPOS_2_bm  (1<<5)  /* Positive Input MUX Selection bit 2 mask. */
+#define AC_MUXPOS_2_bp  5  /* Positive Input MUX Selection bit 2 position. */
+#define AC_INITVAL_bm  0x40  /* AC Output Initial Value bit mask. */
+#define AC_INITVAL_bp  6  /* AC Output Initial Value bit position. */
+#define AC_INVERT_bm  0x80  /* Invert AC Output bit mask. */
+#define AC_INVERT_bp  7  /* Invert AC Output bit position. */
+
+/* AC.DACREF  bit masks and bit positions */
+#define AC_DACREF_gm  0xFF  /* DACREF group mask. */
+#define AC_DACREF_gp  0  /* DACREF group position. */
+#define AC_DACREF_0_bm  (1<<0)  /* DACREF bit 0 mask. */
+#define AC_DACREF_0_bp  0  /* DACREF bit 0 position. */
+#define AC_DACREF_1_bm  (1<<1)  /* DACREF bit 1 mask. */
+#define AC_DACREF_1_bp  1  /* DACREF bit 1 position. */
+#define AC_DACREF_2_bm  (1<<2)  /* DACREF bit 2 mask. */
+#define AC_DACREF_2_bp  2  /* DACREF bit 2 position. */
+#define AC_DACREF_3_bm  (1<<3)  /* DACREF bit 3 mask. */
+#define AC_DACREF_3_bp  3  /* DACREF bit 3 position. */
+#define AC_DACREF_4_bm  (1<<4)  /* DACREF bit 4 mask. */
+#define AC_DACREF_4_bp  4  /* DACREF bit 4 position. */
+#define AC_DACREF_5_bm  (1<<5)  /* DACREF bit 5 mask. */
+#define AC_DACREF_5_bp  5  /* DACREF bit 5 position. */
+#define AC_DACREF_6_bm  (1<<6)  /* DACREF bit 6 mask. */
+#define AC_DACREF_6_bp  6  /* DACREF bit 6 position. */
+#define AC_DACREF_7_bm  (1<<7)  /* DACREF bit 7 mask. */
+#define AC_DACREF_7_bp  7  /* DACREF bit 7 position. */
+
+/* AC.INTCTRL  bit masks and bit positions */
+#define AC_CMP_bm  0x01  /* Interrupt Enable bit mask. */
+#define AC_CMP_bp  0  /* Interrupt Enable bit position. */
+#define AC_INTMODE_NORMAL_gm  0x30  /* Interrupt Mode group mask. */
+#define AC_INTMODE_NORMAL_gp  4  /* Interrupt Mode group position. */
+#define AC_INTMODE_NORMAL_0_bm  (1<<4)  /* Interrupt Mode bit 0 mask. */
+#define AC_INTMODE_NORMAL_0_bp  4  /* Interrupt Mode bit 0 position. */
+#define AC_INTMODE_NORMAL_1_bm  (1<<5)  /* Interrupt Mode bit 1 mask. */
+#define AC_INTMODE_NORMAL_1_bp  5  /* Interrupt Mode bit 1 position. */
+#define AC_INTMODE_WINDOW_gm  0x30  /* Interrupt Mode group mask. */
+#define AC_INTMODE_WINDOW_gp  4  /* Interrupt Mode group position. */
+#define AC_INTMODE_WINDOW_0_bm  (1<<4)  /* Interrupt Mode bit 0 mask. */
+#define AC_INTMODE_WINDOW_0_bp  4  /* Interrupt Mode bit 0 position. */
+#define AC_INTMODE_WINDOW_1_bm  (1<<5)  /* Interrupt Mode bit 1 mask. */
+#define AC_INTMODE_WINDOW_1_bp  5  /* Interrupt Mode bit 1 position. */
+
+/* AC.STATUS  bit masks and bit positions */
+#define AC_CMPIF_bm  0x01  /* Analog Comparator Interrupt Flag bit mask. */
+#define AC_CMPIF_bp  0  /* Analog Comparator Interrupt Flag bit position. */
+#define AC_CMPSTATE_bm  0x10  /* Analog Comparator State bit mask. */
+#define AC_CMPSTATE_bp  4  /* Analog Comparator State bit position. */
+#define AC_WINSTATE_gm  0xC0  /* Analog Comparator Window State group mask. */
+#define AC_WINSTATE_gp  6  /* Analog Comparator Window State group position. */
+#define AC_WINSTATE_0_bm  (1<<6)  /* Analog Comparator Window State bit 0 mask. */
+#define AC_WINSTATE_0_bp  6  /* Analog Comparator Window State bit 0 position. */
+#define AC_WINSTATE_1_bm  (1<<7)  /* Analog Comparator Window State bit 1 mask. */
+#define AC_WINSTATE_1_bp  7  /* Analog Comparator Window State bit 1 position. */
+
+
+/* ADC - Analog to Digital Converter */
+/* ADC.CTRLA  bit masks and bit positions */
+#define ADC_ENABLE_bm  0x01  /* ADC Enable bit mask. */
+#define ADC_ENABLE_bp  0  /* ADC Enable bit position. */
+#define ADC_LOWLAT_bm  0x20  /* Low Latency bit mask. */
+#define ADC_LOWLAT_bp  5  /* Low Latency bit position. */
+#define ADC_RUNSTDBY_bm  0x80  /* Run in Standby bit mask. */
+#define ADC_RUNSTDBY_bp  7  /* Run in Standby bit position. */
+
+/* ADC.CTRLB  bit masks and bit positions */
+#define ADC_PRESC_gm  0x0F  /* Prescaler Value group mask. */
+#define ADC_PRESC_gp  0  /* Prescaler Value group position. */
+#define ADC_PRESC_0_bm  (1<<0)  /* Prescaler Value bit 0 mask. */
+#define ADC_PRESC_0_bp  0  /* Prescaler Value bit 0 position. */
+#define ADC_PRESC_1_bm  (1<<1)  /* Prescaler Value bit 1 mask. */
+#define ADC_PRESC_1_bp  1  /* Prescaler Value bit 1 position. */
+#define ADC_PRESC_2_bm  (1<<2)  /* Prescaler Value bit 2 mask. */
+#define ADC_PRESC_2_bp  2  /* Prescaler Value bit 2 position. */
+#define ADC_PRESC_3_bm  (1<<3)  /* Prescaler Value bit 3 mask. */
+#define ADC_PRESC_3_bp  3  /* Prescaler Value bit 3 position. */
+
+/* ADC.CTRLC  bit masks and bit positions */
+#define ADC_REFSEL_gm  0x07  /* Reference select group mask. */
+#define ADC_REFSEL_gp  0  /* Reference select group position. */
+#define ADC_REFSEL_0_bm  (1<<0)  /* Reference select bit 0 mask. */
+#define ADC_REFSEL_0_bp  0  /* Reference select bit 0 position. */
+#define ADC_REFSEL_1_bm  (1<<1)  /* Reference select bit 1 mask. */
+#define ADC_REFSEL_1_bp  1  /* Reference select bit 1 position. */
+#define ADC_REFSEL_2_bm  (1<<2)  /* Reference select bit 2 mask. */
+#define ADC_REFSEL_2_bp  2  /* Reference select bit 2 position. */
+
+/* ADC.CTRLD  bit masks and bit positions */
+#define ADC_WINCM_gm  0x07  /* Window Comparator Mode group mask. */
+#define ADC_WINCM_gp  0  /* Window Comparator Mode group position. */
+#define ADC_WINCM_0_bm  (1<<0)  /* Window Comparator Mode bit 0 mask. */
+#define ADC_WINCM_0_bp  0  /* Window Comparator Mode bit 0 position. */
+#define ADC_WINCM_1_bm  (1<<1)  /* Window Comparator Mode bit 1 mask. */
+#define ADC_WINCM_1_bp  1  /* Window Comparator Mode bit 1 position. */
+#define ADC_WINCM_2_bm  (1<<2)  /* Window Comparator Mode bit 2 mask. */
+#define ADC_WINCM_2_bp  2  /* Window Comparator Mode bit 2 position. */
+#define ADC_WINSRC_bm  0x08  /* Window Mode Source bit mask. */
+#define ADC_WINSRC_bp  3  /* Window Mode Source bit position. */
+
+/* ADC.INTCTRL  bit masks and bit positions */
+#define ADC_RESRDY_bm  0x01  /* Result Ready Interrupt Enable bit mask. */
+#define ADC_RESRDY_bp  0  /* Result Ready Interrupt Enable bit position. */
+#define ADC_SAMPRDY_bm  0x02  /* Sample Ready Interrupt Enable bit mask. */
+#define ADC_SAMPRDY_bp  1  /* Sample Ready Interrupt Enable bit position. */
+#define ADC_WCMP_bm  0x04  /* Window Comparator Interrupt Enable bit mask. */
+#define ADC_WCMP_bp  2  /* Window Comparator Interrupt Enable bit position. */
+#define ADC_RESOVR_bm  0x08  /* Result Overwrite Interrupt Enable bit mask. */
+#define ADC_RESOVR_bp  3  /* Result Overwrite Interrupt Enable bit position. */
+#define ADC_SAMPOVR_bm  0x10  /* Sample Overwrite Interrupt Enable bit mask. */
+#define ADC_SAMPOVR_bp  4  /* Sample Overwrite Interrupt Enable bit position. */
+#define ADC_TRIGOVR_bm  0x20  /* Trigger Overrun Interrupt Enable bit mask. */
+#define ADC_TRIGOVR_bp  5  /* Trigger Overrun Interrupt Enable bit position. */
+
+/* ADC.INTFLAGS  bit masks and bit positions */
+/* ADC_RESRDY  is already defined. */
+/* ADC_SAMPRDY  is already defined. */
+/* ADC_WCMP  is already defined. */
+/* ADC_RESOVR  is already defined. */
+/* ADC_SAMPOVR  is already defined. */
+/* ADC_TRIGOVR  is already defined. */
+
+/* ADC.STATUS  bit masks and bit positions */
+#define ADC_ADCBUSY_bm  0x01  /* ADC Busy bit mask. */
+#define ADC_ADCBUSY_bp  0  /* ADC Busy bit position. */
+
+/* ADC.DBGCTRL  bit masks and bit positions */
+#define ADC_DBGRUN_bm  0x01  /* Run in Debug Mode bit mask. */
+#define ADC_DBGRUN_bp  0  /* Run in Debug Mode bit position. */
+
+/* ADC.CTRLE  bit masks and bit positions */
+#define ADC_SAMPDUR_gm  0xFF  /* Sample Duration group mask. */
+#define ADC_SAMPDUR_gp  0  /* Sample Duration group position. */
+#define ADC_SAMPDUR_0_bm  (1<<0)  /* Sample Duration bit 0 mask. */
+#define ADC_SAMPDUR_0_bp  0  /* Sample Duration bit 0 position. */
+#define ADC_SAMPDUR_1_bm  (1<<1)  /* Sample Duration bit 1 mask. */
+#define ADC_SAMPDUR_1_bp  1  /* Sample Duration bit 1 position. */
+#define ADC_SAMPDUR_2_bm  (1<<2)  /* Sample Duration bit 2 mask. */
+#define ADC_SAMPDUR_2_bp  2  /* Sample Duration bit 2 position. */
+#define ADC_SAMPDUR_3_bm  (1<<3)  /* Sample Duration bit 3 mask. */
+#define ADC_SAMPDUR_3_bp  3  /* Sample Duration bit 3 position. */
+#define ADC_SAMPDUR_4_bm  (1<<4)  /* Sample Duration bit 4 mask. */
+#define ADC_SAMPDUR_4_bp  4  /* Sample Duration bit 4 position. */
+#define ADC_SAMPDUR_5_bm  (1<<5)  /* Sample Duration bit 5 mask. */
+#define ADC_SAMPDUR_5_bp  5  /* Sample Duration bit 5 position. */
+#define ADC_SAMPDUR_6_bm  (1<<6)  /* Sample Duration bit 6 mask. */
+#define ADC_SAMPDUR_6_bp  6  /* Sample Duration bit 6 position. */
+#define ADC_SAMPDUR_7_bm  (1<<7)  /* Sample Duration bit 7 mask. */
+#define ADC_SAMPDUR_7_bp  7  /* Sample Duration bit 7 position. */
+
+/* ADC.CTRLF  bit masks and bit positions */
+#define ADC_SAMPNUM_gm  0x0F  /* Sample numbers group mask. */
+#define ADC_SAMPNUM_gp  0  /* Sample numbers group position. */
+#define ADC_SAMPNUM_0_bm  (1<<0)  /* Sample numbers bit 0 mask. */
+#define ADC_SAMPNUM_0_bp  0  /* Sample numbers bit 0 position. */
+#define ADC_SAMPNUM_1_bm  (1<<1)  /* Sample numbers bit 1 mask. */
+#define ADC_SAMPNUM_1_bp  1  /* Sample numbers bit 1 position. */
+#define ADC_SAMPNUM_2_bm  (1<<2)  /* Sample numbers bit 2 mask. */
+#define ADC_SAMPNUM_2_bp  2  /* Sample numbers bit 2 position. */
+#define ADC_SAMPNUM_3_bm  (1<<3)  /* Sample numbers bit 3 mask. */
+#define ADC_SAMPNUM_3_bp  3  /* Sample numbers bit 3 position. */
+#define ADC_LEFTADJ_bm  0x10  /* Left Adjust bit mask. */
+#define ADC_LEFTADJ_bp  4  /* Left Adjust bit position. */
+#define ADC_FREERUN_bm  0x20  /* Free-Running mode bit mask. */
+#define ADC_FREERUN_bp  5  /* Free-Running mode bit position. */
+#define ADC_CHOPPING_bm  0x40  /* Sign Chopping bit mask. */
+#define ADC_CHOPPING_bp  6  /* Sign Chopping bit position. */
+
+/* ADC.COMMAND  bit masks and bit positions */
+#define ADC_START_gm  0x07  /* Start command group mask. */
+#define ADC_START_gp  0  /* Start command group position. */
+#define ADC_START_0_bm  (1<<0)  /* Start command bit 0 mask. */
+#define ADC_START_0_bp  0  /* Start command bit 0 position. */
+#define ADC_START_1_bm  (1<<1)  /* Start command bit 1 mask. */
+#define ADC_START_1_bp  1  /* Start command bit 1 position. */
+#define ADC_START_2_bm  (1<<2)  /* Start command bit 2 mask. */
+#define ADC_START_2_bp  2  /* Start command bit 2 position. */
+#define ADC_MODE_gm  0x70  /* Mode group mask. */
+#define ADC_MODE_gp  4  /* Mode group position. */
+#define ADC_MODE_0_bm  (1<<4)  /* Mode bit 0 mask. */
+#define ADC_MODE_0_bp  4  /* Mode bit 0 position. */
+#define ADC_MODE_1_bm  (1<<5)  /* Mode bit 1 mask. */
+#define ADC_MODE_1_bp  5  /* Mode bit 1 position. */
+#define ADC_MODE_2_bm  (1<<6)  /* Mode bit 2 mask. */
+#define ADC_MODE_2_bp  6  /* Mode bit 2 position. */
+#define ADC_DIFF_bm  0x80  /* Differential mode bit mask. */
+#define ADC_DIFF_bp  7  /* Differential mode bit position. */
+
+/* ADC.PGACTRL  bit masks and bit positions */
+#define ADC_PGAEN_bm  0x01  /* PGA Enable bit mask. */
+#define ADC_PGAEN_bp  0  /* PGA Enable bit position. */
+#define ADC_PGABIASSEL_gm  0x18  /* PGA BIAS Select group mask. */
+#define ADC_PGABIASSEL_gp  3  /* PGA BIAS Select group position. */
+#define ADC_PGABIASSEL_0_bm  (1<<3)  /* PGA BIAS Select bit 0 mask. */
+#define ADC_PGABIASSEL_0_bp  3  /* PGA BIAS Select bit 0 position. */
+#define ADC_PGABIASSEL_1_bm  (1<<4)  /* PGA BIAS Select bit 1 mask. */
+#define ADC_PGABIASSEL_1_bp  4  /* PGA BIAS Select bit 1 position. */
+#define ADC_GAIN_gm  0xE0  /* Gain group mask. */
+#define ADC_GAIN_gp  5  /* Gain group position. */
+#define ADC_GAIN_0_bm  (1<<5)  /* Gain bit 0 mask. */
+#define ADC_GAIN_0_bp  5  /* Gain bit 0 position. */
+#define ADC_GAIN_1_bm  (1<<6)  /* Gain bit 1 mask. */
+#define ADC_GAIN_1_bp  6  /* Gain bit 1 position. */
+#define ADC_GAIN_2_bm  (1<<7)  /* Gain bit 2 mask. */
+#define ADC_GAIN_2_bp  7  /* Gain bit 2 position. */
+
+/* ADC.MUXPOS  bit masks and bit positions */
+#define ADC_MUXPOS_gm  0x3F  /* Analog Channel Selection Bits group mask. */
+#define ADC_MUXPOS_gp  0  /* Analog Channel Selection Bits group position. */
+#define ADC_MUXPOS_0_bm  (1<<0)  /* Analog Channel Selection Bits bit 0 mask. */
+#define ADC_MUXPOS_0_bp  0  /* Analog Channel Selection Bits bit 0 position. */
+#define ADC_MUXPOS_1_bm  (1<<1)  /* Analog Channel Selection Bits bit 1 mask. */
+#define ADC_MUXPOS_1_bp  1  /* Analog Channel Selection Bits bit 1 position. */
+#define ADC_MUXPOS_2_bm  (1<<2)  /* Analog Channel Selection Bits bit 2 mask. */
+#define ADC_MUXPOS_2_bp  2  /* Analog Channel Selection Bits bit 2 position. */
+#define ADC_MUXPOS_3_bm  (1<<3)  /* Analog Channel Selection Bits bit 3 mask. */
+#define ADC_MUXPOS_3_bp  3  /* Analog Channel Selection Bits bit 3 position. */
+#define ADC_MUXPOS_4_bm  (1<<4)  /* Analog Channel Selection Bits bit 4 mask. */
+#define ADC_MUXPOS_4_bp  4  /* Analog Channel Selection Bits bit 4 position. */
+#define ADC_MUXPOS_5_bm  (1<<5)  /* Analog Channel Selection Bits bit 5 mask. */
+#define ADC_MUXPOS_5_bp  5  /* Analog Channel Selection Bits bit 5 position. */
+#define ADC_VIA_gm  0xC0  /* VIA group mask. */
+#define ADC_VIA_gp  6  /* VIA group position. */
+#define ADC_VIA_0_bm  (1<<6)  /* VIA bit 0 mask. */
+#define ADC_VIA_0_bp  6  /* VIA bit 0 position. */
+#define ADC_VIA_1_bm  (1<<7)  /* VIA bit 1 mask. */
+#define ADC_VIA_1_bp  7  /* VIA bit 1 position. */
+
+/* ADC.MUXNEG  bit masks and bit positions */
+#define ADC_MUXNEG_gm  0x3F  /* Analog Channel Selection Bits group mask. */
+#define ADC_MUXNEG_gp  0  /* Analog Channel Selection Bits group position. */
+#define ADC_MUXNEG_0_bm  (1<<0)  /* Analog Channel Selection Bits bit 0 mask. */
+#define ADC_MUXNEG_0_bp  0  /* Analog Channel Selection Bits bit 0 position. */
+#define ADC_MUXNEG_1_bm  (1<<1)  /* Analog Channel Selection Bits bit 1 mask. */
+#define ADC_MUXNEG_1_bp  1  /* Analog Channel Selection Bits bit 1 position. */
+#define ADC_MUXNEG_2_bm  (1<<2)  /* Analog Channel Selection Bits bit 2 mask. */
+#define ADC_MUXNEG_2_bp  2  /* Analog Channel Selection Bits bit 2 position. */
+#define ADC_MUXNEG_3_bm  (1<<3)  /* Analog Channel Selection Bits bit 3 mask. */
+#define ADC_MUXNEG_3_bp  3  /* Analog Channel Selection Bits bit 3 position. */
+#define ADC_MUXNEG_4_bm  (1<<4)  /* Analog Channel Selection Bits bit 4 mask. */
+#define ADC_MUXNEG_4_bp  4  /* Analog Channel Selection Bits bit 4 position. */
+#define ADC_MUXNEG_5_bm  (1<<5)  /* Analog Channel Selection Bits bit 5 mask. */
+#define ADC_MUXNEG_5_bp  5  /* Analog Channel Selection Bits bit 5 position. */
+/* ADC_VIA  is already defined. */
+
+
+/* BOD - Bod interface */
+/* BOD.CTRLA  bit masks and bit positions */
+#define BOD_SLEEP_gm  0x03  /* Operation in sleep mode group mask. */
+#define BOD_SLEEP_gp  0  /* Operation in sleep mode group position. */
+#define BOD_SLEEP_0_bm  (1<<0)  /* Operation in sleep mode bit 0 mask. */
+#define BOD_SLEEP_0_bp  0  /* Operation in sleep mode bit 0 position. */
+#define BOD_SLEEP_1_bm  (1<<1)  /* Operation in sleep mode bit 1 mask. */
+#define BOD_SLEEP_1_bp  1  /* Operation in sleep mode bit 1 position. */
+#define BOD_ACTIVE_gm  0x0C  /* Operation in active mode group mask. */
+#define BOD_ACTIVE_gp  2  /* Operation in active mode group position. */
+#define BOD_ACTIVE_0_bm  (1<<2)  /* Operation in active mode bit 0 mask. */
+#define BOD_ACTIVE_0_bp  2  /* Operation in active mode bit 0 position. */
+#define BOD_ACTIVE_1_bm  (1<<3)  /* Operation in active mode bit 1 mask. */
+#define BOD_ACTIVE_1_bp  3  /* Operation in active mode bit 1 position. */
+#define BOD_SAMPFREQ_bm  0x10  /* Sample frequency bit mask. */
+#define BOD_SAMPFREQ_bp  4  /* Sample frequency bit position. */
+
+/* BOD.CTRLB  bit masks and bit positions */
+#define BOD_LVL_gm  0x07  /* Bod level group mask. */
+#define BOD_LVL_gp  0  /* Bod level group position. */
+#define BOD_LVL_0_bm  (1<<0)  /* Bod level bit 0 mask. */
+#define BOD_LVL_0_bp  0  /* Bod level bit 0 position. */
+#define BOD_LVL_1_bm  (1<<1)  /* Bod level bit 1 mask. */
+#define BOD_LVL_1_bp  1  /* Bod level bit 1 position. */
+#define BOD_LVL_2_bm  (1<<2)  /* Bod level bit 2 mask. */
+#define BOD_LVL_2_bp  2  /* Bod level bit 2 position. */
+
+/* BOD.VLMCTRLA  bit masks and bit positions */
+#define BOD_VLMLVL_gm  0x03  /* voltage level monitor level group mask. */
+#define BOD_VLMLVL_gp  0  /* voltage level monitor level group position. */
+#define BOD_VLMLVL_0_bm  (1<<0)  /* voltage level monitor level bit 0 mask. */
+#define BOD_VLMLVL_0_bp  0  /* voltage level monitor level bit 0 position. */
+#define BOD_VLMLVL_1_bm  (1<<1)  /* voltage level monitor level bit 1 mask. */
+#define BOD_VLMLVL_1_bp  1  /* voltage level monitor level bit 1 position. */
+
+/* BOD.INTCTRL  bit masks and bit positions */
+#define BOD_VLMIE_bm  0x01  /* voltage level monitor interrrupt enable bit mask. */
+#define BOD_VLMIE_bp  0  /* voltage level monitor interrrupt enable bit position. */
+#define BOD_VLMCFG_gm  0x06  /* Configuration group mask. */
+#define BOD_VLMCFG_gp  1  /* Configuration group position. */
+#define BOD_VLMCFG_0_bm  (1<<1)  /* Configuration bit 0 mask. */
+#define BOD_VLMCFG_0_bp  1  /* Configuration bit 0 position. */
+#define BOD_VLMCFG_1_bm  (1<<2)  /* Configuration bit 1 mask. */
+#define BOD_VLMCFG_1_bp  2  /* Configuration bit 1 position. */
+
+/* BOD.INTFLAGS  bit masks and bit positions */
+#define BOD_VLMIF_bm  0x01  /* Voltage level monitor interrupt flag bit mask. */
+#define BOD_VLMIF_bp  0  /* Voltage level monitor interrupt flag bit position. */
+
+/* BOD.STATUS  bit masks and bit positions */
+#define BOD_VLMS_bm  0x01  /* Voltage level monitor status bit mask. */
+#define BOD_VLMS_bp  0  /* Voltage level monitor status bit position. */
+
+
+/* CCL - Configurable Custom Logic */
+/* CCL.CTRLA  bit masks and bit positions */
+#define CCL_ENABLE_bm  0x01  /* Enable bit mask. */
+#define CCL_ENABLE_bp  0  /* Enable bit position. */
+#define CCL_RUNSTDBY_bm  0x40  /* Run in Standby bit mask. */
+#define CCL_RUNSTDBY_bp  6  /* Run in Standby bit position. */
+
+/* CCL.SEQCTRL0  bit masks and bit positions */
+#define CCL_SEQSEL_gm  0x07  /* Sequential Selection group mask. */
+#define CCL_SEQSEL_gp  0  /* Sequential Selection group position. */
+#define CCL_SEQSEL_0_bm  (1<<0)  /* Sequential Selection bit 0 mask. */
+#define CCL_SEQSEL_0_bp  0  /* Sequential Selection bit 0 position. */
+#define CCL_SEQSEL_1_bm  (1<<1)  /* Sequential Selection bit 1 mask. */
+#define CCL_SEQSEL_1_bp  1  /* Sequential Selection bit 1 position. */
+#define CCL_SEQSEL_2_bm  (1<<2)  /* Sequential Selection bit 2 mask. */
+#define CCL_SEQSEL_2_bp  2  /* Sequential Selection bit 2 position. */
+
+/* CCL.SEQCTRL1  bit masks and bit positions */
+/* CCL_SEQSEL  is already defined. */
+
+/* CCL.INTCTRL0  bit masks and bit positions */
+#define CCL_INTMODE0_gm  0x03  /* Interrupt Mode for LUT0 group mask. */
+#define CCL_INTMODE0_gp  0  /* Interrupt Mode for LUT0 group position. */
+#define CCL_INTMODE0_0_bm  (1<<0)  /* Interrupt Mode for LUT0 bit 0 mask. */
+#define CCL_INTMODE0_0_bp  0  /* Interrupt Mode for LUT0 bit 0 position. */
+#define CCL_INTMODE0_1_bm  (1<<1)  /* Interrupt Mode for LUT0 bit 1 mask. */
+#define CCL_INTMODE0_1_bp  1  /* Interrupt Mode for LUT0 bit 1 position. */
+#define CCL_INTMODE1_gm  0x0C  /* Interrupt Mode for LUT1 group mask. */
+#define CCL_INTMODE1_gp  2  /* Interrupt Mode for LUT1 group position. */
+#define CCL_INTMODE1_0_bm  (1<<2)  /* Interrupt Mode for LUT1 bit 0 mask. */
+#define CCL_INTMODE1_0_bp  2  /* Interrupt Mode for LUT1 bit 0 position. */
+#define CCL_INTMODE1_1_bm  (1<<3)  /* Interrupt Mode for LUT1 bit 1 mask. */
+#define CCL_INTMODE1_1_bp  3  /* Interrupt Mode for LUT1 bit 1 position. */
+#define CCL_INTMODE2_gm  0x30  /* Interrupt Mode for LUT2 group mask. */
+#define CCL_INTMODE2_gp  4  /* Interrupt Mode for LUT2 group position. */
+#define CCL_INTMODE2_0_bm  (1<<4)  /* Interrupt Mode for LUT2 bit 0 mask. */
+#define CCL_INTMODE2_0_bp  4  /* Interrupt Mode for LUT2 bit 0 position. */
+#define CCL_INTMODE2_1_bm  (1<<5)  /* Interrupt Mode for LUT2 bit 1 mask. */
+#define CCL_INTMODE2_1_bp  5  /* Interrupt Mode for LUT2 bit 1 position. */
+#define CCL_INTMODE3_gm  0xC0  /* Interrupt Mode for LUT3 group mask. */
+#define CCL_INTMODE3_gp  6  /* Interrupt Mode for LUT3 group position. */
+#define CCL_INTMODE3_0_bm  (1<<6)  /* Interrupt Mode for LUT3 bit 0 mask. */
+#define CCL_INTMODE3_0_bp  6  /* Interrupt Mode for LUT3 bit 0 position. */
+#define CCL_INTMODE3_1_bm  (1<<7)  /* Interrupt Mode for LUT3 bit 1 mask. */
+#define CCL_INTMODE3_1_bp  7  /* Interrupt Mode for LUT3 bit 1 position. */
+
+/* CCL.INTFLAGS  bit masks and bit positions */
+#define CCL_INT_gm  0x0F  /* Interrupt Flag group mask. */
+#define CCL_INT_gp  0  /* Interrupt Flag group position. */
+#define CCL_INT_0_bm  (1<<0)  /* Interrupt Flag bit 0 mask. */
+#define CCL_INT_0_bp  0  /* Interrupt Flag bit 0 position. */
+#define CCL_INT0_bm  CCL_INT_0_bm  /* This define is deprecated and should not be used */
+#define CCL_INT0_bp  CCL_INT_0_bp  /* This define is deprecated and should not be used */
+#define CCL_INT_1_bm  (1<<1)  /* Interrupt Flag bit 1 mask. */
+#define CCL_INT_1_bp  1  /* Interrupt Flag bit 1 position. */
+#define CCL_INT1_bm  CCL_INT_1_bm  /* This define is deprecated and should not be used */
+#define CCL_INT1_bp  CCL_INT_1_bp  /* This define is deprecated and should not be used */
+#define CCL_INT_2_bm  (1<<2)  /* Interrupt Flag bit 2 mask. */
+#define CCL_INT_2_bp  2  /* Interrupt Flag bit 2 position. */
+#define CCL_INT2_bm  CCL_INT_2_bm  /* This define is deprecated and should not be used */
+#define CCL_INT2_bp  CCL_INT_2_bp  /* This define is deprecated and should not be used */
+#define CCL_INT_3_bm  (1<<3)  /* Interrupt Flag bit 3 mask. */
+#define CCL_INT_3_bp  3  /* Interrupt Flag bit 3 position. */
+#define CCL_INT3_bm  CCL_INT_3_bm  /* This define is deprecated and should not be used */
+#define CCL_INT3_bp  CCL_INT_3_bp  /* This define is deprecated and should not be used */
+
+/* CCL.LUT0CTRLA  bit masks and bit positions */
+/* CCL_ENABLE  is already defined. */
+#define CCL_CLKSRC_gm  0x0E  /* Clock Source Selection group mask. */
+#define CCL_CLKSRC_gp  1  /* Clock Source Selection group position. */
+#define CCL_CLKSRC_0_bm  (1<<1)  /* Clock Source Selection bit 0 mask. */
+#define CCL_CLKSRC_0_bp  1  /* Clock Source Selection bit 0 position. */
+#define CCL_CLKSRC_1_bm  (1<<2)  /* Clock Source Selection bit 1 mask. */
+#define CCL_CLKSRC_1_bp  2  /* Clock Source Selection bit 1 position. */
+#define CCL_CLKSRC_2_bm  (1<<3)  /* Clock Source Selection bit 2 mask. */
+#define CCL_CLKSRC_2_bp  3  /* Clock Source Selection bit 2 position. */
+#define CCL_FILTSEL_gm  0x30  /* Filter Selection group mask. */
+#define CCL_FILTSEL_gp  4  /* Filter Selection group position. */
+#define CCL_FILTSEL_0_bm  (1<<4)  /* Filter Selection bit 0 mask. */
+#define CCL_FILTSEL_0_bp  4  /* Filter Selection bit 0 position. */
+#define CCL_FILTSEL_1_bm  (1<<5)  /* Filter Selection bit 1 mask. */
+#define CCL_FILTSEL_1_bp  5  /* Filter Selection bit 1 position. */
+#define CCL_OUTEN_bm  0x40  /* Output Enable bit mask. */
+#define CCL_OUTEN_bp  6  /* Output Enable bit position. */
+#define CCL_EDGEDET_bm  0x80  /* Edge Detection Enable bit mask. */
+#define CCL_EDGEDET_bp  7  /* Edge Detection Enable bit position. */
+
+/* CCL.LUT0CTRLB  bit masks and bit positions */
+#define CCL_INSEL0_gm  0x0F  /* LUT Input 0 Source Selection group mask. */
+#define CCL_INSEL0_gp  0  /* LUT Input 0 Source Selection group position. */
+#define CCL_INSEL0_0_bm  (1<<0)  /* LUT Input 0 Source Selection bit 0 mask. */
+#define CCL_INSEL0_0_bp  0  /* LUT Input 0 Source Selection bit 0 position. */
+#define CCL_INSEL0_1_bm  (1<<1)  /* LUT Input 0 Source Selection bit 1 mask. */
+#define CCL_INSEL0_1_bp  1  /* LUT Input 0 Source Selection bit 1 position. */
+#define CCL_INSEL0_2_bm  (1<<2)  /* LUT Input 0 Source Selection bit 2 mask. */
+#define CCL_INSEL0_2_bp  2  /* LUT Input 0 Source Selection bit 2 position. */
+#define CCL_INSEL0_3_bm  (1<<3)  /* LUT Input 0 Source Selection bit 3 mask. */
+#define CCL_INSEL0_3_bp  3  /* LUT Input 0 Source Selection bit 3 position. */
+#define CCL_INSEL1_gm  0xF0  /* LUT Input 1 Source Selection group mask. */
+#define CCL_INSEL1_gp  4  /* LUT Input 1 Source Selection group position. */
+#define CCL_INSEL1_0_bm  (1<<4)  /* LUT Input 1 Source Selection bit 0 mask. */
+#define CCL_INSEL1_0_bp  4  /* LUT Input 1 Source Selection bit 0 position. */
+#define CCL_INSEL1_1_bm  (1<<5)  /* LUT Input 1 Source Selection bit 1 mask. */
+#define CCL_INSEL1_1_bp  5  /* LUT Input 1 Source Selection bit 1 position. */
+#define CCL_INSEL1_2_bm  (1<<6)  /* LUT Input 1 Source Selection bit 2 mask. */
+#define CCL_INSEL1_2_bp  6  /* LUT Input 1 Source Selection bit 2 position. */
+#define CCL_INSEL1_3_bm  (1<<7)  /* LUT Input 1 Source Selection bit 3 mask. */
+#define CCL_INSEL1_3_bp  7  /* LUT Input 1 Source Selection bit 3 position. */
+
+/* CCL.LUT0CTRLC  bit masks and bit positions */
+#define CCL_INSEL2_gm  0x0F  /* LUT Input 2 Source Selection group mask. */
+#define CCL_INSEL2_gp  0  /* LUT Input 2 Source Selection group position. */
+#define CCL_INSEL2_0_bm  (1<<0)  /* LUT Input 2 Source Selection bit 0 mask. */
+#define CCL_INSEL2_0_bp  0  /* LUT Input 2 Source Selection bit 0 position. */
+#define CCL_INSEL2_1_bm  (1<<1)  /* LUT Input 2 Source Selection bit 1 mask. */
+#define CCL_INSEL2_1_bp  1  /* LUT Input 2 Source Selection bit 1 position. */
+#define CCL_INSEL2_2_bm  (1<<2)  /* LUT Input 2 Source Selection bit 2 mask. */
+#define CCL_INSEL2_2_bp  2  /* LUT Input 2 Source Selection bit 2 position. */
+#define CCL_INSEL2_3_bm  (1<<3)  /* LUT Input 2 Source Selection bit 3 mask. */
+#define CCL_INSEL2_3_bp  3  /* LUT Input 2 Source Selection bit 3 position. */
+
+/* CCL.TRUTH0  bit masks and bit positions */
+#define CCL_TRUTH_gm  0xFF  /* Truth Table group mask. */
+#define CCL_TRUTH_gp  0  /* Truth Table group position. */
+#define CCL_TRUTH_0_bm  (1<<0)  /* Truth Table bit 0 mask. */
+#define CCL_TRUTH_0_bp  0  /* Truth Table bit 0 position. */
+#define CCL_TRUTH_1_bm  (1<<1)  /* Truth Table bit 1 mask. */
+#define CCL_TRUTH_1_bp  1  /* Truth Table bit 1 position. */
+#define CCL_TRUTH_2_bm  (1<<2)  /* Truth Table bit 2 mask. */
+#define CCL_TRUTH_2_bp  2  /* Truth Table bit 2 position. */
+#define CCL_TRUTH_3_bm  (1<<3)  /* Truth Table bit 3 mask. */
+#define CCL_TRUTH_3_bp  3  /* Truth Table bit 3 position. */
+#define CCL_TRUTH_4_bm  (1<<4)  /* Truth Table bit 4 mask. */
+#define CCL_TRUTH_4_bp  4  /* Truth Table bit 4 position. */
+#define CCL_TRUTH_5_bm  (1<<5)  /* Truth Table bit 5 mask. */
+#define CCL_TRUTH_5_bp  5  /* Truth Table bit 5 position. */
+#define CCL_TRUTH_6_bm  (1<<6)  /* Truth Table bit 6 mask. */
+#define CCL_TRUTH_6_bp  6  /* Truth Table bit 6 position. */
+#define CCL_TRUTH_7_bm  (1<<7)  /* Truth Table bit 7 mask. */
+#define CCL_TRUTH_7_bp  7  /* Truth Table bit 7 position. */
+
+/* CCL.LUT1CTRLA  bit masks and bit positions */
+/* CCL_ENABLE  is already defined. */
+/* CCL_CLKSRC  is already defined. */
+/* CCL_FILTSEL  is already defined. */
+/* CCL_OUTEN  is already defined. */
+/* CCL_EDGEDET  is already defined. */
+
+/* CCL.LUT1CTRLB  bit masks and bit positions */
+/* CCL_INSEL0  is already defined. */
+/* CCL_INSEL1  is already defined. */
+
+/* CCL.LUT1CTRLC  bit masks and bit positions */
+/* CCL_INSEL2  is already defined. */
+
+/* CCL.TRUTH1  bit masks and bit positions */
+/* CCL_TRUTH  is already defined. */
+
+/* CCL.LUT2CTRLA  bit masks and bit positions */
+/* CCL_ENABLE  is already defined. */
+/* CCL_CLKSRC  is already defined. */
+/* CCL_FILTSEL  is already defined. */
+/* CCL_OUTEN  is already defined. */
+/* CCL_EDGEDET  is already defined. */
+
+/* CCL.LUT2CTRLB  bit masks and bit positions */
+/* CCL_INSEL0  is already defined. */
+/* CCL_INSEL1  is already defined. */
+
+/* CCL.LUT2CTRLC  bit masks and bit positions */
+/* CCL_INSEL2  is already defined. */
+
+/* CCL.TRUTH2  bit masks and bit positions */
+/* CCL_TRUTH  is already defined. */
+
+/* CCL.LUT3CTRLA  bit masks and bit positions */
+/* CCL_ENABLE  is already defined. */
+/* CCL_CLKSRC  is already defined. */
+/* CCL_FILTSEL  is already defined. */
+/* CCL_OUTEN  is already defined. */
+/* CCL_EDGEDET  is already defined. */
+
+/* CCL.LUT3CTRLB  bit masks and bit positions */
+/* CCL_INSEL0  is already defined. */
+/* CCL_INSEL1  is already defined. */
+
+/* CCL.LUT3CTRLC  bit masks and bit positions */
+/* CCL_INSEL2  is already defined. */
+
+/* CCL.TRUTH3  bit masks and bit positions */
+/* CCL_TRUTH  is already defined. */
+
+
+/* CLKCTRL - Clock controller */
+/* CLKCTRL.MCLKCTRLA  bit masks and bit positions */
+#define CLKCTRL_CLKSEL_gm  0x07  /* Clock select group mask. */
+#define CLKCTRL_CLKSEL_gp  0  /* Clock select group position. */
+#define CLKCTRL_CLKSEL_0_bm  (1<<0)  /* Clock select bit 0 mask. */
+#define CLKCTRL_CLKSEL_0_bp  0  /* Clock select bit 0 position. */
+#define CLKCTRL_CLKSEL_1_bm  (1<<1)  /* Clock select bit 1 mask. */
+#define CLKCTRL_CLKSEL_1_bp  1  /* Clock select bit 1 position. */
+#define CLKCTRL_CLKSEL_2_bm  (1<<2)  /* Clock select bit 2 mask. */
+#define CLKCTRL_CLKSEL_2_bp  2  /* Clock select bit 2 position. */
+#define CLKCTRL_CLKOUT_bm  0x80  /* System clock out bit mask. */
+#define CLKCTRL_CLKOUT_bp  7  /* System clock out bit position. */
+
+/* CLKCTRL.MCLKCTRLB  bit masks and bit positions */
+#define CLKCTRL_PEN_bm  0x01  /* Prescaler enable bit mask. */
+#define CLKCTRL_PEN_bp  0  /* Prescaler enable bit position. */
+#define CLKCTRL_PDIV_gm  0x1E  /* Prescaler division group mask. */
+#define CLKCTRL_PDIV_gp  1  /* Prescaler division group position. */
+#define CLKCTRL_PDIV_0_bm  (1<<1)  /* Prescaler division bit 0 mask. */
+#define CLKCTRL_PDIV_0_bp  1  /* Prescaler division bit 0 position. */
+#define CLKCTRL_PDIV_1_bm  (1<<2)  /* Prescaler division bit 1 mask. */
+#define CLKCTRL_PDIV_1_bp  2  /* Prescaler division bit 1 position. */
+#define CLKCTRL_PDIV_2_bm  (1<<3)  /* Prescaler division bit 2 mask. */
+#define CLKCTRL_PDIV_2_bp  3  /* Prescaler division bit 2 position. */
+#define CLKCTRL_PDIV_3_bm  (1<<4)  /* Prescaler division bit 3 mask. */
+#define CLKCTRL_PDIV_3_bp  4  /* Prescaler division bit 3 position. */
+
+/* CLKCTRL.MCLKCTRLC  bit masks and bit positions */
+#define CLKCTRL_CFDEN_bm  0x01  /* Clock Failure Detect Enable bit mask. */
+#define CLKCTRL_CFDEN_bp  0  /* Clock Failure Detect Enable bit position. */
+#define CLKCTRL_CFDTST_bm  0x02  /* CFD Test bit mask. */
+#define CLKCTRL_CFDTST_bp  1  /* CFD Test bit position. */
+#define CLKCTRL_CFDSRC_gm  0x0C  /* CFD Source group mask. */
+#define CLKCTRL_CFDSRC_gp  2  /* CFD Source group position. */
+#define CLKCTRL_CFDSRC_0_bm  (1<<2)  /* CFD Source bit 0 mask. */
+#define CLKCTRL_CFDSRC_0_bp  2  /* CFD Source bit 0 position. */
+#define CLKCTRL_CFDSRC_1_bm  (1<<3)  /* CFD Source bit 1 mask. */
+#define CLKCTRL_CFDSRC_1_bp  3  /* CFD Source bit 1 position. */
+
+/* CLKCTRL.MCLKINTCTRL  bit masks and bit positions */
+#define CLKCTRL_CFD_bm  0x01  /* Interrupt Enable bit mask. */
+#define CLKCTRL_CFD_bp  0  /* Interrupt Enable bit position. */
+#define CLKCTRL_INTTYPE_bm  0x80  /* Interrupt Type bit mask. */
+#define CLKCTRL_INTTYPE_bp  7  /* Interrupt Type bit position. */
+
+/* CLKCTRL.MCLKINTFLAGS  bit masks and bit positions */
+/* CLKCTRL_CFD  is already defined. */
+
+/* CLKCTRL.MCLKSTATUS  bit masks and bit positions */
+#define CLKCTRL_SOSC_bm  0x01  /* System Oscillator changing bit mask. */
+#define CLKCTRL_SOSC_bp  0  /* System Oscillator changing bit position. */
+#define CLKCTRL_OSCHFS_bm  0x02  /* High frequency oscillator status bit mask. */
+#define CLKCTRL_OSCHFS_bp  1  /* High frequency oscillator status bit position. */
+#define CLKCTRL_OSC32KS_bm  0x04  /* 32KHz oscillator status bit mask. */
+#define CLKCTRL_OSC32KS_bp  2  /* 32KHz oscillator status bit position. */
+#define CLKCTRL_XOSC32KS_bm  0x08  /* 32.768 kHz Crystal Oscillator status bit mask. */
+#define CLKCTRL_XOSC32KS_bp  3  /* 32.768 kHz Crystal Oscillator status bit position. */
+#define CLKCTRL_EXTS_bm  0x10  /* External Clock status / XOSCHF status bit mask. */
+#define CLKCTRL_EXTS_bp  4  /* External Clock status / XOSCHF status bit position. */
+
+/* CLKCTRL.MCLKTIMEBASE  bit masks and bit positions */
+#define CLKCTRL_TIMEBASE_gm  0x1F  /* Timebase group mask. */
+#define CLKCTRL_TIMEBASE_gp  0  /* Timebase group position. */
+#define CLKCTRL_TIMEBASE_0_bm  (1<<0)  /* Timebase bit 0 mask. */
+#define CLKCTRL_TIMEBASE_0_bp  0  /* Timebase bit 0 position. */
+#define CLKCTRL_TIMEBASE_1_bm  (1<<1)  /* Timebase bit 1 mask. */
+#define CLKCTRL_TIMEBASE_1_bp  1  /* Timebase bit 1 position. */
+#define CLKCTRL_TIMEBASE_2_bm  (1<<2)  /* Timebase bit 2 mask. */
+#define CLKCTRL_TIMEBASE_2_bp  2  /* Timebase bit 2 position. */
+#define CLKCTRL_TIMEBASE_3_bm  (1<<3)  /* Timebase bit 3 mask. */
+#define CLKCTRL_TIMEBASE_3_bp  3  /* Timebase bit 3 position. */
+#define CLKCTRL_TIMEBASE_4_bm  (1<<4)  /* Timebase bit 4 mask. */
+#define CLKCTRL_TIMEBASE_4_bp  4  /* Timebase bit 4 position. */
+
+/* CLKCTRL.OSCHFCTRLA  bit masks and bit positions */
+#define CLKCTRL_AUTOTUNE_gm  0x03  /* Automatic Oscillator Tune group mask. */
+#define CLKCTRL_AUTOTUNE_gp  0  /* Automatic Oscillator Tune group position. */
+#define CLKCTRL_AUTOTUNE_0_bm  (1<<0)  /* Automatic Oscillator Tune bit 0 mask. */
+#define CLKCTRL_AUTOTUNE_0_bp  0  /* Automatic Oscillator Tune bit 0 position. */
+#define CLKCTRL_AUTOTUNE_1_bm  (1<<1)  /* Automatic Oscillator Tune bit 1 mask. */
+#define CLKCTRL_AUTOTUNE_1_bp  1  /* Automatic Oscillator Tune bit 1 position. */
+#define CLKCTRL_RUNSTDBY_bm  0x80  /* Run in standby bit mask. */
+#define CLKCTRL_RUNSTDBY_bp  7  /* Run in standby bit position. */
+
+/* CLKCTRL.OSCHFTUNE  bit masks and bit positions */
+#define CLKCTRL_TUNE_gm  0xFF  /* Oscillator Tune group mask. */
+#define CLKCTRL_TUNE_gp  0  /* Oscillator Tune group position. */
+#define CLKCTRL_TUNE_0_bm  (1<<0)  /* Oscillator Tune bit 0 mask. */
+#define CLKCTRL_TUNE_0_bp  0  /* Oscillator Tune bit 0 position. */
+#define CLKCTRL_TUNE_1_bm  (1<<1)  /* Oscillator Tune bit 1 mask. */
+#define CLKCTRL_TUNE_1_bp  1  /* Oscillator Tune bit 1 position. */
+#define CLKCTRL_TUNE_2_bm  (1<<2)  /* Oscillator Tune bit 2 mask. */
+#define CLKCTRL_TUNE_2_bp  2  /* Oscillator Tune bit 2 position. */
+#define CLKCTRL_TUNE_3_bm  (1<<3)  /* Oscillator Tune bit 3 mask. */
+#define CLKCTRL_TUNE_3_bp  3  /* Oscillator Tune bit 3 position. */
+#define CLKCTRL_TUNE_4_bm  (1<<4)  /* Oscillator Tune bit 4 mask. */
+#define CLKCTRL_TUNE_4_bp  4  /* Oscillator Tune bit 4 position. */
+#define CLKCTRL_TUNE_5_bm  (1<<5)  /* Oscillator Tune bit 5 mask. */
+#define CLKCTRL_TUNE_5_bp  5  /* Oscillator Tune bit 5 position. */
+#define CLKCTRL_TUNE_6_bm  (1<<6)  /* Oscillator Tune bit 6 mask. */
+#define CLKCTRL_TUNE_6_bp  6  /* Oscillator Tune bit 6 position. */
+#define CLKCTRL_TUNE_7_bm  (1<<7)  /* Oscillator Tune bit 7 mask. */
+#define CLKCTRL_TUNE_7_bp  7  /* Oscillator Tune bit 7 position. */
+
+/* CLKCTRL.OSC32KCTRLA  bit masks and bit positions */
+/* CLKCTRL_RUNSTDBY  is already defined. */
+
+/* CLKCTRL.XOSC32KCTRLA  bit masks and bit positions */
+#define CLKCTRL_ENABLE_bm  0x01  /* Enable bit mask. */
+#define CLKCTRL_ENABLE_bp  0  /* Enable bit position. */
+#define CLKCTRL_LPMODE_bm  0x02  /* Low power mode bit mask. */
+#define CLKCTRL_LPMODE_bp  1  /* Low power mode bit position. */
+#define CLKCTRL_SEL_bm  0x04  /* Select bit mask. */
+#define CLKCTRL_SEL_bp  2  /* Select bit position. */
+#define CLKCTRL_CSUT_gm  0x30  /* Crystal startup time group mask. */
+#define CLKCTRL_CSUT_gp  4  /* Crystal startup time group position. */
+#define CLKCTRL_CSUT_0_bm  (1<<4)  /* Crystal startup time bit 0 mask. */
+#define CLKCTRL_CSUT_0_bp  4  /* Crystal startup time bit 0 position. */
+#define CLKCTRL_CSUT_1_bm  (1<<5)  /* Crystal startup time bit 1 mask. */
+#define CLKCTRL_CSUT_1_bp  5  /* Crystal startup time bit 1 position. */
+/* CLKCTRL_RUNSTDBY  is already defined. */
+
+/* CLKCTRL.XOSCHFCTRLA  bit masks and bit positions */
+/* CLKCTRL_ENABLE  is already defined. */
+#define CLKCTRL_SELHF_bm  0x02  /* Source Select bit mask. */
+#define CLKCTRL_SELHF_bp  1  /* Source Select bit position. */
+#define CLKCTRL_CSUTHF_gm  0x30  /* Start-Up Time group mask. */
+#define CLKCTRL_CSUTHF_gp  4  /* Start-Up Time group position. */
+#define CLKCTRL_CSUTHF_0_bm  (1<<4)  /* Start-Up Time bit 0 mask. */
+#define CLKCTRL_CSUTHF_0_bp  4  /* Start-Up Time bit 0 position. */
+#define CLKCTRL_CSUTHF_1_bm  (1<<5)  /* Start-Up Time bit 1 mask. */
+#define CLKCTRL_CSUTHF_1_bp  5  /* Start-Up Time bit 1 position. */
+/* CLKCTRL_RUNSTDBY  is already defined. */
+
+
+/* CPU - CPU */
+/* CPU.CCP  bit masks and bit positions */
+#define CPU_CCP_gm  0xFF  /* CCP signature group mask. */
+#define CPU_CCP_gp  0  /* CCP signature group position. */
+#define CPU_CCP_0_bm  (1<<0)  /* CCP signature bit 0 mask. */
+#define CPU_CCP_0_bp  0  /* CCP signature bit 0 position. */
+#define CPU_CCP_1_bm  (1<<1)  /* CCP signature bit 1 mask. */
+#define CPU_CCP_1_bp  1  /* CCP signature bit 1 position. */
+#define CPU_CCP_2_bm  (1<<2)  /* CCP signature bit 2 mask. */
+#define CPU_CCP_2_bp  2  /* CCP signature bit 2 position. */
+#define CPU_CCP_3_bm  (1<<3)  /* CCP signature bit 3 mask. */
+#define CPU_CCP_3_bp  3  /* CCP signature bit 3 position. */
+#define CPU_CCP_4_bm  (1<<4)  /* CCP signature bit 4 mask. */
+#define CPU_CCP_4_bp  4  /* CCP signature bit 4 position. */
+#define CPU_CCP_5_bm  (1<<5)  /* CCP signature bit 5 mask. */
+#define CPU_CCP_5_bp  5  /* CCP signature bit 5 position. */
+#define CPU_CCP_6_bm  (1<<6)  /* CCP signature bit 6 mask. */
+#define CPU_CCP_6_bp  6  /* CCP signature bit 6 position. */
+#define CPU_CCP_7_bm  (1<<7)  /* CCP signature bit 7 mask. */
+#define CPU_CCP_7_bp  7  /* CCP signature bit 7 position. */
+
+/* CPU.SREG  bit masks and bit positions */
+#define CPU_C_bm  0x01  /* Carry Flag bit mask. */
+#define CPU_C_bp  0  /* Carry Flag bit position. */
+#define CPU_Z_bm  0x02  /* Zero Flag bit mask. */
+#define CPU_Z_bp  1  /* Zero Flag bit position. */
+#define CPU_N_bm  0x04  /* Negative Flag bit mask. */
+#define CPU_N_bp  2  /* Negative Flag bit position. */
+#define CPU_V_bm  0x08  /* Two's Complement Overflow Flag bit mask. */
+#define CPU_V_bp  3  /* Two's Complement Overflow Flag bit position. */
+#define CPU_S_bm  0x10  /* N Exclusive Or V Flag bit mask. */
+#define CPU_S_bp  4  /* N Exclusive Or V Flag bit position. */
+#define CPU_H_bm  0x20  /* Half Carry Flag bit mask. */
+#define CPU_H_bp  5  /* Half Carry Flag bit position. */
+#define CPU_T_bm  0x40  /* Transfer Bit bit mask. */
+#define CPU_T_bp  6  /* Transfer Bit bit position. */
+#define CPU_I_bm  0x80  /* Global Interrupt Enable Flag bit mask. */
+#define CPU_I_bp  7  /* Global Interrupt Enable Flag bit position. */
+
+
+/* CPUINT - Interrupt Controller */
+/* CPUINT.CTRLA  bit masks and bit positions */
+#define CPUINT_LVL0RR_bm  0x01  /* Round-robin Scheduling Enable bit mask. */
+#define CPUINT_LVL0RR_bp  0  /* Round-robin Scheduling Enable bit position. */
+#define CPUINT_CVT_bm  0x20  /* Compact Vector Table bit mask. */
+#define CPUINT_CVT_bp  5  /* Compact Vector Table bit position. */
+#define CPUINT_IVSEL_bm  0x40  /* Interrupt Vector Select bit mask. */
+#define CPUINT_IVSEL_bp  6  /* Interrupt Vector Select bit position. */
+
+/* CPUINT.STATUS  bit masks and bit positions */
+#define CPUINT_LVL0EX_bm  0x01  /* Level 0 Interrupt Executing bit mask. */
+#define CPUINT_LVL0EX_bp  0  /* Level 0 Interrupt Executing bit position. */
+#define CPUINT_LVL1EX_bm  0x02  /* Level 1 Interrupt Executing bit mask. */
+#define CPUINT_LVL1EX_bp  1  /* Level 1 Interrupt Executing bit position. */
+#define CPUINT_NMIEX_bm  0x80  /* Non-maskable Interrupt Executing bit mask. */
+#define CPUINT_NMIEX_bp  7  /* Non-maskable Interrupt Executing bit position. */
+
+/* CPUINT.LVL0PRI  bit masks and bit positions */
+#define CPUINT_LVL0PRI_gm  0xFF  /* Interrupt Level Priority group mask. */
+#define CPUINT_LVL0PRI_gp  0  /* Interrupt Level Priority group position. */
+#define CPUINT_LVL0PRI_0_bm  (1<<0)  /* Interrupt Level Priority bit 0 mask. */
+#define CPUINT_LVL0PRI_0_bp  0  /* Interrupt Level Priority bit 0 position. */
+#define CPUINT_LVL0PRI_1_bm  (1<<1)  /* Interrupt Level Priority bit 1 mask. */
+#define CPUINT_LVL0PRI_1_bp  1  /* Interrupt Level Priority bit 1 position. */
+#define CPUINT_LVL0PRI_2_bm  (1<<2)  /* Interrupt Level Priority bit 2 mask. */
+#define CPUINT_LVL0PRI_2_bp  2  /* Interrupt Level Priority bit 2 position. */
+#define CPUINT_LVL0PRI_3_bm  (1<<3)  /* Interrupt Level Priority bit 3 mask. */
+#define CPUINT_LVL0PRI_3_bp  3  /* Interrupt Level Priority bit 3 position. */
+#define CPUINT_LVL0PRI_4_bm  (1<<4)  /* Interrupt Level Priority bit 4 mask. */
+#define CPUINT_LVL0PRI_4_bp  4  /* Interrupt Level Priority bit 4 position. */
+#define CPUINT_LVL0PRI_5_bm  (1<<5)  /* Interrupt Level Priority bit 5 mask. */
+#define CPUINT_LVL0PRI_5_bp  5  /* Interrupt Level Priority bit 5 position. */
+#define CPUINT_LVL0PRI_6_bm  (1<<6)  /* Interrupt Level Priority bit 6 mask. */
+#define CPUINT_LVL0PRI_6_bp  6  /* Interrupt Level Priority bit 6 position. */
+#define CPUINT_LVL0PRI_7_bm  (1<<7)  /* Interrupt Level Priority bit 7 mask. */
+#define CPUINT_LVL0PRI_7_bp  7  /* Interrupt Level Priority bit 7 position. */
+
+/* CPUINT.LVL1VEC  bit masks and bit positions */
+#define CPUINT_LVL1VEC_gm  0xFF  /* Interrupt Vector with High Priority group mask. */
+#define CPUINT_LVL1VEC_gp  0  /* Interrupt Vector with High Priority group position. */
+#define CPUINT_LVL1VEC_0_bm  (1<<0)  /* Interrupt Vector with High Priority bit 0 mask. */
+#define CPUINT_LVL1VEC_0_bp  0  /* Interrupt Vector with High Priority bit 0 position. */
+#define CPUINT_LVL1VEC_1_bm  (1<<1)  /* Interrupt Vector with High Priority bit 1 mask. */
+#define CPUINT_LVL1VEC_1_bp  1  /* Interrupt Vector with High Priority bit 1 position. */
+#define CPUINT_LVL1VEC_2_bm  (1<<2)  /* Interrupt Vector with High Priority bit 2 mask. */
+#define CPUINT_LVL1VEC_2_bp  2  /* Interrupt Vector with High Priority bit 2 position. */
+#define CPUINT_LVL1VEC_3_bm  (1<<3)  /* Interrupt Vector with High Priority bit 3 mask. */
+#define CPUINT_LVL1VEC_3_bp  3  /* Interrupt Vector with High Priority bit 3 position. */
+#define CPUINT_LVL1VEC_4_bm  (1<<4)  /* Interrupt Vector with High Priority bit 4 mask. */
+#define CPUINT_LVL1VEC_4_bp  4  /* Interrupt Vector with High Priority bit 4 position. */
+#define CPUINT_LVL1VEC_5_bm  (1<<5)  /* Interrupt Vector with High Priority bit 5 mask. */
+#define CPUINT_LVL1VEC_5_bp  5  /* Interrupt Vector with High Priority bit 5 position. */
+#define CPUINT_LVL1VEC_6_bm  (1<<6)  /* Interrupt Vector with High Priority bit 6 mask. */
+#define CPUINT_LVL1VEC_6_bp  6  /* Interrupt Vector with High Priority bit 6 position. */
+#define CPUINT_LVL1VEC_7_bm  (1<<7)  /* Interrupt Vector with High Priority bit 7 mask. */
+#define CPUINT_LVL1VEC_7_bp  7  /* Interrupt Vector with High Priority bit 7 position. */
+
+
+/* CRCSCAN - CRCSCAN */
+/* CRCSCAN.CTRLA  bit masks and bit positions */
+#define CRCSCAN_ENABLE_bm  0x01  /* Enable CRC scan bit mask. */
+#define CRCSCAN_ENABLE_bp  0  /* Enable CRC scan bit position. */
+#define CRCSCAN_NMIEN_bm  0x02  /* Enable NMI Trigger bit mask. */
+#define CRCSCAN_NMIEN_bp  1  /* Enable NMI Trigger bit position. */
+#define CRCSCAN_RESET_bm  0x80  /* Reset CRC scan bit mask. */
+#define CRCSCAN_RESET_bp  7  /* Reset CRC scan bit position. */
+
+/* CRCSCAN.CTRLB  bit masks and bit positions */
+#define CRCSCAN_SRC_gm  0x03  /* CRC Source group mask. */
+#define CRCSCAN_SRC_gp  0  /* CRC Source group position. */
+#define CRCSCAN_SRC_0_bm  (1<<0)  /* CRC Source bit 0 mask. */
+#define CRCSCAN_SRC_0_bp  0  /* CRC Source bit 0 position. */
+#define CRCSCAN_SRC_1_bm  (1<<1)  /* CRC Source bit 1 mask. */
+#define CRCSCAN_SRC_1_bp  1  /* CRC Source bit 1 position. */
+
+/* CRCSCAN.STATUS  bit masks and bit positions */
+#define CRCSCAN_BUSY_bm  0x01  /* CRC Busy bit mask. */
+#define CRCSCAN_BUSY_bp  0  /* CRC Busy bit position. */
+#define CRCSCAN_OK_bm  0x02  /* CRC Ok bit mask. */
+#define CRCSCAN_OK_bp  1  /* CRC Ok bit position. */
+
+
+/* DAC - Digital to Analog Converter */
+/* DAC.CTRLA  bit masks and bit positions */
+#define DAC_ENABLE_bm  0x01  /* DAC Enable bit mask. */
+#define DAC_ENABLE_bp  0  /* DAC Enable bit position. */
+#define DAC_OUTRANGE_gm  0x30  /* Output Buffer Range group mask. */
+#define DAC_OUTRANGE_gp  4  /* Output Buffer Range group position. */
+#define DAC_OUTRANGE_0_bm  (1<<4)  /* Output Buffer Range bit 0 mask. */
+#define DAC_OUTRANGE_0_bp  4  /* Output Buffer Range bit 0 position. */
+#define DAC_OUTRANGE_1_bm  (1<<5)  /* Output Buffer Range bit 1 mask. */
+#define DAC_OUTRANGE_1_bp  5  /* Output Buffer Range bit 1 position. */
+#define DAC_OUTEN_bm  0x40  /* Output Buffer Enable bit mask. */
+#define DAC_OUTEN_bp  6  /* Output Buffer Enable bit position. */
+#define DAC_RUNSTDBY_bm  0x80  /* Run in Standby Mode bit mask. */
+#define DAC_RUNSTDBY_bp  7  /* Run in Standby Mode bit position. */
+
+/* DAC.DATA  bit masks and bit positions */
+#define DAC_DATA_gm  0xFFC0  /* Data group mask. */
+#define DAC_DATA_gp  6  /* Data group position. */
+#define DAC_DATA_0_bm  (1<<6)  /* Data bit 0 mask. */
+#define DAC_DATA_0_bp  6  /* Data bit 0 position. */
+#define DAC_DATA_1_bm  (1<<7)  /* Data bit 1 mask. */
+#define DAC_DATA_1_bp  7  /* Data bit 1 position. */
+#define DAC_DATA_2_bm  (1<<8)  /* Data bit 2 mask. */
+#define DAC_DATA_2_bp  8  /* Data bit 2 position. */
+#define DAC_DATA_3_bm  (1<<9)  /* Data bit 3 mask. */
+#define DAC_DATA_3_bp  9  /* Data bit 3 position. */
+#define DAC_DATA_4_bm  (1<<10)  /* Data bit 4 mask. */
+#define DAC_DATA_4_bp  10  /* Data bit 4 position. */
+#define DAC_DATA_5_bm  (1<<11)  /* Data bit 5 mask. */
+#define DAC_DATA_5_bp  11  /* Data bit 5 position. */
+#define DAC_DATA_6_bm  (1<<12)  /* Data bit 6 mask. */
+#define DAC_DATA_6_bp  12  /* Data bit 6 position. */
+#define DAC_DATA_7_bm  (1<<13)  /* Data bit 7 mask. */
+#define DAC_DATA_7_bp  13  /* Data bit 7 position. */
+#define DAC_DATA_8_bm  (1<<14)  /* Data bit 8 mask. */
+#define DAC_DATA_8_bp  14  /* Data bit 8 position. */
+#define DAC_DATA_9_bm  (1<<15)  /* Data bit 9 mask. */
+#define DAC_DATA_9_bp  15  /* Data bit 9 position. */
+
+
+/* EVSYS - Event System */
+/* EVSYS.SWEVENTA  bit masks and bit positions */
+#define EVSYS_SWEVENTA_gm  0xFF  /* Software event on channel select group mask. */
+#define EVSYS_SWEVENTA_gp  0  /* Software event on channel select group position. */
+#define EVSYS_SWEVENTA_0_bm  (1<<0)  /* Software event on channel select bit 0 mask. */
+#define EVSYS_SWEVENTA_0_bp  0  /* Software event on channel select bit 0 position. */
+#define EVSYS_SWEVENTA_1_bm  (1<<1)  /* Software event on channel select bit 1 mask. */
+#define EVSYS_SWEVENTA_1_bp  1  /* Software event on channel select bit 1 position. */
+#define EVSYS_SWEVENTA_2_bm  (1<<2)  /* Software event on channel select bit 2 mask. */
+#define EVSYS_SWEVENTA_2_bp  2  /* Software event on channel select bit 2 position. */
+#define EVSYS_SWEVENTA_3_bm  (1<<3)  /* Software event on channel select bit 3 mask. */
+#define EVSYS_SWEVENTA_3_bp  3  /* Software event on channel select bit 3 position. */
+#define EVSYS_SWEVENTA_4_bm  (1<<4)  /* Software event on channel select bit 4 mask. */
+#define EVSYS_SWEVENTA_4_bp  4  /* Software event on channel select bit 4 position. */
+#define EVSYS_SWEVENTA_5_bm  (1<<5)  /* Software event on channel select bit 5 mask. */
+#define EVSYS_SWEVENTA_5_bp  5  /* Software event on channel select bit 5 position. */
+#define EVSYS_SWEVENTA_6_bm  (1<<6)  /* Software event on channel select bit 6 mask. */
+#define EVSYS_SWEVENTA_6_bp  6  /* Software event on channel select bit 6 position. */
+#define EVSYS_SWEVENTA_7_bm  (1<<7)  /* Software event on channel select bit 7 mask. */
+#define EVSYS_SWEVENTA_7_bp  7  /* Software event on channel select bit 7 position. */
+
+/* EVSYS.CHANNEL0  bit masks and bit positions */
+#define EVSYS_CHANNEL_gm  0xFF  /* Channel generator select group mask. */
+#define EVSYS_CHANNEL_gp  0  /* Channel generator select group position. */
+#define EVSYS_CHANNEL_0_bm  (1<<0)  /* Channel generator select bit 0 mask. */
+#define EVSYS_CHANNEL_0_bp  0  /* Channel generator select bit 0 position. */
+#define EVSYS_CHANNEL_1_bm  (1<<1)  /* Channel generator select bit 1 mask. */
+#define EVSYS_CHANNEL_1_bp  1  /* Channel generator select bit 1 position. */
+#define EVSYS_CHANNEL_2_bm  (1<<2)  /* Channel generator select bit 2 mask. */
+#define EVSYS_CHANNEL_2_bp  2  /* Channel generator select bit 2 position. */
+#define EVSYS_CHANNEL_3_bm  (1<<3)  /* Channel generator select bit 3 mask. */
+#define EVSYS_CHANNEL_3_bp  3  /* Channel generator select bit 3 position. */
+#define EVSYS_CHANNEL_4_bm  (1<<4)  /* Channel generator select bit 4 mask. */
+#define EVSYS_CHANNEL_4_bp  4  /* Channel generator select bit 4 position. */
+#define EVSYS_CHANNEL_5_bm  (1<<5)  /* Channel generator select bit 5 mask. */
+#define EVSYS_CHANNEL_5_bp  5  /* Channel generator select bit 5 position. */
+#define EVSYS_CHANNEL_6_bm  (1<<6)  /* Channel generator select bit 6 mask. */
+#define EVSYS_CHANNEL_6_bp  6  /* Channel generator select bit 6 position. */
+#define EVSYS_CHANNEL_7_bm  (1<<7)  /* Channel generator select bit 7 mask. */
+#define EVSYS_CHANNEL_7_bp  7  /* Channel generator select bit 7 position. */
+
+/* EVSYS.CHANNEL1  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.CHANNEL2  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.CHANNEL3  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.CHANNEL4  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.CHANNEL5  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.USERCCLLUT0A  bit masks and bit positions */
+#define EVSYS_USER_gm  0xFF  /* User channel select group mask. */
+#define EVSYS_USER_gp  0  /* User channel select group position. */
+#define EVSYS_USER_0_bm  (1<<0)  /* User channel select bit 0 mask. */
+#define EVSYS_USER_0_bp  0  /* User channel select bit 0 position. */
+#define EVSYS_USER_1_bm  (1<<1)  /* User channel select bit 1 mask. */
+#define EVSYS_USER_1_bp  1  /* User channel select bit 1 position. */
+#define EVSYS_USER_2_bm  (1<<2)  /* User channel select bit 2 mask. */
+#define EVSYS_USER_2_bp  2  /* User channel select bit 2 position. */
+#define EVSYS_USER_3_bm  (1<<3)  /* User channel select bit 3 mask. */
+#define EVSYS_USER_3_bp  3  /* User channel select bit 3 position. */
+#define EVSYS_USER_4_bm  (1<<4)  /* User channel select bit 4 mask. */
+#define EVSYS_USER_4_bp  4  /* User channel select bit 4 position. */
+#define EVSYS_USER_5_bm  (1<<5)  /* User channel select bit 5 mask. */
+#define EVSYS_USER_5_bp  5  /* User channel select bit 5 position. */
+#define EVSYS_USER_6_bm  (1<<6)  /* User channel select bit 6 mask. */
+#define EVSYS_USER_6_bp  6  /* User channel select bit 6 position. */
+#define EVSYS_USER_7_bm  (1<<7)  /* User channel select bit 7 mask. */
+#define EVSYS_USER_7_bp  7  /* User channel select bit 7 position. */
+
+/* EVSYS.USERCCLLUT0B  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT1A  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT1B  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT2A  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT2B  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT3A  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT3B  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERADC0START  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTC  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTD  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTF  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERUSART0IRDA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERUSART1IRDA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERUSART2IRDA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCA0CNTA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCA0CNTB  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCA1CNTA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCA1CNTB  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB0CAPT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB0COUNT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB1CAPT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB1COUNT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB2CAPT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB2COUNT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB3CAPT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB3COUNT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+
+/* FUSE - Fuses */
+/* FUSE.WDTCFG  bit masks and bit positions */
+#define FUSE_PERIOD_gm  0x0F  /* Watchdog Timeout Period group mask. */
+#define FUSE_PERIOD_gp  0  /* Watchdog Timeout Period group position. */
+#define FUSE_PERIOD_0_bm  (1<<0)  /* Watchdog Timeout Period bit 0 mask. */
+#define FUSE_PERIOD_0_bp  0  /* Watchdog Timeout Period bit 0 position. */
+#define FUSE_PERIOD_1_bm  (1<<1)  /* Watchdog Timeout Period bit 1 mask. */
+#define FUSE_PERIOD_1_bp  1  /* Watchdog Timeout Period bit 1 position. */
+#define FUSE_PERIOD_2_bm  (1<<2)  /* Watchdog Timeout Period bit 2 mask. */
+#define FUSE_PERIOD_2_bp  2  /* Watchdog Timeout Period bit 2 position. */
+#define FUSE_PERIOD_3_bm  (1<<3)  /* Watchdog Timeout Period bit 3 mask. */
+#define FUSE_PERIOD_3_bp  3  /* Watchdog Timeout Period bit 3 position. */
+#define FUSE_WINDOW_gm  0xF0  /* Watchdog Window Timeout Period group mask. */
+#define FUSE_WINDOW_gp  4  /* Watchdog Window Timeout Period group position. */
+#define FUSE_WINDOW_0_bm  (1<<4)  /* Watchdog Window Timeout Period bit 0 mask. */
+#define FUSE_WINDOW_0_bp  4  /* Watchdog Window Timeout Period bit 0 position. */
+#define FUSE_WINDOW_1_bm  (1<<5)  /* Watchdog Window Timeout Period bit 1 mask. */
+#define FUSE_WINDOW_1_bp  5  /* Watchdog Window Timeout Period bit 1 position. */
+#define FUSE_WINDOW_2_bm  (1<<6)  /* Watchdog Window Timeout Period bit 2 mask. */
+#define FUSE_WINDOW_2_bp  6  /* Watchdog Window Timeout Period bit 2 position. */
+#define FUSE_WINDOW_3_bm  (1<<7)  /* Watchdog Window Timeout Period bit 3 mask. */
+#define FUSE_WINDOW_3_bp  7  /* Watchdog Window Timeout Period bit 3 position. */
+
+/* FUSE.BODCFG  bit masks and bit positions */
+#define FUSE_SLEEP_gm  0x03  /* BOD Operation in Sleep Mode group mask. */
+#define FUSE_SLEEP_gp  0  /* BOD Operation in Sleep Mode group position. */
+#define FUSE_SLEEP_0_bm  (1<<0)  /* BOD Operation in Sleep Mode bit 0 mask. */
+#define FUSE_SLEEP_0_bp  0  /* BOD Operation in Sleep Mode bit 0 position. */
+#define FUSE_SLEEP_1_bm  (1<<1)  /* BOD Operation in Sleep Mode bit 1 mask. */
+#define FUSE_SLEEP_1_bp  1  /* BOD Operation in Sleep Mode bit 1 position. */
+#define FUSE_ACTIVE_gm  0x0C  /* BOD Operation in Active Mode group mask. */
+#define FUSE_ACTIVE_gp  2  /* BOD Operation in Active Mode group position. */
+#define FUSE_ACTIVE_0_bm  (1<<2)  /* BOD Operation in Active Mode bit 0 mask. */
+#define FUSE_ACTIVE_0_bp  2  /* BOD Operation in Active Mode bit 0 position. */
+#define FUSE_ACTIVE_1_bm  (1<<3)  /* BOD Operation in Active Mode bit 1 mask. */
+#define FUSE_ACTIVE_1_bp  3  /* BOD Operation in Active Mode bit 1 position. */
+#define FUSE_SAMPFREQ_bm  0x10  /* BOD Sample Frequency bit mask. */
+#define FUSE_SAMPFREQ_bp  4  /* BOD Sample Frequency bit position. */
+#define FUSE_LVL_gm  0xE0  /* BOD Level group mask. */
+#define FUSE_LVL_gp  5  /* BOD Level group position. */
+#define FUSE_LVL_0_bm  (1<<5)  /* BOD Level bit 0 mask. */
+#define FUSE_LVL_0_bp  5  /* BOD Level bit 0 position. */
+#define FUSE_LVL_1_bm  (1<<6)  /* BOD Level bit 1 mask. */
+#define FUSE_LVL_1_bp  6  /* BOD Level bit 1 position. */
+#define FUSE_LVL_2_bm  (1<<7)  /* BOD Level bit 2 mask. */
+#define FUSE_LVL_2_bp  7  /* BOD Level bit 2 position. */
+
+/* FUSE.OSCCFG  bit masks and bit positions */
+#define FUSE_OSCHFFRQ_bm  0x08  /* High-frequency Oscillator Frequency bit mask. */
+#define FUSE_OSCHFFRQ_bp  3  /* High-frequency Oscillator Frequency bit position. */
+
+/* FUSE.SYSCFG0  bit masks and bit positions */
+#define FUSE_EESAVE_bm  0x01  /* EEPROM Save bit mask. */
+#define FUSE_EESAVE_bp  0  /* EEPROM Save bit position. */
+#define FUSE_RSTPINCFG_bm  0x08  /* Reset Pin Configuration bit mask. */
+#define FUSE_RSTPINCFG_bp  3  /* Reset Pin Configuration bit position. */
+#define FUSE_UPDIPINCFG_bm  0x10  /* UPDI Pin Configuration bit mask. */
+#define FUSE_UPDIPINCFG_bp  4  /* UPDI Pin Configuration bit position. */
+#define FUSE_CRCSEL_bm  0x20  /* CRC Select bit mask. */
+#define FUSE_CRCSEL_bp  5  /* CRC Select bit position. */
+#define FUSE_CRCSRC_gm  0xC0  /* CRC Source group mask. */
+#define FUSE_CRCSRC_gp  6  /* CRC Source group position. */
+#define FUSE_CRCSRC_0_bm  (1<<6)  /* CRC Source bit 0 mask. */
+#define FUSE_CRCSRC_0_bp  6  /* CRC Source bit 0 position. */
+#define FUSE_CRCSRC_1_bm  (1<<7)  /* CRC Source bit 1 mask. */
+#define FUSE_CRCSRC_1_bp  7  /* CRC Source bit 1 position. */
+
+/* FUSE.SYSCFG1  bit masks and bit positions */
+#define FUSE_SUT_gm  0x07  /* Startup Time group mask. */
+#define FUSE_SUT_gp  0  /* Startup Time group position. */
+#define FUSE_SUT_0_bm  (1<<0)  /* Startup Time bit 0 mask. */
+#define FUSE_SUT_0_bp  0  /* Startup Time bit 0 position. */
+#define FUSE_SUT_1_bm  (1<<1)  /* Startup Time bit 1 mask. */
+#define FUSE_SUT_1_bp  1  /* Startup Time bit 1 position. */
+#define FUSE_SUT_2_bm  (1<<2)  /* Startup Time bit 2 mask. */
+#define FUSE_SUT_2_bp  2  /* Startup Time bit 2 position. */
+
+
+
+/* LOCK - Lockbits */
+/* LOCK.KEY  bit masks and bit positions */
+#define LOCK_KEY_gm  0xFFFFFFFF  /* Lock Key group mask. */
+#define LOCK_KEY_gp  0  /* Lock Key group position. */
+#define LOCK_KEY_0_bm  (1<<0)  /* Lock Key bit 0 mask. */
+#define LOCK_KEY_0_bp  0  /* Lock Key bit 0 position. */
+#define LOCK_KEY_1_bm  (1<<1)  /* Lock Key bit 1 mask. */
+#define LOCK_KEY_1_bp  1  /* Lock Key bit 1 position. */
+#define LOCK_KEY_2_bm  (1<<2)  /* Lock Key bit 2 mask. */
+#define LOCK_KEY_2_bp  2  /* Lock Key bit 2 position. */
+#define LOCK_KEY_3_bm  (1<<3)  /* Lock Key bit 3 mask. */
+#define LOCK_KEY_3_bp  3  /* Lock Key bit 3 position. */
+#define LOCK_KEY_4_bm  (1<<4)  /* Lock Key bit 4 mask. */
+#define LOCK_KEY_4_bp  4  /* Lock Key bit 4 position. */
+#define LOCK_KEY_5_bm  (1<<5)  /* Lock Key bit 5 mask. */
+#define LOCK_KEY_5_bp  5  /* Lock Key bit 5 position. */
+#define LOCK_KEY_6_bm  (1<<6)  /* Lock Key bit 6 mask. */
+#define LOCK_KEY_6_bp  6  /* Lock Key bit 6 position. */
+#define LOCK_KEY_7_bm  (1<<7)  /* Lock Key bit 7 mask. */
+#define LOCK_KEY_7_bp  7  /* Lock Key bit 7 position. */
+#define LOCK_KEY_8_bm  (1<<8)  /* Lock Key bit 8 mask. */
+#define LOCK_KEY_8_bp  8  /* Lock Key bit 8 position. */
+#define LOCK_KEY_9_bm  (1<<9)  /* Lock Key bit 9 mask. */
+#define LOCK_KEY_9_bp  9  /* Lock Key bit 9 position. */
+#define LOCK_KEY_10_bm  (1<<10)  /* Lock Key bit 10 mask. */
+#define LOCK_KEY_10_bp  10  /* Lock Key bit 10 position. */
+#define LOCK_KEY_11_bm  (1<<11)  /* Lock Key bit 11 mask. */
+#define LOCK_KEY_11_bp  11  /* Lock Key bit 11 position. */
+#define LOCK_KEY_12_bm  (1<<12)  /* Lock Key bit 12 mask. */
+#define LOCK_KEY_12_bp  12  /* Lock Key bit 12 position. */
+#define LOCK_KEY_13_bm  (1<<13)  /* Lock Key bit 13 mask. */
+#define LOCK_KEY_13_bp  13  /* Lock Key bit 13 position. */
+#define LOCK_KEY_14_bm  (1<<14)  /* Lock Key bit 14 mask. */
+#define LOCK_KEY_14_bp  14  /* Lock Key bit 14 position. */
+#define LOCK_KEY_15_bm  (1<<15)  /* Lock Key bit 15 mask. */
+#define LOCK_KEY_15_bp  15  /* Lock Key bit 15 position. */
+#define LOCK_KEY_16_bm  (1<<16)  /* Lock Key bit 16 mask. */
+#define LOCK_KEY_16_bp  16  /* Lock Key bit 16 position. */
+#define LOCK_KEY_17_bm  (1<<17)  /* Lock Key bit 17 mask. */
+#define LOCK_KEY_17_bp  17  /* Lock Key bit 17 position. */
+#define LOCK_KEY_18_bm  (1<<18)  /* Lock Key bit 18 mask. */
+#define LOCK_KEY_18_bp  18  /* Lock Key bit 18 position. */
+#define LOCK_KEY_19_bm  (1<<19)  /* Lock Key bit 19 mask. */
+#define LOCK_KEY_19_bp  19  /* Lock Key bit 19 position. */
+#define LOCK_KEY_20_bm  (1<<20)  /* Lock Key bit 20 mask. */
+#define LOCK_KEY_20_bp  20  /* Lock Key bit 20 position. */
+#define LOCK_KEY_21_bm  (1<<21)  /* Lock Key bit 21 mask. */
+#define LOCK_KEY_21_bp  21  /* Lock Key bit 21 position. */
+#define LOCK_KEY_22_bm  (1<<22)  /* Lock Key bit 22 mask. */
+#define LOCK_KEY_22_bp  22  /* Lock Key bit 22 position. */
+#define LOCK_KEY_23_bm  (1<<23)  /* Lock Key bit 23 mask. */
+#define LOCK_KEY_23_bp  23  /* Lock Key bit 23 position. */
+#define LOCK_KEY_24_bm  (1<<24)  /* Lock Key bit 24 mask. */
+#define LOCK_KEY_24_bp  24  /* Lock Key bit 24 position. */
+#define LOCK_KEY_25_bm  (1<<25)  /* Lock Key bit 25 mask. */
+#define LOCK_KEY_25_bp  25  /* Lock Key bit 25 position. */
+#define LOCK_KEY_26_bm  (1<<26)  /* Lock Key bit 26 mask. */
+#define LOCK_KEY_26_bp  26  /* Lock Key bit 26 position. */
+#define LOCK_KEY_27_bm  (1<<27)  /* Lock Key bit 27 mask. */
+#define LOCK_KEY_27_bp  27  /* Lock Key bit 27 position. */
+#define LOCK_KEY_28_bm  (1<<28)  /* Lock Key bit 28 mask. */
+#define LOCK_KEY_28_bp  28  /* Lock Key bit 28 position. */
+#define LOCK_KEY_29_bm  (1<<29)  /* Lock Key bit 29 mask. */
+#define LOCK_KEY_29_bp  29  /* Lock Key bit 29 position. */
+#define LOCK_KEY_30_bm  (1<<30)  /* Lock Key bit 30 mask. */
+#define LOCK_KEY_30_bp  30  /* Lock Key bit 30 position. */
+#define LOCK_KEY_31_bm  (1<<31)  /* Lock Key bit 31 mask. */
+#define LOCK_KEY_31_bp  31  /* Lock Key bit 31 position. */
+
+
+/* NVMCTRL - Non-volatile Memory Controller */
+/* NVMCTRL.CTRLA  bit masks and bit positions */
+#define NVMCTRL_CMD_gm  0x7F  /* Command group mask. */
+#define NVMCTRL_CMD_gp  0  /* Command group position. */
+#define NVMCTRL_CMD_0_bm  (1<<0)  /* Command bit 0 mask. */
+#define NVMCTRL_CMD_0_bp  0  /* Command bit 0 position. */
+#define NVMCTRL_CMD_1_bm  (1<<1)  /* Command bit 1 mask. */
+#define NVMCTRL_CMD_1_bp  1  /* Command bit 1 position. */
+#define NVMCTRL_CMD_2_bm  (1<<2)  /* Command bit 2 mask. */
+#define NVMCTRL_CMD_2_bp  2  /* Command bit 2 position. */
+#define NVMCTRL_CMD_3_bm  (1<<3)  /* Command bit 3 mask. */
+#define NVMCTRL_CMD_3_bp  3  /* Command bit 3 position. */
+#define NVMCTRL_CMD_4_bm  (1<<4)  /* Command bit 4 mask. */
+#define NVMCTRL_CMD_4_bp  4  /* Command bit 4 position. */
+#define NVMCTRL_CMD_5_bm  (1<<5)  /* Command bit 5 mask. */
+#define NVMCTRL_CMD_5_bp  5  /* Command bit 5 position. */
+#define NVMCTRL_CMD_6_bm  (1<<6)  /* Command bit 6 mask. */
+#define NVMCTRL_CMD_6_bp  6  /* Command bit 6 position. */
+
+/* NVMCTRL.CTRLB  bit masks and bit positions */
+#define NVMCTRL_APPCODEWP_bm  0x01  /* Application Code Write Protect bit mask. */
+#define NVMCTRL_APPCODEWP_bp  0  /* Application Code Write Protect bit position. */
+#define NVMCTRL_BOOTRP_bm  0x02  /* Boot Read Protect bit mask. */
+#define NVMCTRL_BOOTRP_bp  1  /* Boot Read Protect bit position. */
+#define NVMCTRL_APPDATAWP_bm  0x04  /* Application Data Write Protect bit mask. */
+#define NVMCTRL_APPDATAWP_bp  2  /* Application Data Write Protect bit position. */
+#define NVMCTRL_EEWP_bm  0x08  /* EEPROM Write Protect bit mask. */
+#define NVMCTRL_EEWP_bp  3  /* EEPROM Write Protect bit position. */
+#define NVMCTRL_FLMAP_gm  0x30  /* Flash Mapping in Data space group mask. */
+#define NVMCTRL_FLMAP_gp  4  /* Flash Mapping in Data space group position. */
+#define NVMCTRL_FLMAP_0_bm  (1<<4)  /* Flash Mapping in Data space bit 0 mask. */
+#define NVMCTRL_FLMAP_0_bp  4  /* Flash Mapping in Data space bit 0 position. */
+#define NVMCTRL_FLMAP_1_bm  (1<<5)  /* Flash Mapping in Data space bit 1 mask. */
+#define NVMCTRL_FLMAP_1_bp  5  /* Flash Mapping in Data space bit 1 position. */
+#define NVMCTRL_FLMAPLOCK_bm  0x80  /* Flash Mapping Lock bit mask. */
+#define NVMCTRL_FLMAPLOCK_bp  7  /* Flash Mapping Lock bit position. */
+
+/* NVMCTRL.INTCTRL  bit masks and bit positions */
+#define NVMCTRL_EEREADY_bm  0x01  /* EEPROM Ready bit mask. */
+#define NVMCTRL_EEREADY_bp  0  /* EEPROM Ready bit position. */
+#define NVMCTRL_FLREADY_bm  0x02  /* Flash Ready bit mask. */
+#define NVMCTRL_FLREADY_bp  1  /* Flash Ready bit position. */
+
+/* NVMCTRL.INTFLAGS  bit masks and bit positions */
+/* NVMCTRL_EEREADY  is already defined. */
+/* NVMCTRL_FLREADY  is already defined. */
+
+/* NVMCTRL.STATUS  bit masks and bit positions */
+#define NVMCTRL_EEBUSY_bm  0x01  /* EEPROM busy bit mask. */
+#define NVMCTRL_EEBUSY_bp  0  /* EEPROM busy bit position. */
+#define NVMCTRL_FLBUSY_bm  0x02  /* Flash busy bit mask. */
+#define NVMCTRL_FLBUSY_bp  1  /* Flash busy bit position. */
+#define NVMCTRL_ERROR_gm  0x70  /* Write error group mask. */
+#define NVMCTRL_ERROR_gp  4  /* Write error group position. */
+#define NVMCTRL_ERROR_0_bm  (1<<4)  /* Write error bit 0 mask. */
+#define NVMCTRL_ERROR_0_bp  4  /* Write error bit 0 position. */
+#define NVMCTRL_ERROR_1_bm  (1<<5)  /* Write error bit 1 mask. */
+#define NVMCTRL_ERROR_1_bp  5  /* Write error bit 1 position. */
+#define NVMCTRL_ERROR_2_bm  (1<<6)  /* Write error bit 2 mask. */
+#define NVMCTRL_ERROR_2_bp  6  /* Write error bit 2 position. */
+
+
+/* PORT - I/O Ports */
+/* PORT.INTFLAGS  bit masks and bit positions */
+#define PORT_INT_gm  0xFF  /* Pin Interrupt Flag group mask. */
+#define PORT_INT_gp  0  /* Pin Interrupt Flag group position. */
+#define PORT_INT_0_bm  (1<<0)  /* Pin Interrupt Flag bit 0 mask. */
+#define PORT_INT_0_bp  0  /* Pin Interrupt Flag bit 0 position. */
+#define PORT_INT0_bm  PORT_INT_0_bm  /* This define is deprecated and should not be used */
+#define PORT_INT0_bp  PORT_INT_0_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_1_bm  (1<<1)  /* Pin Interrupt Flag bit 1 mask. */
+#define PORT_INT_1_bp  1  /* Pin Interrupt Flag bit 1 position. */
+#define PORT_INT1_bm  PORT_INT_1_bm  /* This define is deprecated and should not be used */
+#define PORT_INT1_bp  PORT_INT_1_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_2_bm  (1<<2)  /* Pin Interrupt Flag bit 2 mask. */
+#define PORT_INT_2_bp  2  /* Pin Interrupt Flag bit 2 position. */
+#define PORT_INT2_bm  PORT_INT_2_bm  /* This define is deprecated and should not be used */
+#define PORT_INT2_bp  PORT_INT_2_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_3_bm  (1<<3)  /* Pin Interrupt Flag bit 3 mask. */
+#define PORT_INT_3_bp  3  /* Pin Interrupt Flag bit 3 position. */
+#define PORT_INT3_bm  PORT_INT_3_bm  /* This define is deprecated and should not be used */
+#define PORT_INT3_bp  PORT_INT_3_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_4_bm  (1<<4)  /* Pin Interrupt Flag bit 4 mask. */
+#define PORT_INT_4_bp  4  /* Pin Interrupt Flag bit 4 position. */
+#define PORT_INT4_bm  PORT_INT_4_bm  /* This define is deprecated and should not be used */
+#define PORT_INT4_bp  PORT_INT_4_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_5_bm  (1<<5)  /* Pin Interrupt Flag bit 5 mask. */
+#define PORT_INT_5_bp  5  /* Pin Interrupt Flag bit 5 position. */
+#define PORT_INT5_bm  PORT_INT_5_bm  /* This define is deprecated and should not be used */
+#define PORT_INT5_bp  PORT_INT_5_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_6_bm  (1<<6)  /* Pin Interrupt Flag bit 6 mask. */
+#define PORT_INT_6_bp  6  /* Pin Interrupt Flag bit 6 position. */
+#define PORT_INT6_bm  PORT_INT_6_bm  /* This define is deprecated and should not be used */
+#define PORT_INT6_bp  PORT_INT_6_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_7_bm  (1<<7)  /* Pin Interrupt Flag bit 7 mask. */
+#define PORT_INT_7_bp  7  /* Pin Interrupt Flag bit 7 position. */
+#define PORT_INT7_bm  PORT_INT_7_bm  /* This define is deprecated and should not be used */
+#define PORT_INT7_bp  PORT_INT_7_bp  /* This define is deprecated and should not be used */
+
+/* PORT.PORTCTRL  bit masks and bit positions */
+#define PORT_SRL_bm  0x01  /* Slew Rate Limit Enable bit mask. */
+#define PORT_SRL_bp  0  /* Slew Rate Limit Enable bit position. */
+
+/* PORT.PINCONFIG  bit masks and bit positions */
+#define PORT_ISC_gm  0x07  /* Input/Sense Configuration group mask. */
+#define PORT_ISC_gp  0  /* Input/Sense Configuration group position. */
+#define PORT_ISC_0_bm  (1<<0)  /* Input/Sense Configuration bit 0 mask. */
+#define PORT_ISC_0_bp  0  /* Input/Sense Configuration bit 0 position. */
+#define PORT_ISC_1_bm  (1<<1)  /* Input/Sense Configuration bit 1 mask. */
+#define PORT_ISC_1_bp  1  /* Input/Sense Configuration bit 1 position. */
+#define PORT_ISC_2_bm  (1<<2)  /* Input/Sense Configuration bit 2 mask. */
+#define PORT_ISC_2_bp  2  /* Input/Sense Configuration bit 2 position. */
+#define PORT_PULLUPEN_bm  0x08  /* Pullup enable bit mask. */
+#define PORT_PULLUPEN_bp  3  /* Pullup enable bit position. */
+#define PORT_INLVL_bm  0x40  /* Input Level Select bit mask. */
+#define PORT_INLVL_bp  6  /* Input Level Select bit position. */
+#define PORT_INVEN_bm  0x80  /* Inverted I/O Enable bit mask. */
+#define PORT_INVEN_bp  7  /* Inverted I/O Enable bit position. */
+
+/* PORT.PIN0CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN1CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN2CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN3CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN4CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN5CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN6CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN7CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.EVGENCTRL  bit masks and bit positions */
+#define PORT_EVGEN0SEL_gm  0x07  /* Event Generator 0 Select group mask. */
+#define PORT_EVGEN0SEL_gp  0  /* Event Generator 0 Select group position. */
+#define PORT_EVGEN0SEL_0_bm  (1<<0)  /* Event Generator 0 Select bit 0 mask. */
+#define PORT_EVGEN0SEL_0_bp  0  /* Event Generator 0 Select bit 0 position. */
+#define PORT_EVGEN0SEL_1_bm  (1<<1)  /* Event Generator 0 Select bit 1 mask. */
+#define PORT_EVGEN0SEL_1_bp  1  /* Event Generator 0 Select bit 1 position. */
+#define PORT_EVGEN0SEL_2_bm  (1<<2)  /* Event Generator 0 Select bit 2 mask. */
+#define PORT_EVGEN0SEL_2_bp  2  /* Event Generator 0 Select bit 2 position. */
+#define PORT_EVGEN1SEL_gm  0x70  /* Event Generator 1 Select group mask. */
+#define PORT_EVGEN1SEL_gp  4  /* Event Generator 1 Select group position. */
+#define PORT_EVGEN1SEL_0_bm  (1<<4)  /* Event Generator 1 Select bit 0 mask. */
+#define PORT_EVGEN1SEL_0_bp  4  /* Event Generator 1 Select bit 0 position. */
+#define PORT_EVGEN1SEL_1_bm  (1<<5)  /* Event Generator 1 Select bit 1 mask. */
+#define PORT_EVGEN1SEL_1_bp  5  /* Event Generator 1 Select bit 1 position. */
+#define PORT_EVGEN1SEL_2_bm  (1<<6)  /* Event Generator 1 Select bit 2 mask. */
+#define PORT_EVGEN1SEL_2_bp  6  /* Event Generator 1 Select bit 2 position. */
+
+
+/* PORTMUX - Port Multiplexer */
+/* PORTMUX.EVSYSROUTEA  bit masks and bit positions */
+#define PORTMUX_EVOUTA_bm  0x01  /* Event Output A bit mask. */
+#define PORTMUX_EVOUTA_bp  0  /* Event Output A bit position. */
+#define PORTMUX_EVOUTC_bm  0x04  /* Event Output C bit mask. */
+#define PORTMUX_EVOUTC_bp  2  /* Event Output C bit position. */
+#define PORTMUX_EVOUTD_bm  0x08  /* Event Output D bit mask. */
+#define PORTMUX_EVOUTD_bp  3  /* Event Output D bit position. */
+#define PORTMUX_EVOUTF_bm  0x20  /* Event Output F bit mask. */
+#define PORTMUX_EVOUTF_bp  5  /* Event Output F bit position. */
+
+/* PORTMUX.CCLROUTEA  bit masks and bit positions */
+#define PORTMUX_LUT0_bm  0x01  /* CCL Look-Up Table 0 Signals bit mask. */
+#define PORTMUX_LUT0_bp  0  /* CCL Look-Up Table 0 Signals bit position. */
+#define PORTMUX_LUT1_bm  0x02  /* CCL Look-Up Table 1 Signals bit mask. */
+#define PORTMUX_LUT1_bp  1  /* CCL Look-Up Table 1 Signals bit position. */
+#define PORTMUX_LUT2_bm  0x04  /* CCL Look-Up Table 2 Signals bit mask. */
+#define PORTMUX_LUT2_bp  2  /* CCL Look-Up Table 2 Signals bit position. */
+
+/* PORTMUX.USARTROUTEA  bit masks and bit positions */
+#define PORTMUX_USART0_gm  0x07  /* USART0 Routing group mask. */
+#define PORTMUX_USART0_gp  0  /* USART0 Routing group position. */
+#define PORTMUX_USART0_0_bm  (1<<0)  /* USART0 Routing bit 0 mask. */
+#define PORTMUX_USART0_0_bp  0  /* USART0 Routing bit 0 position. */
+#define PORTMUX_USART0_1_bm  (1<<1)  /* USART0 Routing bit 1 mask. */
+#define PORTMUX_USART0_1_bp  1  /* USART0 Routing bit 1 position. */
+#define PORTMUX_USART0_2_bm  (1<<2)  /* USART0 Routing bit 2 mask. */
+#define PORTMUX_USART0_2_bp  2  /* USART0 Routing bit 2 position. */
+#define PORTMUX_USART1_gm  0x18  /* USART1 Routing group mask. */
+#define PORTMUX_USART1_gp  3  /* USART1 Routing group position. */
+#define PORTMUX_USART1_0_bm  (1<<3)  /* USART1 Routing bit 0 mask. */
+#define PORTMUX_USART1_0_bp  3  /* USART1 Routing bit 0 position. */
+#define PORTMUX_USART1_1_bm  (1<<4)  /* USART1 Routing bit 1 mask. */
+#define PORTMUX_USART1_1_bp  4  /* USART1 Routing bit 1 position. */
+
+/* PORTMUX.USARTROUTEB  bit masks and bit positions */
+#define PORTMUX_USART2_gm  0x03  /* USART2 Routing group mask. */
+#define PORTMUX_USART2_gp  0  /* USART2 Routing group position. */
+#define PORTMUX_USART2_0_bm  (1<<0)  /* USART2 Routing bit 0 mask. */
+#define PORTMUX_USART2_0_bp  0  /* USART2 Routing bit 0 position. */
+#define PORTMUX_USART2_1_bm  (1<<1)  /* USART2 Routing bit 1 mask. */
+#define PORTMUX_USART2_1_bp  1  /* USART2 Routing bit 1 position. */
+
+/* PORTMUX.SPIROUTEA  bit masks and bit positions */
+#define PORTMUX_SPI0_gm  0x07  /* SPI0 Signals group mask. */
+#define PORTMUX_SPI0_gp  0  /* SPI0 Signals group position. */
+#define PORTMUX_SPI0_0_bm  (1<<0)  /* SPI0 Signals bit 0 mask. */
+#define PORTMUX_SPI0_0_bp  0  /* SPI0 Signals bit 0 position. */
+#define PORTMUX_SPI0_1_bm  (1<<1)  /* SPI0 Signals bit 1 mask. */
+#define PORTMUX_SPI0_1_bp  1  /* SPI0 Signals bit 1 position. */
+#define PORTMUX_SPI0_2_bm  (1<<2)  /* SPI0 Signals bit 2 mask. */
+#define PORTMUX_SPI0_2_bp  2  /* SPI0 Signals bit 2 position. */
+
+/* PORTMUX.TWIROUTEA  bit masks and bit positions */
+#define PORTMUX_TWI0_gm  0x03  /* TWI0 Signals group mask. */
+#define PORTMUX_TWI0_gp  0  /* TWI0 Signals group position. */
+#define PORTMUX_TWI0_0_bm  (1<<0)  /* TWI0 Signals bit 0 mask. */
+#define PORTMUX_TWI0_0_bp  0  /* TWI0 Signals bit 0 position. */
+#define PORTMUX_TWI0_1_bm  (1<<1)  /* TWI0 Signals bit 1 mask. */
+#define PORTMUX_TWI0_1_bp  1  /* TWI0 Signals bit 1 position. */
+
+/* PORTMUX.TCAROUTEA  bit masks and bit positions */
+#define PORTMUX_TCA0_gm  0x07  /* TCA0 Signals group mask. */
+#define PORTMUX_TCA0_gp  0  /* TCA0 Signals group position. */
+#define PORTMUX_TCA0_0_bm  (1<<0)  /* TCA0 Signals bit 0 mask. */
+#define PORTMUX_TCA0_0_bp  0  /* TCA0 Signals bit 0 position. */
+#define PORTMUX_TCA0_1_bm  (1<<1)  /* TCA0 Signals bit 1 mask. */
+#define PORTMUX_TCA0_1_bp  1  /* TCA0 Signals bit 1 position. */
+#define PORTMUX_TCA0_2_bm  (1<<2)  /* TCA0 Signals bit 2 mask. */
+#define PORTMUX_TCA0_2_bp  2  /* TCA0 Signals bit 2 position. */
+#define PORTMUX_TCA1_gm  0x38  /* TCA1 Signals group mask. */
+#define PORTMUX_TCA1_gp  3  /* TCA1 Signals group position. */
+#define PORTMUX_TCA1_0_bm  (1<<3)  /* TCA1 Signals bit 0 mask. */
+#define PORTMUX_TCA1_0_bp  3  /* TCA1 Signals bit 0 position. */
+#define PORTMUX_TCA1_1_bm  (1<<4)  /* TCA1 Signals bit 1 mask. */
+#define PORTMUX_TCA1_1_bp  4  /* TCA1 Signals bit 1 position. */
+#define PORTMUX_TCA1_2_bm  (1<<5)  /* TCA1 Signals bit 2 mask. */
+#define PORTMUX_TCA1_2_bp  5  /* TCA1 Signals bit 2 position. */
+
+/* PORTMUX.TCBROUTEA  bit masks and bit positions */
+#define PORTMUX_TCB0_bm  0x01  /* TCB0 Output bit mask. */
+#define PORTMUX_TCB0_bp  0  /* TCB0 Output bit position. */
+#define PORTMUX_TCB1_bm  0x02  /* TCB1 Output bit mask. */
+#define PORTMUX_TCB1_bp  1  /* TCB1 Output bit position. */
+#define PORTMUX_TCB2_bm  0x04  /* TCB2 Output bit mask. */
+#define PORTMUX_TCB2_bp  2  /* TCB2 Output bit position. */
+#define PORTMUX_TCB3_bm  0x08  /* TCB3 Output bit mask. */
+#define PORTMUX_TCB3_bp  3  /* TCB3 Output bit position. */
+
+/* PORTMUX.ACROUTEA  bit masks and bit positions */
+#define PORTMUX_AC0_bm  0x01  /* Analog Comparator 0 Output bit mask. */
+#define PORTMUX_AC0_bp  0  /* Analog Comparator 0 Output bit position. */
+#define PORTMUX_AC1_bm  0x02  /* Analog Comparator 1 Output bit mask. */
+#define PORTMUX_AC1_bp  1  /* Analog Comparator 1 Output bit position. */
+
+
+/* RSTCTRL - Reset controller */
+/* RSTCTRL.RSTFR  bit masks and bit positions */
+#define RSTCTRL_PORF_bm  0x01  /* Power on Reset flag bit mask. */
+#define RSTCTRL_PORF_bp  0  /* Power on Reset flag bit position. */
+#define RSTCTRL_BORF_bm  0x02  /* Brown out detector Reset flag bit mask. */
+#define RSTCTRL_BORF_bp  1  /* Brown out detector Reset flag bit position. */
+#define RSTCTRL_EXTRF_bm  0x04  /* External Reset flag bit mask. */
+#define RSTCTRL_EXTRF_bp  2  /* External Reset flag bit position. */
+#define RSTCTRL_WDRF_bm  0x08  /* Watch dog Reset flag bit mask. */
+#define RSTCTRL_WDRF_bp  3  /* Watch dog Reset flag bit position. */
+#define RSTCTRL_SWRF_bm  0x10  /* Software Reset flag bit mask. */
+#define RSTCTRL_SWRF_bp  4  /* Software Reset flag bit position. */
+#define RSTCTRL_UPDIRF_bm  0x20  /* UPDI Reset flag bit mask. */
+#define RSTCTRL_UPDIRF_bp  5  /* UPDI Reset flag bit position. */
+
+/* RSTCTRL.SWRR  bit masks and bit positions */
+#define RSTCTRL_SWRE_bm  0x01  /* Software Reset Enable bit mask. */
+#define RSTCTRL_SWRE_bp  0  /* Software Reset Enable bit position. */
+
+
+/* RTC - Real-Time Counter */
+/* RTC.CTRLA  bit masks and bit positions */
+#define RTC_RTCEN_bm  0x01  /* Enable bit mask. */
+#define RTC_RTCEN_bp  0  /* Enable bit position. */
+#define RTC_CORREN_bm  0x04  /* Correction enable bit mask. */
+#define RTC_CORREN_bp  2  /* Correction enable bit position. */
+#define RTC_PRESCALER_gm  0x78  /* Prescaling Factor group mask. */
+#define RTC_PRESCALER_gp  3  /* Prescaling Factor group position. */
+#define RTC_PRESCALER_0_bm  (1<<3)  /* Prescaling Factor bit 0 mask. */
+#define RTC_PRESCALER_0_bp  3  /* Prescaling Factor bit 0 position. */
+#define RTC_PRESCALER_1_bm  (1<<4)  /* Prescaling Factor bit 1 mask. */
+#define RTC_PRESCALER_1_bp  4  /* Prescaling Factor bit 1 position. */
+#define RTC_PRESCALER_2_bm  (1<<5)  /* Prescaling Factor bit 2 mask. */
+#define RTC_PRESCALER_2_bp  5  /* Prescaling Factor bit 2 position. */
+#define RTC_PRESCALER_3_bm  (1<<6)  /* Prescaling Factor bit 3 mask. */
+#define RTC_PRESCALER_3_bp  6  /* Prescaling Factor bit 3 position. */
+#define RTC_RUNSTDBY_bm  0x80  /* Run In Standby bit mask. */
+#define RTC_RUNSTDBY_bp  7  /* Run In Standby bit position. */
+
+/* RTC.STATUS  bit masks and bit positions */
+#define RTC_CTRLABUSY_bm  0x01  /* CTRLA Synchronization Busy Flag bit mask. */
+#define RTC_CTRLABUSY_bp  0  /* CTRLA Synchronization Busy Flag bit position. */
+#define RTC_CNTBUSY_bm  0x02  /* Count Synchronization Busy Flag bit mask. */
+#define RTC_CNTBUSY_bp  1  /* Count Synchronization Busy Flag bit position. */
+#define RTC_PERBUSY_bm  0x04  /* Period Synchronization Busy Flag bit mask. */
+#define RTC_PERBUSY_bp  2  /* Period Synchronization Busy Flag bit position. */
+#define RTC_CMPBUSY_bm  0x08  /* Comparator Synchronization Busy Flag bit mask. */
+#define RTC_CMPBUSY_bp  3  /* Comparator Synchronization Busy Flag bit position. */
+
+/* RTC.INTCTRL  bit masks and bit positions */
+#define RTC_OVF_bm  0x01  /* Overflow Interrupt enable bit mask. */
+#define RTC_OVF_bp  0  /* Overflow Interrupt enable bit position. */
+#define RTC_CMP_bm  0x02  /* Compare Match Interrupt enable bit mask. */
+#define RTC_CMP_bp  1  /* Compare Match Interrupt enable bit position. */
+
+/* RTC.INTFLAGS  bit masks and bit positions */
+/* RTC_OVF  is already defined. */
+/* RTC_CMP  is already defined. */
+
+/* RTC.DBGCTRL  bit masks and bit positions */
+#define RTC_DBGRUN_bm  0x01  /* Run in debug bit mask. */
+#define RTC_DBGRUN_bp  0  /* Run in debug bit position. */
+
+/* RTC.CALIB  bit masks and bit positions */
+#define RTC_ERROR_gm  0x7F  /* Error Correction Value group mask. */
+#define RTC_ERROR_gp  0  /* Error Correction Value group position. */
+#define RTC_ERROR_0_bm  (1<<0)  /* Error Correction Value bit 0 mask. */
+#define RTC_ERROR_0_bp  0  /* Error Correction Value bit 0 position. */
+#define RTC_ERROR_1_bm  (1<<1)  /* Error Correction Value bit 1 mask. */
+#define RTC_ERROR_1_bp  1  /* Error Correction Value bit 1 position. */
+#define RTC_ERROR_2_bm  (1<<2)  /* Error Correction Value bit 2 mask. */
+#define RTC_ERROR_2_bp  2  /* Error Correction Value bit 2 position. */
+#define RTC_ERROR_3_bm  (1<<3)  /* Error Correction Value bit 3 mask. */
+#define RTC_ERROR_3_bp  3  /* Error Correction Value bit 3 position. */
+#define RTC_ERROR_4_bm  (1<<4)  /* Error Correction Value bit 4 mask. */
+#define RTC_ERROR_4_bp  4  /* Error Correction Value bit 4 position. */
+#define RTC_ERROR_5_bm  (1<<5)  /* Error Correction Value bit 5 mask. */
+#define RTC_ERROR_5_bp  5  /* Error Correction Value bit 5 position. */
+#define RTC_ERROR_6_bm  (1<<6)  /* Error Correction Value bit 6 mask. */
+#define RTC_ERROR_6_bp  6  /* Error Correction Value bit 6 position. */
+#define RTC_SIGN_bm  0x80  /* Error Correction Sign Bit bit mask. */
+#define RTC_SIGN_bp  7  /* Error Correction Sign Bit bit position. */
+
+/* RTC.CLKSEL  bit masks and bit positions */
+#define RTC_CLKSEL_gm  0x03  /* Clock Select group mask. */
+#define RTC_CLKSEL_gp  0  /* Clock Select group position. */
+#define RTC_CLKSEL_0_bm  (1<<0)  /* Clock Select bit 0 mask. */
+#define RTC_CLKSEL_0_bp  0  /* Clock Select bit 0 position. */
+#define RTC_CLKSEL_1_bm  (1<<1)  /* Clock Select bit 1 mask. */
+#define RTC_CLKSEL_1_bp  1  /* Clock Select bit 1 position. */
+
+/* RTC.PITCTRLA  bit masks and bit positions */
+#define RTC_PITEN_bm  0x01  /* Enable bit mask. */
+#define RTC_PITEN_bp  0  /* Enable bit position. */
+#define RTC_PERIOD_gm  0x78  /* Period group mask. */
+#define RTC_PERIOD_gp  3  /* Period group position. */
+#define RTC_PERIOD_0_bm  (1<<3)  /* Period bit 0 mask. */
+#define RTC_PERIOD_0_bp  3  /* Period bit 0 position. */
+#define RTC_PERIOD_1_bm  (1<<4)  /* Period bit 1 mask. */
+#define RTC_PERIOD_1_bp  4  /* Period bit 1 position. */
+#define RTC_PERIOD_2_bm  (1<<5)  /* Period bit 2 mask. */
+#define RTC_PERIOD_2_bp  5  /* Period bit 2 position. */
+#define RTC_PERIOD_3_bm  (1<<6)  /* Period bit 3 mask. */
+#define RTC_PERIOD_3_bp  6  /* Period bit 3 position. */
+
+/* RTC.PITSTATUS  bit masks and bit positions */
+#define RTC_CTRLBUSY_bm  0x01  /* CTRLA Synchronization Busy Flag bit mask. */
+#define RTC_CTRLBUSY_bp  0  /* CTRLA Synchronization Busy Flag bit position. */
+
+/* RTC.PITINTCTRL  bit masks and bit positions */
+#define RTC_PI_bm  0x01  /* Periodic Interrupt bit mask. */
+#define RTC_PI_bp  0  /* Periodic Interrupt bit position. */
+
+/* RTC.PITINTFLAGS  bit masks and bit positions */
+/* RTC_PI  is already defined. */
+
+/* RTC.PITDBGCTRL  bit masks and bit positions */
+/* RTC_DBGRUN  is already defined. */
+
+/* RTC.PITEVGENCTRLA  bit masks and bit positions */
+#define RTC_EVGEN0SEL_gm  0x0F  /* Event Generation 0 Select group mask. */
+#define RTC_EVGEN0SEL_gp  0  /* Event Generation 0 Select group position. */
+#define RTC_EVGEN0SEL_0_bm  (1<<0)  /* Event Generation 0 Select bit 0 mask. */
+#define RTC_EVGEN0SEL_0_bp  0  /* Event Generation 0 Select bit 0 position. */
+#define RTC_EVGEN0SEL_1_bm  (1<<1)  /* Event Generation 0 Select bit 1 mask. */
+#define RTC_EVGEN0SEL_1_bp  1  /* Event Generation 0 Select bit 1 position. */
+#define RTC_EVGEN0SEL_2_bm  (1<<2)  /* Event Generation 0 Select bit 2 mask. */
+#define RTC_EVGEN0SEL_2_bp  2  /* Event Generation 0 Select bit 2 position. */
+#define RTC_EVGEN0SEL_3_bm  (1<<3)  /* Event Generation 0 Select bit 3 mask. */
+#define RTC_EVGEN0SEL_3_bp  3  /* Event Generation 0 Select bit 3 position. */
+#define RTC_EVGEN1SEL_gm  0xF0  /* Event Generation 1 Select group mask. */
+#define RTC_EVGEN1SEL_gp  4  /* Event Generation 1 Select group position. */
+#define RTC_EVGEN1SEL_0_bm  (1<<4)  /* Event Generation 1 Select bit 0 mask. */
+#define RTC_EVGEN1SEL_0_bp  4  /* Event Generation 1 Select bit 0 position. */
+#define RTC_EVGEN1SEL_1_bm  (1<<5)  /* Event Generation 1 Select bit 1 mask. */
+#define RTC_EVGEN1SEL_1_bp  5  /* Event Generation 1 Select bit 1 position. */
+#define RTC_EVGEN1SEL_2_bm  (1<<6)  /* Event Generation 1 Select bit 2 mask. */
+#define RTC_EVGEN1SEL_2_bp  6  /* Event Generation 1 Select bit 2 position. */
+#define RTC_EVGEN1SEL_3_bm  (1<<7)  /* Event Generation 1 Select bit 3 mask. */
+#define RTC_EVGEN1SEL_3_bp  7  /* Event Generation 1 Select bit 3 position. */
+
+
+
+/* SLPCTRL - Sleep Controller */
+/* SLPCTRL.CTRLA  bit masks and bit positions */
+#define SLPCTRL_SEN_bm  0x01  /* Sleep enable bit mask. */
+#define SLPCTRL_SEN_bp  0  /* Sleep enable bit position. */
+#define SLPCTRL_SMODE_gm  0x06  /* Sleep mode group mask. */
+#define SLPCTRL_SMODE_gp  1  /* Sleep mode group position. */
+#define SLPCTRL_SMODE_0_bm  (1<<1)  /* Sleep mode bit 0 mask. */
+#define SLPCTRL_SMODE_0_bp  1  /* Sleep mode bit 0 position. */
+#define SLPCTRL_SMODE_1_bm  (1<<2)  /* Sleep mode bit 1 mask. */
+#define SLPCTRL_SMODE_1_bp  2  /* Sleep mode bit 1 position. */
+
+
+/* SPI - Serial Peripheral Interface */
+/* SPI.CTRLA  bit masks and bit positions */
+#define SPI_ENABLE_bm  0x01  /* Enable Module bit mask. */
+#define SPI_ENABLE_bp  0  /* Enable Module bit position. */
+#define SPI_PRESC_gm  0x06  /* Prescaler group mask. */
+#define SPI_PRESC_gp  1  /* Prescaler group position. */
+#define SPI_PRESC_0_bm  (1<<1)  /* Prescaler bit 0 mask. */
+#define SPI_PRESC_0_bp  1  /* Prescaler bit 0 position. */
+#define SPI_PRESC_1_bm  (1<<2)  /* Prescaler bit 1 mask. */
+#define SPI_PRESC_1_bp  2  /* Prescaler bit 1 position. */
+#define SPI_CLK2X_bm  0x10  /* Enable Double Speed bit mask. */
+#define SPI_CLK2X_bp  4  /* Enable Double Speed bit position. */
+#define SPI_MASTER_bm  0x20  /* Host Operation Enable bit mask. */
+#define SPI_MASTER_bp  5  /* Host Operation Enable bit position. */
+#define SPI_DORD_bm  0x40  /* Data Order Setting bit mask. */
+#define SPI_DORD_bp  6  /* Data Order Setting bit position. */
+
+/* SPI.CTRLB  bit masks and bit positions */
+#define SPI_MODE_gm  0x03  /* SPI Mode group mask. */
+#define SPI_MODE_gp  0  /* SPI Mode group position. */
+#define SPI_MODE_0_bm  (1<<0)  /* SPI Mode bit 0 mask. */
+#define SPI_MODE_0_bp  0  /* SPI Mode bit 0 position. */
+#define SPI_MODE_1_bm  (1<<1)  /* SPI Mode bit 1 mask. */
+#define SPI_MODE_1_bp  1  /* SPI Mode bit 1 position. */
+#define SPI_SSD_bm  0x04  /* SPI Select Disable bit mask. */
+#define SPI_SSD_bp  2  /* SPI Select Disable bit position. */
+#define SPI_BUFWR_bm  0x40  /* Buffer Mode Wait for Receive bit mask. */
+#define SPI_BUFWR_bp  6  /* Buffer Mode Wait for Receive bit position. */
+#define SPI_BUFEN_bm  0x80  /* Buffer Mode Enable bit mask. */
+#define SPI_BUFEN_bp  7  /* Buffer Mode Enable bit position. */
+
+/* SPI.INTCTRL  bit masks and bit positions */
+#define SPI_IE_bm  0x01  /* Interrupt Enable bit mask. */
+#define SPI_IE_bp  0  /* Interrupt Enable bit position. */
+#define SPI_SSIE_bm  0x10  /* SPI Select Trigger Interrupt Enable bit mask. */
+#define SPI_SSIE_bp  4  /* SPI Select Trigger Interrupt Enable bit position. */
+#define SPI_DREIE_bm  0x20  /* Data Register Empty Interrupt Enable bit mask. */
+#define SPI_DREIE_bp  5  /* Data Register Empty Interrupt Enable bit position. */
+#define SPI_TXCIE_bm  0x40  /* Transfer Complete Interrupt Enable bit mask. */
+#define SPI_TXCIE_bp  6  /* Transfer Complete Interrupt Enable bit position. */
+#define SPI_RXCIE_bm  0x80  /* Receive Complete Interrupt Enable bit mask. */
+#define SPI_RXCIE_bp  7  /* Receive Complete Interrupt Enable bit position. */
+
+/* SPI.INTFLAGS  bit masks and bit positions */
+#define SPI_BUFOVF_bm  0x01  /* Buffer Overflow bit mask. */
+#define SPI_BUFOVF_bp  0  /* Buffer Overflow bit position. */
+#define SPI_SSIF_bm  0x10  /* SPI Select Trigger Interrupt Flag bit mask. */
+#define SPI_SSIF_bp  4  /* SPI Select Trigger Interrupt Flag bit position. */
+#define SPI_DREIF_bm  0x20  /* Data Register Empty Interrupt Flag bit mask. */
+#define SPI_DREIF_bp  5  /* Data Register Empty Interrupt Flag bit position. */
+#define SPI_TXCIF_bm  0x40  /* Transfer Complete Interrupt Flag bit mask. */
+#define SPI_TXCIF_bp  6  /* Transfer Complete Interrupt Flag bit position. */
+#define SPI_WRCOL_bm  0x40  /* Write Collision bit mask. */
+#define SPI_WRCOL_bp  6  /* Write Collision bit position. */
+#define SPI_RXCIF_bm  0x80  /* Receive Complete Interrupt Flag bit mask. */
+#define SPI_RXCIF_bp  7  /* Receive Complete Interrupt Flag bit position. */
+#define SPI_IF_bm  0x80  /* Interrupt Flag bit mask. */
+#define SPI_IF_bp  7  /* Interrupt Flag bit position. */
+
+
+/* SYSCFG - System Configuration Registers */
+/* SYSCFG.REVID  bit masks and bit positions */
+#define SYSCFG_MINOR_gm  0x0F  /* Minor Revision group mask. */
+#define SYSCFG_MINOR_gp  0  /* Minor Revision group position. */
+#define SYSCFG_MINOR_0_bm  (1<<0)  /* Minor Revision bit 0 mask. */
+#define SYSCFG_MINOR_0_bp  0  /* Minor Revision bit 0 position. */
+#define SYSCFG_MINOR_1_bm  (1<<1)  /* Minor Revision bit 1 mask. */
+#define SYSCFG_MINOR_1_bp  1  /* Minor Revision bit 1 position. */
+#define SYSCFG_MINOR_2_bm  (1<<2)  /* Minor Revision bit 2 mask. */
+#define SYSCFG_MINOR_2_bp  2  /* Minor Revision bit 2 position. */
+#define SYSCFG_MINOR_3_bm  (1<<3)  /* Minor Revision bit 3 mask. */
+#define SYSCFG_MINOR_3_bp  3  /* Minor Revision bit 3 position. */
+#define SYSCFG_MAJOR_gm  0xF0  /* Major Revision group mask. */
+#define SYSCFG_MAJOR_gp  4  /* Major Revision group position. */
+#define SYSCFG_MAJOR_0_bm  (1<<4)  /* Major Revision bit 0 mask. */
+#define SYSCFG_MAJOR_0_bp  4  /* Major Revision bit 0 position. */
+#define SYSCFG_MAJOR_1_bm  (1<<5)  /* Major Revision bit 1 mask. */
+#define SYSCFG_MAJOR_1_bp  5  /* Major Revision bit 1 position. */
+#define SYSCFG_MAJOR_2_bm  (1<<6)  /* Major Revision bit 2 mask. */
+#define SYSCFG_MAJOR_2_bp  6  /* Major Revision bit 2 position. */
+#define SYSCFG_MAJOR_3_bm  (1<<7)  /* Major Revision bit 3 mask. */
+#define SYSCFG_MAJOR_3_bp  7  /* Major Revision bit 3 position. */
+
+/* SYSCFG.OCDMCTRL  bit masks and bit positions */
+#define SYSCFG_OCDM_gm  0xFF  /* OCD Message group mask. */
+#define SYSCFG_OCDM_gp  0  /* OCD Message group position. */
+#define SYSCFG_OCDM_0_bm  (1<<0)  /* OCD Message bit 0 mask. */
+#define SYSCFG_OCDM_0_bp  0  /* OCD Message bit 0 position. */
+#define SYSCFG_OCDM_1_bm  (1<<1)  /* OCD Message bit 1 mask. */
+#define SYSCFG_OCDM_1_bp  1  /* OCD Message bit 1 position. */
+#define SYSCFG_OCDM_2_bm  (1<<2)  /* OCD Message bit 2 mask. */
+#define SYSCFG_OCDM_2_bp  2  /* OCD Message bit 2 position. */
+#define SYSCFG_OCDM_3_bm  (1<<3)  /* OCD Message bit 3 mask. */
+#define SYSCFG_OCDM_3_bp  3  /* OCD Message bit 3 position. */
+#define SYSCFG_OCDM_4_bm  (1<<4)  /* OCD Message bit 4 mask. */
+#define SYSCFG_OCDM_4_bp  4  /* OCD Message bit 4 position. */
+#define SYSCFG_OCDM_5_bm  (1<<5)  /* OCD Message bit 5 mask. */
+#define SYSCFG_OCDM_5_bp  5  /* OCD Message bit 5 position. */
+#define SYSCFG_OCDM_6_bm  (1<<6)  /* OCD Message bit 6 mask. */
+#define SYSCFG_OCDM_6_bp  6  /* OCD Message bit 6 position. */
+#define SYSCFG_OCDM_7_bm  (1<<7)  /* OCD Message bit 7 mask. */
+#define SYSCFG_OCDM_7_bp  7  /* OCD Message bit 7 position. */
+
+/* SYSCFG.OCDMSTATUS  bit masks and bit positions */
+#define SYSCFG_VALID_bm  0x01  /* OCD Message Valid bit mask. */
+#define SYSCFG_VALID_bp  0  /* OCD Message Valid bit position. */
+
+
+/* TCA - 16-bit Timer/Counter Type A */
+/* TCA_SINGLE.CTRLA  bit masks and bit positions */
+#define TCA_SINGLE_ENABLE_bm  0x01  /* Module Enable bit mask. */
+#define TCA_SINGLE_ENABLE_bp  0  /* Module Enable bit position. */
+#define TCA_SINGLE_CLKSEL_gm  0x0E  /* Clock Selection group mask. */
+#define TCA_SINGLE_CLKSEL_gp  1  /* Clock Selection group position. */
+#define TCA_SINGLE_CLKSEL_0_bm  (1<<1)  /* Clock Selection bit 0 mask. */
+#define TCA_SINGLE_CLKSEL_0_bp  1  /* Clock Selection bit 0 position. */
+#define TCA_SINGLE_CLKSEL_1_bm  (1<<2)  /* Clock Selection bit 1 mask. */
+#define TCA_SINGLE_CLKSEL_1_bp  2  /* Clock Selection bit 1 position. */
+#define TCA_SINGLE_CLKSEL_2_bm  (1<<3)  /* Clock Selection bit 2 mask. */
+#define TCA_SINGLE_CLKSEL_2_bp  3  /* Clock Selection bit 2 position. */
+#define TCA_SINGLE_RUNSTDBY_bm  0x80  /* Run in Standby bit mask. */
+#define TCA_SINGLE_RUNSTDBY_bp  7  /* Run in Standby bit position. */
+
+/* TCA_SINGLE.CTRLB  bit masks and bit positions */
+#define TCA_SINGLE_WGMODE_gm  0x07  /* Waveform generation mode group mask. */
+#define TCA_SINGLE_WGMODE_gp  0  /* Waveform generation mode group position. */
+#define TCA_SINGLE_WGMODE_0_bm  (1<<0)  /* Waveform generation mode bit 0 mask. */
+#define TCA_SINGLE_WGMODE_0_bp  0  /* Waveform generation mode bit 0 position. */
+#define TCA_SINGLE_WGMODE_1_bm  (1<<1)  /* Waveform generation mode bit 1 mask. */
+#define TCA_SINGLE_WGMODE_1_bp  1  /* Waveform generation mode bit 1 position. */
+#define TCA_SINGLE_WGMODE_2_bm  (1<<2)  /* Waveform generation mode bit 2 mask. */
+#define TCA_SINGLE_WGMODE_2_bp  2  /* Waveform generation mode bit 2 position. */
+#define TCA_SINGLE_ALUPD_bm  0x08  /* Auto Lock Update bit mask. */
+#define TCA_SINGLE_ALUPD_bp  3  /* Auto Lock Update bit position. */
+#define TCA_SINGLE_CMP0EN_bm  0x10  /* Compare 0 Enable bit mask. */
+#define TCA_SINGLE_CMP0EN_bp  4  /* Compare 0 Enable bit position. */
+#define TCA_SINGLE_CMP1EN_bm  0x20  /* Compare 1 Enable bit mask. */
+#define TCA_SINGLE_CMP1EN_bp  5  /* Compare 1 Enable bit position. */
+#define TCA_SINGLE_CMP2EN_bm  0x40  /* Compare 2 Enable bit mask. */
+#define TCA_SINGLE_CMP2EN_bp  6  /* Compare 2 Enable bit position. */
+
+/* TCA_SINGLE.CTRLC  bit masks and bit positions */
+#define TCA_SINGLE_CMP0OV_bm  0x01  /* Compare 0 Waveform Output Value bit mask. */
+#define TCA_SINGLE_CMP0OV_bp  0  /* Compare 0 Waveform Output Value bit position. */
+#define TCA_SINGLE_CMP1OV_bm  0x02  /* Compare 1 Waveform Output Value bit mask. */
+#define TCA_SINGLE_CMP1OV_bp  1  /* Compare 1 Waveform Output Value bit position. */
+#define TCA_SINGLE_CMP2OV_bm  0x04  /* Compare 2 Waveform Output Value bit mask. */
+#define TCA_SINGLE_CMP2OV_bp  2  /* Compare 2 Waveform Output Value bit position. */
+
+/* TCA_SINGLE.CTRLD  bit masks and bit positions */
+#define TCA_SINGLE_SPLITM_bm  0x01  /* Split Mode Enable bit mask. */
+#define TCA_SINGLE_SPLITM_bp  0  /* Split Mode Enable bit position. */
+
+/* TCA_SINGLE.CTRLECLR  bit masks and bit positions */
+#define TCA_SINGLE_DIR_bm  0x01  /* Direction bit mask. */
+#define TCA_SINGLE_DIR_bp  0  /* Direction bit position. */
+#define TCA_SINGLE_LUPD_bm  0x02  /* Lock Update bit mask. */
+#define TCA_SINGLE_LUPD_bp  1  /* Lock Update bit position. */
+#define TCA_SINGLE_CMD_gm  0x0C  /* Command group mask. */
+#define TCA_SINGLE_CMD_gp  2  /* Command group position. */
+#define TCA_SINGLE_CMD_0_bm  (1<<2)  /* Command bit 0 mask. */
+#define TCA_SINGLE_CMD_0_bp  2  /* Command bit 0 position. */
+#define TCA_SINGLE_CMD_1_bm  (1<<3)  /* Command bit 1 mask. */
+#define TCA_SINGLE_CMD_1_bp  3  /* Command bit 1 position. */
+
+/* TCA_SINGLE.CTRLESET  bit masks and bit positions */
+/* TCA_SINGLE_DIR  is already defined. */
+/* TCA_SINGLE_LUPD  is already defined. */
+/* TCA_SINGLE_CMD  is already defined. */
+
+/* TCA_SINGLE.CTRLFCLR  bit masks and bit positions */
+#define TCA_SINGLE_PERBV_bm  0x01  /* Period Buffer Valid bit mask. */
+#define TCA_SINGLE_PERBV_bp  0  /* Period Buffer Valid bit position. */
+#define TCA_SINGLE_CMP0BV_bm  0x02  /* Compare 0 Buffer Valid bit mask. */
+#define TCA_SINGLE_CMP0BV_bp  1  /* Compare 0 Buffer Valid bit position. */
+#define TCA_SINGLE_CMP1BV_bm  0x04  /* Compare 1 Buffer Valid bit mask. */
+#define TCA_SINGLE_CMP1BV_bp  2  /* Compare 1 Buffer Valid bit position. */
+#define TCA_SINGLE_CMP2BV_bm  0x08  /* Compare 2 Buffer Valid bit mask. */
+#define TCA_SINGLE_CMP2BV_bp  3  /* Compare 2 Buffer Valid bit position. */
+
+/* TCA_SINGLE.CTRLFSET  bit masks and bit positions */
+/* TCA_SINGLE_PERBV  is already defined. */
+/* TCA_SINGLE_CMP0BV  is already defined. */
+/* TCA_SINGLE_CMP1BV  is already defined. */
+/* TCA_SINGLE_CMP2BV  is already defined. */
+
+/* TCA_SINGLE.EVCTRL  bit masks and bit positions */
+#define TCA_SINGLE_CNTAEI_bm  0x01  /* Count on Event Input A bit mask. */
+#define TCA_SINGLE_CNTAEI_bp  0  /* Count on Event Input A bit position. */
+#define TCA_SINGLE_EVACTA_gm  0x0E  /* Event Action A group mask. */
+#define TCA_SINGLE_EVACTA_gp  1  /* Event Action A group position. */
+#define TCA_SINGLE_EVACTA_0_bm  (1<<1)  /* Event Action A bit 0 mask. */
+#define TCA_SINGLE_EVACTA_0_bp  1  /* Event Action A bit 0 position. */
+#define TCA_SINGLE_EVACTA_1_bm  (1<<2)  /* Event Action A bit 1 mask. */
+#define TCA_SINGLE_EVACTA_1_bp  2  /* Event Action A bit 1 position. */
+#define TCA_SINGLE_EVACTA_2_bm  (1<<3)  /* Event Action A bit 2 mask. */
+#define TCA_SINGLE_EVACTA_2_bp  3  /* Event Action A bit 2 position. */
+#define TCA_SINGLE_CNTBEI_bm  0x10  /* Count on Event Input B bit mask. */
+#define TCA_SINGLE_CNTBEI_bp  4  /* Count on Event Input B bit position. */
+#define TCA_SINGLE_EVACTB_gm  0xE0  /* Event Action B group mask. */
+#define TCA_SINGLE_EVACTB_gp  5  /* Event Action B group position. */
+#define TCA_SINGLE_EVACTB_0_bm  (1<<5)  /* Event Action B bit 0 mask. */
+#define TCA_SINGLE_EVACTB_0_bp  5  /* Event Action B bit 0 position. */
+#define TCA_SINGLE_EVACTB_1_bm  (1<<6)  /* Event Action B bit 1 mask. */
+#define TCA_SINGLE_EVACTB_1_bp  6  /* Event Action B bit 1 position. */
+#define TCA_SINGLE_EVACTB_2_bm  (1<<7)  /* Event Action B bit 2 mask. */
+#define TCA_SINGLE_EVACTB_2_bp  7  /* Event Action B bit 2 position. */
+
+/* TCA_SINGLE.INTCTRL  bit masks and bit positions */
+#define TCA_SINGLE_OVF_bm  0x01  /* Overflow Interrupt bit mask. */
+#define TCA_SINGLE_OVF_bp  0  /* Overflow Interrupt bit position. */
+#define TCA_SINGLE_CMP0_bm  0x10  /* Compare 0 Interrupt bit mask. */
+#define TCA_SINGLE_CMP0_bp  4  /* Compare 0 Interrupt bit position. */
+#define TCA_SINGLE_CMP1_bm  0x20  /* Compare 1 Interrupt bit mask. */
+#define TCA_SINGLE_CMP1_bp  5  /* Compare 1 Interrupt bit position. */
+#define TCA_SINGLE_CMP2_bm  0x40  /* Compare 2 Interrupt bit mask. */
+#define TCA_SINGLE_CMP2_bp  6  /* Compare 2 Interrupt bit position. */
+
+/* TCA_SINGLE.INTFLAGS  bit masks and bit positions */
+/* TCA_SINGLE_OVF  is already defined. */
+/* TCA_SINGLE_CMP0  is already defined. */
+/* TCA_SINGLE_CMP1  is already defined. */
+/* TCA_SINGLE_CMP2  is already defined. */
+
+/* TCA_SINGLE.DBGCTRL  bit masks and bit positions */
+#define TCA_SINGLE_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define TCA_SINGLE_DBGRUN_bp  0  /* Debug Run bit position. */
+
+/* TCA_SPLIT.CTRLA  bit masks and bit positions */
+#define TCA_SPLIT_ENABLE_bm  0x01  /* Module Enable bit mask. */
+#define TCA_SPLIT_ENABLE_bp  0  /* Module Enable bit position. */
+#define TCA_SPLIT_CLKSEL_gm  0x0E  /* Clock Selection group mask. */
+#define TCA_SPLIT_CLKSEL_gp  1  /* Clock Selection group position. */
+#define TCA_SPLIT_CLKSEL_0_bm  (1<<1)  /* Clock Selection bit 0 mask. */
+#define TCA_SPLIT_CLKSEL_0_bp  1  /* Clock Selection bit 0 position. */
+#define TCA_SPLIT_CLKSEL_1_bm  (1<<2)  /* Clock Selection bit 1 mask. */
+#define TCA_SPLIT_CLKSEL_1_bp  2  /* Clock Selection bit 1 position. */
+#define TCA_SPLIT_CLKSEL_2_bm  (1<<3)  /* Clock Selection bit 2 mask. */
+#define TCA_SPLIT_CLKSEL_2_bp  3  /* Clock Selection bit 2 position. */
+#define TCA_SPLIT_RUNSTDBY_bm  0x80  /* Run in Standby bit mask. */
+#define TCA_SPLIT_RUNSTDBY_bp  7  /* Run in Standby bit position. */
+
+/* TCA_SPLIT.CTRLB  bit masks and bit positions */
+#define TCA_SPLIT_LCMP0EN_bm  0x01  /* Low Compare 0 Enable bit mask. */
+#define TCA_SPLIT_LCMP0EN_bp  0  /* Low Compare 0 Enable bit position. */
+#define TCA_SPLIT_LCMP1EN_bm  0x02  /* Low Compare 1 Enable bit mask. */
+#define TCA_SPLIT_LCMP1EN_bp  1  /* Low Compare 1 Enable bit position. */
+#define TCA_SPLIT_LCMP2EN_bm  0x04  /* Low Compare 2 Enable bit mask. */
+#define TCA_SPLIT_LCMP2EN_bp  2  /* Low Compare 2 Enable bit position. */
+#define TCA_SPLIT_HCMP0EN_bm  0x10  /* High Compare 0 Enable bit mask. */
+#define TCA_SPLIT_HCMP0EN_bp  4  /* High Compare 0 Enable bit position. */
+#define TCA_SPLIT_HCMP1EN_bm  0x20  /* High Compare 1 Enable bit mask. */
+#define TCA_SPLIT_HCMP1EN_bp  5  /* High Compare 1 Enable bit position. */
+#define TCA_SPLIT_HCMP2EN_bm  0x40  /* High Compare 2 Enable bit mask. */
+#define TCA_SPLIT_HCMP2EN_bp  6  /* High Compare 2 Enable bit position. */
+
+/* TCA_SPLIT.CTRLC  bit masks and bit positions */
+#define TCA_SPLIT_LCMP0OV_bm  0x01  /* Low Compare 0 Output Value bit mask. */
+#define TCA_SPLIT_LCMP0OV_bp  0  /* Low Compare 0 Output Value bit position. */
+#define TCA_SPLIT_LCMP1OV_bm  0x02  /* Low Compare 1 Output Value bit mask. */
+#define TCA_SPLIT_LCMP1OV_bp  1  /* Low Compare 1 Output Value bit position. */
+#define TCA_SPLIT_LCMP2OV_bm  0x04  /* Low Compare 2 Output Value bit mask. */
+#define TCA_SPLIT_LCMP2OV_bp  2  /* Low Compare 2 Output Value bit position. */
+#define TCA_SPLIT_HCMP0OV_bm  0x10  /* High Compare 0 Output Value bit mask. */
+#define TCA_SPLIT_HCMP0OV_bp  4  /* High Compare 0 Output Value bit position. */
+#define TCA_SPLIT_HCMP1OV_bm  0x20  /* High Compare 1 Output Value bit mask. */
+#define TCA_SPLIT_HCMP1OV_bp  5  /* High Compare 1 Output Value bit position. */
+#define TCA_SPLIT_HCMP2OV_bm  0x40  /* High Compare 2 Output Value bit mask. */
+#define TCA_SPLIT_HCMP2OV_bp  6  /* High Compare 2 Output Value bit position. */
+
+/* TCA_SPLIT.CTRLD  bit masks and bit positions */
+#define TCA_SPLIT_SPLITM_bm  0x01  /* Split Mode Enable bit mask. */
+#define TCA_SPLIT_SPLITM_bp  0  /* Split Mode Enable bit position. */
+
+/* TCA_SPLIT.CTRLECLR  bit masks and bit positions */
+#define TCA_SPLIT_CMDEN_gm  0x03  /* Command Enable group mask. */
+#define TCA_SPLIT_CMDEN_gp  0  /* Command Enable group position. */
+#define TCA_SPLIT_CMDEN_0_bm  (1<<0)  /* Command Enable bit 0 mask. */
+#define TCA_SPLIT_CMDEN_0_bp  0  /* Command Enable bit 0 position. */
+#define TCA_SPLIT_CMDEN_1_bm  (1<<1)  /* Command Enable bit 1 mask. */
+#define TCA_SPLIT_CMDEN_1_bp  1  /* Command Enable bit 1 position. */
+#define TCA_SPLIT_CMD_gm  0x0C  /* Command group mask. */
+#define TCA_SPLIT_CMD_gp  2  /* Command group position. */
+#define TCA_SPLIT_CMD_0_bm  (1<<2)  /* Command bit 0 mask. */
+#define TCA_SPLIT_CMD_0_bp  2  /* Command bit 0 position. */
+#define TCA_SPLIT_CMD_1_bm  (1<<3)  /* Command bit 1 mask. */
+#define TCA_SPLIT_CMD_1_bp  3  /* Command bit 1 position. */
+
+/* TCA_SPLIT.CTRLESET  bit masks and bit positions */
+/* TCA_SPLIT_CMDEN  is already defined. */
+/* TCA_SPLIT_CMD  is already defined. */
+
+/* TCA_SPLIT.INTCTRL  bit masks and bit positions */
+#define TCA_SPLIT_LUNF_bm  0x01  /* Low Underflow Interrupt Enable bit mask. */
+#define TCA_SPLIT_LUNF_bp  0  /* Low Underflow Interrupt Enable bit position. */
+#define TCA_SPLIT_HUNF_bm  0x02  /* High Underflow Interrupt Enable bit mask. */
+#define TCA_SPLIT_HUNF_bp  1  /* High Underflow Interrupt Enable bit position. */
+#define TCA_SPLIT_LCMP0_bm  0x10  /* Low Compare 0 Interrupt Enable bit mask. */
+#define TCA_SPLIT_LCMP0_bp  4  /* Low Compare 0 Interrupt Enable bit position. */
+#define TCA_SPLIT_LCMP1_bm  0x20  /* Low Compare 1 Interrupt Enable bit mask. */
+#define TCA_SPLIT_LCMP1_bp  5  /* Low Compare 1 Interrupt Enable bit position. */
+#define TCA_SPLIT_LCMP2_bm  0x40  /* Low Compare 2 Interrupt Enable bit mask. */
+#define TCA_SPLIT_LCMP2_bp  6  /* Low Compare 2 Interrupt Enable bit position. */
+
+/* TCA_SPLIT.INTFLAGS  bit masks and bit positions */
+/* TCA_SPLIT_LUNF  is already defined. */
+/* TCA_SPLIT_HUNF  is already defined. */
+/* TCA_SPLIT_LCMP0  is already defined. */
+/* TCA_SPLIT_LCMP1  is already defined. */
+/* TCA_SPLIT_LCMP2  is already defined. */
+
+/* TCA_SPLIT.DBGCTRL  bit masks and bit positions */
+#define TCA_SPLIT_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define TCA_SPLIT_DBGRUN_bp  0  /* Debug Run bit position. */
+
+
+/* TCB - 16-bit Timer Type B */
+/* TCB.CTRLA  bit masks and bit positions */
+#define TCB_ENABLE_bm  0x01  /* Enable bit mask. */
+#define TCB_ENABLE_bp  0  /* Enable bit position. */
+#define TCB_CLKSEL_gm  0x0E  /* Clock Select group mask. */
+#define TCB_CLKSEL_gp  1  /* Clock Select group position. */
+#define TCB_CLKSEL_0_bm  (1<<1)  /* Clock Select bit 0 mask. */
+#define TCB_CLKSEL_0_bp  1  /* Clock Select bit 0 position. */
+#define TCB_CLKSEL_1_bm  (1<<2)  /* Clock Select bit 1 mask. */
+#define TCB_CLKSEL_1_bp  2  /* Clock Select bit 1 position. */
+#define TCB_CLKSEL_2_bm  (1<<3)  /* Clock Select bit 2 mask. */
+#define TCB_CLKSEL_2_bp  3  /* Clock Select bit 2 position. */
+#define TCB_SYNCUPD_bm  0x10  /* Synchronize Update bit mask. */
+#define TCB_SYNCUPD_bp  4  /* Synchronize Update bit position. */
+#define TCB_CASCADE_bm  0x20  /* Cascade two timers bit mask. */
+#define TCB_CASCADE_bp  5  /* Cascade two timers bit position. */
+#define TCB_RUNSTDBY_bm  0x40  /* Run Standby bit mask. */
+#define TCB_RUNSTDBY_bp  6  /* Run Standby bit position. */
+
+/* TCB.CTRLB  bit masks and bit positions */
+#define TCB_CNTMODE_gm  0x07  /* Timer Mode group mask. */
+#define TCB_CNTMODE_gp  0  /* Timer Mode group position. */
+#define TCB_CNTMODE_0_bm  (1<<0)  /* Timer Mode bit 0 mask. */
+#define TCB_CNTMODE_0_bp  0  /* Timer Mode bit 0 position. */
+#define TCB_CNTMODE_1_bm  (1<<1)  /* Timer Mode bit 1 mask. */
+#define TCB_CNTMODE_1_bp  1  /* Timer Mode bit 1 position. */
+#define TCB_CNTMODE_2_bm  (1<<2)  /* Timer Mode bit 2 mask. */
+#define TCB_CNTMODE_2_bp  2  /* Timer Mode bit 2 position. */
+#define TCB_CCMPEN_bm  0x10  /* Pin Output Enable bit mask. */
+#define TCB_CCMPEN_bp  4  /* Pin Output Enable bit position. */
+#define TCB_CCMPINIT_bm  0x20  /* Pin Initial State bit mask. */
+#define TCB_CCMPINIT_bp  5  /* Pin Initial State bit position. */
+#define TCB_ASYNC_bm  0x40  /* Asynchronous Enable bit mask. */
+#define TCB_ASYNC_bp  6  /* Asynchronous Enable bit position. */
+
+/* TCB.EVCTRL  bit masks and bit positions */
+#define TCB_CAPTEI_bm  0x01  /* Event Input Enable bit mask. */
+#define TCB_CAPTEI_bp  0  /* Event Input Enable bit position. */
+#define TCB_EDGE_bm  0x10  /* Event Edge bit mask. */
+#define TCB_EDGE_bp  4  /* Event Edge bit position. */
+#define TCB_FILTER_bm  0x40  /* Input Capture Noise Cancellation Filter bit mask. */
+#define TCB_FILTER_bp  6  /* Input Capture Noise Cancellation Filter bit position. */
+
+/* TCB.INTCTRL  bit masks and bit positions */
+#define TCB_CAPT_bm  0x01  /* Capture or Timeout bit mask. */
+#define TCB_CAPT_bp  0  /* Capture or Timeout bit position. */
+#define TCB_OVF_bm  0x02  /* Overflow bit mask. */
+#define TCB_OVF_bp  1  /* Overflow bit position. */
+
+/* TCB.INTFLAGS  bit masks and bit positions */
+/* TCB_CAPT  is already defined. */
+/* TCB_OVF  is already defined. */
+
+/* TCB.STATUS  bit masks and bit positions */
+#define TCB_RUN_bm  0x01  /* Run bit mask. */
+#define TCB_RUN_bp  0  /* Run bit position. */
+
+/* TCB.DBGCTRL  bit masks and bit positions */
+#define TCB_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define TCB_DBGRUN_bp  0  /* Debug Run bit position. */
+
+
+/* TWI - Two-Wire Interface */
+/* TWI.CTRLA  bit masks and bit positions */
+#define TWI_FMEN_bm  0x01  /* Fast-mode Enable bit mask. */
+#define TWI_FMEN_bp  0  /* Fast-mode Enable bit position. */
+#define TWI_FMPEN_bm  0x02  /* Fast-mode Plus Enable bit mask. */
+#define TWI_FMPEN_bp  1  /* Fast-mode Plus Enable bit position. */
+#define TWI_SDAHOLD_gm  0x0C  /* SDA Hold Time group mask. */
+#define TWI_SDAHOLD_gp  2  /* SDA Hold Time group position. */
+#define TWI_SDAHOLD_0_bm  (1<<2)  /* SDA Hold Time bit 0 mask. */
+#define TWI_SDAHOLD_0_bp  2  /* SDA Hold Time bit 0 position. */
+#define TWI_SDAHOLD_1_bm  (1<<3)  /* SDA Hold Time bit 1 mask. */
+#define TWI_SDAHOLD_1_bp  3  /* SDA Hold Time bit 1 position. */
+#define TWI_SDASETUP_bm  0x10  /* SDA Setup Time bit mask. */
+#define TWI_SDASETUP_bp  4  /* SDA Setup Time bit position. */
+#define TWI_INPUTLVL_bm  0x40  /* Input voltage transition level bit mask. */
+#define TWI_INPUTLVL_bp  6  /* Input voltage transition level bit position. */
+
+/* TWI.DUALCTRL  bit masks and bit positions */
+#define TWI_ENABLE_bm  0x01  /* Enable bit mask. */
+#define TWI_ENABLE_bp  0  /* Enable bit position. */
+/* TWI_FMPEN  is already defined. */
+/* TWI_SDAHOLD  is already defined. */
+/* TWI_INPUTLVL  is already defined. */
+
+/* TWI.DBGCTRL  bit masks and bit positions */
+#define TWI_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define TWI_DBGRUN_bp  0  /* Debug Run bit position. */
+
+/* TWI.MCTRLA  bit masks and bit positions */
+/* TWI_ENABLE  is already defined. */
+#define TWI_SMEN_bm  0x02  /* Smart Mode Enable bit mask. */
+#define TWI_SMEN_bp  1  /* Smart Mode Enable bit position. */
+#define TWI_TIMEOUT_gm  0x0C  /* Inactive Bus Time-Out group mask. */
+#define TWI_TIMEOUT_gp  2  /* Inactive Bus Time-Out group position. */
+#define TWI_TIMEOUT_0_bm  (1<<2)  /* Inactive Bus Time-Out bit 0 mask. */
+#define TWI_TIMEOUT_0_bp  2  /* Inactive Bus Time-Out bit 0 position. */
+#define TWI_TIMEOUT_1_bm  (1<<3)  /* Inactive Bus Time-Out bit 1 mask. */
+#define TWI_TIMEOUT_1_bp  3  /* Inactive Bus Time-Out bit 1 position. */
+#define TWI_QCEN_bm  0x10  /* Quick Command Enable bit mask. */
+#define TWI_QCEN_bp  4  /* Quick Command Enable bit position. */
+#define TWI_WIEN_bm  0x40  /* Write Interrupt Enable bit mask. */
+#define TWI_WIEN_bp  6  /* Write Interrupt Enable bit position. */
+#define TWI_RIEN_bm  0x80  /* Read Interrupt Enable bit mask. */
+#define TWI_RIEN_bp  7  /* Read Interrupt Enable bit position. */
+
+/* TWI.MCTRLB  bit masks and bit positions */
+#define TWI_MCMD_gm  0x03  /* Command group mask. */
+#define TWI_MCMD_gp  0  /* Command group position. */
+#define TWI_MCMD_0_bm  (1<<0)  /* Command bit 0 mask. */
+#define TWI_MCMD_0_bp  0  /* Command bit 0 position. */
+#define TWI_MCMD_1_bm  (1<<1)  /* Command bit 1 mask. */
+#define TWI_MCMD_1_bp  1  /* Command bit 1 position. */
+#define TWI_ACKACT_bm  0x04  /* Acknowledge Action bit mask. */
+#define TWI_ACKACT_bp  2  /* Acknowledge Action bit position. */
+#define TWI_FLUSH_bm  0x08  /* Flush bit mask. */
+#define TWI_FLUSH_bp  3  /* Flush bit position. */
+
+/* TWI.MSTATUS  bit masks and bit positions */
+#define TWI_BUSSTATE_gm  0x03  /* Bus State group mask. */
+#define TWI_BUSSTATE_gp  0  /* Bus State group position. */
+#define TWI_BUSSTATE_0_bm  (1<<0)  /* Bus State bit 0 mask. */
+#define TWI_BUSSTATE_0_bp  0  /* Bus State bit 0 position. */
+#define TWI_BUSSTATE_1_bm  (1<<1)  /* Bus State bit 1 mask. */
+#define TWI_BUSSTATE_1_bp  1  /* Bus State bit 1 position. */
+#define TWI_BUSERR_bm  0x04  /* Bus Error bit mask. */
+#define TWI_BUSERR_bp  2  /* Bus Error bit position. */
+#define TWI_ARBLOST_bm  0x08  /* Arbitration Lost bit mask. */
+#define TWI_ARBLOST_bp  3  /* Arbitration Lost bit position. */
+#define TWI_RXACK_bm  0x10  /* Received Acknowledge bit mask. */
+#define TWI_RXACK_bp  4  /* Received Acknowledge bit position. */
+#define TWI_CLKHOLD_bm  0x20  /* Clock Hold bit mask. */
+#define TWI_CLKHOLD_bp  5  /* Clock Hold bit position. */
+#define TWI_WIF_bm  0x40  /* Write Interrupt Flag bit mask. */
+#define TWI_WIF_bp  6  /* Write Interrupt Flag bit position. */
+#define TWI_RIF_bm  0x80  /* Read Interrupt Flag bit mask. */
+#define TWI_RIF_bp  7  /* Read Interrupt Flag bit position. */
+
+/* TWI.MBAUD  bit masks and bit positions */
+#define TWI_BAUD_gm  0xFF  /* Baud Rate group mask. */
+#define TWI_BAUD_gp  0  /* Baud Rate group position. */
+#define TWI_BAUD_0_bm  (1<<0)  /* Baud Rate bit 0 mask. */
+#define TWI_BAUD_0_bp  0  /* Baud Rate bit 0 position. */
+#define TWI_BAUD_1_bm  (1<<1)  /* Baud Rate bit 1 mask. */
+#define TWI_BAUD_1_bp  1  /* Baud Rate bit 1 position. */
+#define TWI_BAUD_2_bm  (1<<2)  /* Baud Rate bit 2 mask. */
+#define TWI_BAUD_2_bp  2  /* Baud Rate bit 2 position. */
+#define TWI_BAUD_3_bm  (1<<3)  /* Baud Rate bit 3 mask. */
+#define TWI_BAUD_3_bp  3  /* Baud Rate bit 3 position. */
+#define TWI_BAUD_4_bm  (1<<4)  /* Baud Rate bit 4 mask. */
+#define TWI_BAUD_4_bp  4  /* Baud Rate bit 4 position. */
+#define TWI_BAUD_5_bm  (1<<5)  /* Baud Rate bit 5 mask. */
+#define TWI_BAUD_5_bp  5  /* Baud Rate bit 5 position. */
+#define TWI_BAUD_6_bm  (1<<6)  /* Baud Rate bit 6 mask. */
+#define TWI_BAUD_6_bp  6  /* Baud Rate bit 6 position. */
+#define TWI_BAUD_7_bm  (1<<7)  /* Baud Rate bit 7 mask. */
+#define TWI_BAUD_7_bp  7  /* Baud Rate bit 7 position. */
+
+/* TWI.MADDR  bit masks and bit positions */
+#define TWI_ADDR_gm  0xFF  /* Address group mask. */
+#define TWI_ADDR_gp  0  /* Address group position. */
+#define TWI_ADDR_0_bm  (1<<0)  /* Address bit 0 mask. */
+#define TWI_ADDR_0_bp  0  /* Address bit 0 position. */
+#define TWI_ADDR_1_bm  (1<<1)  /* Address bit 1 mask. */
+#define TWI_ADDR_1_bp  1  /* Address bit 1 position. */
+#define TWI_ADDR_2_bm  (1<<2)  /* Address bit 2 mask. */
+#define TWI_ADDR_2_bp  2  /* Address bit 2 position. */
+#define TWI_ADDR_3_bm  (1<<3)  /* Address bit 3 mask. */
+#define TWI_ADDR_3_bp  3  /* Address bit 3 position. */
+#define TWI_ADDR_4_bm  (1<<4)  /* Address bit 4 mask. */
+#define TWI_ADDR_4_bp  4  /* Address bit 4 position. */
+#define TWI_ADDR_5_bm  (1<<5)  /* Address bit 5 mask. */
+#define TWI_ADDR_5_bp  5  /* Address bit 5 position. */
+#define TWI_ADDR_6_bm  (1<<6)  /* Address bit 6 mask. */
+#define TWI_ADDR_6_bp  6  /* Address bit 6 position. */
+#define TWI_ADDR_7_bm  (1<<7)  /* Address bit 7 mask. */
+#define TWI_ADDR_7_bp  7  /* Address bit 7 position. */
+
+/* TWI.MDATA  bit masks and bit positions */
+#define TWI_DATA_gm  0xFF  /* Data group mask. */
+#define TWI_DATA_gp  0  /* Data group position. */
+#define TWI_DATA_0_bm  (1<<0)  /* Data bit 0 mask. */
+#define TWI_DATA_0_bp  0  /* Data bit 0 position. */
+#define TWI_DATA_1_bm  (1<<1)  /* Data bit 1 mask. */
+#define TWI_DATA_1_bp  1  /* Data bit 1 position. */
+#define TWI_DATA_2_bm  (1<<2)  /* Data bit 2 mask. */
+#define TWI_DATA_2_bp  2  /* Data bit 2 position. */
+#define TWI_DATA_3_bm  (1<<3)  /* Data bit 3 mask. */
+#define TWI_DATA_3_bp  3  /* Data bit 3 position. */
+#define TWI_DATA_4_bm  (1<<4)  /* Data bit 4 mask. */
+#define TWI_DATA_4_bp  4  /* Data bit 4 position. */
+#define TWI_DATA_5_bm  (1<<5)  /* Data bit 5 mask. */
+#define TWI_DATA_5_bp  5  /* Data bit 5 position. */
+#define TWI_DATA_6_bm  (1<<6)  /* Data bit 6 mask. */
+#define TWI_DATA_6_bp  6  /* Data bit 6 position. */
+#define TWI_DATA_7_bm  (1<<7)  /* Data bit 7 mask. */
+#define TWI_DATA_7_bp  7  /* Data bit 7 position. */
+
+/* TWI.SCTRLA  bit masks and bit positions */
+/* TWI_ENABLE  is already defined. */
+/* TWI_SMEN  is already defined. */
+#define TWI_PMEN_bm  0x04  /* Address Recognition Mode bit mask. */
+#define TWI_PMEN_bp  2  /* Address Recognition Mode bit position. */
+#define TWI_PIEN_bm  0x20  /* Stop Interrupt Enable bit mask. */
+#define TWI_PIEN_bp  5  /* Stop Interrupt Enable bit position. */
+#define TWI_APIEN_bm  0x40  /* Address or Stop Interrupt Enable bit mask. */
+#define TWI_APIEN_bp  6  /* Address or Stop Interrupt Enable bit position. */
+#define TWI_DIEN_bm  0x80  /* Data Interrupt Enable bit mask. */
+#define TWI_DIEN_bp  7  /* Data Interrupt Enable bit position. */
+
+/* TWI.SCTRLB  bit masks and bit positions */
+#define TWI_SCMD_gm  0x03  /* Command group mask. */
+#define TWI_SCMD_gp  0  /* Command group position. */
+#define TWI_SCMD_0_bm  (1<<0)  /* Command bit 0 mask. */
+#define TWI_SCMD_0_bp  0  /* Command bit 0 position. */
+#define TWI_SCMD_1_bm  (1<<1)  /* Command bit 1 mask. */
+#define TWI_SCMD_1_bp  1  /* Command bit 1 position. */
+/* TWI_ACKACT  is already defined. */
+
+/* TWI.SSTATUS  bit masks and bit positions */
+#define TWI_AP_bm  0x01  /* Address or Stop bit mask. */
+#define TWI_AP_bp  0  /* Address or Stop bit position. */
+#define TWI_DIR_bm  0x02  /* Read/Write Direction bit mask. */
+#define TWI_DIR_bp  1  /* Read/Write Direction bit position. */
+/* TWI_BUSERR  is already defined. */
+#define TWI_COLL_bm  0x08  /* Collision bit mask. */
+#define TWI_COLL_bp  3  /* Collision bit position. */
+/* TWI_RXACK  is already defined. */
+/* TWI_CLKHOLD  is already defined. */
+#define TWI_APIF_bm  0x40  /* Address or Stop Interrupt Flag bit mask. */
+#define TWI_APIF_bp  6  /* Address or Stop Interrupt Flag bit position. */
+#define TWI_DIF_bm  0x80  /* Data Interrupt Flag bit mask. */
+#define TWI_DIF_bp  7  /* Data Interrupt Flag bit position. */
+
+/* TWI.SADDR  bit masks and bit positions */
+/* TWI_ADDR  is already defined. */
+
+/* TWI.SDATA  bit masks and bit positions */
+/* TWI_DATA  is already defined. */
+
+/* TWI.SADDRMASK  bit masks and bit positions */
+#define TWI_ADDREN_bm  0x01  /* Address Mask Enable bit mask. */
+#define TWI_ADDREN_bp  0  /* Address Mask Enable bit position. */
+#define TWI_ADDRMASK_gm  0xFE  /* Address Mask group mask. */
+#define TWI_ADDRMASK_gp  1  /* Address Mask group position. */
+#define TWI_ADDRMASK_0_bm  (1<<1)  /* Address Mask bit 0 mask. */
+#define TWI_ADDRMASK_0_bp  1  /* Address Mask bit 0 position. */
+#define TWI_ADDRMASK_1_bm  (1<<2)  /* Address Mask bit 1 mask. */
+#define TWI_ADDRMASK_1_bp  2  /* Address Mask bit 1 position. */
+#define TWI_ADDRMASK_2_bm  (1<<3)  /* Address Mask bit 2 mask. */
+#define TWI_ADDRMASK_2_bp  3  /* Address Mask bit 2 position. */
+#define TWI_ADDRMASK_3_bm  (1<<4)  /* Address Mask bit 3 mask. */
+#define TWI_ADDRMASK_3_bp  4  /* Address Mask bit 3 position. */
+#define TWI_ADDRMASK_4_bm  (1<<5)  /* Address Mask bit 4 mask. */
+#define TWI_ADDRMASK_4_bp  5  /* Address Mask bit 4 position. */
+#define TWI_ADDRMASK_5_bm  (1<<6)  /* Address Mask bit 5 mask. */
+#define TWI_ADDRMASK_5_bp  6  /* Address Mask bit 5 position. */
+#define TWI_ADDRMASK_6_bm  (1<<7)  /* Address Mask bit 6 mask. */
+#define TWI_ADDRMASK_6_bp  7  /* Address Mask bit 6 position. */
+
+
+/* USART - Universal Synchronous and Asynchronous Receiver and Transmitter */
+/* USART.RXDATAL  bit masks and bit positions */
+#define USART_DATA_gm  0xFF  /* RX Data group mask. */
+#define USART_DATA_gp  0  /* RX Data group position. */
+#define USART_DATA_0_bm  (1<<0)  /* RX Data bit 0 mask. */
+#define USART_DATA_0_bp  0  /* RX Data bit 0 position. */
+#define USART_DATA_1_bm  (1<<1)  /* RX Data bit 1 mask. */
+#define USART_DATA_1_bp  1  /* RX Data bit 1 position. */
+#define USART_DATA_2_bm  (1<<2)  /* RX Data bit 2 mask. */
+#define USART_DATA_2_bp  2  /* RX Data bit 2 position. */
+#define USART_DATA_3_bm  (1<<3)  /* RX Data bit 3 mask. */
+#define USART_DATA_3_bp  3  /* RX Data bit 3 position. */
+#define USART_DATA_4_bm  (1<<4)  /* RX Data bit 4 mask. */
+#define USART_DATA_4_bp  4  /* RX Data bit 4 position. */
+#define USART_DATA_5_bm  (1<<5)  /* RX Data bit 5 mask. */
+#define USART_DATA_5_bp  5  /* RX Data bit 5 position. */
+#define USART_DATA_6_bm  (1<<6)  /* RX Data bit 6 mask. */
+#define USART_DATA_6_bp  6  /* RX Data bit 6 position. */
+#define USART_DATA_7_bm  (1<<7)  /* RX Data bit 7 mask. */
+#define USART_DATA_7_bp  7  /* RX Data bit 7 position. */
+
+/* USART.RXDATAH  bit masks and bit positions */
+#define USART_DATA8_bm  0x01  /* Receiver Data Register bit mask. */
+#define USART_DATA8_bp  0  /* Receiver Data Register bit position. */
+#define USART_PERR_bm  0x02  /* Parity Error bit mask. */
+#define USART_PERR_bp  1  /* Parity Error bit position. */
+#define USART_FERR_bm  0x04  /* Frame Error bit mask. */
+#define USART_FERR_bp  2  /* Frame Error bit position. */
+#define USART_BUFOVF_bm  0x40  /* Buffer Overflow bit mask. */
+#define USART_BUFOVF_bp  6  /* Buffer Overflow bit position. */
+#define USART_RXCIF_bm  0x80  /* Receive Complete Interrupt Flag bit mask. */
+#define USART_RXCIF_bp  7  /* Receive Complete Interrupt Flag bit position. */
+
+/* USART.TXDATAL  bit masks and bit positions */
+/* USART_DATA  is already defined. */
+
+/* USART.TXDATAH  bit masks and bit positions */
+/* USART_DATA8  is already defined. */
+
+/* USART.STATUS  bit masks and bit positions */
+#define USART_WFB_bm  0x01  /* Wait For Break bit mask. */
+#define USART_WFB_bp  0  /* Wait For Break bit position. */
+#define USART_BDF_bm  0x02  /* Break Detected Flag bit mask. */
+#define USART_BDF_bp  1  /* Break Detected Flag bit position. */
+#define USART_ISFIF_bm  0x08  /* Inconsistent Sync Field Interrupt Flag bit mask. */
+#define USART_ISFIF_bp  3  /* Inconsistent Sync Field Interrupt Flag bit position. */
+#define USART_RXSIF_bm  0x10  /* Receive Start Interrupt bit mask. */
+#define USART_RXSIF_bp  4  /* Receive Start Interrupt bit position. */
+#define USART_DREIF_bm  0x20  /* Data Register Empty Flag bit mask. */
+#define USART_DREIF_bp  5  /* Data Register Empty Flag bit position. */
+#define USART_TXCIF_bm  0x40  /* Transmit Interrupt Flag bit mask. */
+#define USART_TXCIF_bp  6  /* Transmit Interrupt Flag bit position. */
+/* USART_RXCIF  is already defined. */
+
+/* USART.CTRLA  bit masks and bit positions */
+#define USART_RS485_bm  0x01  /* RS485 Mode internal transmitter bit mask. */
+#define USART_RS485_bp  0  /* RS485 Mode internal transmitter bit position. */
+#define USART_ABEIE_bm  0x04  /* Auto-baud Error Interrupt Enable bit mask. */
+#define USART_ABEIE_bp  2  /* Auto-baud Error Interrupt Enable bit position. */
+#define USART_LBME_bm  0x08  /* Loop-back Mode Enable bit mask. */
+#define USART_LBME_bp  3  /* Loop-back Mode Enable bit position. */
+#define USART_RXSIE_bm  0x10  /* Receiver Start Frame Interrupt Enable bit mask. */
+#define USART_RXSIE_bp  4  /* Receiver Start Frame Interrupt Enable bit position. */
+#define USART_DREIE_bm  0x20  /* Data Register Empty Interrupt Enable bit mask. */
+#define USART_DREIE_bp  5  /* Data Register Empty Interrupt Enable bit position. */
+#define USART_TXCIE_bm  0x40  /* Transmit Complete Interrupt Enable bit mask. */
+#define USART_TXCIE_bp  6  /* Transmit Complete Interrupt Enable bit position. */
+#define USART_RXCIE_bm  0x80  /* Receive Complete Interrupt Enable bit mask. */
+#define USART_RXCIE_bp  7  /* Receive Complete Interrupt Enable bit position. */
+
+/* USART.CTRLB  bit masks and bit positions */
+#define USART_MPCM_bm  0x01  /* Multi-processor Communication Mode bit mask. */
+#define USART_MPCM_bp  0  /* Multi-processor Communication Mode bit position. */
+#define USART_RXMODE_gm  0x06  /* Receiver Mode group mask. */
+#define USART_RXMODE_gp  1  /* Receiver Mode group position. */
+#define USART_RXMODE_0_bm  (1<<1)  /* Receiver Mode bit 0 mask. */
+#define USART_RXMODE_0_bp  1  /* Receiver Mode bit 0 position. */
+#define USART_RXMODE_1_bm  (1<<2)  /* Receiver Mode bit 1 mask. */
+#define USART_RXMODE_1_bp  2  /* Receiver Mode bit 1 position. */
+#define USART_ODME_bm  0x08  /* Open Drain Mode Enable bit mask. */
+#define USART_ODME_bp  3  /* Open Drain Mode Enable bit position. */
+#define USART_SFDEN_bm  0x10  /* Start Frame Detection Enable bit mask. */
+#define USART_SFDEN_bp  4  /* Start Frame Detection Enable bit position. */
+#define USART_TXEN_bm  0x40  /* Transmitter Enable bit mask. */
+#define USART_TXEN_bp  6  /* Transmitter Enable bit position. */
+#define USART_RXEN_bm  0x80  /* Reciever enable bit mask. */
+#define USART_RXEN_bp  7  /* Reciever enable bit position. */
+
+/* USART.CTRLC  bit masks and bit positions */
+#define USART_UCPHA_bm  0x02  /* SPI Host Mode, Clock Phase bit mask. */
+#define USART_UCPHA_bp  1  /* SPI Host Mode, Clock Phase bit position. */
+#define USART_UDORD_bm  0x04  /* SPI Host Mode, Data Order bit mask. */
+#define USART_UDORD_bp  2  /* SPI Host Mode, Data Order bit position. */
+#define USART_CHSIZE_gm  0x07  /* Character Size group mask. */
+#define USART_CHSIZE_gp  0  /* Character Size group position. */
+#define USART_CHSIZE_0_bm  (1<<0)  /* Character Size bit 0 mask. */
+#define USART_CHSIZE_0_bp  0  /* Character Size bit 0 position. */
+#define USART_CHSIZE_1_bm  (1<<1)  /* Character Size bit 1 mask. */
+#define USART_CHSIZE_1_bp  1  /* Character Size bit 1 position. */
+#define USART_CHSIZE_2_bm  (1<<2)  /* Character Size bit 2 mask. */
+#define USART_CHSIZE_2_bp  2  /* Character Size bit 2 position. */
+#define USART_SBMODE_bm  0x08  /* Stop Bit Mode bit mask. */
+#define USART_SBMODE_bp  3  /* Stop Bit Mode bit position. */
+#define USART_PMODE_gm  0x30  /* Parity Mode group mask. */
+#define USART_PMODE_gp  4  /* Parity Mode group position. */
+#define USART_PMODE_0_bm  (1<<4)  /* Parity Mode bit 0 mask. */
+#define USART_PMODE_0_bp  4  /* Parity Mode bit 0 position. */
+#define USART_PMODE_1_bm  (1<<5)  /* Parity Mode bit 1 mask. */
+#define USART_PMODE_1_bp  5  /* Parity Mode bit 1 position. */
+#define USART_CMODE_gm  0xC0  /* Communication Mode group mask. */
+#define USART_CMODE_gp  6  /* Communication Mode group position. */
+#define USART_CMODE_0_bm  (1<<6)  /* Communication Mode bit 0 mask. */
+#define USART_CMODE_0_bp  6  /* Communication Mode bit 0 position. */
+#define USART_CMODE_1_bm  (1<<7)  /* Communication Mode bit 1 mask. */
+#define USART_CMODE_1_bp  7  /* Communication Mode bit 1 position. */
+
+/* USART.CTRLD  bit masks and bit positions */
+#define USART_ABW_gm  0xC0  /* Auto Baud Window group mask. */
+#define USART_ABW_gp  6  /* Auto Baud Window group position. */
+#define USART_ABW_0_bm  (1<<6)  /* Auto Baud Window bit 0 mask. */
+#define USART_ABW_0_bp  6  /* Auto Baud Window bit 0 position. */
+#define USART_ABW_1_bm  (1<<7)  /* Auto Baud Window bit 1 mask. */
+#define USART_ABW_1_bp  7  /* Auto Baud Window bit 1 position. */
+
+/* USART.DBGCTRL  bit masks and bit positions */
+#define USART_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define USART_DBGRUN_bp  0  /* Debug Run bit position. */
+
+/* USART.EVCTRL  bit masks and bit positions */
+#define USART_IREI_bm  0x01  /* IrDA Event Input Enable bit mask. */
+#define USART_IREI_bp  0  /* IrDA Event Input Enable bit position. */
+
+/* USART.TXPLCTRL  bit masks and bit positions */
+#define USART_TXPL_gm  0xFF  /* Transmit pulse length group mask. */
+#define USART_TXPL_gp  0  /* Transmit pulse length group position. */
+#define USART_TXPL_0_bm  (1<<0)  /* Transmit pulse length bit 0 mask. */
+#define USART_TXPL_0_bp  0  /* Transmit pulse length bit 0 position. */
+#define USART_TXPL_1_bm  (1<<1)  /* Transmit pulse length bit 1 mask. */
+#define USART_TXPL_1_bp  1  /* Transmit pulse length bit 1 position. */
+#define USART_TXPL_2_bm  (1<<2)  /* Transmit pulse length bit 2 mask. */
+#define USART_TXPL_2_bp  2  /* Transmit pulse length bit 2 position. */
+#define USART_TXPL_3_bm  (1<<3)  /* Transmit pulse length bit 3 mask. */
+#define USART_TXPL_3_bp  3  /* Transmit pulse length bit 3 position. */
+#define USART_TXPL_4_bm  (1<<4)  /* Transmit pulse length bit 4 mask. */
+#define USART_TXPL_4_bp  4  /* Transmit pulse length bit 4 position. */
+#define USART_TXPL_5_bm  (1<<5)  /* Transmit pulse length bit 5 mask. */
+#define USART_TXPL_5_bp  5  /* Transmit pulse length bit 5 position. */
+#define USART_TXPL_6_bm  (1<<6)  /* Transmit pulse length bit 6 mask. */
+#define USART_TXPL_6_bp  6  /* Transmit pulse length bit 6 position. */
+#define USART_TXPL_7_bm  (1<<7)  /* Transmit pulse length bit 7 mask. */
+#define USART_TXPL_7_bp  7  /* Transmit pulse length bit 7 position. */
+
+/* USART.RXPLCTRL  bit masks and bit positions */
+#define USART_RXPL_gm  0x7F  /* Receiver Pulse Lenght group mask. */
+#define USART_RXPL_gp  0  /* Receiver Pulse Lenght group position. */
+#define USART_RXPL_0_bm  (1<<0)  /* Receiver Pulse Lenght bit 0 mask. */
+#define USART_RXPL_0_bp  0  /* Receiver Pulse Lenght bit 0 position. */
+#define USART_RXPL_1_bm  (1<<1)  /* Receiver Pulse Lenght bit 1 mask. */
+#define USART_RXPL_1_bp  1  /* Receiver Pulse Lenght bit 1 position. */
+#define USART_RXPL_2_bm  (1<<2)  /* Receiver Pulse Lenght bit 2 mask. */
+#define USART_RXPL_2_bp  2  /* Receiver Pulse Lenght bit 2 position. */
+#define USART_RXPL_3_bm  (1<<3)  /* Receiver Pulse Lenght bit 3 mask. */
+#define USART_RXPL_3_bp  3  /* Receiver Pulse Lenght bit 3 position. */
+#define USART_RXPL_4_bm  (1<<4)  /* Receiver Pulse Lenght bit 4 mask. */
+#define USART_RXPL_4_bp  4  /* Receiver Pulse Lenght bit 4 position. */
+#define USART_RXPL_5_bm  (1<<5)  /* Receiver Pulse Lenght bit 5 mask. */
+#define USART_RXPL_5_bp  5  /* Receiver Pulse Lenght bit 5 position. */
+#define USART_RXPL_6_bm  (1<<6)  /* Receiver Pulse Lenght bit 6 mask. */
+#define USART_RXPL_6_bp  6  /* Receiver Pulse Lenght bit 6 position. */
+
+
+
+/* VPORT - Virtual Ports */
+/* VPORT.INTFLAGS  bit masks and bit positions */
+#define VPORT_INT_gm  0xFF  /* Pin Interrupt Flag group mask. */
+#define VPORT_INT_gp  0  /* Pin Interrupt Flag group position. */
+#define VPORT_INT_0_bm  (1<<0)  /* Pin Interrupt Flag bit 0 mask. */
+#define VPORT_INT_0_bp  0  /* Pin Interrupt Flag bit 0 position. */
+#define VPORT_INT_1_bm  (1<<1)  /* Pin Interrupt Flag bit 1 mask. */
+#define VPORT_INT_1_bp  1  /* Pin Interrupt Flag bit 1 position. */
+#define VPORT_INT_2_bm  (1<<2)  /* Pin Interrupt Flag bit 2 mask. */
+#define VPORT_INT_2_bp  2  /* Pin Interrupt Flag bit 2 position. */
+#define VPORT_INT_3_bm  (1<<3)  /* Pin Interrupt Flag bit 3 mask. */
+#define VPORT_INT_3_bp  3  /* Pin Interrupt Flag bit 3 position. */
+#define VPORT_INT_4_bm  (1<<4)  /* Pin Interrupt Flag bit 4 mask. */
+#define VPORT_INT_4_bp  4  /* Pin Interrupt Flag bit 4 position. */
+#define VPORT_INT_5_bm  (1<<5)  /* Pin Interrupt Flag bit 5 mask. */
+#define VPORT_INT_5_bp  5  /* Pin Interrupt Flag bit 5 position. */
+#define VPORT_INT_6_bm  (1<<6)  /* Pin Interrupt Flag bit 6 mask. */
+#define VPORT_INT_6_bp  6  /* Pin Interrupt Flag bit 6 position. */
+#define VPORT_INT_7_bm  (1<<7)  /* Pin Interrupt Flag bit 7 mask. */
+#define VPORT_INT_7_bp  7  /* Pin Interrupt Flag bit 7 position. */
+
+
+/* VREF - Voltage reference */
+/* VREF.DAC0REF  bit masks and bit positions */
+#define VREF_REFSEL_gm  0x07  /* Reference select group mask. */
+#define VREF_REFSEL_gp  0  /* Reference select group position. */
+#define VREF_REFSEL_0_bm  (1<<0)  /* Reference select bit 0 mask. */
+#define VREF_REFSEL_0_bp  0  /* Reference select bit 0 position. */
+#define VREF_REFSEL_1_bm  (1<<1)  /* Reference select bit 1 mask. */
+#define VREF_REFSEL_1_bp  1  /* Reference select bit 1 position. */
+#define VREF_REFSEL_2_bm  (1<<2)  /* Reference select bit 2 mask. */
+#define VREF_REFSEL_2_bp  2  /* Reference select bit 2 position. */
+#define VREF_ALWAYSON_bm  0x80  /* Always on bit mask. */
+#define VREF_ALWAYSON_bp  7  /* Always on bit position. */
+
+/* VREF.ACREF  bit masks and bit positions */
+/* VREF_REFSEL  is already defined. */
+/* VREF_ALWAYSON  is already defined. */
+
+
+/* WDT - Watch-Dog Timer */
+/* WDT.CTRLA  bit masks and bit positions */
+#define WDT_PERIOD_gm  0x0F  /* Period group mask. */
+#define WDT_PERIOD_gp  0  /* Period group position. */
+#define WDT_PERIOD_0_bm  (1<<0)  /* Period bit 0 mask. */
+#define WDT_PERIOD_0_bp  0  /* Period bit 0 position. */
+#define WDT_PERIOD_1_bm  (1<<1)  /* Period bit 1 mask. */
+#define WDT_PERIOD_1_bp  1  /* Period bit 1 position. */
+#define WDT_PERIOD_2_bm  (1<<2)  /* Period bit 2 mask. */
+#define WDT_PERIOD_2_bp  2  /* Period bit 2 position. */
+#define WDT_PERIOD_3_bm  (1<<3)  /* Period bit 3 mask. */
+#define WDT_PERIOD_3_bp  3  /* Period bit 3 position. */
+#define WDT_WINDOW_gm  0xF0  /* Window group mask. */
+#define WDT_WINDOW_gp  4  /* Window group position. */
+#define WDT_WINDOW_0_bm  (1<<4)  /* Window bit 0 mask. */
+#define WDT_WINDOW_0_bp  4  /* Window bit 0 position. */
+#define WDT_WINDOW_1_bm  (1<<5)  /* Window bit 1 mask. */
+#define WDT_WINDOW_1_bp  5  /* Window bit 1 position. */
+#define WDT_WINDOW_2_bm  (1<<6)  /* Window bit 2 mask. */
+#define WDT_WINDOW_2_bp  6  /* Window bit 2 position. */
+#define WDT_WINDOW_3_bm  (1<<7)  /* Window bit 3 mask. */
+#define WDT_WINDOW_3_bp  7  /* Window bit 3 position. */
+
+/* WDT.STATUS  bit masks and bit positions */
+#define WDT_SYNCBUSY_bm  0x01  /* Syncronization busy bit mask. */
+#define WDT_SYNCBUSY_bp  0  /* Syncronization busy bit position. */
+#define WDT_LOCK_bm  0x80  /* Lock enable bit mask. */
+#define WDT_LOCK_bp  7  /* Lock enable bit position. */
+
+
+/* ========== Generic Port Pins ========== */
+#define PIN0_bm 0x01
+#define PIN0_bp 0
+#define PIN1_bm 0x02
+#define PIN1_bp 1
+#define PIN2_bm 0x04
+#define PIN2_bp 2
+#define PIN3_bm 0x08
+#define PIN3_bp 3
+#define PIN4_bm 0x10
+#define PIN4_bp 4
+#define PIN5_bm 0x20
+#define PIN5_bp 5
+#define PIN6_bm 0x40
+#define PIN6_bp 6
+#define PIN7_bm 0x80
+#define PIN7_bp 7
+
+/* ========== Interrupt Vector Definitions ========== */
+/* Vector 0 is the reset vector */
+
+/* NMI interrupt vectors */
+#define NMI_vect_num  1
+#define NMI_vect      _VECTOR(1)  /*  */
+
+/* BOD interrupt vectors */
+#define BOD_VLM_vect_num  2
+#define BOD_VLM_vect      _VECTOR(2)  /*  */
+
+/* CLKCTRL interrupt vectors */
+#define CLKCTRL_CFD_vect_num  3
+#define CLKCTRL_CFD_vect      _VECTOR(3)  /*  */
+
+/* RTC interrupt vectors */
+#define RTC_CNT_vect_num  4
+#define RTC_CNT_vect      _VECTOR(4)  /*  */
+#define RTC_PIT_vect_num  5
+#define RTC_PIT_vect      _VECTOR(5)  /*  */
+
+/* CCL interrupt vectors */
+#define CCL_CCL_vect_num  6
+#define CCL_CCL_vect      _VECTOR(6)  /*  */
+
+/* PORTA interrupt vectors */
+#define PORTA_PORT_vect_num  7
+#define PORTA_PORT_vect      _VECTOR(7)  /*  */
+
+/* TCA0 interrupt vectors */
+#define TCA0_LUNF_vect_num  8
+#define TCA0_LUNF_vect      _VECTOR(8)  /*  */
+#define TCA0_OVF_vect_num  8
+#define TCA0_OVF_vect      _VECTOR(8)  /*  */
+#define TCA0_HUNF_vect_num  9
+#define TCA0_HUNF_vect      _VECTOR(9)  /*  */
+#define TCA0_CMP0_vect_num  10
+#define TCA0_CMP0_vect      _VECTOR(10)  /*  */
+#define TCA0_LCMP0_vect_num  10
+#define TCA0_LCMP0_vect      _VECTOR(10)  /*  */
+#define TCA0_CMP1_vect_num  11
+#define TCA0_CMP1_vect      _VECTOR(11)  /*  */
+#define TCA0_LCMP1_vect_num  11
+#define TCA0_LCMP1_vect      _VECTOR(11)  /*  */
+#define TCA0_CMP2_vect_num  12
+#define TCA0_CMP2_vect      _VECTOR(12)  /*  */
+#define TCA0_LCMP2_vect_num  12
+#define TCA0_LCMP2_vect      _VECTOR(12)  /*  */
+
+/* TCB0 interrupt vectors */
+#define TCB0_INT_vect_num  13
+#define TCB0_INT_vect      _VECTOR(13)  /*  */
+
+/* TCB1 interrupt vectors */
+#define TCB1_INT_vect_num  14
+#define TCB1_INT_vect      _VECTOR(14)  /*  */
+
+/* TWI0 interrupt vectors */
+#define TWI0_TWIS_vect_num  15
+#define TWI0_TWIS_vect      _VECTOR(15)  /*  */
+#define TWI0_TWIM_vect_num  16
+#define TWI0_TWIM_vect      _VECTOR(16)  /*  */
+
+/* SPI0 interrupt vectors */
+#define SPI0_INT_vect_num  17
+#define SPI0_INT_vect      _VECTOR(17)  /*  */
+
+/* USART0 interrupt vectors */
+#define USART0_RXC_vect_num  18
+#define USART0_RXC_vect      _VECTOR(18)  /*  */
+#define USART0_DRE_vect_num  19
+#define USART0_DRE_vect      _VECTOR(19)  /*  */
+#define USART0_TXC_vect_num  20
+#define USART0_TXC_vect      _VECTOR(20)  /*  */
+
+/* PORTD interrupt vectors */
+#define PORTD_PORT_vect_num  21
+#define PORTD_PORT_vect      _VECTOR(21)  /*  */
+
+/* AC0 interrupt vectors */
+#define AC0_AC_vect_num  22
+#define AC0_AC_vect      _VECTOR(22)  /*  */
+
+/* ADC0 interrupt vectors */
+#define ADC0_ERROR_vect_num  23
+#define ADC0_ERROR_vect      _VECTOR(23)  /*  */
+#define ADC0_RESRDY_vect_num  24
+#define ADC0_RESRDY_vect      _VECTOR(24)  /*  */
+#define ADC0_SAMPRDY_vect_num  25
+#define ADC0_SAMPRDY_vect      _VECTOR(25)  /*  */
+
+/* AC1 interrupt vectors */
+#define AC1_AC_vect_num  26
+#define AC1_AC_vect      _VECTOR(26)  /*  */
+
+/* PORTC interrupt vectors */
+#define PORTC_PORT_vect_num  27
+#define PORTC_PORT_vect      _VECTOR(27)  /*  */
+
+/* TCB2 interrupt vectors */
+#define TCB2_INT_vect_num  28
+#define TCB2_INT_vect      _VECTOR(28)  /*  */
+
+/* USART1 interrupt vectors */
+#define USART1_RXC_vect_num  29
+#define USART1_RXC_vect      _VECTOR(29)  /*  */
+#define USART1_DRE_vect_num  30
+#define USART1_DRE_vect      _VECTOR(30)  /*  */
+#define USART1_TXC_vect_num  31
+#define USART1_TXC_vect      _VECTOR(31)  /*  */
+
+/* PORTF interrupt vectors */
+#define PORTF_PORT_vect_num  32
+#define PORTF_PORT_vect      _VECTOR(32)  /*  */
+
+/* NVMCTRL interrupt vectors */
+#define NVMCTRL_EEREADY_vect_num  33
+#define NVMCTRL_EEREADY_vect      _VECTOR(33)  /*  */
+#define NVMCTRL_FLREADY_vect_num  33
+#define NVMCTRL_FLREADY_vect      _VECTOR(33)  /*  */
+#define NVMCTRL_NVMREADY_vect_num  33
+#define NVMCTRL_NVMREADY_vect      _VECTOR(33)  /*  */
+
+/* USART2 interrupt vectors */
+#define USART2_RXC_vect_num  34
+#define USART2_RXC_vect      _VECTOR(34)  /*  */
+#define USART2_DRE_vect_num  35
+#define USART2_DRE_vect      _VECTOR(35)  /*  */
+#define USART2_TXC_vect_num  36
+#define USART2_TXC_vect      _VECTOR(36)  /*  */
+
+#define _VECTOR_SIZE 4 /* Size of individual vector. */
+#define _VECTORS_SIZE (37 * _VECTOR_SIZE)
+
+
+/* ========== Constants ========== */
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define DATAMEM_START     (0x0000)
+#  define DATAMEM_SIZE      (65536)
+#else
+#  define DATAMEM_START     (0x0000U)
+#  define DATAMEM_SIZE      (65536U)
+#endif
+#define DATAMEM_END       (DATAMEM_START + DATAMEM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define IO_START     (0x0000)
+#  define IO_SIZE      (4159)
+#  define IO_PAGE_SIZE (0)
+#else
+#  define IO_START     (0x0000U)
+#  define IO_SIZE      (4159U)
+#  define IO_PAGE_SIZE (0U)
+#endif
+#define IO_END       (IO_START + IO_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define LOCKBITS_START     (0x1040)
+#  define LOCKBITS_SIZE      (4)
+#  define LOCKBITS_PAGE_SIZE (4)
+#else
+#  define LOCKBITS_START     (0x1040U)
+#  define LOCKBITS_SIZE      (4U)
+#  define LOCKBITS_PAGE_SIZE (4U)
+#endif
+#define LOCKBITS_END       (LOCKBITS_START + LOCKBITS_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define FUSES_START     (0x1050)
+#  define FUSES_SIZE      (16)
+#  define FUSES_PAGE_SIZE (8)
+#else
+#  define FUSES_START     (0x1050U)
+#  define FUSES_SIZE      (16U)
+#  define FUSES_PAGE_SIZE (8U)
+#endif
+#define FUSES_END       (FUSES_START + FUSES_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define USER_SIGNATURES_START     (0x1080)
+#  define USER_SIGNATURES_SIZE      (64)
+#  define USER_SIGNATURES_PAGE_SIZE (64)
+#else
+#  define USER_SIGNATURES_START     (0x1080U)
+#  define USER_SIGNATURES_SIZE      (64U)
+#  define USER_SIGNATURES_PAGE_SIZE (64U)
+#endif
+#define USER_SIGNATURES_END       (USER_SIGNATURES_START + USER_SIGNATURES_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define SIGNATURES_START     (0x1100)
+#  define SIGNATURES_SIZE      (3)
+#  define SIGNATURES_PAGE_SIZE (128)
+#else
+#  define SIGNATURES_START     (0x1100U)
+#  define SIGNATURES_SIZE      (3U)
+#  define SIGNATURES_PAGE_SIZE (128U)
+#endif
+#define SIGNATURES_END       (SIGNATURES_START + SIGNATURES_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define PROD_SIGNATURES_START     (0x1103)
+#  define PROD_SIGNATURES_SIZE      (125)
+#  define PROD_SIGNATURES_PAGE_SIZE (128)
+#else
+#  define PROD_SIGNATURES_START     (0x1103U)
+#  define PROD_SIGNATURES_SIZE      (125U)
+#  define PROD_SIGNATURES_PAGE_SIZE (128U)
+#endif
+#define PROD_SIGNATURES_END       (PROD_SIGNATURES_START + PROD_SIGNATURES_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define EEPROM_START     (0x1400)
+#  define EEPROM_SIZE      (512)
+#  define EEPROM_PAGE_SIZE (8)
+#else
+#  define EEPROM_START     (0x1400U)
+#  define EEPROM_SIZE      (512U)
+#  define EEPROM_PAGE_SIZE (8U)
+#endif
+#define EEPROM_END       (EEPROM_START + EEPROM_SIZE - 1)
+
+/* Added MAPPED_EEPROM segment names for avr-libc */
+#define MAPPED_EEPROM_START     (EEPROM_START)
+#define MAPPED_EEPROM_SIZE      (EEPROM_SIZE)
+#define MAPPED_EEPROM_PAGE_SIZE (EEPROM_PAGE_SIZE)
+#define MAPPED_EEPROM_END       (MAPPED_EEPROM_START + MAPPED_EEPROM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define INTERNAL_SRAM_START     (0x6800)
+#  define INTERNAL_SRAM_SIZE      (6144)
+#  define INTERNAL_SRAM_PAGE_SIZE (0)
+#else
+#  define INTERNAL_SRAM_START     (0x6800U)
+#  define INTERNAL_SRAM_SIZE      (6144U)
+#  define INTERNAL_SRAM_PAGE_SIZE (0U)
+#endif
+#define INTERNAL_SRAM_END       (INTERNAL_SRAM_START + INTERNAL_SRAM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define MAPPED_PROGMEM_START     (0x8000)
+#  define MAPPED_PROGMEM_SIZE      (32768)
+#  define MAPPED_PROGMEM_PAGE_SIZE (128)
+#else
+#  define MAPPED_PROGMEM_START     (0x8000U)
+#  define MAPPED_PROGMEM_SIZE      (32768U)
+#  define MAPPED_PROGMEM_PAGE_SIZE (128U)
+#endif
+#define MAPPED_PROGMEM_END       (MAPPED_PROGMEM_START + MAPPED_PROGMEM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define PROGMEM_START     (0x0000)
+#  define PROGMEM_SIZE      (65536)
+#  define PROGMEM_PAGE_SIZE (128)
+#else
+#  define PROGMEM_START     (0x0000U)
+#  define PROGMEM_SIZE      (65536U)
+#  define PROGMEM_PAGE_SIZE (128U)
+#endif
+#define PROGMEM_END       (PROGMEM_START + PROGMEM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define PROGMEM_NRWW_START     (0x0000)
+#  define PROGMEM_NRWW_SIZE      (8192)
+#  define PROGMEM_NRWW_PAGE_SIZE (128)
+#else
+#  define PROGMEM_NRWW_START     (0x0000U)
+#  define PROGMEM_NRWW_SIZE      (8192U)
+#  define PROGMEM_NRWW_PAGE_SIZE (128U)
+#endif
+#define PROGMEM_NRWW_END       (PROGMEM_NRWW_START + PROGMEM_NRWW_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define PROGMEM_RWW_START     (0x2000)
+#  define PROGMEM_RWW_SIZE      (57344)
+#  define PROGMEM_RWW_PAGE_SIZE (128)
+#else
+#  define PROGMEM_RWW_START     (0x2000U)
+#  define PROGMEM_RWW_SIZE      (57344U)
+#  define PROGMEM_RWW_PAGE_SIZE (128U)
+#endif
+#define PROGMEM_RWW_END       (PROGMEM_RWW_START + PROGMEM_RWW_SIZE - 1)
+
+#define FLASHSTART   PROGMEM_START
+#define FLASHEND     PROGMEM_END
+#define RAMSTART     INTERNAL_SRAM_START
+#define RAMSIZE      INTERNAL_SRAM_SIZE
+#define RAMEND       INTERNAL_SRAM_END
+#define E2END        EEPROM_END
+#define E2PAGESIZE   EEPROM_PAGE_SIZE
+
+/* ========== Fuses ========== */
+#define FUSE_MEMORY_SIZE 16
+
+/* Fuse Byte 0 (WDTCFG) */
+#define FUSE_PERIOD0  (unsigned char)_BV(0)  /* Watchdog Timeout Period Bit 0 */
+#define FUSE_PERIOD1  (unsigned char)_BV(1)  /* Watchdog Timeout Period Bit 1 */
+#define FUSE_PERIOD2  (unsigned char)_BV(2)  /* Watchdog Timeout Period Bit 2 */
+#define FUSE_PERIOD3  (unsigned char)_BV(3)  /* Watchdog Timeout Period Bit 3 */
+#define FUSE_WINDOW0  (unsigned char)_BV(4)  /* Watchdog Window Timeout Period Bit 0 */
+#define FUSE_WINDOW1  (unsigned char)_BV(5)  /* Watchdog Window Timeout Period Bit 1 */
+#define FUSE_WINDOW2  (unsigned char)_BV(6)  /* Watchdog Window Timeout Period Bit 2 */
+#define FUSE_WINDOW3  (unsigned char)_BV(7)  /* Watchdog Window Timeout Period Bit 3 */
+#define FUSE0_DEFAULT  (0x0)
+#define FUSE_WDTCFG_DEFAULT  (0x0)
+
+/* Fuse Byte 1 (BODCFG) */
+#define FUSE_SLEEP0  (unsigned char)_BV(0)  /* BOD Operation in Sleep Mode Bit 0 */
+#define FUSE_SLEEP1  (unsigned char)_BV(1)  /* BOD Operation in Sleep Mode Bit 1 */
+#define FUSE_ACTIVE0  (unsigned char)_BV(2)  /* BOD Operation in Active Mode Bit 0 */
+#define FUSE_ACTIVE1  (unsigned char)_BV(3)  /* BOD Operation in Active Mode Bit 1 */
+#define FUSE_SAMPFREQ  (unsigned char)_BV(4)  /* BOD Sample Frequency */
+#define FUSE_LVL0  (unsigned char)_BV(5)  /* BOD Level Bit 0 */
+#define FUSE_LVL1  (unsigned char)_BV(6)  /* BOD Level Bit 1 */
+#define FUSE_LVL2  (unsigned char)_BV(7)  /* BOD Level Bit 2 */
+#define FUSE1_DEFAULT  (0x0)
+#define FUSE_BODCFG_DEFAULT  (0x0)
+
+/* Fuse Byte 2 (OSCCFG) */
+#define FUSE_OSCHFFRQ  (unsigned char)_BV(3)  /* High-frequency Oscillator Frequency */
+#define FUSE2_DEFAULT  (0x0)
+#define FUSE_OSCCFG_DEFAULT  (0x0)
+
+/* Fuse Byte 3 Reserved */
+
+/* Fuse Byte 4 Reserved */
+
+/* Fuse Byte 5 (SYSCFG0) */
+#define FUSE_EESAVE  (unsigned char)_BV(0)  /* EEPROM Save */
+#define FUSE_RSTPINCFG  (unsigned char)_BV(3)  /* Reset Pin Configuration */
+#define FUSE_UPDIPINCFG  (unsigned char)_BV(4)  /* UPDI Pin Configuration */
+#define FUSE_CRCSEL  (unsigned char)_BV(5)  /* CRC Select */
+#define FUSE_CRCSRC0  (unsigned char)_BV(6)  /* CRC Source Bit 0 */
+#define FUSE_CRCSRC1  (unsigned char)_BV(7)  /* CRC Source Bit 1 */
+#define FUSE5_DEFAULT  (0xD0)
+#define FUSE_SYSCFG0_DEFAULT  (0xD0)
+
+/* Fuse Byte 6 (SYSCFG1) */
+#define FUSE_SUT0  (unsigned char)_BV(0)  /* Startup Time Bit 0 */
+#define FUSE_SUT1  (unsigned char)_BV(1)  /* Startup Time Bit 1 */
+#define FUSE_SUT2  (unsigned char)_BV(2)  /* Startup Time Bit 2 */
+#define FUSE6_DEFAULT  (0x7)
+#define FUSE_SYSCFG1_DEFAULT  (0x7)
+
+/* Fuse Byte 7 (CODESIZE) */
+#define FUSE7_DEFAULT  (0x0)
+#define FUSE_CODESIZE_DEFAULT  (0x0)
+
+/* Fuse Byte 8 (BOOTSIZE) */
+#define FUSE8_DEFAULT  (0x0)
+#define FUSE_BOOTSIZE_DEFAULT  (0x0)
+
+/* ========== Lock Bits ========== */
+#define __LOCK_KEY_EXIST
+#ifdef LOCKBITS_DEFAULT
+#undef LOCKBITS_DEFAULT
+#endif //LOCKBITS_DEFAULT
+#define LOCKBITS_DEFAULT  (0x5CC5C55C)
+
+/* ========== Signature ========== */
+#define SIGNATURE_0 0x1E
+#define SIGNATURE_1 0x96
+#define SIGNATURE_2 0x20
+
+#endif /* #ifdef _AVR_AVR64EA28_H_INCLUDED */
+

--- a/include/avr/ioavr64ea32.h
+++ b/include/avr/ioavr64ea32.h
@@ -1,0 +1,5811 @@
+/*
+ * Copyright (C) 2023, Microchip Technology Inc. and its subsidiaries ("Microchip")
+ * All rights reserved.
+ *
+ * This software is developed by Microchip Technology Inc. and its subsidiaries ("Microchip").
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other
+ *        materials provided with the distribution. Publication is not required when
+ *        this file is used in an embedded application.
+ *
+ *     3. Microchip's name may not be used to endorse or promote products derived from this
+ *        software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY MICROCHIP "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL MICROCHIP BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING BUT NOT LIMITED TO
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWSOEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _AVR_IO_H_
+#  error "Include <avr/io.h> instead of this file."
+#endif
+
+#ifndef _AVR_IOXXX_H_
+#  define _AVR_IOXXX_H_ "ioavr64ea32.h"
+#else
+#  error "Attempt to include more than one <avr/ioXXX.h> file."
+#endif
+
+#ifndef _AVR_AVR64EA32_H_INCLUDED
+#define _AVR_AVR64EA32_H_INCLUDED
+
+/* Ungrouped common registers */
+#define CCP  _SFR_MEM8(0x0034)  /* Configuration Change Protection */
+#define SP  _SFR_MEM16(0x003D)  /* Stack Pointer */
+#define SPL  _SFR_MEM8(0x003D)  /* Stack Pointer Low */
+#define SPH  _SFR_MEM8(0x003E)  /* Stack Pointer High */
+#define SREG  _SFR_MEM8(0x003F)  /* Status Register */
+
+/* C Language Only */
+#if !defined (__ASSEMBLER__)
+
+#include <stdint.h>
+
+typedef volatile uint8_t register8_t;
+typedef volatile uint16_t register16_t;
+typedef volatile uint32_t register32_t;
+
+
+#ifdef _WORDREGISTER
+#undef _WORDREGISTER
+#endif
+#define _WORDREGISTER(regname)   \
+    __extension__ union \
+    { \
+        register16_t regname; \
+        struct \
+        { \
+            register8_t regname ## L; \
+            register8_t regname ## H; \
+        }; \
+    }
+
+#ifdef _DWORDREGISTER
+#undef _DWORDREGISTER
+#endif
+#define _DWORDREGISTER(regname)  \
+    __extension__ union \
+    { \
+        register32_t regname; \
+        struct \
+        { \
+            register8_t regname ## 0; \
+            register8_t regname ## 1; \
+            register8_t regname ## 2; \
+            register8_t regname ## 3; \
+        }; \
+    }
+
+
+/*
+==========================================================================
+IO Module Structures
+==========================================================================
+*/
+
+
+/*
+--------------------------------------------------------------------------
+AC - Analog Comparator
+--------------------------------------------------------------------------
+*/
+
+/* Analog Comparator */
+typedef struct AC_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t MUXCTRL;  /* Mux Control A */
+    register8_t reserved_1[2];
+    register8_t DACREF;  /* DAC Voltage Reference */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t STATUS;  /* Status */
+} AC_t;
+
+/* Hysteresis Mode select */
+typedef enum AC_HYSMODE_enum
+{
+    AC_HYSMODE_NONE_gc = (0x00<<1),  /* No hysteresis */
+    AC_HYSMODE_SMALL_gc = (0x01<<1),  /* Small hysteresis */
+    AC_HYSMODE_MEDIUM_gc = (0x02<<1),  /* Medium hysteresis */
+    AC_HYSMODE_LARGE_gc = (0x03<<1)  /* Large hysteresis */
+} AC_HYSMODE_t;
+
+/* AC Output Initial Value select */
+typedef enum AC_INITVAL_enum
+{
+    AC_INITVAL_LOW_gc = (0x00<<6),  /* Output initialized to 0 */
+    AC_INITVAL_HIGH_gc = (0x01<<6)  /* Output initialized to 1 */
+} AC_INITVAL_t;
+
+/* Interrupt Mode select */
+typedef enum AC_INTMODE_NORMAL_enum
+{
+    AC_INTMODE_NORMAL_BOTHEDGE_gc = (0x00<<4),  /* Positive and negative inputs crosses */
+    AC_INTMODE_NORMAL_NEGEDGE_gc = (0x02<<4),  /* Positive input goes below negative input */
+    AC_INTMODE_NORMAL_POSEDGE_gc = (0x03<<4)  /* Positive input goes above negative input */
+} AC_INTMODE_NORMAL_t;
+
+/* Interrupt Mode select */
+typedef enum AC_INTMODE_WINDOW_enum
+{
+    AC_INTMODE_WINDOW_ABOVE_gc = (0x00<<4),  /* Window interrupt when input above both references */
+    AC_INTMODE_WINDOW_INSIDE_gc = (0x01<<4),  /* Window interrupt when input betweeen references */
+    AC_INTMODE_WINDOW_BELOW_gc = (0x02<<4),  /* Window interrupt when input below both references */
+    AC_INTMODE_WINDOW_OUTSIDE_gc = (0x03<<4)  /* Window interrupt when input outside reference */
+} AC_INTMODE_WINDOW_t;
+
+/* Negative Input MUX Selection */
+typedef enum AC_MUXNEG_enum
+{
+    AC_MUXNEG_AINN0_gc = (0x00<<0),  /* Negative Pin 0 */
+    AC_MUXNEG_AINN1_gc = (0x01<<0),  /* Negative Pin 1 */
+    AC_MUXNEG_AINN2_gc = (0x02<<0),  /* Negative Pin 2 */
+    AC_MUXNEG_AINN3_gc = (0x03<<0),  /* Negative Pin 3 */
+    AC_MUXNEG_DACREF_gc = (0x04<<0)  /* DAC Reference */
+} AC_MUXNEG_t;
+
+/* Positive Input MUX Selection */
+typedef enum AC_MUXPOS_enum
+{
+    AC_MUXPOS_AINP0_gc = (0x00<<3),  /* Positive Pin 0 */
+    AC_MUXPOS_AINP1_gc = (0x01<<3),  /* Positive Pin 1 */
+    AC_MUXPOS_AINP2_gc = (0x02<<3),  /* Positive Pin 2 */
+    AC_MUXPOS_AINP3_gc = (0x03<<3),  /* Positive Pin 3 */
+    AC_MUXPOS_AINP4_gc = (0x04<<3)  /* Positive Pin 4 */
+} AC_MUXPOS_t;
+
+/* Power profile select */
+typedef enum AC_POWER_enum
+{
+    AC_POWER_PROFILE0_gc = (0x00<<3),  /* Power profile 0, Fastest response time, highest consumption */
+    AC_POWER_PROFILE1_gc = (0x01<<3)  /* Power profile 1 */
+} AC_POWER_t;
+
+/* Window selection mode */
+typedef enum AC_WINSEL_enum
+{
+    AC_WINSEL_DISABLED_gc = (0x00<<0),  /* Window function disabled */
+    AC_WINSEL_UPSEL1_gc = (0x01<<0)  /* Select ACn+1 as upper limit in window compare */
+} AC_WINSEL_t;
+
+/* Analog Comparator Window State select */
+typedef enum AC_WINSTATE_enum
+{
+    AC_WINSTATE_ABOVE_gc = (0x00<<6),  /* Above window */
+    AC_WINSTATE_INSIDE_gc = (0x01<<6),  /* Inside window */
+    AC_WINSTATE_BELOW_gc = (0x02<<6)  /* Below window */
+} AC_WINSTATE_t;
+
+/*
+--------------------------------------------------------------------------
+ADC - Analog to Digital Converter
+--------------------------------------------------------------------------
+*/
+
+/* Analog to Digital Converter */
+typedef struct ADC_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    register8_t CTRLD;  /* Control D */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t STATUS;  /* Status register */
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t CTRLE;  /* Control E */
+    register8_t CTRLF;  /* Control F */
+    register8_t COMMAND;  /* Command register */
+    register8_t PGACTRL;  /* PGA Control */
+    register8_t MUXPOS;  /* Positive Input Multiplexer */
+    register8_t MUXNEG;  /* Negative Input Multiplexer */
+    register8_t reserved_1[2];
+    _DWORDREGISTER(RESULT);  /* Result */
+    _WORDREGISTER(SAMPLE);  /* Sample */
+    register8_t reserved_2[2];
+    register8_t TEMP0;  /* Temporary Data 0 */
+    register8_t TEMP1;  /* Temporary Data 1 */
+    register8_t TEMP2;  /* Temporary Data 2 */
+    register8_t reserved_3[1];
+    _WORDREGISTER(WINLT);  /* Window Low Threshold */
+    _WORDREGISTER(WINHT);  /* Window High Threshold */
+    register8_t reserved_4[32];
+} ADC_t;
+
+/* Sign Chopping select */
+typedef enum ADC_CHOPPING_enum
+{
+    ADC_CHOPPING_DISABLE_gc = (0x00<<6),  /* Sign Chopping Disabled */
+    ADC_CHOPPING_ENABLE_gc = (0x01<<6)  /* Sign Chopping Enabled */
+} ADC_CHOPPING_t;
+
+/* Gain select */
+typedef enum ADC_GAIN_enum
+{
+    ADC_GAIN_1X_gc = (0x00<<5),  /* 1x gain */
+    ADC_GAIN_2X_gc = (0x01<<5),  /* 2x gain */
+    ADC_GAIN_4X_gc = (0x02<<5),  /* 4x gain */
+    ADC_GAIN_8X_gc = (0x03<<5),  /* 8x gain */
+    ADC_GAIN_16X_gc = (0x04<<5)  /* 16x gain */
+} ADC_GAIN_t;
+
+/* Mode select */
+typedef enum ADC_MODE_enum
+{
+    ADC_MODE_SINGLE_8BIT_gc = (0x00<<4),  /* Single Conversion with 8-bit resolution */
+    ADC_MODE_SINGLE_12BIT_gc = (0x01<<4),  /* Single Conversion with 12-bit resolution */
+    ADC_MODE_SERIES_gc = (0x02<<4),  /* Series with accumulation, separate trigger for every 12-bit conversion */
+    ADC_MODE_SERIES_SCALING_gc = (0x03<<4),  /* Series with accumulation and scaling, separate trigger for every 12-bit conversion */
+    ADC_MODE_BURST_gc = (0x04<<4),  /* Burst with accumulation, one trigger will run SAMPNUM 12-bit conversions */
+    ADC_MODE_BURST_SCALING_gc = (0x05<<4)  /* Burst with accumulation and scaling, one trigger will run SAMPNUM 12-bit conversions */
+} ADC_MODE_t;
+
+/* Analog Channel Selection Bits */
+typedef enum ADC_MUXNEG_enum
+{
+    ADC_MUXNEG_AIN0_gc = (0x00<<0),  /* ADC input pin 0 */
+    ADC_MUXNEG_AIN1_gc = (0x01<<0),  /* ADC input pin 1 */
+    ADC_MUXNEG_AIN2_gc = (0x02<<0),  /* ADC input pin 2 */
+    ADC_MUXNEG_AIN3_gc = (0x03<<0),  /* ADC input pin 3 */
+    ADC_MUXNEG_AIN4_gc = (0x04<<0),  /* ADC input pin 4 */
+    ADC_MUXNEG_AIN5_gc = (0x05<<0),  /* ADC input pin 5 */
+    ADC_MUXNEG_AIN6_gc = (0x06<<0),  /* ADC input pin 6 */
+    ADC_MUXNEG_AIN7_gc = (0x07<<0),  /* ADC input pin 7 */
+    ADC_MUXNEG_AIN16_gc = (0x10<<0),  /* ADC input pin 16 */
+    ADC_MUXNEG_AIN17_gc = (0x11<<0),  /* ADC input pin 17 */
+    ADC_MUXNEG_AIN18_gc = (0x12<<0),  /* ADC input pin 18 */
+    ADC_MUXNEG_AIN19_gc = (0x13<<0),  /* ADC input pin 19 */
+    ADC_MUXNEG_AIN20_gc = (0x14<<0),  /* ADC input pin 20 */
+    ADC_MUXNEG_AIN21_gc = (0x15<<0),  /* ADC input pin 21 */
+    ADC_MUXNEG_AIN22_gc = (0x16<<0),  /* ADC input pin 22 */
+    ADC_MUXNEG_AIN23_gc = (0x17<<0),  /* ADC input pin 23 */
+    ADC_MUXNEG_AIN24_gc = (0x18<<0),  /* ADC input pin 24 */
+    ADC_MUXNEG_AIN25_gc = (0x19<<0),  /* ADC input pin 25 */
+    ADC_MUXNEG_AIN26_gc = (0x1A<<0),  /* ADC input pin 26 */
+    ADC_MUXNEG_AIN27_gc = (0x1B<<0),  /* ADC input pin 27 */
+    ADC_MUXNEG_AIN28_gc = (0x1C<<0),  /* ADC input pin 28 */
+    ADC_MUXNEG_AIN29_gc = (0x1D<<0),  /* ADC input pin 29 */
+    ADC_MUXNEG_AIN30_gc = (0x1E<<0),  /* ADC input pin 30 */
+    ADC_MUXNEG_AIN31_gc = (0x1F<<0),  /* ADC input pin 31 */
+    ADC_MUXNEG_GND_gc = (0x30<<0),  /* Ground */
+    ADC_MUXNEG_DAC0_gc = (0x38<<0),  /* Digital to Analog Converter 0 */
+    ADC_MUXNEG_DACREF0_gc = (0x39<<0),  /* AC0 DAC reference */
+    ADC_MUXNEG_DACREF1_gc = (0x3A<<0)  /* AC1 DAC reference */
+} ADC_MUXNEG_t;
+
+/* Analog Channel Selection Bits */
+typedef enum ADC_MUXPOS_enum
+{
+    ADC_MUXPOS_AIN0_gc = (0x00<<0),  /* ADC input pin 0 */
+    ADC_MUXPOS_AIN1_gc = (0x01<<0),  /* ADC input pin 1 */
+    ADC_MUXPOS_AIN2_gc = (0x02<<0),  /* ADC input pin 2 */
+    ADC_MUXPOS_AIN3_gc = (0x03<<0),  /* ADC input pin 3 */
+    ADC_MUXPOS_AIN4_gc = (0x04<<0),  /* ADC input pin 4 */
+    ADC_MUXPOS_AIN5_gc = (0x05<<0),  /* ADC input pin 5 */
+    ADC_MUXPOS_AIN6_gc = (0x06<<0),  /* ADC input pin 6 */
+    ADC_MUXPOS_AIN7_gc = (0x07<<0),  /* ADC input pin 7 */
+    ADC_MUXPOS_AIN16_gc = (0x10<<0),  /* ADC input pin 16 */
+    ADC_MUXPOS_AIN17_gc = (0x11<<0),  /* ADC input pin 17 */
+    ADC_MUXPOS_AIN18_gc = (0x12<<0),  /* ADC input pin 18 */
+    ADC_MUXPOS_AIN19_gc = (0x13<<0),  /* ADC input pin 19 */
+    ADC_MUXPOS_AIN20_gc = (0x14<<0),  /* ADC input pin 20 */
+    ADC_MUXPOS_AIN21_gc = (0x15<<0),  /* ADC input pin 21 */
+    ADC_MUXPOS_AIN22_gc = (0x16<<0),  /* ADC input pin 22 */
+    ADC_MUXPOS_AIN23_gc = (0x17<<0),  /* ADC input pin 23 */
+    ADC_MUXPOS_AIN24_gc = (0x18<<0),  /* ADC input pin 24 */
+    ADC_MUXPOS_AIN25_gc = (0x19<<0),  /* ADC input pin 25 */
+    ADC_MUXPOS_AIN26_gc = (0x1A<<0),  /* ADC input pin 26 */
+    ADC_MUXPOS_AIN27_gc = (0x1B<<0),  /* ADC input pin 27 */
+    ADC_MUXPOS_AIN28_gc = (0x1C<<0),  /* ADC input pin 28 */
+    ADC_MUXPOS_AIN29_gc = (0x1D<<0),  /* ADC input pin 29 */
+    ADC_MUXPOS_AIN30_gc = (0x1E<<0),  /* ADC input pin 30 */
+    ADC_MUXPOS_AIN31_gc = (0x1F<<0),  /* ADC input pin 31 */
+    ADC_MUXPOS_GND_gc = (0x30<<0),  /* Ground */
+    ADC_MUXPOS_VDD10_gc = (0x31<<0),  /* VDD Divided by 10 */
+    ADC_MUXPOS_TEMPSENSE_gc = (0x32<<0),  /* Temperature Sensor */
+    ADC_MUXPOS_DAC0_gc = (0x38<<0)  /* Digital to Analog Converter 0 */
+} ADC_MUXPOS_t;
+
+/* PGA BIAS Select */
+typedef enum ADC_PGABIASSEL_enum
+{
+    ADC_PGABIASSEL_100PCT_gc = (0x00<<3),  /* 100% BIAS current. */
+    ADC_PGABIASSEL_75PCT_gc = (0x01<<3),  /* 75% BIAS current. Usable for CLK_ADC<4.5MHz */
+    ADC_PGABIASSEL_50PCT_gc = (0x02<<3),  /* 50% BIAS current. Usable for CLK_ADC<3MHz */
+    ADC_PGABIASSEL_25PCT_gc = (0x03<<3)  /* 25% BIAS current. Usable for CLK_ADC<1.5MHz */
+} ADC_PGABIASSEL_t;
+
+/* Prescaler Value select */
+typedef enum ADC_PRESC_enum
+{
+    ADC_PRESC_DIV2_gc = (0x00<<0),  /* System clock divided by 2 */
+    ADC_PRESC_DIV4_gc = (0x01<<0),  /* System clock divided by 4 */
+    ADC_PRESC_DIV6_gc = (0x02<<0),  /* System clock divided by 6 */
+    ADC_PRESC_DIV8_gc = (0x03<<0),  /* System clock divided by 8 */
+    ADC_PRESC_DIV10_gc = (0x04<<0),  /* System clock divided by 10 */
+    ADC_PRESC_DIV12_gc = (0x05<<0),  /* System clock divided by 12 */
+    ADC_PRESC_DIV14_gc = (0x06<<0),  /* System clock divided by 14 */
+    ADC_PRESC_DIV16_gc = (0x07<<0),  /* System clock divided by 16 */
+    ADC_PRESC_DIV20_gc = (0x08<<0),  /* System clock divided by 20 */
+    ADC_PRESC_DIV24_gc = (0x09<<0),  /* System clock divided by 24 */
+    ADC_PRESC_DIV28_gc = (0x0A<<0),  /* System clock divided by 28 */
+    ADC_PRESC_DIV32_gc = (0x0B<<0),  /* System clock divided by 32 */
+    ADC_PRESC_DIV40_gc = (0x0C<<0),  /* System clock divided by 40 */
+    ADC_PRESC_DIV48_gc = (0x0D<<0),  /* System clock divided by 48 */
+    ADC_PRESC_DIV56_gc = (0x0E<<0),  /* System clock divided by 56 */
+    ADC_PRESC_DIV64_gc = (0x0F<<0)  /* System clock divided by 64 */
+} ADC_PRESC_t;
+
+/* Reference select */
+typedef enum ADC_REFSEL_enum
+{
+    ADC_REFSEL_VDD_gc = (0x00<<0),  /* VDD */
+    ADC_REFSEL_VREFA_gc = (0x02<<0),  /* External Reference */
+    ADC_REFSEL_1V024_gc = (0x04<<0),  /* Internal 1.024V Reference */
+    ADC_REFSEL_2V048_gc = (0x05<<0),  /* Internal 2.048V Reference */
+    ADC_REFSEL_4V096_gc = (0x06<<0),  /* Internal 4.096V Reference */
+    ADC_REFSEL_2V500_gc = (0x07<<0)  /* Internal 2.500V Reference */
+} ADC_REFSEL_t;
+
+/* Sample numbers select */
+typedef enum ADC_SAMPNUM_enum
+{
+    ADC_SAMPNUM_NONE_gc = (0x00<<0),  /* No accumulation */
+    ADC_SAMPNUM_ACC2_gc = (0x01<<0),  /* 2 samples accumulated */
+    ADC_SAMPNUM_ACC4_gc = (0x02<<0),  /* 4 samples accumulated */
+    ADC_SAMPNUM_ACC8_gc = (0x03<<0),  /* 8 samples accumulated */
+    ADC_SAMPNUM_ACC16_gc = (0x04<<0),  /* 16 samples accumulated */
+    ADC_SAMPNUM_ACC32_gc = (0x05<<0),  /* 32 samples accumulated */
+    ADC_SAMPNUM_ACC64_gc = (0x06<<0),  /* 64 samples accumulated */
+    ADC_SAMPNUM_ACC128_gc = (0x07<<0),  /* 128 samples accumulated */
+    ADC_SAMPNUM_ACC256_gc = (0x08<<0),  /* 256 samples accumulated */
+    ADC_SAMPNUM_ACC512_gc = (0x09<<0),  /* 512 samples accumulated */
+    ADC_SAMPNUM_ACC1024_gc = (0x0A<<0)  /* 1024 samples accumulated */
+} ADC_SAMPNUM_t;
+
+/* Start command select */
+typedef enum ADC_START_enum
+{
+    ADC_START_STOP_gc = (0x00<<0),  /* Stop an ongoing conversion */
+    ADC_START_IMMEDIATE_gc = (0x01<<0),  /* Start a conversion immediately. This will be set back to STOP when the first conversion is done, unless Free-Running mode is enabled */
+    ADC_START_MUXPOS_WRITE_gc = (0x02<<0),  /* Start when MUXPOS register is written */
+    ADC_START_MUXNEG_WRITE_gc = (0x03<<0),  /* Start when MUXNEG register is written */
+    ADC_START_EVENT_TRIGGER_gc = (0x04<<0)  /* Start when an event is received */
+} ADC_START_t;
+
+/* VIA select */
+typedef enum ADC_VIA_enum
+{
+    ADC_VIA_DIRECT_gc = (0x00<<6),  /* Inputs connected directly to ADC */
+    ADC_VIA_PGA_gc = (0x01<<6)  /* Inputs connected via PGA */
+} ADC_VIA_t;
+
+/* Window Comparator Mode select */
+typedef enum ADC_WINCM_enum
+{
+    ADC_WINCM_NONE_gc = (0x00<<0),  /* No Window Comparison */
+    ADC_WINCM_BELOW_gc = (0x01<<0),  /* Below Window */
+    ADC_WINCM_ABOVE_gc = (0x02<<0),  /* Above Window */
+    ADC_WINCM_INSIDE_gc = (0x03<<0),  /* Inside Window */
+    ADC_WINCM_OUTSIDE_gc = (0x04<<0)  /* Outside Window */
+} ADC_WINCM_t;
+
+/* Window Mode Source select */
+typedef enum ADC_WINSRC_enum
+{
+    ADC_WINSRC_RESULT_gc = (0x00<<3),  /* Result register used as Window Comparator Source */
+    ADC_WINSRC_SAMPLE_gc = (0x01<<3)  /* Sample register used as Window Comparator Source */
+} ADC_WINSRC_t;
+
+/*
+--------------------------------------------------------------------------
+BOD - Bod interface
+--------------------------------------------------------------------------
+*/
+
+/* Bod interface */
+typedef struct BOD_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t reserved_1[6];
+    register8_t VLMCTRLA;  /* Voltage level monitor Control */
+    register8_t INTCTRL;  /* Voltage level monitor interrupt Control */
+    register8_t INTFLAGS;  /* Voltage level monitor interrupt Flags */
+    register8_t STATUS;  /* Voltage level monitor status */
+    register8_t reserved_2[4];
+} BOD_t;
+
+/* Operation in active mode select */
+typedef enum BOD_ACTIVE_enum
+{
+    BOD_ACTIVE_DISABLE_gc = (0x00<<2),  /* Disabled */
+    BOD_ACTIVE_ENABLED_gc = (0x01<<2),  /* Enabled in continuous mode */
+    BOD_ACTIVE_SAMPLED_gc = (0x02<<2),  /* Enabled in sampled mode */
+    BOD_ACTIVE_ENABLEWAIT_gc = (0x03<<2)  /* Enabled in continuous mode. Execution halted at wake-up until BOD is running */
+} BOD_ACTIVE_t;
+
+/* Bod level select */
+typedef enum BOD_LVL_enum
+{
+    BOD_LVL_BODLEVEL0_gc = (0x00<<0),  /* BOD Disabled during normal operation */
+    BOD_LVL_BODLEVEL1_gc = (0x01<<0),  /* 1.9 V */
+    BOD_LVL_BODLEVEL2_gc = (0x02<<0),  /* 2.7 V */
+    BOD_LVL_BODLEVEL3_gc = (0x03<<0)  /* 4.5 V */
+} BOD_LVL_t;
+
+/* Sample frequency select */
+typedef enum BOD_SAMPFREQ_enum
+{
+    BOD_SAMPFREQ_128HZ_gc = (0x00<<4),  /* Sampling frequency is 128 Hz */
+    BOD_SAMPFREQ_32HZ_gc = (0x01<<4)  /* Sample frequency is 32 Hz */
+} BOD_SAMPFREQ_t;
+
+/* Operation in sleep mode select */
+typedef enum BOD_SLEEP_enum
+{
+    BOD_SLEEP_DISABLE_gc = (0x00<<0),  /* Disabled */
+    BOD_SLEEP_ENABLE_gc = (0x01<<0),  /* Enabled in continuous mode */
+    BOD_SLEEP_SAMPLE_gc = (0x02<<0)  /* Enabled in sampled mode */
+} BOD_SLEEP_t;
+
+/* Configuration select */
+typedef enum BOD_VLMCFG_enum
+{
+    BOD_VLMCFG_FALLING_gc = (0x00<<1),  /* VDD falls below VLM threshold */
+    BOD_VLMCFG_RISING_gc = (0x01<<1),  /* VDD rises above VLM threshold */
+    BOD_VLMCFG_BOTH_gc = (0x02<<1)  /* VDD crosses VLM threshold */
+} BOD_VLMCFG_t;
+
+/* voltage level monitor level select */
+typedef enum BOD_VLMLVL_enum
+{
+    BOD_VLMLVL_OFF_gc = (0x00<<0),  /* VLM Disabled */
+    BOD_VLMLVL_5ABOVE_gc = (0x01<<0),  /* VLM threshold 5% above BOD level */
+    BOD_VLMLVL_15ABOVE_gc = (0x02<<0),  /* VLM threshold 15% above BOD level */
+    BOD_VLMLVL_25ABOVE_gc = (0x03<<0)  /* VLM threshold 25% above BOD level */
+} BOD_VLMLVL_t;
+
+/* Voltage level monitor status select */
+typedef enum BOD_VLMS_enum
+{
+    BOD_VLMS_ABOVE_gc = (0x00<<0),  /* The voltage is above the VLM threshold level */
+    BOD_VLMS_BELOW_gc = (0x01<<0)  /* The voltage is below the VLM threshold level */
+} BOD_VLMS_t;
+
+/*
+--------------------------------------------------------------------------
+CCL - Configurable Custom Logic
+--------------------------------------------------------------------------
+*/
+
+/* Configurable Custom Logic */
+typedef struct CCL_struct
+{
+    register8_t CTRLA;  /* Control Register A */
+    register8_t SEQCTRL0;  /* Sequential Control 0 */
+    register8_t SEQCTRL1;  /* Sequential Control 1 */
+    register8_t reserved_1[2];
+    register8_t INTCTRL0;  /* Interrupt Control 0 */
+    register8_t reserved_2[1];
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t LUT0CTRLA;  /* LUT 0 Control A */
+    register8_t LUT0CTRLB;  /* LUT 0 Control B */
+    register8_t LUT0CTRLC;  /* LUT 0 Control C */
+    register8_t TRUTH0;  /* Truth 0 */
+    register8_t LUT1CTRLA;  /* LUT 1 Control A */
+    register8_t LUT1CTRLB;  /* LUT 1 Control B */
+    register8_t LUT1CTRLC;  /* LUT 1 Control C */
+    register8_t TRUTH1;  /* Truth 1 */
+    register8_t LUT2CTRLA;  /* LUT 2 Control A */
+    register8_t LUT2CTRLB;  /* LUT 2 Control B */
+    register8_t LUT2CTRLC;  /* LUT 2 Control C */
+    register8_t TRUTH2;  /* Truth 2 */
+    register8_t LUT3CTRLA;  /* LUT 3 Control A */
+    register8_t LUT3CTRLB;  /* LUT 3 Control B */
+    register8_t LUT3CTRLC;  /* LUT 3 Control C */
+    register8_t TRUTH3;  /* Truth 3 */
+    register8_t reserved_3[40];
+} CCL_t;
+
+/* Clock Source Selection */
+typedef enum CCL_CLKSRC_enum
+{
+    CCL_CLKSRC_CLKPER_gc = (0x00<<1),  /* Peripheral Clock */
+    CCL_CLKSRC_IN2_gc = (0x01<<1),  /* INSEL2 selection */
+    CCL_CLKSRC_OSCHF_gc = (0x04<<1),  /* Internal High Frequency oscillator */
+    CCL_CLKSRC_OSC32K_gc = (0x05<<1),  /* Internal 32.768 kHz oscillator */
+    CCL_CLKSRC_OSC1K_gc = (0x06<<1)  /* Internal 32.768 kHz oscillator divided by 32 */
+} CCL_CLKSRC_t;
+
+/* Edge Detection Enable select */
+typedef enum CCL_EDGEDET_enum
+{
+    CCL_EDGEDET_DIS_gc = (0x00<<7),  /* Edge detector is disabled */
+    CCL_EDGEDET_EN_gc = (0x01<<7)  /* Edge detector is enabled */
+} CCL_EDGEDET_t;
+
+/* Filter Selection */
+typedef enum CCL_FILTSEL_enum
+{
+    CCL_FILTSEL_DISABLE_gc = (0x00<<4),  /* Filter disabled */
+    CCL_FILTSEL_SYNCH_gc = (0x01<<4),  /* Synchronizer enabled */
+    CCL_FILTSEL_FILTER_gc = (0x02<<4)  /* Filter enabled */
+} CCL_FILTSEL_t;
+
+/* LUT Input 0 Source Selection */
+typedef enum CCL_INSEL0_enum
+{
+    CCL_INSEL0_MASK_gc = (0x00<<0),  /* Masked input */
+    CCL_INSEL0_FEEDBACK_gc = (0x01<<0),  /* Feedback input */
+    CCL_INSEL0_LINK_gc = (0x02<<0),  /* Output from LUT[n+1] as input source */
+    CCL_INSEL0_EVENTA_gc = (0x03<<0),  /* Event A as input source */
+    CCL_INSEL0_EVENTB_gc = (0x04<<0),  /* Event B as input source */
+    CCL_INSEL0_IO_gc = (0x05<<0),  /* IN0 input source */
+    CCL_INSEL0_AC0_gc = (0x06<<0),  /* AC0 output input source */
+    CCL_INSEL0_USART0_gc = (0x07<<0),  /* USART0 TxD input source */
+    CCL_INSEL0_SPI0_gc = (0x08<<0),  /* SPI0 MISO input source */
+    CCL_INSEL0_TCA0_gc = (0x09<<0),  /* TCA0 WO0 input source */
+    CCL_INSEL0_TCA1_gc = (0x0A<<0),  /* TCA1 WO0 input source */
+    CCL_INSEL0_TCB0_gc = (0x0B<<0)  /* TCB0 WO input source */
+} CCL_INSEL0_t;
+
+/* LUT Input 1 Source Selection */
+typedef enum CCL_INSEL1_enum
+{
+    CCL_INSEL1_MASK_gc = (0x00<<4),  /* Masked input */
+    CCL_INSEL1_FEEDBACK_gc = (0x01<<4),  /* Feedback input */
+    CCL_INSEL1_LINK_gc = (0x02<<4),  /* Output from LUT[n+1] as input source */
+    CCL_INSEL1_EVENTA_gc = (0x03<<4),  /* Event A as input source */
+    CCL_INSEL1_EVENTB_gc = (0x04<<4),  /* Event B as input source */
+    CCL_INSEL1_IO_gc = (0x05<<4),  /* IN0 input source */
+    CCL_INSEL1_AC1_gc = (0x06<<4),  /* AC1 output input source */
+    CCL_INSEL1_USART1_gc = (0x07<<4),  /* USART1 TxD input source */
+    CCL_INSEL1_SPI0_gc = (0x08<<4),  /* SPI0 MISO input source */
+    CCL_INSEL1_TCA0_gc = (0x09<<4),  /* TCA0 WO1 input source */
+    CCL_INSEL1_TCA1_gc = (0x0A<<4),  /* TCA1 WO1 input source */
+    CCL_INSEL1_TCB1_gc = (0x0B<<4)  /* TCB1 WO input source */
+} CCL_INSEL1_t;
+
+/* LUT Input 2 Source Selection */
+typedef enum CCL_INSEL2_enum
+{
+    CCL_INSEL2_MASK_gc = (0x00<<0),  /* Masked input */
+    CCL_INSEL2_FEEDBACK_gc = (0x01<<0),  /* Feedback input */
+    CCL_INSEL2_LINK_gc = (0x02<<0),  /* Output from LUT[n+1] as input source */
+    CCL_INSEL2_EVENTA_gc = (0x03<<0),  /* Event A as input source */
+    CCL_INSEL2_EVENTB_gc = (0x04<<0),  /* Event B as input source */
+    CCL_INSEL2_IO_gc = (0x05<<0),  /* IN0 input source */
+    CCL_INSEL2_AC1_gc = (0x06<<0),  /* AC1 output input source */
+    CCL_INSEL2_USART2_gc = (0x07<<0),  /* USART2 TxD input source */
+    CCL_INSEL2_SPI0_gc = (0x08<<0),  /* SPI0 MISO input source */
+    CCL_INSEL2_TCA0_gc = (0x09<<0),  /* TCA0 WO2 input source */
+    CCL_INSEL2_TCA1_gc = (0x0A<<0),  /* TCA1 WO2 input source */
+    CCL_INSEL2_TCB2_gc = (0x0B<<0)  /* TCB2 WO input source */
+} CCL_INSEL2_t;
+
+/* Interrupt Mode for LUT0 select */
+typedef enum CCL_INTMODE0_enum
+{
+    CCL_INTMODE0_INTDISABLE_gc = (0x00<<0),  /* Interrupt disabled */
+    CCL_INTMODE0_RISING_gc = (0x01<<0),  /* Sense rising edge */
+    CCL_INTMODE0_FALLING_gc = (0x02<<0),  /* Sense falling edge */
+    CCL_INTMODE0_BOTH_gc = (0x03<<0)  /* Sense both edges */
+} CCL_INTMODE0_t;
+
+/* Interrupt Mode for LUT1 select */
+typedef enum CCL_INTMODE1_enum
+{
+    CCL_INTMODE1_INTDISABLE_gc = (0x00<<2),  /* Interrupt disabled */
+    CCL_INTMODE1_RISING_gc = (0x01<<2),  /* Sense rising edge */
+    CCL_INTMODE1_FALLING_gc = (0x02<<2),  /* Sense falling edge */
+    CCL_INTMODE1_BOTH_gc = (0x03<<2)  /* Sense both edges */
+} CCL_INTMODE1_t;
+
+/* Interrupt Mode for LUT2 select */
+typedef enum CCL_INTMODE2_enum
+{
+    CCL_INTMODE2_INTDISABLE_gc = (0x00<<4),  /* Interrupt disabled */
+    CCL_INTMODE2_RISING_gc = (0x01<<4),  /* Sense rising edge */
+    CCL_INTMODE2_FALLING_gc = (0x02<<4),  /* Sense falling edge */
+    CCL_INTMODE2_BOTH_gc = (0x03<<4)  /* Sense both edges */
+} CCL_INTMODE2_t;
+
+/* Interrupt Mode for LUT3 select */
+typedef enum CCL_INTMODE3_enum
+{
+    CCL_INTMODE3_INTDISABLE_gc = (0x00<<6),  /* Interrupt disabled */
+    CCL_INTMODE3_RISING_gc = (0x01<<6),  /* Sense rising edge */
+    CCL_INTMODE3_FALLING_gc = (0x02<<6),  /* Sense falling edge */
+    CCL_INTMODE3_BOTH_gc = (0x03<<6)  /* Sense both edges */
+} CCL_INTMODE3_t;
+
+/* Sequential Selection */
+typedef enum CCL_SEQSEL_enum
+{
+    CCL_SEQSEL_DISABLE_gc = (0x00<<0),  /* Sequential logic disabled */
+    CCL_SEQSEL_DFF_gc = (0x01<<0),  /* D FlipFlop */
+    CCL_SEQSEL_JK_gc = (0x02<<0),  /* JK FlipFlop */
+    CCL_SEQSEL_LATCH_gc = (0x03<<0),  /* D Latch */
+    CCL_SEQSEL_RS_gc = (0x04<<0)  /* RS Latch */
+} CCL_SEQSEL_t;
+
+/*
+--------------------------------------------------------------------------
+CLKCTRL - Clock controller
+--------------------------------------------------------------------------
+*/
+
+/* Clock controller */
+typedef struct CLKCTRL_struct
+{
+    register8_t MCLKCTRLA;  /* MCLK Control A */
+    register8_t MCLKCTRLB;  /* MCLK Control B */
+    register8_t MCLKCTRLC;  /* MCLK Control C */
+    register8_t MCLKINTCTRL;  /* MCLK Interrupt Control */
+    register8_t MCLKINTFLAGS;  /* MCLK Interrupt Flags */
+    register8_t MCLKSTATUS;  /* MCLK Status */
+    register8_t MCLKTIMEBASE;  /* MCLK Timebase */
+    register8_t reserved_1[1];
+    register8_t OSCHFCTRLA;  /* OSCHF Control A */
+    register8_t OSCHFTUNE;  /* OSCHF Tune */
+    register8_t reserved_2[14];
+    register8_t OSC32KCTRLA;  /* OSC32K Control A */
+    register8_t reserved_3[3];
+    register8_t XOSC32KCTRLA;  /* XOSC32K Control A */
+    register8_t reserved_4[3];
+    register8_t XOSCHFCTRLA;  /* XOSCHF Control A */
+} CLKCTRL_t;
+
+/* Automatic Oscillator Tune select */
+typedef enum CLKCTRL_AUTOTUNE_enum
+{
+    CLKCTRL_AUTOTUNE_OFF_gc = (0x00<<0),  /* Disabled */
+    CLKCTRL_AUTOTUNE_XOSC32K_gc = (0x01<<0)  /* Tune against 32.768 kHz Crystal Oscillator */
+} CLKCTRL_AUTOTUNE_t;
+
+/* CFD Source select */
+typedef enum CLKCTRL_CFDSRC_enum
+{
+    CLKCTRL_CFDSRC_CLKMAIN_gc = (0x00<<2),  /* Main Clock */
+    CLKCTRL_CFDSRC_XOSCHF_gc = (0x01<<2),  /* High Frequency Crystal Oscillator */
+    CLKCTRL_CFDSRC_XOSC32K_gc = (0x02<<2)  /* 32.768 kHz Crystal Oscillator */
+} CLKCTRL_CFDSRC_t;
+
+/* Clock select */
+typedef enum CLKCTRL_CLKSEL_enum
+{
+    CLKCTRL_CLKSEL_OSCHF_gc = (0x00<<0),  /* Internal high-frequency oscillator */
+    CLKCTRL_CLKSEL_OSC32K_gc = (0x01<<0),  /* Internal 32.768 kHz oscillator */
+    CLKCTRL_CLKSEL_XOSC32K_gc = (0x02<<0),  /* 32.768 kHz crystal oscillator */
+    CLKCTRL_CLKSEL_EXTCLK_gc = (0x03<<0)  /* External clock */
+} CLKCTRL_CLKSEL_t;
+
+/* Crystal startup time select */
+typedef enum CLKCTRL_CSUT_enum
+{
+    CLKCTRL_CSUT_1K_gc = (0x00<<4),  /* 1k cycles */
+    CLKCTRL_CSUT_16K_gc = (0x01<<4),  /* 16k cycles */
+    CLKCTRL_CSUT_32K_gc = (0x02<<4),  /* 32k cycles */
+    CLKCTRL_CSUT_64K_gc = (0x03<<4)  /* 64k cycles */
+} CLKCTRL_CSUT_t;
+
+/* Start-Up Time select */
+typedef enum CLKCTRL_CSUTHF_enum
+{
+    CLKCTRL_CSUTHF_256CYC_gc = (0x00<<4),  /* 256 XOSCHF Cycles */
+    CLKCTRL_CSUTHF_1KCYC_gc = (0x01<<4),  /* 1K XOSCHF Cycles */
+    CLKCTRL_CSUTHF_4KCYC_gc = (0x02<<4)  /* 4K XOSCHF Cycles */
+} CLKCTRL_CSUTHF_t;
+
+/* Interrupt Type select */
+typedef enum CLKCTRL_INTTYPE_enum
+{
+    CLKCTRL_INTTYPE_INT_gc = (0x00<<7),  /* Regular interrupt */
+    CLKCTRL_INTTYPE_NMI_gc = (0x01<<7)  /* Non-maskable interrupt */
+} CLKCTRL_INTTYPE_t;
+
+/* Prescaler division select */
+typedef enum CLKCTRL_PDIV_enum
+{
+    CLKCTRL_PDIV_DIV2_gc = (0x00<<1),  /* Divide by 2 */
+    CLKCTRL_PDIV_DIV4_gc = (0x01<<1),  /* Divide by 4 */
+    CLKCTRL_PDIV_DIV8_gc = (0x02<<1),  /* Divide by 8 */
+    CLKCTRL_PDIV_DIV16_gc = (0x03<<1),  /* Divide by 16 */
+    CLKCTRL_PDIV_DIV32_gc = (0x04<<1),  /* Divide by 32 */
+    CLKCTRL_PDIV_DIV64_gc = (0x05<<1),  /* Divide by 64 */
+    CLKCTRL_PDIV_DIV6_gc = (0x08<<1),  /* Divide by 6 */
+    CLKCTRL_PDIV_DIV10_gc = (0x09<<1),  /* Divide by 10 */
+    CLKCTRL_PDIV_DIV12_gc = (0x0A<<1),  /* Divide by 12 */
+    CLKCTRL_PDIV_DIV24_gc = (0x0B<<1),  /* Divide by 24 */
+    CLKCTRL_PDIV_DIV48_gc = (0x0C<<1)  /* Divide by 48 */
+} CLKCTRL_PDIV_t;
+
+/* Source Select */
+typedef enum CLKCTRL_SELHF_enum
+{
+    CLKCTRL_SELHF_CRYSTAL_gc = (0x00<<1),  /* External Crystal */
+    CLKCTRL_SELHF_EXTCLK_gc = (0x01<<1)  /* Extenal Clock on XTALHF1 pin */
+} CLKCTRL_SELHF_t;
+
+/*
+--------------------------------------------------------------------------
+CPU - CPU
+--------------------------------------------------------------------------
+*/
+
+#define CORE_VERSION  V4S
+
+/* CCP signature select */
+typedef enum CCP_enum
+{
+    CCP_SPM_gc = (0x9D<<0),  /* SPM Instruction Protection */
+    CCP_IOREG_gc = (0xD8<<0)  /* IO Register Protection */
+} CCP_t;
+
+/*
+--------------------------------------------------------------------------
+CPUINT - Interrupt Controller
+--------------------------------------------------------------------------
+*/
+
+/* Interrupt Controller */
+typedef struct CPUINT_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t STATUS;  /* Status */
+    register8_t LVL0PRI;  /* Interrupt Level 0 Priority */
+    register8_t LVL1VEC;  /* Interrupt Level 1 Priority Vector */
+} CPUINT_t;
+
+
+/*
+--------------------------------------------------------------------------
+CRCSCAN - CRCSCAN
+--------------------------------------------------------------------------
+*/
+
+/* CRCSCAN */
+typedef struct CRCSCAN_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t STATUS;  /* Status */
+    register8_t reserved_1[13];
+} CRCSCAN_t;
+
+/* CRC Source select */
+typedef enum CRCSCAN_SRC_enum
+{
+    CRCSCAN_SRC_FLASH_gc = (0x00<<0),  /* CRC on entire flash */
+    CRCSCAN_SRC_APPLICATION_gc = (0x01<<0),  /* CRC on boot and appl section of flash */
+    CRCSCAN_SRC_BOOT_gc = (0x02<<0)  /* CRC on boot section of flash */
+} CRCSCAN_SRC_t;
+
+/*
+--------------------------------------------------------------------------
+DAC - Digital to Analog Converter
+--------------------------------------------------------------------------
+*/
+
+/* Digital to Analog Converter */
+typedef struct DAC_struct
+{
+    register8_t CTRLA;  /* Control Register A */
+    register8_t reserved_1[1];
+    _WORDREGISTER(DATA);  /* DATA Register */
+    register8_t reserved_2[12];
+} DAC_t;
+
+/* Output Buffer Range select */
+typedef enum DAC_OUTRANGE_enum
+{
+    DAC_OUTRANGE_AUTO_gc = (0x00<<4),  /* Output buffer automatically choose best range */
+    DAC_OUTRANGE_LOW_gc = (0x02<<4),  /* Output buffer configured to low range */
+    DAC_OUTRANGE_HIGH_gc = (0x03<<4)  /* Output buffer configured to high range */
+} DAC_OUTRANGE_t;
+
+/*
+--------------------------------------------------------------------------
+EVSYS - Event System
+--------------------------------------------------------------------------
+*/
+
+/* Event System */
+typedef struct EVSYS_struct
+{
+    register8_t SWEVENTA;  /* Software Event A */
+    register8_t reserved_1[15];
+    register8_t CHANNEL0;  /* Multiplexer Channel 0 */
+    register8_t CHANNEL1;  /* Multiplexer Channel 1 */
+    register8_t CHANNEL2;  /* Multiplexer Channel 2 */
+    register8_t CHANNEL3;  /* Multiplexer Channel 3 */
+    register8_t CHANNEL4;  /* Multiplexer Channel 4 */
+    register8_t CHANNEL5;  /* Multiplexer Channel 5 */
+    register8_t reserved_2[10];
+    register8_t USERCCLLUT0A;  /* CCL0 Event A */
+    register8_t USERCCLLUT0B;  /* CCL0 Event B */
+    register8_t USERCCLLUT1A;  /* CCL1 Event A */
+    register8_t USERCCLLUT1B;  /* CCL1 Event B */
+    register8_t USERCCLLUT2A;  /* CCL2 Event A */
+    register8_t USERCCLLUT2B;  /* CCL2 Event B */
+    register8_t USERCCLLUT3A;  /* CCL3 Event A */
+    register8_t USERCCLLUT3B;  /* CCL3 Event B */
+    register8_t USERADC0START;  /* ADC0 */
+    register8_t USEREVSYSEVOUTA;  /* EVOUTA */
+    register8_t reserved_3[1];
+    register8_t USEREVSYSEVOUTC;  /* EVOUTC */
+    register8_t USEREVSYSEVOUTD;  /* EVOUTD */
+    register8_t reserved_4[1];
+    register8_t USEREVSYSEVOUTF;  /* EVOUTF */
+    register8_t USERUSART0IRDA;  /* USART0 */
+    register8_t USERUSART1IRDA;  /* USART1 */
+    register8_t USERUSART2IRDA;  /* USART2 */
+    register8_t USERTCA0CNTA;  /* TCA0 Event A */
+    register8_t USERTCA0CNTB;  /* TCA0 Event B */
+    register8_t USERTCA1CNTA;  /* TCA1 Event A */
+    register8_t USERTCA1CNTB;  /* TCA1 Event B */
+    register8_t USERTCB0CAPT;  /* TCB0 Event A */
+    register8_t USERTCB0COUNT;  /* TCB0 Event B */
+    register8_t USERTCB1CAPT;  /* TCB1 Event A */
+    register8_t USERTCB1COUNT;  /* TCB1 Event B */
+    register8_t USERTCB2CAPT;  /* TCB2 Event A */
+    register8_t USERTCB2COUNT;  /* TCB2 Event B */
+    register8_t USERTCB3CAPT;  /* TCB3 Event A */
+    register8_t USERTCB3COUNT;  /* TCB3 Event B */
+    register8_t reserved_5[2];
+} EVSYS_t;
+
+/* Channel generator select */
+typedef enum EVSYS_CHANNEL_enum
+{
+    EVSYS_CHANNEL_OFF_gc = (0x00<<0),  /* Off */
+    EVSYS_CHANNEL_UPDI_SYNCH_gc = (0x01<<0),  /* UPDI SYNCH character */
+    EVSYS_CHANNEL_RTC_OVF_gc = (0x06<<0),  /* Real Time Counter overflow */
+    EVSYS_CHANNEL_RTC_CMP_gc = (0x07<<0),  /* Real Time Counter compare */
+    EVSYS_CHANNEL_RTC_PITEV0_gc = (0x08<<0),  /* Periodic Interrupt Timer Event 0 */
+    EVSYS_CHANNEL_RTC_PITEV1_gc = (0x09<<0),  /* Periodic Interrupt Timer Event 1 */
+    EVSYS_CHANNEL_CCL_LUT0_gc = (0x10<<0),  /* Configurable Custom Logic LUT0 */
+    EVSYS_CHANNEL_CCL_LUT1_gc = (0x11<<0),  /* Configurable Custom Logic LUT1 */
+    EVSYS_CHANNEL_CCL_LUT2_gc = (0x12<<0),  /* Configurable Custom Logic LUT2 */
+    EVSYS_CHANNEL_CCL_LUT3_gc = (0x13<<0),  /* Configurable Custom Logic LUT3 */
+    EVSYS_CHANNEL_AC0_OUT_gc = (0x20<<0),  /* Analog Comparator 0 out */
+    EVSYS_CHANNEL_AC1_OUT_gc = (0x21<<0),  /* Analog Comparator 1 out */
+    EVSYS_CHANNEL_ADC0_RES_gc = (0x24<<0),  /* ADC 0 Result Ready */
+    EVSYS_CHANNEL_ADC0_SAMP_gc = (0x25<<0),  /* ADC 0 Sample Ready */
+    EVSYS_CHANNEL_ADC0_WCMP_gc = (0x26<<0),  /* ADC 0 Window Compare */
+    EVSYS_CHANNEL_PORTA_EV0_gc = (0x40<<0),  /* Port A Event 0 */
+    EVSYS_CHANNEL_PORTA_EV1_gc = (0x41<<0),  /* Port A Event 1 */
+    EVSYS_CHANNEL_PORTC_EV0_gc = (0x44<<0),  /* Port C Event 0 */
+    EVSYS_CHANNEL_PORTC_EV1_gc = (0x45<<0),  /* Port C Event 1 */
+    EVSYS_CHANNEL_PORTD_EV0_gc = (0x46<<0),  /* Port D Event 0 */
+    EVSYS_CHANNEL_PORTD_EV1_gc = (0x47<<0),  /* Port D Event 1 */
+    EVSYS_CHANNEL_PORTF_EV0_gc = (0x4A<<0),  /* Port F Event 0 */
+    EVSYS_CHANNEL_PORTF_EV1_gc = (0x4B<<0),  /* Port F Event 1 */
+    EVSYS_CHANNEL_USART0_XCK_gc = (0x60<<0),  /* USART 0 XCK */
+    EVSYS_CHANNEL_USART1_XCK_gc = (0x61<<0),  /* USART 1 XCK */
+    EVSYS_CHANNEL_USART2_XCK_gc = (0x62<<0),  /* USART 2 XCK */
+    EVSYS_CHANNEL_SPI0_SCK_gc = (0x68<<0),  /* SPI 0 SCK */
+    EVSYS_CHANNEL_TCA0_OVF_LUNF_gc = (0x80<<0),  /* Timer/Counter A0 overflow / low byte timer underflow */
+    EVSYS_CHANNEL_TCA0_HUNF_gc = (0x81<<0),  /* Timer/Counter A0 high byte timer underflow */
+    EVSYS_CHANNEL_TCA0_CMP0_LCMP0_gc = (0x84<<0),  /* Timer/Counter A0 compare 0 / low byte timer compare 0 */
+    EVSYS_CHANNEL_TCA0_CMP1_LCMP1_gc = (0x85<<0),  /* Timer/Counter A0 compare 1 / low byte timer compare 1 */
+    EVSYS_CHANNEL_TCA0_CMP2_LCMP2_gc = (0x86<<0),  /* Timer/Counter A0 compare 2 / low byte timer compare 2 */
+    EVSYS_CHANNEL_TCA1_OVF_LUNF_gc = (0x88<<0),  /* Timer/Counter A1 overflow / low byte timer underflow */
+    EVSYS_CHANNEL_TCA1_HUNF_gc = (0x89<<0),  /* Timer/Counter A1 high byte timer underflow */
+    EVSYS_CHANNEL_TCA1_CMP0_LCMP0_gc = (0x8C<<0),  /* Timer/Counter A1 compare 0 / low byte timer compare 0 */
+    EVSYS_CHANNEL_TCA1_CMP1_LCMP1_gc = (0x8D<<0),  /* Timer/Counter A1 compare 1 / low byte timer compare 1 */
+    EVSYS_CHANNEL_TCA1_CMP2_LCMP2_gc = (0x8E<<0),  /* Timer/Counter A1 compare 2 / low byte timer compare 2 */
+    EVSYS_CHANNEL_TCB0_CAPT_gc = (0xA0<<0),  /* Timer/Counter B0 capture */
+    EVSYS_CHANNEL_TCB0_OVF_gc = (0xA1<<0),  /* Timer/Counter B0 overflow */
+    EVSYS_CHANNEL_TCB1_CAPT_gc = (0xA2<<0),  /* Timer/Counter B1 capture */
+    EVSYS_CHANNEL_TCB1_OVF_gc = (0xA3<<0),  /* Timer/Counter B1 overflow */
+    EVSYS_CHANNEL_TCB2_CAPT_gc = (0xA4<<0),  /* Timer/Counter B2 capture */
+    EVSYS_CHANNEL_TCB2_OVF_gc = (0xA5<<0),  /* Timer/Counter B2 overflow */
+    EVSYS_CHANNEL_TCB3_CAPT_gc = (0xA6<<0),  /* Timer/Counter B3 capture */
+    EVSYS_CHANNEL_TCB3_OVF_gc = (0xA7<<0)  /* Timer/Counter B3 overflow */
+} EVSYS_CHANNEL_t;
+
+/* Software event on channel select */
+typedef enum EVSYS_SWEVENTA_enum
+{
+    EVSYS_SWEVENTA_CH0_gc = (0x01<<0),  /* Software event on channel 0 */
+    EVSYS_SWEVENTA_CH1_gc = (0x02<<0),  /* Software event on channel 1 */
+    EVSYS_SWEVENTA_CH2_gc = (0x04<<0),  /* Software event on channel 2 */
+    EVSYS_SWEVENTA_CH3_gc = (0x08<<0),  /* Software event on channel 3 */
+    EVSYS_SWEVENTA_CH4_gc = (0x10<<0),  /* Software event on channel 4 */
+    EVSYS_SWEVENTA_CH5_gc = (0x20<<0),  /* Software event on channel 5 */
+    EVSYS_SWEVENTA_CH6_gc = (0x40<<0),  /* Software event on channel 6 */
+    EVSYS_SWEVENTA_CH7_gc = (0x80<<0)  /* Software event on channel 7 */
+} EVSYS_SWEVENTA_t;
+
+/* User channel select */
+typedef enum EVSYS_USER_enum
+{
+    EVSYS_USER_OFF_gc = (0x00<<0),  /* Off, No Eventsys Channel connected */
+    EVSYS_USER_CHANNEL0_gc = (0x01<<0),  /* Connect user to event channel 0 */
+    EVSYS_USER_CHANNEL1_gc = (0x02<<0),  /* Connect user to event channel 1 */
+    EVSYS_USER_CHANNEL2_gc = (0x03<<0),  /* Connect user to event channel 2 */
+    EVSYS_USER_CHANNEL3_gc = (0x04<<0),  /* Connect user to event channel 3 */
+    EVSYS_USER_CHANNEL4_gc = (0x05<<0),  /* Connect user to event channel 4 */
+    EVSYS_USER_CHANNEL5_gc = (0x06<<0)  /* Connect user to event channel 5 */
+} EVSYS_USER_t;
+
+/*
+--------------------------------------------------------------------------
+FUSE - Fuses
+--------------------------------------------------------------------------
+*/
+
+/* Fuses */
+typedef struct FUSE_struct
+{
+    register8_t WDTCFG;  /* Watchdog Configuration */
+    register8_t BODCFG;  /* BOD Configuration */
+    register8_t OSCCFG;  /* Oscillator Configuration */
+    register8_t reserved_1[2];
+    register8_t SYSCFG0;  /* System Configuration 0 */
+    register8_t SYSCFG1;  /* System Configuration 1 */
+    register8_t CODESIZE;  /* Code Section Size */
+    register8_t BOOTSIZE;  /* Boot Section Size */
+} FUSE_t;
+
+/* avr-libc typedef for avr/fuse.h */
+typedef FUSE_t NVM_FUSES_t;
+
+/* BOD Operation in Active Mode select */
+typedef enum ACTIVE_enum
+{
+    ACTIVE_DISABLE_gc = (0x00<<2),  /* Disabled */
+    ACTIVE_ENABLED_gc = (0x01<<2),  /* Enabled in continuous mode */
+    ACTIVE_SAMPLED_gc = (0x02<<2),  /* Enabled in sampled mode */
+    ACTIVE_ENABLEWAIT_gc = (0x03<<2)  /* Enabled in continuous mode. Execution halted at wake-up until BOD is running */
+} ACTIVE_t;
+
+/* CRC Select */
+typedef enum CRCSEL_enum
+{
+    CRCSEL_CRC16_gc = (0x00<<5),  /* Enable CRC16 */
+    CRCSEL_CRC32_gc = (0x01<<5)  /* Enable CRC32 */
+} CRCSEL_t;
+
+/* CRC Source select */
+typedef enum CRCSRC_enum
+{
+    CRCSRC_FLASH_gc = (0x00<<6),  /* CRC of full Flash (boot, application code and application data) */
+    CRCSRC_BOOT_gc = (0x01<<6),  /* CRC of boot section */
+    CRCSRC_BOOTAPP_gc = (0x02<<6),  /* CRC of application code and boot sections */
+    CRCSRC_NOCRC_gc = (0x03<<6)  /* No CRC */
+} CRCSRC_t;
+
+/* EEPROM Save select */
+typedef enum EESAVE_enum
+{
+    EESAVE_DISABLE_gc = (0x00<<0),  /* EEPROM content is erased during chip erase */
+    EESAVE_ENABLE_gc = (0x01<<0)  /* EEPROM content is preserved during chip erase */
+} EESAVE_t;
+
+/* BOD Level select */
+typedef enum LVL_enum
+{
+    LVL_BODLEVEL0_gc = (0x00<<5),  /* BOD Disabled during normal operation */
+    LVL_BODLEVEL1_gc = (0x01<<5),  /* 1.9 V */
+    LVL_BODLEVEL2_gc = (0x02<<5),  /* 2.7 V */
+    LVL_BODLEVEL3_gc = (0x03<<5)  /* 4.5 V */
+} LVL_t;
+
+/* High-frequency Oscillator Frequency select */
+typedef enum OSCHFFRQ_enum
+{
+    OSCHFFRQ_20M_gc = (0x00<<3),  /* OSCHF running at 20 MHz */
+    OSCHFFRQ_16M_gc = (0x01<<3)  /* OSCHF running at 16 MHz */
+} OSCHFFRQ_t;
+
+/* Watchdog Timeout Period select */
+typedef enum PERIOD_enum
+{
+    PERIOD_OFF_gc = (0x00<<0),  /* Watch-Dog timer Off */
+    PERIOD_8CLK_gc = (0x01<<0),  /* 8 cycles (8ms) */
+    PERIOD_16CLK_gc = (0x02<<0),  /* 16 cycles (16ms) */
+    PERIOD_32CLK_gc = (0x03<<0),  /* 32 cycles (32ms) */
+    PERIOD_64CLK_gc = (0x04<<0),  /* 64 cycles (64ms) */
+    PERIOD_128CLK_gc = (0x05<<0),  /* 128 cycles (0.128s) */
+    PERIOD_256CLK_gc = (0x06<<0),  /* 256 cycles (0.256s) */
+    PERIOD_512CLK_gc = (0x07<<0),  /* 512 cycles (0.512s) */
+    PERIOD_1KCLK_gc = (0x08<<0),  /* 1K cycles (1.0s) */
+    PERIOD_2KCLK_gc = (0x09<<0),  /* 2K cycles (2.0s) */
+    PERIOD_4KCLK_gc = (0x0A<<0),  /* 4K cycles (4.0s) */
+    PERIOD_8KCLK_gc = (0x0B<<0)  /* 8K cycles (8.0s) */
+} PERIOD_t;
+
+/* Reset Pin Configuration select */
+typedef enum RSTPINCFG_enum
+{
+    RSTPINCFG_NONE_gc = (0x00<<3),  /* No External Reset */
+    RSTPINCFG_RESET_gc = (0x01<<3)  /* PF6 configured as RESET pin */
+} RSTPINCFG_t;
+
+/* BOD Sample Frequency select */
+typedef enum SAMPFREQ_enum
+{
+    SAMPFREQ_128HZ_gc = (0x00<<4),  /* Sampling frequency is 128 Hz */
+    SAMPFREQ_32HZ_gc = (0x01<<4)  /* Sample frequency is 32 Hz */
+} SAMPFREQ_t;
+
+/* BOD Operation in Sleep Mode select */
+typedef enum SLEEP_enum
+{
+    SLEEP_DISABLE_gc = (0x00<<0),  /* Disabled */
+    SLEEP_ENABLE_gc = (0x01<<0),  /* Enabled in continuous mode */
+    SLEEP_SAMPLE_gc = (0x02<<0)  /* Enabled in sampled mode */
+} SLEEP_t;
+
+/* Startup Time select */
+typedef enum SUT_enum
+{
+    SUT_0MS_gc = (0x00<<0),  /* 0 ms */
+    SUT_1MS_gc = (0x01<<0),  /* 1 ms */
+    SUT_2MS_gc = (0x02<<0),  /* 2 ms */
+    SUT_4MS_gc = (0x03<<0),  /* 4 ms */
+    SUT_8MS_gc = (0x04<<0),  /* 8 ms */
+    SUT_16MS_gc = (0x05<<0),  /* 16 ms */
+    SUT_32MS_gc = (0x06<<0),  /* 32 ms */
+    SUT_64MS_gc = (0x07<<0)  /* 64 ms */
+} SUT_t;
+
+/* UPDI Pin Configuration select */
+typedef enum UPDIPINCFG_enum
+{
+    UPDIPINCFG_GPIO_gc = (0x00<<4),  /* PF7 Configured as GPIO pin */
+    UPDIPINCFG_UPDI_gc = (0x01<<4)  /* PF7 Configured as UPDI pin */
+} UPDIPINCFG_t;
+
+/* Watchdog Window Timeout Period select */
+typedef enum WINDOW_enum
+{
+    WINDOW_OFF_gc = (0x00<<4),  /* Window mode off */
+    WINDOW_8CLK_gc = (0x01<<4),  /* 8 cycles (8ms) */
+    WINDOW_16CLK_gc = (0x02<<4),  /* 16 cycles (16ms) */
+    WINDOW_32CLK_gc = (0x03<<4),  /* 32 cycles (32ms) */
+    WINDOW_64CLK_gc = (0x04<<4),  /* 64 cycles (64ms) */
+    WINDOW_128CLK_gc = (0x05<<4),  /* 128 cycles (0.128s) */
+    WINDOW_256CLK_gc = (0x06<<4),  /* 256 cycles (0.256s) */
+    WINDOW_512CLK_gc = (0x07<<4),  /* 512 cycles (0.512s) */
+    WINDOW_1KCLK_gc = (0x08<<4),  /* 1K cycles (1.0s) */
+    WINDOW_2KCLK_gc = (0x09<<4),  /* 2K cycles (2.0s) */
+    WINDOW_4KCLK_gc = (0x0A<<4),  /* 4K cycles (4.0s) */
+    WINDOW_8KCLK_gc = (0x0B<<4)  /* 8K cycles (8.0s) */
+} WINDOW_t;
+
+/*
+--------------------------------------------------------------------------
+GPR - General Purpose Registers
+--------------------------------------------------------------------------
+*/
+
+/* General Purpose Registers */
+typedef struct GPR_struct
+{
+    register8_t GPR0;  /* General Purpose Register 0 */
+    register8_t GPR1;  /* General Purpose Register 1 */
+    register8_t GPR2;  /* General Purpose Register 2 */
+    register8_t GPR3;  /* General Purpose Register 3 */
+} GPR_t;
+
+
+/*
+--------------------------------------------------------------------------
+LOCK - Lockbits
+--------------------------------------------------------------------------
+*/
+
+/* Lockbits */
+typedef struct LOCK_struct
+{
+    _DWORDREGISTER(KEY);  /* Lock Key Bits */
+} LOCK_t;
+
+/* Lock Key select */
+typedef enum LOCK_KEY_enum
+{
+    LOCK_KEY_NOLOCK_gc = (0x5CC5C55C<<0),  /* No locks */
+    LOCK_KEY_RWLOCK_gc = (0xA33A3AA3<<0)  /* Read and write lock */
+} LOCK_KEY_t;
+
+/*
+--------------------------------------------------------------------------
+NVMCTRL - Non-volatile Memory Controller
+--------------------------------------------------------------------------
+*/
+
+/* Non-volatile Memory Controller */
+typedef struct NVMCTRL_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t reserved_1[2];
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t STATUS;  /* Status */
+    register8_t reserved_2[1];
+    _WORDREGISTER(DATA);  /* Data */
+    register8_t reserved_3[2];
+    _DWORDREGISTER(ADDR);  /* Address */
+    register8_t reserved_4[48];
+} NVMCTRL_t;
+
+/* Command select */
+typedef enum NVMCTRL_CMD_enum
+{
+    NVMCTRL_CMD_NOCMD_gc = (0x00<<0),  /* No Command */
+    NVMCTRL_CMD_NOOP_gc = (0x01<<0),  /* No Operation */
+    NVMCTRL_CMD_FLPW_gc = (0x04<<0),  /* Flash Page Write */
+    NVMCTRL_CMD_FLPERW_gc = (0x05<<0),  /* Flash Page Erase and Write */
+    NVMCTRL_CMD_FLPER_gc = (0x08<<0),  /* Flash Page Erase */
+    NVMCTRL_CMD_FLMPER2_gc = (0x09<<0),  /* Flash 2-page erase enable */
+    NVMCTRL_CMD_FLMPER4_gc = (0x0A<<0),  /* Flash 4-page erase enable */
+    NVMCTRL_CMD_FLMPER8_gc = (0x0B<<0),  /* Flash 8-page erase enable */
+    NVMCTRL_CMD_FLMPER16_gc = (0x0C<<0),  /* Flash 16-page erase enable */
+    NVMCTRL_CMD_FLMPER32_gc = (0x0D<<0),  /* Flash 32-page erase enable */
+    NVMCTRL_CMD_FLPBCLR_gc = (0x0F<<0),  /* Flash Page Buffer Clear */
+    NVMCTRL_CMD_EEPW_gc = (0x14<<0),  /* EEPROM Page Write */
+    NVMCTRL_CMD_EEPERW_gc = (0x15<<0),  /* EEPROM Page Erase and Write */
+    NVMCTRL_CMD_EEPER_gc = (0x17<<0),  /* EEPROM Page Erase */
+    NVMCTRL_CMD_EEPBCLR_gc = (0x1F<<0),  /* EEPROM Page Buffer Clear */
+    NVMCTRL_CMD_CHER_gc = (0x20<<0),  /* Chip Erase Command (UPDI only) */
+    NVMCTRL_CMD_EECHER_gc = (0x30<<0)  /* EEPROM Erase Command (UPDI only) */
+} NVMCTRL_CMD_t;
+
+/* Write error select */
+typedef enum NVMCTRL_ERROR_enum
+{
+    NVMCTRL_ERROR_NOERROR_gc = (0x00<<4),  /* No Error */
+    NVMCTRL_ERROR_WRITEPROTECT_gc = (0x02<<4),  /* Attempt to program write protected area */
+    NVMCTRL_ERROR_CMDCOLLISION_gc = (0x03<<4),  /* Selecting new write command while write command already seleted */
+    NVMCTRL_ERROR_WRONGSECTION_gc = (0x04<<4)  /* Address cannot be written with selected command */
+} NVMCTRL_ERROR_t;
+
+/* Flash Mapping in Data space select */
+typedef enum NVMCTRL_FLMAP_enum
+{
+    NVMCTRL_FLMAP_SECTION0_gc = (0x00<<4),  /* Flash section 0, 0 - 32KB */
+    NVMCTRL_FLMAP_SECTION1_gc = (0x01<<4),  /* Flash section 1, 32 - 64KB */
+    NVMCTRL_FLMAP_SECTION2_gc = (0x02<<4),  /* Flash section 2, 64 - 96KB */
+    NVMCTRL_FLMAP_SECTION3_gc = (0x03<<4)  /* Flash section 3, 96 - 128KB */
+} NVMCTRL_FLMAP_t;
+
+/*
+--------------------------------------------------------------------------
+PORT - I/O Ports
+--------------------------------------------------------------------------
+*/
+
+/* I/O Ports */
+typedef struct PORT_struct
+{
+    register8_t DIR;  /* Data Direction */
+    register8_t DIRSET;  /* Data Direction Set */
+    register8_t DIRCLR;  /* Data Direction Clear */
+    register8_t DIRTGL;  /* Data Direction Toggle */
+    register8_t OUT;  /* Output Value */
+    register8_t OUTSET;  /* Output Value Set */
+    register8_t OUTCLR;  /* Output Value Clear */
+    register8_t OUTTGL;  /* Output Value Toggle */
+    register8_t IN;  /* Input Value */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t PORTCTRL;  /* Port Control */
+    register8_t PINCONFIG;  /* Pin Control Config */
+    register8_t PINCTRLUPD;  /* Pin Control Update */
+    register8_t PINCTRLSET;  /* Pin Control Set */
+    register8_t PINCTRLCLR;  /* Pin Control Clear */
+    register8_t reserved_1[1];
+    register8_t PIN0CTRL;  /* Pin 0 Control */
+    register8_t PIN1CTRL;  /* Pin 1 Control */
+    register8_t PIN2CTRL;  /* Pin 2 Control */
+    register8_t PIN3CTRL;  /* Pin 3 Control */
+    register8_t PIN4CTRL;  /* Pin 4 Control */
+    register8_t PIN5CTRL;  /* Pin 5 Control */
+    register8_t PIN6CTRL;  /* Pin 6 Control */
+    register8_t PIN7CTRL;  /* Pin 7 Control */
+    register8_t EVGENCTRL;  /* Event Generation Control */
+    register8_t reserved_2[7];
+} PORT_t;
+
+/* Event Generator 0 Select */
+typedef enum PORT_EVGEN0SEL_enum
+{
+    PORT_EVGEN0SEL_PIN0_gc = (0x00<<0),  /* Pin 0 used as event generator */
+    PORT_EVGEN0SEL_PIN1_gc = (0x01<<0),  /* Pin 1 used as event generator */
+    PORT_EVGEN0SEL_PIN2_gc = (0x02<<0),  /* Pin 2 used as event generator */
+    PORT_EVGEN0SEL_PIN3_gc = (0x03<<0),  /* Pin 3 used as event generator */
+    PORT_EVGEN0SEL_PIN4_gc = (0x04<<0),  /* Pin 4 used as event generator */
+    PORT_EVGEN0SEL_PIN5_gc = (0x05<<0),  /* Pin 5 used as event generator */
+    PORT_EVGEN0SEL_PIN6_gc = (0x06<<0),  /* Pin 6 used as event generator */
+    PORT_EVGEN0SEL_PIN7_gc = (0x07<<0)  /* Pin 7 used as event generator */
+} PORT_EVGEN0SEL_t;
+
+/* Event Generator 1 Select */
+typedef enum PORT_EVGEN1SEL_enum
+{
+    PORT_EVGEN1SEL_PIN0_gc = (0x00<<4),  /* Pin 0 used as event generator */
+    PORT_EVGEN1SEL_PIN1_gc = (0x01<<4),  /* Pin 1 used as event generator */
+    PORT_EVGEN1SEL_PIN2_gc = (0x02<<4),  /* Pin 2 used as event generator */
+    PORT_EVGEN1SEL_PIN3_gc = (0x03<<4),  /* Pin 3 used as event generator */
+    PORT_EVGEN1SEL_PIN4_gc = (0x04<<4),  /* Pin 4 used as event generator */
+    PORT_EVGEN1SEL_PIN5_gc = (0x05<<4),  /* Pin 5 used as event generator */
+    PORT_EVGEN1SEL_PIN6_gc = (0x06<<4),  /* Pin 6 used as event generator */
+    PORT_EVGEN1SEL_PIN7_gc = (0x07<<4)  /* Pin 7 used as event generator */
+} PORT_EVGEN1SEL_t;
+
+/* Input Level Select */
+typedef enum PORT_INLVL_enum
+{
+    PORT_INLVL_ST_gc = (0x00<<6),  /* Schmitt-Trigger input level */
+    PORT_INLVL_TTL_gc = (0x01<<6)  /* TTL Input level */
+} PORT_INLVL_t;
+
+/* Input/Sense Configuration select */
+typedef enum PORT_ISC_enum
+{
+    PORT_ISC_INTDISABLE_gc = (0x00<<0),  /* Interrupt disabled but input buffer enabled */
+    PORT_ISC_BOTHEDGES_gc = (0x01<<0),  /* Sense Both Edges */
+    PORT_ISC_RISING_gc = (0x02<<0),  /* Sense Rising Edge */
+    PORT_ISC_FALLING_gc = (0x03<<0),  /* Sense Falling Edge */
+    PORT_ISC_INPUT_DISABLE_gc = (0x04<<0),  /* Digital Input Buffer disabled */
+    PORT_ISC_LEVEL_gc = (0x05<<0)  /* Sense low Level */
+} PORT_ISC_t;
+
+/*
+--------------------------------------------------------------------------
+PORTMUX - Port Multiplexer
+--------------------------------------------------------------------------
+*/
+
+/* Port Multiplexer */
+typedef struct PORTMUX_struct
+{
+    register8_t EVSYSROUTEA;  /* EVSYS route A */
+    register8_t CCLROUTEA;  /* CCL route A */
+    register8_t USARTROUTEA;  /* USART route A */
+    register8_t USARTROUTEB;  /* USART route B */
+    register8_t reserved_1[1];
+    register8_t SPIROUTEA;  /* SPI route A */
+    register8_t TWIROUTEA;  /* TWI route A */
+    register8_t TCAROUTEA;  /* TCA route A */
+    register8_t TCBROUTEA;  /* TCB route A */
+    register8_t reserved_2[1];
+    register8_t ACROUTEA;  /* AC route A */
+    register8_t reserved_3[21];
+} PORTMUX_t;
+
+/* Analog Comparator 0 Output select */
+typedef enum PORTMUX_AC0_enum
+{
+    PORTMUX_AC0_DEFAULT_gc = (0x00<<0)  /* OUT: PA7 */
+} PORTMUX_AC0_t;
+
+/* Analog Comparator 1 Output select */
+typedef enum PORTMUX_AC1_enum
+{
+    PORTMUX_AC1_DEFAULT_gc = (0x00<<1)  /* OUT: PA7 */
+} PORTMUX_AC1_t;
+
+/* Event Output A select */
+typedef enum PORTMUX_EVOUTA_enum
+{
+    PORTMUX_EVOUTA_DEFAULT_gc = (0x00<<0),  /* EVOUTA: PA2 */
+    PORTMUX_EVOUTA_ALT1_gc = (0x01<<0)  /* EVOUTA: PA7 */
+} PORTMUX_EVOUTA_t;
+
+/* Event Output C select */
+typedef enum PORTMUX_EVOUTC_enum
+{
+    PORTMUX_EVOUTC_DEFAULT_gc = (0x00<<2)  /* EVOUTC: PC2 */
+} PORTMUX_EVOUTC_t;
+
+/* Event Output D select */
+typedef enum PORTMUX_EVOUTD_enum
+{
+    PORTMUX_EVOUTD_DEFAULT_gc = (0x00<<3),  /* EVOUTD: PD2 */
+    PORTMUX_EVOUTD_ALT1_gc = (0x01<<3)  /* EVOUTD: PD7 */
+} PORTMUX_EVOUTD_t;
+
+/* Event Output F select */
+typedef enum PORTMUX_EVOUTF_enum
+{
+    PORTMUX_EVOUTF_DEFAULT_gc = (0x00<<5),  /* EVOUTF: PF2 */
+    PORTMUX_EVOUTF_ALT1_gc = (0x01<<5)  /* EVOUTF: PF7 */
+} PORTMUX_EVOUTF_t;
+
+/* CCL Look-Up Table 0 Signals select */
+typedef enum PORTMUX_LUT0_enum
+{
+    PORTMUX_LUT0_DEFAULT_gc = (0x00<<0),  /* In: PA0, PA1, PA2, Out: PA3 */
+    PORTMUX_LUT0_ALT1_gc = (0x01<<0)  /* In: PA0, PA1, PA2, Out: PA6 */
+} PORTMUX_LUT0_t;
+
+/* CCL Look-Up Table 1 Signals select */
+typedef enum PORTMUX_LUT1_enum
+{
+    PORTMUX_LUT1_DEFAULT_gc = (0x00<<1),  /* In: PC0, PC1, PC2, Out: PC3 */
+    PORTMUX_LUT1_ALT1_gc = (0x01<<1)  /* In: PC0, PC1, PC2, Out: - */
+} PORTMUX_LUT1_t;
+
+/* CCL Look-Up Table 2 Signals select */
+typedef enum PORTMUX_LUT2_enum
+{
+    PORTMUX_LUT2_DEFAULT_gc = (0x00<<2),  /* In: PD0, PD1, PD2, Out: PD3 */
+    PORTMUX_LUT2_ALT1_gc = (0x01<<2)  /* In: PD0, PD1, PD2, Out: PD6 */
+} PORTMUX_LUT2_t;
+
+/* SPI0 Signals select */
+typedef enum PORTMUX_SPI0_enum
+{
+    PORTMUX_SPI0_DEFAULT_gc = (0x00<<0),  /* MOSI: PA4, MISO: PA5, SCK: PA6, SS: PA7 */
+    PORTMUX_SPI0_ALT3_gc = (0x03<<0),  /* MOSI: PA0, MISO: PA1, SCK: PC0, SS: PC1 */
+    PORTMUX_SPI0_ALT4_gc = (0x04<<0),  /* MOSI: PD4, MISO: PD5, SCK: PD6, SS: PD7 */
+    PORTMUX_SPI0_ALT5_gc = (0x05<<0),  /* MOSI: PC0, MISO: PC1, SCK: PC2, SS: PC3 */
+    PORTMUX_SPI0_ALT6_gc = (0x06<<0),  /* MOSI: PC1, MISO: PC2, SCK: PC3, SS: PF7 */
+    PORTMUX_SPI0_NONE_gc = (0x07<<0)  /* Not connected to any pins, SS set to 1 */
+} PORTMUX_SPI0_t;
+
+/* TCA0 Signals select */
+typedef enum PORTMUX_TCA0_enum
+{
+    PORTMUX_TCA0_PORTA_gc = (0x00<<0),  /* WOn: PA0, PA1, PA2, PA3, PA4, PA5 */
+    PORTMUX_TCA0_PORTC_gc = (0x02<<0),  /* WOn: PC0, PC1, PC2, PC3, -, - */
+    PORTMUX_TCA0_PORTD_gc = (0x03<<0),  /* WOn: PD0, PD1, PD2, PD3, PD4, PD5 */
+    PORTMUX_TCA0_PORTF_gc = (0x05<<0)  /* WOn: PF0, PF1, PF2, PF3, PF4, PF5 */
+} PORTMUX_TCA0_t;
+
+/* TCA1 Signals select */
+typedef enum PORTMUX_TCA1_enum
+{
+    PORTMUX_TCA1_PORTB_gc = (0x00<<3),  /* Not connected to any pins */
+    PORTMUX_TCA1_PORTA_gc = (0x04<<3),  /* WOn: PA4, PA5, PA6, -, -, - */
+    PORTMUX_TCA1_PORTD_gc = (0x05<<3)  /* WOn: PD4, PD5, PD6, -, -, - */
+} PORTMUX_TCA1_t;
+
+/* TCB0 Output select */
+typedef enum PORTMUX_TCB0_enum
+{
+    PORTMUX_TCB0_DEFAULT_gc = (0x00<<0),  /* WO: PA2 */
+    PORTMUX_TCB0_ALT1_gc = (0x01<<0)  /* WO: PF4 */
+} PORTMUX_TCB0_t;
+
+/* TCB1 Output select */
+typedef enum PORTMUX_TCB1_enum
+{
+    PORTMUX_TCB1_DEFAULT_gc = (0x00<<1),  /* WO: PA3 */
+    PORTMUX_TCB1_ALT1_gc = (0x01<<1)  /* WO: PF5 */
+} PORTMUX_TCB1_t;
+
+/* TCB2 Output select */
+typedef enum PORTMUX_TCB2_enum
+{
+    PORTMUX_TCB2_DEFAULT_gc = (0x00<<2)  /* WO: PC0 */
+} PORTMUX_TCB2_t;
+
+/* TCB3 Output select */
+typedef enum PORTMUX_TCB3_enum
+{
+    PORTMUX_TCB3_DEFAULT_gc = (0x00<<3),  /* Not connected to any pins */
+    PORTMUX_TCB3_ALT1_gc = (0x01<<3)  /* WO: PC1 */
+} PORTMUX_TCB3_t;
+
+/* TWI0 Signals select */
+typedef enum PORTMUX_TWI0_enum
+{
+    PORTMUX_TWI0_DEFAULT_gc = (0x00<<0),  /* SDA: PA2, SCL: PA3. Dual mode: SDA: PC2, SCL: PC3 */
+    PORTMUX_TWI0_ALT1_gc = (0x01<<0),  /* SDA: PA2, SCL: PA3. Dual mode: SDA: -, SCL: - */
+    PORTMUX_TWI0_ALT2_gc = (0x02<<0),  /* SDA: PC2, SCL: PC3. Dual mode: SDA: -, SCL: - */
+    PORTMUX_TWI0_ALT3_gc = (0x03<<0)  /* SDA: PA0, SCL: PA1. Dual mode: SDA: PC2, SCL: PC3 */
+} PORTMUX_TWI0_t;
+
+/* USART0 Routing select */
+typedef enum PORTMUX_USART0_enum
+{
+    PORTMUX_USART0_DEFAULT_gc = (0x00<<0),  /* TxD: PA0, RxD: PA1, XCK: PA2, XDIR: PA3 */
+    PORTMUX_USART0_ALT1_gc = (0x01<<0),  /* TxD: PA4, RxD: PA5, XCK: PA6, XDIR: PA7 */
+    PORTMUX_USART0_ALT2_gc = (0x02<<0),  /* TxD: PA2, RxD: PA3, XCK: -, XDIR: - */
+    PORTMUX_USART0_ALT3_gc = (0x03<<0),  /* TxD: PD4, RxD: PD5, XCK: PD6, XDIR: PD7 */
+    PORTMUX_USART0_ALT4_gc = (0x04<<0),  /* TxD: PC1, RxD: PC2, XCK: PC3, XDIR: - */
+    PORTMUX_USART0_NONE_gc = (0x05<<0)  /* Not connected to any pins */
+} PORTMUX_USART0_t;
+
+/* USART1 Routing select */
+typedef enum PORTMUX_USART1_enum
+{
+    PORTMUX_USART1_DEFAULT_gc = (0x00<<3),  /* TxD: PC0, RxD: PC1, XCK: PC2, XDIR: PC3 */
+    PORTMUX_USART1_ALT2_gc = (0x02<<3),  /* TxD: PD6, RxD: PD7, XCK: -, XDIR: - */
+    PORTMUX_USART1_NONE_gc = (0x03<<3)  /* Not connected to any pins */
+} PORTMUX_USART1_t;
+
+/* USART2 Routing select */
+typedef enum PORTMUX_USART2_enum
+{
+    PORTMUX_USART2_DEFAULT_gc = (0x00<<0),  /* TxD: PF0, RxD: PF1, XCK: PF2, XDIR: PF3 */
+    PORTMUX_USART2_ALT1_gc = (0x01<<0),  /* TxD: PF4, RxD: PF5, XCK: - , XDIR: - */
+    PORTMUX_USART2_NONE_gc = (0x03<<0)  /* Not connected to any pins */
+} PORTMUX_USART2_t;
+
+/*
+--------------------------------------------------------------------------
+RSTCTRL - Reset controller
+--------------------------------------------------------------------------
+*/
+
+/* Reset controller */
+typedef struct RSTCTRL_struct
+{
+    register8_t RSTFR;  /* Reset Flags */
+    register8_t SWRR;  /* Software Reset */
+    register8_t reserved_1[14];
+} RSTCTRL_t;
+
+
+/*
+--------------------------------------------------------------------------
+RTC - Real-Time Counter
+--------------------------------------------------------------------------
+*/
+
+/* Real-Time Counter */
+typedef struct RTC_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t STATUS;  /* Status */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t TEMP;  /* Temporary */
+    register8_t DBGCTRL;  /* Debug control */
+    register8_t CALIB;  /* Calibration */
+    register8_t CLKSEL;  /* Clock Select */
+    _WORDREGISTER(CNT);  /* Counter */
+    _WORDREGISTER(PER);  /* Period */
+    _WORDREGISTER(CMP);  /* Compare */
+    register8_t reserved_1[2];
+    register8_t PITCTRLA;  /* PIT Control A */
+    register8_t PITSTATUS;  /* PIT Status */
+    register8_t PITINTCTRL;  /* PIT Interrupt Control */
+    register8_t PITINTFLAGS;  /* PIT Interrupt Flags */
+    register8_t reserved_2[1];
+    register8_t PITDBGCTRL;  /* PIT Debug control */
+    register8_t PITEVGENCTRLA;  /* PIT Event Generation Control A */
+    register8_t reserved_3[9];
+} RTC_t;
+
+/* Clock Select */
+typedef enum RTC_CLKSEL_enum
+{
+    RTC_CLKSEL_OSC32K_gc = (0x00<<0),  /* Internal 32.768 kHz Oscillator */
+    RTC_CLKSEL_OSC1K_gc = (0x01<<0),  /* Internal 32.768 kHz Oscillator Divided by 32 */
+    RTC_CLKSEL_XOSC32K_gc = (0x02<<0),  /* 32.768 kHz Crystal Oscillator */
+    RTC_CLKSEL_EXTCLK_gc = (0x03<<0)  /* External Clock */
+} RTC_CLKSEL_t;
+
+/* Event Generation 0 Select */
+typedef enum RTC_EVGEN0SEL_enum
+{
+    RTC_EVGEN0SEL_OFF_gc = (0x00<<0),  /* No Event Generated */
+    RTC_EVGEN0SEL_DIV4_gc = (0x01<<0),  /* CLK_RTC divided by 4 */
+    RTC_EVGEN0SEL_DIV8_gc = (0x02<<0),  /* CLK_RTC divided by 8 */
+    RTC_EVGEN0SEL_DIV16_gc = (0x03<<0),  /* CLK_RTC divided by 16 */
+    RTC_EVGEN0SEL_DIV32_gc = (0x04<<0),  /* CLK_RTC divided by 32 */
+    RTC_EVGEN0SEL_DIV64_gc = (0x05<<0),  /* CLK_RTC divided by 64 */
+    RTC_EVGEN0SEL_DIV128_gc = (0x06<<0),  /* CLK_RTC divided by 128 */
+    RTC_EVGEN0SEL_DIV256_gc = (0x07<<0),  /* CLK_RTC divided by 256 */
+    RTC_EVGEN0SEL_DIV512_gc = (0x08<<0),  /* CLK_RTC divided by 512 */
+    RTC_EVGEN0SEL_DIV1024_gc = (0x09<<0),  /* CLK_RTC divided by 1024 */
+    RTC_EVGEN0SEL_DIV2048_gc = (0x0A<<0),  /* CLK_RTC divided by 2048 */
+    RTC_EVGEN0SEL_DIV4096_gc = (0x0B<<0),  /* CLK_RTC divided by 4096 */
+    RTC_EVGEN0SEL_DIV8192_gc = (0x0C<<0),  /* CLK_RTC divided by 8192 */
+    RTC_EVGEN0SEL_DIV16384_gc = (0x0D<<0),  /* CLK_RTC divided by 16384 */
+    RTC_EVGEN0SEL_DIV32768_gc = (0x0E<<0)  /* CLK_RTC divided by 32768 */
+} RTC_EVGEN0SEL_t;
+
+/* Event Generation 1 Select */
+typedef enum RTC_EVGEN1SEL_enum
+{
+    RTC_EVGEN1SEL_OFF_gc = (0x00<<4),  /* No Event Generated */
+    RTC_EVGEN1SEL_DIV4_gc = (0x01<<4),  /* CLK_RTC divided by 4 */
+    RTC_EVGEN1SEL_DIV8_gc = (0x02<<4),  /* CLK_RTC divided by 8 */
+    RTC_EVGEN1SEL_DIV16_gc = (0x03<<4),  /* CLK_RTC divided by 16 */
+    RTC_EVGEN1SEL_DIV32_gc = (0x04<<4),  /* CLK_RTC divided by 32 */
+    RTC_EVGEN1SEL_DIV64_gc = (0x05<<4),  /* CLK_RTC divided by 64 */
+    RTC_EVGEN1SEL_DIV128_gc = (0x06<<4),  /* CLK_RTC divided by 128 */
+    RTC_EVGEN1SEL_DIV256_gc = (0x07<<4),  /* CLK_RTC divided by 256 */
+    RTC_EVGEN1SEL_DIV512_gc = (0x08<<4),  /* CLK_RTC divided by 512 */
+    RTC_EVGEN1SEL_DIV1024_gc = (0x09<<4),  /* CLK_RTC divided by 1024 */
+    RTC_EVGEN1SEL_DIV2048_gc = (0x0A<<4),  /* CLK_RTC divided by 2048 */
+    RTC_EVGEN1SEL_DIV4096_gc = (0x0B<<4),  /* CLK_RTC divided by 4096 */
+    RTC_EVGEN1SEL_DIV8192_gc = (0x0C<<4),  /* CLK_RTC divided by 8192 */
+    RTC_EVGEN1SEL_DIV16384_gc = (0x0D<<4),  /* CLK_RTC divided by 16384 */
+    RTC_EVGEN1SEL_DIV32768_gc = (0x0E<<4)  /* CLK_RTC divided by 32768 */
+} RTC_EVGEN1SEL_t;
+
+/* Period select */
+typedef enum RTC_PERIOD_enum
+{
+    RTC_PERIOD_OFF_gc = (0x00<<3),  /* Off */
+    RTC_PERIOD_CYC4_gc = (0x01<<3),  /* RTC Clock Cycles 4 */
+    RTC_PERIOD_CYC8_gc = (0x02<<3),  /* RTC Clock Cycles 8 */
+    RTC_PERIOD_CYC16_gc = (0x03<<3),  /* RTC Clock Cycles 16 */
+    RTC_PERIOD_CYC32_gc = (0x04<<3),  /* RTC Clock Cycles 32 */
+    RTC_PERIOD_CYC64_gc = (0x05<<3),  /* RTC Clock Cycles 64 */
+    RTC_PERIOD_CYC128_gc = (0x06<<3),  /* RTC Clock Cycles 128 */
+    RTC_PERIOD_CYC256_gc = (0x07<<3),  /* RTC Clock Cycles 256 */
+    RTC_PERIOD_CYC512_gc = (0x08<<3),  /* RTC Clock Cycles 512 */
+    RTC_PERIOD_CYC1024_gc = (0x09<<3),  /* RTC Clock Cycles 1024 */
+    RTC_PERIOD_CYC2048_gc = (0x0A<<3),  /* RTC Clock Cycles 2048 */
+    RTC_PERIOD_CYC4096_gc = (0x0B<<3),  /* RTC Clock Cycles 4096 */
+    RTC_PERIOD_CYC8192_gc = (0x0C<<3),  /* RTC Clock Cycles 8192 */
+    RTC_PERIOD_CYC16384_gc = (0x0D<<3),  /* RTC Clock Cycles 16384 */
+    RTC_PERIOD_CYC32768_gc = (0x0E<<3)  /* RTC Clock Cycles 32768 */
+} RTC_PERIOD_t;
+
+/* Prescaling Factor select */
+typedef enum RTC_PRESCALER_enum
+{
+    RTC_PRESCALER_DIV1_gc = (0x00<<3),  /* RTC Clock / 1 */
+    RTC_PRESCALER_DIV2_gc = (0x01<<3),  /* RTC Clock / 2 */
+    RTC_PRESCALER_DIV4_gc = (0x02<<3),  /* RTC Clock / 4 */
+    RTC_PRESCALER_DIV8_gc = (0x03<<3),  /* RTC Clock / 8 */
+    RTC_PRESCALER_DIV16_gc = (0x04<<3),  /* RTC Clock / 16 */
+    RTC_PRESCALER_DIV32_gc = (0x05<<3),  /* RTC Clock / 32 */
+    RTC_PRESCALER_DIV64_gc = (0x06<<3),  /* RTC Clock / 64 */
+    RTC_PRESCALER_DIV128_gc = (0x07<<3),  /* RTC Clock / 128 */
+    RTC_PRESCALER_DIV256_gc = (0x08<<3),  /* RTC Clock / 256 */
+    RTC_PRESCALER_DIV512_gc = (0x09<<3),  /* RTC Clock / 512 */
+    RTC_PRESCALER_DIV1024_gc = (0x0A<<3),  /* RTC Clock / 1024 */
+    RTC_PRESCALER_DIV2048_gc = (0x0B<<3),  /* RTC Clock / 2048 */
+    RTC_PRESCALER_DIV4096_gc = (0x0C<<3),  /* RTC Clock / 4096 */
+    RTC_PRESCALER_DIV8192_gc = (0x0D<<3),  /* RTC Clock / 8192 */
+    RTC_PRESCALER_DIV16384_gc = (0x0E<<3),  /* RTC Clock / 16384 */
+    RTC_PRESCALER_DIV32768_gc = (0x0F<<3)  /* RTC Clock / 32768 */
+} RTC_PRESCALER_t;
+
+/*
+--------------------------------------------------------------------------
+SIGROW - Signature row
+--------------------------------------------------------------------------
+*/
+
+/* Signature row */
+typedef struct SIGROW_struct
+{
+    register8_t DEVICEID0;  /* Device ID Byte 0 */
+    register8_t DEVICEID1;  /* Device ID Byte 1 */
+    register8_t DEVICEID2;  /* Device ID Byte 2 */
+    register8_t reserved_1[1];
+    _WORDREGISTER(TEMPSENSE0);  /* Temperature Calibration 0 */
+    _WORDREGISTER(TEMPSENSE1);  /* Temperature Calibration 1 */
+    register8_t reserved_2[8];
+    register8_t SERNUM0;  /* Serial Number Byte 0 */
+    register8_t SERNUM1;  /* Serial Number Byte 1 */
+    register8_t SERNUM2;  /* Serial Number Byte 2 */
+    register8_t SERNUM3;  /* Serial Number Byte 3 */
+    register8_t SERNUM4;  /* Serial Number Byte 4 */
+    register8_t SERNUM5;  /* Serial Number Byte 5 */
+    register8_t SERNUM6;  /* Serial Number Byte 6 */
+    register8_t SERNUM7;  /* Serial Number Byte 7 */
+    register8_t SERNUM8;  /* Serial Number Byte 8 */
+    register8_t SERNUM9;  /* Serial Number Byte 9 */
+    register8_t SERNUM10;  /* Serial Number Byte 10 */
+    register8_t SERNUM11;  /* Serial Number Byte 11 */
+    register8_t SERNUM12;  /* Serial Number Byte 12 */
+    register8_t SERNUM13;  /* Serial Number Byte 13 */
+    register8_t SERNUM14;  /* Serial Number Byte 14 */
+    register8_t SERNUM15;  /* Serial Number Byte 15 */
+    register8_t reserved_3[32];
+} SIGROW_t;
+
+
+/*
+--------------------------------------------------------------------------
+SLPCTRL - Sleep Controller
+--------------------------------------------------------------------------
+*/
+
+/* Sleep Controller */
+typedef struct SLPCTRL_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t reserved_1[1];
+} SLPCTRL_t;
+
+/* Sleep mode select */
+typedef enum SLPCTRL_SMODE_enum
+{
+    SLPCTRL_SMODE_IDLE_gc = (0x00<<1),  /* Idle mode */
+    SLPCTRL_SMODE_STDBY_gc = (0x01<<1),  /* Standby Mode */
+    SLPCTRL_SMODE_PDOWN_gc = (0x02<<1)  /* Power-down Mode */
+} SLPCTRL_SMODE_t;
+
+#define SLEEP_MODE_IDLE (0x00<<1)
+#define SLEEP_MODE_STANDBY (0x01<<1)
+#define SLEEP_MODE_PWR_DOWN (0x02<<1)
+/*
+--------------------------------------------------------------------------
+SPI - Serial Peripheral Interface
+--------------------------------------------------------------------------
+*/
+
+/* Serial Peripheral Interface */
+typedef struct SPI_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t DATA;  /* Data */
+    register8_t reserved_1[3];
+} SPI_t;
+
+/* SPI Mode select */
+typedef enum SPI_MODE_enum
+{
+    SPI_MODE_0_gc = (0x00<<0),  /* SPI Mode 0 */
+    SPI_MODE_1_gc = (0x01<<0),  /* SPI Mode 1 */
+    SPI_MODE_2_gc = (0x02<<0),  /* SPI Mode 2 */
+    SPI_MODE_3_gc = (0x03<<0)  /* SPI Mode 3 */
+} SPI_MODE_t;
+
+/* Prescaler select */
+typedef enum SPI_PRESC_enum
+{
+    SPI_PRESC_DIV4_gc = (0x00<<1),  /* CLK_PER / 4 */
+    SPI_PRESC_DIV16_gc = (0x01<<1),  /* CLK_PER / 16 */
+    SPI_PRESC_DIV64_gc = (0x02<<1),  /* CLK_PER / 64 */
+    SPI_PRESC_DIV128_gc = (0x03<<1)  /* CLK_PER / 128 */
+} SPI_PRESC_t;
+
+/*
+--------------------------------------------------------------------------
+SYSCFG - System Configuration Registers
+--------------------------------------------------------------------------
+*/
+
+/* System Configuration Registers */
+typedef struct SYSCFG_struct
+{
+    register8_t reserved_1[1];
+    register8_t REVID;  /* Revision ID */
+    register8_t reserved_2[2];
+    register8_t OCDMCTRL;  /* OCD Message Control */
+    register8_t OCDMSTATUS;  /* OCD Message Status */
+    register8_t reserved_3[26];
+} SYSCFG_t;
+
+
+/*
+--------------------------------------------------------------------------
+TCA - 16-bit Timer/Counter Type A
+--------------------------------------------------------------------------
+*/
+
+/* 16-bit Timer/Counter Type A - Single Mode */
+typedef struct TCA_SINGLE_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    register8_t CTRLD;  /* Control D */
+    register8_t CTRLECLR;  /* Control E Clear */
+    register8_t CTRLESET;  /* Control E Set */
+    register8_t CTRLFCLR;  /* Control F Clear */
+    register8_t CTRLFSET;  /* Control F Set */
+    register8_t reserved_1[1];
+    register8_t EVCTRL;  /* Event Control */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t reserved_2[2];
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t TEMP;  /* Temporary data for 16-bit Access */
+    register8_t reserved_3[16];
+    _WORDREGISTER(CNT);  /* Count */
+    register8_t reserved_4[4];
+    _WORDREGISTER(PER);  /* Period */
+    _WORDREGISTER(CMP0);  /* Compare 0 */
+    _WORDREGISTER(CMP1);  /* Compare 1 */
+    _WORDREGISTER(CMP2);  /* Compare 2 */
+    register8_t reserved_5[8];
+    _WORDREGISTER(PERBUF);  /* Period Buffer */
+    _WORDREGISTER(CMP0BUF);  /* Compare 0 Buffer */
+    _WORDREGISTER(CMP1BUF);  /* Compare 1 Buffer */
+    _WORDREGISTER(CMP2BUF);  /* Compare 2 Buffer */
+    register8_t reserved_6[2];
+} TCA_SINGLE_t;
+
+/* 16-bit Timer/Counter Type A - Split Mode */
+typedef struct TCA_SPLIT_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    register8_t CTRLD;  /* Control D */
+    register8_t CTRLECLR;  /* Control E Clear */
+    register8_t CTRLESET;  /* Control E Set */
+    register8_t reserved_1[4];
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t reserved_2[2];
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t reserved_3[17];
+    register8_t LCNT;  /* Low Count */
+    register8_t HCNT;  /* High Count */
+    register8_t reserved_4[4];
+    register8_t LPER;  /* Low Period */
+    register8_t HPER;  /* High Period */
+    register8_t LCMP0;  /* Low Compare */
+    register8_t HCMP0;  /* High Compare */
+    register8_t LCMP1;  /* Low Compare */
+    register8_t HCMP1;  /* High Compare */
+    register8_t LCMP2;  /* Low Compare */
+    register8_t HCMP2;  /* High Compare */
+    register8_t reserved_5[18];
+} TCA_SPLIT_t;
+
+/* 16-bit Timer/Counter Type A */
+typedef union TCA_union
+{
+    TCA_SINGLE_t SINGLE;  /* Single Mode */
+    TCA_SPLIT_t SPLIT;  /* Split Mode */
+} TCA_t;
+
+/* Clock Selection */
+typedef enum TCA_SINGLE_CLKSEL_enum
+{
+    TCA_SINGLE_CLKSEL_DIV1_gc = (0x00<<1),  /* CLK_PER */
+    TCA_SINGLE_CLKSEL_DIV2_gc = (0x01<<1),  /* CLK_PER / 2 */
+    TCA_SINGLE_CLKSEL_DIV4_gc = (0x02<<1),  /* CLK_PER / 4 */
+    TCA_SINGLE_CLKSEL_DIV8_gc = (0x03<<1),  /* CLK_PER / 8 */
+    TCA_SINGLE_CLKSEL_DIV16_gc = (0x04<<1),  /* CLK_PER / 16 */
+    TCA_SINGLE_CLKSEL_DIV64_gc = (0x05<<1),  /* CLK_PER / 64 */
+    TCA_SINGLE_CLKSEL_DIV256_gc = (0x06<<1),  /* CLK_PER / 256 */
+    TCA_SINGLE_CLKSEL_DIV1024_gc = (0x07<<1)  /* CLK_PER / 1024 */
+} TCA_SINGLE_CLKSEL_t;
+
+/* Command select */
+typedef enum TCA_SINGLE_CMD_enum
+{
+    TCA_SINGLE_CMD_NONE_gc = (0x00<<2),  /* No Command */
+    TCA_SINGLE_CMD_UPDATE_gc = (0x01<<2),  /* Force Update */
+    TCA_SINGLE_CMD_RESTART_gc = (0x02<<2),  /* Force Restart */
+    TCA_SINGLE_CMD_RESET_gc = (0x03<<2)  /* Force Hard Reset */
+} TCA_SINGLE_CMD_t;
+
+/* Direction select */
+typedef enum TCA_SINGLE_DIR_enum
+{
+    TCA_SINGLE_DIR_UP_gc = (0x00<<0),  /* Count up */
+    TCA_SINGLE_DIR_DOWN_gc = (0x01<<0)  /* Count down */
+} TCA_SINGLE_DIR_t;
+
+/* Event Action A select */
+typedef enum TCA_SINGLE_EVACTA_enum
+{
+    TCA_SINGLE_EVACTA_CNT_POSEDGE_gc = (0x00<<1),  /* Count on positive edge event */
+    TCA_SINGLE_EVACTA_CNT_ANYEDGE_gc = (0x01<<1),  /* Count on any edge event */
+    TCA_SINGLE_EVACTA_CNT_HIGHLVL_gc = (0x02<<1),  /* Count on prescaled clock while event line is 1. */
+    TCA_SINGLE_EVACTA_UPDOWN_gc = (0x03<<1)  /* Count on prescaled clock. Event controls count direction. Up-count when event line is 0, down-count when event line is 1. */
+} TCA_SINGLE_EVACTA_t;
+
+/* Event Action B select */
+typedef enum TCA_SINGLE_EVACTB_enum
+{
+    TCA_SINGLE_EVACTB_NONE_gc = (0x00<<5),  /* No Action */
+    TCA_SINGLE_EVACTB_UPDOWN_gc = (0x03<<5),  /* Count on prescaled clock. Event controls count direction. Up-count when event line is 0, down-count when event line is 1. */
+    TCA_SINGLE_EVACTB_RESTART_POSEDGE_gc = (0x04<<5),  /* Restart counter at positive edge event */
+    TCA_SINGLE_EVACTB_RESTART_ANYEDGE_gc = (0x05<<5),  /* Restart counter on any edge event */
+    TCA_SINGLE_EVACTB_RESTART_HIGHLVL_gc = (0x06<<5)  /* Restart counter while event line is 1. */
+} TCA_SINGLE_EVACTB_t;
+
+/* Waveform generation mode select */
+typedef enum TCA_SINGLE_WGMODE_enum
+{
+    TCA_SINGLE_WGMODE_NORMAL_gc = (0x00<<0),  /* Normal Mode */
+    TCA_SINGLE_WGMODE_FRQ_gc = (0x01<<0),  /* Frequency Generation Mode */
+    TCA_SINGLE_WGMODE_SINGLESLOPE_gc = (0x03<<0),  /* Single Slope PWM */
+    TCA_SINGLE_WGMODE_DSTOP_gc = (0x05<<0),  /* Dual Slope PWM, overflow on TOP */
+    TCA_SINGLE_WGMODE_DSBOTH_gc = (0x06<<0),  /* Dual Slope PWM, overflow on TOP and BOTTOM */
+    TCA_SINGLE_WGMODE_DSBOTTOM_gc = (0x07<<0)  /* Dual Slope PWM, overflow on BOTTOM */
+} TCA_SINGLE_WGMODE_t;
+
+/* Clock Selection */
+typedef enum TCA_SPLIT_CLKSEL_enum
+{
+    TCA_SPLIT_CLKSEL_DIV1_gc = (0x00<<1),  /* CLK_PER */
+    TCA_SPLIT_CLKSEL_DIV2_gc = (0x01<<1),  /* CLK_PER / 2 */
+    TCA_SPLIT_CLKSEL_DIV4_gc = (0x02<<1),  /* CLK_PER / 4 */
+    TCA_SPLIT_CLKSEL_DIV8_gc = (0x03<<1),  /* CLK_PER / 8 */
+    TCA_SPLIT_CLKSEL_DIV16_gc = (0x04<<1),  /* CLK_PER / 16 */
+    TCA_SPLIT_CLKSEL_DIV64_gc = (0x05<<1),  /* CLK_PER / 64 */
+    TCA_SPLIT_CLKSEL_DIV256_gc = (0x06<<1),  /* CLK_PER / 256 */
+    TCA_SPLIT_CLKSEL_DIV1024_gc = (0x07<<1)  /* CLK_PER / 1024 */
+} TCA_SPLIT_CLKSEL_t;
+
+/* Command select */
+typedef enum TCA_SPLIT_CMD_enum
+{
+    TCA_SPLIT_CMD_NONE_gc = (0x00<<2),  /* No Command */
+    TCA_SPLIT_CMD_UPDATE_gc = (0x01<<2),  /* Force Update */
+    TCA_SPLIT_CMD_RESTART_gc = (0x02<<2),  /* Force Restart */
+    TCA_SPLIT_CMD_RESET_gc = (0x03<<2)  /* Force Hard Reset */
+} TCA_SPLIT_CMD_t;
+
+/* Command Enable select */
+typedef enum TCA_SPLIT_CMDEN_enum
+{
+    TCA_SPLIT_CMDEN_NONE_gc = (0x00<<0),  /* None */
+    TCA_SPLIT_CMDEN_BOTH_gc = (0x03<<0)  /* Both low byte and high byte counter */
+} TCA_SPLIT_CMDEN_t;
+
+/*
+--------------------------------------------------------------------------
+TCB - 16-bit Timer Type B
+--------------------------------------------------------------------------
+*/
+
+/* 16-bit Timer Type B */
+typedef struct TCB_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control Register B */
+    register8_t reserved_1[2];
+    register8_t EVCTRL;  /* Event Control */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t STATUS;  /* Status */
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t TEMP;  /* Temporary Value */
+    _WORDREGISTER(CNT);  /* Count */
+    _WORDREGISTER(CCMP);  /* Compare or Capture */
+    register8_t reserved_2[2];
+} TCB_t;
+
+/* Clock Select */
+typedef enum TCB_CLKSEL_enum
+{
+    TCB_CLKSEL_DIV1_gc = (0x00<<1),  /* CLK_PER */
+    TCB_CLKSEL_DIV2_gc = (0x01<<1),  /* CLK_PER/2 */
+    TCB_CLKSEL_TCA0_gc = (0x02<<1),  /* Use CLK_TCA from TCA0 */
+    TCB_CLKSEL_TCA1_gc = (0x03<<1),  /* Use CLK_TCA from TCA1 */
+    TCB_CLKSEL_EVENT_gc = (0x07<<1)  /* Count on event edge */
+} TCB_CLKSEL_t;
+
+/* Timer Mode select */
+typedef enum TCB_CNTMODE_enum
+{
+    TCB_CNTMODE_INT_gc = (0x00<<0),  /* Periodic Interrupt */
+    TCB_CNTMODE_TIMEOUT_gc = (0x01<<0),  /* Periodic Timeout */
+    TCB_CNTMODE_CAPT_gc = (0x02<<0),  /* Input Capture Event */
+    TCB_CNTMODE_FRQ_gc = (0x03<<0),  /* Input Capture Frequency measurement */
+    TCB_CNTMODE_PW_gc = (0x04<<0),  /* Input Capture Pulse-Width measurement */
+    TCB_CNTMODE_FRQPW_gc = (0x05<<0),  /* Input Capture Frequency and Pulse-Width measurement */
+    TCB_CNTMODE_SINGLE_gc = (0x06<<0),  /* Single Shot */
+    TCB_CNTMODE_PWM8_gc = (0x07<<0)  /* 8-bit PWM */
+} TCB_CNTMODE_t;
+
+/*
+--------------------------------------------------------------------------
+TWI - Two-Wire Interface
+--------------------------------------------------------------------------
+*/
+
+/* Two-Wire Interface */
+typedef struct TWI_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t DUALCTRL;  /* Dual Mode Control */
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t MCTRLA;  /* Host Control A */
+    register8_t MCTRLB;  /* Host Control B */
+    register8_t MSTATUS;  /* Host STATUS */
+    register8_t MBAUD;  /* Host Baud Rate */
+    register8_t MADDR;  /* Host Address */
+    register8_t MDATA;  /* Host Data */
+    register8_t SCTRLA;  /* Client Control A */
+    register8_t SCTRLB;  /* Client Control B */
+    register8_t SSTATUS;  /* Client Status */
+    register8_t SADDR;  /* Client Address */
+    register8_t SDATA;  /* Client Data */
+    register8_t SADDRMASK;  /* Client Address Mask */
+    register8_t reserved_1[1];
+} TWI_t;
+
+/* Acknowledge Action select */
+typedef enum TWI_ACKACT_enum
+{
+    TWI_ACKACT_ACK_gc = (0x00<<2),  /* Send ACK */
+    TWI_ACKACT_NACK_gc = (0x01<<2)  /* Send NACK */
+} TWI_ACKACT_t;
+
+/* Address or Stop select */
+typedef enum TWI_AP_enum
+{
+    TWI_AP_STOP_gc = (0x00<<0),  /* A Stop condition generated the interrupt on APIF flag */
+    TWI_AP_ADR_gc = (0x01<<0)  /* Address detection generated the interrupt on APIF flag */
+} TWI_AP_t;
+
+/* Bus State select */
+typedef enum TWI_BUSSTATE_enum
+{
+    TWI_BUSSTATE_UNKNOWN_gc = (0x00<<0),  /* Unknown bus state */
+    TWI_BUSSTATE_IDLE_gc = (0x01<<0),  /* Bus is idle */
+    TWI_BUSSTATE_OWNER_gc = (0x02<<0),  /* This TWI controls the bus */
+    TWI_BUSSTATE_BUSY_gc = (0x03<<0)  /* The bus is busy */
+} TWI_BUSSTATE_t;
+
+/* Debug Run select */
+typedef enum TWI_DBGRUN_enum
+{
+    TWI_DBGRUN_HALT_gc = (0x00<<0),  /* The peripheral is halted in Break Debug mode and ignores events */
+    TWI_DBGRUN_RUN_gc = (0x01<<0)  /* The peripheral will continue to run in Break Debug mode when the CPU is halted */
+} TWI_DBGRUN_t;
+
+/* Fast-mode Enable select */
+typedef enum TWI_FMEN_enum
+{
+    TWI_FMEN_OFF_gc = (0x00<<0),  /* SCL duty cycle operating according to Sm specification */
+    TWI_FMEN_ON_gc = (0x01<<0)  /* SCL duty cycle operating according to Fm specification */
+} TWI_FMEN_t;
+
+/* Fast-mode Plus Enable select */
+typedef enum TWI_FMPEN_enum
+{
+    TWI_FMPEN_OFF_gc = (0x00<<1),  /* Operating in Standard-mode or Fast-mode */
+    TWI_FMPEN_ON_gc = (0x01<<1)  /* Operating in Fast-mode Plus */
+} TWI_FMPEN_t;
+
+/* Input voltage transition level select */
+typedef enum TWI_INPUTLVL_enum
+{
+    TWI_INPUTLVL_I2C_gc = (0x00<<6),  /* I2C input voltage transition level */
+    TWI_INPUTLVL_SMBUS_gc = (0x01<<6)  /* SMBus 3.0 input voltage transition level */
+} TWI_INPUTLVL_t;
+
+/* Command select */
+typedef enum TWI_MCMD_enum
+{
+    TWI_MCMD_NOACT_gc = (0x00<<0),  /* No action */
+    TWI_MCMD_REPSTART_gc = (0x01<<0),  /* Execute Acknowledge Action followed by repeated Start. */
+    TWI_MCMD_RECVTRANS_gc = (0x02<<0),  /* Execute Acknowledge Action followed by a byte read/write operation. Read/write is defined by DIR. */
+    TWI_MCMD_STOP_gc = (0x03<<0)  /* Execute Acknowledge Action followed by issuing a Stop condition. */
+} TWI_MCMD_t;
+
+/* Command select */
+typedef enum TWI_SCMD_enum
+{
+    TWI_SCMD_NOACT_gc = (0x00<<0),  /* No Action */
+    TWI_SCMD_COMPTRANS_gc = (0x02<<0),  /* Complete transaction */
+    TWI_SCMD_RESPONSE_gc = (0x03<<0)  /* Used in response to an interrupt */
+} TWI_SCMD_t;
+
+/* SDA Hold Time select */
+typedef enum TWI_SDAHOLD_enum
+{
+    TWI_SDAHOLD_OFF_gc = (0x00<<2),  /* No SDA Hold Delay */
+    TWI_SDAHOLD_50NS_gc = (0x01<<2),  /* Short SDA hold time */
+    TWI_SDAHOLD_300NS_gc = (0x02<<2),  /* Meets SMBUS 2.0 specification under typical conditions */
+    TWI_SDAHOLD_500NS_gc = (0x03<<2)  /* Meets SMBUS 2.0 specificaiton across all corners */
+} TWI_SDAHOLD_t;
+
+/* SDA Setup Time select */
+typedef enum TWI_SDASETUP_enum
+{
+    TWI_SDASETUP_4CYC_gc = (0x00<<4),  /* SDA setup time is four clock cycles */
+    TWI_SDASETUP_8CYC_gc = (0x01<<4)  /* SDA setup time is eight clock cycle */
+} TWI_SDASETUP_t;
+
+/* Inactive Bus Time-Out select */
+typedef enum TWI_TIMEOUT_enum
+{
+    TWI_TIMEOUT_DISABLED_gc = (0x00<<2),  /* Bus time-out disabled. I2C. */
+    TWI_TIMEOUT_50US_gc = (0x01<<2),  /* 50us - SMBus */
+    TWI_TIMEOUT_100US_gc = (0x02<<2),  /* 100us */
+    TWI_TIMEOUT_200US_gc = (0x03<<2)  /* 200us */
+} TWI_TIMEOUT_t;
+
+/*
+--------------------------------------------------------------------------
+USART - Universal Synchronous and Asynchronous Receiver and Transmitter
+--------------------------------------------------------------------------
+*/
+
+/* Universal Synchronous and Asynchronous Receiver and Transmitter */
+typedef struct USART_struct
+{
+    register8_t RXDATAL;  /* Receive Data Low Byte */
+    register8_t RXDATAH;  /* Receive Data High Byte */
+    register8_t TXDATAL;  /* Transmit Data Low Byte */
+    register8_t TXDATAH;  /* Transmit Data High Byte */
+    register8_t STATUS;  /* Status */
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    _WORDREGISTER(BAUD);  /* Baud Rate */
+    register8_t CTRLD;  /* Control D */
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t EVCTRL;  /* Event Control */
+    register8_t TXPLCTRL;  /* IRCOM Transmitter Pulse Length Control */
+    register8_t RXPLCTRL;  /* IRCOM Receiver Pulse Length Control */
+    register8_t reserved_1[1];
+} USART_t;
+
+/* Auto Baud Window select */
+typedef enum USART_ABW_enum
+{
+    USART_ABW_WDW0_gc = (0x00<<6),  /* 18% tolerance */
+    USART_ABW_WDW1_gc = (0x01<<6),  /* 15% tolerance */
+    USART_ABW_WDW2_gc = (0x02<<6),  /* 21% tolerance */
+    USART_ABW_WDW3_gc = (0x03<<6)  /* 25% tolerance */
+} USART_ABW_t;
+
+/* Character Size select */
+typedef enum USART_CHSIZE_enum
+{
+    USART_CHSIZE_5BIT_gc = (0x00<<0),  /* Character size: 5 bit */
+    USART_CHSIZE_6BIT_gc = (0x01<<0),  /* Character size: 6 bit */
+    USART_CHSIZE_7BIT_gc = (0x02<<0),  /* Character size: 7 bit */
+    USART_CHSIZE_8BIT_gc = (0x03<<0),  /* Character size: 8 bit */
+    USART_CHSIZE_9BITL_gc = (0x06<<0),  /* Character size: 9 bit read low byte first */
+    USART_CHSIZE_9BITH_gc = (0x07<<0)  /* Character size: 9 bit read high byte first */
+} USART_CHSIZE_t;
+
+/* Communication Mode select */
+typedef enum USART_CMODE_enum
+{
+    USART_CMODE_ASYNCHRONOUS_gc = (0x00<<6),  /* Asynchronous Mode */
+    USART_CMODE_SYNCHRONOUS_gc = (0x01<<6),  /* Synchronous Mode */
+    USART_CMODE_IRCOM_gc = (0x02<<6),  /* Infrared Communication */
+    USART_CMODE_MSPI_gc = (0x03<<6)  /* SPI Host Mode */
+} USART_CMODE_t;
+
+/* Parity Mode select */
+typedef enum USART_PMODE_enum
+{
+    USART_PMODE_DISABLED_gc = (0x00<<4),  /* No Parity */
+    USART_PMODE_EVEN_gc = (0x02<<4),  /* Even Parity */
+    USART_PMODE_ODD_gc = (0x03<<4)  /* Odd Parity */
+} USART_PMODE_t;
+
+/* RS485 Mode internal transmitter select */
+typedef enum USART_RS485_enum
+{
+    USART_RS485_DISABLE_gc = (0x00<<0),  /* RS485 Mode disabled */
+    USART_RS485_ENABLE_gc = (0x01<<0)  /* RS485 Mode enabled */
+} USART_RS485_t;
+
+/* Receiver Mode select */
+typedef enum USART_RXMODE_enum
+{
+    USART_RXMODE_NORMAL_gc = (0x00<<1),  /* Normal mode */
+    USART_RXMODE_CLK2X_gc = (0x01<<1),  /* CLK2x mode */
+    USART_RXMODE_GENAUTO_gc = (0x02<<1),  /* Generic autobaud mode */
+    USART_RXMODE_LINAUTO_gc = (0x03<<1)  /* LIN constrained autobaud mode */
+} USART_RXMODE_t;
+
+/* Stop Bit Mode select */
+typedef enum USART_SBMODE_enum
+{
+    USART_SBMODE_1BIT_gc = (0x00<<3),  /* 1 stop bit */
+    USART_SBMODE_2BIT_gc = (0x01<<3)  /* 2 stop bits */
+} USART_SBMODE_t;
+
+/*
+--------------------------------------------------------------------------
+USERROW - User Row
+--------------------------------------------------------------------------
+*/
+
+/* User Row */
+typedef struct USERROW_struct
+{
+    register8_t USERROW0;  /* User Row Byte 0 */
+    register8_t USERROW1;  /* User Row Byte 1 */
+    register8_t USERROW2;  /* User Row Byte 2 */
+    register8_t USERROW3;  /* User Row Byte 3 */
+    register8_t USERROW4;  /* User Row Byte 4 */
+    register8_t USERROW5;  /* User Row Byte 5 */
+    register8_t USERROW6;  /* User Row Byte 6 */
+    register8_t USERROW7;  /* User Row Byte 7 */
+    register8_t USERROW8;  /* User Row Byte 8 */
+    register8_t USERROW9;  /* User Row Byte 9 */
+    register8_t USERROW10;  /* User Row Byte 10 */
+    register8_t USERROW11;  /* User Row Byte 11 */
+    register8_t USERROW12;  /* User Row Byte 12 */
+    register8_t USERROW13;  /* User Row Byte 13 */
+    register8_t USERROW14;  /* User Row Byte 14 */
+    register8_t USERROW15;  /* User Row Byte 15 */
+    register8_t USERROW16;  /* User Row Byte 16 */
+    register8_t USERROW17;  /* User Row Byte 17 */
+    register8_t USERROW18;  /* User Row Byte 18 */
+    register8_t USERROW19;  /* User Row Byte 19 */
+    register8_t USERROW20;  /* User Row Byte 20 */
+    register8_t USERROW21;  /* User Row Byte 21 */
+    register8_t USERROW22;  /* User Row Byte 22 */
+    register8_t USERROW23;  /* User Row Byte 23 */
+    register8_t USERROW24;  /* User Row Byte 24 */
+    register8_t USERROW25;  /* User Row Byte 25 */
+    register8_t USERROW26;  /* User Row Byte 26 */
+    register8_t USERROW27;  /* User Row Byte 27 */
+    register8_t USERROW28;  /* User Row Byte 28 */
+    register8_t USERROW29;  /* User Row Byte 29 */
+    register8_t USERROW30;  /* User Row Byte 30 */
+    register8_t USERROW31;  /* User Row Byte 31 */
+    register8_t USERROW32;  /* User Row Byte 32 */
+    register8_t USERROW33;  /* User Row Byte 33 */
+    register8_t USERROW34;  /* User Row Byte 34 */
+    register8_t USERROW35;  /* User Row Byte 35 */
+    register8_t USERROW36;  /* User Row Byte 36 */
+    register8_t USERROW37;  /* User Row Byte 37 */
+    register8_t USERROW38;  /* User Row Byte 38 */
+    register8_t USERROW39;  /* User Row Byte 39 */
+    register8_t USERROW40;  /* User Row Byte 40 */
+    register8_t USERROW41;  /* User Row Byte 41 */
+    register8_t USERROW42;  /* User Row Byte 42 */
+    register8_t USERROW43;  /* User Row Byte 43 */
+    register8_t USERROW44;  /* User Row Byte 44 */
+    register8_t USERROW45;  /* User Row Byte 45 */
+    register8_t USERROW46;  /* User Row Byte 46 */
+    register8_t USERROW47;  /* User Row Byte 47 */
+    register8_t USERROW48;  /* User Row Byte 48 */
+    register8_t USERROW49;  /* User Row Byte 49 */
+    register8_t USERROW50;  /* User Row Byte 50 */
+    register8_t USERROW51;  /* User Row Byte 51 */
+    register8_t USERROW52;  /* User Row Byte 52 */
+    register8_t USERROW53;  /* User Row Byte 53 */
+    register8_t USERROW54;  /* User Row Byte 54 */
+    register8_t USERROW55;  /* User Row Byte 55 */
+    register8_t USERROW56;  /* User Row Byte 56 */
+    register8_t USERROW57;  /* User Row Byte 57 */
+    register8_t USERROW58;  /* User Row Byte 58 */
+    register8_t USERROW59;  /* User Row Byte 59 */
+    register8_t USERROW60;  /* User Row Byte 60 */
+    register8_t USERROW61;  /* User Row Byte 61 */
+    register8_t USERROW62;  /* User Row Byte 62 */
+    register8_t USERROW63;  /* User Row Byte 63 */
+} USERROW_t;
+
+
+/*
+--------------------------------------------------------------------------
+VPORT - Virtual Ports
+--------------------------------------------------------------------------
+*/
+
+/* Virtual Ports */
+typedef struct VPORT_struct
+{
+    register8_t DIR;  /* Data Direction */
+    register8_t OUT;  /* Output Value */
+    register8_t IN;  /* Input Value */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+} VPORT_t;
+
+
+/*
+--------------------------------------------------------------------------
+VREF - Voltage reference
+--------------------------------------------------------------------------
+*/
+
+/* Voltage reference */
+typedef struct VREF_struct
+{
+    register8_t reserved_1[2];
+    register8_t DAC0REF;  /* DAC0 Reference */
+    register8_t reserved_2[1];
+    register8_t ACREF;  /* AC Reference */
+} VREF_t;
+
+/* Reference select */
+typedef enum VREF_REFSEL_enum
+{
+    VREF_REFSEL_1V024_gc = (0x00<<0),  /* Internal 1.024V reference */
+    VREF_REFSEL_2V048_gc = (0x01<<0),  /* Internal 2.048V reference */
+    VREF_REFSEL_4V096_gc = (0x02<<0),  /* Internal 4.096V reference */
+    VREF_REFSEL_2V500_gc = (0x03<<0),  /* Internal 2.500V reference */
+    VREF_REFSEL_VDD_gc = (0x05<<0),  /* VDD as reference */
+    VREF_REFSEL_VREFA_gc = (0x06<<0)  /* External reference on VREFA pin */
+} VREF_REFSEL_t;
+
+/*
+--------------------------------------------------------------------------
+WDT - Watch-Dog Timer
+--------------------------------------------------------------------------
+*/
+
+/* Watch-Dog Timer */
+typedef struct WDT_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t STATUS;  /* Status */
+    register8_t reserved_1[14];
+} WDT_t;
+
+/* Period select */
+typedef enum WDT_PERIOD_enum
+{
+    WDT_PERIOD_OFF_gc = (0x00<<0),  /* Off */
+    WDT_PERIOD_8CLK_gc = (0x01<<0),  /* 8 cycles (8ms) */
+    WDT_PERIOD_16CLK_gc = (0x02<<0),  /* 16 cycles (16ms) */
+    WDT_PERIOD_32CLK_gc = (0x03<<0),  /* 32 cycles (32ms) */
+    WDT_PERIOD_64CLK_gc = (0x04<<0),  /* 64 cycles (64ms) */
+    WDT_PERIOD_128CLK_gc = (0x05<<0),  /* 128 cycles (0.128s) */
+    WDT_PERIOD_256CLK_gc = (0x06<<0),  /* 256 cycles (0.256s) */
+    WDT_PERIOD_512CLK_gc = (0x07<<0),  /* 512 cycles (0.512s) */
+    WDT_PERIOD_1KCLK_gc = (0x08<<0),  /* 1K cycles (1.0s) */
+    WDT_PERIOD_2KCLK_gc = (0x09<<0),  /* 2K cycles (2.0s) */
+    WDT_PERIOD_4KCLK_gc = (0x0A<<0),  /* 4K cycles (4.1s) */
+    WDT_PERIOD_8KCLK_gc = (0x0B<<0)  /* 8K cycles (8.2s) */
+} WDT_PERIOD_t;
+
+/* Window select */
+typedef enum WDT_WINDOW_enum
+{
+    WDT_WINDOW_OFF_gc = (0x00<<4),  /* Off */
+    WDT_WINDOW_8CLK_gc = (0x01<<4),  /* 8 cycles (8ms) */
+    WDT_WINDOW_16CLK_gc = (0x02<<4),  /* 16 cycles (16ms) */
+    WDT_WINDOW_32CLK_gc = (0x03<<4),  /* 32 cycles (32ms) */
+    WDT_WINDOW_64CLK_gc = (0x04<<4),  /* 64 cycles (64ms) */
+    WDT_WINDOW_128CLK_gc = (0x05<<4),  /* 128 cycles (0.128s) */
+    WDT_WINDOW_256CLK_gc = (0x06<<4),  /* 256 cycles (0.256s) */
+    WDT_WINDOW_512CLK_gc = (0x07<<4),  /* 512 cycles (0.512s) */
+    WDT_WINDOW_1KCLK_gc = (0x08<<4),  /* 1K cycles (1.0s) */
+    WDT_WINDOW_2KCLK_gc = (0x09<<4),  /* 2K cycles (2.0s) */
+    WDT_WINDOW_4KCLK_gc = (0x0A<<4),  /* 4K cycles (4.1s) */
+    WDT_WINDOW_8KCLK_gc = (0x0B<<4)  /* 8K cycles (8.2s) */
+} WDT_WINDOW_t;
+/*
+==========================================================================
+IO Module Instances. Mapped to memory.
+==========================================================================
+*/
+
+#define VPORTA              (*(VPORT_t *) 0x0000) /* Virtual Ports */
+#define VPORTC              (*(VPORT_t *) 0x0008) /* Virtual Ports */
+#define VPORTD              (*(VPORT_t *) 0x000C) /* Virtual Ports */
+#define VPORTF              (*(VPORT_t *) 0x0014) /* Virtual Ports */
+#define GPR                   (*(GPR_t *) 0x001C) /* General Purpose Registers */
+#define RSTCTRL           (*(RSTCTRL_t *) 0x0040) /* Reset controller */
+#define SLPCTRL           (*(SLPCTRL_t *) 0x0050) /* Sleep Controller */
+#define CLKCTRL           (*(CLKCTRL_t *) 0x0060) /* Clock controller */
+#define BOD                   (*(BOD_t *) 0x00A0) /* Bod interface */
+#define VREF                 (*(VREF_t *) 0x00B0) /* Voltage reference */
+#define WDT                   (*(WDT_t *) 0x0100) /* Watch-Dog Timer */
+#define CPUINT             (*(CPUINT_t *) 0x0110) /* Interrupt Controller */
+#define CRCSCAN           (*(CRCSCAN_t *) 0x0120) /* CRCSCAN */
+#define RTC                   (*(RTC_t *) 0x0140) /* Real-Time Counter */
+#define CCL                   (*(CCL_t *) 0x01C0) /* Configurable Custom Logic */
+#define EVSYS               (*(EVSYS_t *) 0x0200) /* Event System */
+#define PORTA                (*(PORT_t *) 0x0400) /* I/O Ports */
+#define PORTC                (*(PORT_t *) 0x0440) /* I/O Ports */
+#define PORTD                (*(PORT_t *) 0x0460) /* I/O Ports */
+#define PORTF                (*(PORT_t *) 0x04A0) /* I/O Ports */
+#define PORTMUX           (*(PORTMUX_t *) 0x05E0) /* Port Multiplexer */
+#define ADC0                  (*(ADC_t *) 0x0600) /* Analog to Digital Converter */
+#define AC0                    (*(AC_t *) 0x0680) /* Analog Comparator */
+#define AC1                    (*(AC_t *) 0x0688) /* Analog Comparator */
+#define DAC0                  (*(DAC_t *) 0x06A0) /* Digital to Analog Converter */
+#define USART0              (*(USART_t *) 0x0800) /* Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define USART1              (*(USART_t *) 0x0820) /* Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define USART2              (*(USART_t *) 0x0840) /* Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define TWI0                  (*(TWI_t *) 0x0900) /* Two-Wire Interface */
+#define SPI0                  (*(SPI_t *) 0x0940) /* Serial Peripheral Interface */
+#define TCA0                  (*(TCA_t *) 0x0A00) /* 16-bit Timer/Counter Type A */
+#define TCB0                  (*(TCB_t *) 0x0B00) /* 16-bit Timer Type B */
+#define TCB1                  (*(TCB_t *) 0x0B10) /* 16-bit Timer Type B */
+#define TCB2                  (*(TCB_t *) 0x0B20) /* 16-bit Timer Type B */
+#define SYSCFG             (*(SYSCFG_t *) 0x0F00) /* System Configuration Registers */
+#define NVMCTRL           (*(NVMCTRL_t *) 0x1000) /* Non-volatile Memory Controller */
+#define LOCK                 (*(LOCK_t *) 0x1040) /* Lockbits */
+#define FUSE                 (*(FUSE_t *) 0x1050) /* Fuses */
+#define USERROW           (*(USERROW_t *) 0x1080) /* User Row */
+#define SIGROW             (*(SIGROW_t *) 0x1100) /* Signature row */
+
+#endif /* !defined (__ASSEMBLER__) */
+
+
+/* ========== Flattened fully qualified IO register names ========== */
+
+
+/* VPORT (VPORTA) - Virtual Ports */
+#define VPORTA_DIR  _SFR_MEM8(0x0000)
+#define VPORTA_OUT  _SFR_MEM8(0x0001)
+#define VPORTA_IN  _SFR_MEM8(0x0002)
+#define VPORTA_INTFLAGS  _SFR_MEM8(0x0003)
+
+
+/* VPORT (VPORTC) - Virtual Ports */
+#define VPORTC_DIR  _SFR_MEM8(0x0008)
+#define VPORTC_OUT  _SFR_MEM8(0x0009)
+#define VPORTC_IN  _SFR_MEM8(0x000A)
+#define VPORTC_INTFLAGS  _SFR_MEM8(0x000B)
+
+
+/* VPORT (VPORTD) - Virtual Ports */
+#define VPORTD_DIR  _SFR_MEM8(0x000C)
+#define VPORTD_OUT  _SFR_MEM8(0x000D)
+#define VPORTD_IN  _SFR_MEM8(0x000E)
+#define VPORTD_INTFLAGS  _SFR_MEM8(0x000F)
+
+
+/* VPORT (VPORTF) - Virtual Ports */
+#define VPORTF_DIR  _SFR_MEM8(0x0014)
+#define VPORTF_OUT  _SFR_MEM8(0x0015)
+#define VPORTF_IN  _SFR_MEM8(0x0016)
+#define VPORTF_INTFLAGS  _SFR_MEM8(0x0017)
+
+
+/* GPR - General Purpose Registers */
+#define GPR_GPR0  _SFR_MEM8(0x001C)
+#define GPR_GPR1  _SFR_MEM8(0x001D)
+#define GPR_GPR2  _SFR_MEM8(0x001E)
+#define GPR_GPR3  _SFR_MEM8(0x001F)
+
+
+/* CPU - CPU */
+#define CPU_CCP  _SFR_MEM8(0x0034)
+#define CPU_SP  _SFR_MEM16(0x003D)
+#define CPU_SPL  _SFR_MEM8(0x003D)
+#define CPU_SPH  _SFR_MEM8(0x003E)
+#define CPU_SREG  _SFR_MEM8(0x003F)
+
+
+/* RSTCTRL - Reset controller */
+#define RSTCTRL_RSTFR  _SFR_MEM8(0x0040)
+#define RSTCTRL_SWRR  _SFR_MEM8(0x0041)
+
+
+/* SLPCTRL - Sleep Controller */
+#define SLPCTRL_CTRLA  _SFR_MEM8(0x0050)
+
+
+/* CLKCTRL - Clock controller */
+#define CLKCTRL_MCLKCTRLA  _SFR_MEM8(0x0060)
+#define CLKCTRL_MCLKCTRLB  _SFR_MEM8(0x0061)
+#define CLKCTRL_MCLKCTRLC  _SFR_MEM8(0x0062)
+#define CLKCTRL_MCLKINTCTRL  _SFR_MEM8(0x0063)
+#define CLKCTRL_MCLKINTFLAGS  _SFR_MEM8(0x0064)
+#define CLKCTRL_MCLKSTATUS  _SFR_MEM8(0x0065)
+#define CLKCTRL_MCLKTIMEBASE  _SFR_MEM8(0x0066)
+#define CLKCTRL_OSCHFCTRLA  _SFR_MEM8(0x0068)
+#define CLKCTRL_OSCHFTUNE  _SFR_MEM8(0x0069)
+#define CLKCTRL_OSC32KCTRLA  _SFR_MEM8(0x0078)
+#define CLKCTRL_XOSC32KCTRLA  _SFR_MEM8(0x007C)
+#define CLKCTRL_XOSCHFCTRLA  _SFR_MEM8(0x0080)
+
+
+/* BOD - Bod interface */
+#define BOD_CTRLA  _SFR_MEM8(0x00A0)
+#define BOD_CTRLB  _SFR_MEM8(0x00A1)
+#define BOD_VLMCTRLA  _SFR_MEM8(0x00A8)
+#define BOD_INTCTRL  _SFR_MEM8(0x00A9)
+#define BOD_INTFLAGS  _SFR_MEM8(0x00AA)
+#define BOD_STATUS  _SFR_MEM8(0x00AB)
+
+
+/* VREF - Voltage reference */
+#define VREF_DAC0REF  _SFR_MEM8(0x00B2)
+#define VREF_ACREF  _SFR_MEM8(0x00B4)
+
+
+/* WDT - Watch-Dog Timer */
+#define WDT_CTRLA  _SFR_MEM8(0x0100)
+#define WDT_STATUS  _SFR_MEM8(0x0101)
+
+
+/* CPUINT - Interrupt Controller */
+#define CPUINT_CTRLA  _SFR_MEM8(0x0110)
+#define CPUINT_STATUS  _SFR_MEM8(0x0111)
+#define CPUINT_LVL0PRI  _SFR_MEM8(0x0112)
+#define CPUINT_LVL1VEC  _SFR_MEM8(0x0113)
+
+
+/* CRCSCAN - CRCSCAN */
+#define CRCSCAN_CTRLA  _SFR_MEM8(0x0120)
+#define CRCSCAN_CTRLB  _SFR_MEM8(0x0121)
+#define CRCSCAN_STATUS  _SFR_MEM8(0x0122)
+
+
+/* RTC - Real-Time Counter */
+#define RTC_CTRLA  _SFR_MEM8(0x0140)
+#define RTC_STATUS  _SFR_MEM8(0x0141)
+#define RTC_INTCTRL  _SFR_MEM8(0x0142)
+#define RTC_INTFLAGS  _SFR_MEM8(0x0143)
+#define RTC_TEMP  _SFR_MEM8(0x0144)
+#define RTC_DBGCTRL  _SFR_MEM8(0x0145)
+#define RTC_CALIB  _SFR_MEM8(0x0146)
+#define RTC_CLKSEL  _SFR_MEM8(0x0147)
+#define RTC_CNT  _SFR_MEM16(0x0148)
+#define RTC_CNTL  _SFR_MEM8(0x0148)
+#define RTC_CNTH  _SFR_MEM8(0x0149)
+#define RTC_PER  _SFR_MEM16(0x014A)
+#define RTC_PERL  _SFR_MEM8(0x014A)
+#define RTC_PERH  _SFR_MEM8(0x014B)
+#define RTC_CMP  _SFR_MEM16(0x014C)
+#define RTC_CMPL  _SFR_MEM8(0x014C)
+#define RTC_CMPH  _SFR_MEM8(0x014D)
+#define RTC_PITCTRLA  _SFR_MEM8(0x0150)
+#define RTC_PITSTATUS  _SFR_MEM8(0x0151)
+#define RTC_PITINTCTRL  _SFR_MEM8(0x0152)
+#define RTC_PITINTFLAGS  _SFR_MEM8(0x0153)
+#define RTC_PITDBGCTRL  _SFR_MEM8(0x0155)
+#define RTC_PITEVGENCTRLA  _SFR_MEM8(0x0156)
+
+
+/* CCL - Configurable Custom Logic */
+#define CCL_CTRLA  _SFR_MEM8(0x01C0)
+#define CCL_SEQCTRL0  _SFR_MEM8(0x01C1)
+#define CCL_SEQCTRL1  _SFR_MEM8(0x01C2)
+#define CCL_INTCTRL0  _SFR_MEM8(0x01C5)
+#define CCL_INTFLAGS  _SFR_MEM8(0x01C7)
+#define CCL_LUT0CTRLA  _SFR_MEM8(0x01C8)
+#define CCL_LUT0CTRLB  _SFR_MEM8(0x01C9)
+#define CCL_LUT0CTRLC  _SFR_MEM8(0x01CA)
+#define CCL_TRUTH0  _SFR_MEM8(0x01CB)
+#define CCL_LUT1CTRLA  _SFR_MEM8(0x01CC)
+#define CCL_LUT1CTRLB  _SFR_MEM8(0x01CD)
+#define CCL_LUT1CTRLC  _SFR_MEM8(0x01CE)
+#define CCL_TRUTH1  _SFR_MEM8(0x01CF)
+#define CCL_LUT2CTRLA  _SFR_MEM8(0x01D0)
+#define CCL_LUT2CTRLB  _SFR_MEM8(0x01D1)
+#define CCL_LUT2CTRLC  _SFR_MEM8(0x01D2)
+#define CCL_TRUTH2  _SFR_MEM8(0x01D3)
+#define CCL_LUT3CTRLA  _SFR_MEM8(0x01D4)
+#define CCL_LUT3CTRLB  _SFR_MEM8(0x01D5)
+#define CCL_LUT3CTRLC  _SFR_MEM8(0x01D6)
+#define CCL_TRUTH3  _SFR_MEM8(0x01D7)
+
+
+/* EVSYS - Event System */
+#define EVSYS_SWEVENTA  _SFR_MEM8(0x0200)
+#define EVSYS_CHANNEL0  _SFR_MEM8(0x0210)
+#define EVSYS_CHANNEL1  _SFR_MEM8(0x0211)
+#define EVSYS_CHANNEL2  _SFR_MEM8(0x0212)
+#define EVSYS_CHANNEL3  _SFR_MEM8(0x0213)
+#define EVSYS_CHANNEL4  _SFR_MEM8(0x0214)
+#define EVSYS_CHANNEL5  _SFR_MEM8(0x0215)
+#define EVSYS_USERCCLLUT0A  _SFR_MEM8(0x0220)
+#define EVSYS_USERCCLLUT0B  _SFR_MEM8(0x0221)
+#define EVSYS_USERCCLLUT1A  _SFR_MEM8(0x0222)
+#define EVSYS_USERCCLLUT1B  _SFR_MEM8(0x0223)
+#define EVSYS_USERCCLLUT2A  _SFR_MEM8(0x0224)
+#define EVSYS_USERCCLLUT2B  _SFR_MEM8(0x0225)
+#define EVSYS_USERCCLLUT3A  _SFR_MEM8(0x0226)
+#define EVSYS_USERCCLLUT3B  _SFR_MEM8(0x0227)
+#define EVSYS_USERADC0START  _SFR_MEM8(0x0228)
+#define EVSYS_USEREVSYSEVOUTA  _SFR_MEM8(0x0229)
+#define EVSYS_USEREVSYSEVOUTC  _SFR_MEM8(0x022B)
+#define EVSYS_USEREVSYSEVOUTD  _SFR_MEM8(0x022C)
+#define EVSYS_USEREVSYSEVOUTF  _SFR_MEM8(0x022E)
+#define EVSYS_USERUSART0IRDA  _SFR_MEM8(0x022F)
+#define EVSYS_USERUSART1IRDA  _SFR_MEM8(0x0230)
+#define EVSYS_USERUSART2IRDA  _SFR_MEM8(0x0231)
+#define EVSYS_USERTCA0CNTA  _SFR_MEM8(0x0232)
+#define EVSYS_USERTCA0CNTB  _SFR_MEM8(0x0233)
+#define EVSYS_USERTCA1CNTA  _SFR_MEM8(0x0234)
+#define EVSYS_USERTCA1CNTB  _SFR_MEM8(0x0235)
+#define EVSYS_USERTCB0CAPT  _SFR_MEM8(0x0236)
+#define EVSYS_USERTCB0COUNT  _SFR_MEM8(0x0237)
+#define EVSYS_USERTCB1CAPT  _SFR_MEM8(0x0238)
+#define EVSYS_USERTCB1COUNT  _SFR_MEM8(0x0239)
+#define EVSYS_USERTCB2CAPT  _SFR_MEM8(0x023A)
+#define EVSYS_USERTCB2COUNT  _SFR_MEM8(0x023B)
+#define EVSYS_USERTCB3CAPT  _SFR_MEM8(0x023C)
+#define EVSYS_USERTCB3COUNT  _SFR_MEM8(0x023D)
+
+
+/* PORT (PORTA) - I/O Ports */
+#define PORTA_DIR  _SFR_MEM8(0x0400)
+#define PORTA_DIRSET  _SFR_MEM8(0x0401)
+#define PORTA_DIRCLR  _SFR_MEM8(0x0402)
+#define PORTA_DIRTGL  _SFR_MEM8(0x0403)
+#define PORTA_OUT  _SFR_MEM8(0x0404)
+#define PORTA_OUTSET  _SFR_MEM8(0x0405)
+#define PORTA_OUTCLR  _SFR_MEM8(0x0406)
+#define PORTA_OUTTGL  _SFR_MEM8(0x0407)
+#define PORTA_IN  _SFR_MEM8(0x0408)
+#define PORTA_INTFLAGS  _SFR_MEM8(0x0409)
+#define PORTA_PORTCTRL  _SFR_MEM8(0x040A)
+#define PORTA_PINCONFIG  _SFR_MEM8(0x040B)
+#define PORTA_PINCTRLUPD  _SFR_MEM8(0x040C)
+#define PORTA_PINCTRLSET  _SFR_MEM8(0x040D)
+#define PORTA_PINCTRLCLR  _SFR_MEM8(0x040E)
+#define PORTA_PIN0CTRL  _SFR_MEM8(0x0410)
+#define PORTA_PIN1CTRL  _SFR_MEM8(0x0411)
+#define PORTA_PIN2CTRL  _SFR_MEM8(0x0412)
+#define PORTA_PIN3CTRL  _SFR_MEM8(0x0413)
+#define PORTA_PIN4CTRL  _SFR_MEM8(0x0414)
+#define PORTA_PIN5CTRL  _SFR_MEM8(0x0415)
+#define PORTA_PIN6CTRL  _SFR_MEM8(0x0416)
+#define PORTA_PIN7CTRL  _SFR_MEM8(0x0417)
+#define PORTA_EVGENCTRL  _SFR_MEM8(0x0418)
+
+
+/* PORT (PORTC) - I/O Ports */
+#define PORTC_DIR  _SFR_MEM8(0x0440)
+#define PORTC_DIRSET  _SFR_MEM8(0x0441)
+#define PORTC_DIRCLR  _SFR_MEM8(0x0442)
+#define PORTC_DIRTGL  _SFR_MEM8(0x0443)
+#define PORTC_OUT  _SFR_MEM8(0x0444)
+#define PORTC_OUTSET  _SFR_MEM8(0x0445)
+#define PORTC_OUTCLR  _SFR_MEM8(0x0446)
+#define PORTC_OUTTGL  _SFR_MEM8(0x0447)
+#define PORTC_IN  _SFR_MEM8(0x0448)
+#define PORTC_INTFLAGS  _SFR_MEM8(0x0449)
+#define PORTC_PORTCTRL  _SFR_MEM8(0x044A)
+#define PORTC_PINCONFIG  _SFR_MEM8(0x044B)
+#define PORTC_PINCTRLUPD  _SFR_MEM8(0x044C)
+#define PORTC_PINCTRLSET  _SFR_MEM8(0x044D)
+#define PORTC_PINCTRLCLR  _SFR_MEM8(0x044E)
+#define PORTC_PIN0CTRL  _SFR_MEM8(0x0450)
+#define PORTC_PIN1CTRL  _SFR_MEM8(0x0451)
+#define PORTC_PIN2CTRL  _SFR_MEM8(0x0452)
+#define PORTC_PIN3CTRL  _SFR_MEM8(0x0453)
+#define PORTC_PIN4CTRL  _SFR_MEM8(0x0454)
+#define PORTC_PIN5CTRL  _SFR_MEM8(0x0455)
+#define PORTC_PIN6CTRL  _SFR_MEM8(0x0456)
+#define PORTC_PIN7CTRL  _SFR_MEM8(0x0457)
+#define PORTC_EVGENCTRL  _SFR_MEM8(0x0458)
+
+
+/* PORT (PORTD) - I/O Ports */
+#define PORTD_DIR  _SFR_MEM8(0x0460)
+#define PORTD_DIRSET  _SFR_MEM8(0x0461)
+#define PORTD_DIRCLR  _SFR_MEM8(0x0462)
+#define PORTD_DIRTGL  _SFR_MEM8(0x0463)
+#define PORTD_OUT  _SFR_MEM8(0x0464)
+#define PORTD_OUTSET  _SFR_MEM8(0x0465)
+#define PORTD_OUTCLR  _SFR_MEM8(0x0466)
+#define PORTD_OUTTGL  _SFR_MEM8(0x0467)
+#define PORTD_IN  _SFR_MEM8(0x0468)
+#define PORTD_INTFLAGS  _SFR_MEM8(0x0469)
+#define PORTD_PORTCTRL  _SFR_MEM8(0x046A)
+#define PORTD_PINCONFIG  _SFR_MEM8(0x046B)
+#define PORTD_PINCTRLUPD  _SFR_MEM8(0x046C)
+#define PORTD_PINCTRLSET  _SFR_MEM8(0x046D)
+#define PORTD_PINCTRLCLR  _SFR_MEM8(0x046E)
+#define PORTD_PIN0CTRL  _SFR_MEM8(0x0470)
+#define PORTD_PIN1CTRL  _SFR_MEM8(0x0471)
+#define PORTD_PIN2CTRL  _SFR_MEM8(0x0472)
+#define PORTD_PIN3CTRL  _SFR_MEM8(0x0473)
+#define PORTD_PIN4CTRL  _SFR_MEM8(0x0474)
+#define PORTD_PIN5CTRL  _SFR_MEM8(0x0475)
+#define PORTD_PIN6CTRL  _SFR_MEM8(0x0476)
+#define PORTD_PIN7CTRL  _SFR_MEM8(0x0477)
+#define PORTD_EVGENCTRL  _SFR_MEM8(0x0478)
+
+
+/* PORT (PORTF) - I/O Ports */
+#define PORTF_DIR  _SFR_MEM8(0x04A0)
+#define PORTF_DIRSET  _SFR_MEM8(0x04A1)
+#define PORTF_DIRCLR  _SFR_MEM8(0x04A2)
+#define PORTF_DIRTGL  _SFR_MEM8(0x04A3)
+#define PORTF_OUT  _SFR_MEM8(0x04A4)
+#define PORTF_OUTSET  _SFR_MEM8(0x04A5)
+#define PORTF_OUTCLR  _SFR_MEM8(0x04A6)
+#define PORTF_OUTTGL  _SFR_MEM8(0x04A7)
+#define PORTF_IN  _SFR_MEM8(0x04A8)
+#define PORTF_INTFLAGS  _SFR_MEM8(0x04A9)
+#define PORTF_PORTCTRL  _SFR_MEM8(0x04AA)
+#define PORTF_PINCONFIG  _SFR_MEM8(0x04AB)
+#define PORTF_PINCTRLUPD  _SFR_MEM8(0x04AC)
+#define PORTF_PINCTRLSET  _SFR_MEM8(0x04AD)
+#define PORTF_PINCTRLCLR  _SFR_MEM8(0x04AE)
+#define PORTF_PIN0CTRL  _SFR_MEM8(0x04B0)
+#define PORTF_PIN1CTRL  _SFR_MEM8(0x04B1)
+#define PORTF_PIN2CTRL  _SFR_MEM8(0x04B2)
+#define PORTF_PIN3CTRL  _SFR_MEM8(0x04B3)
+#define PORTF_PIN4CTRL  _SFR_MEM8(0x04B4)
+#define PORTF_PIN5CTRL  _SFR_MEM8(0x04B5)
+#define PORTF_PIN6CTRL  _SFR_MEM8(0x04B6)
+#define PORTF_PIN7CTRL  _SFR_MEM8(0x04B7)
+#define PORTF_EVGENCTRL  _SFR_MEM8(0x04B8)
+
+
+/* PORTMUX - Port Multiplexer */
+#define PORTMUX_EVSYSROUTEA  _SFR_MEM8(0x05E0)
+#define PORTMUX_CCLROUTEA  _SFR_MEM8(0x05E1)
+#define PORTMUX_USARTROUTEA  _SFR_MEM8(0x05E2)
+#define PORTMUX_USARTROUTEB  _SFR_MEM8(0x05E3)
+#define PORTMUX_SPIROUTEA  _SFR_MEM8(0x05E5)
+#define PORTMUX_TWIROUTEA  _SFR_MEM8(0x05E6)
+#define PORTMUX_TCAROUTEA  _SFR_MEM8(0x05E7)
+#define PORTMUX_TCBROUTEA  _SFR_MEM8(0x05E8)
+#define PORTMUX_ACROUTEA  _SFR_MEM8(0x05EA)
+
+
+/* ADC (ADC0) - Analog to Digital Converter */
+#define ADC0_CTRLA  _SFR_MEM8(0x0600)
+#define ADC0_CTRLB  _SFR_MEM8(0x0601)
+#define ADC0_CTRLC  _SFR_MEM8(0x0602)
+#define ADC0_CTRLD  _SFR_MEM8(0x0603)
+#define ADC0_INTCTRL  _SFR_MEM8(0x0604)
+#define ADC0_INTFLAGS  _SFR_MEM8(0x0605)
+#define ADC0_STATUS  _SFR_MEM8(0x0606)
+#define ADC0_DBGCTRL  _SFR_MEM8(0x0607)
+#define ADC0_CTRLE  _SFR_MEM8(0x0608)
+#define ADC0_CTRLF  _SFR_MEM8(0x0609)
+#define ADC0_COMMAND  _SFR_MEM8(0x060A)
+#define ADC0_PGACTRL  _SFR_MEM8(0x060B)
+#define ADC0_MUXPOS  _SFR_MEM8(0x060C)
+#define ADC0_MUXNEG  _SFR_MEM8(0x060D)
+#define ADC0_RESULT  _SFR_MEM32(0x0610)
+#define ADC0_RESULT0  _SFR_MEM8(0x0610)
+#define ADC0_RESULT1  _SFR_MEM8(0x0611)
+#define ADC0_RESULT2  _SFR_MEM8(0x0612)
+#define ADC0_RESULT3  _SFR_MEM8(0x0613)
+#define ADC0_SAMPLE  _SFR_MEM16(0x0614)
+#define ADC0_SAMPLEL  _SFR_MEM8(0x0614)
+#define ADC0_SAMPLEH  _SFR_MEM8(0x0615)
+#define ADC0_TEMP0  _SFR_MEM8(0x0618)
+#define ADC0_TEMP1  _SFR_MEM8(0x0619)
+#define ADC0_TEMP2  _SFR_MEM8(0x061A)
+#define ADC0_WINLT  _SFR_MEM16(0x061C)
+#define ADC0_WINLTL  _SFR_MEM8(0x061C)
+#define ADC0_WINLTH  _SFR_MEM8(0x061D)
+#define ADC0_WINHT  _SFR_MEM16(0x061E)
+#define ADC0_WINHTL  _SFR_MEM8(0x061E)
+#define ADC0_WINHTH  _SFR_MEM8(0x061F)
+
+
+/* AC (AC0) - Analog Comparator */
+#define AC0_CTRLA  _SFR_MEM8(0x0680)
+#define AC0_CTRLB  _SFR_MEM8(0x0681)
+#define AC0_MUXCTRL  _SFR_MEM8(0x0682)
+#define AC0_DACREF  _SFR_MEM8(0x0685)
+#define AC0_INTCTRL  _SFR_MEM8(0x0686)
+#define AC0_STATUS  _SFR_MEM8(0x0687)
+
+
+/* AC (AC1) - Analog Comparator */
+#define AC1_CTRLA  _SFR_MEM8(0x0688)
+#define AC1_CTRLB  _SFR_MEM8(0x0689)
+#define AC1_MUXCTRL  _SFR_MEM8(0x068A)
+#define AC1_DACREF  _SFR_MEM8(0x068D)
+#define AC1_INTCTRL  _SFR_MEM8(0x068E)
+#define AC1_STATUS  _SFR_MEM8(0x068F)
+
+
+/* DAC (DAC0) - Digital to Analog Converter */
+#define DAC0_CTRLA  _SFR_MEM8(0x06A0)
+#define DAC0_DATA  _SFR_MEM16(0x06A2)
+#define DAC0_DATAL  _SFR_MEM8(0x06A2)
+#define DAC0_DATAH  _SFR_MEM8(0x06A3)
+
+
+/* USART (USART0) - Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define USART0_RXDATAL  _SFR_MEM8(0x0800)
+#define USART0_RXDATAH  _SFR_MEM8(0x0801)
+#define USART0_TXDATAL  _SFR_MEM8(0x0802)
+#define USART0_TXDATAH  _SFR_MEM8(0x0803)
+#define USART0_STATUS  _SFR_MEM8(0x0804)
+#define USART0_CTRLA  _SFR_MEM8(0x0805)
+#define USART0_CTRLB  _SFR_MEM8(0x0806)
+#define USART0_CTRLC  _SFR_MEM8(0x0807)
+#define USART0_BAUD  _SFR_MEM16(0x0808)
+#define USART0_BAUDL  _SFR_MEM8(0x0808)
+#define USART0_BAUDH  _SFR_MEM8(0x0809)
+#define USART0_CTRLD  _SFR_MEM8(0x080A)
+#define USART0_DBGCTRL  _SFR_MEM8(0x080B)
+#define USART0_EVCTRL  _SFR_MEM8(0x080C)
+#define USART0_TXPLCTRL  _SFR_MEM8(0x080D)
+#define USART0_RXPLCTRL  _SFR_MEM8(0x080E)
+
+
+/* USART (USART1) - Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define USART1_RXDATAL  _SFR_MEM8(0x0820)
+#define USART1_RXDATAH  _SFR_MEM8(0x0821)
+#define USART1_TXDATAL  _SFR_MEM8(0x0822)
+#define USART1_TXDATAH  _SFR_MEM8(0x0823)
+#define USART1_STATUS  _SFR_MEM8(0x0824)
+#define USART1_CTRLA  _SFR_MEM8(0x0825)
+#define USART1_CTRLB  _SFR_MEM8(0x0826)
+#define USART1_CTRLC  _SFR_MEM8(0x0827)
+#define USART1_BAUD  _SFR_MEM16(0x0828)
+#define USART1_BAUDL  _SFR_MEM8(0x0828)
+#define USART1_BAUDH  _SFR_MEM8(0x0829)
+#define USART1_CTRLD  _SFR_MEM8(0x082A)
+#define USART1_DBGCTRL  _SFR_MEM8(0x082B)
+#define USART1_EVCTRL  _SFR_MEM8(0x082C)
+#define USART1_TXPLCTRL  _SFR_MEM8(0x082D)
+#define USART1_RXPLCTRL  _SFR_MEM8(0x082E)
+
+
+/* USART (USART2) - Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define USART2_RXDATAL  _SFR_MEM8(0x0840)
+#define USART2_RXDATAH  _SFR_MEM8(0x0841)
+#define USART2_TXDATAL  _SFR_MEM8(0x0842)
+#define USART2_TXDATAH  _SFR_MEM8(0x0843)
+#define USART2_STATUS  _SFR_MEM8(0x0844)
+#define USART2_CTRLA  _SFR_MEM8(0x0845)
+#define USART2_CTRLB  _SFR_MEM8(0x0846)
+#define USART2_CTRLC  _SFR_MEM8(0x0847)
+#define USART2_BAUD  _SFR_MEM16(0x0848)
+#define USART2_BAUDL  _SFR_MEM8(0x0848)
+#define USART2_BAUDH  _SFR_MEM8(0x0849)
+#define USART2_CTRLD  _SFR_MEM8(0x084A)
+#define USART2_DBGCTRL  _SFR_MEM8(0x084B)
+#define USART2_EVCTRL  _SFR_MEM8(0x084C)
+#define USART2_TXPLCTRL  _SFR_MEM8(0x084D)
+#define USART2_RXPLCTRL  _SFR_MEM8(0x084E)
+
+
+/* TWI (TWI0) - Two-Wire Interface */
+#define TWI0_CTRLA  _SFR_MEM8(0x0900)
+#define TWI0_DUALCTRL  _SFR_MEM8(0x0901)
+#define TWI0_DBGCTRL  _SFR_MEM8(0x0902)
+#define TWI0_MCTRLA  _SFR_MEM8(0x0903)
+#define TWI0_MCTRLB  _SFR_MEM8(0x0904)
+#define TWI0_MSTATUS  _SFR_MEM8(0x0905)
+#define TWI0_MBAUD  _SFR_MEM8(0x0906)
+#define TWI0_MADDR  _SFR_MEM8(0x0907)
+#define TWI0_MDATA  _SFR_MEM8(0x0908)
+#define TWI0_SCTRLA  _SFR_MEM8(0x0909)
+#define TWI0_SCTRLB  _SFR_MEM8(0x090A)
+#define TWI0_SSTATUS  _SFR_MEM8(0x090B)
+#define TWI0_SADDR  _SFR_MEM8(0x090C)
+#define TWI0_SDATA  _SFR_MEM8(0x090D)
+#define TWI0_SADDRMASK  _SFR_MEM8(0x090E)
+
+
+/* SPI (SPI0) - Serial Peripheral Interface */
+#define SPI0_CTRLA  _SFR_MEM8(0x0940)
+#define SPI0_CTRLB  _SFR_MEM8(0x0941)
+#define SPI0_INTCTRL  _SFR_MEM8(0x0942)
+#define SPI0_INTFLAGS  _SFR_MEM8(0x0943)
+#define SPI0_DATA  _SFR_MEM8(0x0944)
+
+
+/* TCA (TCA0) - 16-bit Timer/Counter Type A - Single Mode */
+#define TCA0_SINGLE_CTRLA  _SFR_MEM8(0x0A00)
+#define TCA0_SINGLE_CTRLB  _SFR_MEM8(0x0A01)
+#define TCA0_SINGLE_CTRLC  _SFR_MEM8(0x0A02)
+#define TCA0_SINGLE_CTRLD  _SFR_MEM8(0x0A03)
+#define TCA0_SINGLE_CTRLECLR  _SFR_MEM8(0x0A04)
+#define TCA0_SINGLE_CTRLESET  _SFR_MEM8(0x0A05)
+#define TCA0_SINGLE_CTRLFCLR  _SFR_MEM8(0x0A06)
+#define TCA0_SINGLE_CTRLFSET  _SFR_MEM8(0x0A07)
+#define TCA0_SINGLE_EVCTRL  _SFR_MEM8(0x0A09)
+#define TCA0_SINGLE_INTCTRL  _SFR_MEM8(0x0A0A)
+#define TCA0_SINGLE_INTFLAGS  _SFR_MEM8(0x0A0B)
+#define TCA0_SINGLE_DBGCTRL  _SFR_MEM8(0x0A0E)
+#define TCA0_SINGLE_TEMP  _SFR_MEM8(0x0A0F)
+#define TCA0_SINGLE_CNT  _SFR_MEM16(0x0A20)
+#define TCA0_SINGLE_CNTL  _SFR_MEM8(0x0A20)
+#define TCA0_SINGLE_CNTH  _SFR_MEM8(0x0A21)
+#define TCA0_SINGLE_PER  _SFR_MEM16(0x0A26)
+#define TCA0_SINGLE_PERL  _SFR_MEM8(0x0A26)
+#define TCA0_SINGLE_PERH  _SFR_MEM8(0x0A27)
+#define TCA0_SINGLE_CMP0  _SFR_MEM16(0x0A28)
+#define TCA0_SINGLE_CMP0L  _SFR_MEM8(0x0A28)
+#define TCA0_SINGLE_CMP0H  _SFR_MEM8(0x0A29)
+#define TCA0_SINGLE_CMP1  _SFR_MEM16(0x0A2A)
+#define TCA0_SINGLE_CMP1L  _SFR_MEM8(0x0A2A)
+#define TCA0_SINGLE_CMP1H  _SFR_MEM8(0x0A2B)
+#define TCA0_SINGLE_CMP2  _SFR_MEM16(0x0A2C)
+#define TCA0_SINGLE_CMP2L  _SFR_MEM8(0x0A2C)
+#define TCA0_SINGLE_CMP2H  _SFR_MEM8(0x0A2D)
+#define TCA0_SINGLE_PERBUF  _SFR_MEM16(0x0A36)
+#define TCA0_SINGLE_PERBUFL  _SFR_MEM8(0x0A36)
+#define TCA0_SINGLE_PERBUFH  _SFR_MEM8(0x0A37)
+#define TCA0_SINGLE_CMP0BUF  _SFR_MEM16(0x0A38)
+#define TCA0_SINGLE_CMP0BUFL  _SFR_MEM8(0x0A38)
+#define TCA0_SINGLE_CMP0BUFH  _SFR_MEM8(0x0A39)
+#define TCA0_SINGLE_CMP1BUF  _SFR_MEM16(0x0A3A)
+#define TCA0_SINGLE_CMP1BUFL  _SFR_MEM8(0x0A3A)
+#define TCA0_SINGLE_CMP1BUFH  _SFR_MEM8(0x0A3B)
+#define TCA0_SINGLE_CMP2BUF  _SFR_MEM16(0x0A3C)
+#define TCA0_SINGLE_CMP2BUFL  _SFR_MEM8(0x0A3C)
+#define TCA0_SINGLE_CMP2BUFH  _SFR_MEM8(0x0A3D)
+
+
+/* TCA (TCA0) - 16-bit Timer/Counter Type A - Split Mode */
+#define TCA0_SPLIT_CTRLA  _SFR_MEM8(0x0A00)
+#define TCA0_SPLIT_CTRLB  _SFR_MEM8(0x0A01)
+#define TCA0_SPLIT_CTRLC  _SFR_MEM8(0x0A02)
+#define TCA0_SPLIT_CTRLD  _SFR_MEM8(0x0A03)
+#define TCA0_SPLIT_CTRLECLR  _SFR_MEM8(0x0A04)
+#define TCA0_SPLIT_CTRLESET  _SFR_MEM8(0x0A05)
+#define TCA0_SPLIT_INTCTRL  _SFR_MEM8(0x0A0A)
+#define TCA0_SPLIT_INTFLAGS  _SFR_MEM8(0x0A0B)
+#define TCA0_SPLIT_DBGCTRL  _SFR_MEM8(0x0A0E)
+#define TCA0_SPLIT_LCNT  _SFR_MEM8(0x0A20)
+#define TCA0_SPLIT_HCNT  _SFR_MEM8(0x0A21)
+#define TCA0_SPLIT_LPER  _SFR_MEM8(0x0A26)
+#define TCA0_SPLIT_HPER  _SFR_MEM8(0x0A27)
+#define TCA0_SPLIT_LCMP0  _SFR_MEM8(0x0A28)
+#define TCA0_SPLIT_HCMP0  _SFR_MEM8(0x0A29)
+#define TCA0_SPLIT_LCMP1  _SFR_MEM8(0x0A2A)
+#define TCA0_SPLIT_HCMP1  _SFR_MEM8(0x0A2B)
+#define TCA0_SPLIT_LCMP2  _SFR_MEM8(0x0A2C)
+#define TCA0_SPLIT_HCMP2  _SFR_MEM8(0x0A2D)
+
+
+/* TCB (TCB0) - 16-bit Timer Type B */
+#define TCB0_CTRLA  _SFR_MEM8(0x0B00)
+#define TCB0_CTRLB  _SFR_MEM8(0x0B01)
+#define TCB0_EVCTRL  _SFR_MEM8(0x0B04)
+#define TCB0_INTCTRL  _SFR_MEM8(0x0B05)
+#define TCB0_INTFLAGS  _SFR_MEM8(0x0B06)
+#define TCB0_STATUS  _SFR_MEM8(0x0B07)
+#define TCB0_DBGCTRL  _SFR_MEM8(0x0B08)
+#define TCB0_TEMP  _SFR_MEM8(0x0B09)
+#define TCB0_CNT  _SFR_MEM16(0x0B0A)
+#define TCB0_CNTL  _SFR_MEM8(0x0B0A)
+#define TCB0_CNTH  _SFR_MEM8(0x0B0B)
+#define TCB0_CCMP  _SFR_MEM16(0x0B0C)
+#define TCB0_CCMPL  _SFR_MEM8(0x0B0C)
+#define TCB0_CCMPH  _SFR_MEM8(0x0B0D)
+
+
+/* TCB (TCB1) - 16-bit Timer Type B */
+#define TCB1_CTRLA  _SFR_MEM8(0x0B10)
+#define TCB1_CTRLB  _SFR_MEM8(0x0B11)
+#define TCB1_EVCTRL  _SFR_MEM8(0x0B14)
+#define TCB1_INTCTRL  _SFR_MEM8(0x0B15)
+#define TCB1_INTFLAGS  _SFR_MEM8(0x0B16)
+#define TCB1_STATUS  _SFR_MEM8(0x0B17)
+#define TCB1_DBGCTRL  _SFR_MEM8(0x0B18)
+#define TCB1_TEMP  _SFR_MEM8(0x0B19)
+#define TCB1_CNT  _SFR_MEM16(0x0B1A)
+#define TCB1_CNTL  _SFR_MEM8(0x0B1A)
+#define TCB1_CNTH  _SFR_MEM8(0x0B1B)
+#define TCB1_CCMP  _SFR_MEM16(0x0B1C)
+#define TCB1_CCMPL  _SFR_MEM8(0x0B1C)
+#define TCB1_CCMPH  _SFR_MEM8(0x0B1D)
+
+
+/* TCB (TCB2) - 16-bit Timer Type B */
+#define TCB2_CTRLA  _SFR_MEM8(0x0B20)
+#define TCB2_CTRLB  _SFR_MEM8(0x0B21)
+#define TCB2_EVCTRL  _SFR_MEM8(0x0B24)
+#define TCB2_INTCTRL  _SFR_MEM8(0x0B25)
+#define TCB2_INTFLAGS  _SFR_MEM8(0x0B26)
+#define TCB2_STATUS  _SFR_MEM8(0x0B27)
+#define TCB2_DBGCTRL  _SFR_MEM8(0x0B28)
+#define TCB2_TEMP  _SFR_MEM8(0x0B29)
+#define TCB2_CNT  _SFR_MEM16(0x0B2A)
+#define TCB2_CNTL  _SFR_MEM8(0x0B2A)
+#define TCB2_CNTH  _SFR_MEM8(0x0B2B)
+#define TCB2_CCMP  _SFR_MEM16(0x0B2C)
+#define TCB2_CCMPL  _SFR_MEM8(0x0B2C)
+#define TCB2_CCMPH  _SFR_MEM8(0x0B2D)
+
+
+/* SYSCFG - System Configuration Registers */
+#define SYSCFG_REVID  _SFR_MEM8(0x0F01)
+#define SYSCFG_OCDMCTRL  _SFR_MEM8(0x0F04)
+#define SYSCFG_OCDMSTATUS  _SFR_MEM8(0x0F05)
+
+
+/* NVMCTRL - Non-volatile Memory Controller */
+#define NVMCTRL_CTRLA  _SFR_MEM8(0x1000)
+#define NVMCTRL_CTRLB  _SFR_MEM8(0x1001)
+#define NVMCTRL_INTCTRL  _SFR_MEM8(0x1004)
+#define NVMCTRL_INTFLAGS  _SFR_MEM8(0x1005)
+#define NVMCTRL_STATUS  _SFR_MEM8(0x1006)
+#define NVMCTRL_DATA  _SFR_MEM16(0x1008)
+#define NVMCTRL_DATAL  _SFR_MEM8(0x1008)
+#define NVMCTRL_DATAH  _SFR_MEM8(0x1009)
+#define NVMCTRL_ADDR  _SFR_MEM32(0x100C)
+#define NVMCTRL_ADDR0  _SFR_MEM8(0x100C)
+#define NVMCTRL_ADDR1  _SFR_MEM8(0x100D)
+#define NVMCTRL_ADDR2  _SFR_MEM8(0x100E)
+#define NVMCTRL_ADDR3  _SFR_MEM8(0x100F)
+
+
+/* LOCK - Lockbits */
+#define LOCK_KEY  _SFR_MEM32(0x1040)
+#define LOCK_KEY0  _SFR_MEM8(0x1040)
+#define LOCK_KEY1  _SFR_MEM8(0x1041)
+#define LOCK_KEY2  _SFR_MEM8(0x1042)
+#define LOCK_KEY3  _SFR_MEM8(0x1043)
+
+
+/* FUSE - Fuses */
+#define FUSE_WDTCFG  _SFR_MEM8(0x1050)
+#define FUSE_BODCFG  _SFR_MEM8(0x1051)
+#define FUSE_OSCCFG  _SFR_MEM8(0x1052)
+#define FUSE_SYSCFG0  _SFR_MEM8(0x1055)
+#define FUSE_SYSCFG1  _SFR_MEM8(0x1056)
+#define FUSE_CODESIZE  _SFR_MEM8(0x1057)
+#define FUSE_BOOTSIZE  _SFR_MEM8(0x1058)
+
+
+/* USERROW - User Row */
+#define USERROW_USERROW0  _SFR_MEM8(0x1080)
+#define USERROW_USERROW1  _SFR_MEM8(0x1081)
+#define USERROW_USERROW2  _SFR_MEM8(0x1082)
+#define USERROW_USERROW3  _SFR_MEM8(0x1083)
+#define USERROW_USERROW4  _SFR_MEM8(0x1084)
+#define USERROW_USERROW5  _SFR_MEM8(0x1085)
+#define USERROW_USERROW6  _SFR_MEM8(0x1086)
+#define USERROW_USERROW7  _SFR_MEM8(0x1087)
+#define USERROW_USERROW8  _SFR_MEM8(0x1088)
+#define USERROW_USERROW9  _SFR_MEM8(0x1089)
+#define USERROW_USERROW10  _SFR_MEM8(0x108A)
+#define USERROW_USERROW11  _SFR_MEM8(0x108B)
+#define USERROW_USERROW12  _SFR_MEM8(0x108C)
+#define USERROW_USERROW13  _SFR_MEM8(0x108D)
+#define USERROW_USERROW14  _SFR_MEM8(0x108E)
+#define USERROW_USERROW15  _SFR_MEM8(0x108F)
+#define USERROW_USERROW16  _SFR_MEM8(0x1090)
+#define USERROW_USERROW17  _SFR_MEM8(0x1091)
+#define USERROW_USERROW18  _SFR_MEM8(0x1092)
+#define USERROW_USERROW19  _SFR_MEM8(0x1093)
+#define USERROW_USERROW20  _SFR_MEM8(0x1094)
+#define USERROW_USERROW21  _SFR_MEM8(0x1095)
+#define USERROW_USERROW22  _SFR_MEM8(0x1096)
+#define USERROW_USERROW23  _SFR_MEM8(0x1097)
+#define USERROW_USERROW24  _SFR_MEM8(0x1098)
+#define USERROW_USERROW25  _SFR_MEM8(0x1099)
+#define USERROW_USERROW26  _SFR_MEM8(0x109A)
+#define USERROW_USERROW27  _SFR_MEM8(0x109B)
+#define USERROW_USERROW28  _SFR_MEM8(0x109C)
+#define USERROW_USERROW29  _SFR_MEM8(0x109D)
+#define USERROW_USERROW30  _SFR_MEM8(0x109E)
+#define USERROW_USERROW31  _SFR_MEM8(0x109F)
+#define USERROW_USERROW32  _SFR_MEM8(0x10A0)
+#define USERROW_USERROW33  _SFR_MEM8(0x10A1)
+#define USERROW_USERROW34  _SFR_MEM8(0x10A2)
+#define USERROW_USERROW35  _SFR_MEM8(0x10A3)
+#define USERROW_USERROW36  _SFR_MEM8(0x10A4)
+#define USERROW_USERROW37  _SFR_MEM8(0x10A5)
+#define USERROW_USERROW38  _SFR_MEM8(0x10A6)
+#define USERROW_USERROW39  _SFR_MEM8(0x10A7)
+#define USERROW_USERROW40  _SFR_MEM8(0x10A8)
+#define USERROW_USERROW41  _SFR_MEM8(0x10A9)
+#define USERROW_USERROW42  _SFR_MEM8(0x10AA)
+#define USERROW_USERROW43  _SFR_MEM8(0x10AB)
+#define USERROW_USERROW44  _SFR_MEM8(0x10AC)
+#define USERROW_USERROW45  _SFR_MEM8(0x10AD)
+#define USERROW_USERROW46  _SFR_MEM8(0x10AE)
+#define USERROW_USERROW47  _SFR_MEM8(0x10AF)
+#define USERROW_USERROW48  _SFR_MEM8(0x10B0)
+#define USERROW_USERROW49  _SFR_MEM8(0x10B1)
+#define USERROW_USERROW50  _SFR_MEM8(0x10B2)
+#define USERROW_USERROW51  _SFR_MEM8(0x10B3)
+#define USERROW_USERROW52  _SFR_MEM8(0x10B4)
+#define USERROW_USERROW53  _SFR_MEM8(0x10B5)
+#define USERROW_USERROW54  _SFR_MEM8(0x10B6)
+#define USERROW_USERROW55  _SFR_MEM8(0x10B7)
+#define USERROW_USERROW56  _SFR_MEM8(0x10B8)
+#define USERROW_USERROW57  _SFR_MEM8(0x10B9)
+#define USERROW_USERROW58  _SFR_MEM8(0x10BA)
+#define USERROW_USERROW59  _SFR_MEM8(0x10BB)
+#define USERROW_USERROW60  _SFR_MEM8(0x10BC)
+#define USERROW_USERROW61  _SFR_MEM8(0x10BD)
+#define USERROW_USERROW62  _SFR_MEM8(0x10BE)
+#define USERROW_USERROW63  _SFR_MEM8(0x10BF)
+
+
+/* SIGROW - Signature row */
+#define SIGROW_DEVICEID0  _SFR_MEM8(0x1100)
+#define SIGROW_DEVICEID1  _SFR_MEM8(0x1101)
+#define SIGROW_DEVICEID2  _SFR_MEM8(0x1102)
+#define SIGROW_TEMPSENSE0  _SFR_MEM16(0x1104)
+#define SIGROW_TEMPSENSE0L  _SFR_MEM8(0x1104)
+#define SIGROW_TEMPSENSE0H  _SFR_MEM8(0x1105)
+#define SIGROW_TEMPSENSE1  _SFR_MEM16(0x1106)
+#define SIGROW_TEMPSENSE1L  _SFR_MEM8(0x1106)
+#define SIGROW_TEMPSENSE1H  _SFR_MEM8(0x1107)
+#define SIGROW_SERNUM0  _SFR_MEM8(0x1110)
+#define SIGROW_SERNUM1  _SFR_MEM8(0x1111)
+#define SIGROW_SERNUM2  _SFR_MEM8(0x1112)
+#define SIGROW_SERNUM3  _SFR_MEM8(0x1113)
+#define SIGROW_SERNUM4  _SFR_MEM8(0x1114)
+#define SIGROW_SERNUM5  _SFR_MEM8(0x1115)
+#define SIGROW_SERNUM6  _SFR_MEM8(0x1116)
+#define SIGROW_SERNUM7  _SFR_MEM8(0x1117)
+#define SIGROW_SERNUM8  _SFR_MEM8(0x1118)
+#define SIGROW_SERNUM9  _SFR_MEM8(0x1119)
+#define SIGROW_SERNUM10  _SFR_MEM8(0x111A)
+#define SIGROW_SERNUM11  _SFR_MEM8(0x111B)
+#define SIGROW_SERNUM12  _SFR_MEM8(0x111C)
+#define SIGROW_SERNUM13  _SFR_MEM8(0x111D)
+#define SIGROW_SERNUM14  _SFR_MEM8(0x111E)
+#define SIGROW_SERNUM15  _SFR_MEM8(0x111F)
+
+
+
+/*================== Bitfield Definitions ================== */
+
+/* AC - Analog Comparator */
+/* AC.CTRLA  bit masks and bit positions */
+#define AC_ENABLE_bm  0x01  /* Enable bit mask. */
+#define AC_ENABLE_bp  0  /* Enable bit position. */
+#define AC_HYSMODE_gm  0x06  /* Hysteresis Mode group mask. */
+#define AC_HYSMODE_gp  1  /* Hysteresis Mode group position. */
+#define AC_HYSMODE_0_bm  (1<<1)  /* Hysteresis Mode bit 0 mask. */
+#define AC_HYSMODE_0_bp  1  /* Hysteresis Mode bit 0 position. */
+#define AC_HYSMODE_1_bm  (1<<2)  /* Hysteresis Mode bit 1 mask. */
+#define AC_HYSMODE_1_bp  2  /* Hysteresis Mode bit 1 position. */
+#define AC_POWER_gm  0x18  /* Power profile group mask. */
+#define AC_POWER_gp  3  /* Power profile group position. */
+#define AC_POWER_0_bm  (1<<3)  /* Power profile bit 0 mask. */
+#define AC_POWER_0_bp  3  /* Power profile bit 0 position. */
+#define AC_POWER_1_bm  (1<<4)  /* Power profile bit 1 mask. */
+#define AC_POWER_1_bp  4  /* Power profile bit 1 position. */
+#define AC_OUTEN_bm  0x40  /* Output Pad Enable bit mask. */
+#define AC_OUTEN_bp  6  /* Output Pad Enable bit position. */
+#define AC_RUNSTDBY_bm  0x80  /* Run in Standby Mode bit mask. */
+#define AC_RUNSTDBY_bp  7  /* Run in Standby Mode bit position. */
+
+/* AC.CTRLB  bit masks and bit positions */
+#define AC_WINSEL_gm  0x03  /* Window selection mode group mask. */
+#define AC_WINSEL_gp  0  /* Window selection mode group position. */
+#define AC_WINSEL_0_bm  (1<<0)  /* Window selection mode bit 0 mask. */
+#define AC_WINSEL_0_bp  0  /* Window selection mode bit 0 position. */
+#define AC_WINSEL_1_bm  (1<<1)  /* Window selection mode bit 1 mask. */
+#define AC_WINSEL_1_bp  1  /* Window selection mode bit 1 position. */
+
+/* AC.MUXCTRL  bit masks and bit positions */
+#define AC_MUXNEG_gm  0x07  /* Negative Input MUX Selection group mask. */
+#define AC_MUXNEG_gp  0  /* Negative Input MUX Selection group position. */
+#define AC_MUXNEG_0_bm  (1<<0)  /* Negative Input MUX Selection bit 0 mask. */
+#define AC_MUXNEG_0_bp  0  /* Negative Input MUX Selection bit 0 position. */
+#define AC_MUXNEG_1_bm  (1<<1)  /* Negative Input MUX Selection bit 1 mask. */
+#define AC_MUXNEG_1_bp  1  /* Negative Input MUX Selection bit 1 position. */
+#define AC_MUXNEG_2_bm  (1<<2)  /* Negative Input MUX Selection bit 2 mask. */
+#define AC_MUXNEG_2_bp  2  /* Negative Input MUX Selection bit 2 position. */
+#define AC_MUXPOS_gm  0x38  /* Positive Input MUX Selection group mask. */
+#define AC_MUXPOS_gp  3  /* Positive Input MUX Selection group position. */
+#define AC_MUXPOS_0_bm  (1<<3)  /* Positive Input MUX Selection bit 0 mask. */
+#define AC_MUXPOS_0_bp  3  /* Positive Input MUX Selection bit 0 position. */
+#define AC_MUXPOS_1_bm  (1<<4)  /* Positive Input MUX Selection bit 1 mask. */
+#define AC_MUXPOS_1_bp  4  /* Positive Input MUX Selection bit 1 position. */
+#define AC_MUXPOS_2_bm  (1<<5)  /* Positive Input MUX Selection bit 2 mask. */
+#define AC_MUXPOS_2_bp  5  /* Positive Input MUX Selection bit 2 position. */
+#define AC_INITVAL_bm  0x40  /* AC Output Initial Value bit mask. */
+#define AC_INITVAL_bp  6  /* AC Output Initial Value bit position. */
+#define AC_INVERT_bm  0x80  /* Invert AC Output bit mask. */
+#define AC_INVERT_bp  7  /* Invert AC Output bit position. */
+
+/* AC.DACREF  bit masks and bit positions */
+#define AC_DACREF_gm  0xFF  /* DACREF group mask. */
+#define AC_DACREF_gp  0  /* DACREF group position. */
+#define AC_DACREF_0_bm  (1<<0)  /* DACREF bit 0 mask. */
+#define AC_DACREF_0_bp  0  /* DACREF bit 0 position. */
+#define AC_DACREF_1_bm  (1<<1)  /* DACREF bit 1 mask. */
+#define AC_DACREF_1_bp  1  /* DACREF bit 1 position. */
+#define AC_DACREF_2_bm  (1<<2)  /* DACREF bit 2 mask. */
+#define AC_DACREF_2_bp  2  /* DACREF bit 2 position. */
+#define AC_DACREF_3_bm  (1<<3)  /* DACREF bit 3 mask. */
+#define AC_DACREF_3_bp  3  /* DACREF bit 3 position. */
+#define AC_DACREF_4_bm  (1<<4)  /* DACREF bit 4 mask. */
+#define AC_DACREF_4_bp  4  /* DACREF bit 4 position. */
+#define AC_DACREF_5_bm  (1<<5)  /* DACREF bit 5 mask. */
+#define AC_DACREF_5_bp  5  /* DACREF bit 5 position. */
+#define AC_DACREF_6_bm  (1<<6)  /* DACREF bit 6 mask. */
+#define AC_DACREF_6_bp  6  /* DACREF bit 6 position. */
+#define AC_DACREF_7_bm  (1<<7)  /* DACREF bit 7 mask. */
+#define AC_DACREF_7_bp  7  /* DACREF bit 7 position. */
+
+/* AC.INTCTRL  bit masks and bit positions */
+#define AC_CMP_bm  0x01  /* Interrupt Enable bit mask. */
+#define AC_CMP_bp  0  /* Interrupt Enable bit position. */
+#define AC_INTMODE_NORMAL_gm  0x30  /* Interrupt Mode group mask. */
+#define AC_INTMODE_NORMAL_gp  4  /* Interrupt Mode group position. */
+#define AC_INTMODE_NORMAL_0_bm  (1<<4)  /* Interrupt Mode bit 0 mask. */
+#define AC_INTMODE_NORMAL_0_bp  4  /* Interrupt Mode bit 0 position. */
+#define AC_INTMODE_NORMAL_1_bm  (1<<5)  /* Interrupt Mode bit 1 mask. */
+#define AC_INTMODE_NORMAL_1_bp  5  /* Interrupt Mode bit 1 position. */
+#define AC_INTMODE_WINDOW_gm  0x30  /* Interrupt Mode group mask. */
+#define AC_INTMODE_WINDOW_gp  4  /* Interrupt Mode group position. */
+#define AC_INTMODE_WINDOW_0_bm  (1<<4)  /* Interrupt Mode bit 0 mask. */
+#define AC_INTMODE_WINDOW_0_bp  4  /* Interrupt Mode bit 0 position. */
+#define AC_INTMODE_WINDOW_1_bm  (1<<5)  /* Interrupt Mode bit 1 mask. */
+#define AC_INTMODE_WINDOW_1_bp  5  /* Interrupt Mode bit 1 position. */
+
+/* AC.STATUS  bit masks and bit positions */
+#define AC_CMPIF_bm  0x01  /* Analog Comparator Interrupt Flag bit mask. */
+#define AC_CMPIF_bp  0  /* Analog Comparator Interrupt Flag bit position. */
+#define AC_CMPSTATE_bm  0x10  /* Analog Comparator State bit mask. */
+#define AC_CMPSTATE_bp  4  /* Analog Comparator State bit position. */
+#define AC_WINSTATE_gm  0xC0  /* Analog Comparator Window State group mask. */
+#define AC_WINSTATE_gp  6  /* Analog Comparator Window State group position. */
+#define AC_WINSTATE_0_bm  (1<<6)  /* Analog Comparator Window State bit 0 mask. */
+#define AC_WINSTATE_0_bp  6  /* Analog Comparator Window State bit 0 position. */
+#define AC_WINSTATE_1_bm  (1<<7)  /* Analog Comparator Window State bit 1 mask. */
+#define AC_WINSTATE_1_bp  7  /* Analog Comparator Window State bit 1 position. */
+
+
+/* ADC - Analog to Digital Converter */
+/* ADC.CTRLA  bit masks and bit positions */
+#define ADC_ENABLE_bm  0x01  /* ADC Enable bit mask. */
+#define ADC_ENABLE_bp  0  /* ADC Enable bit position. */
+#define ADC_LOWLAT_bm  0x20  /* Low Latency bit mask. */
+#define ADC_LOWLAT_bp  5  /* Low Latency bit position. */
+#define ADC_RUNSTDBY_bm  0x80  /* Run in Standby bit mask. */
+#define ADC_RUNSTDBY_bp  7  /* Run in Standby bit position. */
+
+/* ADC.CTRLB  bit masks and bit positions */
+#define ADC_PRESC_gm  0x0F  /* Prescaler Value group mask. */
+#define ADC_PRESC_gp  0  /* Prescaler Value group position. */
+#define ADC_PRESC_0_bm  (1<<0)  /* Prescaler Value bit 0 mask. */
+#define ADC_PRESC_0_bp  0  /* Prescaler Value bit 0 position. */
+#define ADC_PRESC_1_bm  (1<<1)  /* Prescaler Value bit 1 mask. */
+#define ADC_PRESC_1_bp  1  /* Prescaler Value bit 1 position. */
+#define ADC_PRESC_2_bm  (1<<2)  /* Prescaler Value bit 2 mask. */
+#define ADC_PRESC_2_bp  2  /* Prescaler Value bit 2 position. */
+#define ADC_PRESC_3_bm  (1<<3)  /* Prescaler Value bit 3 mask. */
+#define ADC_PRESC_3_bp  3  /* Prescaler Value bit 3 position. */
+
+/* ADC.CTRLC  bit masks and bit positions */
+#define ADC_REFSEL_gm  0x07  /* Reference select group mask. */
+#define ADC_REFSEL_gp  0  /* Reference select group position. */
+#define ADC_REFSEL_0_bm  (1<<0)  /* Reference select bit 0 mask. */
+#define ADC_REFSEL_0_bp  0  /* Reference select bit 0 position. */
+#define ADC_REFSEL_1_bm  (1<<1)  /* Reference select bit 1 mask. */
+#define ADC_REFSEL_1_bp  1  /* Reference select bit 1 position. */
+#define ADC_REFSEL_2_bm  (1<<2)  /* Reference select bit 2 mask. */
+#define ADC_REFSEL_2_bp  2  /* Reference select bit 2 position. */
+
+/* ADC.CTRLD  bit masks and bit positions */
+#define ADC_WINCM_gm  0x07  /* Window Comparator Mode group mask. */
+#define ADC_WINCM_gp  0  /* Window Comparator Mode group position. */
+#define ADC_WINCM_0_bm  (1<<0)  /* Window Comparator Mode bit 0 mask. */
+#define ADC_WINCM_0_bp  0  /* Window Comparator Mode bit 0 position. */
+#define ADC_WINCM_1_bm  (1<<1)  /* Window Comparator Mode bit 1 mask. */
+#define ADC_WINCM_1_bp  1  /* Window Comparator Mode bit 1 position. */
+#define ADC_WINCM_2_bm  (1<<2)  /* Window Comparator Mode bit 2 mask. */
+#define ADC_WINCM_2_bp  2  /* Window Comparator Mode bit 2 position. */
+#define ADC_WINSRC_bm  0x08  /* Window Mode Source bit mask. */
+#define ADC_WINSRC_bp  3  /* Window Mode Source bit position. */
+
+/* ADC.INTCTRL  bit masks and bit positions */
+#define ADC_RESRDY_bm  0x01  /* Result Ready Interrupt Enable bit mask. */
+#define ADC_RESRDY_bp  0  /* Result Ready Interrupt Enable bit position. */
+#define ADC_SAMPRDY_bm  0x02  /* Sample Ready Interrupt Enable bit mask. */
+#define ADC_SAMPRDY_bp  1  /* Sample Ready Interrupt Enable bit position. */
+#define ADC_WCMP_bm  0x04  /* Window Comparator Interrupt Enable bit mask. */
+#define ADC_WCMP_bp  2  /* Window Comparator Interrupt Enable bit position. */
+#define ADC_RESOVR_bm  0x08  /* Result Overwrite Interrupt Enable bit mask. */
+#define ADC_RESOVR_bp  3  /* Result Overwrite Interrupt Enable bit position. */
+#define ADC_SAMPOVR_bm  0x10  /* Sample Overwrite Interrupt Enable bit mask. */
+#define ADC_SAMPOVR_bp  4  /* Sample Overwrite Interrupt Enable bit position. */
+#define ADC_TRIGOVR_bm  0x20  /* Trigger Overrun Interrupt Enable bit mask. */
+#define ADC_TRIGOVR_bp  5  /* Trigger Overrun Interrupt Enable bit position. */
+
+/* ADC.INTFLAGS  bit masks and bit positions */
+/* ADC_RESRDY  is already defined. */
+/* ADC_SAMPRDY  is already defined. */
+/* ADC_WCMP  is already defined. */
+/* ADC_RESOVR  is already defined. */
+/* ADC_SAMPOVR  is already defined. */
+/* ADC_TRIGOVR  is already defined. */
+
+/* ADC.STATUS  bit masks and bit positions */
+#define ADC_ADCBUSY_bm  0x01  /* ADC Busy bit mask. */
+#define ADC_ADCBUSY_bp  0  /* ADC Busy bit position. */
+
+/* ADC.DBGCTRL  bit masks and bit positions */
+#define ADC_DBGRUN_bm  0x01  /* Run in Debug Mode bit mask. */
+#define ADC_DBGRUN_bp  0  /* Run in Debug Mode bit position. */
+
+/* ADC.CTRLE  bit masks and bit positions */
+#define ADC_SAMPDUR_gm  0xFF  /* Sample Duration group mask. */
+#define ADC_SAMPDUR_gp  0  /* Sample Duration group position. */
+#define ADC_SAMPDUR_0_bm  (1<<0)  /* Sample Duration bit 0 mask. */
+#define ADC_SAMPDUR_0_bp  0  /* Sample Duration bit 0 position. */
+#define ADC_SAMPDUR_1_bm  (1<<1)  /* Sample Duration bit 1 mask. */
+#define ADC_SAMPDUR_1_bp  1  /* Sample Duration bit 1 position. */
+#define ADC_SAMPDUR_2_bm  (1<<2)  /* Sample Duration bit 2 mask. */
+#define ADC_SAMPDUR_2_bp  2  /* Sample Duration bit 2 position. */
+#define ADC_SAMPDUR_3_bm  (1<<3)  /* Sample Duration bit 3 mask. */
+#define ADC_SAMPDUR_3_bp  3  /* Sample Duration bit 3 position. */
+#define ADC_SAMPDUR_4_bm  (1<<4)  /* Sample Duration bit 4 mask. */
+#define ADC_SAMPDUR_4_bp  4  /* Sample Duration bit 4 position. */
+#define ADC_SAMPDUR_5_bm  (1<<5)  /* Sample Duration bit 5 mask. */
+#define ADC_SAMPDUR_5_bp  5  /* Sample Duration bit 5 position. */
+#define ADC_SAMPDUR_6_bm  (1<<6)  /* Sample Duration bit 6 mask. */
+#define ADC_SAMPDUR_6_bp  6  /* Sample Duration bit 6 position. */
+#define ADC_SAMPDUR_7_bm  (1<<7)  /* Sample Duration bit 7 mask. */
+#define ADC_SAMPDUR_7_bp  7  /* Sample Duration bit 7 position. */
+
+/* ADC.CTRLF  bit masks and bit positions */
+#define ADC_SAMPNUM_gm  0x0F  /* Sample numbers group mask. */
+#define ADC_SAMPNUM_gp  0  /* Sample numbers group position. */
+#define ADC_SAMPNUM_0_bm  (1<<0)  /* Sample numbers bit 0 mask. */
+#define ADC_SAMPNUM_0_bp  0  /* Sample numbers bit 0 position. */
+#define ADC_SAMPNUM_1_bm  (1<<1)  /* Sample numbers bit 1 mask. */
+#define ADC_SAMPNUM_1_bp  1  /* Sample numbers bit 1 position. */
+#define ADC_SAMPNUM_2_bm  (1<<2)  /* Sample numbers bit 2 mask. */
+#define ADC_SAMPNUM_2_bp  2  /* Sample numbers bit 2 position. */
+#define ADC_SAMPNUM_3_bm  (1<<3)  /* Sample numbers bit 3 mask. */
+#define ADC_SAMPNUM_3_bp  3  /* Sample numbers bit 3 position. */
+#define ADC_LEFTADJ_bm  0x10  /* Left Adjust bit mask. */
+#define ADC_LEFTADJ_bp  4  /* Left Adjust bit position. */
+#define ADC_FREERUN_bm  0x20  /* Free-Running mode bit mask. */
+#define ADC_FREERUN_bp  5  /* Free-Running mode bit position. */
+#define ADC_CHOPPING_bm  0x40  /* Sign Chopping bit mask. */
+#define ADC_CHOPPING_bp  6  /* Sign Chopping bit position. */
+
+/* ADC.COMMAND  bit masks and bit positions */
+#define ADC_START_gm  0x07  /* Start command group mask. */
+#define ADC_START_gp  0  /* Start command group position. */
+#define ADC_START_0_bm  (1<<0)  /* Start command bit 0 mask. */
+#define ADC_START_0_bp  0  /* Start command bit 0 position. */
+#define ADC_START_1_bm  (1<<1)  /* Start command bit 1 mask. */
+#define ADC_START_1_bp  1  /* Start command bit 1 position. */
+#define ADC_START_2_bm  (1<<2)  /* Start command bit 2 mask. */
+#define ADC_START_2_bp  2  /* Start command bit 2 position. */
+#define ADC_MODE_gm  0x70  /* Mode group mask. */
+#define ADC_MODE_gp  4  /* Mode group position. */
+#define ADC_MODE_0_bm  (1<<4)  /* Mode bit 0 mask. */
+#define ADC_MODE_0_bp  4  /* Mode bit 0 position. */
+#define ADC_MODE_1_bm  (1<<5)  /* Mode bit 1 mask. */
+#define ADC_MODE_1_bp  5  /* Mode bit 1 position. */
+#define ADC_MODE_2_bm  (1<<6)  /* Mode bit 2 mask. */
+#define ADC_MODE_2_bp  6  /* Mode bit 2 position. */
+#define ADC_DIFF_bm  0x80  /* Differential mode bit mask. */
+#define ADC_DIFF_bp  7  /* Differential mode bit position. */
+
+/* ADC.PGACTRL  bit masks and bit positions */
+#define ADC_PGAEN_bm  0x01  /* PGA Enable bit mask. */
+#define ADC_PGAEN_bp  0  /* PGA Enable bit position. */
+#define ADC_PGABIASSEL_gm  0x18  /* PGA BIAS Select group mask. */
+#define ADC_PGABIASSEL_gp  3  /* PGA BIAS Select group position. */
+#define ADC_PGABIASSEL_0_bm  (1<<3)  /* PGA BIAS Select bit 0 mask. */
+#define ADC_PGABIASSEL_0_bp  3  /* PGA BIAS Select bit 0 position. */
+#define ADC_PGABIASSEL_1_bm  (1<<4)  /* PGA BIAS Select bit 1 mask. */
+#define ADC_PGABIASSEL_1_bp  4  /* PGA BIAS Select bit 1 position. */
+#define ADC_GAIN_gm  0xE0  /* Gain group mask. */
+#define ADC_GAIN_gp  5  /* Gain group position. */
+#define ADC_GAIN_0_bm  (1<<5)  /* Gain bit 0 mask. */
+#define ADC_GAIN_0_bp  5  /* Gain bit 0 position. */
+#define ADC_GAIN_1_bm  (1<<6)  /* Gain bit 1 mask. */
+#define ADC_GAIN_1_bp  6  /* Gain bit 1 position. */
+#define ADC_GAIN_2_bm  (1<<7)  /* Gain bit 2 mask. */
+#define ADC_GAIN_2_bp  7  /* Gain bit 2 position. */
+
+/* ADC.MUXPOS  bit masks and bit positions */
+#define ADC_MUXPOS_gm  0x3F  /* Analog Channel Selection Bits group mask. */
+#define ADC_MUXPOS_gp  0  /* Analog Channel Selection Bits group position. */
+#define ADC_MUXPOS_0_bm  (1<<0)  /* Analog Channel Selection Bits bit 0 mask. */
+#define ADC_MUXPOS_0_bp  0  /* Analog Channel Selection Bits bit 0 position. */
+#define ADC_MUXPOS_1_bm  (1<<1)  /* Analog Channel Selection Bits bit 1 mask. */
+#define ADC_MUXPOS_1_bp  1  /* Analog Channel Selection Bits bit 1 position. */
+#define ADC_MUXPOS_2_bm  (1<<2)  /* Analog Channel Selection Bits bit 2 mask. */
+#define ADC_MUXPOS_2_bp  2  /* Analog Channel Selection Bits bit 2 position. */
+#define ADC_MUXPOS_3_bm  (1<<3)  /* Analog Channel Selection Bits bit 3 mask. */
+#define ADC_MUXPOS_3_bp  3  /* Analog Channel Selection Bits bit 3 position. */
+#define ADC_MUXPOS_4_bm  (1<<4)  /* Analog Channel Selection Bits bit 4 mask. */
+#define ADC_MUXPOS_4_bp  4  /* Analog Channel Selection Bits bit 4 position. */
+#define ADC_MUXPOS_5_bm  (1<<5)  /* Analog Channel Selection Bits bit 5 mask. */
+#define ADC_MUXPOS_5_bp  5  /* Analog Channel Selection Bits bit 5 position. */
+#define ADC_VIA_gm  0xC0  /* VIA group mask. */
+#define ADC_VIA_gp  6  /* VIA group position. */
+#define ADC_VIA_0_bm  (1<<6)  /* VIA bit 0 mask. */
+#define ADC_VIA_0_bp  6  /* VIA bit 0 position. */
+#define ADC_VIA_1_bm  (1<<7)  /* VIA bit 1 mask. */
+#define ADC_VIA_1_bp  7  /* VIA bit 1 position. */
+
+/* ADC.MUXNEG  bit masks and bit positions */
+#define ADC_MUXNEG_gm  0x3F  /* Analog Channel Selection Bits group mask. */
+#define ADC_MUXNEG_gp  0  /* Analog Channel Selection Bits group position. */
+#define ADC_MUXNEG_0_bm  (1<<0)  /* Analog Channel Selection Bits bit 0 mask. */
+#define ADC_MUXNEG_0_bp  0  /* Analog Channel Selection Bits bit 0 position. */
+#define ADC_MUXNEG_1_bm  (1<<1)  /* Analog Channel Selection Bits bit 1 mask. */
+#define ADC_MUXNEG_1_bp  1  /* Analog Channel Selection Bits bit 1 position. */
+#define ADC_MUXNEG_2_bm  (1<<2)  /* Analog Channel Selection Bits bit 2 mask. */
+#define ADC_MUXNEG_2_bp  2  /* Analog Channel Selection Bits bit 2 position. */
+#define ADC_MUXNEG_3_bm  (1<<3)  /* Analog Channel Selection Bits bit 3 mask. */
+#define ADC_MUXNEG_3_bp  3  /* Analog Channel Selection Bits bit 3 position. */
+#define ADC_MUXNEG_4_bm  (1<<4)  /* Analog Channel Selection Bits bit 4 mask. */
+#define ADC_MUXNEG_4_bp  4  /* Analog Channel Selection Bits bit 4 position. */
+#define ADC_MUXNEG_5_bm  (1<<5)  /* Analog Channel Selection Bits bit 5 mask. */
+#define ADC_MUXNEG_5_bp  5  /* Analog Channel Selection Bits bit 5 position. */
+/* ADC_VIA  is already defined. */
+
+
+/* BOD - Bod interface */
+/* BOD.CTRLA  bit masks and bit positions */
+#define BOD_SLEEP_gm  0x03  /* Operation in sleep mode group mask. */
+#define BOD_SLEEP_gp  0  /* Operation in sleep mode group position. */
+#define BOD_SLEEP_0_bm  (1<<0)  /* Operation in sleep mode bit 0 mask. */
+#define BOD_SLEEP_0_bp  0  /* Operation in sleep mode bit 0 position. */
+#define BOD_SLEEP_1_bm  (1<<1)  /* Operation in sleep mode bit 1 mask. */
+#define BOD_SLEEP_1_bp  1  /* Operation in sleep mode bit 1 position. */
+#define BOD_ACTIVE_gm  0x0C  /* Operation in active mode group mask. */
+#define BOD_ACTIVE_gp  2  /* Operation in active mode group position. */
+#define BOD_ACTIVE_0_bm  (1<<2)  /* Operation in active mode bit 0 mask. */
+#define BOD_ACTIVE_0_bp  2  /* Operation in active mode bit 0 position. */
+#define BOD_ACTIVE_1_bm  (1<<3)  /* Operation in active mode bit 1 mask. */
+#define BOD_ACTIVE_1_bp  3  /* Operation in active mode bit 1 position. */
+#define BOD_SAMPFREQ_bm  0x10  /* Sample frequency bit mask. */
+#define BOD_SAMPFREQ_bp  4  /* Sample frequency bit position. */
+
+/* BOD.CTRLB  bit masks and bit positions */
+#define BOD_LVL_gm  0x07  /* Bod level group mask. */
+#define BOD_LVL_gp  0  /* Bod level group position. */
+#define BOD_LVL_0_bm  (1<<0)  /* Bod level bit 0 mask. */
+#define BOD_LVL_0_bp  0  /* Bod level bit 0 position. */
+#define BOD_LVL_1_bm  (1<<1)  /* Bod level bit 1 mask. */
+#define BOD_LVL_1_bp  1  /* Bod level bit 1 position. */
+#define BOD_LVL_2_bm  (1<<2)  /* Bod level bit 2 mask. */
+#define BOD_LVL_2_bp  2  /* Bod level bit 2 position. */
+
+/* BOD.VLMCTRLA  bit masks and bit positions */
+#define BOD_VLMLVL_gm  0x03  /* voltage level monitor level group mask. */
+#define BOD_VLMLVL_gp  0  /* voltage level monitor level group position. */
+#define BOD_VLMLVL_0_bm  (1<<0)  /* voltage level monitor level bit 0 mask. */
+#define BOD_VLMLVL_0_bp  0  /* voltage level monitor level bit 0 position. */
+#define BOD_VLMLVL_1_bm  (1<<1)  /* voltage level monitor level bit 1 mask. */
+#define BOD_VLMLVL_1_bp  1  /* voltage level monitor level bit 1 position. */
+
+/* BOD.INTCTRL  bit masks and bit positions */
+#define BOD_VLMIE_bm  0x01  /* voltage level monitor interrrupt enable bit mask. */
+#define BOD_VLMIE_bp  0  /* voltage level monitor interrrupt enable bit position. */
+#define BOD_VLMCFG_gm  0x06  /* Configuration group mask. */
+#define BOD_VLMCFG_gp  1  /* Configuration group position. */
+#define BOD_VLMCFG_0_bm  (1<<1)  /* Configuration bit 0 mask. */
+#define BOD_VLMCFG_0_bp  1  /* Configuration bit 0 position. */
+#define BOD_VLMCFG_1_bm  (1<<2)  /* Configuration bit 1 mask. */
+#define BOD_VLMCFG_1_bp  2  /* Configuration bit 1 position. */
+
+/* BOD.INTFLAGS  bit masks and bit positions */
+#define BOD_VLMIF_bm  0x01  /* Voltage level monitor interrupt flag bit mask. */
+#define BOD_VLMIF_bp  0  /* Voltage level monitor interrupt flag bit position. */
+
+/* BOD.STATUS  bit masks and bit positions */
+#define BOD_VLMS_bm  0x01  /* Voltage level monitor status bit mask. */
+#define BOD_VLMS_bp  0  /* Voltage level monitor status bit position. */
+
+
+/* CCL - Configurable Custom Logic */
+/* CCL.CTRLA  bit masks and bit positions */
+#define CCL_ENABLE_bm  0x01  /* Enable bit mask. */
+#define CCL_ENABLE_bp  0  /* Enable bit position. */
+#define CCL_RUNSTDBY_bm  0x40  /* Run in Standby bit mask. */
+#define CCL_RUNSTDBY_bp  6  /* Run in Standby bit position. */
+
+/* CCL.SEQCTRL0  bit masks and bit positions */
+#define CCL_SEQSEL_gm  0x07  /* Sequential Selection group mask. */
+#define CCL_SEQSEL_gp  0  /* Sequential Selection group position. */
+#define CCL_SEQSEL_0_bm  (1<<0)  /* Sequential Selection bit 0 mask. */
+#define CCL_SEQSEL_0_bp  0  /* Sequential Selection bit 0 position. */
+#define CCL_SEQSEL_1_bm  (1<<1)  /* Sequential Selection bit 1 mask. */
+#define CCL_SEQSEL_1_bp  1  /* Sequential Selection bit 1 position. */
+#define CCL_SEQSEL_2_bm  (1<<2)  /* Sequential Selection bit 2 mask. */
+#define CCL_SEQSEL_2_bp  2  /* Sequential Selection bit 2 position. */
+
+/* CCL.SEQCTRL1  bit masks and bit positions */
+/* CCL_SEQSEL  is already defined. */
+
+/* CCL.INTCTRL0  bit masks and bit positions */
+#define CCL_INTMODE0_gm  0x03  /* Interrupt Mode for LUT0 group mask. */
+#define CCL_INTMODE0_gp  0  /* Interrupt Mode for LUT0 group position. */
+#define CCL_INTMODE0_0_bm  (1<<0)  /* Interrupt Mode for LUT0 bit 0 mask. */
+#define CCL_INTMODE0_0_bp  0  /* Interrupt Mode for LUT0 bit 0 position. */
+#define CCL_INTMODE0_1_bm  (1<<1)  /* Interrupt Mode for LUT0 bit 1 mask. */
+#define CCL_INTMODE0_1_bp  1  /* Interrupt Mode for LUT0 bit 1 position. */
+#define CCL_INTMODE1_gm  0x0C  /* Interrupt Mode for LUT1 group mask. */
+#define CCL_INTMODE1_gp  2  /* Interrupt Mode for LUT1 group position. */
+#define CCL_INTMODE1_0_bm  (1<<2)  /* Interrupt Mode for LUT1 bit 0 mask. */
+#define CCL_INTMODE1_0_bp  2  /* Interrupt Mode for LUT1 bit 0 position. */
+#define CCL_INTMODE1_1_bm  (1<<3)  /* Interrupt Mode for LUT1 bit 1 mask. */
+#define CCL_INTMODE1_1_bp  3  /* Interrupt Mode for LUT1 bit 1 position. */
+#define CCL_INTMODE2_gm  0x30  /* Interrupt Mode for LUT2 group mask. */
+#define CCL_INTMODE2_gp  4  /* Interrupt Mode for LUT2 group position. */
+#define CCL_INTMODE2_0_bm  (1<<4)  /* Interrupt Mode for LUT2 bit 0 mask. */
+#define CCL_INTMODE2_0_bp  4  /* Interrupt Mode for LUT2 bit 0 position. */
+#define CCL_INTMODE2_1_bm  (1<<5)  /* Interrupt Mode for LUT2 bit 1 mask. */
+#define CCL_INTMODE2_1_bp  5  /* Interrupt Mode for LUT2 bit 1 position. */
+#define CCL_INTMODE3_gm  0xC0  /* Interrupt Mode for LUT3 group mask. */
+#define CCL_INTMODE3_gp  6  /* Interrupt Mode for LUT3 group position. */
+#define CCL_INTMODE3_0_bm  (1<<6)  /* Interrupt Mode for LUT3 bit 0 mask. */
+#define CCL_INTMODE3_0_bp  6  /* Interrupt Mode for LUT3 bit 0 position. */
+#define CCL_INTMODE3_1_bm  (1<<7)  /* Interrupt Mode for LUT3 bit 1 mask. */
+#define CCL_INTMODE3_1_bp  7  /* Interrupt Mode for LUT3 bit 1 position. */
+
+/* CCL.INTFLAGS  bit masks and bit positions */
+#define CCL_INT_gm  0x0F  /* Interrupt Flag group mask. */
+#define CCL_INT_gp  0  /* Interrupt Flag group position. */
+#define CCL_INT_0_bm  (1<<0)  /* Interrupt Flag bit 0 mask. */
+#define CCL_INT_0_bp  0  /* Interrupt Flag bit 0 position. */
+#define CCL_INT0_bm  CCL_INT_0_bm  /* This define is deprecated and should not be used */
+#define CCL_INT0_bp  CCL_INT_0_bp  /* This define is deprecated and should not be used */
+#define CCL_INT_1_bm  (1<<1)  /* Interrupt Flag bit 1 mask. */
+#define CCL_INT_1_bp  1  /* Interrupt Flag bit 1 position. */
+#define CCL_INT1_bm  CCL_INT_1_bm  /* This define is deprecated and should not be used */
+#define CCL_INT1_bp  CCL_INT_1_bp  /* This define is deprecated and should not be used */
+#define CCL_INT_2_bm  (1<<2)  /* Interrupt Flag bit 2 mask. */
+#define CCL_INT_2_bp  2  /* Interrupt Flag bit 2 position. */
+#define CCL_INT2_bm  CCL_INT_2_bm  /* This define is deprecated and should not be used */
+#define CCL_INT2_bp  CCL_INT_2_bp  /* This define is deprecated and should not be used */
+#define CCL_INT_3_bm  (1<<3)  /* Interrupt Flag bit 3 mask. */
+#define CCL_INT_3_bp  3  /* Interrupt Flag bit 3 position. */
+#define CCL_INT3_bm  CCL_INT_3_bm  /* This define is deprecated and should not be used */
+#define CCL_INT3_bp  CCL_INT_3_bp  /* This define is deprecated and should not be used */
+
+/* CCL.LUT0CTRLA  bit masks and bit positions */
+/* CCL_ENABLE  is already defined. */
+#define CCL_CLKSRC_gm  0x0E  /* Clock Source Selection group mask. */
+#define CCL_CLKSRC_gp  1  /* Clock Source Selection group position. */
+#define CCL_CLKSRC_0_bm  (1<<1)  /* Clock Source Selection bit 0 mask. */
+#define CCL_CLKSRC_0_bp  1  /* Clock Source Selection bit 0 position. */
+#define CCL_CLKSRC_1_bm  (1<<2)  /* Clock Source Selection bit 1 mask. */
+#define CCL_CLKSRC_1_bp  2  /* Clock Source Selection bit 1 position. */
+#define CCL_CLKSRC_2_bm  (1<<3)  /* Clock Source Selection bit 2 mask. */
+#define CCL_CLKSRC_2_bp  3  /* Clock Source Selection bit 2 position. */
+#define CCL_FILTSEL_gm  0x30  /* Filter Selection group mask. */
+#define CCL_FILTSEL_gp  4  /* Filter Selection group position. */
+#define CCL_FILTSEL_0_bm  (1<<4)  /* Filter Selection bit 0 mask. */
+#define CCL_FILTSEL_0_bp  4  /* Filter Selection bit 0 position. */
+#define CCL_FILTSEL_1_bm  (1<<5)  /* Filter Selection bit 1 mask. */
+#define CCL_FILTSEL_1_bp  5  /* Filter Selection bit 1 position. */
+#define CCL_OUTEN_bm  0x40  /* Output Enable bit mask. */
+#define CCL_OUTEN_bp  6  /* Output Enable bit position. */
+#define CCL_EDGEDET_bm  0x80  /* Edge Detection Enable bit mask. */
+#define CCL_EDGEDET_bp  7  /* Edge Detection Enable bit position. */
+
+/* CCL.LUT0CTRLB  bit masks and bit positions */
+#define CCL_INSEL0_gm  0x0F  /* LUT Input 0 Source Selection group mask. */
+#define CCL_INSEL0_gp  0  /* LUT Input 0 Source Selection group position. */
+#define CCL_INSEL0_0_bm  (1<<0)  /* LUT Input 0 Source Selection bit 0 mask. */
+#define CCL_INSEL0_0_bp  0  /* LUT Input 0 Source Selection bit 0 position. */
+#define CCL_INSEL0_1_bm  (1<<1)  /* LUT Input 0 Source Selection bit 1 mask. */
+#define CCL_INSEL0_1_bp  1  /* LUT Input 0 Source Selection bit 1 position. */
+#define CCL_INSEL0_2_bm  (1<<2)  /* LUT Input 0 Source Selection bit 2 mask. */
+#define CCL_INSEL0_2_bp  2  /* LUT Input 0 Source Selection bit 2 position. */
+#define CCL_INSEL0_3_bm  (1<<3)  /* LUT Input 0 Source Selection bit 3 mask. */
+#define CCL_INSEL0_3_bp  3  /* LUT Input 0 Source Selection bit 3 position. */
+#define CCL_INSEL1_gm  0xF0  /* LUT Input 1 Source Selection group mask. */
+#define CCL_INSEL1_gp  4  /* LUT Input 1 Source Selection group position. */
+#define CCL_INSEL1_0_bm  (1<<4)  /* LUT Input 1 Source Selection bit 0 mask. */
+#define CCL_INSEL1_0_bp  4  /* LUT Input 1 Source Selection bit 0 position. */
+#define CCL_INSEL1_1_bm  (1<<5)  /* LUT Input 1 Source Selection bit 1 mask. */
+#define CCL_INSEL1_1_bp  5  /* LUT Input 1 Source Selection bit 1 position. */
+#define CCL_INSEL1_2_bm  (1<<6)  /* LUT Input 1 Source Selection bit 2 mask. */
+#define CCL_INSEL1_2_bp  6  /* LUT Input 1 Source Selection bit 2 position. */
+#define CCL_INSEL1_3_bm  (1<<7)  /* LUT Input 1 Source Selection bit 3 mask. */
+#define CCL_INSEL1_3_bp  7  /* LUT Input 1 Source Selection bit 3 position. */
+
+/* CCL.LUT0CTRLC  bit masks and bit positions */
+#define CCL_INSEL2_gm  0x0F  /* LUT Input 2 Source Selection group mask. */
+#define CCL_INSEL2_gp  0  /* LUT Input 2 Source Selection group position. */
+#define CCL_INSEL2_0_bm  (1<<0)  /* LUT Input 2 Source Selection bit 0 mask. */
+#define CCL_INSEL2_0_bp  0  /* LUT Input 2 Source Selection bit 0 position. */
+#define CCL_INSEL2_1_bm  (1<<1)  /* LUT Input 2 Source Selection bit 1 mask. */
+#define CCL_INSEL2_1_bp  1  /* LUT Input 2 Source Selection bit 1 position. */
+#define CCL_INSEL2_2_bm  (1<<2)  /* LUT Input 2 Source Selection bit 2 mask. */
+#define CCL_INSEL2_2_bp  2  /* LUT Input 2 Source Selection bit 2 position. */
+#define CCL_INSEL2_3_bm  (1<<3)  /* LUT Input 2 Source Selection bit 3 mask. */
+#define CCL_INSEL2_3_bp  3  /* LUT Input 2 Source Selection bit 3 position. */
+
+/* CCL.TRUTH0  bit masks and bit positions */
+#define CCL_TRUTH_gm  0xFF  /* Truth Table group mask. */
+#define CCL_TRUTH_gp  0  /* Truth Table group position. */
+#define CCL_TRUTH_0_bm  (1<<0)  /* Truth Table bit 0 mask. */
+#define CCL_TRUTH_0_bp  0  /* Truth Table bit 0 position. */
+#define CCL_TRUTH_1_bm  (1<<1)  /* Truth Table bit 1 mask. */
+#define CCL_TRUTH_1_bp  1  /* Truth Table bit 1 position. */
+#define CCL_TRUTH_2_bm  (1<<2)  /* Truth Table bit 2 mask. */
+#define CCL_TRUTH_2_bp  2  /* Truth Table bit 2 position. */
+#define CCL_TRUTH_3_bm  (1<<3)  /* Truth Table bit 3 mask. */
+#define CCL_TRUTH_3_bp  3  /* Truth Table bit 3 position. */
+#define CCL_TRUTH_4_bm  (1<<4)  /* Truth Table bit 4 mask. */
+#define CCL_TRUTH_4_bp  4  /* Truth Table bit 4 position. */
+#define CCL_TRUTH_5_bm  (1<<5)  /* Truth Table bit 5 mask. */
+#define CCL_TRUTH_5_bp  5  /* Truth Table bit 5 position. */
+#define CCL_TRUTH_6_bm  (1<<6)  /* Truth Table bit 6 mask. */
+#define CCL_TRUTH_6_bp  6  /* Truth Table bit 6 position. */
+#define CCL_TRUTH_7_bm  (1<<7)  /* Truth Table bit 7 mask. */
+#define CCL_TRUTH_7_bp  7  /* Truth Table bit 7 position. */
+
+/* CCL.LUT1CTRLA  bit masks and bit positions */
+/* CCL_ENABLE  is already defined. */
+/* CCL_CLKSRC  is already defined. */
+/* CCL_FILTSEL  is already defined. */
+/* CCL_OUTEN  is already defined. */
+/* CCL_EDGEDET  is already defined. */
+
+/* CCL.LUT1CTRLB  bit masks and bit positions */
+/* CCL_INSEL0  is already defined. */
+/* CCL_INSEL1  is already defined. */
+
+/* CCL.LUT1CTRLC  bit masks and bit positions */
+/* CCL_INSEL2  is already defined. */
+
+/* CCL.TRUTH1  bit masks and bit positions */
+/* CCL_TRUTH  is already defined. */
+
+/* CCL.LUT2CTRLA  bit masks and bit positions */
+/* CCL_ENABLE  is already defined. */
+/* CCL_CLKSRC  is already defined. */
+/* CCL_FILTSEL  is already defined. */
+/* CCL_OUTEN  is already defined. */
+/* CCL_EDGEDET  is already defined. */
+
+/* CCL.LUT2CTRLB  bit masks and bit positions */
+/* CCL_INSEL0  is already defined. */
+/* CCL_INSEL1  is already defined. */
+
+/* CCL.LUT2CTRLC  bit masks and bit positions */
+/* CCL_INSEL2  is already defined. */
+
+/* CCL.TRUTH2  bit masks and bit positions */
+/* CCL_TRUTH  is already defined. */
+
+/* CCL.LUT3CTRLA  bit masks and bit positions */
+/* CCL_ENABLE  is already defined. */
+/* CCL_CLKSRC  is already defined. */
+/* CCL_FILTSEL  is already defined. */
+/* CCL_OUTEN  is already defined. */
+/* CCL_EDGEDET  is already defined. */
+
+/* CCL.LUT3CTRLB  bit masks and bit positions */
+/* CCL_INSEL0  is already defined. */
+/* CCL_INSEL1  is already defined. */
+
+/* CCL.LUT3CTRLC  bit masks and bit positions */
+/* CCL_INSEL2  is already defined. */
+
+/* CCL.TRUTH3  bit masks and bit positions */
+/* CCL_TRUTH  is already defined. */
+
+
+/* CLKCTRL - Clock controller */
+/* CLKCTRL.MCLKCTRLA  bit masks and bit positions */
+#define CLKCTRL_CLKSEL_gm  0x07  /* Clock select group mask. */
+#define CLKCTRL_CLKSEL_gp  0  /* Clock select group position. */
+#define CLKCTRL_CLKSEL_0_bm  (1<<0)  /* Clock select bit 0 mask. */
+#define CLKCTRL_CLKSEL_0_bp  0  /* Clock select bit 0 position. */
+#define CLKCTRL_CLKSEL_1_bm  (1<<1)  /* Clock select bit 1 mask. */
+#define CLKCTRL_CLKSEL_1_bp  1  /* Clock select bit 1 position. */
+#define CLKCTRL_CLKSEL_2_bm  (1<<2)  /* Clock select bit 2 mask. */
+#define CLKCTRL_CLKSEL_2_bp  2  /* Clock select bit 2 position. */
+#define CLKCTRL_CLKOUT_bm  0x80  /* System clock out bit mask. */
+#define CLKCTRL_CLKOUT_bp  7  /* System clock out bit position. */
+
+/* CLKCTRL.MCLKCTRLB  bit masks and bit positions */
+#define CLKCTRL_PEN_bm  0x01  /* Prescaler enable bit mask. */
+#define CLKCTRL_PEN_bp  0  /* Prescaler enable bit position. */
+#define CLKCTRL_PDIV_gm  0x1E  /* Prescaler division group mask. */
+#define CLKCTRL_PDIV_gp  1  /* Prescaler division group position. */
+#define CLKCTRL_PDIV_0_bm  (1<<1)  /* Prescaler division bit 0 mask. */
+#define CLKCTRL_PDIV_0_bp  1  /* Prescaler division bit 0 position. */
+#define CLKCTRL_PDIV_1_bm  (1<<2)  /* Prescaler division bit 1 mask. */
+#define CLKCTRL_PDIV_1_bp  2  /* Prescaler division bit 1 position. */
+#define CLKCTRL_PDIV_2_bm  (1<<3)  /* Prescaler division bit 2 mask. */
+#define CLKCTRL_PDIV_2_bp  3  /* Prescaler division bit 2 position. */
+#define CLKCTRL_PDIV_3_bm  (1<<4)  /* Prescaler division bit 3 mask. */
+#define CLKCTRL_PDIV_3_bp  4  /* Prescaler division bit 3 position. */
+
+/* CLKCTRL.MCLKCTRLC  bit masks and bit positions */
+#define CLKCTRL_CFDEN_bm  0x01  /* Clock Failure Detect Enable bit mask. */
+#define CLKCTRL_CFDEN_bp  0  /* Clock Failure Detect Enable bit position. */
+#define CLKCTRL_CFDTST_bm  0x02  /* CFD Test bit mask. */
+#define CLKCTRL_CFDTST_bp  1  /* CFD Test bit position. */
+#define CLKCTRL_CFDSRC_gm  0x0C  /* CFD Source group mask. */
+#define CLKCTRL_CFDSRC_gp  2  /* CFD Source group position. */
+#define CLKCTRL_CFDSRC_0_bm  (1<<2)  /* CFD Source bit 0 mask. */
+#define CLKCTRL_CFDSRC_0_bp  2  /* CFD Source bit 0 position. */
+#define CLKCTRL_CFDSRC_1_bm  (1<<3)  /* CFD Source bit 1 mask. */
+#define CLKCTRL_CFDSRC_1_bp  3  /* CFD Source bit 1 position. */
+
+/* CLKCTRL.MCLKINTCTRL  bit masks and bit positions */
+#define CLKCTRL_CFD_bm  0x01  /* Interrupt Enable bit mask. */
+#define CLKCTRL_CFD_bp  0  /* Interrupt Enable bit position. */
+#define CLKCTRL_INTTYPE_bm  0x80  /* Interrupt Type bit mask. */
+#define CLKCTRL_INTTYPE_bp  7  /* Interrupt Type bit position. */
+
+/* CLKCTRL.MCLKINTFLAGS  bit masks and bit positions */
+/* CLKCTRL_CFD  is already defined. */
+
+/* CLKCTRL.MCLKSTATUS  bit masks and bit positions */
+#define CLKCTRL_SOSC_bm  0x01  /* System Oscillator changing bit mask. */
+#define CLKCTRL_SOSC_bp  0  /* System Oscillator changing bit position. */
+#define CLKCTRL_OSCHFS_bm  0x02  /* High frequency oscillator status bit mask. */
+#define CLKCTRL_OSCHFS_bp  1  /* High frequency oscillator status bit position. */
+#define CLKCTRL_OSC32KS_bm  0x04  /* 32KHz oscillator status bit mask. */
+#define CLKCTRL_OSC32KS_bp  2  /* 32KHz oscillator status bit position. */
+#define CLKCTRL_XOSC32KS_bm  0x08  /* 32.768 kHz Crystal Oscillator status bit mask. */
+#define CLKCTRL_XOSC32KS_bp  3  /* 32.768 kHz Crystal Oscillator status bit position. */
+#define CLKCTRL_EXTS_bm  0x10  /* External Clock status / XOSCHF status bit mask. */
+#define CLKCTRL_EXTS_bp  4  /* External Clock status / XOSCHF status bit position. */
+
+/* CLKCTRL.MCLKTIMEBASE  bit masks and bit positions */
+#define CLKCTRL_TIMEBASE_gm  0x1F  /* Timebase group mask. */
+#define CLKCTRL_TIMEBASE_gp  0  /* Timebase group position. */
+#define CLKCTRL_TIMEBASE_0_bm  (1<<0)  /* Timebase bit 0 mask. */
+#define CLKCTRL_TIMEBASE_0_bp  0  /* Timebase bit 0 position. */
+#define CLKCTRL_TIMEBASE_1_bm  (1<<1)  /* Timebase bit 1 mask. */
+#define CLKCTRL_TIMEBASE_1_bp  1  /* Timebase bit 1 position. */
+#define CLKCTRL_TIMEBASE_2_bm  (1<<2)  /* Timebase bit 2 mask. */
+#define CLKCTRL_TIMEBASE_2_bp  2  /* Timebase bit 2 position. */
+#define CLKCTRL_TIMEBASE_3_bm  (1<<3)  /* Timebase bit 3 mask. */
+#define CLKCTRL_TIMEBASE_3_bp  3  /* Timebase bit 3 position. */
+#define CLKCTRL_TIMEBASE_4_bm  (1<<4)  /* Timebase bit 4 mask. */
+#define CLKCTRL_TIMEBASE_4_bp  4  /* Timebase bit 4 position. */
+
+/* CLKCTRL.OSCHFCTRLA  bit masks and bit positions */
+#define CLKCTRL_AUTOTUNE_gm  0x03  /* Automatic Oscillator Tune group mask. */
+#define CLKCTRL_AUTOTUNE_gp  0  /* Automatic Oscillator Tune group position. */
+#define CLKCTRL_AUTOTUNE_0_bm  (1<<0)  /* Automatic Oscillator Tune bit 0 mask. */
+#define CLKCTRL_AUTOTUNE_0_bp  0  /* Automatic Oscillator Tune bit 0 position. */
+#define CLKCTRL_AUTOTUNE_1_bm  (1<<1)  /* Automatic Oscillator Tune bit 1 mask. */
+#define CLKCTRL_AUTOTUNE_1_bp  1  /* Automatic Oscillator Tune bit 1 position. */
+#define CLKCTRL_RUNSTDBY_bm  0x80  /* Run in standby bit mask. */
+#define CLKCTRL_RUNSTDBY_bp  7  /* Run in standby bit position. */
+
+/* CLKCTRL.OSCHFTUNE  bit masks and bit positions */
+#define CLKCTRL_TUNE_gm  0xFF  /* Oscillator Tune group mask. */
+#define CLKCTRL_TUNE_gp  0  /* Oscillator Tune group position. */
+#define CLKCTRL_TUNE_0_bm  (1<<0)  /* Oscillator Tune bit 0 mask. */
+#define CLKCTRL_TUNE_0_bp  0  /* Oscillator Tune bit 0 position. */
+#define CLKCTRL_TUNE_1_bm  (1<<1)  /* Oscillator Tune bit 1 mask. */
+#define CLKCTRL_TUNE_1_bp  1  /* Oscillator Tune bit 1 position. */
+#define CLKCTRL_TUNE_2_bm  (1<<2)  /* Oscillator Tune bit 2 mask. */
+#define CLKCTRL_TUNE_2_bp  2  /* Oscillator Tune bit 2 position. */
+#define CLKCTRL_TUNE_3_bm  (1<<3)  /* Oscillator Tune bit 3 mask. */
+#define CLKCTRL_TUNE_3_bp  3  /* Oscillator Tune bit 3 position. */
+#define CLKCTRL_TUNE_4_bm  (1<<4)  /* Oscillator Tune bit 4 mask. */
+#define CLKCTRL_TUNE_4_bp  4  /* Oscillator Tune bit 4 position. */
+#define CLKCTRL_TUNE_5_bm  (1<<5)  /* Oscillator Tune bit 5 mask. */
+#define CLKCTRL_TUNE_5_bp  5  /* Oscillator Tune bit 5 position. */
+#define CLKCTRL_TUNE_6_bm  (1<<6)  /* Oscillator Tune bit 6 mask. */
+#define CLKCTRL_TUNE_6_bp  6  /* Oscillator Tune bit 6 position. */
+#define CLKCTRL_TUNE_7_bm  (1<<7)  /* Oscillator Tune bit 7 mask. */
+#define CLKCTRL_TUNE_7_bp  7  /* Oscillator Tune bit 7 position. */
+
+/* CLKCTRL.OSC32KCTRLA  bit masks and bit positions */
+/* CLKCTRL_RUNSTDBY  is already defined. */
+
+/* CLKCTRL.XOSC32KCTRLA  bit masks and bit positions */
+#define CLKCTRL_ENABLE_bm  0x01  /* Enable bit mask. */
+#define CLKCTRL_ENABLE_bp  0  /* Enable bit position. */
+#define CLKCTRL_LPMODE_bm  0x02  /* Low power mode bit mask. */
+#define CLKCTRL_LPMODE_bp  1  /* Low power mode bit position. */
+#define CLKCTRL_SEL_bm  0x04  /* Select bit mask. */
+#define CLKCTRL_SEL_bp  2  /* Select bit position. */
+#define CLKCTRL_CSUT_gm  0x30  /* Crystal startup time group mask. */
+#define CLKCTRL_CSUT_gp  4  /* Crystal startup time group position. */
+#define CLKCTRL_CSUT_0_bm  (1<<4)  /* Crystal startup time bit 0 mask. */
+#define CLKCTRL_CSUT_0_bp  4  /* Crystal startup time bit 0 position. */
+#define CLKCTRL_CSUT_1_bm  (1<<5)  /* Crystal startup time bit 1 mask. */
+#define CLKCTRL_CSUT_1_bp  5  /* Crystal startup time bit 1 position. */
+/* CLKCTRL_RUNSTDBY  is already defined. */
+
+/* CLKCTRL.XOSCHFCTRLA  bit masks and bit positions */
+/* CLKCTRL_ENABLE  is already defined. */
+#define CLKCTRL_SELHF_bm  0x02  /* Source Select bit mask. */
+#define CLKCTRL_SELHF_bp  1  /* Source Select bit position. */
+#define CLKCTRL_CSUTHF_gm  0x30  /* Start-Up Time group mask. */
+#define CLKCTRL_CSUTHF_gp  4  /* Start-Up Time group position. */
+#define CLKCTRL_CSUTHF_0_bm  (1<<4)  /* Start-Up Time bit 0 mask. */
+#define CLKCTRL_CSUTHF_0_bp  4  /* Start-Up Time bit 0 position. */
+#define CLKCTRL_CSUTHF_1_bm  (1<<5)  /* Start-Up Time bit 1 mask. */
+#define CLKCTRL_CSUTHF_1_bp  5  /* Start-Up Time bit 1 position. */
+/* CLKCTRL_RUNSTDBY  is already defined. */
+
+
+/* CPU - CPU */
+/* CPU.CCP  bit masks and bit positions */
+#define CPU_CCP_gm  0xFF  /* CCP signature group mask. */
+#define CPU_CCP_gp  0  /* CCP signature group position. */
+#define CPU_CCP_0_bm  (1<<0)  /* CCP signature bit 0 mask. */
+#define CPU_CCP_0_bp  0  /* CCP signature bit 0 position. */
+#define CPU_CCP_1_bm  (1<<1)  /* CCP signature bit 1 mask. */
+#define CPU_CCP_1_bp  1  /* CCP signature bit 1 position. */
+#define CPU_CCP_2_bm  (1<<2)  /* CCP signature bit 2 mask. */
+#define CPU_CCP_2_bp  2  /* CCP signature bit 2 position. */
+#define CPU_CCP_3_bm  (1<<3)  /* CCP signature bit 3 mask. */
+#define CPU_CCP_3_bp  3  /* CCP signature bit 3 position. */
+#define CPU_CCP_4_bm  (1<<4)  /* CCP signature bit 4 mask. */
+#define CPU_CCP_4_bp  4  /* CCP signature bit 4 position. */
+#define CPU_CCP_5_bm  (1<<5)  /* CCP signature bit 5 mask. */
+#define CPU_CCP_5_bp  5  /* CCP signature bit 5 position. */
+#define CPU_CCP_6_bm  (1<<6)  /* CCP signature bit 6 mask. */
+#define CPU_CCP_6_bp  6  /* CCP signature bit 6 position. */
+#define CPU_CCP_7_bm  (1<<7)  /* CCP signature bit 7 mask. */
+#define CPU_CCP_7_bp  7  /* CCP signature bit 7 position. */
+
+/* CPU.SREG  bit masks and bit positions */
+#define CPU_C_bm  0x01  /* Carry Flag bit mask. */
+#define CPU_C_bp  0  /* Carry Flag bit position. */
+#define CPU_Z_bm  0x02  /* Zero Flag bit mask. */
+#define CPU_Z_bp  1  /* Zero Flag bit position. */
+#define CPU_N_bm  0x04  /* Negative Flag bit mask. */
+#define CPU_N_bp  2  /* Negative Flag bit position. */
+#define CPU_V_bm  0x08  /* Two's Complement Overflow Flag bit mask. */
+#define CPU_V_bp  3  /* Two's Complement Overflow Flag bit position. */
+#define CPU_S_bm  0x10  /* N Exclusive Or V Flag bit mask. */
+#define CPU_S_bp  4  /* N Exclusive Or V Flag bit position. */
+#define CPU_H_bm  0x20  /* Half Carry Flag bit mask. */
+#define CPU_H_bp  5  /* Half Carry Flag bit position. */
+#define CPU_T_bm  0x40  /* Transfer Bit bit mask. */
+#define CPU_T_bp  6  /* Transfer Bit bit position. */
+#define CPU_I_bm  0x80  /* Global Interrupt Enable Flag bit mask. */
+#define CPU_I_bp  7  /* Global Interrupt Enable Flag bit position. */
+
+
+/* CPUINT - Interrupt Controller */
+/* CPUINT.CTRLA  bit masks and bit positions */
+#define CPUINT_LVL0RR_bm  0x01  /* Round-robin Scheduling Enable bit mask. */
+#define CPUINT_LVL0RR_bp  0  /* Round-robin Scheduling Enable bit position. */
+#define CPUINT_CVT_bm  0x20  /* Compact Vector Table bit mask. */
+#define CPUINT_CVT_bp  5  /* Compact Vector Table bit position. */
+#define CPUINT_IVSEL_bm  0x40  /* Interrupt Vector Select bit mask. */
+#define CPUINT_IVSEL_bp  6  /* Interrupt Vector Select bit position. */
+
+/* CPUINT.STATUS  bit masks and bit positions */
+#define CPUINT_LVL0EX_bm  0x01  /* Level 0 Interrupt Executing bit mask. */
+#define CPUINT_LVL0EX_bp  0  /* Level 0 Interrupt Executing bit position. */
+#define CPUINT_LVL1EX_bm  0x02  /* Level 1 Interrupt Executing bit mask. */
+#define CPUINT_LVL1EX_bp  1  /* Level 1 Interrupt Executing bit position. */
+#define CPUINT_NMIEX_bm  0x80  /* Non-maskable Interrupt Executing bit mask. */
+#define CPUINT_NMIEX_bp  7  /* Non-maskable Interrupt Executing bit position. */
+
+/* CPUINT.LVL0PRI  bit masks and bit positions */
+#define CPUINT_LVL0PRI_gm  0xFF  /* Interrupt Level Priority group mask. */
+#define CPUINT_LVL0PRI_gp  0  /* Interrupt Level Priority group position. */
+#define CPUINT_LVL0PRI_0_bm  (1<<0)  /* Interrupt Level Priority bit 0 mask. */
+#define CPUINT_LVL0PRI_0_bp  0  /* Interrupt Level Priority bit 0 position. */
+#define CPUINT_LVL0PRI_1_bm  (1<<1)  /* Interrupt Level Priority bit 1 mask. */
+#define CPUINT_LVL0PRI_1_bp  1  /* Interrupt Level Priority bit 1 position. */
+#define CPUINT_LVL0PRI_2_bm  (1<<2)  /* Interrupt Level Priority bit 2 mask. */
+#define CPUINT_LVL0PRI_2_bp  2  /* Interrupt Level Priority bit 2 position. */
+#define CPUINT_LVL0PRI_3_bm  (1<<3)  /* Interrupt Level Priority bit 3 mask. */
+#define CPUINT_LVL0PRI_3_bp  3  /* Interrupt Level Priority bit 3 position. */
+#define CPUINT_LVL0PRI_4_bm  (1<<4)  /* Interrupt Level Priority bit 4 mask. */
+#define CPUINT_LVL0PRI_4_bp  4  /* Interrupt Level Priority bit 4 position. */
+#define CPUINT_LVL0PRI_5_bm  (1<<5)  /* Interrupt Level Priority bit 5 mask. */
+#define CPUINT_LVL0PRI_5_bp  5  /* Interrupt Level Priority bit 5 position. */
+#define CPUINT_LVL0PRI_6_bm  (1<<6)  /* Interrupt Level Priority bit 6 mask. */
+#define CPUINT_LVL0PRI_6_bp  6  /* Interrupt Level Priority bit 6 position. */
+#define CPUINT_LVL0PRI_7_bm  (1<<7)  /* Interrupt Level Priority bit 7 mask. */
+#define CPUINT_LVL0PRI_7_bp  7  /* Interrupt Level Priority bit 7 position. */
+
+/* CPUINT.LVL1VEC  bit masks and bit positions */
+#define CPUINT_LVL1VEC_gm  0xFF  /* Interrupt Vector with High Priority group mask. */
+#define CPUINT_LVL1VEC_gp  0  /* Interrupt Vector with High Priority group position. */
+#define CPUINT_LVL1VEC_0_bm  (1<<0)  /* Interrupt Vector with High Priority bit 0 mask. */
+#define CPUINT_LVL1VEC_0_bp  0  /* Interrupt Vector with High Priority bit 0 position. */
+#define CPUINT_LVL1VEC_1_bm  (1<<1)  /* Interrupt Vector with High Priority bit 1 mask. */
+#define CPUINT_LVL1VEC_1_bp  1  /* Interrupt Vector with High Priority bit 1 position. */
+#define CPUINT_LVL1VEC_2_bm  (1<<2)  /* Interrupt Vector with High Priority bit 2 mask. */
+#define CPUINT_LVL1VEC_2_bp  2  /* Interrupt Vector with High Priority bit 2 position. */
+#define CPUINT_LVL1VEC_3_bm  (1<<3)  /* Interrupt Vector with High Priority bit 3 mask. */
+#define CPUINT_LVL1VEC_3_bp  3  /* Interrupt Vector with High Priority bit 3 position. */
+#define CPUINT_LVL1VEC_4_bm  (1<<4)  /* Interrupt Vector with High Priority bit 4 mask. */
+#define CPUINT_LVL1VEC_4_bp  4  /* Interrupt Vector with High Priority bit 4 position. */
+#define CPUINT_LVL1VEC_5_bm  (1<<5)  /* Interrupt Vector with High Priority bit 5 mask. */
+#define CPUINT_LVL1VEC_5_bp  5  /* Interrupt Vector with High Priority bit 5 position. */
+#define CPUINT_LVL1VEC_6_bm  (1<<6)  /* Interrupt Vector with High Priority bit 6 mask. */
+#define CPUINT_LVL1VEC_6_bp  6  /* Interrupt Vector with High Priority bit 6 position. */
+#define CPUINT_LVL1VEC_7_bm  (1<<7)  /* Interrupt Vector with High Priority bit 7 mask. */
+#define CPUINT_LVL1VEC_7_bp  7  /* Interrupt Vector with High Priority bit 7 position. */
+
+
+/* CRCSCAN - CRCSCAN */
+/* CRCSCAN.CTRLA  bit masks and bit positions */
+#define CRCSCAN_ENABLE_bm  0x01  /* Enable CRC scan bit mask. */
+#define CRCSCAN_ENABLE_bp  0  /* Enable CRC scan bit position. */
+#define CRCSCAN_NMIEN_bm  0x02  /* Enable NMI Trigger bit mask. */
+#define CRCSCAN_NMIEN_bp  1  /* Enable NMI Trigger bit position. */
+#define CRCSCAN_RESET_bm  0x80  /* Reset CRC scan bit mask. */
+#define CRCSCAN_RESET_bp  7  /* Reset CRC scan bit position. */
+
+/* CRCSCAN.CTRLB  bit masks and bit positions */
+#define CRCSCAN_SRC_gm  0x03  /* CRC Source group mask. */
+#define CRCSCAN_SRC_gp  0  /* CRC Source group position. */
+#define CRCSCAN_SRC_0_bm  (1<<0)  /* CRC Source bit 0 mask. */
+#define CRCSCAN_SRC_0_bp  0  /* CRC Source bit 0 position. */
+#define CRCSCAN_SRC_1_bm  (1<<1)  /* CRC Source bit 1 mask. */
+#define CRCSCAN_SRC_1_bp  1  /* CRC Source bit 1 position. */
+
+/* CRCSCAN.STATUS  bit masks and bit positions */
+#define CRCSCAN_BUSY_bm  0x01  /* CRC Busy bit mask. */
+#define CRCSCAN_BUSY_bp  0  /* CRC Busy bit position. */
+#define CRCSCAN_OK_bm  0x02  /* CRC Ok bit mask. */
+#define CRCSCAN_OK_bp  1  /* CRC Ok bit position. */
+
+
+/* DAC - Digital to Analog Converter */
+/* DAC.CTRLA  bit masks and bit positions */
+#define DAC_ENABLE_bm  0x01  /* DAC Enable bit mask. */
+#define DAC_ENABLE_bp  0  /* DAC Enable bit position. */
+#define DAC_OUTRANGE_gm  0x30  /* Output Buffer Range group mask. */
+#define DAC_OUTRANGE_gp  4  /* Output Buffer Range group position. */
+#define DAC_OUTRANGE_0_bm  (1<<4)  /* Output Buffer Range bit 0 mask. */
+#define DAC_OUTRANGE_0_bp  4  /* Output Buffer Range bit 0 position. */
+#define DAC_OUTRANGE_1_bm  (1<<5)  /* Output Buffer Range bit 1 mask. */
+#define DAC_OUTRANGE_1_bp  5  /* Output Buffer Range bit 1 position. */
+#define DAC_OUTEN_bm  0x40  /* Output Buffer Enable bit mask. */
+#define DAC_OUTEN_bp  6  /* Output Buffer Enable bit position. */
+#define DAC_RUNSTDBY_bm  0x80  /* Run in Standby Mode bit mask. */
+#define DAC_RUNSTDBY_bp  7  /* Run in Standby Mode bit position. */
+
+/* DAC.DATA  bit masks and bit positions */
+#define DAC_DATA_gm  0xFFC0  /* Data group mask. */
+#define DAC_DATA_gp  6  /* Data group position. */
+#define DAC_DATA_0_bm  (1<<6)  /* Data bit 0 mask. */
+#define DAC_DATA_0_bp  6  /* Data bit 0 position. */
+#define DAC_DATA_1_bm  (1<<7)  /* Data bit 1 mask. */
+#define DAC_DATA_1_bp  7  /* Data bit 1 position. */
+#define DAC_DATA_2_bm  (1<<8)  /* Data bit 2 mask. */
+#define DAC_DATA_2_bp  8  /* Data bit 2 position. */
+#define DAC_DATA_3_bm  (1<<9)  /* Data bit 3 mask. */
+#define DAC_DATA_3_bp  9  /* Data bit 3 position. */
+#define DAC_DATA_4_bm  (1<<10)  /* Data bit 4 mask. */
+#define DAC_DATA_4_bp  10  /* Data bit 4 position. */
+#define DAC_DATA_5_bm  (1<<11)  /* Data bit 5 mask. */
+#define DAC_DATA_5_bp  11  /* Data bit 5 position. */
+#define DAC_DATA_6_bm  (1<<12)  /* Data bit 6 mask. */
+#define DAC_DATA_6_bp  12  /* Data bit 6 position. */
+#define DAC_DATA_7_bm  (1<<13)  /* Data bit 7 mask. */
+#define DAC_DATA_7_bp  13  /* Data bit 7 position. */
+#define DAC_DATA_8_bm  (1<<14)  /* Data bit 8 mask. */
+#define DAC_DATA_8_bp  14  /* Data bit 8 position. */
+#define DAC_DATA_9_bm  (1<<15)  /* Data bit 9 mask. */
+#define DAC_DATA_9_bp  15  /* Data bit 9 position. */
+
+
+/* EVSYS - Event System */
+/* EVSYS.SWEVENTA  bit masks and bit positions */
+#define EVSYS_SWEVENTA_gm  0xFF  /* Software event on channel select group mask. */
+#define EVSYS_SWEVENTA_gp  0  /* Software event on channel select group position. */
+#define EVSYS_SWEVENTA_0_bm  (1<<0)  /* Software event on channel select bit 0 mask. */
+#define EVSYS_SWEVENTA_0_bp  0  /* Software event on channel select bit 0 position. */
+#define EVSYS_SWEVENTA_1_bm  (1<<1)  /* Software event on channel select bit 1 mask. */
+#define EVSYS_SWEVENTA_1_bp  1  /* Software event on channel select bit 1 position. */
+#define EVSYS_SWEVENTA_2_bm  (1<<2)  /* Software event on channel select bit 2 mask. */
+#define EVSYS_SWEVENTA_2_bp  2  /* Software event on channel select bit 2 position. */
+#define EVSYS_SWEVENTA_3_bm  (1<<3)  /* Software event on channel select bit 3 mask. */
+#define EVSYS_SWEVENTA_3_bp  3  /* Software event on channel select bit 3 position. */
+#define EVSYS_SWEVENTA_4_bm  (1<<4)  /* Software event on channel select bit 4 mask. */
+#define EVSYS_SWEVENTA_4_bp  4  /* Software event on channel select bit 4 position. */
+#define EVSYS_SWEVENTA_5_bm  (1<<5)  /* Software event on channel select bit 5 mask. */
+#define EVSYS_SWEVENTA_5_bp  5  /* Software event on channel select bit 5 position. */
+#define EVSYS_SWEVENTA_6_bm  (1<<6)  /* Software event on channel select bit 6 mask. */
+#define EVSYS_SWEVENTA_6_bp  6  /* Software event on channel select bit 6 position. */
+#define EVSYS_SWEVENTA_7_bm  (1<<7)  /* Software event on channel select bit 7 mask. */
+#define EVSYS_SWEVENTA_7_bp  7  /* Software event on channel select bit 7 position. */
+
+/* EVSYS.CHANNEL0  bit masks and bit positions */
+#define EVSYS_CHANNEL_gm  0xFF  /* Channel generator select group mask. */
+#define EVSYS_CHANNEL_gp  0  /* Channel generator select group position. */
+#define EVSYS_CHANNEL_0_bm  (1<<0)  /* Channel generator select bit 0 mask. */
+#define EVSYS_CHANNEL_0_bp  0  /* Channel generator select bit 0 position. */
+#define EVSYS_CHANNEL_1_bm  (1<<1)  /* Channel generator select bit 1 mask. */
+#define EVSYS_CHANNEL_1_bp  1  /* Channel generator select bit 1 position. */
+#define EVSYS_CHANNEL_2_bm  (1<<2)  /* Channel generator select bit 2 mask. */
+#define EVSYS_CHANNEL_2_bp  2  /* Channel generator select bit 2 position. */
+#define EVSYS_CHANNEL_3_bm  (1<<3)  /* Channel generator select bit 3 mask. */
+#define EVSYS_CHANNEL_3_bp  3  /* Channel generator select bit 3 position. */
+#define EVSYS_CHANNEL_4_bm  (1<<4)  /* Channel generator select bit 4 mask. */
+#define EVSYS_CHANNEL_4_bp  4  /* Channel generator select bit 4 position. */
+#define EVSYS_CHANNEL_5_bm  (1<<5)  /* Channel generator select bit 5 mask. */
+#define EVSYS_CHANNEL_5_bp  5  /* Channel generator select bit 5 position. */
+#define EVSYS_CHANNEL_6_bm  (1<<6)  /* Channel generator select bit 6 mask. */
+#define EVSYS_CHANNEL_6_bp  6  /* Channel generator select bit 6 position. */
+#define EVSYS_CHANNEL_7_bm  (1<<7)  /* Channel generator select bit 7 mask. */
+#define EVSYS_CHANNEL_7_bp  7  /* Channel generator select bit 7 position. */
+
+/* EVSYS.CHANNEL1  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.CHANNEL2  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.CHANNEL3  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.CHANNEL4  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.CHANNEL5  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.USERCCLLUT0A  bit masks and bit positions */
+#define EVSYS_USER_gm  0xFF  /* User channel select group mask. */
+#define EVSYS_USER_gp  0  /* User channel select group position. */
+#define EVSYS_USER_0_bm  (1<<0)  /* User channel select bit 0 mask. */
+#define EVSYS_USER_0_bp  0  /* User channel select bit 0 position. */
+#define EVSYS_USER_1_bm  (1<<1)  /* User channel select bit 1 mask. */
+#define EVSYS_USER_1_bp  1  /* User channel select bit 1 position. */
+#define EVSYS_USER_2_bm  (1<<2)  /* User channel select bit 2 mask. */
+#define EVSYS_USER_2_bp  2  /* User channel select bit 2 position. */
+#define EVSYS_USER_3_bm  (1<<3)  /* User channel select bit 3 mask. */
+#define EVSYS_USER_3_bp  3  /* User channel select bit 3 position. */
+#define EVSYS_USER_4_bm  (1<<4)  /* User channel select bit 4 mask. */
+#define EVSYS_USER_4_bp  4  /* User channel select bit 4 position. */
+#define EVSYS_USER_5_bm  (1<<5)  /* User channel select bit 5 mask. */
+#define EVSYS_USER_5_bp  5  /* User channel select bit 5 position. */
+#define EVSYS_USER_6_bm  (1<<6)  /* User channel select bit 6 mask. */
+#define EVSYS_USER_6_bp  6  /* User channel select bit 6 position. */
+#define EVSYS_USER_7_bm  (1<<7)  /* User channel select bit 7 mask. */
+#define EVSYS_USER_7_bp  7  /* User channel select bit 7 position. */
+
+/* EVSYS.USERCCLLUT0B  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT1A  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT1B  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT2A  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT2B  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT3A  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT3B  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERADC0START  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTC  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTD  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTF  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERUSART0IRDA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERUSART1IRDA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERUSART2IRDA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCA0CNTA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCA0CNTB  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCA1CNTA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCA1CNTB  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB0CAPT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB0COUNT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB1CAPT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB1COUNT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB2CAPT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB2COUNT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB3CAPT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB3COUNT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+
+/* FUSE - Fuses */
+/* FUSE.WDTCFG  bit masks and bit positions */
+#define FUSE_PERIOD_gm  0x0F  /* Watchdog Timeout Period group mask. */
+#define FUSE_PERIOD_gp  0  /* Watchdog Timeout Period group position. */
+#define FUSE_PERIOD_0_bm  (1<<0)  /* Watchdog Timeout Period bit 0 mask. */
+#define FUSE_PERIOD_0_bp  0  /* Watchdog Timeout Period bit 0 position. */
+#define FUSE_PERIOD_1_bm  (1<<1)  /* Watchdog Timeout Period bit 1 mask. */
+#define FUSE_PERIOD_1_bp  1  /* Watchdog Timeout Period bit 1 position. */
+#define FUSE_PERIOD_2_bm  (1<<2)  /* Watchdog Timeout Period bit 2 mask. */
+#define FUSE_PERIOD_2_bp  2  /* Watchdog Timeout Period bit 2 position. */
+#define FUSE_PERIOD_3_bm  (1<<3)  /* Watchdog Timeout Period bit 3 mask. */
+#define FUSE_PERIOD_3_bp  3  /* Watchdog Timeout Period bit 3 position. */
+#define FUSE_WINDOW_gm  0xF0  /* Watchdog Window Timeout Period group mask. */
+#define FUSE_WINDOW_gp  4  /* Watchdog Window Timeout Period group position. */
+#define FUSE_WINDOW_0_bm  (1<<4)  /* Watchdog Window Timeout Period bit 0 mask. */
+#define FUSE_WINDOW_0_bp  4  /* Watchdog Window Timeout Period bit 0 position. */
+#define FUSE_WINDOW_1_bm  (1<<5)  /* Watchdog Window Timeout Period bit 1 mask. */
+#define FUSE_WINDOW_1_bp  5  /* Watchdog Window Timeout Period bit 1 position. */
+#define FUSE_WINDOW_2_bm  (1<<6)  /* Watchdog Window Timeout Period bit 2 mask. */
+#define FUSE_WINDOW_2_bp  6  /* Watchdog Window Timeout Period bit 2 position. */
+#define FUSE_WINDOW_3_bm  (1<<7)  /* Watchdog Window Timeout Period bit 3 mask. */
+#define FUSE_WINDOW_3_bp  7  /* Watchdog Window Timeout Period bit 3 position. */
+
+/* FUSE.BODCFG  bit masks and bit positions */
+#define FUSE_SLEEP_gm  0x03  /* BOD Operation in Sleep Mode group mask. */
+#define FUSE_SLEEP_gp  0  /* BOD Operation in Sleep Mode group position. */
+#define FUSE_SLEEP_0_bm  (1<<0)  /* BOD Operation in Sleep Mode bit 0 mask. */
+#define FUSE_SLEEP_0_bp  0  /* BOD Operation in Sleep Mode bit 0 position. */
+#define FUSE_SLEEP_1_bm  (1<<1)  /* BOD Operation in Sleep Mode bit 1 mask. */
+#define FUSE_SLEEP_1_bp  1  /* BOD Operation in Sleep Mode bit 1 position. */
+#define FUSE_ACTIVE_gm  0x0C  /* BOD Operation in Active Mode group mask. */
+#define FUSE_ACTIVE_gp  2  /* BOD Operation in Active Mode group position. */
+#define FUSE_ACTIVE_0_bm  (1<<2)  /* BOD Operation in Active Mode bit 0 mask. */
+#define FUSE_ACTIVE_0_bp  2  /* BOD Operation in Active Mode bit 0 position. */
+#define FUSE_ACTIVE_1_bm  (1<<3)  /* BOD Operation in Active Mode bit 1 mask. */
+#define FUSE_ACTIVE_1_bp  3  /* BOD Operation in Active Mode bit 1 position. */
+#define FUSE_SAMPFREQ_bm  0x10  /* BOD Sample Frequency bit mask. */
+#define FUSE_SAMPFREQ_bp  4  /* BOD Sample Frequency bit position. */
+#define FUSE_LVL_gm  0xE0  /* BOD Level group mask. */
+#define FUSE_LVL_gp  5  /* BOD Level group position. */
+#define FUSE_LVL_0_bm  (1<<5)  /* BOD Level bit 0 mask. */
+#define FUSE_LVL_0_bp  5  /* BOD Level bit 0 position. */
+#define FUSE_LVL_1_bm  (1<<6)  /* BOD Level bit 1 mask. */
+#define FUSE_LVL_1_bp  6  /* BOD Level bit 1 position. */
+#define FUSE_LVL_2_bm  (1<<7)  /* BOD Level bit 2 mask. */
+#define FUSE_LVL_2_bp  7  /* BOD Level bit 2 position. */
+
+/* FUSE.OSCCFG  bit masks and bit positions */
+#define FUSE_OSCHFFRQ_bm  0x08  /* High-frequency Oscillator Frequency bit mask. */
+#define FUSE_OSCHFFRQ_bp  3  /* High-frequency Oscillator Frequency bit position. */
+
+/* FUSE.SYSCFG0  bit masks and bit positions */
+#define FUSE_EESAVE_bm  0x01  /* EEPROM Save bit mask. */
+#define FUSE_EESAVE_bp  0  /* EEPROM Save bit position. */
+#define FUSE_RSTPINCFG_bm  0x08  /* Reset Pin Configuration bit mask. */
+#define FUSE_RSTPINCFG_bp  3  /* Reset Pin Configuration bit position. */
+#define FUSE_UPDIPINCFG_bm  0x10  /* UPDI Pin Configuration bit mask. */
+#define FUSE_UPDIPINCFG_bp  4  /* UPDI Pin Configuration bit position. */
+#define FUSE_CRCSEL_bm  0x20  /* CRC Select bit mask. */
+#define FUSE_CRCSEL_bp  5  /* CRC Select bit position. */
+#define FUSE_CRCSRC_gm  0xC0  /* CRC Source group mask. */
+#define FUSE_CRCSRC_gp  6  /* CRC Source group position. */
+#define FUSE_CRCSRC_0_bm  (1<<6)  /* CRC Source bit 0 mask. */
+#define FUSE_CRCSRC_0_bp  6  /* CRC Source bit 0 position. */
+#define FUSE_CRCSRC_1_bm  (1<<7)  /* CRC Source bit 1 mask. */
+#define FUSE_CRCSRC_1_bp  7  /* CRC Source bit 1 position. */
+
+/* FUSE.SYSCFG1  bit masks and bit positions */
+#define FUSE_SUT_gm  0x07  /* Startup Time group mask. */
+#define FUSE_SUT_gp  0  /* Startup Time group position. */
+#define FUSE_SUT_0_bm  (1<<0)  /* Startup Time bit 0 mask. */
+#define FUSE_SUT_0_bp  0  /* Startup Time bit 0 position. */
+#define FUSE_SUT_1_bm  (1<<1)  /* Startup Time bit 1 mask. */
+#define FUSE_SUT_1_bp  1  /* Startup Time bit 1 position. */
+#define FUSE_SUT_2_bm  (1<<2)  /* Startup Time bit 2 mask. */
+#define FUSE_SUT_2_bp  2  /* Startup Time bit 2 position. */
+
+
+
+/* LOCK - Lockbits */
+/* LOCK.KEY  bit masks and bit positions */
+#define LOCK_KEY_gm  0xFFFFFFFF  /* Lock Key group mask. */
+#define LOCK_KEY_gp  0  /* Lock Key group position. */
+#define LOCK_KEY_0_bm  (1<<0)  /* Lock Key bit 0 mask. */
+#define LOCK_KEY_0_bp  0  /* Lock Key bit 0 position. */
+#define LOCK_KEY_1_bm  (1<<1)  /* Lock Key bit 1 mask. */
+#define LOCK_KEY_1_bp  1  /* Lock Key bit 1 position. */
+#define LOCK_KEY_2_bm  (1<<2)  /* Lock Key bit 2 mask. */
+#define LOCK_KEY_2_bp  2  /* Lock Key bit 2 position. */
+#define LOCK_KEY_3_bm  (1<<3)  /* Lock Key bit 3 mask. */
+#define LOCK_KEY_3_bp  3  /* Lock Key bit 3 position. */
+#define LOCK_KEY_4_bm  (1<<4)  /* Lock Key bit 4 mask. */
+#define LOCK_KEY_4_bp  4  /* Lock Key bit 4 position. */
+#define LOCK_KEY_5_bm  (1<<5)  /* Lock Key bit 5 mask. */
+#define LOCK_KEY_5_bp  5  /* Lock Key bit 5 position. */
+#define LOCK_KEY_6_bm  (1<<6)  /* Lock Key bit 6 mask. */
+#define LOCK_KEY_6_bp  6  /* Lock Key bit 6 position. */
+#define LOCK_KEY_7_bm  (1<<7)  /* Lock Key bit 7 mask. */
+#define LOCK_KEY_7_bp  7  /* Lock Key bit 7 position. */
+#define LOCK_KEY_8_bm  (1<<8)  /* Lock Key bit 8 mask. */
+#define LOCK_KEY_8_bp  8  /* Lock Key bit 8 position. */
+#define LOCK_KEY_9_bm  (1<<9)  /* Lock Key bit 9 mask. */
+#define LOCK_KEY_9_bp  9  /* Lock Key bit 9 position. */
+#define LOCK_KEY_10_bm  (1<<10)  /* Lock Key bit 10 mask. */
+#define LOCK_KEY_10_bp  10  /* Lock Key bit 10 position. */
+#define LOCK_KEY_11_bm  (1<<11)  /* Lock Key bit 11 mask. */
+#define LOCK_KEY_11_bp  11  /* Lock Key bit 11 position. */
+#define LOCK_KEY_12_bm  (1<<12)  /* Lock Key bit 12 mask. */
+#define LOCK_KEY_12_bp  12  /* Lock Key bit 12 position. */
+#define LOCK_KEY_13_bm  (1<<13)  /* Lock Key bit 13 mask. */
+#define LOCK_KEY_13_bp  13  /* Lock Key bit 13 position. */
+#define LOCK_KEY_14_bm  (1<<14)  /* Lock Key bit 14 mask. */
+#define LOCK_KEY_14_bp  14  /* Lock Key bit 14 position. */
+#define LOCK_KEY_15_bm  (1<<15)  /* Lock Key bit 15 mask. */
+#define LOCK_KEY_15_bp  15  /* Lock Key bit 15 position. */
+#define LOCK_KEY_16_bm  (1<<16)  /* Lock Key bit 16 mask. */
+#define LOCK_KEY_16_bp  16  /* Lock Key bit 16 position. */
+#define LOCK_KEY_17_bm  (1<<17)  /* Lock Key bit 17 mask. */
+#define LOCK_KEY_17_bp  17  /* Lock Key bit 17 position. */
+#define LOCK_KEY_18_bm  (1<<18)  /* Lock Key bit 18 mask. */
+#define LOCK_KEY_18_bp  18  /* Lock Key bit 18 position. */
+#define LOCK_KEY_19_bm  (1<<19)  /* Lock Key bit 19 mask. */
+#define LOCK_KEY_19_bp  19  /* Lock Key bit 19 position. */
+#define LOCK_KEY_20_bm  (1<<20)  /* Lock Key bit 20 mask. */
+#define LOCK_KEY_20_bp  20  /* Lock Key bit 20 position. */
+#define LOCK_KEY_21_bm  (1<<21)  /* Lock Key bit 21 mask. */
+#define LOCK_KEY_21_bp  21  /* Lock Key bit 21 position. */
+#define LOCK_KEY_22_bm  (1<<22)  /* Lock Key bit 22 mask. */
+#define LOCK_KEY_22_bp  22  /* Lock Key bit 22 position. */
+#define LOCK_KEY_23_bm  (1<<23)  /* Lock Key bit 23 mask. */
+#define LOCK_KEY_23_bp  23  /* Lock Key bit 23 position. */
+#define LOCK_KEY_24_bm  (1<<24)  /* Lock Key bit 24 mask. */
+#define LOCK_KEY_24_bp  24  /* Lock Key bit 24 position. */
+#define LOCK_KEY_25_bm  (1<<25)  /* Lock Key bit 25 mask. */
+#define LOCK_KEY_25_bp  25  /* Lock Key bit 25 position. */
+#define LOCK_KEY_26_bm  (1<<26)  /* Lock Key bit 26 mask. */
+#define LOCK_KEY_26_bp  26  /* Lock Key bit 26 position. */
+#define LOCK_KEY_27_bm  (1<<27)  /* Lock Key bit 27 mask. */
+#define LOCK_KEY_27_bp  27  /* Lock Key bit 27 position. */
+#define LOCK_KEY_28_bm  (1<<28)  /* Lock Key bit 28 mask. */
+#define LOCK_KEY_28_bp  28  /* Lock Key bit 28 position. */
+#define LOCK_KEY_29_bm  (1<<29)  /* Lock Key bit 29 mask. */
+#define LOCK_KEY_29_bp  29  /* Lock Key bit 29 position. */
+#define LOCK_KEY_30_bm  (1<<30)  /* Lock Key bit 30 mask. */
+#define LOCK_KEY_30_bp  30  /* Lock Key bit 30 position. */
+#define LOCK_KEY_31_bm  (1<<31)  /* Lock Key bit 31 mask. */
+#define LOCK_KEY_31_bp  31  /* Lock Key bit 31 position. */
+
+
+/* NVMCTRL - Non-volatile Memory Controller */
+/* NVMCTRL.CTRLA  bit masks and bit positions */
+#define NVMCTRL_CMD_gm  0x7F  /* Command group mask. */
+#define NVMCTRL_CMD_gp  0  /* Command group position. */
+#define NVMCTRL_CMD_0_bm  (1<<0)  /* Command bit 0 mask. */
+#define NVMCTRL_CMD_0_bp  0  /* Command bit 0 position. */
+#define NVMCTRL_CMD_1_bm  (1<<1)  /* Command bit 1 mask. */
+#define NVMCTRL_CMD_1_bp  1  /* Command bit 1 position. */
+#define NVMCTRL_CMD_2_bm  (1<<2)  /* Command bit 2 mask. */
+#define NVMCTRL_CMD_2_bp  2  /* Command bit 2 position. */
+#define NVMCTRL_CMD_3_bm  (1<<3)  /* Command bit 3 mask. */
+#define NVMCTRL_CMD_3_bp  3  /* Command bit 3 position. */
+#define NVMCTRL_CMD_4_bm  (1<<4)  /* Command bit 4 mask. */
+#define NVMCTRL_CMD_4_bp  4  /* Command bit 4 position. */
+#define NVMCTRL_CMD_5_bm  (1<<5)  /* Command bit 5 mask. */
+#define NVMCTRL_CMD_5_bp  5  /* Command bit 5 position. */
+#define NVMCTRL_CMD_6_bm  (1<<6)  /* Command bit 6 mask. */
+#define NVMCTRL_CMD_6_bp  6  /* Command bit 6 position. */
+
+/* NVMCTRL.CTRLB  bit masks and bit positions */
+#define NVMCTRL_APPCODEWP_bm  0x01  /* Application Code Write Protect bit mask. */
+#define NVMCTRL_APPCODEWP_bp  0  /* Application Code Write Protect bit position. */
+#define NVMCTRL_BOOTRP_bm  0x02  /* Boot Read Protect bit mask. */
+#define NVMCTRL_BOOTRP_bp  1  /* Boot Read Protect bit position. */
+#define NVMCTRL_APPDATAWP_bm  0x04  /* Application Data Write Protect bit mask. */
+#define NVMCTRL_APPDATAWP_bp  2  /* Application Data Write Protect bit position. */
+#define NVMCTRL_EEWP_bm  0x08  /* EEPROM Write Protect bit mask. */
+#define NVMCTRL_EEWP_bp  3  /* EEPROM Write Protect bit position. */
+#define NVMCTRL_FLMAP_gm  0x30  /* Flash Mapping in Data space group mask. */
+#define NVMCTRL_FLMAP_gp  4  /* Flash Mapping in Data space group position. */
+#define NVMCTRL_FLMAP_0_bm  (1<<4)  /* Flash Mapping in Data space bit 0 mask. */
+#define NVMCTRL_FLMAP_0_bp  4  /* Flash Mapping in Data space bit 0 position. */
+#define NVMCTRL_FLMAP_1_bm  (1<<5)  /* Flash Mapping in Data space bit 1 mask. */
+#define NVMCTRL_FLMAP_1_bp  5  /* Flash Mapping in Data space bit 1 position. */
+#define NVMCTRL_FLMAPLOCK_bm  0x80  /* Flash Mapping Lock bit mask. */
+#define NVMCTRL_FLMAPLOCK_bp  7  /* Flash Mapping Lock bit position. */
+
+/* NVMCTRL.INTCTRL  bit masks and bit positions */
+#define NVMCTRL_EEREADY_bm  0x01  /* EEPROM Ready bit mask. */
+#define NVMCTRL_EEREADY_bp  0  /* EEPROM Ready bit position. */
+#define NVMCTRL_FLREADY_bm  0x02  /* Flash Ready bit mask. */
+#define NVMCTRL_FLREADY_bp  1  /* Flash Ready bit position. */
+
+/* NVMCTRL.INTFLAGS  bit masks and bit positions */
+/* NVMCTRL_EEREADY  is already defined. */
+/* NVMCTRL_FLREADY  is already defined. */
+
+/* NVMCTRL.STATUS  bit masks and bit positions */
+#define NVMCTRL_EEBUSY_bm  0x01  /* EEPROM busy bit mask. */
+#define NVMCTRL_EEBUSY_bp  0  /* EEPROM busy bit position. */
+#define NVMCTRL_FLBUSY_bm  0x02  /* Flash busy bit mask. */
+#define NVMCTRL_FLBUSY_bp  1  /* Flash busy bit position. */
+#define NVMCTRL_ERROR_gm  0x70  /* Write error group mask. */
+#define NVMCTRL_ERROR_gp  4  /* Write error group position. */
+#define NVMCTRL_ERROR_0_bm  (1<<4)  /* Write error bit 0 mask. */
+#define NVMCTRL_ERROR_0_bp  4  /* Write error bit 0 position. */
+#define NVMCTRL_ERROR_1_bm  (1<<5)  /* Write error bit 1 mask. */
+#define NVMCTRL_ERROR_1_bp  5  /* Write error bit 1 position. */
+#define NVMCTRL_ERROR_2_bm  (1<<6)  /* Write error bit 2 mask. */
+#define NVMCTRL_ERROR_2_bp  6  /* Write error bit 2 position. */
+
+
+/* PORT - I/O Ports */
+/* PORT.INTFLAGS  bit masks and bit positions */
+#define PORT_INT_gm  0xFF  /* Pin Interrupt Flag group mask. */
+#define PORT_INT_gp  0  /* Pin Interrupt Flag group position. */
+#define PORT_INT_0_bm  (1<<0)  /* Pin Interrupt Flag bit 0 mask. */
+#define PORT_INT_0_bp  0  /* Pin Interrupt Flag bit 0 position. */
+#define PORT_INT0_bm  PORT_INT_0_bm  /* This define is deprecated and should not be used */
+#define PORT_INT0_bp  PORT_INT_0_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_1_bm  (1<<1)  /* Pin Interrupt Flag bit 1 mask. */
+#define PORT_INT_1_bp  1  /* Pin Interrupt Flag bit 1 position. */
+#define PORT_INT1_bm  PORT_INT_1_bm  /* This define is deprecated and should not be used */
+#define PORT_INT1_bp  PORT_INT_1_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_2_bm  (1<<2)  /* Pin Interrupt Flag bit 2 mask. */
+#define PORT_INT_2_bp  2  /* Pin Interrupt Flag bit 2 position. */
+#define PORT_INT2_bm  PORT_INT_2_bm  /* This define is deprecated and should not be used */
+#define PORT_INT2_bp  PORT_INT_2_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_3_bm  (1<<3)  /* Pin Interrupt Flag bit 3 mask. */
+#define PORT_INT_3_bp  3  /* Pin Interrupt Flag bit 3 position. */
+#define PORT_INT3_bm  PORT_INT_3_bm  /* This define is deprecated and should not be used */
+#define PORT_INT3_bp  PORT_INT_3_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_4_bm  (1<<4)  /* Pin Interrupt Flag bit 4 mask. */
+#define PORT_INT_4_bp  4  /* Pin Interrupt Flag bit 4 position. */
+#define PORT_INT4_bm  PORT_INT_4_bm  /* This define is deprecated and should not be used */
+#define PORT_INT4_bp  PORT_INT_4_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_5_bm  (1<<5)  /* Pin Interrupt Flag bit 5 mask. */
+#define PORT_INT_5_bp  5  /* Pin Interrupt Flag bit 5 position. */
+#define PORT_INT5_bm  PORT_INT_5_bm  /* This define is deprecated and should not be used */
+#define PORT_INT5_bp  PORT_INT_5_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_6_bm  (1<<6)  /* Pin Interrupt Flag bit 6 mask. */
+#define PORT_INT_6_bp  6  /* Pin Interrupt Flag bit 6 position. */
+#define PORT_INT6_bm  PORT_INT_6_bm  /* This define is deprecated and should not be used */
+#define PORT_INT6_bp  PORT_INT_6_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_7_bm  (1<<7)  /* Pin Interrupt Flag bit 7 mask. */
+#define PORT_INT_7_bp  7  /* Pin Interrupt Flag bit 7 position. */
+#define PORT_INT7_bm  PORT_INT_7_bm  /* This define is deprecated and should not be used */
+#define PORT_INT7_bp  PORT_INT_7_bp  /* This define is deprecated and should not be used */
+
+/* PORT.PORTCTRL  bit masks and bit positions */
+#define PORT_SRL_bm  0x01  /* Slew Rate Limit Enable bit mask. */
+#define PORT_SRL_bp  0  /* Slew Rate Limit Enable bit position. */
+
+/* PORT.PINCONFIG  bit masks and bit positions */
+#define PORT_ISC_gm  0x07  /* Input/Sense Configuration group mask. */
+#define PORT_ISC_gp  0  /* Input/Sense Configuration group position. */
+#define PORT_ISC_0_bm  (1<<0)  /* Input/Sense Configuration bit 0 mask. */
+#define PORT_ISC_0_bp  0  /* Input/Sense Configuration bit 0 position. */
+#define PORT_ISC_1_bm  (1<<1)  /* Input/Sense Configuration bit 1 mask. */
+#define PORT_ISC_1_bp  1  /* Input/Sense Configuration bit 1 position. */
+#define PORT_ISC_2_bm  (1<<2)  /* Input/Sense Configuration bit 2 mask. */
+#define PORT_ISC_2_bp  2  /* Input/Sense Configuration bit 2 position. */
+#define PORT_PULLUPEN_bm  0x08  /* Pullup enable bit mask. */
+#define PORT_PULLUPEN_bp  3  /* Pullup enable bit position. */
+#define PORT_INLVL_bm  0x40  /* Input Level Select bit mask. */
+#define PORT_INLVL_bp  6  /* Input Level Select bit position. */
+#define PORT_INVEN_bm  0x80  /* Inverted I/O Enable bit mask. */
+#define PORT_INVEN_bp  7  /* Inverted I/O Enable bit position. */
+
+/* PORT.PIN0CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN1CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN2CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN3CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN4CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN5CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN6CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN7CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.EVGENCTRL  bit masks and bit positions */
+#define PORT_EVGEN0SEL_gm  0x07  /* Event Generator 0 Select group mask. */
+#define PORT_EVGEN0SEL_gp  0  /* Event Generator 0 Select group position. */
+#define PORT_EVGEN0SEL_0_bm  (1<<0)  /* Event Generator 0 Select bit 0 mask. */
+#define PORT_EVGEN0SEL_0_bp  0  /* Event Generator 0 Select bit 0 position. */
+#define PORT_EVGEN0SEL_1_bm  (1<<1)  /* Event Generator 0 Select bit 1 mask. */
+#define PORT_EVGEN0SEL_1_bp  1  /* Event Generator 0 Select bit 1 position. */
+#define PORT_EVGEN0SEL_2_bm  (1<<2)  /* Event Generator 0 Select bit 2 mask. */
+#define PORT_EVGEN0SEL_2_bp  2  /* Event Generator 0 Select bit 2 position. */
+#define PORT_EVGEN1SEL_gm  0x70  /* Event Generator 1 Select group mask. */
+#define PORT_EVGEN1SEL_gp  4  /* Event Generator 1 Select group position. */
+#define PORT_EVGEN1SEL_0_bm  (1<<4)  /* Event Generator 1 Select bit 0 mask. */
+#define PORT_EVGEN1SEL_0_bp  4  /* Event Generator 1 Select bit 0 position. */
+#define PORT_EVGEN1SEL_1_bm  (1<<5)  /* Event Generator 1 Select bit 1 mask. */
+#define PORT_EVGEN1SEL_1_bp  5  /* Event Generator 1 Select bit 1 position. */
+#define PORT_EVGEN1SEL_2_bm  (1<<6)  /* Event Generator 1 Select bit 2 mask. */
+#define PORT_EVGEN1SEL_2_bp  6  /* Event Generator 1 Select bit 2 position. */
+
+
+/* PORTMUX - Port Multiplexer */
+/* PORTMUX.EVSYSROUTEA  bit masks and bit positions */
+#define PORTMUX_EVOUTA_bm  0x01  /* Event Output A bit mask. */
+#define PORTMUX_EVOUTA_bp  0  /* Event Output A bit position. */
+#define PORTMUX_EVOUTC_bm  0x04  /* Event Output C bit mask. */
+#define PORTMUX_EVOUTC_bp  2  /* Event Output C bit position. */
+#define PORTMUX_EVOUTD_bm  0x08  /* Event Output D bit mask. */
+#define PORTMUX_EVOUTD_bp  3  /* Event Output D bit position. */
+#define PORTMUX_EVOUTF_bm  0x20  /* Event Output F bit mask. */
+#define PORTMUX_EVOUTF_bp  5  /* Event Output F bit position. */
+
+/* PORTMUX.CCLROUTEA  bit masks and bit positions */
+#define PORTMUX_LUT0_bm  0x01  /* CCL Look-Up Table 0 Signals bit mask. */
+#define PORTMUX_LUT0_bp  0  /* CCL Look-Up Table 0 Signals bit position. */
+#define PORTMUX_LUT1_bm  0x02  /* CCL Look-Up Table 1 Signals bit mask. */
+#define PORTMUX_LUT1_bp  1  /* CCL Look-Up Table 1 Signals bit position. */
+#define PORTMUX_LUT2_bm  0x04  /* CCL Look-Up Table 2 Signals bit mask. */
+#define PORTMUX_LUT2_bp  2  /* CCL Look-Up Table 2 Signals bit position. */
+
+/* PORTMUX.USARTROUTEA  bit masks and bit positions */
+#define PORTMUX_USART0_gm  0x07  /* USART0 Routing group mask. */
+#define PORTMUX_USART0_gp  0  /* USART0 Routing group position. */
+#define PORTMUX_USART0_0_bm  (1<<0)  /* USART0 Routing bit 0 mask. */
+#define PORTMUX_USART0_0_bp  0  /* USART0 Routing bit 0 position. */
+#define PORTMUX_USART0_1_bm  (1<<1)  /* USART0 Routing bit 1 mask. */
+#define PORTMUX_USART0_1_bp  1  /* USART0 Routing bit 1 position. */
+#define PORTMUX_USART0_2_bm  (1<<2)  /* USART0 Routing bit 2 mask. */
+#define PORTMUX_USART0_2_bp  2  /* USART0 Routing bit 2 position. */
+#define PORTMUX_USART1_gm  0x18  /* USART1 Routing group mask. */
+#define PORTMUX_USART1_gp  3  /* USART1 Routing group position. */
+#define PORTMUX_USART1_0_bm  (1<<3)  /* USART1 Routing bit 0 mask. */
+#define PORTMUX_USART1_0_bp  3  /* USART1 Routing bit 0 position. */
+#define PORTMUX_USART1_1_bm  (1<<4)  /* USART1 Routing bit 1 mask. */
+#define PORTMUX_USART1_1_bp  4  /* USART1 Routing bit 1 position. */
+
+/* PORTMUX.USARTROUTEB  bit masks and bit positions */
+#define PORTMUX_USART2_gm  0x03  /* USART2 Routing group mask. */
+#define PORTMUX_USART2_gp  0  /* USART2 Routing group position. */
+#define PORTMUX_USART2_0_bm  (1<<0)  /* USART2 Routing bit 0 mask. */
+#define PORTMUX_USART2_0_bp  0  /* USART2 Routing bit 0 position. */
+#define PORTMUX_USART2_1_bm  (1<<1)  /* USART2 Routing bit 1 mask. */
+#define PORTMUX_USART2_1_bp  1  /* USART2 Routing bit 1 position. */
+
+/* PORTMUX.SPIROUTEA  bit masks and bit positions */
+#define PORTMUX_SPI0_gm  0x07  /* SPI0 Signals group mask. */
+#define PORTMUX_SPI0_gp  0  /* SPI0 Signals group position. */
+#define PORTMUX_SPI0_0_bm  (1<<0)  /* SPI0 Signals bit 0 mask. */
+#define PORTMUX_SPI0_0_bp  0  /* SPI0 Signals bit 0 position. */
+#define PORTMUX_SPI0_1_bm  (1<<1)  /* SPI0 Signals bit 1 mask. */
+#define PORTMUX_SPI0_1_bp  1  /* SPI0 Signals bit 1 position. */
+#define PORTMUX_SPI0_2_bm  (1<<2)  /* SPI0 Signals bit 2 mask. */
+#define PORTMUX_SPI0_2_bp  2  /* SPI0 Signals bit 2 position. */
+
+/* PORTMUX.TWIROUTEA  bit masks and bit positions */
+#define PORTMUX_TWI0_gm  0x03  /* TWI0 Signals group mask. */
+#define PORTMUX_TWI0_gp  0  /* TWI0 Signals group position. */
+#define PORTMUX_TWI0_0_bm  (1<<0)  /* TWI0 Signals bit 0 mask. */
+#define PORTMUX_TWI0_0_bp  0  /* TWI0 Signals bit 0 position. */
+#define PORTMUX_TWI0_1_bm  (1<<1)  /* TWI0 Signals bit 1 mask. */
+#define PORTMUX_TWI0_1_bp  1  /* TWI0 Signals bit 1 position. */
+
+/* PORTMUX.TCAROUTEA  bit masks and bit positions */
+#define PORTMUX_TCA0_gm  0x07  /* TCA0 Signals group mask. */
+#define PORTMUX_TCA0_gp  0  /* TCA0 Signals group position. */
+#define PORTMUX_TCA0_0_bm  (1<<0)  /* TCA0 Signals bit 0 mask. */
+#define PORTMUX_TCA0_0_bp  0  /* TCA0 Signals bit 0 position. */
+#define PORTMUX_TCA0_1_bm  (1<<1)  /* TCA0 Signals bit 1 mask. */
+#define PORTMUX_TCA0_1_bp  1  /* TCA0 Signals bit 1 position. */
+#define PORTMUX_TCA0_2_bm  (1<<2)  /* TCA0 Signals bit 2 mask. */
+#define PORTMUX_TCA0_2_bp  2  /* TCA0 Signals bit 2 position. */
+#define PORTMUX_TCA1_gm  0x38  /* TCA1 Signals group mask. */
+#define PORTMUX_TCA1_gp  3  /* TCA1 Signals group position. */
+#define PORTMUX_TCA1_0_bm  (1<<3)  /* TCA1 Signals bit 0 mask. */
+#define PORTMUX_TCA1_0_bp  3  /* TCA1 Signals bit 0 position. */
+#define PORTMUX_TCA1_1_bm  (1<<4)  /* TCA1 Signals bit 1 mask. */
+#define PORTMUX_TCA1_1_bp  4  /* TCA1 Signals bit 1 position. */
+#define PORTMUX_TCA1_2_bm  (1<<5)  /* TCA1 Signals bit 2 mask. */
+#define PORTMUX_TCA1_2_bp  5  /* TCA1 Signals bit 2 position. */
+
+/* PORTMUX.TCBROUTEA  bit masks and bit positions */
+#define PORTMUX_TCB0_bm  0x01  /* TCB0 Output bit mask. */
+#define PORTMUX_TCB0_bp  0  /* TCB0 Output bit position. */
+#define PORTMUX_TCB1_bm  0x02  /* TCB1 Output bit mask. */
+#define PORTMUX_TCB1_bp  1  /* TCB1 Output bit position. */
+#define PORTMUX_TCB2_bm  0x04  /* TCB2 Output bit mask. */
+#define PORTMUX_TCB2_bp  2  /* TCB2 Output bit position. */
+#define PORTMUX_TCB3_bm  0x08  /* TCB3 Output bit mask. */
+#define PORTMUX_TCB3_bp  3  /* TCB3 Output bit position. */
+
+/* PORTMUX.ACROUTEA  bit masks and bit positions */
+#define PORTMUX_AC0_bm  0x01  /* Analog Comparator 0 Output bit mask. */
+#define PORTMUX_AC0_bp  0  /* Analog Comparator 0 Output bit position. */
+#define PORTMUX_AC1_bm  0x02  /* Analog Comparator 1 Output bit mask. */
+#define PORTMUX_AC1_bp  1  /* Analog Comparator 1 Output bit position. */
+
+
+/* RSTCTRL - Reset controller */
+/* RSTCTRL.RSTFR  bit masks and bit positions */
+#define RSTCTRL_PORF_bm  0x01  /* Power on Reset flag bit mask. */
+#define RSTCTRL_PORF_bp  0  /* Power on Reset flag bit position. */
+#define RSTCTRL_BORF_bm  0x02  /* Brown out detector Reset flag bit mask. */
+#define RSTCTRL_BORF_bp  1  /* Brown out detector Reset flag bit position. */
+#define RSTCTRL_EXTRF_bm  0x04  /* External Reset flag bit mask. */
+#define RSTCTRL_EXTRF_bp  2  /* External Reset flag bit position. */
+#define RSTCTRL_WDRF_bm  0x08  /* Watch dog Reset flag bit mask. */
+#define RSTCTRL_WDRF_bp  3  /* Watch dog Reset flag bit position. */
+#define RSTCTRL_SWRF_bm  0x10  /* Software Reset flag bit mask. */
+#define RSTCTRL_SWRF_bp  4  /* Software Reset flag bit position. */
+#define RSTCTRL_UPDIRF_bm  0x20  /* UPDI Reset flag bit mask. */
+#define RSTCTRL_UPDIRF_bp  5  /* UPDI Reset flag bit position. */
+
+/* RSTCTRL.SWRR  bit masks and bit positions */
+#define RSTCTRL_SWRE_bm  0x01  /* Software Reset Enable bit mask. */
+#define RSTCTRL_SWRE_bp  0  /* Software Reset Enable bit position. */
+
+
+/* RTC - Real-Time Counter */
+/* RTC.CTRLA  bit masks and bit positions */
+#define RTC_RTCEN_bm  0x01  /* Enable bit mask. */
+#define RTC_RTCEN_bp  0  /* Enable bit position. */
+#define RTC_CORREN_bm  0x04  /* Correction enable bit mask. */
+#define RTC_CORREN_bp  2  /* Correction enable bit position. */
+#define RTC_PRESCALER_gm  0x78  /* Prescaling Factor group mask. */
+#define RTC_PRESCALER_gp  3  /* Prescaling Factor group position. */
+#define RTC_PRESCALER_0_bm  (1<<3)  /* Prescaling Factor bit 0 mask. */
+#define RTC_PRESCALER_0_bp  3  /* Prescaling Factor bit 0 position. */
+#define RTC_PRESCALER_1_bm  (1<<4)  /* Prescaling Factor bit 1 mask. */
+#define RTC_PRESCALER_1_bp  4  /* Prescaling Factor bit 1 position. */
+#define RTC_PRESCALER_2_bm  (1<<5)  /* Prescaling Factor bit 2 mask. */
+#define RTC_PRESCALER_2_bp  5  /* Prescaling Factor bit 2 position. */
+#define RTC_PRESCALER_3_bm  (1<<6)  /* Prescaling Factor bit 3 mask. */
+#define RTC_PRESCALER_3_bp  6  /* Prescaling Factor bit 3 position. */
+#define RTC_RUNSTDBY_bm  0x80  /* Run In Standby bit mask. */
+#define RTC_RUNSTDBY_bp  7  /* Run In Standby bit position. */
+
+/* RTC.STATUS  bit masks and bit positions */
+#define RTC_CTRLABUSY_bm  0x01  /* CTRLA Synchronization Busy Flag bit mask. */
+#define RTC_CTRLABUSY_bp  0  /* CTRLA Synchronization Busy Flag bit position. */
+#define RTC_CNTBUSY_bm  0x02  /* Count Synchronization Busy Flag bit mask. */
+#define RTC_CNTBUSY_bp  1  /* Count Synchronization Busy Flag bit position. */
+#define RTC_PERBUSY_bm  0x04  /* Period Synchronization Busy Flag bit mask. */
+#define RTC_PERBUSY_bp  2  /* Period Synchronization Busy Flag bit position. */
+#define RTC_CMPBUSY_bm  0x08  /* Comparator Synchronization Busy Flag bit mask. */
+#define RTC_CMPBUSY_bp  3  /* Comparator Synchronization Busy Flag bit position. */
+
+/* RTC.INTCTRL  bit masks and bit positions */
+#define RTC_OVF_bm  0x01  /* Overflow Interrupt enable bit mask. */
+#define RTC_OVF_bp  0  /* Overflow Interrupt enable bit position. */
+#define RTC_CMP_bm  0x02  /* Compare Match Interrupt enable bit mask. */
+#define RTC_CMP_bp  1  /* Compare Match Interrupt enable bit position. */
+
+/* RTC.INTFLAGS  bit masks and bit positions */
+/* RTC_OVF  is already defined. */
+/* RTC_CMP  is already defined. */
+
+/* RTC.DBGCTRL  bit masks and bit positions */
+#define RTC_DBGRUN_bm  0x01  /* Run in debug bit mask. */
+#define RTC_DBGRUN_bp  0  /* Run in debug bit position. */
+
+/* RTC.CALIB  bit masks and bit positions */
+#define RTC_ERROR_gm  0x7F  /* Error Correction Value group mask. */
+#define RTC_ERROR_gp  0  /* Error Correction Value group position. */
+#define RTC_ERROR_0_bm  (1<<0)  /* Error Correction Value bit 0 mask. */
+#define RTC_ERROR_0_bp  0  /* Error Correction Value bit 0 position. */
+#define RTC_ERROR_1_bm  (1<<1)  /* Error Correction Value bit 1 mask. */
+#define RTC_ERROR_1_bp  1  /* Error Correction Value bit 1 position. */
+#define RTC_ERROR_2_bm  (1<<2)  /* Error Correction Value bit 2 mask. */
+#define RTC_ERROR_2_bp  2  /* Error Correction Value bit 2 position. */
+#define RTC_ERROR_3_bm  (1<<3)  /* Error Correction Value bit 3 mask. */
+#define RTC_ERROR_3_bp  3  /* Error Correction Value bit 3 position. */
+#define RTC_ERROR_4_bm  (1<<4)  /* Error Correction Value bit 4 mask. */
+#define RTC_ERROR_4_bp  4  /* Error Correction Value bit 4 position. */
+#define RTC_ERROR_5_bm  (1<<5)  /* Error Correction Value bit 5 mask. */
+#define RTC_ERROR_5_bp  5  /* Error Correction Value bit 5 position. */
+#define RTC_ERROR_6_bm  (1<<6)  /* Error Correction Value bit 6 mask. */
+#define RTC_ERROR_6_bp  6  /* Error Correction Value bit 6 position. */
+#define RTC_SIGN_bm  0x80  /* Error Correction Sign Bit bit mask. */
+#define RTC_SIGN_bp  7  /* Error Correction Sign Bit bit position. */
+
+/* RTC.CLKSEL  bit masks and bit positions */
+#define RTC_CLKSEL_gm  0x03  /* Clock Select group mask. */
+#define RTC_CLKSEL_gp  0  /* Clock Select group position. */
+#define RTC_CLKSEL_0_bm  (1<<0)  /* Clock Select bit 0 mask. */
+#define RTC_CLKSEL_0_bp  0  /* Clock Select bit 0 position. */
+#define RTC_CLKSEL_1_bm  (1<<1)  /* Clock Select bit 1 mask. */
+#define RTC_CLKSEL_1_bp  1  /* Clock Select bit 1 position. */
+
+/* RTC.PITCTRLA  bit masks and bit positions */
+#define RTC_PITEN_bm  0x01  /* Enable bit mask. */
+#define RTC_PITEN_bp  0  /* Enable bit position. */
+#define RTC_PERIOD_gm  0x78  /* Period group mask. */
+#define RTC_PERIOD_gp  3  /* Period group position. */
+#define RTC_PERIOD_0_bm  (1<<3)  /* Period bit 0 mask. */
+#define RTC_PERIOD_0_bp  3  /* Period bit 0 position. */
+#define RTC_PERIOD_1_bm  (1<<4)  /* Period bit 1 mask. */
+#define RTC_PERIOD_1_bp  4  /* Period bit 1 position. */
+#define RTC_PERIOD_2_bm  (1<<5)  /* Period bit 2 mask. */
+#define RTC_PERIOD_2_bp  5  /* Period bit 2 position. */
+#define RTC_PERIOD_3_bm  (1<<6)  /* Period bit 3 mask. */
+#define RTC_PERIOD_3_bp  6  /* Period bit 3 position. */
+
+/* RTC.PITSTATUS  bit masks and bit positions */
+#define RTC_CTRLBUSY_bm  0x01  /* CTRLA Synchronization Busy Flag bit mask. */
+#define RTC_CTRLBUSY_bp  0  /* CTRLA Synchronization Busy Flag bit position. */
+
+/* RTC.PITINTCTRL  bit masks and bit positions */
+#define RTC_PI_bm  0x01  /* Periodic Interrupt bit mask. */
+#define RTC_PI_bp  0  /* Periodic Interrupt bit position. */
+
+/* RTC.PITINTFLAGS  bit masks and bit positions */
+/* RTC_PI  is already defined. */
+
+/* RTC.PITDBGCTRL  bit masks and bit positions */
+/* RTC_DBGRUN  is already defined. */
+
+/* RTC.PITEVGENCTRLA  bit masks and bit positions */
+#define RTC_EVGEN0SEL_gm  0x0F  /* Event Generation 0 Select group mask. */
+#define RTC_EVGEN0SEL_gp  0  /* Event Generation 0 Select group position. */
+#define RTC_EVGEN0SEL_0_bm  (1<<0)  /* Event Generation 0 Select bit 0 mask. */
+#define RTC_EVGEN0SEL_0_bp  0  /* Event Generation 0 Select bit 0 position. */
+#define RTC_EVGEN0SEL_1_bm  (1<<1)  /* Event Generation 0 Select bit 1 mask. */
+#define RTC_EVGEN0SEL_1_bp  1  /* Event Generation 0 Select bit 1 position. */
+#define RTC_EVGEN0SEL_2_bm  (1<<2)  /* Event Generation 0 Select bit 2 mask. */
+#define RTC_EVGEN0SEL_2_bp  2  /* Event Generation 0 Select bit 2 position. */
+#define RTC_EVGEN0SEL_3_bm  (1<<3)  /* Event Generation 0 Select bit 3 mask. */
+#define RTC_EVGEN0SEL_3_bp  3  /* Event Generation 0 Select bit 3 position. */
+#define RTC_EVGEN1SEL_gm  0xF0  /* Event Generation 1 Select group mask. */
+#define RTC_EVGEN1SEL_gp  4  /* Event Generation 1 Select group position. */
+#define RTC_EVGEN1SEL_0_bm  (1<<4)  /* Event Generation 1 Select bit 0 mask. */
+#define RTC_EVGEN1SEL_0_bp  4  /* Event Generation 1 Select bit 0 position. */
+#define RTC_EVGEN1SEL_1_bm  (1<<5)  /* Event Generation 1 Select bit 1 mask. */
+#define RTC_EVGEN1SEL_1_bp  5  /* Event Generation 1 Select bit 1 position. */
+#define RTC_EVGEN1SEL_2_bm  (1<<6)  /* Event Generation 1 Select bit 2 mask. */
+#define RTC_EVGEN1SEL_2_bp  6  /* Event Generation 1 Select bit 2 position. */
+#define RTC_EVGEN1SEL_3_bm  (1<<7)  /* Event Generation 1 Select bit 3 mask. */
+#define RTC_EVGEN1SEL_3_bp  7  /* Event Generation 1 Select bit 3 position. */
+
+
+
+/* SLPCTRL - Sleep Controller */
+/* SLPCTRL.CTRLA  bit masks and bit positions */
+#define SLPCTRL_SEN_bm  0x01  /* Sleep enable bit mask. */
+#define SLPCTRL_SEN_bp  0  /* Sleep enable bit position. */
+#define SLPCTRL_SMODE_gm  0x06  /* Sleep mode group mask. */
+#define SLPCTRL_SMODE_gp  1  /* Sleep mode group position. */
+#define SLPCTRL_SMODE_0_bm  (1<<1)  /* Sleep mode bit 0 mask. */
+#define SLPCTRL_SMODE_0_bp  1  /* Sleep mode bit 0 position. */
+#define SLPCTRL_SMODE_1_bm  (1<<2)  /* Sleep mode bit 1 mask. */
+#define SLPCTRL_SMODE_1_bp  2  /* Sleep mode bit 1 position. */
+
+
+/* SPI - Serial Peripheral Interface */
+/* SPI.CTRLA  bit masks and bit positions */
+#define SPI_ENABLE_bm  0x01  /* Enable Module bit mask. */
+#define SPI_ENABLE_bp  0  /* Enable Module bit position. */
+#define SPI_PRESC_gm  0x06  /* Prescaler group mask. */
+#define SPI_PRESC_gp  1  /* Prescaler group position. */
+#define SPI_PRESC_0_bm  (1<<1)  /* Prescaler bit 0 mask. */
+#define SPI_PRESC_0_bp  1  /* Prescaler bit 0 position. */
+#define SPI_PRESC_1_bm  (1<<2)  /* Prescaler bit 1 mask. */
+#define SPI_PRESC_1_bp  2  /* Prescaler bit 1 position. */
+#define SPI_CLK2X_bm  0x10  /* Enable Double Speed bit mask. */
+#define SPI_CLK2X_bp  4  /* Enable Double Speed bit position. */
+#define SPI_MASTER_bm  0x20  /* Host Operation Enable bit mask. */
+#define SPI_MASTER_bp  5  /* Host Operation Enable bit position. */
+#define SPI_DORD_bm  0x40  /* Data Order Setting bit mask. */
+#define SPI_DORD_bp  6  /* Data Order Setting bit position. */
+
+/* SPI.CTRLB  bit masks and bit positions */
+#define SPI_MODE_gm  0x03  /* SPI Mode group mask. */
+#define SPI_MODE_gp  0  /* SPI Mode group position. */
+#define SPI_MODE_0_bm  (1<<0)  /* SPI Mode bit 0 mask. */
+#define SPI_MODE_0_bp  0  /* SPI Mode bit 0 position. */
+#define SPI_MODE_1_bm  (1<<1)  /* SPI Mode bit 1 mask. */
+#define SPI_MODE_1_bp  1  /* SPI Mode bit 1 position. */
+#define SPI_SSD_bm  0x04  /* SPI Select Disable bit mask. */
+#define SPI_SSD_bp  2  /* SPI Select Disable bit position. */
+#define SPI_BUFWR_bm  0x40  /* Buffer Mode Wait for Receive bit mask. */
+#define SPI_BUFWR_bp  6  /* Buffer Mode Wait for Receive bit position. */
+#define SPI_BUFEN_bm  0x80  /* Buffer Mode Enable bit mask. */
+#define SPI_BUFEN_bp  7  /* Buffer Mode Enable bit position. */
+
+/* SPI.INTCTRL  bit masks and bit positions */
+#define SPI_IE_bm  0x01  /* Interrupt Enable bit mask. */
+#define SPI_IE_bp  0  /* Interrupt Enable bit position. */
+#define SPI_SSIE_bm  0x10  /* SPI Select Trigger Interrupt Enable bit mask. */
+#define SPI_SSIE_bp  4  /* SPI Select Trigger Interrupt Enable bit position. */
+#define SPI_DREIE_bm  0x20  /* Data Register Empty Interrupt Enable bit mask. */
+#define SPI_DREIE_bp  5  /* Data Register Empty Interrupt Enable bit position. */
+#define SPI_TXCIE_bm  0x40  /* Transfer Complete Interrupt Enable bit mask. */
+#define SPI_TXCIE_bp  6  /* Transfer Complete Interrupt Enable bit position. */
+#define SPI_RXCIE_bm  0x80  /* Receive Complete Interrupt Enable bit mask. */
+#define SPI_RXCIE_bp  7  /* Receive Complete Interrupt Enable bit position. */
+
+/* SPI.INTFLAGS  bit masks and bit positions */
+#define SPI_BUFOVF_bm  0x01  /* Buffer Overflow bit mask. */
+#define SPI_BUFOVF_bp  0  /* Buffer Overflow bit position. */
+#define SPI_SSIF_bm  0x10  /* SPI Select Trigger Interrupt Flag bit mask. */
+#define SPI_SSIF_bp  4  /* SPI Select Trigger Interrupt Flag bit position. */
+#define SPI_DREIF_bm  0x20  /* Data Register Empty Interrupt Flag bit mask. */
+#define SPI_DREIF_bp  5  /* Data Register Empty Interrupt Flag bit position. */
+#define SPI_TXCIF_bm  0x40  /* Transfer Complete Interrupt Flag bit mask. */
+#define SPI_TXCIF_bp  6  /* Transfer Complete Interrupt Flag bit position. */
+#define SPI_WRCOL_bm  0x40  /* Write Collision bit mask. */
+#define SPI_WRCOL_bp  6  /* Write Collision bit position. */
+#define SPI_RXCIF_bm  0x80  /* Receive Complete Interrupt Flag bit mask. */
+#define SPI_RXCIF_bp  7  /* Receive Complete Interrupt Flag bit position. */
+#define SPI_IF_bm  0x80  /* Interrupt Flag bit mask. */
+#define SPI_IF_bp  7  /* Interrupt Flag bit position. */
+
+
+/* SYSCFG - System Configuration Registers */
+/* SYSCFG.REVID  bit masks and bit positions */
+#define SYSCFG_MINOR_gm  0x0F  /* Minor Revision group mask. */
+#define SYSCFG_MINOR_gp  0  /* Minor Revision group position. */
+#define SYSCFG_MINOR_0_bm  (1<<0)  /* Minor Revision bit 0 mask. */
+#define SYSCFG_MINOR_0_bp  0  /* Minor Revision bit 0 position. */
+#define SYSCFG_MINOR_1_bm  (1<<1)  /* Minor Revision bit 1 mask. */
+#define SYSCFG_MINOR_1_bp  1  /* Minor Revision bit 1 position. */
+#define SYSCFG_MINOR_2_bm  (1<<2)  /* Minor Revision bit 2 mask. */
+#define SYSCFG_MINOR_2_bp  2  /* Minor Revision bit 2 position. */
+#define SYSCFG_MINOR_3_bm  (1<<3)  /* Minor Revision bit 3 mask. */
+#define SYSCFG_MINOR_3_bp  3  /* Minor Revision bit 3 position. */
+#define SYSCFG_MAJOR_gm  0xF0  /* Major Revision group mask. */
+#define SYSCFG_MAJOR_gp  4  /* Major Revision group position. */
+#define SYSCFG_MAJOR_0_bm  (1<<4)  /* Major Revision bit 0 mask. */
+#define SYSCFG_MAJOR_0_bp  4  /* Major Revision bit 0 position. */
+#define SYSCFG_MAJOR_1_bm  (1<<5)  /* Major Revision bit 1 mask. */
+#define SYSCFG_MAJOR_1_bp  5  /* Major Revision bit 1 position. */
+#define SYSCFG_MAJOR_2_bm  (1<<6)  /* Major Revision bit 2 mask. */
+#define SYSCFG_MAJOR_2_bp  6  /* Major Revision bit 2 position. */
+#define SYSCFG_MAJOR_3_bm  (1<<7)  /* Major Revision bit 3 mask. */
+#define SYSCFG_MAJOR_3_bp  7  /* Major Revision bit 3 position. */
+
+/* SYSCFG.OCDMCTRL  bit masks and bit positions */
+#define SYSCFG_OCDM_gm  0xFF  /* OCD Message group mask. */
+#define SYSCFG_OCDM_gp  0  /* OCD Message group position. */
+#define SYSCFG_OCDM_0_bm  (1<<0)  /* OCD Message bit 0 mask. */
+#define SYSCFG_OCDM_0_bp  0  /* OCD Message bit 0 position. */
+#define SYSCFG_OCDM_1_bm  (1<<1)  /* OCD Message bit 1 mask. */
+#define SYSCFG_OCDM_1_bp  1  /* OCD Message bit 1 position. */
+#define SYSCFG_OCDM_2_bm  (1<<2)  /* OCD Message bit 2 mask. */
+#define SYSCFG_OCDM_2_bp  2  /* OCD Message bit 2 position. */
+#define SYSCFG_OCDM_3_bm  (1<<3)  /* OCD Message bit 3 mask. */
+#define SYSCFG_OCDM_3_bp  3  /* OCD Message bit 3 position. */
+#define SYSCFG_OCDM_4_bm  (1<<4)  /* OCD Message bit 4 mask. */
+#define SYSCFG_OCDM_4_bp  4  /* OCD Message bit 4 position. */
+#define SYSCFG_OCDM_5_bm  (1<<5)  /* OCD Message bit 5 mask. */
+#define SYSCFG_OCDM_5_bp  5  /* OCD Message bit 5 position. */
+#define SYSCFG_OCDM_6_bm  (1<<6)  /* OCD Message bit 6 mask. */
+#define SYSCFG_OCDM_6_bp  6  /* OCD Message bit 6 position. */
+#define SYSCFG_OCDM_7_bm  (1<<7)  /* OCD Message bit 7 mask. */
+#define SYSCFG_OCDM_7_bp  7  /* OCD Message bit 7 position. */
+
+/* SYSCFG.OCDMSTATUS  bit masks and bit positions */
+#define SYSCFG_VALID_bm  0x01  /* OCD Message Valid bit mask. */
+#define SYSCFG_VALID_bp  0  /* OCD Message Valid bit position. */
+
+
+/* TCA - 16-bit Timer/Counter Type A */
+/* TCA_SINGLE.CTRLA  bit masks and bit positions */
+#define TCA_SINGLE_ENABLE_bm  0x01  /* Module Enable bit mask. */
+#define TCA_SINGLE_ENABLE_bp  0  /* Module Enable bit position. */
+#define TCA_SINGLE_CLKSEL_gm  0x0E  /* Clock Selection group mask. */
+#define TCA_SINGLE_CLKSEL_gp  1  /* Clock Selection group position. */
+#define TCA_SINGLE_CLKSEL_0_bm  (1<<1)  /* Clock Selection bit 0 mask. */
+#define TCA_SINGLE_CLKSEL_0_bp  1  /* Clock Selection bit 0 position. */
+#define TCA_SINGLE_CLKSEL_1_bm  (1<<2)  /* Clock Selection bit 1 mask. */
+#define TCA_SINGLE_CLKSEL_1_bp  2  /* Clock Selection bit 1 position. */
+#define TCA_SINGLE_CLKSEL_2_bm  (1<<3)  /* Clock Selection bit 2 mask. */
+#define TCA_SINGLE_CLKSEL_2_bp  3  /* Clock Selection bit 2 position. */
+#define TCA_SINGLE_RUNSTDBY_bm  0x80  /* Run in Standby bit mask. */
+#define TCA_SINGLE_RUNSTDBY_bp  7  /* Run in Standby bit position. */
+
+/* TCA_SINGLE.CTRLB  bit masks and bit positions */
+#define TCA_SINGLE_WGMODE_gm  0x07  /* Waveform generation mode group mask. */
+#define TCA_SINGLE_WGMODE_gp  0  /* Waveform generation mode group position. */
+#define TCA_SINGLE_WGMODE_0_bm  (1<<0)  /* Waveform generation mode bit 0 mask. */
+#define TCA_SINGLE_WGMODE_0_bp  0  /* Waveform generation mode bit 0 position. */
+#define TCA_SINGLE_WGMODE_1_bm  (1<<1)  /* Waveform generation mode bit 1 mask. */
+#define TCA_SINGLE_WGMODE_1_bp  1  /* Waveform generation mode bit 1 position. */
+#define TCA_SINGLE_WGMODE_2_bm  (1<<2)  /* Waveform generation mode bit 2 mask. */
+#define TCA_SINGLE_WGMODE_2_bp  2  /* Waveform generation mode bit 2 position. */
+#define TCA_SINGLE_ALUPD_bm  0x08  /* Auto Lock Update bit mask. */
+#define TCA_SINGLE_ALUPD_bp  3  /* Auto Lock Update bit position. */
+#define TCA_SINGLE_CMP0EN_bm  0x10  /* Compare 0 Enable bit mask. */
+#define TCA_SINGLE_CMP0EN_bp  4  /* Compare 0 Enable bit position. */
+#define TCA_SINGLE_CMP1EN_bm  0x20  /* Compare 1 Enable bit mask. */
+#define TCA_SINGLE_CMP1EN_bp  5  /* Compare 1 Enable bit position. */
+#define TCA_SINGLE_CMP2EN_bm  0x40  /* Compare 2 Enable bit mask. */
+#define TCA_SINGLE_CMP2EN_bp  6  /* Compare 2 Enable bit position. */
+
+/* TCA_SINGLE.CTRLC  bit masks and bit positions */
+#define TCA_SINGLE_CMP0OV_bm  0x01  /* Compare 0 Waveform Output Value bit mask. */
+#define TCA_SINGLE_CMP0OV_bp  0  /* Compare 0 Waveform Output Value bit position. */
+#define TCA_SINGLE_CMP1OV_bm  0x02  /* Compare 1 Waveform Output Value bit mask. */
+#define TCA_SINGLE_CMP1OV_bp  1  /* Compare 1 Waveform Output Value bit position. */
+#define TCA_SINGLE_CMP2OV_bm  0x04  /* Compare 2 Waveform Output Value bit mask. */
+#define TCA_SINGLE_CMP2OV_bp  2  /* Compare 2 Waveform Output Value bit position. */
+
+/* TCA_SINGLE.CTRLD  bit masks and bit positions */
+#define TCA_SINGLE_SPLITM_bm  0x01  /* Split Mode Enable bit mask. */
+#define TCA_SINGLE_SPLITM_bp  0  /* Split Mode Enable bit position. */
+
+/* TCA_SINGLE.CTRLECLR  bit masks and bit positions */
+#define TCA_SINGLE_DIR_bm  0x01  /* Direction bit mask. */
+#define TCA_SINGLE_DIR_bp  0  /* Direction bit position. */
+#define TCA_SINGLE_LUPD_bm  0x02  /* Lock Update bit mask. */
+#define TCA_SINGLE_LUPD_bp  1  /* Lock Update bit position. */
+#define TCA_SINGLE_CMD_gm  0x0C  /* Command group mask. */
+#define TCA_SINGLE_CMD_gp  2  /* Command group position. */
+#define TCA_SINGLE_CMD_0_bm  (1<<2)  /* Command bit 0 mask. */
+#define TCA_SINGLE_CMD_0_bp  2  /* Command bit 0 position. */
+#define TCA_SINGLE_CMD_1_bm  (1<<3)  /* Command bit 1 mask. */
+#define TCA_SINGLE_CMD_1_bp  3  /* Command bit 1 position. */
+
+/* TCA_SINGLE.CTRLESET  bit masks and bit positions */
+/* TCA_SINGLE_DIR  is already defined. */
+/* TCA_SINGLE_LUPD  is already defined. */
+/* TCA_SINGLE_CMD  is already defined. */
+
+/* TCA_SINGLE.CTRLFCLR  bit masks and bit positions */
+#define TCA_SINGLE_PERBV_bm  0x01  /* Period Buffer Valid bit mask. */
+#define TCA_SINGLE_PERBV_bp  0  /* Period Buffer Valid bit position. */
+#define TCA_SINGLE_CMP0BV_bm  0x02  /* Compare 0 Buffer Valid bit mask. */
+#define TCA_SINGLE_CMP0BV_bp  1  /* Compare 0 Buffer Valid bit position. */
+#define TCA_SINGLE_CMP1BV_bm  0x04  /* Compare 1 Buffer Valid bit mask. */
+#define TCA_SINGLE_CMP1BV_bp  2  /* Compare 1 Buffer Valid bit position. */
+#define TCA_SINGLE_CMP2BV_bm  0x08  /* Compare 2 Buffer Valid bit mask. */
+#define TCA_SINGLE_CMP2BV_bp  3  /* Compare 2 Buffer Valid bit position. */
+
+/* TCA_SINGLE.CTRLFSET  bit masks and bit positions */
+/* TCA_SINGLE_PERBV  is already defined. */
+/* TCA_SINGLE_CMP0BV  is already defined. */
+/* TCA_SINGLE_CMP1BV  is already defined. */
+/* TCA_SINGLE_CMP2BV  is already defined. */
+
+/* TCA_SINGLE.EVCTRL  bit masks and bit positions */
+#define TCA_SINGLE_CNTAEI_bm  0x01  /* Count on Event Input A bit mask. */
+#define TCA_SINGLE_CNTAEI_bp  0  /* Count on Event Input A bit position. */
+#define TCA_SINGLE_EVACTA_gm  0x0E  /* Event Action A group mask. */
+#define TCA_SINGLE_EVACTA_gp  1  /* Event Action A group position. */
+#define TCA_SINGLE_EVACTA_0_bm  (1<<1)  /* Event Action A bit 0 mask. */
+#define TCA_SINGLE_EVACTA_0_bp  1  /* Event Action A bit 0 position. */
+#define TCA_SINGLE_EVACTA_1_bm  (1<<2)  /* Event Action A bit 1 mask. */
+#define TCA_SINGLE_EVACTA_1_bp  2  /* Event Action A bit 1 position. */
+#define TCA_SINGLE_EVACTA_2_bm  (1<<3)  /* Event Action A bit 2 mask. */
+#define TCA_SINGLE_EVACTA_2_bp  3  /* Event Action A bit 2 position. */
+#define TCA_SINGLE_CNTBEI_bm  0x10  /* Count on Event Input B bit mask. */
+#define TCA_SINGLE_CNTBEI_bp  4  /* Count on Event Input B bit position. */
+#define TCA_SINGLE_EVACTB_gm  0xE0  /* Event Action B group mask. */
+#define TCA_SINGLE_EVACTB_gp  5  /* Event Action B group position. */
+#define TCA_SINGLE_EVACTB_0_bm  (1<<5)  /* Event Action B bit 0 mask. */
+#define TCA_SINGLE_EVACTB_0_bp  5  /* Event Action B bit 0 position. */
+#define TCA_SINGLE_EVACTB_1_bm  (1<<6)  /* Event Action B bit 1 mask. */
+#define TCA_SINGLE_EVACTB_1_bp  6  /* Event Action B bit 1 position. */
+#define TCA_SINGLE_EVACTB_2_bm  (1<<7)  /* Event Action B bit 2 mask. */
+#define TCA_SINGLE_EVACTB_2_bp  7  /* Event Action B bit 2 position. */
+
+/* TCA_SINGLE.INTCTRL  bit masks and bit positions */
+#define TCA_SINGLE_OVF_bm  0x01  /* Overflow Interrupt bit mask. */
+#define TCA_SINGLE_OVF_bp  0  /* Overflow Interrupt bit position. */
+#define TCA_SINGLE_CMP0_bm  0x10  /* Compare 0 Interrupt bit mask. */
+#define TCA_SINGLE_CMP0_bp  4  /* Compare 0 Interrupt bit position. */
+#define TCA_SINGLE_CMP1_bm  0x20  /* Compare 1 Interrupt bit mask. */
+#define TCA_SINGLE_CMP1_bp  5  /* Compare 1 Interrupt bit position. */
+#define TCA_SINGLE_CMP2_bm  0x40  /* Compare 2 Interrupt bit mask. */
+#define TCA_SINGLE_CMP2_bp  6  /* Compare 2 Interrupt bit position. */
+
+/* TCA_SINGLE.INTFLAGS  bit masks and bit positions */
+/* TCA_SINGLE_OVF  is already defined. */
+/* TCA_SINGLE_CMP0  is already defined. */
+/* TCA_SINGLE_CMP1  is already defined. */
+/* TCA_SINGLE_CMP2  is already defined. */
+
+/* TCA_SINGLE.DBGCTRL  bit masks and bit positions */
+#define TCA_SINGLE_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define TCA_SINGLE_DBGRUN_bp  0  /* Debug Run bit position. */
+
+/* TCA_SPLIT.CTRLA  bit masks and bit positions */
+#define TCA_SPLIT_ENABLE_bm  0x01  /* Module Enable bit mask. */
+#define TCA_SPLIT_ENABLE_bp  0  /* Module Enable bit position. */
+#define TCA_SPLIT_CLKSEL_gm  0x0E  /* Clock Selection group mask. */
+#define TCA_SPLIT_CLKSEL_gp  1  /* Clock Selection group position. */
+#define TCA_SPLIT_CLKSEL_0_bm  (1<<1)  /* Clock Selection bit 0 mask. */
+#define TCA_SPLIT_CLKSEL_0_bp  1  /* Clock Selection bit 0 position. */
+#define TCA_SPLIT_CLKSEL_1_bm  (1<<2)  /* Clock Selection bit 1 mask. */
+#define TCA_SPLIT_CLKSEL_1_bp  2  /* Clock Selection bit 1 position. */
+#define TCA_SPLIT_CLKSEL_2_bm  (1<<3)  /* Clock Selection bit 2 mask. */
+#define TCA_SPLIT_CLKSEL_2_bp  3  /* Clock Selection bit 2 position. */
+#define TCA_SPLIT_RUNSTDBY_bm  0x80  /* Run in Standby bit mask. */
+#define TCA_SPLIT_RUNSTDBY_bp  7  /* Run in Standby bit position. */
+
+/* TCA_SPLIT.CTRLB  bit masks and bit positions */
+#define TCA_SPLIT_LCMP0EN_bm  0x01  /* Low Compare 0 Enable bit mask. */
+#define TCA_SPLIT_LCMP0EN_bp  0  /* Low Compare 0 Enable bit position. */
+#define TCA_SPLIT_LCMP1EN_bm  0x02  /* Low Compare 1 Enable bit mask. */
+#define TCA_SPLIT_LCMP1EN_bp  1  /* Low Compare 1 Enable bit position. */
+#define TCA_SPLIT_LCMP2EN_bm  0x04  /* Low Compare 2 Enable bit mask. */
+#define TCA_SPLIT_LCMP2EN_bp  2  /* Low Compare 2 Enable bit position. */
+#define TCA_SPLIT_HCMP0EN_bm  0x10  /* High Compare 0 Enable bit mask. */
+#define TCA_SPLIT_HCMP0EN_bp  4  /* High Compare 0 Enable bit position. */
+#define TCA_SPLIT_HCMP1EN_bm  0x20  /* High Compare 1 Enable bit mask. */
+#define TCA_SPLIT_HCMP1EN_bp  5  /* High Compare 1 Enable bit position. */
+#define TCA_SPLIT_HCMP2EN_bm  0x40  /* High Compare 2 Enable bit mask. */
+#define TCA_SPLIT_HCMP2EN_bp  6  /* High Compare 2 Enable bit position. */
+
+/* TCA_SPLIT.CTRLC  bit masks and bit positions */
+#define TCA_SPLIT_LCMP0OV_bm  0x01  /* Low Compare 0 Output Value bit mask. */
+#define TCA_SPLIT_LCMP0OV_bp  0  /* Low Compare 0 Output Value bit position. */
+#define TCA_SPLIT_LCMP1OV_bm  0x02  /* Low Compare 1 Output Value bit mask. */
+#define TCA_SPLIT_LCMP1OV_bp  1  /* Low Compare 1 Output Value bit position. */
+#define TCA_SPLIT_LCMP2OV_bm  0x04  /* Low Compare 2 Output Value bit mask. */
+#define TCA_SPLIT_LCMP2OV_bp  2  /* Low Compare 2 Output Value bit position. */
+#define TCA_SPLIT_HCMP0OV_bm  0x10  /* High Compare 0 Output Value bit mask. */
+#define TCA_SPLIT_HCMP0OV_bp  4  /* High Compare 0 Output Value bit position. */
+#define TCA_SPLIT_HCMP1OV_bm  0x20  /* High Compare 1 Output Value bit mask. */
+#define TCA_SPLIT_HCMP1OV_bp  5  /* High Compare 1 Output Value bit position. */
+#define TCA_SPLIT_HCMP2OV_bm  0x40  /* High Compare 2 Output Value bit mask. */
+#define TCA_SPLIT_HCMP2OV_bp  6  /* High Compare 2 Output Value bit position. */
+
+/* TCA_SPLIT.CTRLD  bit masks and bit positions */
+#define TCA_SPLIT_SPLITM_bm  0x01  /* Split Mode Enable bit mask. */
+#define TCA_SPLIT_SPLITM_bp  0  /* Split Mode Enable bit position. */
+
+/* TCA_SPLIT.CTRLECLR  bit masks and bit positions */
+#define TCA_SPLIT_CMDEN_gm  0x03  /* Command Enable group mask. */
+#define TCA_SPLIT_CMDEN_gp  0  /* Command Enable group position. */
+#define TCA_SPLIT_CMDEN_0_bm  (1<<0)  /* Command Enable bit 0 mask. */
+#define TCA_SPLIT_CMDEN_0_bp  0  /* Command Enable bit 0 position. */
+#define TCA_SPLIT_CMDEN_1_bm  (1<<1)  /* Command Enable bit 1 mask. */
+#define TCA_SPLIT_CMDEN_1_bp  1  /* Command Enable bit 1 position. */
+#define TCA_SPLIT_CMD_gm  0x0C  /* Command group mask. */
+#define TCA_SPLIT_CMD_gp  2  /* Command group position. */
+#define TCA_SPLIT_CMD_0_bm  (1<<2)  /* Command bit 0 mask. */
+#define TCA_SPLIT_CMD_0_bp  2  /* Command bit 0 position. */
+#define TCA_SPLIT_CMD_1_bm  (1<<3)  /* Command bit 1 mask. */
+#define TCA_SPLIT_CMD_1_bp  3  /* Command bit 1 position. */
+
+/* TCA_SPLIT.CTRLESET  bit masks and bit positions */
+/* TCA_SPLIT_CMDEN  is already defined. */
+/* TCA_SPLIT_CMD  is already defined. */
+
+/* TCA_SPLIT.INTCTRL  bit masks and bit positions */
+#define TCA_SPLIT_LUNF_bm  0x01  /* Low Underflow Interrupt Enable bit mask. */
+#define TCA_SPLIT_LUNF_bp  0  /* Low Underflow Interrupt Enable bit position. */
+#define TCA_SPLIT_HUNF_bm  0x02  /* High Underflow Interrupt Enable bit mask. */
+#define TCA_SPLIT_HUNF_bp  1  /* High Underflow Interrupt Enable bit position. */
+#define TCA_SPLIT_LCMP0_bm  0x10  /* Low Compare 0 Interrupt Enable bit mask. */
+#define TCA_SPLIT_LCMP0_bp  4  /* Low Compare 0 Interrupt Enable bit position. */
+#define TCA_SPLIT_LCMP1_bm  0x20  /* Low Compare 1 Interrupt Enable bit mask. */
+#define TCA_SPLIT_LCMP1_bp  5  /* Low Compare 1 Interrupt Enable bit position. */
+#define TCA_SPLIT_LCMP2_bm  0x40  /* Low Compare 2 Interrupt Enable bit mask. */
+#define TCA_SPLIT_LCMP2_bp  6  /* Low Compare 2 Interrupt Enable bit position. */
+
+/* TCA_SPLIT.INTFLAGS  bit masks and bit positions */
+/* TCA_SPLIT_LUNF  is already defined. */
+/* TCA_SPLIT_HUNF  is already defined. */
+/* TCA_SPLIT_LCMP0  is already defined. */
+/* TCA_SPLIT_LCMP1  is already defined. */
+/* TCA_SPLIT_LCMP2  is already defined. */
+
+/* TCA_SPLIT.DBGCTRL  bit masks and bit positions */
+#define TCA_SPLIT_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define TCA_SPLIT_DBGRUN_bp  0  /* Debug Run bit position. */
+
+
+/* TCB - 16-bit Timer Type B */
+/* TCB.CTRLA  bit masks and bit positions */
+#define TCB_ENABLE_bm  0x01  /* Enable bit mask. */
+#define TCB_ENABLE_bp  0  /* Enable bit position. */
+#define TCB_CLKSEL_gm  0x0E  /* Clock Select group mask. */
+#define TCB_CLKSEL_gp  1  /* Clock Select group position. */
+#define TCB_CLKSEL_0_bm  (1<<1)  /* Clock Select bit 0 mask. */
+#define TCB_CLKSEL_0_bp  1  /* Clock Select bit 0 position. */
+#define TCB_CLKSEL_1_bm  (1<<2)  /* Clock Select bit 1 mask. */
+#define TCB_CLKSEL_1_bp  2  /* Clock Select bit 1 position. */
+#define TCB_CLKSEL_2_bm  (1<<3)  /* Clock Select bit 2 mask. */
+#define TCB_CLKSEL_2_bp  3  /* Clock Select bit 2 position. */
+#define TCB_SYNCUPD_bm  0x10  /* Synchronize Update bit mask. */
+#define TCB_SYNCUPD_bp  4  /* Synchronize Update bit position. */
+#define TCB_CASCADE_bm  0x20  /* Cascade two timers bit mask. */
+#define TCB_CASCADE_bp  5  /* Cascade two timers bit position. */
+#define TCB_RUNSTDBY_bm  0x40  /* Run Standby bit mask. */
+#define TCB_RUNSTDBY_bp  6  /* Run Standby bit position. */
+
+/* TCB.CTRLB  bit masks and bit positions */
+#define TCB_CNTMODE_gm  0x07  /* Timer Mode group mask. */
+#define TCB_CNTMODE_gp  0  /* Timer Mode group position. */
+#define TCB_CNTMODE_0_bm  (1<<0)  /* Timer Mode bit 0 mask. */
+#define TCB_CNTMODE_0_bp  0  /* Timer Mode bit 0 position. */
+#define TCB_CNTMODE_1_bm  (1<<1)  /* Timer Mode bit 1 mask. */
+#define TCB_CNTMODE_1_bp  1  /* Timer Mode bit 1 position. */
+#define TCB_CNTMODE_2_bm  (1<<2)  /* Timer Mode bit 2 mask. */
+#define TCB_CNTMODE_2_bp  2  /* Timer Mode bit 2 position. */
+#define TCB_CCMPEN_bm  0x10  /* Pin Output Enable bit mask. */
+#define TCB_CCMPEN_bp  4  /* Pin Output Enable bit position. */
+#define TCB_CCMPINIT_bm  0x20  /* Pin Initial State bit mask. */
+#define TCB_CCMPINIT_bp  5  /* Pin Initial State bit position. */
+#define TCB_ASYNC_bm  0x40  /* Asynchronous Enable bit mask. */
+#define TCB_ASYNC_bp  6  /* Asynchronous Enable bit position. */
+
+/* TCB.EVCTRL  bit masks and bit positions */
+#define TCB_CAPTEI_bm  0x01  /* Event Input Enable bit mask. */
+#define TCB_CAPTEI_bp  0  /* Event Input Enable bit position. */
+#define TCB_EDGE_bm  0x10  /* Event Edge bit mask. */
+#define TCB_EDGE_bp  4  /* Event Edge bit position. */
+#define TCB_FILTER_bm  0x40  /* Input Capture Noise Cancellation Filter bit mask. */
+#define TCB_FILTER_bp  6  /* Input Capture Noise Cancellation Filter bit position. */
+
+/* TCB.INTCTRL  bit masks and bit positions */
+#define TCB_CAPT_bm  0x01  /* Capture or Timeout bit mask. */
+#define TCB_CAPT_bp  0  /* Capture or Timeout bit position. */
+#define TCB_OVF_bm  0x02  /* Overflow bit mask. */
+#define TCB_OVF_bp  1  /* Overflow bit position. */
+
+/* TCB.INTFLAGS  bit masks and bit positions */
+/* TCB_CAPT  is already defined. */
+/* TCB_OVF  is already defined. */
+
+/* TCB.STATUS  bit masks and bit positions */
+#define TCB_RUN_bm  0x01  /* Run bit mask. */
+#define TCB_RUN_bp  0  /* Run bit position. */
+
+/* TCB.DBGCTRL  bit masks and bit positions */
+#define TCB_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define TCB_DBGRUN_bp  0  /* Debug Run bit position. */
+
+
+/* TWI - Two-Wire Interface */
+/* TWI.CTRLA  bit masks and bit positions */
+#define TWI_FMEN_bm  0x01  /* Fast-mode Enable bit mask. */
+#define TWI_FMEN_bp  0  /* Fast-mode Enable bit position. */
+#define TWI_FMPEN_bm  0x02  /* Fast-mode Plus Enable bit mask. */
+#define TWI_FMPEN_bp  1  /* Fast-mode Plus Enable bit position. */
+#define TWI_SDAHOLD_gm  0x0C  /* SDA Hold Time group mask. */
+#define TWI_SDAHOLD_gp  2  /* SDA Hold Time group position. */
+#define TWI_SDAHOLD_0_bm  (1<<2)  /* SDA Hold Time bit 0 mask. */
+#define TWI_SDAHOLD_0_bp  2  /* SDA Hold Time bit 0 position. */
+#define TWI_SDAHOLD_1_bm  (1<<3)  /* SDA Hold Time bit 1 mask. */
+#define TWI_SDAHOLD_1_bp  3  /* SDA Hold Time bit 1 position. */
+#define TWI_SDASETUP_bm  0x10  /* SDA Setup Time bit mask. */
+#define TWI_SDASETUP_bp  4  /* SDA Setup Time bit position. */
+#define TWI_INPUTLVL_bm  0x40  /* Input voltage transition level bit mask. */
+#define TWI_INPUTLVL_bp  6  /* Input voltage transition level bit position. */
+
+/* TWI.DUALCTRL  bit masks and bit positions */
+#define TWI_ENABLE_bm  0x01  /* Enable bit mask. */
+#define TWI_ENABLE_bp  0  /* Enable bit position. */
+/* TWI_FMPEN  is already defined. */
+/* TWI_SDAHOLD  is already defined. */
+/* TWI_INPUTLVL  is already defined. */
+
+/* TWI.DBGCTRL  bit masks and bit positions */
+#define TWI_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define TWI_DBGRUN_bp  0  /* Debug Run bit position. */
+
+/* TWI.MCTRLA  bit masks and bit positions */
+/* TWI_ENABLE  is already defined. */
+#define TWI_SMEN_bm  0x02  /* Smart Mode Enable bit mask. */
+#define TWI_SMEN_bp  1  /* Smart Mode Enable bit position. */
+#define TWI_TIMEOUT_gm  0x0C  /* Inactive Bus Time-Out group mask. */
+#define TWI_TIMEOUT_gp  2  /* Inactive Bus Time-Out group position. */
+#define TWI_TIMEOUT_0_bm  (1<<2)  /* Inactive Bus Time-Out bit 0 mask. */
+#define TWI_TIMEOUT_0_bp  2  /* Inactive Bus Time-Out bit 0 position. */
+#define TWI_TIMEOUT_1_bm  (1<<3)  /* Inactive Bus Time-Out bit 1 mask. */
+#define TWI_TIMEOUT_1_bp  3  /* Inactive Bus Time-Out bit 1 position. */
+#define TWI_QCEN_bm  0x10  /* Quick Command Enable bit mask. */
+#define TWI_QCEN_bp  4  /* Quick Command Enable bit position. */
+#define TWI_WIEN_bm  0x40  /* Write Interrupt Enable bit mask. */
+#define TWI_WIEN_bp  6  /* Write Interrupt Enable bit position. */
+#define TWI_RIEN_bm  0x80  /* Read Interrupt Enable bit mask. */
+#define TWI_RIEN_bp  7  /* Read Interrupt Enable bit position. */
+
+/* TWI.MCTRLB  bit masks and bit positions */
+#define TWI_MCMD_gm  0x03  /* Command group mask. */
+#define TWI_MCMD_gp  0  /* Command group position. */
+#define TWI_MCMD_0_bm  (1<<0)  /* Command bit 0 mask. */
+#define TWI_MCMD_0_bp  0  /* Command bit 0 position. */
+#define TWI_MCMD_1_bm  (1<<1)  /* Command bit 1 mask. */
+#define TWI_MCMD_1_bp  1  /* Command bit 1 position. */
+#define TWI_ACKACT_bm  0x04  /* Acknowledge Action bit mask. */
+#define TWI_ACKACT_bp  2  /* Acknowledge Action bit position. */
+#define TWI_FLUSH_bm  0x08  /* Flush bit mask. */
+#define TWI_FLUSH_bp  3  /* Flush bit position. */
+
+/* TWI.MSTATUS  bit masks and bit positions */
+#define TWI_BUSSTATE_gm  0x03  /* Bus State group mask. */
+#define TWI_BUSSTATE_gp  0  /* Bus State group position. */
+#define TWI_BUSSTATE_0_bm  (1<<0)  /* Bus State bit 0 mask. */
+#define TWI_BUSSTATE_0_bp  0  /* Bus State bit 0 position. */
+#define TWI_BUSSTATE_1_bm  (1<<1)  /* Bus State bit 1 mask. */
+#define TWI_BUSSTATE_1_bp  1  /* Bus State bit 1 position. */
+#define TWI_BUSERR_bm  0x04  /* Bus Error bit mask. */
+#define TWI_BUSERR_bp  2  /* Bus Error bit position. */
+#define TWI_ARBLOST_bm  0x08  /* Arbitration Lost bit mask. */
+#define TWI_ARBLOST_bp  3  /* Arbitration Lost bit position. */
+#define TWI_RXACK_bm  0x10  /* Received Acknowledge bit mask. */
+#define TWI_RXACK_bp  4  /* Received Acknowledge bit position. */
+#define TWI_CLKHOLD_bm  0x20  /* Clock Hold bit mask. */
+#define TWI_CLKHOLD_bp  5  /* Clock Hold bit position. */
+#define TWI_WIF_bm  0x40  /* Write Interrupt Flag bit mask. */
+#define TWI_WIF_bp  6  /* Write Interrupt Flag bit position. */
+#define TWI_RIF_bm  0x80  /* Read Interrupt Flag bit mask. */
+#define TWI_RIF_bp  7  /* Read Interrupt Flag bit position. */
+
+/* TWI.MBAUD  bit masks and bit positions */
+#define TWI_BAUD_gm  0xFF  /* Baud Rate group mask. */
+#define TWI_BAUD_gp  0  /* Baud Rate group position. */
+#define TWI_BAUD_0_bm  (1<<0)  /* Baud Rate bit 0 mask. */
+#define TWI_BAUD_0_bp  0  /* Baud Rate bit 0 position. */
+#define TWI_BAUD_1_bm  (1<<1)  /* Baud Rate bit 1 mask. */
+#define TWI_BAUD_1_bp  1  /* Baud Rate bit 1 position. */
+#define TWI_BAUD_2_bm  (1<<2)  /* Baud Rate bit 2 mask. */
+#define TWI_BAUD_2_bp  2  /* Baud Rate bit 2 position. */
+#define TWI_BAUD_3_bm  (1<<3)  /* Baud Rate bit 3 mask. */
+#define TWI_BAUD_3_bp  3  /* Baud Rate bit 3 position. */
+#define TWI_BAUD_4_bm  (1<<4)  /* Baud Rate bit 4 mask. */
+#define TWI_BAUD_4_bp  4  /* Baud Rate bit 4 position. */
+#define TWI_BAUD_5_bm  (1<<5)  /* Baud Rate bit 5 mask. */
+#define TWI_BAUD_5_bp  5  /* Baud Rate bit 5 position. */
+#define TWI_BAUD_6_bm  (1<<6)  /* Baud Rate bit 6 mask. */
+#define TWI_BAUD_6_bp  6  /* Baud Rate bit 6 position. */
+#define TWI_BAUD_7_bm  (1<<7)  /* Baud Rate bit 7 mask. */
+#define TWI_BAUD_7_bp  7  /* Baud Rate bit 7 position. */
+
+/* TWI.MADDR  bit masks and bit positions */
+#define TWI_ADDR_gm  0xFF  /* Address group mask. */
+#define TWI_ADDR_gp  0  /* Address group position. */
+#define TWI_ADDR_0_bm  (1<<0)  /* Address bit 0 mask. */
+#define TWI_ADDR_0_bp  0  /* Address bit 0 position. */
+#define TWI_ADDR_1_bm  (1<<1)  /* Address bit 1 mask. */
+#define TWI_ADDR_1_bp  1  /* Address bit 1 position. */
+#define TWI_ADDR_2_bm  (1<<2)  /* Address bit 2 mask. */
+#define TWI_ADDR_2_bp  2  /* Address bit 2 position. */
+#define TWI_ADDR_3_bm  (1<<3)  /* Address bit 3 mask. */
+#define TWI_ADDR_3_bp  3  /* Address bit 3 position. */
+#define TWI_ADDR_4_bm  (1<<4)  /* Address bit 4 mask. */
+#define TWI_ADDR_4_bp  4  /* Address bit 4 position. */
+#define TWI_ADDR_5_bm  (1<<5)  /* Address bit 5 mask. */
+#define TWI_ADDR_5_bp  5  /* Address bit 5 position. */
+#define TWI_ADDR_6_bm  (1<<6)  /* Address bit 6 mask. */
+#define TWI_ADDR_6_bp  6  /* Address bit 6 position. */
+#define TWI_ADDR_7_bm  (1<<7)  /* Address bit 7 mask. */
+#define TWI_ADDR_7_bp  7  /* Address bit 7 position. */
+
+/* TWI.MDATA  bit masks and bit positions */
+#define TWI_DATA_gm  0xFF  /* Data group mask. */
+#define TWI_DATA_gp  0  /* Data group position. */
+#define TWI_DATA_0_bm  (1<<0)  /* Data bit 0 mask. */
+#define TWI_DATA_0_bp  0  /* Data bit 0 position. */
+#define TWI_DATA_1_bm  (1<<1)  /* Data bit 1 mask. */
+#define TWI_DATA_1_bp  1  /* Data bit 1 position. */
+#define TWI_DATA_2_bm  (1<<2)  /* Data bit 2 mask. */
+#define TWI_DATA_2_bp  2  /* Data bit 2 position. */
+#define TWI_DATA_3_bm  (1<<3)  /* Data bit 3 mask. */
+#define TWI_DATA_3_bp  3  /* Data bit 3 position. */
+#define TWI_DATA_4_bm  (1<<4)  /* Data bit 4 mask. */
+#define TWI_DATA_4_bp  4  /* Data bit 4 position. */
+#define TWI_DATA_5_bm  (1<<5)  /* Data bit 5 mask. */
+#define TWI_DATA_5_bp  5  /* Data bit 5 position. */
+#define TWI_DATA_6_bm  (1<<6)  /* Data bit 6 mask. */
+#define TWI_DATA_6_bp  6  /* Data bit 6 position. */
+#define TWI_DATA_7_bm  (1<<7)  /* Data bit 7 mask. */
+#define TWI_DATA_7_bp  7  /* Data bit 7 position. */
+
+/* TWI.SCTRLA  bit masks and bit positions */
+/* TWI_ENABLE  is already defined. */
+/* TWI_SMEN  is already defined. */
+#define TWI_PMEN_bm  0x04  /* Address Recognition Mode bit mask. */
+#define TWI_PMEN_bp  2  /* Address Recognition Mode bit position. */
+#define TWI_PIEN_bm  0x20  /* Stop Interrupt Enable bit mask. */
+#define TWI_PIEN_bp  5  /* Stop Interrupt Enable bit position. */
+#define TWI_APIEN_bm  0x40  /* Address or Stop Interrupt Enable bit mask. */
+#define TWI_APIEN_bp  6  /* Address or Stop Interrupt Enable bit position. */
+#define TWI_DIEN_bm  0x80  /* Data Interrupt Enable bit mask. */
+#define TWI_DIEN_bp  7  /* Data Interrupt Enable bit position. */
+
+/* TWI.SCTRLB  bit masks and bit positions */
+#define TWI_SCMD_gm  0x03  /* Command group mask. */
+#define TWI_SCMD_gp  0  /* Command group position. */
+#define TWI_SCMD_0_bm  (1<<0)  /* Command bit 0 mask. */
+#define TWI_SCMD_0_bp  0  /* Command bit 0 position. */
+#define TWI_SCMD_1_bm  (1<<1)  /* Command bit 1 mask. */
+#define TWI_SCMD_1_bp  1  /* Command bit 1 position. */
+/* TWI_ACKACT  is already defined. */
+
+/* TWI.SSTATUS  bit masks and bit positions */
+#define TWI_AP_bm  0x01  /* Address or Stop bit mask. */
+#define TWI_AP_bp  0  /* Address or Stop bit position. */
+#define TWI_DIR_bm  0x02  /* Read/Write Direction bit mask. */
+#define TWI_DIR_bp  1  /* Read/Write Direction bit position. */
+/* TWI_BUSERR  is already defined. */
+#define TWI_COLL_bm  0x08  /* Collision bit mask. */
+#define TWI_COLL_bp  3  /* Collision bit position. */
+/* TWI_RXACK  is already defined. */
+/* TWI_CLKHOLD  is already defined. */
+#define TWI_APIF_bm  0x40  /* Address or Stop Interrupt Flag bit mask. */
+#define TWI_APIF_bp  6  /* Address or Stop Interrupt Flag bit position. */
+#define TWI_DIF_bm  0x80  /* Data Interrupt Flag bit mask. */
+#define TWI_DIF_bp  7  /* Data Interrupt Flag bit position. */
+
+/* TWI.SADDR  bit masks and bit positions */
+/* TWI_ADDR  is already defined. */
+
+/* TWI.SDATA  bit masks and bit positions */
+/* TWI_DATA  is already defined. */
+
+/* TWI.SADDRMASK  bit masks and bit positions */
+#define TWI_ADDREN_bm  0x01  /* Address Mask Enable bit mask. */
+#define TWI_ADDREN_bp  0  /* Address Mask Enable bit position. */
+#define TWI_ADDRMASK_gm  0xFE  /* Address Mask group mask. */
+#define TWI_ADDRMASK_gp  1  /* Address Mask group position. */
+#define TWI_ADDRMASK_0_bm  (1<<1)  /* Address Mask bit 0 mask. */
+#define TWI_ADDRMASK_0_bp  1  /* Address Mask bit 0 position. */
+#define TWI_ADDRMASK_1_bm  (1<<2)  /* Address Mask bit 1 mask. */
+#define TWI_ADDRMASK_1_bp  2  /* Address Mask bit 1 position. */
+#define TWI_ADDRMASK_2_bm  (1<<3)  /* Address Mask bit 2 mask. */
+#define TWI_ADDRMASK_2_bp  3  /* Address Mask bit 2 position. */
+#define TWI_ADDRMASK_3_bm  (1<<4)  /* Address Mask bit 3 mask. */
+#define TWI_ADDRMASK_3_bp  4  /* Address Mask bit 3 position. */
+#define TWI_ADDRMASK_4_bm  (1<<5)  /* Address Mask bit 4 mask. */
+#define TWI_ADDRMASK_4_bp  5  /* Address Mask bit 4 position. */
+#define TWI_ADDRMASK_5_bm  (1<<6)  /* Address Mask bit 5 mask. */
+#define TWI_ADDRMASK_5_bp  6  /* Address Mask bit 5 position. */
+#define TWI_ADDRMASK_6_bm  (1<<7)  /* Address Mask bit 6 mask. */
+#define TWI_ADDRMASK_6_bp  7  /* Address Mask bit 6 position. */
+
+
+/* USART - Universal Synchronous and Asynchronous Receiver and Transmitter */
+/* USART.RXDATAL  bit masks and bit positions */
+#define USART_DATA_gm  0xFF  /* RX Data group mask. */
+#define USART_DATA_gp  0  /* RX Data group position. */
+#define USART_DATA_0_bm  (1<<0)  /* RX Data bit 0 mask. */
+#define USART_DATA_0_bp  0  /* RX Data bit 0 position. */
+#define USART_DATA_1_bm  (1<<1)  /* RX Data bit 1 mask. */
+#define USART_DATA_1_bp  1  /* RX Data bit 1 position. */
+#define USART_DATA_2_bm  (1<<2)  /* RX Data bit 2 mask. */
+#define USART_DATA_2_bp  2  /* RX Data bit 2 position. */
+#define USART_DATA_3_bm  (1<<3)  /* RX Data bit 3 mask. */
+#define USART_DATA_3_bp  3  /* RX Data bit 3 position. */
+#define USART_DATA_4_bm  (1<<4)  /* RX Data bit 4 mask. */
+#define USART_DATA_4_bp  4  /* RX Data bit 4 position. */
+#define USART_DATA_5_bm  (1<<5)  /* RX Data bit 5 mask. */
+#define USART_DATA_5_bp  5  /* RX Data bit 5 position. */
+#define USART_DATA_6_bm  (1<<6)  /* RX Data bit 6 mask. */
+#define USART_DATA_6_bp  6  /* RX Data bit 6 position. */
+#define USART_DATA_7_bm  (1<<7)  /* RX Data bit 7 mask. */
+#define USART_DATA_7_bp  7  /* RX Data bit 7 position. */
+
+/* USART.RXDATAH  bit masks and bit positions */
+#define USART_DATA8_bm  0x01  /* Receiver Data Register bit mask. */
+#define USART_DATA8_bp  0  /* Receiver Data Register bit position. */
+#define USART_PERR_bm  0x02  /* Parity Error bit mask. */
+#define USART_PERR_bp  1  /* Parity Error bit position. */
+#define USART_FERR_bm  0x04  /* Frame Error bit mask. */
+#define USART_FERR_bp  2  /* Frame Error bit position. */
+#define USART_BUFOVF_bm  0x40  /* Buffer Overflow bit mask. */
+#define USART_BUFOVF_bp  6  /* Buffer Overflow bit position. */
+#define USART_RXCIF_bm  0x80  /* Receive Complete Interrupt Flag bit mask. */
+#define USART_RXCIF_bp  7  /* Receive Complete Interrupt Flag bit position. */
+
+/* USART.TXDATAL  bit masks and bit positions */
+/* USART_DATA  is already defined. */
+
+/* USART.TXDATAH  bit masks and bit positions */
+/* USART_DATA8  is already defined. */
+
+/* USART.STATUS  bit masks and bit positions */
+#define USART_WFB_bm  0x01  /* Wait For Break bit mask. */
+#define USART_WFB_bp  0  /* Wait For Break bit position. */
+#define USART_BDF_bm  0x02  /* Break Detected Flag bit mask. */
+#define USART_BDF_bp  1  /* Break Detected Flag bit position. */
+#define USART_ISFIF_bm  0x08  /* Inconsistent Sync Field Interrupt Flag bit mask. */
+#define USART_ISFIF_bp  3  /* Inconsistent Sync Field Interrupt Flag bit position. */
+#define USART_RXSIF_bm  0x10  /* Receive Start Interrupt bit mask. */
+#define USART_RXSIF_bp  4  /* Receive Start Interrupt bit position. */
+#define USART_DREIF_bm  0x20  /* Data Register Empty Flag bit mask. */
+#define USART_DREIF_bp  5  /* Data Register Empty Flag bit position. */
+#define USART_TXCIF_bm  0x40  /* Transmit Interrupt Flag bit mask. */
+#define USART_TXCIF_bp  6  /* Transmit Interrupt Flag bit position. */
+/* USART_RXCIF  is already defined. */
+
+/* USART.CTRLA  bit masks and bit positions */
+#define USART_RS485_bm  0x01  /* RS485 Mode internal transmitter bit mask. */
+#define USART_RS485_bp  0  /* RS485 Mode internal transmitter bit position. */
+#define USART_ABEIE_bm  0x04  /* Auto-baud Error Interrupt Enable bit mask. */
+#define USART_ABEIE_bp  2  /* Auto-baud Error Interrupt Enable bit position. */
+#define USART_LBME_bm  0x08  /* Loop-back Mode Enable bit mask. */
+#define USART_LBME_bp  3  /* Loop-back Mode Enable bit position. */
+#define USART_RXSIE_bm  0x10  /* Receiver Start Frame Interrupt Enable bit mask. */
+#define USART_RXSIE_bp  4  /* Receiver Start Frame Interrupt Enable bit position. */
+#define USART_DREIE_bm  0x20  /* Data Register Empty Interrupt Enable bit mask. */
+#define USART_DREIE_bp  5  /* Data Register Empty Interrupt Enable bit position. */
+#define USART_TXCIE_bm  0x40  /* Transmit Complete Interrupt Enable bit mask. */
+#define USART_TXCIE_bp  6  /* Transmit Complete Interrupt Enable bit position. */
+#define USART_RXCIE_bm  0x80  /* Receive Complete Interrupt Enable bit mask. */
+#define USART_RXCIE_bp  7  /* Receive Complete Interrupt Enable bit position. */
+
+/* USART.CTRLB  bit masks and bit positions */
+#define USART_MPCM_bm  0x01  /* Multi-processor Communication Mode bit mask. */
+#define USART_MPCM_bp  0  /* Multi-processor Communication Mode bit position. */
+#define USART_RXMODE_gm  0x06  /* Receiver Mode group mask. */
+#define USART_RXMODE_gp  1  /* Receiver Mode group position. */
+#define USART_RXMODE_0_bm  (1<<1)  /* Receiver Mode bit 0 mask. */
+#define USART_RXMODE_0_bp  1  /* Receiver Mode bit 0 position. */
+#define USART_RXMODE_1_bm  (1<<2)  /* Receiver Mode bit 1 mask. */
+#define USART_RXMODE_1_bp  2  /* Receiver Mode bit 1 position. */
+#define USART_ODME_bm  0x08  /* Open Drain Mode Enable bit mask. */
+#define USART_ODME_bp  3  /* Open Drain Mode Enable bit position. */
+#define USART_SFDEN_bm  0x10  /* Start Frame Detection Enable bit mask. */
+#define USART_SFDEN_bp  4  /* Start Frame Detection Enable bit position. */
+#define USART_TXEN_bm  0x40  /* Transmitter Enable bit mask. */
+#define USART_TXEN_bp  6  /* Transmitter Enable bit position. */
+#define USART_RXEN_bm  0x80  /* Reciever enable bit mask. */
+#define USART_RXEN_bp  7  /* Reciever enable bit position. */
+
+/* USART.CTRLC  bit masks and bit positions */
+#define USART_UCPHA_bm  0x02  /* SPI Host Mode, Clock Phase bit mask. */
+#define USART_UCPHA_bp  1  /* SPI Host Mode, Clock Phase bit position. */
+#define USART_UDORD_bm  0x04  /* SPI Host Mode, Data Order bit mask. */
+#define USART_UDORD_bp  2  /* SPI Host Mode, Data Order bit position. */
+#define USART_CHSIZE_gm  0x07  /* Character Size group mask. */
+#define USART_CHSIZE_gp  0  /* Character Size group position. */
+#define USART_CHSIZE_0_bm  (1<<0)  /* Character Size bit 0 mask. */
+#define USART_CHSIZE_0_bp  0  /* Character Size bit 0 position. */
+#define USART_CHSIZE_1_bm  (1<<1)  /* Character Size bit 1 mask. */
+#define USART_CHSIZE_1_bp  1  /* Character Size bit 1 position. */
+#define USART_CHSIZE_2_bm  (1<<2)  /* Character Size bit 2 mask. */
+#define USART_CHSIZE_2_bp  2  /* Character Size bit 2 position. */
+#define USART_SBMODE_bm  0x08  /* Stop Bit Mode bit mask. */
+#define USART_SBMODE_bp  3  /* Stop Bit Mode bit position. */
+#define USART_PMODE_gm  0x30  /* Parity Mode group mask. */
+#define USART_PMODE_gp  4  /* Parity Mode group position. */
+#define USART_PMODE_0_bm  (1<<4)  /* Parity Mode bit 0 mask. */
+#define USART_PMODE_0_bp  4  /* Parity Mode bit 0 position. */
+#define USART_PMODE_1_bm  (1<<5)  /* Parity Mode bit 1 mask. */
+#define USART_PMODE_1_bp  5  /* Parity Mode bit 1 position. */
+#define USART_CMODE_gm  0xC0  /* Communication Mode group mask. */
+#define USART_CMODE_gp  6  /* Communication Mode group position. */
+#define USART_CMODE_0_bm  (1<<6)  /* Communication Mode bit 0 mask. */
+#define USART_CMODE_0_bp  6  /* Communication Mode bit 0 position. */
+#define USART_CMODE_1_bm  (1<<7)  /* Communication Mode bit 1 mask. */
+#define USART_CMODE_1_bp  7  /* Communication Mode bit 1 position. */
+
+/* USART.CTRLD  bit masks and bit positions */
+#define USART_ABW_gm  0xC0  /* Auto Baud Window group mask. */
+#define USART_ABW_gp  6  /* Auto Baud Window group position. */
+#define USART_ABW_0_bm  (1<<6)  /* Auto Baud Window bit 0 mask. */
+#define USART_ABW_0_bp  6  /* Auto Baud Window bit 0 position. */
+#define USART_ABW_1_bm  (1<<7)  /* Auto Baud Window bit 1 mask. */
+#define USART_ABW_1_bp  7  /* Auto Baud Window bit 1 position. */
+
+/* USART.DBGCTRL  bit masks and bit positions */
+#define USART_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define USART_DBGRUN_bp  0  /* Debug Run bit position. */
+
+/* USART.EVCTRL  bit masks and bit positions */
+#define USART_IREI_bm  0x01  /* IrDA Event Input Enable bit mask. */
+#define USART_IREI_bp  0  /* IrDA Event Input Enable bit position. */
+
+/* USART.TXPLCTRL  bit masks and bit positions */
+#define USART_TXPL_gm  0xFF  /* Transmit pulse length group mask. */
+#define USART_TXPL_gp  0  /* Transmit pulse length group position. */
+#define USART_TXPL_0_bm  (1<<0)  /* Transmit pulse length bit 0 mask. */
+#define USART_TXPL_0_bp  0  /* Transmit pulse length bit 0 position. */
+#define USART_TXPL_1_bm  (1<<1)  /* Transmit pulse length bit 1 mask. */
+#define USART_TXPL_1_bp  1  /* Transmit pulse length bit 1 position. */
+#define USART_TXPL_2_bm  (1<<2)  /* Transmit pulse length bit 2 mask. */
+#define USART_TXPL_2_bp  2  /* Transmit pulse length bit 2 position. */
+#define USART_TXPL_3_bm  (1<<3)  /* Transmit pulse length bit 3 mask. */
+#define USART_TXPL_3_bp  3  /* Transmit pulse length bit 3 position. */
+#define USART_TXPL_4_bm  (1<<4)  /* Transmit pulse length bit 4 mask. */
+#define USART_TXPL_4_bp  4  /* Transmit pulse length bit 4 position. */
+#define USART_TXPL_5_bm  (1<<5)  /* Transmit pulse length bit 5 mask. */
+#define USART_TXPL_5_bp  5  /* Transmit pulse length bit 5 position. */
+#define USART_TXPL_6_bm  (1<<6)  /* Transmit pulse length bit 6 mask. */
+#define USART_TXPL_6_bp  6  /* Transmit pulse length bit 6 position. */
+#define USART_TXPL_7_bm  (1<<7)  /* Transmit pulse length bit 7 mask. */
+#define USART_TXPL_7_bp  7  /* Transmit pulse length bit 7 position. */
+
+/* USART.RXPLCTRL  bit masks and bit positions */
+#define USART_RXPL_gm  0x7F  /* Receiver Pulse Lenght group mask. */
+#define USART_RXPL_gp  0  /* Receiver Pulse Lenght group position. */
+#define USART_RXPL_0_bm  (1<<0)  /* Receiver Pulse Lenght bit 0 mask. */
+#define USART_RXPL_0_bp  0  /* Receiver Pulse Lenght bit 0 position. */
+#define USART_RXPL_1_bm  (1<<1)  /* Receiver Pulse Lenght bit 1 mask. */
+#define USART_RXPL_1_bp  1  /* Receiver Pulse Lenght bit 1 position. */
+#define USART_RXPL_2_bm  (1<<2)  /* Receiver Pulse Lenght bit 2 mask. */
+#define USART_RXPL_2_bp  2  /* Receiver Pulse Lenght bit 2 position. */
+#define USART_RXPL_3_bm  (1<<3)  /* Receiver Pulse Lenght bit 3 mask. */
+#define USART_RXPL_3_bp  3  /* Receiver Pulse Lenght bit 3 position. */
+#define USART_RXPL_4_bm  (1<<4)  /* Receiver Pulse Lenght bit 4 mask. */
+#define USART_RXPL_4_bp  4  /* Receiver Pulse Lenght bit 4 position. */
+#define USART_RXPL_5_bm  (1<<5)  /* Receiver Pulse Lenght bit 5 mask. */
+#define USART_RXPL_5_bp  5  /* Receiver Pulse Lenght bit 5 position. */
+#define USART_RXPL_6_bm  (1<<6)  /* Receiver Pulse Lenght bit 6 mask. */
+#define USART_RXPL_6_bp  6  /* Receiver Pulse Lenght bit 6 position. */
+
+
+
+/* VPORT - Virtual Ports */
+/* VPORT.INTFLAGS  bit masks and bit positions */
+#define VPORT_INT_gm  0xFF  /* Pin Interrupt Flag group mask. */
+#define VPORT_INT_gp  0  /* Pin Interrupt Flag group position. */
+#define VPORT_INT_0_bm  (1<<0)  /* Pin Interrupt Flag bit 0 mask. */
+#define VPORT_INT_0_bp  0  /* Pin Interrupt Flag bit 0 position. */
+#define VPORT_INT_1_bm  (1<<1)  /* Pin Interrupt Flag bit 1 mask. */
+#define VPORT_INT_1_bp  1  /* Pin Interrupt Flag bit 1 position. */
+#define VPORT_INT_2_bm  (1<<2)  /* Pin Interrupt Flag bit 2 mask. */
+#define VPORT_INT_2_bp  2  /* Pin Interrupt Flag bit 2 position. */
+#define VPORT_INT_3_bm  (1<<3)  /* Pin Interrupt Flag bit 3 mask. */
+#define VPORT_INT_3_bp  3  /* Pin Interrupt Flag bit 3 position. */
+#define VPORT_INT_4_bm  (1<<4)  /* Pin Interrupt Flag bit 4 mask. */
+#define VPORT_INT_4_bp  4  /* Pin Interrupt Flag bit 4 position. */
+#define VPORT_INT_5_bm  (1<<5)  /* Pin Interrupt Flag bit 5 mask. */
+#define VPORT_INT_5_bp  5  /* Pin Interrupt Flag bit 5 position. */
+#define VPORT_INT_6_bm  (1<<6)  /* Pin Interrupt Flag bit 6 mask. */
+#define VPORT_INT_6_bp  6  /* Pin Interrupt Flag bit 6 position. */
+#define VPORT_INT_7_bm  (1<<7)  /* Pin Interrupt Flag bit 7 mask. */
+#define VPORT_INT_7_bp  7  /* Pin Interrupt Flag bit 7 position. */
+
+
+/* VREF - Voltage reference */
+/* VREF.DAC0REF  bit masks and bit positions */
+#define VREF_REFSEL_gm  0x07  /* Reference select group mask. */
+#define VREF_REFSEL_gp  0  /* Reference select group position. */
+#define VREF_REFSEL_0_bm  (1<<0)  /* Reference select bit 0 mask. */
+#define VREF_REFSEL_0_bp  0  /* Reference select bit 0 position. */
+#define VREF_REFSEL_1_bm  (1<<1)  /* Reference select bit 1 mask. */
+#define VREF_REFSEL_1_bp  1  /* Reference select bit 1 position. */
+#define VREF_REFSEL_2_bm  (1<<2)  /* Reference select bit 2 mask. */
+#define VREF_REFSEL_2_bp  2  /* Reference select bit 2 position. */
+#define VREF_ALWAYSON_bm  0x80  /* Always on bit mask. */
+#define VREF_ALWAYSON_bp  7  /* Always on bit position. */
+
+/* VREF.ACREF  bit masks and bit positions */
+/* VREF_REFSEL  is already defined. */
+/* VREF_ALWAYSON  is already defined. */
+
+
+/* WDT - Watch-Dog Timer */
+/* WDT.CTRLA  bit masks and bit positions */
+#define WDT_PERIOD_gm  0x0F  /* Period group mask. */
+#define WDT_PERIOD_gp  0  /* Period group position. */
+#define WDT_PERIOD_0_bm  (1<<0)  /* Period bit 0 mask. */
+#define WDT_PERIOD_0_bp  0  /* Period bit 0 position. */
+#define WDT_PERIOD_1_bm  (1<<1)  /* Period bit 1 mask. */
+#define WDT_PERIOD_1_bp  1  /* Period bit 1 position. */
+#define WDT_PERIOD_2_bm  (1<<2)  /* Period bit 2 mask. */
+#define WDT_PERIOD_2_bp  2  /* Period bit 2 position. */
+#define WDT_PERIOD_3_bm  (1<<3)  /* Period bit 3 mask. */
+#define WDT_PERIOD_3_bp  3  /* Period bit 3 position. */
+#define WDT_WINDOW_gm  0xF0  /* Window group mask. */
+#define WDT_WINDOW_gp  4  /* Window group position. */
+#define WDT_WINDOW_0_bm  (1<<4)  /* Window bit 0 mask. */
+#define WDT_WINDOW_0_bp  4  /* Window bit 0 position. */
+#define WDT_WINDOW_1_bm  (1<<5)  /* Window bit 1 mask. */
+#define WDT_WINDOW_1_bp  5  /* Window bit 1 position. */
+#define WDT_WINDOW_2_bm  (1<<6)  /* Window bit 2 mask. */
+#define WDT_WINDOW_2_bp  6  /* Window bit 2 position. */
+#define WDT_WINDOW_3_bm  (1<<7)  /* Window bit 3 mask. */
+#define WDT_WINDOW_3_bp  7  /* Window bit 3 position. */
+
+/* WDT.STATUS  bit masks and bit positions */
+#define WDT_SYNCBUSY_bm  0x01  /* Syncronization busy bit mask. */
+#define WDT_SYNCBUSY_bp  0  /* Syncronization busy bit position. */
+#define WDT_LOCK_bm  0x80  /* Lock enable bit mask. */
+#define WDT_LOCK_bp  7  /* Lock enable bit position. */
+
+
+/* ========== Generic Port Pins ========== */
+#define PIN0_bm 0x01
+#define PIN0_bp 0
+#define PIN1_bm 0x02
+#define PIN1_bp 1
+#define PIN2_bm 0x04
+#define PIN2_bp 2
+#define PIN3_bm 0x08
+#define PIN3_bp 3
+#define PIN4_bm 0x10
+#define PIN4_bp 4
+#define PIN5_bm 0x20
+#define PIN5_bp 5
+#define PIN6_bm 0x40
+#define PIN6_bp 6
+#define PIN7_bm 0x80
+#define PIN7_bp 7
+
+/* ========== Interrupt Vector Definitions ========== */
+/* Vector 0 is the reset vector */
+
+/* NMI interrupt vectors */
+#define NMI_vect_num  1
+#define NMI_vect      _VECTOR(1)  /*  */
+
+/* BOD interrupt vectors */
+#define BOD_VLM_vect_num  2
+#define BOD_VLM_vect      _VECTOR(2)  /*  */
+
+/* CLKCTRL interrupt vectors */
+#define CLKCTRL_CFD_vect_num  3
+#define CLKCTRL_CFD_vect      _VECTOR(3)  /*  */
+
+/* RTC interrupt vectors */
+#define RTC_CNT_vect_num  4
+#define RTC_CNT_vect      _VECTOR(4)  /*  */
+#define RTC_PIT_vect_num  5
+#define RTC_PIT_vect      _VECTOR(5)  /*  */
+
+/* CCL interrupt vectors */
+#define CCL_CCL_vect_num  6
+#define CCL_CCL_vect      _VECTOR(6)  /*  */
+
+/* PORTA interrupt vectors */
+#define PORTA_PORT_vect_num  7
+#define PORTA_PORT_vect      _VECTOR(7)  /*  */
+
+/* TCA0 interrupt vectors */
+#define TCA0_LUNF_vect_num  8
+#define TCA0_LUNF_vect      _VECTOR(8)  /*  */
+#define TCA0_OVF_vect_num  8
+#define TCA0_OVF_vect      _VECTOR(8)  /*  */
+#define TCA0_HUNF_vect_num  9
+#define TCA0_HUNF_vect      _VECTOR(9)  /*  */
+#define TCA0_CMP0_vect_num  10
+#define TCA0_CMP0_vect      _VECTOR(10)  /*  */
+#define TCA0_LCMP0_vect_num  10
+#define TCA0_LCMP0_vect      _VECTOR(10)  /*  */
+#define TCA0_CMP1_vect_num  11
+#define TCA0_CMP1_vect      _VECTOR(11)  /*  */
+#define TCA0_LCMP1_vect_num  11
+#define TCA0_LCMP1_vect      _VECTOR(11)  /*  */
+#define TCA0_CMP2_vect_num  12
+#define TCA0_CMP2_vect      _VECTOR(12)  /*  */
+#define TCA0_LCMP2_vect_num  12
+#define TCA0_LCMP2_vect      _VECTOR(12)  /*  */
+
+/* TCB0 interrupt vectors */
+#define TCB0_INT_vect_num  13
+#define TCB0_INT_vect      _VECTOR(13)  /*  */
+
+/* TCB1 interrupt vectors */
+#define TCB1_INT_vect_num  14
+#define TCB1_INT_vect      _VECTOR(14)  /*  */
+
+/* TWI0 interrupt vectors */
+#define TWI0_TWIS_vect_num  15
+#define TWI0_TWIS_vect      _VECTOR(15)  /*  */
+#define TWI0_TWIM_vect_num  16
+#define TWI0_TWIM_vect      _VECTOR(16)  /*  */
+
+/* SPI0 interrupt vectors */
+#define SPI0_INT_vect_num  17
+#define SPI0_INT_vect      _VECTOR(17)  /*  */
+
+/* USART0 interrupt vectors */
+#define USART0_RXC_vect_num  18
+#define USART0_RXC_vect      _VECTOR(18)  /*  */
+#define USART0_DRE_vect_num  19
+#define USART0_DRE_vect      _VECTOR(19)  /*  */
+#define USART0_TXC_vect_num  20
+#define USART0_TXC_vect      _VECTOR(20)  /*  */
+
+/* PORTD interrupt vectors */
+#define PORTD_PORT_vect_num  21
+#define PORTD_PORT_vect      _VECTOR(21)  /*  */
+
+/* AC0 interrupt vectors */
+#define AC0_AC_vect_num  22
+#define AC0_AC_vect      _VECTOR(22)  /*  */
+
+/* ADC0 interrupt vectors */
+#define ADC0_ERROR_vect_num  23
+#define ADC0_ERROR_vect      _VECTOR(23)  /*  */
+#define ADC0_RESRDY_vect_num  24
+#define ADC0_RESRDY_vect      _VECTOR(24)  /*  */
+#define ADC0_SAMPRDY_vect_num  25
+#define ADC0_SAMPRDY_vect      _VECTOR(25)  /*  */
+
+/* AC1 interrupt vectors */
+#define AC1_AC_vect_num  26
+#define AC1_AC_vect      _VECTOR(26)  /*  */
+
+/* PORTC interrupt vectors */
+#define PORTC_PORT_vect_num  27
+#define PORTC_PORT_vect      _VECTOR(27)  /*  */
+
+/* TCB2 interrupt vectors */
+#define TCB2_INT_vect_num  28
+#define TCB2_INT_vect      _VECTOR(28)  /*  */
+
+/* USART1 interrupt vectors */
+#define USART1_RXC_vect_num  29
+#define USART1_RXC_vect      _VECTOR(29)  /*  */
+#define USART1_DRE_vect_num  30
+#define USART1_DRE_vect      _VECTOR(30)  /*  */
+#define USART1_TXC_vect_num  31
+#define USART1_TXC_vect      _VECTOR(31)  /*  */
+
+/* PORTF interrupt vectors */
+#define PORTF_PORT_vect_num  32
+#define PORTF_PORT_vect      _VECTOR(32)  /*  */
+
+/* NVMCTRL interrupt vectors */
+#define NVMCTRL_EEREADY_vect_num  33
+#define NVMCTRL_EEREADY_vect      _VECTOR(33)  /*  */
+#define NVMCTRL_FLREADY_vect_num  33
+#define NVMCTRL_FLREADY_vect      _VECTOR(33)  /*  */
+#define NVMCTRL_NVMREADY_vect_num  33
+#define NVMCTRL_NVMREADY_vect      _VECTOR(33)  /*  */
+
+/* USART2 interrupt vectors */
+#define USART2_RXC_vect_num  34
+#define USART2_RXC_vect      _VECTOR(34)  /*  */
+#define USART2_DRE_vect_num  35
+#define USART2_DRE_vect      _VECTOR(35)  /*  */
+#define USART2_TXC_vect_num  36
+#define USART2_TXC_vect      _VECTOR(36)  /*  */
+
+#define _VECTOR_SIZE 4 /* Size of individual vector. */
+#define _VECTORS_SIZE (37 * _VECTOR_SIZE)
+
+
+/* ========== Constants ========== */
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define DATAMEM_START     (0x0000)
+#  define DATAMEM_SIZE      (65536)
+#else
+#  define DATAMEM_START     (0x0000U)
+#  define DATAMEM_SIZE      (65536U)
+#endif
+#define DATAMEM_END       (DATAMEM_START + DATAMEM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define IO_START     (0x0000)
+#  define IO_SIZE      (4159)
+#  define IO_PAGE_SIZE (0)
+#else
+#  define IO_START     (0x0000U)
+#  define IO_SIZE      (4159U)
+#  define IO_PAGE_SIZE (0U)
+#endif
+#define IO_END       (IO_START + IO_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define LOCKBITS_START     (0x1040)
+#  define LOCKBITS_SIZE      (4)
+#  define LOCKBITS_PAGE_SIZE (4)
+#else
+#  define LOCKBITS_START     (0x1040U)
+#  define LOCKBITS_SIZE      (4U)
+#  define LOCKBITS_PAGE_SIZE (4U)
+#endif
+#define LOCKBITS_END       (LOCKBITS_START + LOCKBITS_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define FUSES_START     (0x1050)
+#  define FUSES_SIZE      (16)
+#  define FUSES_PAGE_SIZE (8)
+#else
+#  define FUSES_START     (0x1050U)
+#  define FUSES_SIZE      (16U)
+#  define FUSES_PAGE_SIZE (8U)
+#endif
+#define FUSES_END       (FUSES_START + FUSES_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define USER_SIGNATURES_START     (0x1080)
+#  define USER_SIGNATURES_SIZE      (64)
+#  define USER_SIGNATURES_PAGE_SIZE (64)
+#else
+#  define USER_SIGNATURES_START     (0x1080U)
+#  define USER_SIGNATURES_SIZE      (64U)
+#  define USER_SIGNATURES_PAGE_SIZE (64U)
+#endif
+#define USER_SIGNATURES_END       (USER_SIGNATURES_START + USER_SIGNATURES_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define SIGNATURES_START     (0x1100)
+#  define SIGNATURES_SIZE      (3)
+#  define SIGNATURES_PAGE_SIZE (128)
+#else
+#  define SIGNATURES_START     (0x1100U)
+#  define SIGNATURES_SIZE      (3U)
+#  define SIGNATURES_PAGE_SIZE (128U)
+#endif
+#define SIGNATURES_END       (SIGNATURES_START + SIGNATURES_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define PROD_SIGNATURES_START     (0x1103)
+#  define PROD_SIGNATURES_SIZE      (125)
+#  define PROD_SIGNATURES_PAGE_SIZE (128)
+#else
+#  define PROD_SIGNATURES_START     (0x1103U)
+#  define PROD_SIGNATURES_SIZE      (125U)
+#  define PROD_SIGNATURES_PAGE_SIZE (128U)
+#endif
+#define PROD_SIGNATURES_END       (PROD_SIGNATURES_START + PROD_SIGNATURES_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define EEPROM_START     (0x1400)
+#  define EEPROM_SIZE      (512)
+#  define EEPROM_PAGE_SIZE (8)
+#else
+#  define EEPROM_START     (0x1400U)
+#  define EEPROM_SIZE      (512U)
+#  define EEPROM_PAGE_SIZE (8U)
+#endif
+#define EEPROM_END       (EEPROM_START + EEPROM_SIZE - 1)
+
+/* Added MAPPED_EEPROM segment names for avr-libc */
+#define MAPPED_EEPROM_START     (EEPROM_START)
+#define MAPPED_EEPROM_SIZE      (EEPROM_SIZE)
+#define MAPPED_EEPROM_PAGE_SIZE (EEPROM_PAGE_SIZE)
+#define MAPPED_EEPROM_END       (MAPPED_EEPROM_START + MAPPED_EEPROM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define INTERNAL_SRAM_START     (0x6800)
+#  define INTERNAL_SRAM_SIZE      (6144)
+#  define INTERNAL_SRAM_PAGE_SIZE (0)
+#else
+#  define INTERNAL_SRAM_START     (0x6800U)
+#  define INTERNAL_SRAM_SIZE      (6144U)
+#  define INTERNAL_SRAM_PAGE_SIZE (0U)
+#endif
+#define INTERNAL_SRAM_END       (INTERNAL_SRAM_START + INTERNAL_SRAM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define MAPPED_PROGMEM_START     (0x8000)
+#  define MAPPED_PROGMEM_SIZE      (32768)
+#  define MAPPED_PROGMEM_PAGE_SIZE (128)
+#else
+#  define MAPPED_PROGMEM_START     (0x8000U)
+#  define MAPPED_PROGMEM_SIZE      (32768U)
+#  define MAPPED_PROGMEM_PAGE_SIZE (128U)
+#endif
+#define MAPPED_PROGMEM_END       (MAPPED_PROGMEM_START + MAPPED_PROGMEM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define PROGMEM_START     (0x0000)
+#  define PROGMEM_SIZE      (65536)
+#  define PROGMEM_PAGE_SIZE (128)
+#else
+#  define PROGMEM_START     (0x0000U)
+#  define PROGMEM_SIZE      (65536U)
+#  define PROGMEM_PAGE_SIZE (128U)
+#endif
+#define PROGMEM_END       (PROGMEM_START + PROGMEM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define PROGMEM_NRWW_START     (0x0000)
+#  define PROGMEM_NRWW_SIZE      (8192)
+#  define PROGMEM_NRWW_PAGE_SIZE (128)
+#else
+#  define PROGMEM_NRWW_START     (0x0000U)
+#  define PROGMEM_NRWW_SIZE      (8192U)
+#  define PROGMEM_NRWW_PAGE_SIZE (128U)
+#endif
+#define PROGMEM_NRWW_END       (PROGMEM_NRWW_START + PROGMEM_NRWW_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define PROGMEM_RWW_START     (0x2000)
+#  define PROGMEM_RWW_SIZE      (57344)
+#  define PROGMEM_RWW_PAGE_SIZE (128)
+#else
+#  define PROGMEM_RWW_START     (0x2000U)
+#  define PROGMEM_RWW_SIZE      (57344U)
+#  define PROGMEM_RWW_PAGE_SIZE (128U)
+#endif
+#define PROGMEM_RWW_END       (PROGMEM_RWW_START + PROGMEM_RWW_SIZE - 1)
+
+#define FLASHSTART   PROGMEM_START
+#define FLASHEND     PROGMEM_END
+#define RAMSTART     INTERNAL_SRAM_START
+#define RAMSIZE      INTERNAL_SRAM_SIZE
+#define RAMEND       INTERNAL_SRAM_END
+#define E2END        EEPROM_END
+#define E2PAGESIZE   EEPROM_PAGE_SIZE
+
+/* ========== Fuses ========== */
+#define FUSE_MEMORY_SIZE 16
+
+/* Fuse Byte 0 (WDTCFG) */
+#define FUSE_PERIOD0  (unsigned char)_BV(0)  /* Watchdog Timeout Period Bit 0 */
+#define FUSE_PERIOD1  (unsigned char)_BV(1)  /* Watchdog Timeout Period Bit 1 */
+#define FUSE_PERIOD2  (unsigned char)_BV(2)  /* Watchdog Timeout Period Bit 2 */
+#define FUSE_PERIOD3  (unsigned char)_BV(3)  /* Watchdog Timeout Period Bit 3 */
+#define FUSE_WINDOW0  (unsigned char)_BV(4)  /* Watchdog Window Timeout Period Bit 0 */
+#define FUSE_WINDOW1  (unsigned char)_BV(5)  /* Watchdog Window Timeout Period Bit 1 */
+#define FUSE_WINDOW2  (unsigned char)_BV(6)  /* Watchdog Window Timeout Period Bit 2 */
+#define FUSE_WINDOW3  (unsigned char)_BV(7)  /* Watchdog Window Timeout Period Bit 3 */
+#define FUSE0_DEFAULT  (0x0)
+#define FUSE_WDTCFG_DEFAULT  (0x0)
+
+/* Fuse Byte 1 (BODCFG) */
+#define FUSE_SLEEP0  (unsigned char)_BV(0)  /* BOD Operation in Sleep Mode Bit 0 */
+#define FUSE_SLEEP1  (unsigned char)_BV(1)  /* BOD Operation in Sleep Mode Bit 1 */
+#define FUSE_ACTIVE0  (unsigned char)_BV(2)  /* BOD Operation in Active Mode Bit 0 */
+#define FUSE_ACTIVE1  (unsigned char)_BV(3)  /* BOD Operation in Active Mode Bit 1 */
+#define FUSE_SAMPFREQ  (unsigned char)_BV(4)  /* BOD Sample Frequency */
+#define FUSE_LVL0  (unsigned char)_BV(5)  /* BOD Level Bit 0 */
+#define FUSE_LVL1  (unsigned char)_BV(6)  /* BOD Level Bit 1 */
+#define FUSE_LVL2  (unsigned char)_BV(7)  /* BOD Level Bit 2 */
+#define FUSE1_DEFAULT  (0x0)
+#define FUSE_BODCFG_DEFAULT  (0x0)
+
+/* Fuse Byte 2 (OSCCFG) */
+#define FUSE_OSCHFFRQ  (unsigned char)_BV(3)  /* High-frequency Oscillator Frequency */
+#define FUSE2_DEFAULT  (0x0)
+#define FUSE_OSCCFG_DEFAULT  (0x0)
+
+/* Fuse Byte 3 Reserved */
+
+/* Fuse Byte 4 Reserved */
+
+/* Fuse Byte 5 (SYSCFG0) */
+#define FUSE_EESAVE  (unsigned char)_BV(0)  /* EEPROM Save */
+#define FUSE_RSTPINCFG  (unsigned char)_BV(3)  /* Reset Pin Configuration */
+#define FUSE_UPDIPINCFG  (unsigned char)_BV(4)  /* UPDI Pin Configuration */
+#define FUSE_CRCSEL  (unsigned char)_BV(5)  /* CRC Select */
+#define FUSE_CRCSRC0  (unsigned char)_BV(6)  /* CRC Source Bit 0 */
+#define FUSE_CRCSRC1  (unsigned char)_BV(7)  /* CRC Source Bit 1 */
+#define FUSE5_DEFAULT  (0xD0)
+#define FUSE_SYSCFG0_DEFAULT  (0xD0)
+
+/* Fuse Byte 6 (SYSCFG1) */
+#define FUSE_SUT0  (unsigned char)_BV(0)  /* Startup Time Bit 0 */
+#define FUSE_SUT1  (unsigned char)_BV(1)  /* Startup Time Bit 1 */
+#define FUSE_SUT2  (unsigned char)_BV(2)  /* Startup Time Bit 2 */
+#define FUSE6_DEFAULT  (0x7)
+#define FUSE_SYSCFG1_DEFAULT  (0x7)
+
+/* Fuse Byte 7 (CODESIZE) */
+#define FUSE7_DEFAULT  (0x0)
+#define FUSE_CODESIZE_DEFAULT  (0x0)
+
+/* Fuse Byte 8 (BOOTSIZE) */
+#define FUSE8_DEFAULT  (0x0)
+#define FUSE_BOOTSIZE_DEFAULT  (0x0)
+
+/* ========== Lock Bits ========== */
+#define __LOCK_KEY_EXIST
+#ifdef LOCKBITS_DEFAULT
+#undef LOCKBITS_DEFAULT
+#endif //LOCKBITS_DEFAULT
+#define LOCKBITS_DEFAULT  (0x5CC5C55C)
+
+/* ========== Signature ========== */
+#define SIGNATURE_0 0x1E
+#define SIGNATURE_1 0x96
+#define SIGNATURE_2 0x1F
+
+#endif /* #ifdef _AVR_AVR64EA32_H_INCLUDED */
+

--- a/include/avr/ioavr64ea48.h
+++ b/include/avr/ioavr64ea48.h
@@ -1,0 +1,6044 @@
+/*
+ * Copyright (C) 2023, Microchip Technology Inc. and its subsidiaries ("Microchip")
+ * All rights reserved.
+ *
+ * This software is developed by Microchip Technology Inc. and its subsidiaries ("Microchip").
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other
+ *        materials provided with the distribution. Publication is not required when
+ *        this file is used in an embedded application.
+ *
+ *     3. Microchip's name may not be used to endorse or promote products derived from this
+ *        software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY MICROCHIP "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL MICROCHIP BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING BUT NOT LIMITED TO
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWSOEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _AVR_IO_H_
+#  error "Include <avr/io.h> instead of this file."
+#endif
+
+#ifndef _AVR_IOXXX_H_
+#  define _AVR_IOXXX_H_ "ioavr64ea48.h"
+#else
+#  error "Attempt to include more than one <avr/ioXXX.h> file."
+#endif
+
+#ifndef _AVR_AVR64EA48_H_INCLUDED
+#define _AVR_AVR64EA48_H_INCLUDED
+
+/* Ungrouped common registers */
+#define CCP  _SFR_MEM8(0x0034)  /* Configuration Change Protection */
+#define SP  _SFR_MEM16(0x003D)  /* Stack Pointer */
+#define SPL  _SFR_MEM8(0x003D)  /* Stack Pointer Low */
+#define SPH  _SFR_MEM8(0x003E)  /* Stack Pointer High */
+#define SREG  _SFR_MEM8(0x003F)  /* Status Register */
+
+/* C Language Only */
+#if !defined (__ASSEMBLER__)
+
+#include <stdint.h>
+
+typedef volatile uint8_t register8_t;
+typedef volatile uint16_t register16_t;
+typedef volatile uint32_t register32_t;
+
+
+#ifdef _WORDREGISTER
+#undef _WORDREGISTER
+#endif
+#define _WORDREGISTER(regname)   \
+    __extension__ union \
+    { \
+        register16_t regname; \
+        struct \
+        { \
+            register8_t regname ## L; \
+            register8_t regname ## H; \
+        }; \
+    }
+
+#ifdef _DWORDREGISTER
+#undef _DWORDREGISTER
+#endif
+#define _DWORDREGISTER(regname)  \
+    __extension__ union \
+    { \
+        register32_t regname; \
+        struct \
+        { \
+            register8_t regname ## 0; \
+            register8_t regname ## 1; \
+            register8_t regname ## 2; \
+            register8_t regname ## 3; \
+        }; \
+    }
+
+
+/*
+==========================================================================
+IO Module Structures
+==========================================================================
+*/
+
+
+/*
+--------------------------------------------------------------------------
+AC - Analog Comparator
+--------------------------------------------------------------------------
+*/
+
+/* Analog Comparator */
+typedef struct AC_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t MUXCTRL;  /* Mux Control A */
+    register8_t reserved_1[2];
+    register8_t DACREF;  /* DAC Voltage Reference */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t STATUS;  /* Status */
+} AC_t;
+
+/* Hysteresis Mode select */
+typedef enum AC_HYSMODE_enum
+{
+    AC_HYSMODE_NONE_gc = (0x00<<1),  /* No hysteresis */
+    AC_HYSMODE_SMALL_gc = (0x01<<1),  /* Small hysteresis */
+    AC_HYSMODE_MEDIUM_gc = (0x02<<1),  /* Medium hysteresis */
+    AC_HYSMODE_LARGE_gc = (0x03<<1)  /* Large hysteresis */
+} AC_HYSMODE_t;
+
+/* AC Output Initial Value select */
+typedef enum AC_INITVAL_enum
+{
+    AC_INITVAL_LOW_gc = (0x00<<6),  /* Output initialized to 0 */
+    AC_INITVAL_HIGH_gc = (0x01<<6)  /* Output initialized to 1 */
+} AC_INITVAL_t;
+
+/* Interrupt Mode select */
+typedef enum AC_INTMODE_NORMAL_enum
+{
+    AC_INTMODE_NORMAL_BOTHEDGE_gc = (0x00<<4),  /* Positive and negative inputs crosses */
+    AC_INTMODE_NORMAL_NEGEDGE_gc = (0x02<<4),  /* Positive input goes below negative input */
+    AC_INTMODE_NORMAL_POSEDGE_gc = (0x03<<4)  /* Positive input goes above negative input */
+} AC_INTMODE_NORMAL_t;
+
+/* Interrupt Mode select */
+typedef enum AC_INTMODE_WINDOW_enum
+{
+    AC_INTMODE_WINDOW_ABOVE_gc = (0x00<<4),  /* Window interrupt when input above both references */
+    AC_INTMODE_WINDOW_INSIDE_gc = (0x01<<4),  /* Window interrupt when input betweeen references */
+    AC_INTMODE_WINDOW_BELOW_gc = (0x02<<4),  /* Window interrupt when input below both references */
+    AC_INTMODE_WINDOW_OUTSIDE_gc = (0x03<<4)  /* Window interrupt when input outside reference */
+} AC_INTMODE_WINDOW_t;
+
+/* Negative Input MUX Selection */
+typedef enum AC_MUXNEG_enum
+{
+    AC_MUXNEG_AINN0_gc = (0x00<<0),  /* Negative Pin 0 */
+    AC_MUXNEG_AINN1_gc = (0x01<<0),  /* Negative Pin 1 */
+    AC_MUXNEG_AINN2_gc = (0x02<<0),  /* Negative Pin 2 */
+    AC_MUXNEG_AINN3_gc = (0x03<<0),  /* Negative Pin 3 */
+    AC_MUXNEG_DACREF_gc = (0x04<<0)  /* DAC Reference */
+} AC_MUXNEG_t;
+
+/* Positive Input MUX Selection */
+typedef enum AC_MUXPOS_enum
+{
+    AC_MUXPOS_AINP0_gc = (0x00<<3),  /* Positive Pin 0 */
+    AC_MUXPOS_AINP1_gc = (0x01<<3),  /* Positive Pin 1 */
+    AC_MUXPOS_AINP2_gc = (0x02<<3),  /* Positive Pin 2 */
+    AC_MUXPOS_AINP3_gc = (0x03<<3),  /* Positive Pin 3 */
+    AC_MUXPOS_AINP4_gc = (0x04<<3)  /* Positive Pin 4 */
+} AC_MUXPOS_t;
+
+/* Power profile select */
+typedef enum AC_POWER_enum
+{
+    AC_POWER_PROFILE0_gc = (0x00<<3),  /* Power profile 0, Fastest response time, highest consumption */
+    AC_POWER_PROFILE1_gc = (0x01<<3)  /* Power profile 1 */
+} AC_POWER_t;
+
+/* Window selection mode */
+typedef enum AC_WINSEL_enum
+{
+    AC_WINSEL_DISABLED_gc = (0x00<<0),  /* Window function disabled */
+    AC_WINSEL_UPSEL1_gc = (0x01<<0)  /* Select ACn+1 as upper limit in window compare */
+} AC_WINSEL_t;
+
+/* Analog Comparator Window State select */
+typedef enum AC_WINSTATE_enum
+{
+    AC_WINSTATE_ABOVE_gc = (0x00<<6),  /* Above window */
+    AC_WINSTATE_INSIDE_gc = (0x01<<6),  /* Inside window */
+    AC_WINSTATE_BELOW_gc = (0x02<<6)  /* Below window */
+} AC_WINSTATE_t;
+
+/*
+--------------------------------------------------------------------------
+ADC - Analog to Digital Converter
+--------------------------------------------------------------------------
+*/
+
+/* Analog to Digital Converter */
+typedef struct ADC_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    register8_t CTRLD;  /* Control D */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t STATUS;  /* Status register */
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t CTRLE;  /* Control E */
+    register8_t CTRLF;  /* Control F */
+    register8_t COMMAND;  /* Command register */
+    register8_t PGACTRL;  /* PGA Control */
+    register8_t MUXPOS;  /* Positive Input Multiplexer */
+    register8_t MUXNEG;  /* Negative Input Multiplexer */
+    register8_t reserved_1[2];
+    _DWORDREGISTER(RESULT);  /* Result */
+    _WORDREGISTER(SAMPLE);  /* Sample */
+    register8_t reserved_2[2];
+    register8_t TEMP0;  /* Temporary Data 0 */
+    register8_t TEMP1;  /* Temporary Data 1 */
+    register8_t TEMP2;  /* Temporary Data 2 */
+    register8_t reserved_3[1];
+    _WORDREGISTER(WINLT);  /* Window Low Threshold */
+    _WORDREGISTER(WINHT);  /* Window High Threshold */
+    register8_t reserved_4[32];
+} ADC_t;
+
+/* Sign Chopping select */
+typedef enum ADC_CHOPPING_enum
+{
+    ADC_CHOPPING_DISABLE_gc = (0x00<<6),  /* Sign Chopping Disabled */
+    ADC_CHOPPING_ENABLE_gc = (0x01<<6)  /* Sign Chopping Enabled */
+} ADC_CHOPPING_t;
+
+/* Gain select */
+typedef enum ADC_GAIN_enum
+{
+    ADC_GAIN_1X_gc = (0x00<<5),  /* 1x gain */
+    ADC_GAIN_2X_gc = (0x01<<5),  /* 2x gain */
+    ADC_GAIN_4X_gc = (0x02<<5),  /* 4x gain */
+    ADC_GAIN_8X_gc = (0x03<<5),  /* 8x gain */
+    ADC_GAIN_16X_gc = (0x04<<5)  /* 16x gain */
+} ADC_GAIN_t;
+
+/* Mode select */
+typedef enum ADC_MODE_enum
+{
+    ADC_MODE_SINGLE_8BIT_gc = (0x00<<4),  /* Single Conversion with 8-bit resolution */
+    ADC_MODE_SINGLE_12BIT_gc = (0x01<<4),  /* Single Conversion with 12-bit resolution */
+    ADC_MODE_SERIES_gc = (0x02<<4),  /* Series with accumulation, separate trigger for every 12-bit conversion */
+    ADC_MODE_SERIES_SCALING_gc = (0x03<<4),  /* Series with accumulation and scaling, separate trigger for every 12-bit conversion */
+    ADC_MODE_BURST_gc = (0x04<<4),  /* Burst with accumulation, one trigger will run SAMPNUM 12-bit conversions */
+    ADC_MODE_BURST_SCALING_gc = (0x05<<4)  /* Burst with accumulation and scaling, one trigger will run SAMPNUM 12-bit conversions */
+} ADC_MODE_t;
+
+/* Analog Channel Selection Bits */
+typedef enum ADC_MUXNEG_enum
+{
+    ADC_MUXNEG_AIN0_gc = (0x00<<0),  /* ADC input pin 0 */
+    ADC_MUXNEG_AIN1_gc = (0x01<<0),  /* ADC input pin 1 */
+    ADC_MUXNEG_AIN2_gc = (0x02<<0),  /* ADC input pin 2 */
+    ADC_MUXNEG_AIN3_gc = (0x03<<0),  /* ADC input pin 3 */
+    ADC_MUXNEG_AIN4_gc = (0x04<<0),  /* ADC input pin 4 */
+    ADC_MUXNEG_AIN5_gc = (0x05<<0),  /* ADC input pin 5 */
+    ADC_MUXNEG_AIN6_gc = (0x06<<0),  /* ADC input pin 6 */
+    ADC_MUXNEG_AIN7_gc = (0x07<<0),  /* ADC input pin 7 */
+    ADC_MUXNEG_AIN8_gc = (0x08<<0),  /* ADC input pin 8 */
+    ADC_MUXNEG_AIN9_gc = (0x09<<0),  /* ADC input pin 9 */
+    ADC_MUXNEG_AIN10_gc = (0x0A<<0),  /* ADC input pin 10 */
+    ADC_MUXNEG_AIN11_gc = (0x0B<<0),  /* ADC input pin 11 */
+    ADC_MUXNEG_AIN16_gc = (0x10<<0),  /* ADC input pin 16 */
+    ADC_MUXNEG_AIN17_gc = (0x11<<0),  /* ADC input pin 17 */
+    ADC_MUXNEG_AIN18_gc = (0x12<<0),  /* ADC input pin 18 */
+    ADC_MUXNEG_AIN19_gc = (0x13<<0),  /* ADC input pin 19 */
+    ADC_MUXNEG_AIN20_gc = (0x14<<0),  /* ADC input pin 20 */
+    ADC_MUXNEG_AIN21_gc = (0x15<<0),  /* ADC input pin 21 */
+    ADC_MUXNEG_AIN22_gc = (0x16<<0),  /* ADC input pin 22 */
+    ADC_MUXNEG_AIN23_gc = (0x17<<0),  /* ADC input pin 23 */
+    ADC_MUXNEG_AIN24_gc = (0x18<<0),  /* ADC input pin 24 */
+    ADC_MUXNEG_AIN25_gc = (0x19<<0),  /* ADC input pin 25 */
+    ADC_MUXNEG_AIN26_gc = (0x1A<<0),  /* ADC input pin 26 */
+    ADC_MUXNEG_AIN27_gc = (0x1B<<0),  /* ADC input pin 27 */
+    ADC_MUXNEG_AIN28_gc = (0x1C<<0),  /* ADC input pin 28 */
+    ADC_MUXNEG_AIN29_gc = (0x1D<<0),  /* ADC input pin 29 */
+    ADC_MUXNEG_AIN30_gc = (0x1E<<0),  /* ADC input pin 30 */
+    ADC_MUXNEG_AIN31_gc = (0x1F<<0),  /* ADC input pin 31 */
+    ADC_MUXNEG_GND_gc = (0x30<<0),  /* Ground */
+    ADC_MUXNEG_DAC0_gc = (0x38<<0),  /* Digital to Analog Converter 0 */
+    ADC_MUXNEG_DACREF0_gc = (0x39<<0),  /* AC0 DAC reference */
+    ADC_MUXNEG_DACREF1_gc = (0x3A<<0)  /* AC1 DAC reference */
+} ADC_MUXNEG_t;
+
+/* Analog Channel Selection Bits */
+typedef enum ADC_MUXPOS_enum
+{
+    ADC_MUXPOS_AIN0_gc = (0x00<<0),  /* ADC input pin 0 */
+    ADC_MUXPOS_AIN1_gc = (0x01<<0),  /* ADC input pin 1 */
+    ADC_MUXPOS_AIN2_gc = (0x02<<0),  /* ADC input pin 2 */
+    ADC_MUXPOS_AIN3_gc = (0x03<<0),  /* ADC input pin 3 */
+    ADC_MUXPOS_AIN4_gc = (0x04<<0),  /* ADC input pin 4 */
+    ADC_MUXPOS_AIN5_gc = (0x05<<0),  /* ADC input pin 5 */
+    ADC_MUXPOS_AIN6_gc = (0x06<<0),  /* ADC input pin 6 */
+    ADC_MUXPOS_AIN7_gc = (0x07<<0),  /* ADC input pin 7 */
+    ADC_MUXPOS_AIN8_gc = (0x08<<0),  /* ADC input pin 8 */
+    ADC_MUXPOS_AIN9_gc = (0x09<<0),  /* ADC input pin 9 */
+    ADC_MUXPOS_AIN10_gc = (0x0A<<0),  /* ADC input pin 10 */
+    ADC_MUXPOS_AIN11_gc = (0x0B<<0),  /* ADC input pin 11 */
+    ADC_MUXPOS_AIN16_gc = (0x10<<0),  /* ADC input pin 16 */
+    ADC_MUXPOS_AIN17_gc = (0x11<<0),  /* ADC input pin 17 */
+    ADC_MUXPOS_AIN18_gc = (0x12<<0),  /* ADC input pin 18 */
+    ADC_MUXPOS_AIN19_gc = (0x13<<0),  /* ADC input pin 19 */
+    ADC_MUXPOS_AIN20_gc = (0x14<<0),  /* ADC input pin 20 */
+    ADC_MUXPOS_AIN21_gc = (0x15<<0),  /* ADC input pin 21 */
+    ADC_MUXPOS_AIN22_gc = (0x16<<0),  /* ADC input pin 22 */
+    ADC_MUXPOS_AIN23_gc = (0x17<<0),  /* ADC input pin 23 */
+    ADC_MUXPOS_AIN24_gc = (0x18<<0),  /* ADC input pin 24 */
+    ADC_MUXPOS_AIN25_gc = (0x19<<0),  /* ADC input pin 25 */
+    ADC_MUXPOS_AIN26_gc = (0x1A<<0),  /* ADC input pin 26 */
+    ADC_MUXPOS_AIN27_gc = (0x1B<<0),  /* ADC input pin 27 */
+    ADC_MUXPOS_AIN28_gc = (0x1C<<0),  /* ADC input pin 28 */
+    ADC_MUXPOS_AIN29_gc = (0x1D<<0),  /* ADC input pin 29 */
+    ADC_MUXPOS_AIN30_gc = (0x1E<<0),  /* ADC input pin 30 */
+    ADC_MUXPOS_AIN31_gc = (0x1F<<0),  /* ADC input pin 31 */
+    ADC_MUXPOS_GND_gc = (0x30<<0),  /* Ground */
+    ADC_MUXPOS_VDD10_gc = (0x31<<0),  /* VDD Divided by 10 */
+    ADC_MUXPOS_TEMPSENSE_gc = (0x32<<0),  /* Temperature Sensor */
+    ADC_MUXPOS_DAC0_gc = (0x38<<0)  /* Digital to Analog Converter 0 */
+} ADC_MUXPOS_t;
+
+/* PGA BIAS Select */
+typedef enum ADC_PGABIASSEL_enum
+{
+    ADC_PGABIASSEL_100PCT_gc = (0x00<<3),  /* 100% BIAS current. */
+    ADC_PGABIASSEL_75PCT_gc = (0x01<<3),  /* 75% BIAS current. Usable for CLK_ADC<4.5MHz */
+    ADC_PGABIASSEL_50PCT_gc = (0x02<<3),  /* 50% BIAS current. Usable for CLK_ADC<3MHz */
+    ADC_PGABIASSEL_25PCT_gc = (0x03<<3)  /* 25% BIAS current. Usable for CLK_ADC<1.5MHz */
+} ADC_PGABIASSEL_t;
+
+/* Prescaler Value select */
+typedef enum ADC_PRESC_enum
+{
+    ADC_PRESC_DIV2_gc = (0x00<<0),  /* System clock divided by 2 */
+    ADC_PRESC_DIV4_gc = (0x01<<0),  /* System clock divided by 4 */
+    ADC_PRESC_DIV6_gc = (0x02<<0),  /* System clock divided by 6 */
+    ADC_PRESC_DIV8_gc = (0x03<<0),  /* System clock divided by 8 */
+    ADC_PRESC_DIV10_gc = (0x04<<0),  /* System clock divided by 10 */
+    ADC_PRESC_DIV12_gc = (0x05<<0),  /* System clock divided by 12 */
+    ADC_PRESC_DIV14_gc = (0x06<<0),  /* System clock divided by 14 */
+    ADC_PRESC_DIV16_gc = (0x07<<0),  /* System clock divided by 16 */
+    ADC_PRESC_DIV20_gc = (0x08<<0),  /* System clock divided by 20 */
+    ADC_PRESC_DIV24_gc = (0x09<<0),  /* System clock divided by 24 */
+    ADC_PRESC_DIV28_gc = (0x0A<<0),  /* System clock divided by 28 */
+    ADC_PRESC_DIV32_gc = (0x0B<<0),  /* System clock divided by 32 */
+    ADC_PRESC_DIV40_gc = (0x0C<<0),  /* System clock divided by 40 */
+    ADC_PRESC_DIV48_gc = (0x0D<<0),  /* System clock divided by 48 */
+    ADC_PRESC_DIV56_gc = (0x0E<<0),  /* System clock divided by 56 */
+    ADC_PRESC_DIV64_gc = (0x0F<<0)  /* System clock divided by 64 */
+} ADC_PRESC_t;
+
+/* Reference select */
+typedef enum ADC_REFSEL_enum
+{
+    ADC_REFSEL_VDD_gc = (0x00<<0),  /* VDD */
+    ADC_REFSEL_VREFA_gc = (0x02<<0),  /* External Reference */
+    ADC_REFSEL_1V024_gc = (0x04<<0),  /* Internal 1.024V Reference */
+    ADC_REFSEL_2V048_gc = (0x05<<0),  /* Internal 2.048V Reference */
+    ADC_REFSEL_4V096_gc = (0x06<<0),  /* Internal 4.096V Reference */
+    ADC_REFSEL_2V500_gc = (0x07<<0)  /* Internal 2.500V Reference */
+} ADC_REFSEL_t;
+
+/* Sample numbers select */
+typedef enum ADC_SAMPNUM_enum
+{
+    ADC_SAMPNUM_NONE_gc = (0x00<<0),  /* No accumulation */
+    ADC_SAMPNUM_ACC2_gc = (0x01<<0),  /* 2 samples accumulated */
+    ADC_SAMPNUM_ACC4_gc = (0x02<<0),  /* 4 samples accumulated */
+    ADC_SAMPNUM_ACC8_gc = (0x03<<0),  /* 8 samples accumulated */
+    ADC_SAMPNUM_ACC16_gc = (0x04<<0),  /* 16 samples accumulated */
+    ADC_SAMPNUM_ACC32_gc = (0x05<<0),  /* 32 samples accumulated */
+    ADC_SAMPNUM_ACC64_gc = (0x06<<0),  /* 64 samples accumulated */
+    ADC_SAMPNUM_ACC128_gc = (0x07<<0),  /* 128 samples accumulated */
+    ADC_SAMPNUM_ACC256_gc = (0x08<<0),  /* 256 samples accumulated */
+    ADC_SAMPNUM_ACC512_gc = (0x09<<0),  /* 512 samples accumulated */
+    ADC_SAMPNUM_ACC1024_gc = (0x0A<<0)  /* 1024 samples accumulated */
+} ADC_SAMPNUM_t;
+
+/* Start command select */
+typedef enum ADC_START_enum
+{
+    ADC_START_STOP_gc = (0x00<<0),  /* Stop an ongoing conversion */
+    ADC_START_IMMEDIATE_gc = (0x01<<0),  /* Start a conversion immediately. This will be set back to STOP when the first conversion is done, unless Free-Running mode is enabled */
+    ADC_START_MUXPOS_WRITE_gc = (0x02<<0),  /* Start when MUXPOS register is written */
+    ADC_START_MUXNEG_WRITE_gc = (0x03<<0),  /* Start when MUXNEG register is written */
+    ADC_START_EVENT_TRIGGER_gc = (0x04<<0)  /* Start when an event is received */
+} ADC_START_t;
+
+/* VIA select */
+typedef enum ADC_VIA_enum
+{
+    ADC_VIA_DIRECT_gc = (0x00<<6),  /* Inputs connected directly to ADC */
+    ADC_VIA_PGA_gc = (0x01<<6)  /* Inputs connected via PGA */
+} ADC_VIA_t;
+
+/* Window Comparator Mode select */
+typedef enum ADC_WINCM_enum
+{
+    ADC_WINCM_NONE_gc = (0x00<<0),  /* No Window Comparison */
+    ADC_WINCM_BELOW_gc = (0x01<<0),  /* Below Window */
+    ADC_WINCM_ABOVE_gc = (0x02<<0),  /* Above Window */
+    ADC_WINCM_INSIDE_gc = (0x03<<0),  /* Inside Window */
+    ADC_WINCM_OUTSIDE_gc = (0x04<<0)  /* Outside Window */
+} ADC_WINCM_t;
+
+/* Window Mode Source select */
+typedef enum ADC_WINSRC_enum
+{
+    ADC_WINSRC_RESULT_gc = (0x00<<3),  /* Result register used as Window Comparator Source */
+    ADC_WINSRC_SAMPLE_gc = (0x01<<3)  /* Sample register used as Window Comparator Source */
+} ADC_WINSRC_t;
+
+/*
+--------------------------------------------------------------------------
+BOD - Bod interface
+--------------------------------------------------------------------------
+*/
+
+/* Bod interface */
+typedef struct BOD_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t reserved_1[6];
+    register8_t VLMCTRLA;  /* Voltage level monitor Control */
+    register8_t INTCTRL;  /* Voltage level monitor interrupt Control */
+    register8_t INTFLAGS;  /* Voltage level monitor interrupt Flags */
+    register8_t STATUS;  /* Voltage level monitor status */
+    register8_t reserved_2[4];
+} BOD_t;
+
+/* Operation in active mode select */
+typedef enum BOD_ACTIVE_enum
+{
+    BOD_ACTIVE_DISABLE_gc = (0x00<<2),  /* Disabled */
+    BOD_ACTIVE_ENABLED_gc = (0x01<<2),  /* Enabled in continuous mode */
+    BOD_ACTIVE_SAMPLED_gc = (0x02<<2),  /* Enabled in sampled mode */
+    BOD_ACTIVE_ENABLEWAIT_gc = (0x03<<2)  /* Enabled in continuous mode. Execution halted at wake-up until BOD is running */
+} BOD_ACTIVE_t;
+
+/* Bod level select */
+typedef enum BOD_LVL_enum
+{
+    BOD_LVL_BODLEVEL0_gc = (0x00<<0),  /* BOD Disabled during normal operation */
+    BOD_LVL_BODLEVEL1_gc = (0x01<<0),  /* 1.9 V */
+    BOD_LVL_BODLEVEL2_gc = (0x02<<0),  /* 2.7 V */
+    BOD_LVL_BODLEVEL3_gc = (0x03<<0)  /* 4.5 V */
+} BOD_LVL_t;
+
+/* Sample frequency select */
+typedef enum BOD_SAMPFREQ_enum
+{
+    BOD_SAMPFREQ_128HZ_gc = (0x00<<4),  /* Sampling frequency is 128 Hz */
+    BOD_SAMPFREQ_32HZ_gc = (0x01<<4)  /* Sample frequency is 32 Hz */
+} BOD_SAMPFREQ_t;
+
+/* Operation in sleep mode select */
+typedef enum BOD_SLEEP_enum
+{
+    BOD_SLEEP_DISABLE_gc = (0x00<<0),  /* Disabled */
+    BOD_SLEEP_ENABLE_gc = (0x01<<0),  /* Enabled in continuous mode */
+    BOD_SLEEP_SAMPLE_gc = (0x02<<0)  /* Enabled in sampled mode */
+} BOD_SLEEP_t;
+
+/* Configuration select */
+typedef enum BOD_VLMCFG_enum
+{
+    BOD_VLMCFG_FALLING_gc = (0x00<<1),  /* VDD falls below VLM threshold */
+    BOD_VLMCFG_RISING_gc = (0x01<<1),  /* VDD rises above VLM threshold */
+    BOD_VLMCFG_BOTH_gc = (0x02<<1)  /* VDD crosses VLM threshold */
+} BOD_VLMCFG_t;
+
+/* voltage level monitor level select */
+typedef enum BOD_VLMLVL_enum
+{
+    BOD_VLMLVL_OFF_gc = (0x00<<0),  /* VLM Disabled */
+    BOD_VLMLVL_5ABOVE_gc = (0x01<<0),  /* VLM threshold 5% above BOD level */
+    BOD_VLMLVL_15ABOVE_gc = (0x02<<0),  /* VLM threshold 15% above BOD level */
+    BOD_VLMLVL_25ABOVE_gc = (0x03<<0)  /* VLM threshold 25% above BOD level */
+} BOD_VLMLVL_t;
+
+/* Voltage level monitor status select */
+typedef enum BOD_VLMS_enum
+{
+    BOD_VLMS_ABOVE_gc = (0x00<<0),  /* The voltage is above the VLM threshold level */
+    BOD_VLMS_BELOW_gc = (0x01<<0)  /* The voltage is below the VLM threshold level */
+} BOD_VLMS_t;
+
+/*
+--------------------------------------------------------------------------
+CCL - Configurable Custom Logic
+--------------------------------------------------------------------------
+*/
+
+/* Configurable Custom Logic */
+typedef struct CCL_struct
+{
+    register8_t CTRLA;  /* Control Register A */
+    register8_t SEQCTRL0;  /* Sequential Control 0 */
+    register8_t SEQCTRL1;  /* Sequential Control 1 */
+    register8_t reserved_1[2];
+    register8_t INTCTRL0;  /* Interrupt Control 0 */
+    register8_t reserved_2[1];
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t LUT0CTRLA;  /* LUT 0 Control A */
+    register8_t LUT0CTRLB;  /* LUT 0 Control B */
+    register8_t LUT0CTRLC;  /* LUT 0 Control C */
+    register8_t TRUTH0;  /* Truth 0 */
+    register8_t LUT1CTRLA;  /* LUT 1 Control A */
+    register8_t LUT1CTRLB;  /* LUT 1 Control B */
+    register8_t LUT1CTRLC;  /* LUT 1 Control C */
+    register8_t TRUTH1;  /* Truth 1 */
+    register8_t LUT2CTRLA;  /* LUT 2 Control A */
+    register8_t LUT2CTRLB;  /* LUT 2 Control B */
+    register8_t LUT2CTRLC;  /* LUT 2 Control C */
+    register8_t TRUTH2;  /* Truth 2 */
+    register8_t LUT3CTRLA;  /* LUT 3 Control A */
+    register8_t LUT3CTRLB;  /* LUT 3 Control B */
+    register8_t LUT3CTRLC;  /* LUT 3 Control C */
+    register8_t TRUTH3;  /* Truth 3 */
+    register8_t reserved_3[40];
+} CCL_t;
+
+/* Clock Source Selection */
+typedef enum CCL_CLKSRC_enum
+{
+    CCL_CLKSRC_CLKPER_gc = (0x00<<1),  /* Peripheral Clock */
+    CCL_CLKSRC_IN2_gc = (0x01<<1),  /* INSEL2 selection */
+    CCL_CLKSRC_OSCHF_gc = (0x04<<1),  /* Internal High Frequency oscillator */
+    CCL_CLKSRC_OSC32K_gc = (0x05<<1),  /* Internal 32.768 kHz oscillator */
+    CCL_CLKSRC_OSC1K_gc = (0x06<<1)  /* Internal 32.768 kHz oscillator divided by 32 */
+} CCL_CLKSRC_t;
+
+/* Edge Detection Enable select */
+typedef enum CCL_EDGEDET_enum
+{
+    CCL_EDGEDET_DIS_gc = (0x00<<7),  /* Edge detector is disabled */
+    CCL_EDGEDET_EN_gc = (0x01<<7)  /* Edge detector is enabled */
+} CCL_EDGEDET_t;
+
+/* Filter Selection */
+typedef enum CCL_FILTSEL_enum
+{
+    CCL_FILTSEL_DISABLE_gc = (0x00<<4),  /* Filter disabled */
+    CCL_FILTSEL_SYNCH_gc = (0x01<<4),  /* Synchronizer enabled */
+    CCL_FILTSEL_FILTER_gc = (0x02<<4)  /* Filter enabled */
+} CCL_FILTSEL_t;
+
+/* LUT Input 0 Source Selection */
+typedef enum CCL_INSEL0_enum
+{
+    CCL_INSEL0_MASK_gc = (0x00<<0),  /* Masked input */
+    CCL_INSEL0_FEEDBACK_gc = (0x01<<0),  /* Feedback input */
+    CCL_INSEL0_LINK_gc = (0x02<<0),  /* Output from LUT[n+1] as input source */
+    CCL_INSEL0_EVENTA_gc = (0x03<<0),  /* Event A as input source */
+    CCL_INSEL0_EVENTB_gc = (0x04<<0),  /* Event B as input source */
+    CCL_INSEL0_IO_gc = (0x05<<0),  /* IN0 input source */
+    CCL_INSEL0_AC0_gc = (0x06<<0),  /* AC0 output input source */
+    CCL_INSEL0_USART0_gc = (0x07<<0),  /* USART0 TxD input source */
+    CCL_INSEL0_SPI0_gc = (0x08<<0),  /* SPI0 MISO input source */
+    CCL_INSEL0_TCA0_gc = (0x09<<0),  /* TCA0 WO0 input source */
+    CCL_INSEL0_TCA1_gc = (0x0A<<0),  /* TCA1 WO0 input source */
+    CCL_INSEL0_TCB0_gc = (0x0B<<0)  /* TCB0 WO input source */
+} CCL_INSEL0_t;
+
+/* LUT Input 1 Source Selection */
+typedef enum CCL_INSEL1_enum
+{
+    CCL_INSEL1_MASK_gc = (0x00<<4),  /* Masked input */
+    CCL_INSEL1_FEEDBACK_gc = (0x01<<4),  /* Feedback input */
+    CCL_INSEL1_LINK_gc = (0x02<<4),  /* Output from LUT[n+1] as input source */
+    CCL_INSEL1_EVENTA_gc = (0x03<<4),  /* Event A as input source */
+    CCL_INSEL1_EVENTB_gc = (0x04<<4),  /* Event B as input source */
+    CCL_INSEL1_IO_gc = (0x05<<4),  /* IN0 input source */
+    CCL_INSEL1_AC1_gc = (0x06<<4),  /* AC1 output input source */
+    CCL_INSEL1_USART1_gc = (0x07<<4),  /* USART1 TxD input source */
+    CCL_INSEL1_SPI0_gc = (0x08<<4),  /* SPI0 MISO input source */
+    CCL_INSEL1_TCA0_gc = (0x09<<4),  /* TCA0 WO1 input source */
+    CCL_INSEL1_TCA1_gc = (0x0A<<4),  /* TCA1 WO1 input source */
+    CCL_INSEL1_TCB1_gc = (0x0B<<4)  /* TCB1 WO input source */
+} CCL_INSEL1_t;
+
+/* LUT Input 2 Source Selection */
+typedef enum CCL_INSEL2_enum
+{
+    CCL_INSEL2_MASK_gc = (0x00<<0),  /* Masked input */
+    CCL_INSEL2_FEEDBACK_gc = (0x01<<0),  /* Feedback input */
+    CCL_INSEL2_LINK_gc = (0x02<<0),  /* Output from LUT[n+1] as input source */
+    CCL_INSEL2_EVENTA_gc = (0x03<<0),  /* Event A as input source */
+    CCL_INSEL2_EVENTB_gc = (0x04<<0),  /* Event B as input source */
+    CCL_INSEL2_IO_gc = (0x05<<0),  /* IN0 input source */
+    CCL_INSEL2_AC1_gc = (0x06<<0),  /* AC1 output input source */
+    CCL_INSEL2_USART2_gc = (0x07<<0),  /* USART2 TxD input source */
+    CCL_INSEL2_SPI0_gc = (0x08<<0),  /* SPI0 MISO input source */
+    CCL_INSEL2_TCA0_gc = (0x09<<0),  /* TCA0 WO2 input source */
+    CCL_INSEL2_TCA1_gc = (0x0A<<0),  /* TCA1 WO2 input source */
+    CCL_INSEL2_TCB2_gc = (0x0B<<0)  /* TCB2 WO input source */
+} CCL_INSEL2_t;
+
+/* Interrupt Mode for LUT0 select */
+typedef enum CCL_INTMODE0_enum
+{
+    CCL_INTMODE0_INTDISABLE_gc = (0x00<<0),  /* Interrupt disabled */
+    CCL_INTMODE0_RISING_gc = (0x01<<0),  /* Sense rising edge */
+    CCL_INTMODE0_FALLING_gc = (0x02<<0),  /* Sense falling edge */
+    CCL_INTMODE0_BOTH_gc = (0x03<<0)  /* Sense both edges */
+} CCL_INTMODE0_t;
+
+/* Interrupt Mode for LUT1 select */
+typedef enum CCL_INTMODE1_enum
+{
+    CCL_INTMODE1_INTDISABLE_gc = (0x00<<2),  /* Interrupt disabled */
+    CCL_INTMODE1_RISING_gc = (0x01<<2),  /* Sense rising edge */
+    CCL_INTMODE1_FALLING_gc = (0x02<<2),  /* Sense falling edge */
+    CCL_INTMODE1_BOTH_gc = (0x03<<2)  /* Sense both edges */
+} CCL_INTMODE1_t;
+
+/* Interrupt Mode for LUT2 select */
+typedef enum CCL_INTMODE2_enum
+{
+    CCL_INTMODE2_INTDISABLE_gc = (0x00<<4),  /* Interrupt disabled */
+    CCL_INTMODE2_RISING_gc = (0x01<<4),  /* Sense rising edge */
+    CCL_INTMODE2_FALLING_gc = (0x02<<4),  /* Sense falling edge */
+    CCL_INTMODE2_BOTH_gc = (0x03<<4)  /* Sense both edges */
+} CCL_INTMODE2_t;
+
+/* Interrupt Mode for LUT3 select */
+typedef enum CCL_INTMODE3_enum
+{
+    CCL_INTMODE3_INTDISABLE_gc = (0x00<<6),  /* Interrupt disabled */
+    CCL_INTMODE3_RISING_gc = (0x01<<6),  /* Sense rising edge */
+    CCL_INTMODE3_FALLING_gc = (0x02<<6),  /* Sense falling edge */
+    CCL_INTMODE3_BOTH_gc = (0x03<<6)  /* Sense both edges */
+} CCL_INTMODE3_t;
+
+/* Sequential Selection */
+typedef enum CCL_SEQSEL_enum
+{
+    CCL_SEQSEL_DISABLE_gc = (0x00<<0),  /* Sequential logic disabled */
+    CCL_SEQSEL_DFF_gc = (0x01<<0),  /* D FlipFlop */
+    CCL_SEQSEL_JK_gc = (0x02<<0),  /* JK FlipFlop */
+    CCL_SEQSEL_LATCH_gc = (0x03<<0),  /* D Latch */
+    CCL_SEQSEL_RS_gc = (0x04<<0)  /* RS Latch */
+} CCL_SEQSEL_t;
+
+/*
+--------------------------------------------------------------------------
+CLKCTRL - Clock controller
+--------------------------------------------------------------------------
+*/
+
+/* Clock controller */
+typedef struct CLKCTRL_struct
+{
+    register8_t MCLKCTRLA;  /* MCLK Control A */
+    register8_t MCLKCTRLB;  /* MCLK Control B */
+    register8_t MCLKCTRLC;  /* MCLK Control C */
+    register8_t MCLKINTCTRL;  /* MCLK Interrupt Control */
+    register8_t MCLKINTFLAGS;  /* MCLK Interrupt Flags */
+    register8_t MCLKSTATUS;  /* MCLK Status */
+    register8_t MCLKTIMEBASE;  /* MCLK Timebase */
+    register8_t reserved_1[1];
+    register8_t OSCHFCTRLA;  /* OSCHF Control A */
+    register8_t OSCHFTUNE;  /* OSCHF Tune */
+    register8_t reserved_2[14];
+    register8_t OSC32KCTRLA;  /* OSC32K Control A */
+    register8_t reserved_3[3];
+    register8_t XOSC32KCTRLA;  /* XOSC32K Control A */
+    register8_t reserved_4[3];
+    register8_t XOSCHFCTRLA;  /* XOSCHF Control A */
+} CLKCTRL_t;
+
+/* Automatic Oscillator Tune select */
+typedef enum CLKCTRL_AUTOTUNE_enum
+{
+    CLKCTRL_AUTOTUNE_OFF_gc = (0x00<<0),  /* Disabled */
+    CLKCTRL_AUTOTUNE_XOSC32K_gc = (0x01<<0)  /* Tune against 32.768 kHz Crystal Oscillator */
+} CLKCTRL_AUTOTUNE_t;
+
+/* CFD Source select */
+typedef enum CLKCTRL_CFDSRC_enum
+{
+    CLKCTRL_CFDSRC_CLKMAIN_gc = (0x00<<2),  /* Main Clock */
+    CLKCTRL_CFDSRC_XOSCHF_gc = (0x01<<2),  /* High Frequency Crystal Oscillator */
+    CLKCTRL_CFDSRC_XOSC32K_gc = (0x02<<2)  /* 32.768 kHz Crystal Oscillator */
+} CLKCTRL_CFDSRC_t;
+
+/* Clock select */
+typedef enum CLKCTRL_CLKSEL_enum
+{
+    CLKCTRL_CLKSEL_OSCHF_gc = (0x00<<0),  /* Internal high-frequency oscillator */
+    CLKCTRL_CLKSEL_OSC32K_gc = (0x01<<0),  /* Internal 32.768 kHz oscillator */
+    CLKCTRL_CLKSEL_XOSC32K_gc = (0x02<<0),  /* 32.768 kHz crystal oscillator */
+    CLKCTRL_CLKSEL_EXTCLK_gc = (0x03<<0)  /* External clock */
+} CLKCTRL_CLKSEL_t;
+
+/* Crystal startup time select */
+typedef enum CLKCTRL_CSUT_enum
+{
+    CLKCTRL_CSUT_1K_gc = (0x00<<4),  /* 1k cycles */
+    CLKCTRL_CSUT_16K_gc = (0x01<<4),  /* 16k cycles */
+    CLKCTRL_CSUT_32K_gc = (0x02<<4),  /* 32k cycles */
+    CLKCTRL_CSUT_64K_gc = (0x03<<4)  /* 64k cycles */
+} CLKCTRL_CSUT_t;
+
+/* Start-Up Time select */
+typedef enum CLKCTRL_CSUTHF_enum
+{
+    CLKCTRL_CSUTHF_256CYC_gc = (0x00<<4),  /* 256 XOSCHF Cycles */
+    CLKCTRL_CSUTHF_1KCYC_gc = (0x01<<4),  /* 1K XOSCHF Cycles */
+    CLKCTRL_CSUTHF_4KCYC_gc = (0x02<<4)  /* 4K XOSCHF Cycles */
+} CLKCTRL_CSUTHF_t;
+
+/* Interrupt Type select */
+typedef enum CLKCTRL_INTTYPE_enum
+{
+    CLKCTRL_INTTYPE_INT_gc = (0x00<<7),  /* Regular interrupt */
+    CLKCTRL_INTTYPE_NMI_gc = (0x01<<7)  /* Non-maskable interrupt */
+} CLKCTRL_INTTYPE_t;
+
+/* Prescaler division select */
+typedef enum CLKCTRL_PDIV_enum
+{
+    CLKCTRL_PDIV_DIV2_gc = (0x00<<1),  /* Divide by 2 */
+    CLKCTRL_PDIV_DIV4_gc = (0x01<<1),  /* Divide by 4 */
+    CLKCTRL_PDIV_DIV8_gc = (0x02<<1),  /* Divide by 8 */
+    CLKCTRL_PDIV_DIV16_gc = (0x03<<1),  /* Divide by 16 */
+    CLKCTRL_PDIV_DIV32_gc = (0x04<<1),  /* Divide by 32 */
+    CLKCTRL_PDIV_DIV64_gc = (0x05<<1),  /* Divide by 64 */
+    CLKCTRL_PDIV_DIV6_gc = (0x08<<1),  /* Divide by 6 */
+    CLKCTRL_PDIV_DIV10_gc = (0x09<<1),  /* Divide by 10 */
+    CLKCTRL_PDIV_DIV12_gc = (0x0A<<1),  /* Divide by 12 */
+    CLKCTRL_PDIV_DIV24_gc = (0x0B<<1),  /* Divide by 24 */
+    CLKCTRL_PDIV_DIV48_gc = (0x0C<<1)  /* Divide by 48 */
+} CLKCTRL_PDIV_t;
+
+/* Source Select */
+typedef enum CLKCTRL_SELHF_enum
+{
+    CLKCTRL_SELHF_CRYSTAL_gc = (0x00<<1),  /* External Crystal */
+    CLKCTRL_SELHF_EXTCLK_gc = (0x01<<1)  /* Extenal Clock on XTALHF1 pin */
+} CLKCTRL_SELHF_t;
+
+/*
+--------------------------------------------------------------------------
+CPU - CPU
+--------------------------------------------------------------------------
+*/
+
+#define CORE_VERSION  V4S
+
+/* CCP signature select */
+typedef enum CCP_enum
+{
+    CCP_SPM_gc = (0x9D<<0),  /* SPM Instruction Protection */
+    CCP_IOREG_gc = (0xD8<<0)  /* IO Register Protection */
+} CCP_t;
+
+/*
+--------------------------------------------------------------------------
+CPUINT - Interrupt Controller
+--------------------------------------------------------------------------
+*/
+
+/* Interrupt Controller */
+typedef struct CPUINT_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t STATUS;  /* Status */
+    register8_t LVL0PRI;  /* Interrupt Level 0 Priority */
+    register8_t LVL1VEC;  /* Interrupt Level 1 Priority Vector */
+} CPUINT_t;
+
+
+/*
+--------------------------------------------------------------------------
+CRCSCAN - CRCSCAN
+--------------------------------------------------------------------------
+*/
+
+/* CRCSCAN */
+typedef struct CRCSCAN_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t STATUS;  /* Status */
+    register8_t reserved_1[13];
+} CRCSCAN_t;
+
+/* CRC Source select */
+typedef enum CRCSCAN_SRC_enum
+{
+    CRCSCAN_SRC_FLASH_gc = (0x00<<0),  /* CRC on entire flash */
+    CRCSCAN_SRC_APPLICATION_gc = (0x01<<0),  /* CRC on boot and appl section of flash */
+    CRCSCAN_SRC_BOOT_gc = (0x02<<0)  /* CRC on boot section of flash */
+} CRCSCAN_SRC_t;
+
+/*
+--------------------------------------------------------------------------
+DAC - Digital to Analog Converter
+--------------------------------------------------------------------------
+*/
+
+/* Digital to Analog Converter */
+typedef struct DAC_struct
+{
+    register8_t CTRLA;  /* Control Register A */
+    register8_t reserved_1[1];
+    _WORDREGISTER(DATA);  /* DATA Register */
+    register8_t reserved_2[12];
+} DAC_t;
+
+/* Output Buffer Range select */
+typedef enum DAC_OUTRANGE_enum
+{
+    DAC_OUTRANGE_AUTO_gc = (0x00<<4),  /* Output buffer automatically choose best range */
+    DAC_OUTRANGE_LOW_gc = (0x02<<4),  /* Output buffer configured to low range */
+    DAC_OUTRANGE_HIGH_gc = (0x03<<4)  /* Output buffer configured to high range */
+} DAC_OUTRANGE_t;
+
+/*
+--------------------------------------------------------------------------
+EVSYS - Event System
+--------------------------------------------------------------------------
+*/
+
+/* Event System */
+typedef struct EVSYS_struct
+{
+    register8_t SWEVENTA;  /* Software Event A */
+    register8_t reserved_1[15];
+    register8_t CHANNEL0;  /* Multiplexer Channel 0 */
+    register8_t CHANNEL1;  /* Multiplexer Channel 1 */
+    register8_t CHANNEL2;  /* Multiplexer Channel 2 */
+    register8_t CHANNEL3;  /* Multiplexer Channel 3 */
+    register8_t CHANNEL4;  /* Multiplexer Channel 4 */
+    register8_t CHANNEL5;  /* Multiplexer Channel 5 */
+    register8_t reserved_2[10];
+    register8_t USERCCLLUT0A;  /* CCL0 Event A */
+    register8_t USERCCLLUT0B;  /* CCL0 Event B */
+    register8_t USERCCLLUT1A;  /* CCL1 Event A */
+    register8_t USERCCLLUT1B;  /* CCL1 Event B */
+    register8_t USERCCLLUT2A;  /* CCL2 Event A */
+    register8_t USERCCLLUT2B;  /* CCL2 Event B */
+    register8_t USERCCLLUT3A;  /* CCL3 Event A */
+    register8_t USERCCLLUT3B;  /* CCL3 Event B */
+    register8_t USERADC0START;  /* ADC0 */
+    register8_t USEREVSYSEVOUTA;  /* EVOUTA */
+    register8_t USEREVSYSEVOUTB;  /* EVOUTB */
+    register8_t USEREVSYSEVOUTC;  /* EVOUTC */
+    register8_t USEREVSYSEVOUTD;  /* EVOUTD */
+    register8_t USEREVSYSEVOUTE;  /* EVOUTE */
+    register8_t USEREVSYSEVOUTF;  /* EVOUTF */
+    register8_t USERUSART0IRDA;  /* USART0 */
+    register8_t USERUSART1IRDA;  /* USART1 */
+    register8_t USERUSART2IRDA;  /* USART2 */
+    register8_t USERTCA0CNTA;  /* TCA0 Event A */
+    register8_t USERTCA0CNTB;  /* TCA0 Event B */
+    register8_t USERTCA1CNTA;  /* TCA1 Event A */
+    register8_t USERTCA1CNTB;  /* TCA1 Event B */
+    register8_t USERTCB0CAPT;  /* TCB0 Event A */
+    register8_t USERTCB0COUNT;  /* TCB0 Event B */
+    register8_t USERTCB1CAPT;  /* TCB1 Event A */
+    register8_t USERTCB1COUNT;  /* TCB1 Event B */
+    register8_t USERTCB2CAPT;  /* TCB2 Event A */
+    register8_t USERTCB2COUNT;  /* TCB2 Event B */
+    register8_t USERTCB3CAPT;  /* TCB3 Event A */
+    register8_t USERTCB3COUNT;  /* TCB3 Event B */
+    register8_t reserved_3[2];
+} EVSYS_t;
+
+/* Channel generator select */
+typedef enum EVSYS_CHANNEL_enum
+{
+    EVSYS_CHANNEL_OFF_gc = (0x00<<0),  /* Off */
+    EVSYS_CHANNEL_UPDI_SYNCH_gc = (0x01<<0),  /* UPDI SYNCH character */
+    EVSYS_CHANNEL_RTC_OVF_gc = (0x06<<0),  /* Real Time Counter overflow */
+    EVSYS_CHANNEL_RTC_CMP_gc = (0x07<<0),  /* Real Time Counter compare */
+    EVSYS_CHANNEL_RTC_PITEV0_gc = (0x08<<0),  /* Periodic Interrupt Timer Event 0 */
+    EVSYS_CHANNEL_RTC_PITEV1_gc = (0x09<<0),  /* Periodic Interrupt Timer Event 1 */
+    EVSYS_CHANNEL_CCL_LUT0_gc = (0x10<<0),  /* Configurable Custom Logic LUT0 */
+    EVSYS_CHANNEL_CCL_LUT1_gc = (0x11<<0),  /* Configurable Custom Logic LUT1 */
+    EVSYS_CHANNEL_CCL_LUT2_gc = (0x12<<0),  /* Configurable Custom Logic LUT2 */
+    EVSYS_CHANNEL_CCL_LUT3_gc = (0x13<<0),  /* Configurable Custom Logic LUT3 */
+    EVSYS_CHANNEL_AC0_OUT_gc = (0x20<<0),  /* Analog Comparator 0 out */
+    EVSYS_CHANNEL_AC1_OUT_gc = (0x21<<0),  /* Analog Comparator 1 out */
+    EVSYS_CHANNEL_ADC0_RES_gc = (0x24<<0),  /* ADC 0 Result Ready */
+    EVSYS_CHANNEL_ADC0_SAMP_gc = (0x25<<0),  /* ADC 0 Sample Ready */
+    EVSYS_CHANNEL_ADC0_WCMP_gc = (0x26<<0),  /* ADC 0 Window Compare */
+    EVSYS_CHANNEL_PORTA_EV0_gc = (0x40<<0),  /* Port A Event 0 */
+    EVSYS_CHANNEL_PORTA_EV1_gc = (0x41<<0),  /* Port A Event 1 */
+    EVSYS_CHANNEL_PORTB_EV0_gc = (0x42<<0),  /* Port B Event 0 */
+    EVSYS_CHANNEL_PORTB_EV1_gc = (0x43<<0),  /* Port B Event 1 */
+    EVSYS_CHANNEL_PORTC_EV0_gc = (0x44<<0),  /* Port C Event 0 */
+    EVSYS_CHANNEL_PORTC_EV1_gc = (0x45<<0),  /* Port C Event 1 */
+    EVSYS_CHANNEL_PORTD_EV0_gc = (0x46<<0),  /* Port D Event 0 */
+    EVSYS_CHANNEL_PORTD_EV1_gc = (0x47<<0),  /* Port D Event 1 */
+    EVSYS_CHANNEL_PORTE_EV0_gc = (0x48<<0),  /* Port E Event 0 */
+    EVSYS_CHANNEL_PORTE_EV1_gc = (0x49<<0),  /* Port E Event 1 */
+    EVSYS_CHANNEL_PORTF_EV0_gc = (0x4A<<0),  /* Port F Event 0 */
+    EVSYS_CHANNEL_PORTF_EV1_gc = (0x4B<<0),  /* Port F Event 1 */
+    EVSYS_CHANNEL_USART0_XCK_gc = (0x60<<0),  /* USART 0 XCK */
+    EVSYS_CHANNEL_USART1_XCK_gc = (0x61<<0),  /* USART 1 XCK */
+    EVSYS_CHANNEL_USART2_XCK_gc = (0x62<<0),  /* USART 2 XCK */
+    EVSYS_CHANNEL_SPI0_SCK_gc = (0x68<<0),  /* SPI 0 SCK */
+    EVSYS_CHANNEL_TCA0_OVF_LUNF_gc = (0x80<<0),  /* Timer/Counter A0 overflow / low byte timer underflow */
+    EVSYS_CHANNEL_TCA0_HUNF_gc = (0x81<<0),  /* Timer/Counter A0 high byte timer underflow */
+    EVSYS_CHANNEL_TCA0_CMP0_LCMP0_gc = (0x84<<0),  /* Timer/Counter A0 compare 0 / low byte timer compare 0 */
+    EVSYS_CHANNEL_TCA0_CMP1_LCMP1_gc = (0x85<<0),  /* Timer/Counter A0 compare 1 / low byte timer compare 1 */
+    EVSYS_CHANNEL_TCA0_CMP2_LCMP2_gc = (0x86<<0),  /* Timer/Counter A0 compare 2 / low byte timer compare 2 */
+    EVSYS_CHANNEL_TCA1_OVF_LUNF_gc = (0x88<<0),  /* Timer/Counter A1 overflow / low byte timer underflow */
+    EVSYS_CHANNEL_TCA1_HUNF_gc = (0x89<<0),  /* Timer/Counter A1 high byte timer underflow */
+    EVSYS_CHANNEL_TCA1_CMP0_LCMP0_gc = (0x8C<<0),  /* Timer/Counter A1 compare 0 / low byte timer compare 0 */
+    EVSYS_CHANNEL_TCA1_CMP1_LCMP1_gc = (0x8D<<0),  /* Timer/Counter A1 compare 1 / low byte timer compare 1 */
+    EVSYS_CHANNEL_TCA1_CMP2_LCMP2_gc = (0x8E<<0),  /* Timer/Counter A1 compare 2 / low byte timer compare 2 */
+    EVSYS_CHANNEL_TCB0_CAPT_gc = (0xA0<<0),  /* Timer/Counter B0 capture */
+    EVSYS_CHANNEL_TCB0_OVF_gc = (0xA1<<0),  /* Timer/Counter B0 overflow */
+    EVSYS_CHANNEL_TCB1_CAPT_gc = (0xA2<<0),  /* Timer/Counter B1 capture */
+    EVSYS_CHANNEL_TCB1_OVF_gc = (0xA3<<0),  /* Timer/Counter B1 overflow */
+    EVSYS_CHANNEL_TCB2_CAPT_gc = (0xA4<<0),  /* Timer/Counter B2 capture */
+    EVSYS_CHANNEL_TCB2_OVF_gc = (0xA5<<0),  /* Timer/Counter B2 overflow */
+    EVSYS_CHANNEL_TCB3_CAPT_gc = (0xA6<<0),  /* Timer/Counter B3 capture */
+    EVSYS_CHANNEL_TCB3_OVF_gc = (0xA7<<0)  /* Timer/Counter B3 overflow */
+} EVSYS_CHANNEL_t;
+
+/* Software event on channel select */
+typedef enum EVSYS_SWEVENTA_enum
+{
+    EVSYS_SWEVENTA_CH0_gc = (0x01<<0),  /* Software event on channel 0 */
+    EVSYS_SWEVENTA_CH1_gc = (0x02<<0),  /* Software event on channel 1 */
+    EVSYS_SWEVENTA_CH2_gc = (0x04<<0),  /* Software event on channel 2 */
+    EVSYS_SWEVENTA_CH3_gc = (0x08<<0),  /* Software event on channel 3 */
+    EVSYS_SWEVENTA_CH4_gc = (0x10<<0),  /* Software event on channel 4 */
+    EVSYS_SWEVENTA_CH5_gc = (0x20<<0),  /* Software event on channel 5 */
+    EVSYS_SWEVENTA_CH6_gc = (0x40<<0),  /* Software event on channel 6 */
+    EVSYS_SWEVENTA_CH7_gc = (0x80<<0)  /* Software event on channel 7 */
+} EVSYS_SWEVENTA_t;
+
+/* User channel select */
+typedef enum EVSYS_USER_enum
+{
+    EVSYS_USER_OFF_gc = (0x00<<0),  /* Off, No Eventsys Channel connected */
+    EVSYS_USER_CHANNEL0_gc = (0x01<<0),  /* Connect user to event channel 0 */
+    EVSYS_USER_CHANNEL1_gc = (0x02<<0),  /* Connect user to event channel 1 */
+    EVSYS_USER_CHANNEL2_gc = (0x03<<0),  /* Connect user to event channel 2 */
+    EVSYS_USER_CHANNEL3_gc = (0x04<<0),  /* Connect user to event channel 3 */
+    EVSYS_USER_CHANNEL4_gc = (0x05<<0),  /* Connect user to event channel 4 */
+    EVSYS_USER_CHANNEL5_gc = (0x06<<0)  /* Connect user to event channel 5 */
+} EVSYS_USER_t;
+
+/*
+--------------------------------------------------------------------------
+FUSE - Fuses
+--------------------------------------------------------------------------
+*/
+
+/* Fuses */
+typedef struct FUSE_struct
+{
+    register8_t WDTCFG;  /* Watchdog Configuration */
+    register8_t BODCFG;  /* BOD Configuration */
+    register8_t OSCCFG;  /* Oscillator Configuration */
+    register8_t reserved_1[2];
+    register8_t SYSCFG0;  /* System Configuration 0 */
+    register8_t SYSCFG1;  /* System Configuration 1 */
+    register8_t CODESIZE;  /* Code Section Size */
+    register8_t BOOTSIZE;  /* Boot Section Size */
+} FUSE_t;
+
+/* avr-libc typedef for avr/fuse.h */
+typedef FUSE_t NVM_FUSES_t;
+
+/* BOD Operation in Active Mode select */
+typedef enum ACTIVE_enum
+{
+    ACTIVE_DISABLE_gc = (0x00<<2),  /* Disabled */
+    ACTIVE_ENABLED_gc = (0x01<<2),  /* Enabled in continuous mode */
+    ACTIVE_SAMPLED_gc = (0x02<<2),  /* Enabled in sampled mode */
+    ACTIVE_ENABLEWAIT_gc = (0x03<<2)  /* Enabled in continuous mode. Execution halted at wake-up until BOD is running */
+} ACTIVE_t;
+
+/* CRC Select */
+typedef enum CRCSEL_enum
+{
+    CRCSEL_CRC16_gc = (0x00<<5),  /* Enable CRC16 */
+    CRCSEL_CRC32_gc = (0x01<<5)  /* Enable CRC32 */
+} CRCSEL_t;
+
+/* CRC Source select */
+typedef enum CRCSRC_enum
+{
+    CRCSRC_FLASH_gc = (0x00<<6),  /* CRC of full Flash (boot, application code and application data) */
+    CRCSRC_BOOT_gc = (0x01<<6),  /* CRC of boot section */
+    CRCSRC_BOOTAPP_gc = (0x02<<6),  /* CRC of application code and boot sections */
+    CRCSRC_NOCRC_gc = (0x03<<6)  /* No CRC */
+} CRCSRC_t;
+
+/* EEPROM Save select */
+typedef enum EESAVE_enum
+{
+    EESAVE_DISABLE_gc = (0x00<<0),  /* EEPROM content is erased during chip erase */
+    EESAVE_ENABLE_gc = (0x01<<0)  /* EEPROM content is preserved during chip erase */
+} EESAVE_t;
+
+/* BOD Level select */
+typedef enum LVL_enum
+{
+    LVL_BODLEVEL0_gc = (0x00<<5),  /* BOD Disabled during normal operation */
+    LVL_BODLEVEL1_gc = (0x01<<5),  /* 1.9 V */
+    LVL_BODLEVEL2_gc = (0x02<<5),  /* 2.7 V */
+    LVL_BODLEVEL3_gc = (0x03<<5)  /* 4.5 V */
+} LVL_t;
+
+/* High-frequency Oscillator Frequency select */
+typedef enum OSCHFFRQ_enum
+{
+    OSCHFFRQ_20M_gc = (0x00<<3),  /* OSCHF running at 20 MHz */
+    OSCHFFRQ_16M_gc = (0x01<<3)  /* OSCHF running at 16 MHz */
+} OSCHFFRQ_t;
+
+/* Watchdog Timeout Period select */
+typedef enum PERIOD_enum
+{
+    PERIOD_OFF_gc = (0x00<<0),  /* Watch-Dog timer Off */
+    PERIOD_8CLK_gc = (0x01<<0),  /* 8 cycles (8ms) */
+    PERIOD_16CLK_gc = (0x02<<0),  /* 16 cycles (16ms) */
+    PERIOD_32CLK_gc = (0x03<<0),  /* 32 cycles (32ms) */
+    PERIOD_64CLK_gc = (0x04<<0),  /* 64 cycles (64ms) */
+    PERIOD_128CLK_gc = (0x05<<0),  /* 128 cycles (0.128s) */
+    PERIOD_256CLK_gc = (0x06<<0),  /* 256 cycles (0.256s) */
+    PERIOD_512CLK_gc = (0x07<<0),  /* 512 cycles (0.512s) */
+    PERIOD_1KCLK_gc = (0x08<<0),  /* 1K cycles (1.0s) */
+    PERIOD_2KCLK_gc = (0x09<<0),  /* 2K cycles (2.0s) */
+    PERIOD_4KCLK_gc = (0x0A<<0),  /* 4K cycles (4.0s) */
+    PERIOD_8KCLK_gc = (0x0B<<0)  /* 8K cycles (8.0s) */
+} PERIOD_t;
+
+/* Reset Pin Configuration select */
+typedef enum RSTPINCFG_enum
+{
+    RSTPINCFG_NONE_gc = (0x00<<3),  /* No External Reset */
+    RSTPINCFG_RESET_gc = (0x01<<3)  /* PF6 configured as RESET pin */
+} RSTPINCFG_t;
+
+/* BOD Sample Frequency select */
+typedef enum SAMPFREQ_enum
+{
+    SAMPFREQ_128HZ_gc = (0x00<<4),  /* Sampling frequency is 128 Hz */
+    SAMPFREQ_32HZ_gc = (0x01<<4)  /* Sample frequency is 32 Hz */
+} SAMPFREQ_t;
+
+/* BOD Operation in Sleep Mode select */
+typedef enum SLEEP_enum
+{
+    SLEEP_DISABLE_gc = (0x00<<0),  /* Disabled */
+    SLEEP_ENABLE_gc = (0x01<<0),  /* Enabled in continuous mode */
+    SLEEP_SAMPLE_gc = (0x02<<0)  /* Enabled in sampled mode */
+} SLEEP_t;
+
+/* Startup Time select */
+typedef enum SUT_enum
+{
+    SUT_0MS_gc = (0x00<<0),  /* 0 ms */
+    SUT_1MS_gc = (0x01<<0),  /* 1 ms */
+    SUT_2MS_gc = (0x02<<0),  /* 2 ms */
+    SUT_4MS_gc = (0x03<<0),  /* 4 ms */
+    SUT_8MS_gc = (0x04<<0),  /* 8 ms */
+    SUT_16MS_gc = (0x05<<0),  /* 16 ms */
+    SUT_32MS_gc = (0x06<<0),  /* 32 ms */
+    SUT_64MS_gc = (0x07<<0)  /* 64 ms */
+} SUT_t;
+
+/* UPDI Pin Configuration select */
+typedef enum UPDIPINCFG_enum
+{
+    UPDIPINCFG_GPIO_gc = (0x00<<4),  /* PF7 Configured as GPIO pin */
+    UPDIPINCFG_UPDI_gc = (0x01<<4)  /* PF7 Configured as UPDI pin */
+} UPDIPINCFG_t;
+
+/* Watchdog Window Timeout Period select */
+typedef enum WINDOW_enum
+{
+    WINDOW_OFF_gc = (0x00<<4),  /* Window mode off */
+    WINDOW_8CLK_gc = (0x01<<4),  /* 8 cycles (8ms) */
+    WINDOW_16CLK_gc = (0x02<<4),  /* 16 cycles (16ms) */
+    WINDOW_32CLK_gc = (0x03<<4),  /* 32 cycles (32ms) */
+    WINDOW_64CLK_gc = (0x04<<4),  /* 64 cycles (64ms) */
+    WINDOW_128CLK_gc = (0x05<<4),  /* 128 cycles (0.128s) */
+    WINDOW_256CLK_gc = (0x06<<4),  /* 256 cycles (0.256s) */
+    WINDOW_512CLK_gc = (0x07<<4),  /* 512 cycles (0.512s) */
+    WINDOW_1KCLK_gc = (0x08<<4),  /* 1K cycles (1.0s) */
+    WINDOW_2KCLK_gc = (0x09<<4),  /* 2K cycles (2.0s) */
+    WINDOW_4KCLK_gc = (0x0A<<4),  /* 4K cycles (4.0s) */
+    WINDOW_8KCLK_gc = (0x0B<<4)  /* 8K cycles (8.0s) */
+} WINDOW_t;
+
+/*
+--------------------------------------------------------------------------
+GPR - General Purpose Registers
+--------------------------------------------------------------------------
+*/
+
+/* General Purpose Registers */
+typedef struct GPR_struct
+{
+    register8_t GPR0;  /* General Purpose Register 0 */
+    register8_t GPR1;  /* General Purpose Register 1 */
+    register8_t GPR2;  /* General Purpose Register 2 */
+    register8_t GPR3;  /* General Purpose Register 3 */
+} GPR_t;
+
+
+/*
+--------------------------------------------------------------------------
+LOCK - Lockbits
+--------------------------------------------------------------------------
+*/
+
+/* Lockbits */
+typedef struct LOCK_struct
+{
+    _DWORDREGISTER(KEY);  /* Lock Key Bits */
+} LOCK_t;
+
+/* Lock Key select */
+typedef enum LOCK_KEY_enum
+{
+    LOCK_KEY_NOLOCK_gc = (0x5CC5C55C<<0),  /* No locks */
+    LOCK_KEY_RWLOCK_gc = (0xA33A3AA3<<0)  /* Read and write lock */
+} LOCK_KEY_t;
+
+/*
+--------------------------------------------------------------------------
+NVMCTRL - Non-volatile Memory Controller
+--------------------------------------------------------------------------
+*/
+
+/* Non-volatile Memory Controller */
+typedef struct NVMCTRL_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t reserved_1[2];
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t STATUS;  /* Status */
+    register8_t reserved_2[1];
+    _WORDREGISTER(DATA);  /* Data */
+    register8_t reserved_3[2];
+    _DWORDREGISTER(ADDR);  /* Address */
+    register8_t reserved_4[48];
+} NVMCTRL_t;
+
+/* Command select */
+typedef enum NVMCTRL_CMD_enum
+{
+    NVMCTRL_CMD_NOCMD_gc = (0x00<<0),  /* No Command */
+    NVMCTRL_CMD_NOOP_gc = (0x01<<0),  /* No Operation */
+    NVMCTRL_CMD_FLPW_gc = (0x04<<0),  /* Flash Page Write */
+    NVMCTRL_CMD_FLPERW_gc = (0x05<<0),  /* Flash Page Erase and Write */
+    NVMCTRL_CMD_FLPER_gc = (0x08<<0),  /* Flash Page Erase */
+    NVMCTRL_CMD_FLMPER2_gc = (0x09<<0),  /* Flash 2-page erase enable */
+    NVMCTRL_CMD_FLMPER4_gc = (0x0A<<0),  /* Flash 4-page erase enable */
+    NVMCTRL_CMD_FLMPER8_gc = (0x0B<<0),  /* Flash 8-page erase enable */
+    NVMCTRL_CMD_FLMPER16_gc = (0x0C<<0),  /* Flash 16-page erase enable */
+    NVMCTRL_CMD_FLMPER32_gc = (0x0D<<0),  /* Flash 32-page erase enable */
+    NVMCTRL_CMD_FLPBCLR_gc = (0x0F<<0),  /* Flash Page Buffer Clear */
+    NVMCTRL_CMD_EEPW_gc = (0x14<<0),  /* EEPROM Page Write */
+    NVMCTRL_CMD_EEPERW_gc = (0x15<<0),  /* EEPROM Page Erase and Write */
+    NVMCTRL_CMD_EEPER_gc = (0x17<<0),  /* EEPROM Page Erase */
+    NVMCTRL_CMD_EEPBCLR_gc = (0x1F<<0),  /* EEPROM Page Buffer Clear */
+    NVMCTRL_CMD_CHER_gc = (0x20<<0),  /* Chip Erase Command (UPDI only) */
+    NVMCTRL_CMD_EECHER_gc = (0x30<<0)  /* EEPROM Erase Command (UPDI only) */
+} NVMCTRL_CMD_t;
+
+/* Write error select */
+typedef enum NVMCTRL_ERROR_enum
+{
+    NVMCTRL_ERROR_NOERROR_gc = (0x00<<4),  /* No Error */
+    NVMCTRL_ERROR_WRITEPROTECT_gc = (0x02<<4),  /* Attempt to program write protected area */
+    NVMCTRL_ERROR_CMDCOLLISION_gc = (0x03<<4),  /* Selecting new write command while write command already seleted */
+    NVMCTRL_ERROR_WRONGSECTION_gc = (0x04<<4)  /* Address cannot be written with selected command */
+} NVMCTRL_ERROR_t;
+
+/* Flash Mapping in Data space select */
+typedef enum NVMCTRL_FLMAP_enum
+{
+    NVMCTRL_FLMAP_SECTION0_gc = (0x00<<4),  /* Flash section 0, 0 - 32KB */
+    NVMCTRL_FLMAP_SECTION1_gc = (0x01<<4),  /* Flash section 1, 32 - 64KB */
+    NVMCTRL_FLMAP_SECTION2_gc = (0x02<<4),  /* Flash section 2, 64 - 96KB */
+    NVMCTRL_FLMAP_SECTION3_gc = (0x03<<4)  /* Flash section 3, 96 - 128KB */
+} NVMCTRL_FLMAP_t;
+
+/*
+--------------------------------------------------------------------------
+PORT - I/O Ports
+--------------------------------------------------------------------------
+*/
+
+/* I/O Ports */
+typedef struct PORT_struct
+{
+    register8_t DIR;  /* Data Direction */
+    register8_t DIRSET;  /* Data Direction Set */
+    register8_t DIRCLR;  /* Data Direction Clear */
+    register8_t DIRTGL;  /* Data Direction Toggle */
+    register8_t OUT;  /* Output Value */
+    register8_t OUTSET;  /* Output Value Set */
+    register8_t OUTCLR;  /* Output Value Clear */
+    register8_t OUTTGL;  /* Output Value Toggle */
+    register8_t IN;  /* Input Value */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t PORTCTRL;  /* Port Control */
+    register8_t PINCONFIG;  /* Pin Control Config */
+    register8_t PINCTRLUPD;  /* Pin Control Update */
+    register8_t PINCTRLSET;  /* Pin Control Set */
+    register8_t PINCTRLCLR;  /* Pin Control Clear */
+    register8_t reserved_1[1];
+    register8_t PIN0CTRL;  /* Pin 0 Control */
+    register8_t PIN1CTRL;  /* Pin 1 Control */
+    register8_t PIN2CTRL;  /* Pin 2 Control */
+    register8_t PIN3CTRL;  /* Pin 3 Control */
+    register8_t PIN4CTRL;  /* Pin 4 Control */
+    register8_t PIN5CTRL;  /* Pin 5 Control */
+    register8_t PIN6CTRL;  /* Pin 6 Control */
+    register8_t PIN7CTRL;  /* Pin 7 Control */
+    register8_t EVGENCTRL;  /* Event Generation Control */
+    register8_t reserved_2[7];
+} PORT_t;
+
+/* Event Generator 0 Select */
+typedef enum PORT_EVGEN0SEL_enum
+{
+    PORT_EVGEN0SEL_PIN0_gc = (0x00<<0),  /* Pin 0 used as event generator */
+    PORT_EVGEN0SEL_PIN1_gc = (0x01<<0),  /* Pin 1 used as event generator */
+    PORT_EVGEN0SEL_PIN2_gc = (0x02<<0),  /* Pin 2 used as event generator */
+    PORT_EVGEN0SEL_PIN3_gc = (0x03<<0),  /* Pin 3 used as event generator */
+    PORT_EVGEN0SEL_PIN4_gc = (0x04<<0),  /* Pin 4 used as event generator */
+    PORT_EVGEN0SEL_PIN5_gc = (0x05<<0),  /* Pin 5 used as event generator */
+    PORT_EVGEN0SEL_PIN6_gc = (0x06<<0),  /* Pin 6 used as event generator */
+    PORT_EVGEN0SEL_PIN7_gc = (0x07<<0)  /* Pin 7 used as event generator */
+} PORT_EVGEN0SEL_t;
+
+/* Event Generator 1 Select */
+typedef enum PORT_EVGEN1SEL_enum
+{
+    PORT_EVGEN1SEL_PIN0_gc = (0x00<<4),  /* Pin 0 used as event generator */
+    PORT_EVGEN1SEL_PIN1_gc = (0x01<<4),  /* Pin 1 used as event generator */
+    PORT_EVGEN1SEL_PIN2_gc = (0x02<<4),  /* Pin 2 used as event generator */
+    PORT_EVGEN1SEL_PIN3_gc = (0x03<<4),  /* Pin 3 used as event generator */
+    PORT_EVGEN1SEL_PIN4_gc = (0x04<<4),  /* Pin 4 used as event generator */
+    PORT_EVGEN1SEL_PIN5_gc = (0x05<<4),  /* Pin 5 used as event generator */
+    PORT_EVGEN1SEL_PIN6_gc = (0x06<<4),  /* Pin 6 used as event generator */
+    PORT_EVGEN1SEL_PIN7_gc = (0x07<<4)  /* Pin 7 used as event generator */
+} PORT_EVGEN1SEL_t;
+
+/* Input Level Select */
+typedef enum PORT_INLVL_enum
+{
+    PORT_INLVL_ST_gc = (0x00<<6),  /* Schmitt-Trigger input level */
+    PORT_INLVL_TTL_gc = (0x01<<6)  /* TTL Input level */
+} PORT_INLVL_t;
+
+/* Input/Sense Configuration select */
+typedef enum PORT_ISC_enum
+{
+    PORT_ISC_INTDISABLE_gc = (0x00<<0),  /* Interrupt disabled but input buffer enabled */
+    PORT_ISC_BOTHEDGES_gc = (0x01<<0),  /* Sense Both Edges */
+    PORT_ISC_RISING_gc = (0x02<<0),  /* Sense Rising Edge */
+    PORT_ISC_FALLING_gc = (0x03<<0),  /* Sense Falling Edge */
+    PORT_ISC_INPUT_DISABLE_gc = (0x04<<0),  /* Digital Input Buffer disabled */
+    PORT_ISC_LEVEL_gc = (0x05<<0)  /* Sense low Level */
+} PORT_ISC_t;
+
+/*
+--------------------------------------------------------------------------
+PORTMUX - Port Multiplexer
+--------------------------------------------------------------------------
+*/
+
+/* Port Multiplexer */
+typedef struct PORTMUX_struct
+{
+    register8_t EVSYSROUTEA;  /* EVSYS route A */
+    register8_t CCLROUTEA;  /* CCL route A */
+    register8_t USARTROUTEA;  /* USART route A */
+    register8_t USARTROUTEB;  /* USART route B */
+    register8_t reserved_1[1];
+    register8_t SPIROUTEA;  /* SPI route A */
+    register8_t TWIROUTEA;  /* TWI route A */
+    register8_t TCAROUTEA;  /* TCA route A */
+    register8_t TCBROUTEA;  /* TCB route A */
+    register8_t reserved_2[1];
+    register8_t ACROUTEA;  /* AC route A */
+    register8_t reserved_3[21];
+} PORTMUX_t;
+
+/* Analog Comparator 0 Output select */
+typedef enum PORTMUX_AC0_enum
+{
+    PORTMUX_AC0_DEFAULT_gc = (0x00<<0),  /* OUT: PA7 */
+    PORTMUX_AC0_ALT1_gc = (0x01<<0)  /* OUT: PC6 */
+} PORTMUX_AC0_t;
+
+/* Analog Comparator 1 Output select */
+typedef enum PORTMUX_AC1_enum
+{
+    PORTMUX_AC1_DEFAULT_gc = (0x00<<1),  /* OUT: PA7 */
+    PORTMUX_AC1_ALT1_gc = (0x01<<1)  /* OUT: PC6 */
+} PORTMUX_AC1_t;
+
+/* Event Output A select */
+typedef enum PORTMUX_EVOUTA_enum
+{
+    PORTMUX_EVOUTA_DEFAULT_gc = (0x00<<0),  /* EVOUTA: PA2 */
+    PORTMUX_EVOUTA_ALT1_gc = (0x01<<0)  /* EVOUTA: PA7 */
+} PORTMUX_EVOUTA_t;
+
+/* Event Output B select */
+typedef enum PORTMUX_EVOUTB_enum
+{
+    PORTMUX_EVOUTB_DEFAULT_gc = (0x00<<1)  /* EVOUTB: PB2 */
+} PORTMUX_EVOUTB_t;
+
+/* Event Output C select */
+typedef enum PORTMUX_EVOUTC_enum
+{
+    PORTMUX_EVOUTC_DEFAULT_gc = (0x00<<2),  /* EVOUTC: PC2 */
+    PORTMUX_EVOUTC_ALT1_gc = (0x01<<2)  /* EVOUTC: PC7 */
+} PORTMUX_EVOUTC_t;
+
+/* Event Output D select */
+typedef enum PORTMUX_EVOUTD_enum
+{
+    PORTMUX_EVOUTD_DEFAULT_gc = (0x00<<3),  /* EVOUTD: PD2 */
+    PORTMUX_EVOUTD_ALT1_gc = (0x01<<3)  /* EVOUTD: PD7 */
+} PORTMUX_EVOUTD_t;
+
+/* Event Output E select */
+typedef enum PORTMUX_EVOUTE_enum
+{
+    PORTMUX_EVOUTE_DEFAULT_gc = (0x00<<4)  /* EVOUTE: PE2 */
+} PORTMUX_EVOUTE_t;
+
+/* Event Output F select */
+typedef enum PORTMUX_EVOUTF_enum
+{
+    PORTMUX_EVOUTF_DEFAULT_gc = (0x00<<5),  /* EVOUTF: PF2 */
+    PORTMUX_EVOUTF_ALT1_gc = (0x01<<5)  /* EVOUTF: PF7 */
+} PORTMUX_EVOUTF_t;
+
+/* CCL Look-Up Table 0 Signals select */
+typedef enum PORTMUX_LUT0_enum
+{
+    PORTMUX_LUT0_DEFAULT_gc = (0x00<<0),  /* In: PA0, PA1, PA2, Out: PA3 */
+    PORTMUX_LUT0_ALT1_gc = (0x01<<0)  /* In: PA0, PA1, PA2, Out: PA6 */
+} PORTMUX_LUT0_t;
+
+/* CCL Look-Up Table 1 Signals select */
+typedef enum PORTMUX_LUT1_enum
+{
+    PORTMUX_LUT1_DEFAULT_gc = (0x00<<1),  /* In: PC0, PC1, PC2, Out: PC3 */
+    PORTMUX_LUT1_ALT1_gc = (0x01<<1)  /* In: PC0, PC1, PC2, Out: PC6 */
+} PORTMUX_LUT1_t;
+
+/* CCL Look-Up Table 2 Signals select */
+typedef enum PORTMUX_LUT2_enum
+{
+    PORTMUX_LUT2_DEFAULT_gc = (0x00<<2),  /* In: PD0, PD1, PD2, Out: PD3 */
+    PORTMUX_LUT2_ALT1_gc = (0x01<<2)  /* In: PD0, PD1, PD2, Out: PD6 */
+} PORTMUX_LUT2_t;
+
+/* SPI0 Signals select */
+typedef enum PORTMUX_SPI0_enum
+{
+    PORTMUX_SPI0_DEFAULT_gc = (0x00<<0),  /* MOSI: PA4, MISO: PA5, SCK: PA6, SS: PA7 */
+    PORTMUX_SPI0_ALT1_gc = (0x01<<0),  /* MOSI: PE0, MISO: PE1, SCK: PE2, SS: PE3 */
+    PORTMUX_SPI0_ALT3_gc = (0x03<<0),  /* MOSI: PA0, MISO: PA1, SCK: PC0, SS: PC1 */
+    PORTMUX_SPI0_ALT4_gc = (0x04<<0),  /* MOSI: PD4, MISO: PD5, SCK: PD6, SS: PD7 */
+    PORTMUX_SPI0_ALT5_gc = (0x05<<0),  /* MOSI: PC0, MISO: PC1, SCK: PC2, SS: PC3 */
+    PORTMUX_SPI0_ALT6_gc = (0x06<<0),  /* MOSI: PC1, MISO: PC2, SCK: PC3, SS: PF7 */
+    PORTMUX_SPI0_NONE_gc = (0x07<<0)  /* Not connected to any pins, SS set to 1 */
+} PORTMUX_SPI0_t;
+
+/* TCA0 Signals select */
+typedef enum PORTMUX_TCA0_enum
+{
+    PORTMUX_TCA0_PORTA_gc = (0x00<<0),  /* WOn: PA0, PA1, PA2, PA3, PA4, PA5 */
+    PORTMUX_TCA0_PORTB_gc = (0x01<<0),  /* WOn: PB0, PB1, PB2, PB3, PB4, PB5 */
+    PORTMUX_TCA0_PORTC_gc = (0x02<<0),  /* WOn: PC0, PC1, PC2, PC3, PC4, PC5 */
+    PORTMUX_TCA0_PORTD_gc = (0x03<<0),  /* WOn: PD0, PD1, PD2, PD3, PD4, PD5 */
+    PORTMUX_TCA0_PORTE_gc = (0x04<<0),  /* WOn: PE0, PE1, PE2, PE3, -, - */
+    PORTMUX_TCA0_PORTF_gc = (0x05<<0)  /* WOn: PF0, PF1, PF2, PF3, PF4, PF5 */
+} PORTMUX_TCA0_t;
+
+/* TCA1 Signals select */
+typedef enum PORTMUX_TCA1_enum
+{
+    PORTMUX_TCA1_PORTB_gc = (0x00<<3),  /* WOn: PB0, PB1, PB2, PB3, PB4, PB5 */
+    PORTMUX_TCA1_PORTC_gc = (0x01<<3),  /* WOn: PC4, PC5, PC6, -, -, - */
+    PORTMUX_TCA1_PORTA_gc = (0x04<<3),  /* WOn: PA4, PA5, PA6, -, -, - */
+    PORTMUX_TCA1_PORTD_gc = (0x05<<3)  /* WOn: PD4, PD5, PD6, -, -, - */
+} PORTMUX_TCA1_t;
+
+/* TCB0 Output select */
+typedef enum PORTMUX_TCB0_enum
+{
+    PORTMUX_TCB0_DEFAULT_gc = (0x00<<0),  /* WO: PA2 */
+    PORTMUX_TCB0_ALT1_gc = (0x01<<0)  /* WO: PF4 */
+} PORTMUX_TCB0_t;
+
+/* TCB1 Output select */
+typedef enum PORTMUX_TCB1_enum
+{
+    PORTMUX_TCB1_DEFAULT_gc = (0x00<<1),  /* WO: PA3 */
+    PORTMUX_TCB1_ALT1_gc = (0x01<<1)  /* WO: PF5 */
+} PORTMUX_TCB1_t;
+
+/* TCB2 Output select */
+typedef enum PORTMUX_TCB2_enum
+{
+    PORTMUX_TCB2_DEFAULT_gc = (0x00<<2),  /* WO: PC0 */
+    PORTMUX_TCB2_ALT1_gc = (0x01<<2)  /* WO: PB4 */
+} PORTMUX_TCB2_t;
+
+/* TCB3 Output select */
+typedef enum PORTMUX_TCB3_enum
+{
+    PORTMUX_TCB3_DEFAULT_gc = (0x00<<3),  /* WO: PB5 */
+    PORTMUX_TCB3_ALT1_gc = (0x01<<3)  /* WO: PC1 */
+} PORTMUX_TCB3_t;
+
+/* TWI0 Signals select */
+typedef enum PORTMUX_TWI0_enum
+{
+    PORTMUX_TWI0_DEFAULT_gc = (0x00<<0),  /* SDA: PA2, SCL: PA3. Dual mode: SDA: PC2, SCL: PC3 */
+    PORTMUX_TWI0_ALT1_gc = (0x01<<0),  /* SDA: PA2, SCL: PA3. Dual mode: SDA: PC6, SCL: PC7 */
+    PORTMUX_TWI0_ALT2_gc = (0x02<<0),  /* SDA: PC2, SCL: PC3. Dual mode: SDA: PC6, SCL: PC7 */
+    PORTMUX_TWI0_ALT3_gc = (0x03<<0)  /* SDA: PA0, SCL: PA1. Dual mode: SDA: PC2, SCL: PC3 */
+} PORTMUX_TWI0_t;
+
+/* USART0 Routing select */
+typedef enum PORTMUX_USART0_enum
+{
+    PORTMUX_USART0_DEFAULT_gc = (0x00<<0),  /* TxD: PA0, RxD: PA1, XCK: PA2, XDIR: PA3 */
+    PORTMUX_USART0_ALT1_gc = (0x01<<0),  /* TxD: PA4, RxD: PA5, XCK: PA6, XDIR: PA7 */
+    PORTMUX_USART0_ALT2_gc = (0x02<<0),  /* TxD: PA2, RxD: PA3, XCK: -, XDIR: - */
+    PORTMUX_USART0_ALT3_gc = (0x03<<0),  /* TxD: PD4, RxD: PD5, XCK: PD6, XDIR: PD7 */
+    PORTMUX_USART0_ALT4_gc = (0x04<<0),  /* TxD: PC1, RxD: PC2, XCK: PC3, XDIR: - */
+    PORTMUX_USART0_NONE_gc = (0x05<<0)  /* Not connected to any pins */
+} PORTMUX_USART0_t;
+
+/* USART1 Routing select */
+typedef enum PORTMUX_USART1_enum
+{
+    PORTMUX_USART1_DEFAULT_gc = (0x00<<3),  /* TxD: PC0, RxD: PC1, XCK: PC2, XDIR: PC3 */
+    PORTMUX_USART1_ALT1_gc = (0x01<<3),  /* TxD: PC4, RxD: PC5, XCK: PC6, XDIR: PC7 */
+    PORTMUX_USART1_ALT2_gc = (0x02<<3),  /* TxD: PD6, RxD: PD7, XCK: -, XDIR: - */
+    PORTMUX_USART1_NONE_gc = (0x03<<3)  /* Not connected to any pins */
+} PORTMUX_USART1_t;
+
+/* USART2 Routing select */
+typedef enum PORTMUX_USART2_enum
+{
+    PORTMUX_USART2_DEFAULT_gc = (0x00<<0),  /* TxD: PF0, RxD: PF1, XCK: PF2, XDIR: PF3 */
+    PORTMUX_USART2_ALT1_gc = (0x01<<0),  /* TxD: PF4, RxD: PF5, XCK: - , XDIR: - */
+    PORTMUX_USART2_NONE_gc = (0x03<<0)  /* Not connected to any pins */
+} PORTMUX_USART2_t;
+
+/*
+--------------------------------------------------------------------------
+RSTCTRL - Reset controller
+--------------------------------------------------------------------------
+*/
+
+/* Reset controller */
+typedef struct RSTCTRL_struct
+{
+    register8_t RSTFR;  /* Reset Flags */
+    register8_t SWRR;  /* Software Reset */
+    register8_t reserved_1[14];
+} RSTCTRL_t;
+
+
+/*
+--------------------------------------------------------------------------
+RTC - Real-Time Counter
+--------------------------------------------------------------------------
+*/
+
+/* Real-Time Counter */
+typedef struct RTC_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t STATUS;  /* Status */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t TEMP;  /* Temporary */
+    register8_t DBGCTRL;  /* Debug control */
+    register8_t CALIB;  /* Calibration */
+    register8_t CLKSEL;  /* Clock Select */
+    _WORDREGISTER(CNT);  /* Counter */
+    _WORDREGISTER(PER);  /* Period */
+    _WORDREGISTER(CMP);  /* Compare */
+    register8_t reserved_1[2];
+    register8_t PITCTRLA;  /* PIT Control A */
+    register8_t PITSTATUS;  /* PIT Status */
+    register8_t PITINTCTRL;  /* PIT Interrupt Control */
+    register8_t PITINTFLAGS;  /* PIT Interrupt Flags */
+    register8_t reserved_2[1];
+    register8_t PITDBGCTRL;  /* PIT Debug control */
+    register8_t PITEVGENCTRLA;  /* PIT Event Generation Control A */
+    register8_t reserved_3[9];
+} RTC_t;
+
+/* Clock Select */
+typedef enum RTC_CLKSEL_enum
+{
+    RTC_CLKSEL_OSC32K_gc = (0x00<<0),  /* Internal 32.768 kHz Oscillator */
+    RTC_CLKSEL_OSC1K_gc = (0x01<<0),  /* Internal 32.768 kHz Oscillator Divided by 32 */
+    RTC_CLKSEL_XOSC32K_gc = (0x02<<0),  /* 32.768 kHz Crystal Oscillator */
+    RTC_CLKSEL_EXTCLK_gc = (0x03<<0)  /* External Clock */
+} RTC_CLKSEL_t;
+
+/* Event Generation 0 Select */
+typedef enum RTC_EVGEN0SEL_enum
+{
+    RTC_EVGEN0SEL_OFF_gc = (0x00<<0),  /* No Event Generated */
+    RTC_EVGEN0SEL_DIV4_gc = (0x01<<0),  /* CLK_RTC divided by 4 */
+    RTC_EVGEN0SEL_DIV8_gc = (0x02<<0),  /* CLK_RTC divided by 8 */
+    RTC_EVGEN0SEL_DIV16_gc = (0x03<<0),  /* CLK_RTC divided by 16 */
+    RTC_EVGEN0SEL_DIV32_gc = (0x04<<0),  /* CLK_RTC divided by 32 */
+    RTC_EVGEN0SEL_DIV64_gc = (0x05<<0),  /* CLK_RTC divided by 64 */
+    RTC_EVGEN0SEL_DIV128_gc = (0x06<<0),  /* CLK_RTC divided by 128 */
+    RTC_EVGEN0SEL_DIV256_gc = (0x07<<0),  /* CLK_RTC divided by 256 */
+    RTC_EVGEN0SEL_DIV512_gc = (0x08<<0),  /* CLK_RTC divided by 512 */
+    RTC_EVGEN0SEL_DIV1024_gc = (0x09<<0),  /* CLK_RTC divided by 1024 */
+    RTC_EVGEN0SEL_DIV2048_gc = (0x0A<<0),  /* CLK_RTC divided by 2048 */
+    RTC_EVGEN0SEL_DIV4096_gc = (0x0B<<0),  /* CLK_RTC divided by 4096 */
+    RTC_EVGEN0SEL_DIV8192_gc = (0x0C<<0),  /* CLK_RTC divided by 8192 */
+    RTC_EVGEN0SEL_DIV16384_gc = (0x0D<<0),  /* CLK_RTC divided by 16384 */
+    RTC_EVGEN0SEL_DIV32768_gc = (0x0E<<0)  /* CLK_RTC divided by 32768 */
+} RTC_EVGEN0SEL_t;
+
+/* Event Generation 1 Select */
+typedef enum RTC_EVGEN1SEL_enum
+{
+    RTC_EVGEN1SEL_OFF_gc = (0x00<<4),  /* No Event Generated */
+    RTC_EVGEN1SEL_DIV4_gc = (0x01<<4),  /* CLK_RTC divided by 4 */
+    RTC_EVGEN1SEL_DIV8_gc = (0x02<<4),  /* CLK_RTC divided by 8 */
+    RTC_EVGEN1SEL_DIV16_gc = (0x03<<4),  /* CLK_RTC divided by 16 */
+    RTC_EVGEN1SEL_DIV32_gc = (0x04<<4),  /* CLK_RTC divided by 32 */
+    RTC_EVGEN1SEL_DIV64_gc = (0x05<<4),  /* CLK_RTC divided by 64 */
+    RTC_EVGEN1SEL_DIV128_gc = (0x06<<4),  /* CLK_RTC divided by 128 */
+    RTC_EVGEN1SEL_DIV256_gc = (0x07<<4),  /* CLK_RTC divided by 256 */
+    RTC_EVGEN1SEL_DIV512_gc = (0x08<<4),  /* CLK_RTC divided by 512 */
+    RTC_EVGEN1SEL_DIV1024_gc = (0x09<<4),  /* CLK_RTC divided by 1024 */
+    RTC_EVGEN1SEL_DIV2048_gc = (0x0A<<4),  /* CLK_RTC divided by 2048 */
+    RTC_EVGEN1SEL_DIV4096_gc = (0x0B<<4),  /* CLK_RTC divided by 4096 */
+    RTC_EVGEN1SEL_DIV8192_gc = (0x0C<<4),  /* CLK_RTC divided by 8192 */
+    RTC_EVGEN1SEL_DIV16384_gc = (0x0D<<4),  /* CLK_RTC divided by 16384 */
+    RTC_EVGEN1SEL_DIV32768_gc = (0x0E<<4)  /* CLK_RTC divided by 32768 */
+} RTC_EVGEN1SEL_t;
+
+/* Period select */
+typedef enum RTC_PERIOD_enum
+{
+    RTC_PERIOD_OFF_gc = (0x00<<3),  /* Off */
+    RTC_PERIOD_CYC4_gc = (0x01<<3),  /* RTC Clock Cycles 4 */
+    RTC_PERIOD_CYC8_gc = (0x02<<3),  /* RTC Clock Cycles 8 */
+    RTC_PERIOD_CYC16_gc = (0x03<<3),  /* RTC Clock Cycles 16 */
+    RTC_PERIOD_CYC32_gc = (0x04<<3),  /* RTC Clock Cycles 32 */
+    RTC_PERIOD_CYC64_gc = (0x05<<3),  /* RTC Clock Cycles 64 */
+    RTC_PERIOD_CYC128_gc = (0x06<<3),  /* RTC Clock Cycles 128 */
+    RTC_PERIOD_CYC256_gc = (0x07<<3),  /* RTC Clock Cycles 256 */
+    RTC_PERIOD_CYC512_gc = (0x08<<3),  /* RTC Clock Cycles 512 */
+    RTC_PERIOD_CYC1024_gc = (0x09<<3),  /* RTC Clock Cycles 1024 */
+    RTC_PERIOD_CYC2048_gc = (0x0A<<3),  /* RTC Clock Cycles 2048 */
+    RTC_PERIOD_CYC4096_gc = (0x0B<<3),  /* RTC Clock Cycles 4096 */
+    RTC_PERIOD_CYC8192_gc = (0x0C<<3),  /* RTC Clock Cycles 8192 */
+    RTC_PERIOD_CYC16384_gc = (0x0D<<3),  /* RTC Clock Cycles 16384 */
+    RTC_PERIOD_CYC32768_gc = (0x0E<<3)  /* RTC Clock Cycles 32768 */
+} RTC_PERIOD_t;
+
+/* Prescaling Factor select */
+typedef enum RTC_PRESCALER_enum
+{
+    RTC_PRESCALER_DIV1_gc = (0x00<<3),  /* RTC Clock / 1 */
+    RTC_PRESCALER_DIV2_gc = (0x01<<3),  /* RTC Clock / 2 */
+    RTC_PRESCALER_DIV4_gc = (0x02<<3),  /* RTC Clock / 4 */
+    RTC_PRESCALER_DIV8_gc = (0x03<<3),  /* RTC Clock / 8 */
+    RTC_PRESCALER_DIV16_gc = (0x04<<3),  /* RTC Clock / 16 */
+    RTC_PRESCALER_DIV32_gc = (0x05<<3),  /* RTC Clock / 32 */
+    RTC_PRESCALER_DIV64_gc = (0x06<<3),  /* RTC Clock / 64 */
+    RTC_PRESCALER_DIV128_gc = (0x07<<3),  /* RTC Clock / 128 */
+    RTC_PRESCALER_DIV256_gc = (0x08<<3),  /* RTC Clock / 256 */
+    RTC_PRESCALER_DIV512_gc = (0x09<<3),  /* RTC Clock / 512 */
+    RTC_PRESCALER_DIV1024_gc = (0x0A<<3),  /* RTC Clock / 1024 */
+    RTC_PRESCALER_DIV2048_gc = (0x0B<<3),  /* RTC Clock / 2048 */
+    RTC_PRESCALER_DIV4096_gc = (0x0C<<3),  /* RTC Clock / 4096 */
+    RTC_PRESCALER_DIV8192_gc = (0x0D<<3),  /* RTC Clock / 8192 */
+    RTC_PRESCALER_DIV16384_gc = (0x0E<<3),  /* RTC Clock / 16384 */
+    RTC_PRESCALER_DIV32768_gc = (0x0F<<3)  /* RTC Clock / 32768 */
+} RTC_PRESCALER_t;
+
+/*
+--------------------------------------------------------------------------
+SIGROW - Signature row
+--------------------------------------------------------------------------
+*/
+
+/* Signature row */
+typedef struct SIGROW_struct
+{
+    register8_t DEVICEID0;  /* Device ID Byte 0 */
+    register8_t DEVICEID1;  /* Device ID Byte 1 */
+    register8_t DEVICEID2;  /* Device ID Byte 2 */
+    register8_t reserved_1[1];
+    _WORDREGISTER(TEMPSENSE0);  /* Temperature Calibration 0 */
+    _WORDREGISTER(TEMPSENSE1);  /* Temperature Calibration 1 */
+    register8_t reserved_2[8];
+    register8_t SERNUM0;  /* Serial Number Byte 0 */
+    register8_t SERNUM1;  /* Serial Number Byte 1 */
+    register8_t SERNUM2;  /* Serial Number Byte 2 */
+    register8_t SERNUM3;  /* Serial Number Byte 3 */
+    register8_t SERNUM4;  /* Serial Number Byte 4 */
+    register8_t SERNUM5;  /* Serial Number Byte 5 */
+    register8_t SERNUM6;  /* Serial Number Byte 6 */
+    register8_t SERNUM7;  /* Serial Number Byte 7 */
+    register8_t SERNUM8;  /* Serial Number Byte 8 */
+    register8_t SERNUM9;  /* Serial Number Byte 9 */
+    register8_t SERNUM10;  /* Serial Number Byte 10 */
+    register8_t SERNUM11;  /* Serial Number Byte 11 */
+    register8_t SERNUM12;  /* Serial Number Byte 12 */
+    register8_t SERNUM13;  /* Serial Number Byte 13 */
+    register8_t SERNUM14;  /* Serial Number Byte 14 */
+    register8_t SERNUM15;  /* Serial Number Byte 15 */
+    register8_t reserved_3[32];
+} SIGROW_t;
+
+
+/*
+--------------------------------------------------------------------------
+SLPCTRL - Sleep Controller
+--------------------------------------------------------------------------
+*/
+
+/* Sleep Controller */
+typedef struct SLPCTRL_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t reserved_1[1];
+} SLPCTRL_t;
+
+/* Sleep mode select */
+typedef enum SLPCTRL_SMODE_enum
+{
+    SLPCTRL_SMODE_IDLE_gc = (0x00<<1),  /* Idle mode */
+    SLPCTRL_SMODE_STDBY_gc = (0x01<<1),  /* Standby Mode */
+    SLPCTRL_SMODE_PDOWN_gc = (0x02<<1)  /* Power-down Mode */
+} SLPCTRL_SMODE_t;
+
+#define SLEEP_MODE_IDLE (0x00<<1)
+#define SLEEP_MODE_STANDBY (0x01<<1)
+#define SLEEP_MODE_PWR_DOWN (0x02<<1)
+/*
+--------------------------------------------------------------------------
+SPI - Serial Peripheral Interface
+--------------------------------------------------------------------------
+*/
+
+/* Serial Peripheral Interface */
+typedef struct SPI_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t DATA;  /* Data */
+    register8_t reserved_1[3];
+} SPI_t;
+
+/* SPI Mode select */
+typedef enum SPI_MODE_enum
+{
+    SPI_MODE_0_gc = (0x00<<0),  /* SPI Mode 0 */
+    SPI_MODE_1_gc = (0x01<<0),  /* SPI Mode 1 */
+    SPI_MODE_2_gc = (0x02<<0),  /* SPI Mode 2 */
+    SPI_MODE_3_gc = (0x03<<0)  /* SPI Mode 3 */
+} SPI_MODE_t;
+
+/* Prescaler select */
+typedef enum SPI_PRESC_enum
+{
+    SPI_PRESC_DIV4_gc = (0x00<<1),  /* CLK_PER / 4 */
+    SPI_PRESC_DIV16_gc = (0x01<<1),  /* CLK_PER / 16 */
+    SPI_PRESC_DIV64_gc = (0x02<<1),  /* CLK_PER / 64 */
+    SPI_PRESC_DIV128_gc = (0x03<<1)  /* CLK_PER / 128 */
+} SPI_PRESC_t;
+
+/*
+--------------------------------------------------------------------------
+SYSCFG - System Configuration Registers
+--------------------------------------------------------------------------
+*/
+
+/* System Configuration Registers */
+typedef struct SYSCFG_struct
+{
+    register8_t reserved_1[1];
+    register8_t REVID;  /* Revision ID */
+    register8_t reserved_2[2];
+    register8_t OCDMCTRL;  /* OCD Message Control */
+    register8_t OCDMSTATUS;  /* OCD Message Status */
+    register8_t reserved_3[26];
+} SYSCFG_t;
+
+
+/*
+--------------------------------------------------------------------------
+TCA - 16-bit Timer/Counter Type A
+--------------------------------------------------------------------------
+*/
+
+/* 16-bit Timer/Counter Type A - Single Mode */
+typedef struct TCA_SINGLE_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    register8_t CTRLD;  /* Control D */
+    register8_t CTRLECLR;  /* Control E Clear */
+    register8_t CTRLESET;  /* Control E Set */
+    register8_t CTRLFCLR;  /* Control F Clear */
+    register8_t CTRLFSET;  /* Control F Set */
+    register8_t reserved_1[1];
+    register8_t EVCTRL;  /* Event Control */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t reserved_2[2];
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t TEMP;  /* Temporary data for 16-bit Access */
+    register8_t reserved_3[16];
+    _WORDREGISTER(CNT);  /* Count */
+    register8_t reserved_4[4];
+    _WORDREGISTER(PER);  /* Period */
+    _WORDREGISTER(CMP0);  /* Compare 0 */
+    _WORDREGISTER(CMP1);  /* Compare 1 */
+    _WORDREGISTER(CMP2);  /* Compare 2 */
+    register8_t reserved_5[8];
+    _WORDREGISTER(PERBUF);  /* Period Buffer */
+    _WORDREGISTER(CMP0BUF);  /* Compare 0 Buffer */
+    _WORDREGISTER(CMP1BUF);  /* Compare 1 Buffer */
+    _WORDREGISTER(CMP2BUF);  /* Compare 2 Buffer */
+    register8_t reserved_6[2];
+} TCA_SINGLE_t;
+
+/* 16-bit Timer/Counter Type A - Split Mode */
+typedef struct TCA_SPLIT_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    register8_t CTRLD;  /* Control D */
+    register8_t CTRLECLR;  /* Control E Clear */
+    register8_t CTRLESET;  /* Control E Set */
+    register8_t reserved_1[4];
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t reserved_2[2];
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t reserved_3[17];
+    register8_t LCNT;  /* Low Count */
+    register8_t HCNT;  /* High Count */
+    register8_t reserved_4[4];
+    register8_t LPER;  /* Low Period */
+    register8_t HPER;  /* High Period */
+    register8_t LCMP0;  /* Low Compare */
+    register8_t HCMP0;  /* High Compare */
+    register8_t LCMP1;  /* Low Compare */
+    register8_t HCMP1;  /* High Compare */
+    register8_t LCMP2;  /* Low Compare */
+    register8_t HCMP2;  /* High Compare */
+    register8_t reserved_5[18];
+} TCA_SPLIT_t;
+
+/* 16-bit Timer/Counter Type A */
+typedef union TCA_union
+{
+    TCA_SINGLE_t SINGLE;  /* Single Mode */
+    TCA_SPLIT_t SPLIT;  /* Split Mode */
+} TCA_t;
+
+/* Clock Selection */
+typedef enum TCA_SINGLE_CLKSEL_enum
+{
+    TCA_SINGLE_CLKSEL_DIV1_gc = (0x00<<1),  /* CLK_PER */
+    TCA_SINGLE_CLKSEL_DIV2_gc = (0x01<<1),  /* CLK_PER / 2 */
+    TCA_SINGLE_CLKSEL_DIV4_gc = (0x02<<1),  /* CLK_PER / 4 */
+    TCA_SINGLE_CLKSEL_DIV8_gc = (0x03<<1),  /* CLK_PER / 8 */
+    TCA_SINGLE_CLKSEL_DIV16_gc = (0x04<<1),  /* CLK_PER / 16 */
+    TCA_SINGLE_CLKSEL_DIV64_gc = (0x05<<1),  /* CLK_PER / 64 */
+    TCA_SINGLE_CLKSEL_DIV256_gc = (0x06<<1),  /* CLK_PER / 256 */
+    TCA_SINGLE_CLKSEL_DIV1024_gc = (0x07<<1)  /* CLK_PER / 1024 */
+} TCA_SINGLE_CLKSEL_t;
+
+/* Command select */
+typedef enum TCA_SINGLE_CMD_enum
+{
+    TCA_SINGLE_CMD_NONE_gc = (0x00<<2),  /* No Command */
+    TCA_SINGLE_CMD_UPDATE_gc = (0x01<<2),  /* Force Update */
+    TCA_SINGLE_CMD_RESTART_gc = (0x02<<2),  /* Force Restart */
+    TCA_SINGLE_CMD_RESET_gc = (0x03<<2)  /* Force Hard Reset */
+} TCA_SINGLE_CMD_t;
+
+/* Direction select */
+typedef enum TCA_SINGLE_DIR_enum
+{
+    TCA_SINGLE_DIR_UP_gc = (0x00<<0),  /* Count up */
+    TCA_SINGLE_DIR_DOWN_gc = (0x01<<0)  /* Count down */
+} TCA_SINGLE_DIR_t;
+
+/* Event Action A select */
+typedef enum TCA_SINGLE_EVACTA_enum
+{
+    TCA_SINGLE_EVACTA_CNT_POSEDGE_gc = (0x00<<1),  /* Count on positive edge event */
+    TCA_SINGLE_EVACTA_CNT_ANYEDGE_gc = (0x01<<1),  /* Count on any edge event */
+    TCA_SINGLE_EVACTA_CNT_HIGHLVL_gc = (0x02<<1),  /* Count on prescaled clock while event line is 1. */
+    TCA_SINGLE_EVACTA_UPDOWN_gc = (0x03<<1)  /* Count on prescaled clock. Event controls count direction. Up-count when event line is 0, down-count when event line is 1. */
+} TCA_SINGLE_EVACTA_t;
+
+/* Event Action B select */
+typedef enum TCA_SINGLE_EVACTB_enum
+{
+    TCA_SINGLE_EVACTB_NONE_gc = (0x00<<5),  /* No Action */
+    TCA_SINGLE_EVACTB_UPDOWN_gc = (0x03<<5),  /* Count on prescaled clock. Event controls count direction. Up-count when event line is 0, down-count when event line is 1. */
+    TCA_SINGLE_EVACTB_RESTART_POSEDGE_gc = (0x04<<5),  /* Restart counter at positive edge event */
+    TCA_SINGLE_EVACTB_RESTART_ANYEDGE_gc = (0x05<<5),  /* Restart counter on any edge event */
+    TCA_SINGLE_EVACTB_RESTART_HIGHLVL_gc = (0x06<<5)  /* Restart counter while event line is 1. */
+} TCA_SINGLE_EVACTB_t;
+
+/* Waveform generation mode select */
+typedef enum TCA_SINGLE_WGMODE_enum
+{
+    TCA_SINGLE_WGMODE_NORMAL_gc = (0x00<<0),  /* Normal Mode */
+    TCA_SINGLE_WGMODE_FRQ_gc = (0x01<<0),  /* Frequency Generation Mode */
+    TCA_SINGLE_WGMODE_SINGLESLOPE_gc = (0x03<<0),  /* Single Slope PWM */
+    TCA_SINGLE_WGMODE_DSTOP_gc = (0x05<<0),  /* Dual Slope PWM, overflow on TOP */
+    TCA_SINGLE_WGMODE_DSBOTH_gc = (0x06<<0),  /* Dual Slope PWM, overflow on TOP and BOTTOM */
+    TCA_SINGLE_WGMODE_DSBOTTOM_gc = (0x07<<0)  /* Dual Slope PWM, overflow on BOTTOM */
+} TCA_SINGLE_WGMODE_t;
+
+/* Clock Selection */
+typedef enum TCA_SPLIT_CLKSEL_enum
+{
+    TCA_SPLIT_CLKSEL_DIV1_gc = (0x00<<1),  /* CLK_PER */
+    TCA_SPLIT_CLKSEL_DIV2_gc = (0x01<<1),  /* CLK_PER / 2 */
+    TCA_SPLIT_CLKSEL_DIV4_gc = (0x02<<1),  /* CLK_PER / 4 */
+    TCA_SPLIT_CLKSEL_DIV8_gc = (0x03<<1),  /* CLK_PER / 8 */
+    TCA_SPLIT_CLKSEL_DIV16_gc = (0x04<<1),  /* CLK_PER / 16 */
+    TCA_SPLIT_CLKSEL_DIV64_gc = (0x05<<1),  /* CLK_PER / 64 */
+    TCA_SPLIT_CLKSEL_DIV256_gc = (0x06<<1),  /* CLK_PER / 256 */
+    TCA_SPLIT_CLKSEL_DIV1024_gc = (0x07<<1)  /* CLK_PER / 1024 */
+} TCA_SPLIT_CLKSEL_t;
+
+/* Command select */
+typedef enum TCA_SPLIT_CMD_enum
+{
+    TCA_SPLIT_CMD_NONE_gc = (0x00<<2),  /* No Command */
+    TCA_SPLIT_CMD_UPDATE_gc = (0x01<<2),  /* Force Update */
+    TCA_SPLIT_CMD_RESTART_gc = (0x02<<2),  /* Force Restart */
+    TCA_SPLIT_CMD_RESET_gc = (0x03<<2)  /* Force Hard Reset */
+} TCA_SPLIT_CMD_t;
+
+/* Command Enable select */
+typedef enum TCA_SPLIT_CMDEN_enum
+{
+    TCA_SPLIT_CMDEN_NONE_gc = (0x00<<0),  /* None */
+    TCA_SPLIT_CMDEN_BOTH_gc = (0x03<<0)  /* Both low byte and high byte counter */
+} TCA_SPLIT_CMDEN_t;
+
+/*
+--------------------------------------------------------------------------
+TCB - 16-bit Timer Type B
+--------------------------------------------------------------------------
+*/
+
+/* 16-bit Timer Type B */
+typedef struct TCB_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control Register B */
+    register8_t reserved_1[2];
+    register8_t EVCTRL;  /* Event Control */
+    register8_t INTCTRL;  /* Interrupt Control */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+    register8_t STATUS;  /* Status */
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t TEMP;  /* Temporary Value */
+    _WORDREGISTER(CNT);  /* Count */
+    _WORDREGISTER(CCMP);  /* Compare or Capture */
+    register8_t reserved_2[2];
+} TCB_t;
+
+/* Clock Select */
+typedef enum TCB_CLKSEL_enum
+{
+    TCB_CLKSEL_DIV1_gc = (0x00<<1),  /* CLK_PER */
+    TCB_CLKSEL_DIV2_gc = (0x01<<1),  /* CLK_PER/2 */
+    TCB_CLKSEL_TCA0_gc = (0x02<<1),  /* Use CLK_TCA from TCA0 */
+    TCB_CLKSEL_TCA1_gc = (0x03<<1),  /* Use CLK_TCA from TCA1 */
+    TCB_CLKSEL_EVENT_gc = (0x07<<1)  /* Count on event edge */
+} TCB_CLKSEL_t;
+
+/* Timer Mode select */
+typedef enum TCB_CNTMODE_enum
+{
+    TCB_CNTMODE_INT_gc = (0x00<<0),  /* Periodic Interrupt */
+    TCB_CNTMODE_TIMEOUT_gc = (0x01<<0),  /* Periodic Timeout */
+    TCB_CNTMODE_CAPT_gc = (0x02<<0),  /* Input Capture Event */
+    TCB_CNTMODE_FRQ_gc = (0x03<<0),  /* Input Capture Frequency measurement */
+    TCB_CNTMODE_PW_gc = (0x04<<0),  /* Input Capture Pulse-Width measurement */
+    TCB_CNTMODE_FRQPW_gc = (0x05<<0),  /* Input Capture Frequency and Pulse-Width measurement */
+    TCB_CNTMODE_SINGLE_gc = (0x06<<0),  /* Single Shot */
+    TCB_CNTMODE_PWM8_gc = (0x07<<0)  /* 8-bit PWM */
+} TCB_CNTMODE_t;
+
+/*
+--------------------------------------------------------------------------
+TWI - Two-Wire Interface
+--------------------------------------------------------------------------
+*/
+
+/* Two-Wire Interface */
+typedef struct TWI_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t DUALCTRL;  /* Dual Mode Control */
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t MCTRLA;  /* Host Control A */
+    register8_t MCTRLB;  /* Host Control B */
+    register8_t MSTATUS;  /* Host STATUS */
+    register8_t MBAUD;  /* Host Baud Rate */
+    register8_t MADDR;  /* Host Address */
+    register8_t MDATA;  /* Host Data */
+    register8_t SCTRLA;  /* Client Control A */
+    register8_t SCTRLB;  /* Client Control B */
+    register8_t SSTATUS;  /* Client Status */
+    register8_t SADDR;  /* Client Address */
+    register8_t SDATA;  /* Client Data */
+    register8_t SADDRMASK;  /* Client Address Mask */
+    register8_t reserved_1[1];
+} TWI_t;
+
+/* Acknowledge Action select */
+typedef enum TWI_ACKACT_enum
+{
+    TWI_ACKACT_ACK_gc = (0x00<<2),  /* Send ACK */
+    TWI_ACKACT_NACK_gc = (0x01<<2)  /* Send NACK */
+} TWI_ACKACT_t;
+
+/* Address or Stop select */
+typedef enum TWI_AP_enum
+{
+    TWI_AP_STOP_gc = (0x00<<0),  /* A Stop condition generated the interrupt on APIF flag */
+    TWI_AP_ADR_gc = (0x01<<0)  /* Address detection generated the interrupt on APIF flag */
+} TWI_AP_t;
+
+/* Bus State select */
+typedef enum TWI_BUSSTATE_enum
+{
+    TWI_BUSSTATE_UNKNOWN_gc = (0x00<<0),  /* Unknown bus state */
+    TWI_BUSSTATE_IDLE_gc = (0x01<<0),  /* Bus is idle */
+    TWI_BUSSTATE_OWNER_gc = (0x02<<0),  /* This TWI controls the bus */
+    TWI_BUSSTATE_BUSY_gc = (0x03<<0)  /* The bus is busy */
+} TWI_BUSSTATE_t;
+
+/* Debug Run select */
+typedef enum TWI_DBGRUN_enum
+{
+    TWI_DBGRUN_HALT_gc = (0x00<<0),  /* The peripheral is halted in Break Debug mode and ignores events */
+    TWI_DBGRUN_RUN_gc = (0x01<<0)  /* The peripheral will continue to run in Break Debug mode when the CPU is halted */
+} TWI_DBGRUN_t;
+
+/* Fast-mode Enable select */
+typedef enum TWI_FMEN_enum
+{
+    TWI_FMEN_OFF_gc = (0x00<<0),  /* SCL duty cycle operating according to Sm specification */
+    TWI_FMEN_ON_gc = (0x01<<0)  /* SCL duty cycle operating according to Fm specification */
+} TWI_FMEN_t;
+
+/* Fast-mode Plus Enable select */
+typedef enum TWI_FMPEN_enum
+{
+    TWI_FMPEN_OFF_gc = (0x00<<1),  /* Operating in Standard-mode or Fast-mode */
+    TWI_FMPEN_ON_gc = (0x01<<1)  /* Operating in Fast-mode Plus */
+} TWI_FMPEN_t;
+
+/* Input voltage transition level select */
+typedef enum TWI_INPUTLVL_enum
+{
+    TWI_INPUTLVL_I2C_gc = (0x00<<6),  /* I2C input voltage transition level */
+    TWI_INPUTLVL_SMBUS_gc = (0x01<<6)  /* SMBus 3.0 input voltage transition level */
+} TWI_INPUTLVL_t;
+
+/* Command select */
+typedef enum TWI_MCMD_enum
+{
+    TWI_MCMD_NOACT_gc = (0x00<<0),  /* No action */
+    TWI_MCMD_REPSTART_gc = (0x01<<0),  /* Execute Acknowledge Action followed by repeated Start. */
+    TWI_MCMD_RECVTRANS_gc = (0x02<<0),  /* Execute Acknowledge Action followed by a byte read/write operation. Read/write is defined by DIR. */
+    TWI_MCMD_STOP_gc = (0x03<<0)  /* Execute Acknowledge Action followed by issuing a Stop condition. */
+} TWI_MCMD_t;
+
+/* Command select */
+typedef enum TWI_SCMD_enum
+{
+    TWI_SCMD_NOACT_gc = (0x00<<0),  /* No Action */
+    TWI_SCMD_COMPTRANS_gc = (0x02<<0),  /* Complete transaction */
+    TWI_SCMD_RESPONSE_gc = (0x03<<0)  /* Used in response to an interrupt */
+} TWI_SCMD_t;
+
+/* SDA Hold Time select */
+typedef enum TWI_SDAHOLD_enum
+{
+    TWI_SDAHOLD_OFF_gc = (0x00<<2),  /* No SDA Hold Delay */
+    TWI_SDAHOLD_50NS_gc = (0x01<<2),  /* Short SDA hold time */
+    TWI_SDAHOLD_300NS_gc = (0x02<<2),  /* Meets SMBUS 2.0 specification under typical conditions */
+    TWI_SDAHOLD_500NS_gc = (0x03<<2)  /* Meets SMBUS 2.0 specificaiton across all corners */
+} TWI_SDAHOLD_t;
+
+/* SDA Setup Time select */
+typedef enum TWI_SDASETUP_enum
+{
+    TWI_SDASETUP_4CYC_gc = (0x00<<4),  /* SDA setup time is four clock cycles */
+    TWI_SDASETUP_8CYC_gc = (0x01<<4)  /* SDA setup time is eight clock cycle */
+} TWI_SDASETUP_t;
+
+/* Inactive Bus Time-Out select */
+typedef enum TWI_TIMEOUT_enum
+{
+    TWI_TIMEOUT_DISABLED_gc = (0x00<<2),  /* Bus time-out disabled. I2C. */
+    TWI_TIMEOUT_50US_gc = (0x01<<2),  /* 50us - SMBus */
+    TWI_TIMEOUT_100US_gc = (0x02<<2),  /* 100us */
+    TWI_TIMEOUT_200US_gc = (0x03<<2)  /* 200us */
+} TWI_TIMEOUT_t;
+
+/*
+--------------------------------------------------------------------------
+USART - Universal Synchronous and Asynchronous Receiver and Transmitter
+--------------------------------------------------------------------------
+*/
+
+/* Universal Synchronous and Asynchronous Receiver and Transmitter */
+typedef struct USART_struct
+{
+    register8_t RXDATAL;  /* Receive Data Low Byte */
+    register8_t RXDATAH;  /* Receive Data High Byte */
+    register8_t TXDATAL;  /* Transmit Data Low Byte */
+    register8_t TXDATAH;  /* Transmit Data High Byte */
+    register8_t STATUS;  /* Status */
+    register8_t CTRLA;  /* Control A */
+    register8_t CTRLB;  /* Control B */
+    register8_t CTRLC;  /* Control C */
+    _WORDREGISTER(BAUD);  /* Baud Rate */
+    register8_t CTRLD;  /* Control D */
+    register8_t DBGCTRL;  /* Debug Control */
+    register8_t EVCTRL;  /* Event Control */
+    register8_t TXPLCTRL;  /* IRCOM Transmitter Pulse Length Control */
+    register8_t RXPLCTRL;  /* IRCOM Receiver Pulse Length Control */
+    register8_t reserved_1[1];
+} USART_t;
+
+/* Auto Baud Window select */
+typedef enum USART_ABW_enum
+{
+    USART_ABW_WDW0_gc = (0x00<<6),  /* 18% tolerance */
+    USART_ABW_WDW1_gc = (0x01<<6),  /* 15% tolerance */
+    USART_ABW_WDW2_gc = (0x02<<6),  /* 21% tolerance */
+    USART_ABW_WDW3_gc = (0x03<<6)  /* 25% tolerance */
+} USART_ABW_t;
+
+/* Character Size select */
+typedef enum USART_CHSIZE_enum
+{
+    USART_CHSIZE_5BIT_gc = (0x00<<0),  /* Character size: 5 bit */
+    USART_CHSIZE_6BIT_gc = (0x01<<0),  /* Character size: 6 bit */
+    USART_CHSIZE_7BIT_gc = (0x02<<0),  /* Character size: 7 bit */
+    USART_CHSIZE_8BIT_gc = (0x03<<0),  /* Character size: 8 bit */
+    USART_CHSIZE_9BITL_gc = (0x06<<0),  /* Character size: 9 bit read low byte first */
+    USART_CHSIZE_9BITH_gc = (0x07<<0)  /* Character size: 9 bit read high byte first */
+} USART_CHSIZE_t;
+
+/* Communication Mode select */
+typedef enum USART_CMODE_enum
+{
+    USART_CMODE_ASYNCHRONOUS_gc = (0x00<<6),  /* Asynchronous Mode */
+    USART_CMODE_SYNCHRONOUS_gc = (0x01<<6),  /* Synchronous Mode */
+    USART_CMODE_IRCOM_gc = (0x02<<6),  /* Infrared Communication */
+    USART_CMODE_MSPI_gc = (0x03<<6)  /* SPI Host Mode */
+} USART_CMODE_t;
+
+/* Parity Mode select */
+typedef enum USART_PMODE_enum
+{
+    USART_PMODE_DISABLED_gc = (0x00<<4),  /* No Parity */
+    USART_PMODE_EVEN_gc = (0x02<<4),  /* Even Parity */
+    USART_PMODE_ODD_gc = (0x03<<4)  /* Odd Parity */
+} USART_PMODE_t;
+
+/* RS485 Mode internal transmitter select */
+typedef enum USART_RS485_enum
+{
+    USART_RS485_DISABLE_gc = (0x00<<0),  /* RS485 Mode disabled */
+    USART_RS485_ENABLE_gc = (0x01<<0)  /* RS485 Mode enabled */
+} USART_RS485_t;
+
+/* Receiver Mode select */
+typedef enum USART_RXMODE_enum
+{
+    USART_RXMODE_NORMAL_gc = (0x00<<1),  /* Normal mode */
+    USART_RXMODE_CLK2X_gc = (0x01<<1),  /* CLK2x mode */
+    USART_RXMODE_GENAUTO_gc = (0x02<<1),  /* Generic autobaud mode */
+    USART_RXMODE_LINAUTO_gc = (0x03<<1)  /* LIN constrained autobaud mode */
+} USART_RXMODE_t;
+
+/* Stop Bit Mode select */
+typedef enum USART_SBMODE_enum
+{
+    USART_SBMODE_1BIT_gc = (0x00<<3),  /* 1 stop bit */
+    USART_SBMODE_2BIT_gc = (0x01<<3)  /* 2 stop bits */
+} USART_SBMODE_t;
+
+/*
+--------------------------------------------------------------------------
+USERROW - User Row
+--------------------------------------------------------------------------
+*/
+
+/* User Row */
+typedef struct USERROW_struct
+{
+    register8_t USERROW0;  /* User Row Byte 0 */
+    register8_t USERROW1;  /* User Row Byte 1 */
+    register8_t USERROW2;  /* User Row Byte 2 */
+    register8_t USERROW3;  /* User Row Byte 3 */
+    register8_t USERROW4;  /* User Row Byte 4 */
+    register8_t USERROW5;  /* User Row Byte 5 */
+    register8_t USERROW6;  /* User Row Byte 6 */
+    register8_t USERROW7;  /* User Row Byte 7 */
+    register8_t USERROW8;  /* User Row Byte 8 */
+    register8_t USERROW9;  /* User Row Byte 9 */
+    register8_t USERROW10;  /* User Row Byte 10 */
+    register8_t USERROW11;  /* User Row Byte 11 */
+    register8_t USERROW12;  /* User Row Byte 12 */
+    register8_t USERROW13;  /* User Row Byte 13 */
+    register8_t USERROW14;  /* User Row Byte 14 */
+    register8_t USERROW15;  /* User Row Byte 15 */
+    register8_t USERROW16;  /* User Row Byte 16 */
+    register8_t USERROW17;  /* User Row Byte 17 */
+    register8_t USERROW18;  /* User Row Byte 18 */
+    register8_t USERROW19;  /* User Row Byte 19 */
+    register8_t USERROW20;  /* User Row Byte 20 */
+    register8_t USERROW21;  /* User Row Byte 21 */
+    register8_t USERROW22;  /* User Row Byte 22 */
+    register8_t USERROW23;  /* User Row Byte 23 */
+    register8_t USERROW24;  /* User Row Byte 24 */
+    register8_t USERROW25;  /* User Row Byte 25 */
+    register8_t USERROW26;  /* User Row Byte 26 */
+    register8_t USERROW27;  /* User Row Byte 27 */
+    register8_t USERROW28;  /* User Row Byte 28 */
+    register8_t USERROW29;  /* User Row Byte 29 */
+    register8_t USERROW30;  /* User Row Byte 30 */
+    register8_t USERROW31;  /* User Row Byte 31 */
+    register8_t USERROW32;  /* User Row Byte 32 */
+    register8_t USERROW33;  /* User Row Byte 33 */
+    register8_t USERROW34;  /* User Row Byte 34 */
+    register8_t USERROW35;  /* User Row Byte 35 */
+    register8_t USERROW36;  /* User Row Byte 36 */
+    register8_t USERROW37;  /* User Row Byte 37 */
+    register8_t USERROW38;  /* User Row Byte 38 */
+    register8_t USERROW39;  /* User Row Byte 39 */
+    register8_t USERROW40;  /* User Row Byte 40 */
+    register8_t USERROW41;  /* User Row Byte 41 */
+    register8_t USERROW42;  /* User Row Byte 42 */
+    register8_t USERROW43;  /* User Row Byte 43 */
+    register8_t USERROW44;  /* User Row Byte 44 */
+    register8_t USERROW45;  /* User Row Byte 45 */
+    register8_t USERROW46;  /* User Row Byte 46 */
+    register8_t USERROW47;  /* User Row Byte 47 */
+    register8_t USERROW48;  /* User Row Byte 48 */
+    register8_t USERROW49;  /* User Row Byte 49 */
+    register8_t USERROW50;  /* User Row Byte 50 */
+    register8_t USERROW51;  /* User Row Byte 51 */
+    register8_t USERROW52;  /* User Row Byte 52 */
+    register8_t USERROW53;  /* User Row Byte 53 */
+    register8_t USERROW54;  /* User Row Byte 54 */
+    register8_t USERROW55;  /* User Row Byte 55 */
+    register8_t USERROW56;  /* User Row Byte 56 */
+    register8_t USERROW57;  /* User Row Byte 57 */
+    register8_t USERROW58;  /* User Row Byte 58 */
+    register8_t USERROW59;  /* User Row Byte 59 */
+    register8_t USERROW60;  /* User Row Byte 60 */
+    register8_t USERROW61;  /* User Row Byte 61 */
+    register8_t USERROW62;  /* User Row Byte 62 */
+    register8_t USERROW63;  /* User Row Byte 63 */
+} USERROW_t;
+
+
+/*
+--------------------------------------------------------------------------
+VPORT - Virtual Ports
+--------------------------------------------------------------------------
+*/
+
+/* Virtual Ports */
+typedef struct VPORT_struct
+{
+    register8_t DIR;  /* Data Direction */
+    register8_t OUT;  /* Output Value */
+    register8_t IN;  /* Input Value */
+    register8_t INTFLAGS;  /* Interrupt Flags */
+} VPORT_t;
+
+
+/*
+--------------------------------------------------------------------------
+VREF - Voltage reference
+--------------------------------------------------------------------------
+*/
+
+/* Voltage reference */
+typedef struct VREF_struct
+{
+    register8_t reserved_1[2];
+    register8_t DAC0REF;  /* DAC0 Reference */
+    register8_t reserved_2[1];
+    register8_t ACREF;  /* AC Reference */
+} VREF_t;
+
+/* Reference select */
+typedef enum VREF_REFSEL_enum
+{
+    VREF_REFSEL_1V024_gc = (0x00<<0),  /* Internal 1.024V reference */
+    VREF_REFSEL_2V048_gc = (0x01<<0),  /* Internal 2.048V reference */
+    VREF_REFSEL_4V096_gc = (0x02<<0),  /* Internal 4.096V reference */
+    VREF_REFSEL_2V500_gc = (0x03<<0),  /* Internal 2.500V reference */
+    VREF_REFSEL_VDD_gc = (0x05<<0),  /* VDD as reference */
+    VREF_REFSEL_VREFA_gc = (0x06<<0)  /* External reference on VREFA pin */
+} VREF_REFSEL_t;
+
+/*
+--------------------------------------------------------------------------
+WDT - Watch-Dog Timer
+--------------------------------------------------------------------------
+*/
+
+/* Watch-Dog Timer */
+typedef struct WDT_struct
+{
+    register8_t CTRLA;  /* Control A */
+    register8_t STATUS;  /* Status */
+    register8_t reserved_1[14];
+} WDT_t;
+
+/* Period select */
+typedef enum WDT_PERIOD_enum
+{
+    WDT_PERIOD_OFF_gc = (0x00<<0),  /* Off */
+    WDT_PERIOD_8CLK_gc = (0x01<<0),  /* 8 cycles (8ms) */
+    WDT_PERIOD_16CLK_gc = (0x02<<0),  /* 16 cycles (16ms) */
+    WDT_PERIOD_32CLK_gc = (0x03<<0),  /* 32 cycles (32ms) */
+    WDT_PERIOD_64CLK_gc = (0x04<<0),  /* 64 cycles (64ms) */
+    WDT_PERIOD_128CLK_gc = (0x05<<0),  /* 128 cycles (0.128s) */
+    WDT_PERIOD_256CLK_gc = (0x06<<0),  /* 256 cycles (0.256s) */
+    WDT_PERIOD_512CLK_gc = (0x07<<0),  /* 512 cycles (0.512s) */
+    WDT_PERIOD_1KCLK_gc = (0x08<<0),  /* 1K cycles (1.0s) */
+    WDT_PERIOD_2KCLK_gc = (0x09<<0),  /* 2K cycles (2.0s) */
+    WDT_PERIOD_4KCLK_gc = (0x0A<<0),  /* 4K cycles (4.1s) */
+    WDT_PERIOD_8KCLK_gc = (0x0B<<0)  /* 8K cycles (8.2s) */
+} WDT_PERIOD_t;
+
+/* Window select */
+typedef enum WDT_WINDOW_enum
+{
+    WDT_WINDOW_OFF_gc = (0x00<<4),  /* Off */
+    WDT_WINDOW_8CLK_gc = (0x01<<4),  /* 8 cycles (8ms) */
+    WDT_WINDOW_16CLK_gc = (0x02<<4),  /* 16 cycles (16ms) */
+    WDT_WINDOW_32CLK_gc = (0x03<<4),  /* 32 cycles (32ms) */
+    WDT_WINDOW_64CLK_gc = (0x04<<4),  /* 64 cycles (64ms) */
+    WDT_WINDOW_128CLK_gc = (0x05<<4),  /* 128 cycles (0.128s) */
+    WDT_WINDOW_256CLK_gc = (0x06<<4),  /* 256 cycles (0.256s) */
+    WDT_WINDOW_512CLK_gc = (0x07<<4),  /* 512 cycles (0.512s) */
+    WDT_WINDOW_1KCLK_gc = (0x08<<4),  /* 1K cycles (1.0s) */
+    WDT_WINDOW_2KCLK_gc = (0x09<<4),  /* 2K cycles (2.0s) */
+    WDT_WINDOW_4KCLK_gc = (0x0A<<4),  /* 4K cycles (4.1s) */
+    WDT_WINDOW_8KCLK_gc = (0x0B<<4)  /* 8K cycles (8.2s) */
+} WDT_WINDOW_t;
+/*
+==========================================================================
+IO Module Instances. Mapped to memory.
+==========================================================================
+*/
+
+#define VPORTA              (*(VPORT_t *) 0x0000) /* Virtual Ports */
+#define VPORTB              (*(VPORT_t *) 0x0004) /* Virtual Ports */
+#define VPORTC              (*(VPORT_t *) 0x0008) /* Virtual Ports */
+#define VPORTD              (*(VPORT_t *) 0x000C) /* Virtual Ports */
+#define VPORTE              (*(VPORT_t *) 0x0010) /* Virtual Ports */
+#define VPORTF              (*(VPORT_t *) 0x0014) /* Virtual Ports */
+#define GPR                   (*(GPR_t *) 0x001C) /* General Purpose Registers */
+#define RSTCTRL           (*(RSTCTRL_t *) 0x0040) /* Reset controller */
+#define SLPCTRL           (*(SLPCTRL_t *) 0x0050) /* Sleep Controller */
+#define CLKCTRL           (*(CLKCTRL_t *) 0x0060) /* Clock controller */
+#define BOD                   (*(BOD_t *) 0x00A0) /* Bod interface */
+#define VREF                 (*(VREF_t *) 0x00B0) /* Voltage reference */
+#define WDT                   (*(WDT_t *) 0x0100) /* Watch-Dog Timer */
+#define CPUINT             (*(CPUINT_t *) 0x0110) /* Interrupt Controller */
+#define CRCSCAN           (*(CRCSCAN_t *) 0x0120) /* CRCSCAN */
+#define RTC                   (*(RTC_t *) 0x0140) /* Real-Time Counter */
+#define CCL                   (*(CCL_t *) 0x01C0) /* Configurable Custom Logic */
+#define EVSYS               (*(EVSYS_t *) 0x0200) /* Event System */
+#define PORTA                (*(PORT_t *) 0x0400) /* I/O Ports */
+#define PORTB                (*(PORT_t *) 0x0420) /* I/O Ports */
+#define PORTC                (*(PORT_t *) 0x0440) /* I/O Ports */
+#define PORTD                (*(PORT_t *) 0x0460) /* I/O Ports */
+#define PORTE                (*(PORT_t *) 0x0480) /* I/O Ports */
+#define PORTF                (*(PORT_t *) 0x04A0) /* I/O Ports */
+#define PORTMUX           (*(PORTMUX_t *) 0x05E0) /* Port Multiplexer */
+#define ADC0                  (*(ADC_t *) 0x0600) /* Analog to Digital Converter */
+#define AC0                    (*(AC_t *) 0x0680) /* Analog Comparator */
+#define AC1                    (*(AC_t *) 0x0688) /* Analog Comparator */
+#define DAC0                  (*(DAC_t *) 0x06A0) /* Digital to Analog Converter */
+#define USART0              (*(USART_t *) 0x0800) /* Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define USART1              (*(USART_t *) 0x0820) /* Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define USART2              (*(USART_t *) 0x0840) /* Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define TWI0                  (*(TWI_t *) 0x0900) /* Two-Wire Interface */
+#define SPI0                  (*(SPI_t *) 0x0940) /* Serial Peripheral Interface */
+#define TCA0                  (*(TCA_t *) 0x0A00) /* 16-bit Timer/Counter Type A */
+#define TCA1                  (*(TCA_t *) 0x0A40) /* 16-bit Timer/Counter Type A */
+#define TCB0                  (*(TCB_t *) 0x0B00) /* 16-bit Timer Type B */
+#define TCB1                  (*(TCB_t *) 0x0B10) /* 16-bit Timer Type B */
+#define TCB2                  (*(TCB_t *) 0x0B20) /* 16-bit Timer Type B */
+#define TCB3                  (*(TCB_t *) 0x0B30) /* 16-bit Timer Type B */
+#define SYSCFG             (*(SYSCFG_t *) 0x0F00) /* System Configuration Registers */
+#define NVMCTRL           (*(NVMCTRL_t *) 0x1000) /* Non-volatile Memory Controller */
+#define LOCK                 (*(LOCK_t *) 0x1040) /* Lockbits */
+#define FUSE                 (*(FUSE_t *) 0x1050) /* Fuses */
+#define USERROW           (*(USERROW_t *) 0x1080) /* User Row */
+#define SIGROW             (*(SIGROW_t *) 0x1100) /* Signature row */
+
+#endif /* !defined (__ASSEMBLER__) */
+
+
+/* ========== Flattened fully qualified IO register names ========== */
+
+
+/* VPORT (VPORTA) - Virtual Ports */
+#define VPORTA_DIR  _SFR_MEM8(0x0000)
+#define VPORTA_OUT  _SFR_MEM8(0x0001)
+#define VPORTA_IN  _SFR_MEM8(0x0002)
+#define VPORTA_INTFLAGS  _SFR_MEM8(0x0003)
+
+
+/* VPORT (VPORTB) - Virtual Ports */
+#define VPORTB_DIR  _SFR_MEM8(0x0004)
+#define VPORTB_OUT  _SFR_MEM8(0x0005)
+#define VPORTB_IN  _SFR_MEM8(0x0006)
+#define VPORTB_INTFLAGS  _SFR_MEM8(0x0007)
+
+
+/* VPORT (VPORTC) - Virtual Ports */
+#define VPORTC_DIR  _SFR_MEM8(0x0008)
+#define VPORTC_OUT  _SFR_MEM8(0x0009)
+#define VPORTC_IN  _SFR_MEM8(0x000A)
+#define VPORTC_INTFLAGS  _SFR_MEM8(0x000B)
+
+
+/* VPORT (VPORTD) - Virtual Ports */
+#define VPORTD_DIR  _SFR_MEM8(0x000C)
+#define VPORTD_OUT  _SFR_MEM8(0x000D)
+#define VPORTD_IN  _SFR_MEM8(0x000E)
+#define VPORTD_INTFLAGS  _SFR_MEM8(0x000F)
+
+
+/* VPORT (VPORTE) - Virtual Ports */
+#define VPORTE_DIR  _SFR_MEM8(0x0010)
+#define VPORTE_OUT  _SFR_MEM8(0x0011)
+#define VPORTE_IN  _SFR_MEM8(0x0012)
+#define VPORTE_INTFLAGS  _SFR_MEM8(0x0013)
+
+
+/* VPORT (VPORTF) - Virtual Ports */
+#define VPORTF_DIR  _SFR_MEM8(0x0014)
+#define VPORTF_OUT  _SFR_MEM8(0x0015)
+#define VPORTF_IN  _SFR_MEM8(0x0016)
+#define VPORTF_INTFLAGS  _SFR_MEM8(0x0017)
+
+
+/* GPR - General Purpose Registers */
+#define GPR_GPR0  _SFR_MEM8(0x001C)
+#define GPR_GPR1  _SFR_MEM8(0x001D)
+#define GPR_GPR2  _SFR_MEM8(0x001E)
+#define GPR_GPR3  _SFR_MEM8(0x001F)
+
+
+/* CPU - CPU */
+#define CPU_CCP  _SFR_MEM8(0x0034)
+#define CPU_SP  _SFR_MEM16(0x003D)
+#define CPU_SPL  _SFR_MEM8(0x003D)
+#define CPU_SPH  _SFR_MEM8(0x003E)
+#define CPU_SREG  _SFR_MEM8(0x003F)
+
+
+/* RSTCTRL - Reset controller */
+#define RSTCTRL_RSTFR  _SFR_MEM8(0x0040)
+#define RSTCTRL_SWRR  _SFR_MEM8(0x0041)
+
+
+/* SLPCTRL - Sleep Controller */
+#define SLPCTRL_CTRLA  _SFR_MEM8(0x0050)
+
+
+/* CLKCTRL - Clock controller */
+#define CLKCTRL_MCLKCTRLA  _SFR_MEM8(0x0060)
+#define CLKCTRL_MCLKCTRLB  _SFR_MEM8(0x0061)
+#define CLKCTRL_MCLKCTRLC  _SFR_MEM8(0x0062)
+#define CLKCTRL_MCLKINTCTRL  _SFR_MEM8(0x0063)
+#define CLKCTRL_MCLKINTFLAGS  _SFR_MEM8(0x0064)
+#define CLKCTRL_MCLKSTATUS  _SFR_MEM8(0x0065)
+#define CLKCTRL_MCLKTIMEBASE  _SFR_MEM8(0x0066)
+#define CLKCTRL_OSCHFCTRLA  _SFR_MEM8(0x0068)
+#define CLKCTRL_OSCHFTUNE  _SFR_MEM8(0x0069)
+#define CLKCTRL_OSC32KCTRLA  _SFR_MEM8(0x0078)
+#define CLKCTRL_XOSC32KCTRLA  _SFR_MEM8(0x007C)
+#define CLKCTRL_XOSCHFCTRLA  _SFR_MEM8(0x0080)
+
+
+/* BOD - Bod interface */
+#define BOD_CTRLA  _SFR_MEM8(0x00A0)
+#define BOD_CTRLB  _SFR_MEM8(0x00A1)
+#define BOD_VLMCTRLA  _SFR_MEM8(0x00A8)
+#define BOD_INTCTRL  _SFR_MEM8(0x00A9)
+#define BOD_INTFLAGS  _SFR_MEM8(0x00AA)
+#define BOD_STATUS  _SFR_MEM8(0x00AB)
+
+
+/* VREF - Voltage reference */
+#define VREF_DAC0REF  _SFR_MEM8(0x00B2)
+#define VREF_ACREF  _SFR_MEM8(0x00B4)
+
+
+/* WDT - Watch-Dog Timer */
+#define WDT_CTRLA  _SFR_MEM8(0x0100)
+#define WDT_STATUS  _SFR_MEM8(0x0101)
+
+
+/* CPUINT - Interrupt Controller */
+#define CPUINT_CTRLA  _SFR_MEM8(0x0110)
+#define CPUINT_STATUS  _SFR_MEM8(0x0111)
+#define CPUINT_LVL0PRI  _SFR_MEM8(0x0112)
+#define CPUINT_LVL1VEC  _SFR_MEM8(0x0113)
+
+
+/* CRCSCAN - CRCSCAN */
+#define CRCSCAN_CTRLA  _SFR_MEM8(0x0120)
+#define CRCSCAN_CTRLB  _SFR_MEM8(0x0121)
+#define CRCSCAN_STATUS  _SFR_MEM8(0x0122)
+
+
+/* RTC - Real-Time Counter */
+#define RTC_CTRLA  _SFR_MEM8(0x0140)
+#define RTC_STATUS  _SFR_MEM8(0x0141)
+#define RTC_INTCTRL  _SFR_MEM8(0x0142)
+#define RTC_INTFLAGS  _SFR_MEM8(0x0143)
+#define RTC_TEMP  _SFR_MEM8(0x0144)
+#define RTC_DBGCTRL  _SFR_MEM8(0x0145)
+#define RTC_CALIB  _SFR_MEM8(0x0146)
+#define RTC_CLKSEL  _SFR_MEM8(0x0147)
+#define RTC_CNT  _SFR_MEM16(0x0148)
+#define RTC_CNTL  _SFR_MEM8(0x0148)
+#define RTC_CNTH  _SFR_MEM8(0x0149)
+#define RTC_PER  _SFR_MEM16(0x014A)
+#define RTC_PERL  _SFR_MEM8(0x014A)
+#define RTC_PERH  _SFR_MEM8(0x014B)
+#define RTC_CMP  _SFR_MEM16(0x014C)
+#define RTC_CMPL  _SFR_MEM8(0x014C)
+#define RTC_CMPH  _SFR_MEM8(0x014D)
+#define RTC_PITCTRLA  _SFR_MEM8(0x0150)
+#define RTC_PITSTATUS  _SFR_MEM8(0x0151)
+#define RTC_PITINTCTRL  _SFR_MEM8(0x0152)
+#define RTC_PITINTFLAGS  _SFR_MEM8(0x0153)
+#define RTC_PITDBGCTRL  _SFR_MEM8(0x0155)
+#define RTC_PITEVGENCTRLA  _SFR_MEM8(0x0156)
+
+
+/* CCL - Configurable Custom Logic */
+#define CCL_CTRLA  _SFR_MEM8(0x01C0)
+#define CCL_SEQCTRL0  _SFR_MEM8(0x01C1)
+#define CCL_SEQCTRL1  _SFR_MEM8(0x01C2)
+#define CCL_INTCTRL0  _SFR_MEM8(0x01C5)
+#define CCL_INTFLAGS  _SFR_MEM8(0x01C7)
+#define CCL_LUT0CTRLA  _SFR_MEM8(0x01C8)
+#define CCL_LUT0CTRLB  _SFR_MEM8(0x01C9)
+#define CCL_LUT0CTRLC  _SFR_MEM8(0x01CA)
+#define CCL_TRUTH0  _SFR_MEM8(0x01CB)
+#define CCL_LUT1CTRLA  _SFR_MEM8(0x01CC)
+#define CCL_LUT1CTRLB  _SFR_MEM8(0x01CD)
+#define CCL_LUT1CTRLC  _SFR_MEM8(0x01CE)
+#define CCL_TRUTH1  _SFR_MEM8(0x01CF)
+#define CCL_LUT2CTRLA  _SFR_MEM8(0x01D0)
+#define CCL_LUT2CTRLB  _SFR_MEM8(0x01D1)
+#define CCL_LUT2CTRLC  _SFR_MEM8(0x01D2)
+#define CCL_TRUTH2  _SFR_MEM8(0x01D3)
+#define CCL_LUT3CTRLA  _SFR_MEM8(0x01D4)
+#define CCL_LUT3CTRLB  _SFR_MEM8(0x01D5)
+#define CCL_LUT3CTRLC  _SFR_MEM8(0x01D6)
+#define CCL_TRUTH3  _SFR_MEM8(0x01D7)
+
+
+/* EVSYS - Event System */
+#define EVSYS_SWEVENTA  _SFR_MEM8(0x0200)
+#define EVSYS_CHANNEL0  _SFR_MEM8(0x0210)
+#define EVSYS_CHANNEL1  _SFR_MEM8(0x0211)
+#define EVSYS_CHANNEL2  _SFR_MEM8(0x0212)
+#define EVSYS_CHANNEL3  _SFR_MEM8(0x0213)
+#define EVSYS_CHANNEL4  _SFR_MEM8(0x0214)
+#define EVSYS_CHANNEL5  _SFR_MEM8(0x0215)
+#define EVSYS_USERCCLLUT0A  _SFR_MEM8(0x0220)
+#define EVSYS_USERCCLLUT0B  _SFR_MEM8(0x0221)
+#define EVSYS_USERCCLLUT1A  _SFR_MEM8(0x0222)
+#define EVSYS_USERCCLLUT1B  _SFR_MEM8(0x0223)
+#define EVSYS_USERCCLLUT2A  _SFR_MEM8(0x0224)
+#define EVSYS_USERCCLLUT2B  _SFR_MEM8(0x0225)
+#define EVSYS_USERCCLLUT3A  _SFR_MEM8(0x0226)
+#define EVSYS_USERCCLLUT3B  _SFR_MEM8(0x0227)
+#define EVSYS_USERADC0START  _SFR_MEM8(0x0228)
+#define EVSYS_USEREVSYSEVOUTA  _SFR_MEM8(0x0229)
+#define EVSYS_USEREVSYSEVOUTB  _SFR_MEM8(0x022A)
+#define EVSYS_USEREVSYSEVOUTC  _SFR_MEM8(0x022B)
+#define EVSYS_USEREVSYSEVOUTD  _SFR_MEM8(0x022C)
+#define EVSYS_USEREVSYSEVOUTE  _SFR_MEM8(0x022D)
+#define EVSYS_USEREVSYSEVOUTF  _SFR_MEM8(0x022E)
+#define EVSYS_USERUSART0IRDA  _SFR_MEM8(0x022F)
+#define EVSYS_USERUSART1IRDA  _SFR_MEM8(0x0230)
+#define EVSYS_USERUSART2IRDA  _SFR_MEM8(0x0231)
+#define EVSYS_USERTCA0CNTA  _SFR_MEM8(0x0232)
+#define EVSYS_USERTCA0CNTB  _SFR_MEM8(0x0233)
+#define EVSYS_USERTCA1CNTA  _SFR_MEM8(0x0234)
+#define EVSYS_USERTCA1CNTB  _SFR_MEM8(0x0235)
+#define EVSYS_USERTCB0CAPT  _SFR_MEM8(0x0236)
+#define EVSYS_USERTCB0COUNT  _SFR_MEM8(0x0237)
+#define EVSYS_USERTCB1CAPT  _SFR_MEM8(0x0238)
+#define EVSYS_USERTCB1COUNT  _SFR_MEM8(0x0239)
+#define EVSYS_USERTCB2CAPT  _SFR_MEM8(0x023A)
+#define EVSYS_USERTCB2COUNT  _SFR_MEM8(0x023B)
+#define EVSYS_USERTCB3CAPT  _SFR_MEM8(0x023C)
+#define EVSYS_USERTCB3COUNT  _SFR_MEM8(0x023D)
+
+
+/* PORT (PORTA) - I/O Ports */
+#define PORTA_DIR  _SFR_MEM8(0x0400)
+#define PORTA_DIRSET  _SFR_MEM8(0x0401)
+#define PORTA_DIRCLR  _SFR_MEM8(0x0402)
+#define PORTA_DIRTGL  _SFR_MEM8(0x0403)
+#define PORTA_OUT  _SFR_MEM8(0x0404)
+#define PORTA_OUTSET  _SFR_MEM8(0x0405)
+#define PORTA_OUTCLR  _SFR_MEM8(0x0406)
+#define PORTA_OUTTGL  _SFR_MEM8(0x0407)
+#define PORTA_IN  _SFR_MEM8(0x0408)
+#define PORTA_INTFLAGS  _SFR_MEM8(0x0409)
+#define PORTA_PORTCTRL  _SFR_MEM8(0x040A)
+#define PORTA_PINCONFIG  _SFR_MEM8(0x040B)
+#define PORTA_PINCTRLUPD  _SFR_MEM8(0x040C)
+#define PORTA_PINCTRLSET  _SFR_MEM8(0x040D)
+#define PORTA_PINCTRLCLR  _SFR_MEM8(0x040E)
+#define PORTA_PIN0CTRL  _SFR_MEM8(0x0410)
+#define PORTA_PIN1CTRL  _SFR_MEM8(0x0411)
+#define PORTA_PIN2CTRL  _SFR_MEM8(0x0412)
+#define PORTA_PIN3CTRL  _SFR_MEM8(0x0413)
+#define PORTA_PIN4CTRL  _SFR_MEM8(0x0414)
+#define PORTA_PIN5CTRL  _SFR_MEM8(0x0415)
+#define PORTA_PIN6CTRL  _SFR_MEM8(0x0416)
+#define PORTA_PIN7CTRL  _SFR_MEM8(0x0417)
+#define PORTA_EVGENCTRL  _SFR_MEM8(0x0418)
+
+
+/* PORT (PORTB) - I/O Ports */
+#define PORTB_DIR  _SFR_MEM8(0x0420)
+#define PORTB_DIRSET  _SFR_MEM8(0x0421)
+#define PORTB_DIRCLR  _SFR_MEM8(0x0422)
+#define PORTB_DIRTGL  _SFR_MEM8(0x0423)
+#define PORTB_OUT  _SFR_MEM8(0x0424)
+#define PORTB_OUTSET  _SFR_MEM8(0x0425)
+#define PORTB_OUTCLR  _SFR_MEM8(0x0426)
+#define PORTB_OUTTGL  _SFR_MEM8(0x0427)
+#define PORTB_IN  _SFR_MEM8(0x0428)
+#define PORTB_INTFLAGS  _SFR_MEM8(0x0429)
+#define PORTB_PORTCTRL  _SFR_MEM8(0x042A)
+#define PORTB_PINCONFIG  _SFR_MEM8(0x042B)
+#define PORTB_PINCTRLUPD  _SFR_MEM8(0x042C)
+#define PORTB_PINCTRLSET  _SFR_MEM8(0x042D)
+#define PORTB_PINCTRLCLR  _SFR_MEM8(0x042E)
+#define PORTB_PIN0CTRL  _SFR_MEM8(0x0430)
+#define PORTB_PIN1CTRL  _SFR_MEM8(0x0431)
+#define PORTB_PIN2CTRL  _SFR_MEM8(0x0432)
+#define PORTB_PIN3CTRL  _SFR_MEM8(0x0433)
+#define PORTB_PIN4CTRL  _SFR_MEM8(0x0434)
+#define PORTB_PIN5CTRL  _SFR_MEM8(0x0435)
+#define PORTB_PIN6CTRL  _SFR_MEM8(0x0436)
+#define PORTB_PIN7CTRL  _SFR_MEM8(0x0437)
+#define PORTB_EVGENCTRL  _SFR_MEM8(0x0438)
+
+
+/* PORT (PORTC) - I/O Ports */
+#define PORTC_DIR  _SFR_MEM8(0x0440)
+#define PORTC_DIRSET  _SFR_MEM8(0x0441)
+#define PORTC_DIRCLR  _SFR_MEM8(0x0442)
+#define PORTC_DIRTGL  _SFR_MEM8(0x0443)
+#define PORTC_OUT  _SFR_MEM8(0x0444)
+#define PORTC_OUTSET  _SFR_MEM8(0x0445)
+#define PORTC_OUTCLR  _SFR_MEM8(0x0446)
+#define PORTC_OUTTGL  _SFR_MEM8(0x0447)
+#define PORTC_IN  _SFR_MEM8(0x0448)
+#define PORTC_INTFLAGS  _SFR_MEM8(0x0449)
+#define PORTC_PORTCTRL  _SFR_MEM8(0x044A)
+#define PORTC_PINCONFIG  _SFR_MEM8(0x044B)
+#define PORTC_PINCTRLUPD  _SFR_MEM8(0x044C)
+#define PORTC_PINCTRLSET  _SFR_MEM8(0x044D)
+#define PORTC_PINCTRLCLR  _SFR_MEM8(0x044E)
+#define PORTC_PIN0CTRL  _SFR_MEM8(0x0450)
+#define PORTC_PIN1CTRL  _SFR_MEM8(0x0451)
+#define PORTC_PIN2CTRL  _SFR_MEM8(0x0452)
+#define PORTC_PIN3CTRL  _SFR_MEM8(0x0453)
+#define PORTC_PIN4CTRL  _SFR_MEM8(0x0454)
+#define PORTC_PIN5CTRL  _SFR_MEM8(0x0455)
+#define PORTC_PIN6CTRL  _SFR_MEM8(0x0456)
+#define PORTC_PIN7CTRL  _SFR_MEM8(0x0457)
+#define PORTC_EVGENCTRL  _SFR_MEM8(0x0458)
+
+
+/* PORT (PORTD) - I/O Ports */
+#define PORTD_DIR  _SFR_MEM8(0x0460)
+#define PORTD_DIRSET  _SFR_MEM8(0x0461)
+#define PORTD_DIRCLR  _SFR_MEM8(0x0462)
+#define PORTD_DIRTGL  _SFR_MEM8(0x0463)
+#define PORTD_OUT  _SFR_MEM8(0x0464)
+#define PORTD_OUTSET  _SFR_MEM8(0x0465)
+#define PORTD_OUTCLR  _SFR_MEM8(0x0466)
+#define PORTD_OUTTGL  _SFR_MEM8(0x0467)
+#define PORTD_IN  _SFR_MEM8(0x0468)
+#define PORTD_INTFLAGS  _SFR_MEM8(0x0469)
+#define PORTD_PORTCTRL  _SFR_MEM8(0x046A)
+#define PORTD_PINCONFIG  _SFR_MEM8(0x046B)
+#define PORTD_PINCTRLUPD  _SFR_MEM8(0x046C)
+#define PORTD_PINCTRLSET  _SFR_MEM8(0x046D)
+#define PORTD_PINCTRLCLR  _SFR_MEM8(0x046E)
+#define PORTD_PIN0CTRL  _SFR_MEM8(0x0470)
+#define PORTD_PIN1CTRL  _SFR_MEM8(0x0471)
+#define PORTD_PIN2CTRL  _SFR_MEM8(0x0472)
+#define PORTD_PIN3CTRL  _SFR_MEM8(0x0473)
+#define PORTD_PIN4CTRL  _SFR_MEM8(0x0474)
+#define PORTD_PIN5CTRL  _SFR_MEM8(0x0475)
+#define PORTD_PIN6CTRL  _SFR_MEM8(0x0476)
+#define PORTD_PIN7CTRL  _SFR_MEM8(0x0477)
+#define PORTD_EVGENCTRL  _SFR_MEM8(0x0478)
+
+
+/* PORT (PORTE) - I/O Ports */
+#define PORTE_DIR  _SFR_MEM8(0x0480)
+#define PORTE_DIRSET  _SFR_MEM8(0x0481)
+#define PORTE_DIRCLR  _SFR_MEM8(0x0482)
+#define PORTE_DIRTGL  _SFR_MEM8(0x0483)
+#define PORTE_OUT  _SFR_MEM8(0x0484)
+#define PORTE_OUTSET  _SFR_MEM8(0x0485)
+#define PORTE_OUTCLR  _SFR_MEM8(0x0486)
+#define PORTE_OUTTGL  _SFR_MEM8(0x0487)
+#define PORTE_IN  _SFR_MEM8(0x0488)
+#define PORTE_INTFLAGS  _SFR_MEM8(0x0489)
+#define PORTE_PORTCTRL  _SFR_MEM8(0x048A)
+#define PORTE_PINCONFIG  _SFR_MEM8(0x048B)
+#define PORTE_PINCTRLUPD  _SFR_MEM8(0x048C)
+#define PORTE_PINCTRLSET  _SFR_MEM8(0x048D)
+#define PORTE_PINCTRLCLR  _SFR_MEM8(0x048E)
+#define PORTE_PIN0CTRL  _SFR_MEM8(0x0490)
+#define PORTE_PIN1CTRL  _SFR_MEM8(0x0491)
+#define PORTE_PIN2CTRL  _SFR_MEM8(0x0492)
+#define PORTE_PIN3CTRL  _SFR_MEM8(0x0493)
+#define PORTE_PIN4CTRL  _SFR_MEM8(0x0494)
+#define PORTE_PIN5CTRL  _SFR_MEM8(0x0495)
+#define PORTE_PIN6CTRL  _SFR_MEM8(0x0496)
+#define PORTE_PIN7CTRL  _SFR_MEM8(0x0497)
+#define PORTE_EVGENCTRL  _SFR_MEM8(0x0498)
+
+
+/* PORT (PORTF) - I/O Ports */
+#define PORTF_DIR  _SFR_MEM8(0x04A0)
+#define PORTF_DIRSET  _SFR_MEM8(0x04A1)
+#define PORTF_DIRCLR  _SFR_MEM8(0x04A2)
+#define PORTF_DIRTGL  _SFR_MEM8(0x04A3)
+#define PORTF_OUT  _SFR_MEM8(0x04A4)
+#define PORTF_OUTSET  _SFR_MEM8(0x04A5)
+#define PORTF_OUTCLR  _SFR_MEM8(0x04A6)
+#define PORTF_OUTTGL  _SFR_MEM8(0x04A7)
+#define PORTF_IN  _SFR_MEM8(0x04A8)
+#define PORTF_INTFLAGS  _SFR_MEM8(0x04A9)
+#define PORTF_PORTCTRL  _SFR_MEM8(0x04AA)
+#define PORTF_PINCONFIG  _SFR_MEM8(0x04AB)
+#define PORTF_PINCTRLUPD  _SFR_MEM8(0x04AC)
+#define PORTF_PINCTRLSET  _SFR_MEM8(0x04AD)
+#define PORTF_PINCTRLCLR  _SFR_MEM8(0x04AE)
+#define PORTF_PIN0CTRL  _SFR_MEM8(0x04B0)
+#define PORTF_PIN1CTRL  _SFR_MEM8(0x04B1)
+#define PORTF_PIN2CTRL  _SFR_MEM8(0x04B2)
+#define PORTF_PIN3CTRL  _SFR_MEM8(0x04B3)
+#define PORTF_PIN4CTRL  _SFR_MEM8(0x04B4)
+#define PORTF_PIN5CTRL  _SFR_MEM8(0x04B5)
+#define PORTF_PIN6CTRL  _SFR_MEM8(0x04B6)
+#define PORTF_PIN7CTRL  _SFR_MEM8(0x04B7)
+#define PORTF_EVGENCTRL  _SFR_MEM8(0x04B8)
+
+
+/* PORTMUX - Port Multiplexer */
+#define PORTMUX_EVSYSROUTEA  _SFR_MEM8(0x05E0)
+#define PORTMUX_CCLROUTEA  _SFR_MEM8(0x05E1)
+#define PORTMUX_USARTROUTEA  _SFR_MEM8(0x05E2)
+#define PORTMUX_USARTROUTEB  _SFR_MEM8(0x05E3)
+#define PORTMUX_SPIROUTEA  _SFR_MEM8(0x05E5)
+#define PORTMUX_TWIROUTEA  _SFR_MEM8(0x05E6)
+#define PORTMUX_TCAROUTEA  _SFR_MEM8(0x05E7)
+#define PORTMUX_TCBROUTEA  _SFR_MEM8(0x05E8)
+#define PORTMUX_ACROUTEA  _SFR_MEM8(0x05EA)
+
+
+/* ADC (ADC0) - Analog to Digital Converter */
+#define ADC0_CTRLA  _SFR_MEM8(0x0600)
+#define ADC0_CTRLB  _SFR_MEM8(0x0601)
+#define ADC0_CTRLC  _SFR_MEM8(0x0602)
+#define ADC0_CTRLD  _SFR_MEM8(0x0603)
+#define ADC0_INTCTRL  _SFR_MEM8(0x0604)
+#define ADC0_INTFLAGS  _SFR_MEM8(0x0605)
+#define ADC0_STATUS  _SFR_MEM8(0x0606)
+#define ADC0_DBGCTRL  _SFR_MEM8(0x0607)
+#define ADC0_CTRLE  _SFR_MEM8(0x0608)
+#define ADC0_CTRLF  _SFR_MEM8(0x0609)
+#define ADC0_COMMAND  _SFR_MEM8(0x060A)
+#define ADC0_PGACTRL  _SFR_MEM8(0x060B)
+#define ADC0_MUXPOS  _SFR_MEM8(0x060C)
+#define ADC0_MUXNEG  _SFR_MEM8(0x060D)
+#define ADC0_RESULT  _SFR_MEM32(0x0610)
+#define ADC0_RESULT0  _SFR_MEM8(0x0610)
+#define ADC0_RESULT1  _SFR_MEM8(0x0611)
+#define ADC0_RESULT2  _SFR_MEM8(0x0612)
+#define ADC0_RESULT3  _SFR_MEM8(0x0613)
+#define ADC0_SAMPLE  _SFR_MEM16(0x0614)
+#define ADC0_SAMPLEL  _SFR_MEM8(0x0614)
+#define ADC0_SAMPLEH  _SFR_MEM8(0x0615)
+#define ADC0_TEMP0  _SFR_MEM8(0x0618)
+#define ADC0_TEMP1  _SFR_MEM8(0x0619)
+#define ADC0_TEMP2  _SFR_MEM8(0x061A)
+#define ADC0_WINLT  _SFR_MEM16(0x061C)
+#define ADC0_WINLTL  _SFR_MEM8(0x061C)
+#define ADC0_WINLTH  _SFR_MEM8(0x061D)
+#define ADC0_WINHT  _SFR_MEM16(0x061E)
+#define ADC0_WINHTL  _SFR_MEM8(0x061E)
+#define ADC0_WINHTH  _SFR_MEM8(0x061F)
+
+
+/* AC (AC0) - Analog Comparator */
+#define AC0_CTRLA  _SFR_MEM8(0x0680)
+#define AC0_CTRLB  _SFR_MEM8(0x0681)
+#define AC0_MUXCTRL  _SFR_MEM8(0x0682)
+#define AC0_DACREF  _SFR_MEM8(0x0685)
+#define AC0_INTCTRL  _SFR_MEM8(0x0686)
+#define AC0_STATUS  _SFR_MEM8(0x0687)
+
+
+/* AC (AC1) - Analog Comparator */
+#define AC1_CTRLA  _SFR_MEM8(0x0688)
+#define AC1_CTRLB  _SFR_MEM8(0x0689)
+#define AC1_MUXCTRL  _SFR_MEM8(0x068A)
+#define AC1_DACREF  _SFR_MEM8(0x068D)
+#define AC1_INTCTRL  _SFR_MEM8(0x068E)
+#define AC1_STATUS  _SFR_MEM8(0x068F)
+
+
+/* DAC (DAC0) - Digital to Analog Converter */
+#define DAC0_CTRLA  _SFR_MEM8(0x06A0)
+#define DAC0_DATA  _SFR_MEM16(0x06A2)
+#define DAC0_DATAL  _SFR_MEM8(0x06A2)
+#define DAC0_DATAH  _SFR_MEM8(0x06A3)
+
+
+/* USART (USART0) - Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define USART0_RXDATAL  _SFR_MEM8(0x0800)
+#define USART0_RXDATAH  _SFR_MEM8(0x0801)
+#define USART0_TXDATAL  _SFR_MEM8(0x0802)
+#define USART0_TXDATAH  _SFR_MEM8(0x0803)
+#define USART0_STATUS  _SFR_MEM8(0x0804)
+#define USART0_CTRLA  _SFR_MEM8(0x0805)
+#define USART0_CTRLB  _SFR_MEM8(0x0806)
+#define USART0_CTRLC  _SFR_MEM8(0x0807)
+#define USART0_BAUD  _SFR_MEM16(0x0808)
+#define USART0_BAUDL  _SFR_MEM8(0x0808)
+#define USART0_BAUDH  _SFR_MEM8(0x0809)
+#define USART0_CTRLD  _SFR_MEM8(0x080A)
+#define USART0_DBGCTRL  _SFR_MEM8(0x080B)
+#define USART0_EVCTRL  _SFR_MEM8(0x080C)
+#define USART0_TXPLCTRL  _SFR_MEM8(0x080D)
+#define USART0_RXPLCTRL  _SFR_MEM8(0x080E)
+
+
+/* USART (USART1) - Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define USART1_RXDATAL  _SFR_MEM8(0x0820)
+#define USART1_RXDATAH  _SFR_MEM8(0x0821)
+#define USART1_TXDATAL  _SFR_MEM8(0x0822)
+#define USART1_TXDATAH  _SFR_MEM8(0x0823)
+#define USART1_STATUS  _SFR_MEM8(0x0824)
+#define USART1_CTRLA  _SFR_MEM8(0x0825)
+#define USART1_CTRLB  _SFR_MEM8(0x0826)
+#define USART1_CTRLC  _SFR_MEM8(0x0827)
+#define USART1_BAUD  _SFR_MEM16(0x0828)
+#define USART1_BAUDL  _SFR_MEM8(0x0828)
+#define USART1_BAUDH  _SFR_MEM8(0x0829)
+#define USART1_CTRLD  _SFR_MEM8(0x082A)
+#define USART1_DBGCTRL  _SFR_MEM8(0x082B)
+#define USART1_EVCTRL  _SFR_MEM8(0x082C)
+#define USART1_TXPLCTRL  _SFR_MEM8(0x082D)
+#define USART1_RXPLCTRL  _SFR_MEM8(0x082E)
+
+
+/* USART (USART2) - Universal Synchronous and Asynchronous Receiver and Transmitter */
+#define USART2_RXDATAL  _SFR_MEM8(0x0840)
+#define USART2_RXDATAH  _SFR_MEM8(0x0841)
+#define USART2_TXDATAL  _SFR_MEM8(0x0842)
+#define USART2_TXDATAH  _SFR_MEM8(0x0843)
+#define USART2_STATUS  _SFR_MEM8(0x0844)
+#define USART2_CTRLA  _SFR_MEM8(0x0845)
+#define USART2_CTRLB  _SFR_MEM8(0x0846)
+#define USART2_CTRLC  _SFR_MEM8(0x0847)
+#define USART2_BAUD  _SFR_MEM16(0x0848)
+#define USART2_BAUDL  _SFR_MEM8(0x0848)
+#define USART2_BAUDH  _SFR_MEM8(0x0849)
+#define USART2_CTRLD  _SFR_MEM8(0x084A)
+#define USART2_DBGCTRL  _SFR_MEM8(0x084B)
+#define USART2_EVCTRL  _SFR_MEM8(0x084C)
+#define USART2_TXPLCTRL  _SFR_MEM8(0x084D)
+#define USART2_RXPLCTRL  _SFR_MEM8(0x084E)
+
+
+/* TWI (TWI0) - Two-Wire Interface */
+#define TWI0_CTRLA  _SFR_MEM8(0x0900)
+#define TWI0_DUALCTRL  _SFR_MEM8(0x0901)
+#define TWI0_DBGCTRL  _SFR_MEM8(0x0902)
+#define TWI0_MCTRLA  _SFR_MEM8(0x0903)
+#define TWI0_MCTRLB  _SFR_MEM8(0x0904)
+#define TWI0_MSTATUS  _SFR_MEM8(0x0905)
+#define TWI0_MBAUD  _SFR_MEM8(0x0906)
+#define TWI0_MADDR  _SFR_MEM8(0x0907)
+#define TWI0_MDATA  _SFR_MEM8(0x0908)
+#define TWI0_SCTRLA  _SFR_MEM8(0x0909)
+#define TWI0_SCTRLB  _SFR_MEM8(0x090A)
+#define TWI0_SSTATUS  _SFR_MEM8(0x090B)
+#define TWI0_SADDR  _SFR_MEM8(0x090C)
+#define TWI0_SDATA  _SFR_MEM8(0x090D)
+#define TWI0_SADDRMASK  _SFR_MEM8(0x090E)
+
+
+/* SPI (SPI0) - Serial Peripheral Interface */
+#define SPI0_CTRLA  _SFR_MEM8(0x0940)
+#define SPI0_CTRLB  _SFR_MEM8(0x0941)
+#define SPI0_INTCTRL  _SFR_MEM8(0x0942)
+#define SPI0_INTFLAGS  _SFR_MEM8(0x0943)
+#define SPI0_DATA  _SFR_MEM8(0x0944)
+
+
+/* TCA (TCA0) - 16-bit Timer/Counter Type A - Single Mode */
+#define TCA0_SINGLE_CTRLA  _SFR_MEM8(0x0A00)
+#define TCA0_SINGLE_CTRLB  _SFR_MEM8(0x0A01)
+#define TCA0_SINGLE_CTRLC  _SFR_MEM8(0x0A02)
+#define TCA0_SINGLE_CTRLD  _SFR_MEM8(0x0A03)
+#define TCA0_SINGLE_CTRLECLR  _SFR_MEM8(0x0A04)
+#define TCA0_SINGLE_CTRLESET  _SFR_MEM8(0x0A05)
+#define TCA0_SINGLE_CTRLFCLR  _SFR_MEM8(0x0A06)
+#define TCA0_SINGLE_CTRLFSET  _SFR_MEM8(0x0A07)
+#define TCA0_SINGLE_EVCTRL  _SFR_MEM8(0x0A09)
+#define TCA0_SINGLE_INTCTRL  _SFR_MEM8(0x0A0A)
+#define TCA0_SINGLE_INTFLAGS  _SFR_MEM8(0x0A0B)
+#define TCA0_SINGLE_DBGCTRL  _SFR_MEM8(0x0A0E)
+#define TCA0_SINGLE_TEMP  _SFR_MEM8(0x0A0F)
+#define TCA0_SINGLE_CNT  _SFR_MEM16(0x0A20)
+#define TCA0_SINGLE_CNTL  _SFR_MEM8(0x0A20)
+#define TCA0_SINGLE_CNTH  _SFR_MEM8(0x0A21)
+#define TCA0_SINGLE_PER  _SFR_MEM16(0x0A26)
+#define TCA0_SINGLE_PERL  _SFR_MEM8(0x0A26)
+#define TCA0_SINGLE_PERH  _SFR_MEM8(0x0A27)
+#define TCA0_SINGLE_CMP0  _SFR_MEM16(0x0A28)
+#define TCA0_SINGLE_CMP0L  _SFR_MEM8(0x0A28)
+#define TCA0_SINGLE_CMP0H  _SFR_MEM8(0x0A29)
+#define TCA0_SINGLE_CMP1  _SFR_MEM16(0x0A2A)
+#define TCA0_SINGLE_CMP1L  _SFR_MEM8(0x0A2A)
+#define TCA0_SINGLE_CMP1H  _SFR_MEM8(0x0A2B)
+#define TCA0_SINGLE_CMP2  _SFR_MEM16(0x0A2C)
+#define TCA0_SINGLE_CMP2L  _SFR_MEM8(0x0A2C)
+#define TCA0_SINGLE_CMP2H  _SFR_MEM8(0x0A2D)
+#define TCA0_SINGLE_PERBUF  _SFR_MEM16(0x0A36)
+#define TCA0_SINGLE_PERBUFL  _SFR_MEM8(0x0A36)
+#define TCA0_SINGLE_PERBUFH  _SFR_MEM8(0x0A37)
+#define TCA0_SINGLE_CMP0BUF  _SFR_MEM16(0x0A38)
+#define TCA0_SINGLE_CMP0BUFL  _SFR_MEM8(0x0A38)
+#define TCA0_SINGLE_CMP0BUFH  _SFR_MEM8(0x0A39)
+#define TCA0_SINGLE_CMP1BUF  _SFR_MEM16(0x0A3A)
+#define TCA0_SINGLE_CMP1BUFL  _SFR_MEM8(0x0A3A)
+#define TCA0_SINGLE_CMP1BUFH  _SFR_MEM8(0x0A3B)
+#define TCA0_SINGLE_CMP2BUF  _SFR_MEM16(0x0A3C)
+#define TCA0_SINGLE_CMP2BUFL  _SFR_MEM8(0x0A3C)
+#define TCA0_SINGLE_CMP2BUFH  _SFR_MEM8(0x0A3D)
+
+
+/* TCA (TCA0) - 16-bit Timer/Counter Type A - Split Mode */
+#define TCA0_SPLIT_CTRLA  _SFR_MEM8(0x0A00)
+#define TCA0_SPLIT_CTRLB  _SFR_MEM8(0x0A01)
+#define TCA0_SPLIT_CTRLC  _SFR_MEM8(0x0A02)
+#define TCA0_SPLIT_CTRLD  _SFR_MEM8(0x0A03)
+#define TCA0_SPLIT_CTRLECLR  _SFR_MEM8(0x0A04)
+#define TCA0_SPLIT_CTRLESET  _SFR_MEM8(0x0A05)
+#define TCA0_SPLIT_INTCTRL  _SFR_MEM8(0x0A0A)
+#define TCA0_SPLIT_INTFLAGS  _SFR_MEM8(0x0A0B)
+#define TCA0_SPLIT_DBGCTRL  _SFR_MEM8(0x0A0E)
+#define TCA0_SPLIT_LCNT  _SFR_MEM8(0x0A20)
+#define TCA0_SPLIT_HCNT  _SFR_MEM8(0x0A21)
+#define TCA0_SPLIT_LPER  _SFR_MEM8(0x0A26)
+#define TCA0_SPLIT_HPER  _SFR_MEM8(0x0A27)
+#define TCA0_SPLIT_LCMP0  _SFR_MEM8(0x0A28)
+#define TCA0_SPLIT_HCMP0  _SFR_MEM8(0x0A29)
+#define TCA0_SPLIT_LCMP1  _SFR_MEM8(0x0A2A)
+#define TCA0_SPLIT_HCMP1  _SFR_MEM8(0x0A2B)
+#define TCA0_SPLIT_LCMP2  _SFR_MEM8(0x0A2C)
+#define TCA0_SPLIT_HCMP2  _SFR_MEM8(0x0A2D)
+
+
+/* TCA (TCA1) - 16-bit Timer/Counter Type A - Single Mode */
+#define TCA1_SINGLE_CTRLA  _SFR_MEM8(0x0A40)
+#define TCA1_SINGLE_CTRLB  _SFR_MEM8(0x0A41)
+#define TCA1_SINGLE_CTRLC  _SFR_MEM8(0x0A42)
+#define TCA1_SINGLE_CTRLD  _SFR_MEM8(0x0A43)
+#define TCA1_SINGLE_CTRLECLR  _SFR_MEM8(0x0A44)
+#define TCA1_SINGLE_CTRLESET  _SFR_MEM8(0x0A45)
+#define TCA1_SINGLE_CTRLFCLR  _SFR_MEM8(0x0A46)
+#define TCA1_SINGLE_CTRLFSET  _SFR_MEM8(0x0A47)
+#define TCA1_SINGLE_EVCTRL  _SFR_MEM8(0x0A49)
+#define TCA1_SINGLE_INTCTRL  _SFR_MEM8(0x0A4A)
+#define TCA1_SINGLE_INTFLAGS  _SFR_MEM8(0x0A4B)
+#define TCA1_SINGLE_DBGCTRL  _SFR_MEM8(0x0A4E)
+#define TCA1_SINGLE_TEMP  _SFR_MEM8(0x0A4F)
+#define TCA1_SINGLE_CNT  _SFR_MEM16(0x0A60)
+#define TCA1_SINGLE_CNTL  _SFR_MEM8(0x0A60)
+#define TCA1_SINGLE_CNTH  _SFR_MEM8(0x0A61)
+#define TCA1_SINGLE_PER  _SFR_MEM16(0x0A66)
+#define TCA1_SINGLE_PERL  _SFR_MEM8(0x0A66)
+#define TCA1_SINGLE_PERH  _SFR_MEM8(0x0A67)
+#define TCA1_SINGLE_CMP0  _SFR_MEM16(0x0A68)
+#define TCA1_SINGLE_CMP0L  _SFR_MEM8(0x0A68)
+#define TCA1_SINGLE_CMP0H  _SFR_MEM8(0x0A69)
+#define TCA1_SINGLE_CMP1  _SFR_MEM16(0x0A6A)
+#define TCA1_SINGLE_CMP1L  _SFR_MEM8(0x0A6A)
+#define TCA1_SINGLE_CMP1H  _SFR_MEM8(0x0A6B)
+#define TCA1_SINGLE_CMP2  _SFR_MEM16(0x0A6C)
+#define TCA1_SINGLE_CMP2L  _SFR_MEM8(0x0A6C)
+#define TCA1_SINGLE_CMP2H  _SFR_MEM8(0x0A6D)
+#define TCA1_SINGLE_PERBUF  _SFR_MEM16(0x0A76)
+#define TCA1_SINGLE_PERBUFL  _SFR_MEM8(0x0A76)
+#define TCA1_SINGLE_PERBUFH  _SFR_MEM8(0x0A77)
+#define TCA1_SINGLE_CMP0BUF  _SFR_MEM16(0x0A78)
+#define TCA1_SINGLE_CMP0BUFL  _SFR_MEM8(0x0A78)
+#define TCA1_SINGLE_CMP0BUFH  _SFR_MEM8(0x0A79)
+#define TCA1_SINGLE_CMP1BUF  _SFR_MEM16(0x0A7A)
+#define TCA1_SINGLE_CMP1BUFL  _SFR_MEM8(0x0A7A)
+#define TCA1_SINGLE_CMP1BUFH  _SFR_MEM8(0x0A7B)
+#define TCA1_SINGLE_CMP2BUF  _SFR_MEM16(0x0A7C)
+#define TCA1_SINGLE_CMP2BUFL  _SFR_MEM8(0x0A7C)
+#define TCA1_SINGLE_CMP2BUFH  _SFR_MEM8(0x0A7D)
+
+
+/* TCA (TCA1) - 16-bit Timer/Counter Type A - Split Mode */
+#define TCA1_SPLIT_CTRLA  _SFR_MEM8(0x0A40)
+#define TCA1_SPLIT_CTRLB  _SFR_MEM8(0x0A41)
+#define TCA1_SPLIT_CTRLC  _SFR_MEM8(0x0A42)
+#define TCA1_SPLIT_CTRLD  _SFR_MEM8(0x0A43)
+#define TCA1_SPLIT_CTRLECLR  _SFR_MEM8(0x0A44)
+#define TCA1_SPLIT_CTRLESET  _SFR_MEM8(0x0A45)
+#define TCA1_SPLIT_INTCTRL  _SFR_MEM8(0x0A4A)
+#define TCA1_SPLIT_INTFLAGS  _SFR_MEM8(0x0A4B)
+#define TCA1_SPLIT_DBGCTRL  _SFR_MEM8(0x0A4E)
+#define TCA1_SPLIT_LCNT  _SFR_MEM8(0x0A60)
+#define TCA1_SPLIT_HCNT  _SFR_MEM8(0x0A61)
+#define TCA1_SPLIT_LPER  _SFR_MEM8(0x0A66)
+#define TCA1_SPLIT_HPER  _SFR_MEM8(0x0A67)
+#define TCA1_SPLIT_LCMP0  _SFR_MEM8(0x0A68)
+#define TCA1_SPLIT_HCMP0  _SFR_MEM8(0x0A69)
+#define TCA1_SPLIT_LCMP1  _SFR_MEM8(0x0A6A)
+#define TCA1_SPLIT_HCMP1  _SFR_MEM8(0x0A6B)
+#define TCA1_SPLIT_LCMP2  _SFR_MEM8(0x0A6C)
+#define TCA1_SPLIT_HCMP2  _SFR_MEM8(0x0A6D)
+
+
+/* TCB (TCB0) - 16-bit Timer Type B */
+#define TCB0_CTRLA  _SFR_MEM8(0x0B00)
+#define TCB0_CTRLB  _SFR_MEM8(0x0B01)
+#define TCB0_EVCTRL  _SFR_MEM8(0x0B04)
+#define TCB0_INTCTRL  _SFR_MEM8(0x0B05)
+#define TCB0_INTFLAGS  _SFR_MEM8(0x0B06)
+#define TCB0_STATUS  _SFR_MEM8(0x0B07)
+#define TCB0_DBGCTRL  _SFR_MEM8(0x0B08)
+#define TCB0_TEMP  _SFR_MEM8(0x0B09)
+#define TCB0_CNT  _SFR_MEM16(0x0B0A)
+#define TCB0_CNTL  _SFR_MEM8(0x0B0A)
+#define TCB0_CNTH  _SFR_MEM8(0x0B0B)
+#define TCB0_CCMP  _SFR_MEM16(0x0B0C)
+#define TCB0_CCMPL  _SFR_MEM8(0x0B0C)
+#define TCB0_CCMPH  _SFR_MEM8(0x0B0D)
+
+
+/* TCB (TCB1) - 16-bit Timer Type B */
+#define TCB1_CTRLA  _SFR_MEM8(0x0B10)
+#define TCB1_CTRLB  _SFR_MEM8(0x0B11)
+#define TCB1_EVCTRL  _SFR_MEM8(0x0B14)
+#define TCB1_INTCTRL  _SFR_MEM8(0x0B15)
+#define TCB1_INTFLAGS  _SFR_MEM8(0x0B16)
+#define TCB1_STATUS  _SFR_MEM8(0x0B17)
+#define TCB1_DBGCTRL  _SFR_MEM8(0x0B18)
+#define TCB1_TEMP  _SFR_MEM8(0x0B19)
+#define TCB1_CNT  _SFR_MEM16(0x0B1A)
+#define TCB1_CNTL  _SFR_MEM8(0x0B1A)
+#define TCB1_CNTH  _SFR_MEM8(0x0B1B)
+#define TCB1_CCMP  _SFR_MEM16(0x0B1C)
+#define TCB1_CCMPL  _SFR_MEM8(0x0B1C)
+#define TCB1_CCMPH  _SFR_MEM8(0x0B1D)
+
+
+/* TCB (TCB2) - 16-bit Timer Type B */
+#define TCB2_CTRLA  _SFR_MEM8(0x0B20)
+#define TCB2_CTRLB  _SFR_MEM8(0x0B21)
+#define TCB2_EVCTRL  _SFR_MEM8(0x0B24)
+#define TCB2_INTCTRL  _SFR_MEM8(0x0B25)
+#define TCB2_INTFLAGS  _SFR_MEM8(0x0B26)
+#define TCB2_STATUS  _SFR_MEM8(0x0B27)
+#define TCB2_DBGCTRL  _SFR_MEM8(0x0B28)
+#define TCB2_TEMP  _SFR_MEM8(0x0B29)
+#define TCB2_CNT  _SFR_MEM16(0x0B2A)
+#define TCB2_CNTL  _SFR_MEM8(0x0B2A)
+#define TCB2_CNTH  _SFR_MEM8(0x0B2B)
+#define TCB2_CCMP  _SFR_MEM16(0x0B2C)
+#define TCB2_CCMPL  _SFR_MEM8(0x0B2C)
+#define TCB2_CCMPH  _SFR_MEM8(0x0B2D)
+
+
+/* TCB (TCB3) - 16-bit Timer Type B */
+#define TCB3_CTRLA  _SFR_MEM8(0x0B30)
+#define TCB3_CTRLB  _SFR_MEM8(0x0B31)
+#define TCB3_EVCTRL  _SFR_MEM8(0x0B34)
+#define TCB3_INTCTRL  _SFR_MEM8(0x0B35)
+#define TCB3_INTFLAGS  _SFR_MEM8(0x0B36)
+#define TCB3_STATUS  _SFR_MEM8(0x0B37)
+#define TCB3_DBGCTRL  _SFR_MEM8(0x0B38)
+#define TCB3_TEMP  _SFR_MEM8(0x0B39)
+#define TCB3_CNT  _SFR_MEM16(0x0B3A)
+#define TCB3_CNTL  _SFR_MEM8(0x0B3A)
+#define TCB3_CNTH  _SFR_MEM8(0x0B3B)
+#define TCB3_CCMP  _SFR_MEM16(0x0B3C)
+#define TCB3_CCMPL  _SFR_MEM8(0x0B3C)
+#define TCB3_CCMPH  _SFR_MEM8(0x0B3D)
+
+
+/* SYSCFG - System Configuration Registers */
+#define SYSCFG_REVID  _SFR_MEM8(0x0F01)
+#define SYSCFG_OCDMCTRL  _SFR_MEM8(0x0F04)
+#define SYSCFG_OCDMSTATUS  _SFR_MEM8(0x0F05)
+
+
+/* NVMCTRL - Non-volatile Memory Controller */
+#define NVMCTRL_CTRLA  _SFR_MEM8(0x1000)
+#define NVMCTRL_CTRLB  _SFR_MEM8(0x1001)
+#define NVMCTRL_INTCTRL  _SFR_MEM8(0x1004)
+#define NVMCTRL_INTFLAGS  _SFR_MEM8(0x1005)
+#define NVMCTRL_STATUS  _SFR_MEM8(0x1006)
+#define NVMCTRL_DATA  _SFR_MEM16(0x1008)
+#define NVMCTRL_DATAL  _SFR_MEM8(0x1008)
+#define NVMCTRL_DATAH  _SFR_MEM8(0x1009)
+#define NVMCTRL_ADDR  _SFR_MEM32(0x100C)
+#define NVMCTRL_ADDR0  _SFR_MEM8(0x100C)
+#define NVMCTRL_ADDR1  _SFR_MEM8(0x100D)
+#define NVMCTRL_ADDR2  _SFR_MEM8(0x100E)
+#define NVMCTRL_ADDR3  _SFR_MEM8(0x100F)
+
+
+/* LOCK - Lockbits */
+#define LOCK_KEY  _SFR_MEM32(0x1040)
+#define LOCK_KEY0  _SFR_MEM8(0x1040)
+#define LOCK_KEY1  _SFR_MEM8(0x1041)
+#define LOCK_KEY2  _SFR_MEM8(0x1042)
+#define LOCK_KEY3  _SFR_MEM8(0x1043)
+
+
+/* FUSE - Fuses */
+#define FUSE_WDTCFG  _SFR_MEM8(0x1050)
+#define FUSE_BODCFG  _SFR_MEM8(0x1051)
+#define FUSE_OSCCFG  _SFR_MEM8(0x1052)
+#define FUSE_SYSCFG0  _SFR_MEM8(0x1055)
+#define FUSE_SYSCFG1  _SFR_MEM8(0x1056)
+#define FUSE_CODESIZE  _SFR_MEM8(0x1057)
+#define FUSE_BOOTSIZE  _SFR_MEM8(0x1058)
+
+
+/* USERROW - User Row */
+#define USERROW_USERROW0  _SFR_MEM8(0x1080)
+#define USERROW_USERROW1  _SFR_MEM8(0x1081)
+#define USERROW_USERROW2  _SFR_MEM8(0x1082)
+#define USERROW_USERROW3  _SFR_MEM8(0x1083)
+#define USERROW_USERROW4  _SFR_MEM8(0x1084)
+#define USERROW_USERROW5  _SFR_MEM8(0x1085)
+#define USERROW_USERROW6  _SFR_MEM8(0x1086)
+#define USERROW_USERROW7  _SFR_MEM8(0x1087)
+#define USERROW_USERROW8  _SFR_MEM8(0x1088)
+#define USERROW_USERROW9  _SFR_MEM8(0x1089)
+#define USERROW_USERROW10  _SFR_MEM8(0x108A)
+#define USERROW_USERROW11  _SFR_MEM8(0x108B)
+#define USERROW_USERROW12  _SFR_MEM8(0x108C)
+#define USERROW_USERROW13  _SFR_MEM8(0x108D)
+#define USERROW_USERROW14  _SFR_MEM8(0x108E)
+#define USERROW_USERROW15  _SFR_MEM8(0x108F)
+#define USERROW_USERROW16  _SFR_MEM8(0x1090)
+#define USERROW_USERROW17  _SFR_MEM8(0x1091)
+#define USERROW_USERROW18  _SFR_MEM8(0x1092)
+#define USERROW_USERROW19  _SFR_MEM8(0x1093)
+#define USERROW_USERROW20  _SFR_MEM8(0x1094)
+#define USERROW_USERROW21  _SFR_MEM8(0x1095)
+#define USERROW_USERROW22  _SFR_MEM8(0x1096)
+#define USERROW_USERROW23  _SFR_MEM8(0x1097)
+#define USERROW_USERROW24  _SFR_MEM8(0x1098)
+#define USERROW_USERROW25  _SFR_MEM8(0x1099)
+#define USERROW_USERROW26  _SFR_MEM8(0x109A)
+#define USERROW_USERROW27  _SFR_MEM8(0x109B)
+#define USERROW_USERROW28  _SFR_MEM8(0x109C)
+#define USERROW_USERROW29  _SFR_MEM8(0x109D)
+#define USERROW_USERROW30  _SFR_MEM8(0x109E)
+#define USERROW_USERROW31  _SFR_MEM8(0x109F)
+#define USERROW_USERROW32  _SFR_MEM8(0x10A0)
+#define USERROW_USERROW33  _SFR_MEM8(0x10A1)
+#define USERROW_USERROW34  _SFR_MEM8(0x10A2)
+#define USERROW_USERROW35  _SFR_MEM8(0x10A3)
+#define USERROW_USERROW36  _SFR_MEM8(0x10A4)
+#define USERROW_USERROW37  _SFR_MEM8(0x10A5)
+#define USERROW_USERROW38  _SFR_MEM8(0x10A6)
+#define USERROW_USERROW39  _SFR_MEM8(0x10A7)
+#define USERROW_USERROW40  _SFR_MEM8(0x10A8)
+#define USERROW_USERROW41  _SFR_MEM8(0x10A9)
+#define USERROW_USERROW42  _SFR_MEM8(0x10AA)
+#define USERROW_USERROW43  _SFR_MEM8(0x10AB)
+#define USERROW_USERROW44  _SFR_MEM8(0x10AC)
+#define USERROW_USERROW45  _SFR_MEM8(0x10AD)
+#define USERROW_USERROW46  _SFR_MEM8(0x10AE)
+#define USERROW_USERROW47  _SFR_MEM8(0x10AF)
+#define USERROW_USERROW48  _SFR_MEM8(0x10B0)
+#define USERROW_USERROW49  _SFR_MEM8(0x10B1)
+#define USERROW_USERROW50  _SFR_MEM8(0x10B2)
+#define USERROW_USERROW51  _SFR_MEM8(0x10B3)
+#define USERROW_USERROW52  _SFR_MEM8(0x10B4)
+#define USERROW_USERROW53  _SFR_MEM8(0x10B5)
+#define USERROW_USERROW54  _SFR_MEM8(0x10B6)
+#define USERROW_USERROW55  _SFR_MEM8(0x10B7)
+#define USERROW_USERROW56  _SFR_MEM8(0x10B8)
+#define USERROW_USERROW57  _SFR_MEM8(0x10B9)
+#define USERROW_USERROW58  _SFR_MEM8(0x10BA)
+#define USERROW_USERROW59  _SFR_MEM8(0x10BB)
+#define USERROW_USERROW60  _SFR_MEM8(0x10BC)
+#define USERROW_USERROW61  _SFR_MEM8(0x10BD)
+#define USERROW_USERROW62  _SFR_MEM8(0x10BE)
+#define USERROW_USERROW63  _SFR_MEM8(0x10BF)
+
+
+/* SIGROW - Signature row */
+#define SIGROW_DEVICEID0  _SFR_MEM8(0x1100)
+#define SIGROW_DEVICEID1  _SFR_MEM8(0x1101)
+#define SIGROW_DEVICEID2  _SFR_MEM8(0x1102)
+#define SIGROW_TEMPSENSE0  _SFR_MEM16(0x1104)
+#define SIGROW_TEMPSENSE0L  _SFR_MEM8(0x1104)
+#define SIGROW_TEMPSENSE0H  _SFR_MEM8(0x1105)
+#define SIGROW_TEMPSENSE1  _SFR_MEM16(0x1106)
+#define SIGROW_TEMPSENSE1L  _SFR_MEM8(0x1106)
+#define SIGROW_TEMPSENSE1H  _SFR_MEM8(0x1107)
+#define SIGROW_SERNUM0  _SFR_MEM8(0x1110)
+#define SIGROW_SERNUM1  _SFR_MEM8(0x1111)
+#define SIGROW_SERNUM2  _SFR_MEM8(0x1112)
+#define SIGROW_SERNUM3  _SFR_MEM8(0x1113)
+#define SIGROW_SERNUM4  _SFR_MEM8(0x1114)
+#define SIGROW_SERNUM5  _SFR_MEM8(0x1115)
+#define SIGROW_SERNUM6  _SFR_MEM8(0x1116)
+#define SIGROW_SERNUM7  _SFR_MEM8(0x1117)
+#define SIGROW_SERNUM8  _SFR_MEM8(0x1118)
+#define SIGROW_SERNUM9  _SFR_MEM8(0x1119)
+#define SIGROW_SERNUM10  _SFR_MEM8(0x111A)
+#define SIGROW_SERNUM11  _SFR_MEM8(0x111B)
+#define SIGROW_SERNUM12  _SFR_MEM8(0x111C)
+#define SIGROW_SERNUM13  _SFR_MEM8(0x111D)
+#define SIGROW_SERNUM14  _SFR_MEM8(0x111E)
+#define SIGROW_SERNUM15  _SFR_MEM8(0x111F)
+
+
+
+/*================== Bitfield Definitions ================== */
+
+/* AC - Analog Comparator */
+/* AC.CTRLA  bit masks and bit positions */
+#define AC_ENABLE_bm  0x01  /* Enable bit mask. */
+#define AC_ENABLE_bp  0  /* Enable bit position. */
+#define AC_HYSMODE_gm  0x06  /* Hysteresis Mode group mask. */
+#define AC_HYSMODE_gp  1  /* Hysteresis Mode group position. */
+#define AC_HYSMODE_0_bm  (1<<1)  /* Hysteresis Mode bit 0 mask. */
+#define AC_HYSMODE_0_bp  1  /* Hysteresis Mode bit 0 position. */
+#define AC_HYSMODE_1_bm  (1<<2)  /* Hysteresis Mode bit 1 mask. */
+#define AC_HYSMODE_1_bp  2  /* Hysteresis Mode bit 1 position. */
+#define AC_POWER_gm  0x18  /* Power profile group mask. */
+#define AC_POWER_gp  3  /* Power profile group position. */
+#define AC_POWER_0_bm  (1<<3)  /* Power profile bit 0 mask. */
+#define AC_POWER_0_bp  3  /* Power profile bit 0 position. */
+#define AC_POWER_1_bm  (1<<4)  /* Power profile bit 1 mask. */
+#define AC_POWER_1_bp  4  /* Power profile bit 1 position. */
+#define AC_OUTEN_bm  0x40  /* Output Pad Enable bit mask. */
+#define AC_OUTEN_bp  6  /* Output Pad Enable bit position. */
+#define AC_RUNSTDBY_bm  0x80  /* Run in Standby Mode bit mask. */
+#define AC_RUNSTDBY_bp  7  /* Run in Standby Mode bit position. */
+
+/* AC.CTRLB  bit masks and bit positions */
+#define AC_WINSEL_gm  0x03  /* Window selection mode group mask. */
+#define AC_WINSEL_gp  0  /* Window selection mode group position. */
+#define AC_WINSEL_0_bm  (1<<0)  /* Window selection mode bit 0 mask. */
+#define AC_WINSEL_0_bp  0  /* Window selection mode bit 0 position. */
+#define AC_WINSEL_1_bm  (1<<1)  /* Window selection mode bit 1 mask. */
+#define AC_WINSEL_1_bp  1  /* Window selection mode bit 1 position. */
+
+/* AC.MUXCTRL  bit masks and bit positions */
+#define AC_MUXNEG_gm  0x07  /* Negative Input MUX Selection group mask. */
+#define AC_MUXNEG_gp  0  /* Negative Input MUX Selection group position. */
+#define AC_MUXNEG_0_bm  (1<<0)  /* Negative Input MUX Selection bit 0 mask. */
+#define AC_MUXNEG_0_bp  0  /* Negative Input MUX Selection bit 0 position. */
+#define AC_MUXNEG_1_bm  (1<<1)  /* Negative Input MUX Selection bit 1 mask. */
+#define AC_MUXNEG_1_bp  1  /* Negative Input MUX Selection bit 1 position. */
+#define AC_MUXNEG_2_bm  (1<<2)  /* Negative Input MUX Selection bit 2 mask. */
+#define AC_MUXNEG_2_bp  2  /* Negative Input MUX Selection bit 2 position. */
+#define AC_MUXPOS_gm  0x38  /* Positive Input MUX Selection group mask. */
+#define AC_MUXPOS_gp  3  /* Positive Input MUX Selection group position. */
+#define AC_MUXPOS_0_bm  (1<<3)  /* Positive Input MUX Selection bit 0 mask. */
+#define AC_MUXPOS_0_bp  3  /* Positive Input MUX Selection bit 0 position. */
+#define AC_MUXPOS_1_bm  (1<<4)  /* Positive Input MUX Selection bit 1 mask. */
+#define AC_MUXPOS_1_bp  4  /* Positive Input MUX Selection bit 1 position. */
+#define AC_MUXPOS_2_bm  (1<<5)  /* Positive Input MUX Selection bit 2 mask. */
+#define AC_MUXPOS_2_bp  5  /* Positive Input MUX Selection bit 2 position. */
+#define AC_INITVAL_bm  0x40  /* AC Output Initial Value bit mask. */
+#define AC_INITVAL_bp  6  /* AC Output Initial Value bit position. */
+#define AC_INVERT_bm  0x80  /* Invert AC Output bit mask. */
+#define AC_INVERT_bp  7  /* Invert AC Output bit position. */
+
+/* AC.DACREF  bit masks and bit positions */
+#define AC_DACREF_gm  0xFF  /* DACREF group mask. */
+#define AC_DACREF_gp  0  /* DACREF group position. */
+#define AC_DACREF_0_bm  (1<<0)  /* DACREF bit 0 mask. */
+#define AC_DACREF_0_bp  0  /* DACREF bit 0 position. */
+#define AC_DACREF_1_bm  (1<<1)  /* DACREF bit 1 mask. */
+#define AC_DACREF_1_bp  1  /* DACREF bit 1 position. */
+#define AC_DACREF_2_bm  (1<<2)  /* DACREF bit 2 mask. */
+#define AC_DACREF_2_bp  2  /* DACREF bit 2 position. */
+#define AC_DACREF_3_bm  (1<<3)  /* DACREF bit 3 mask. */
+#define AC_DACREF_3_bp  3  /* DACREF bit 3 position. */
+#define AC_DACREF_4_bm  (1<<4)  /* DACREF bit 4 mask. */
+#define AC_DACREF_4_bp  4  /* DACREF bit 4 position. */
+#define AC_DACREF_5_bm  (1<<5)  /* DACREF bit 5 mask. */
+#define AC_DACREF_5_bp  5  /* DACREF bit 5 position. */
+#define AC_DACREF_6_bm  (1<<6)  /* DACREF bit 6 mask. */
+#define AC_DACREF_6_bp  6  /* DACREF bit 6 position. */
+#define AC_DACREF_7_bm  (1<<7)  /* DACREF bit 7 mask. */
+#define AC_DACREF_7_bp  7  /* DACREF bit 7 position. */
+
+/* AC.INTCTRL  bit masks and bit positions */
+#define AC_CMP_bm  0x01  /* Interrupt Enable bit mask. */
+#define AC_CMP_bp  0  /* Interrupt Enable bit position. */
+#define AC_INTMODE_NORMAL_gm  0x30  /* Interrupt Mode group mask. */
+#define AC_INTMODE_NORMAL_gp  4  /* Interrupt Mode group position. */
+#define AC_INTMODE_NORMAL_0_bm  (1<<4)  /* Interrupt Mode bit 0 mask. */
+#define AC_INTMODE_NORMAL_0_bp  4  /* Interrupt Mode bit 0 position. */
+#define AC_INTMODE_NORMAL_1_bm  (1<<5)  /* Interrupt Mode bit 1 mask. */
+#define AC_INTMODE_NORMAL_1_bp  5  /* Interrupt Mode bit 1 position. */
+#define AC_INTMODE_WINDOW_gm  0x30  /* Interrupt Mode group mask. */
+#define AC_INTMODE_WINDOW_gp  4  /* Interrupt Mode group position. */
+#define AC_INTMODE_WINDOW_0_bm  (1<<4)  /* Interrupt Mode bit 0 mask. */
+#define AC_INTMODE_WINDOW_0_bp  4  /* Interrupt Mode bit 0 position. */
+#define AC_INTMODE_WINDOW_1_bm  (1<<5)  /* Interrupt Mode bit 1 mask. */
+#define AC_INTMODE_WINDOW_1_bp  5  /* Interrupt Mode bit 1 position. */
+
+/* AC.STATUS  bit masks and bit positions */
+#define AC_CMPIF_bm  0x01  /* Analog Comparator Interrupt Flag bit mask. */
+#define AC_CMPIF_bp  0  /* Analog Comparator Interrupt Flag bit position. */
+#define AC_CMPSTATE_bm  0x10  /* Analog Comparator State bit mask. */
+#define AC_CMPSTATE_bp  4  /* Analog Comparator State bit position. */
+#define AC_WINSTATE_gm  0xC0  /* Analog Comparator Window State group mask. */
+#define AC_WINSTATE_gp  6  /* Analog Comparator Window State group position. */
+#define AC_WINSTATE_0_bm  (1<<6)  /* Analog Comparator Window State bit 0 mask. */
+#define AC_WINSTATE_0_bp  6  /* Analog Comparator Window State bit 0 position. */
+#define AC_WINSTATE_1_bm  (1<<7)  /* Analog Comparator Window State bit 1 mask. */
+#define AC_WINSTATE_1_bp  7  /* Analog Comparator Window State bit 1 position. */
+
+
+/* ADC - Analog to Digital Converter */
+/* ADC.CTRLA  bit masks and bit positions */
+#define ADC_ENABLE_bm  0x01  /* ADC Enable bit mask. */
+#define ADC_ENABLE_bp  0  /* ADC Enable bit position. */
+#define ADC_LOWLAT_bm  0x20  /* Low Latency bit mask. */
+#define ADC_LOWLAT_bp  5  /* Low Latency bit position. */
+#define ADC_RUNSTDBY_bm  0x80  /* Run in Standby bit mask. */
+#define ADC_RUNSTDBY_bp  7  /* Run in Standby bit position. */
+
+/* ADC.CTRLB  bit masks and bit positions */
+#define ADC_PRESC_gm  0x0F  /* Prescaler Value group mask. */
+#define ADC_PRESC_gp  0  /* Prescaler Value group position. */
+#define ADC_PRESC_0_bm  (1<<0)  /* Prescaler Value bit 0 mask. */
+#define ADC_PRESC_0_bp  0  /* Prescaler Value bit 0 position. */
+#define ADC_PRESC_1_bm  (1<<1)  /* Prescaler Value bit 1 mask. */
+#define ADC_PRESC_1_bp  1  /* Prescaler Value bit 1 position. */
+#define ADC_PRESC_2_bm  (1<<2)  /* Prescaler Value bit 2 mask. */
+#define ADC_PRESC_2_bp  2  /* Prescaler Value bit 2 position. */
+#define ADC_PRESC_3_bm  (1<<3)  /* Prescaler Value bit 3 mask. */
+#define ADC_PRESC_3_bp  3  /* Prescaler Value bit 3 position. */
+
+/* ADC.CTRLC  bit masks and bit positions */
+#define ADC_REFSEL_gm  0x07  /* Reference select group mask. */
+#define ADC_REFSEL_gp  0  /* Reference select group position. */
+#define ADC_REFSEL_0_bm  (1<<0)  /* Reference select bit 0 mask. */
+#define ADC_REFSEL_0_bp  0  /* Reference select bit 0 position. */
+#define ADC_REFSEL_1_bm  (1<<1)  /* Reference select bit 1 mask. */
+#define ADC_REFSEL_1_bp  1  /* Reference select bit 1 position. */
+#define ADC_REFSEL_2_bm  (1<<2)  /* Reference select bit 2 mask. */
+#define ADC_REFSEL_2_bp  2  /* Reference select bit 2 position. */
+
+/* ADC.CTRLD  bit masks and bit positions */
+#define ADC_WINCM_gm  0x07  /* Window Comparator Mode group mask. */
+#define ADC_WINCM_gp  0  /* Window Comparator Mode group position. */
+#define ADC_WINCM_0_bm  (1<<0)  /* Window Comparator Mode bit 0 mask. */
+#define ADC_WINCM_0_bp  0  /* Window Comparator Mode bit 0 position. */
+#define ADC_WINCM_1_bm  (1<<1)  /* Window Comparator Mode bit 1 mask. */
+#define ADC_WINCM_1_bp  1  /* Window Comparator Mode bit 1 position. */
+#define ADC_WINCM_2_bm  (1<<2)  /* Window Comparator Mode bit 2 mask. */
+#define ADC_WINCM_2_bp  2  /* Window Comparator Mode bit 2 position. */
+#define ADC_WINSRC_bm  0x08  /* Window Mode Source bit mask. */
+#define ADC_WINSRC_bp  3  /* Window Mode Source bit position. */
+
+/* ADC.INTCTRL  bit masks and bit positions */
+#define ADC_RESRDY_bm  0x01  /* Result Ready Interrupt Enable bit mask. */
+#define ADC_RESRDY_bp  0  /* Result Ready Interrupt Enable bit position. */
+#define ADC_SAMPRDY_bm  0x02  /* Sample Ready Interrupt Enable bit mask. */
+#define ADC_SAMPRDY_bp  1  /* Sample Ready Interrupt Enable bit position. */
+#define ADC_WCMP_bm  0x04  /* Window Comparator Interrupt Enable bit mask. */
+#define ADC_WCMP_bp  2  /* Window Comparator Interrupt Enable bit position. */
+#define ADC_RESOVR_bm  0x08  /* Result Overwrite Interrupt Enable bit mask. */
+#define ADC_RESOVR_bp  3  /* Result Overwrite Interrupt Enable bit position. */
+#define ADC_SAMPOVR_bm  0x10  /* Sample Overwrite Interrupt Enable bit mask. */
+#define ADC_SAMPOVR_bp  4  /* Sample Overwrite Interrupt Enable bit position. */
+#define ADC_TRIGOVR_bm  0x20  /* Trigger Overrun Interrupt Enable bit mask. */
+#define ADC_TRIGOVR_bp  5  /* Trigger Overrun Interrupt Enable bit position. */
+
+/* ADC.INTFLAGS  bit masks and bit positions */
+/* ADC_RESRDY  is already defined. */
+/* ADC_SAMPRDY  is already defined. */
+/* ADC_WCMP  is already defined. */
+/* ADC_RESOVR  is already defined. */
+/* ADC_SAMPOVR  is already defined. */
+/* ADC_TRIGOVR  is already defined. */
+
+/* ADC.STATUS  bit masks and bit positions */
+#define ADC_ADCBUSY_bm  0x01  /* ADC Busy bit mask. */
+#define ADC_ADCBUSY_bp  0  /* ADC Busy bit position. */
+
+/* ADC.DBGCTRL  bit masks and bit positions */
+#define ADC_DBGRUN_bm  0x01  /* Run in Debug Mode bit mask. */
+#define ADC_DBGRUN_bp  0  /* Run in Debug Mode bit position. */
+
+/* ADC.CTRLE  bit masks and bit positions */
+#define ADC_SAMPDUR_gm  0xFF  /* Sample Duration group mask. */
+#define ADC_SAMPDUR_gp  0  /* Sample Duration group position. */
+#define ADC_SAMPDUR_0_bm  (1<<0)  /* Sample Duration bit 0 mask. */
+#define ADC_SAMPDUR_0_bp  0  /* Sample Duration bit 0 position. */
+#define ADC_SAMPDUR_1_bm  (1<<1)  /* Sample Duration bit 1 mask. */
+#define ADC_SAMPDUR_1_bp  1  /* Sample Duration bit 1 position. */
+#define ADC_SAMPDUR_2_bm  (1<<2)  /* Sample Duration bit 2 mask. */
+#define ADC_SAMPDUR_2_bp  2  /* Sample Duration bit 2 position. */
+#define ADC_SAMPDUR_3_bm  (1<<3)  /* Sample Duration bit 3 mask. */
+#define ADC_SAMPDUR_3_bp  3  /* Sample Duration bit 3 position. */
+#define ADC_SAMPDUR_4_bm  (1<<4)  /* Sample Duration bit 4 mask. */
+#define ADC_SAMPDUR_4_bp  4  /* Sample Duration bit 4 position. */
+#define ADC_SAMPDUR_5_bm  (1<<5)  /* Sample Duration bit 5 mask. */
+#define ADC_SAMPDUR_5_bp  5  /* Sample Duration bit 5 position. */
+#define ADC_SAMPDUR_6_bm  (1<<6)  /* Sample Duration bit 6 mask. */
+#define ADC_SAMPDUR_6_bp  6  /* Sample Duration bit 6 position. */
+#define ADC_SAMPDUR_7_bm  (1<<7)  /* Sample Duration bit 7 mask. */
+#define ADC_SAMPDUR_7_bp  7  /* Sample Duration bit 7 position. */
+
+/* ADC.CTRLF  bit masks and bit positions */
+#define ADC_SAMPNUM_gm  0x0F  /* Sample numbers group mask. */
+#define ADC_SAMPNUM_gp  0  /* Sample numbers group position. */
+#define ADC_SAMPNUM_0_bm  (1<<0)  /* Sample numbers bit 0 mask. */
+#define ADC_SAMPNUM_0_bp  0  /* Sample numbers bit 0 position. */
+#define ADC_SAMPNUM_1_bm  (1<<1)  /* Sample numbers bit 1 mask. */
+#define ADC_SAMPNUM_1_bp  1  /* Sample numbers bit 1 position. */
+#define ADC_SAMPNUM_2_bm  (1<<2)  /* Sample numbers bit 2 mask. */
+#define ADC_SAMPNUM_2_bp  2  /* Sample numbers bit 2 position. */
+#define ADC_SAMPNUM_3_bm  (1<<3)  /* Sample numbers bit 3 mask. */
+#define ADC_SAMPNUM_3_bp  3  /* Sample numbers bit 3 position. */
+#define ADC_LEFTADJ_bm  0x10  /* Left Adjust bit mask. */
+#define ADC_LEFTADJ_bp  4  /* Left Adjust bit position. */
+#define ADC_FREERUN_bm  0x20  /* Free-Running mode bit mask. */
+#define ADC_FREERUN_bp  5  /* Free-Running mode bit position. */
+#define ADC_CHOPPING_bm  0x40  /* Sign Chopping bit mask. */
+#define ADC_CHOPPING_bp  6  /* Sign Chopping bit position. */
+
+/* ADC.COMMAND  bit masks and bit positions */
+#define ADC_START_gm  0x07  /* Start command group mask. */
+#define ADC_START_gp  0  /* Start command group position. */
+#define ADC_START_0_bm  (1<<0)  /* Start command bit 0 mask. */
+#define ADC_START_0_bp  0  /* Start command bit 0 position. */
+#define ADC_START_1_bm  (1<<1)  /* Start command bit 1 mask. */
+#define ADC_START_1_bp  1  /* Start command bit 1 position. */
+#define ADC_START_2_bm  (1<<2)  /* Start command bit 2 mask. */
+#define ADC_START_2_bp  2  /* Start command bit 2 position. */
+#define ADC_MODE_gm  0x70  /* Mode group mask. */
+#define ADC_MODE_gp  4  /* Mode group position. */
+#define ADC_MODE_0_bm  (1<<4)  /* Mode bit 0 mask. */
+#define ADC_MODE_0_bp  4  /* Mode bit 0 position. */
+#define ADC_MODE_1_bm  (1<<5)  /* Mode bit 1 mask. */
+#define ADC_MODE_1_bp  5  /* Mode bit 1 position. */
+#define ADC_MODE_2_bm  (1<<6)  /* Mode bit 2 mask. */
+#define ADC_MODE_2_bp  6  /* Mode bit 2 position. */
+#define ADC_DIFF_bm  0x80  /* Differential mode bit mask. */
+#define ADC_DIFF_bp  7  /* Differential mode bit position. */
+
+/* ADC.PGACTRL  bit masks and bit positions */
+#define ADC_PGAEN_bm  0x01  /* PGA Enable bit mask. */
+#define ADC_PGAEN_bp  0  /* PGA Enable bit position. */
+#define ADC_PGABIASSEL_gm  0x18  /* PGA BIAS Select group mask. */
+#define ADC_PGABIASSEL_gp  3  /* PGA BIAS Select group position. */
+#define ADC_PGABIASSEL_0_bm  (1<<3)  /* PGA BIAS Select bit 0 mask. */
+#define ADC_PGABIASSEL_0_bp  3  /* PGA BIAS Select bit 0 position. */
+#define ADC_PGABIASSEL_1_bm  (1<<4)  /* PGA BIAS Select bit 1 mask. */
+#define ADC_PGABIASSEL_1_bp  4  /* PGA BIAS Select bit 1 position. */
+#define ADC_GAIN_gm  0xE0  /* Gain group mask. */
+#define ADC_GAIN_gp  5  /* Gain group position. */
+#define ADC_GAIN_0_bm  (1<<5)  /* Gain bit 0 mask. */
+#define ADC_GAIN_0_bp  5  /* Gain bit 0 position. */
+#define ADC_GAIN_1_bm  (1<<6)  /* Gain bit 1 mask. */
+#define ADC_GAIN_1_bp  6  /* Gain bit 1 position. */
+#define ADC_GAIN_2_bm  (1<<7)  /* Gain bit 2 mask. */
+#define ADC_GAIN_2_bp  7  /* Gain bit 2 position. */
+
+/* ADC.MUXPOS  bit masks and bit positions */
+#define ADC_MUXPOS_gm  0x3F  /* Analog Channel Selection Bits group mask. */
+#define ADC_MUXPOS_gp  0  /* Analog Channel Selection Bits group position. */
+#define ADC_MUXPOS_0_bm  (1<<0)  /* Analog Channel Selection Bits bit 0 mask. */
+#define ADC_MUXPOS_0_bp  0  /* Analog Channel Selection Bits bit 0 position. */
+#define ADC_MUXPOS_1_bm  (1<<1)  /* Analog Channel Selection Bits bit 1 mask. */
+#define ADC_MUXPOS_1_bp  1  /* Analog Channel Selection Bits bit 1 position. */
+#define ADC_MUXPOS_2_bm  (1<<2)  /* Analog Channel Selection Bits bit 2 mask. */
+#define ADC_MUXPOS_2_bp  2  /* Analog Channel Selection Bits bit 2 position. */
+#define ADC_MUXPOS_3_bm  (1<<3)  /* Analog Channel Selection Bits bit 3 mask. */
+#define ADC_MUXPOS_3_bp  3  /* Analog Channel Selection Bits bit 3 position. */
+#define ADC_MUXPOS_4_bm  (1<<4)  /* Analog Channel Selection Bits bit 4 mask. */
+#define ADC_MUXPOS_4_bp  4  /* Analog Channel Selection Bits bit 4 position. */
+#define ADC_MUXPOS_5_bm  (1<<5)  /* Analog Channel Selection Bits bit 5 mask. */
+#define ADC_MUXPOS_5_bp  5  /* Analog Channel Selection Bits bit 5 position. */
+#define ADC_VIA_gm  0xC0  /* VIA group mask. */
+#define ADC_VIA_gp  6  /* VIA group position. */
+#define ADC_VIA_0_bm  (1<<6)  /* VIA bit 0 mask. */
+#define ADC_VIA_0_bp  6  /* VIA bit 0 position. */
+#define ADC_VIA_1_bm  (1<<7)  /* VIA bit 1 mask. */
+#define ADC_VIA_1_bp  7  /* VIA bit 1 position. */
+
+/* ADC.MUXNEG  bit masks and bit positions */
+#define ADC_MUXNEG_gm  0x3F  /* Analog Channel Selection Bits group mask. */
+#define ADC_MUXNEG_gp  0  /* Analog Channel Selection Bits group position. */
+#define ADC_MUXNEG_0_bm  (1<<0)  /* Analog Channel Selection Bits bit 0 mask. */
+#define ADC_MUXNEG_0_bp  0  /* Analog Channel Selection Bits bit 0 position. */
+#define ADC_MUXNEG_1_bm  (1<<1)  /* Analog Channel Selection Bits bit 1 mask. */
+#define ADC_MUXNEG_1_bp  1  /* Analog Channel Selection Bits bit 1 position. */
+#define ADC_MUXNEG_2_bm  (1<<2)  /* Analog Channel Selection Bits bit 2 mask. */
+#define ADC_MUXNEG_2_bp  2  /* Analog Channel Selection Bits bit 2 position. */
+#define ADC_MUXNEG_3_bm  (1<<3)  /* Analog Channel Selection Bits bit 3 mask. */
+#define ADC_MUXNEG_3_bp  3  /* Analog Channel Selection Bits bit 3 position. */
+#define ADC_MUXNEG_4_bm  (1<<4)  /* Analog Channel Selection Bits bit 4 mask. */
+#define ADC_MUXNEG_4_bp  4  /* Analog Channel Selection Bits bit 4 position. */
+#define ADC_MUXNEG_5_bm  (1<<5)  /* Analog Channel Selection Bits bit 5 mask. */
+#define ADC_MUXNEG_5_bp  5  /* Analog Channel Selection Bits bit 5 position. */
+/* ADC_VIA  is already defined. */
+
+
+/* BOD - Bod interface */
+/* BOD.CTRLA  bit masks and bit positions */
+#define BOD_SLEEP_gm  0x03  /* Operation in sleep mode group mask. */
+#define BOD_SLEEP_gp  0  /* Operation in sleep mode group position. */
+#define BOD_SLEEP_0_bm  (1<<0)  /* Operation in sleep mode bit 0 mask. */
+#define BOD_SLEEP_0_bp  0  /* Operation in sleep mode bit 0 position. */
+#define BOD_SLEEP_1_bm  (1<<1)  /* Operation in sleep mode bit 1 mask. */
+#define BOD_SLEEP_1_bp  1  /* Operation in sleep mode bit 1 position. */
+#define BOD_ACTIVE_gm  0x0C  /* Operation in active mode group mask. */
+#define BOD_ACTIVE_gp  2  /* Operation in active mode group position. */
+#define BOD_ACTIVE_0_bm  (1<<2)  /* Operation in active mode bit 0 mask. */
+#define BOD_ACTIVE_0_bp  2  /* Operation in active mode bit 0 position. */
+#define BOD_ACTIVE_1_bm  (1<<3)  /* Operation in active mode bit 1 mask. */
+#define BOD_ACTIVE_1_bp  3  /* Operation in active mode bit 1 position. */
+#define BOD_SAMPFREQ_bm  0x10  /* Sample frequency bit mask. */
+#define BOD_SAMPFREQ_bp  4  /* Sample frequency bit position. */
+
+/* BOD.CTRLB  bit masks and bit positions */
+#define BOD_LVL_gm  0x07  /* Bod level group mask. */
+#define BOD_LVL_gp  0  /* Bod level group position. */
+#define BOD_LVL_0_bm  (1<<0)  /* Bod level bit 0 mask. */
+#define BOD_LVL_0_bp  0  /* Bod level bit 0 position. */
+#define BOD_LVL_1_bm  (1<<1)  /* Bod level bit 1 mask. */
+#define BOD_LVL_1_bp  1  /* Bod level bit 1 position. */
+#define BOD_LVL_2_bm  (1<<2)  /* Bod level bit 2 mask. */
+#define BOD_LVL_2_bp  2  /* Bod level bit 2 position. */
+
+/* BOD.VLMCTRLA  bit masks and bit positions */
+#define BOD_VLMLVL_gm  0x03  /* voltage level monitor level group mask. */
+#define BOD_VLMLVL_gp  0  /* voltage level monitor level group position. */
+#define BOD_VLMLVL_0_bm  (1<<0)  /* voltage level monitor level bit 0 mask. */
+#define BOD_VLMLVL_0_bp  0  /* voltage level monitor level bit 0 position. */
+#define BOD_VLMLVL_1_bm  (1<<1)  /* voltage level monitor level bit 1 mask. */
+#define BOD_VLMLVL_1_bp  1  /* voltage level monitor level bit 1 position. */
+
+/* BOD.INTCTRL  bit masks and bit positions */
+#define BOD_VLMIE_bm  0x01  /* voltage level monitor interrrupt enable bit mask. */
+#define BOD_VLMIE_bp  0  /* voltage level monitor interrrupt enable bit position. */
+#define BOD_VLMCFG_gm  0x06  /* Configuration group mask. */
+#define BOD_VLMCFG_gp  1  /* Configuration group position. */
+#define BOD_VLMCFG_0_bm  (1<<1)  /* Configuration bit 0 mask. */
+#define BOD_VLMCFG_0_bp  1  /* Configuration bit 0 position. */
+#define BOD_VLMCFG_1_bm  (1<<2)  /* Configuration bit 1 mask. */
+#define BOD_VLMCFG_1_bp  2  /* Configuration bit 1 position. */
+
+/* BOD.INTFLAGS  bit masks and bit positions */
+#define BOD_VLMIF_bm  0x01  /* Voltage level monitor interrupt flag bit mask. */
+#define BOD_VLMIF_bp  0  /* Voltage level monitor interrupt flag bit position. */
+
+/* BOD.STATUS  bit masks and bit positions */
+#define BOD_VLMS_bm  0x01  /* Voltage level monitor status bit mask. */
+#define BOD_VLMS_bp  0  /* Voltage level monitor status bit position. */
+
+
+/* CCL - Configurable Custom Logic */
+/* CCL.CTRLA  bit masks and bit positions */
+#define CCL_ENABLE_bm  0x01  /* Enable bit mask. */
+#define CCL_ENABLE_bp  0  /* Enable bit position. */
+#define CCL_RUNSTDBY_bm  0x40  /* Run in Standby bit mask. */
+#define CCL_RUNSTDBY_bp  6  /* Run in Standby bit position. */
+
+/* CCL.SEQCTRL0  bit masks and bit positions */
+#define CCL_SEQSEL_gm  0x07  /* Sequential Selection group mask. */
+#define CCL_SEQSEL_gp  0  /* Sequential Selection group position. */
+#define CCL_SEQSEL_0_bm  (1<<0)  /* Sequential Selection bit 0 mask. */
+#define CCL_SEQSEL_0_bp  0  /* Sequential Selection bit 0 position. */
+#define CCL_SEQSEL_1_bm  (1<<1)  /* Sequential Selection bit 1 mask. */
+#define CCL_SEQSEL_1_bp  1  /* Sequential Selection bit 1 position. */
+#define CCL_SEQSEL_2_bm  (1<<2)  /* Sequential Selection bit 2 mask. */
+#define CCL_SEQSEL_2_bp  2  /* Sequential Selection bit 2 position. */
+
+/* CCL.SEQCTRL1  bit masks and bit positions */
+/* CCL_SEQSEL  is already defined. */
+
+/* CCL.INTCTRL0  bit masks and bit positions */
+#define CCL_INTMODE0_gm  0x03  /* Interrupt Mode for LUT0 group mask. */
+#define CCL_INTMODE0_gp  0  /* Interrupt Mode for LUT0 group position. */
+#define CCL_INTMODE0_0_bm  (1<<0)  /* Interrupt Mode for LUT0 bit 0 mask. */
+#define CCL_INTMODE0_0_bp  0  /* Interrupt Mode for LUT0 bit 0 position. */
+#define CCL_INTMODE0_1_bm  (1<<1)  /* Interrupt Mode for LUT0 bit 1 mask. */
+#define CCL_INTMODE0_1_bp  1  /* Interrupt Mode for LUT0 bit 1 position. */
+#define CCL_INTMODE1_gm  0x0C  /* Interrupt Mode for LUT1 group mask. */
+#define CCL_INTMODE1_gp  2  /* Interrupt Mode for LUT1 group position. */
+#define CCL_INTMODE1_0_bm  (1<<2)  /* Interrupt Mode for LUT1 bit 0 mask. */
+#define CCL_INTMODE1_0_bp  2  /* Interrupt Mode for LUT1 bit 0 position. */
+#define CCL_INTMODE1_1_bm  (1<<3)  /* Interrupt Mode for LUT1 bit 1 mask. */
+#define CCL_INTMODE1_1_bp  3  /* Interrupt Mode for LUT1 bit 1 position. */
+#define CCL_INTMODE2_gm  0x30  /* Interrupt Mode for LUT2 group mask. */
+#define CCL_INTMODE2_gp  4  /* Interrupt Mode for LUT2 group position. */
+#define CCL_INTMODE2_0_bm  (1<<4)  /* Interrupt Mode for LUT2 bit 0 mask. */
+#define CCL_INTMODE2_0_bp  4  /* Interrupt Mode for LUT2 bit 0 position. */
+#define CCL_INTMODE2_1_bm  (1<<5)  /* Interrupt Mode for LUT2 bit 1 mask. */
+#define CCL_INTMODE2_1_bp  5  /* Interrupt Mode for LUT2 bit 1 position. */
+#define CCL_INTMODE3_gm  0xC0  /* Interrupt Mode for LUT3 group mask. */
+#define CCL_INTMODE3_gp  6  /* Interrupt Mode for LUT3 group position. */
+#define CCL_INTMODE3_0_bm  (1<<6)  /* Interrupt Mode for LUT3 bit 0 mask. */
+#define CCL_INTMODE3_0_bp  6  /* Interrupt Mode for LUT3 bit 0 position. */
+#define CCL_INTMODE3_1_bm  (1<<7)  /* Interrupt Mode for LUT3 bit 1 mask. */
+#define CCL_INTMODE3_1_bp  7  /* Interrupt Mode for LUT3 bit 1 position. */
+
+/* CCL.INTFLAGS  bit masks and bit positions */
+#define CCL_INT_gm  0x0F  /* Interrupt Flag group mask. */
+#define CCL_INT_gp  0  /* Interrupt Flag group position. */
+#define CCL_INT_0_bm  (1<<0)  /* Interrupt Flag bit 0 mask. */
+#define CCL_INT_0_bp  0  /* Interrupt Flag bit 0 position. */
+#define CCL_INT0_bm  CCL_INT_0_bm  /* This define is deprecated and should not be used */
+#define CCL_INT0_bp  CCL_INT_0_bp  /* This define is deprecated and should not be used */
+#define CCL_INT_1_bm  (1<<1)  /* Interrupt Flag bit 1 mask. */
+#define CCL_INT_1_bp  1  /* Interrupt Flag bit 1 position. */
+#define CCL_INT1_bm  CCL_INT_1_bm  /* This define is deprecated and should not be used */
+#define CCL_INT1_bp  CCL_INT_1_bp  /* This define is deprecated and should not be used */
+#define CCL_INT_2_bm  (1<<2)  /* Interrupt Flag bit 2 mask. */
+#define CCL_INT_2_bp  2  /* Interrupt Flag bit 2 position. */
+#define CCL_INT2_bm  CCL_INT_2_bm  /* This define is deprecated and should not be used */
+#define CCL_INT2_bp  CCL_INT_2_bp  /* This define is deprecated and should not be used */
+#define CCL_INT_3_bm  (1<<3)  /* Interrupt Flag bit 3 mask. */
+#define CCL_INT_3_bp  3  /* Interrupt Flag bit 3 position. */
+#define CCL_INT3_bm  CCL_INT_3_bm  /* This define is deprecated and should not be used */
+#define CCL_INT3_bp  CCL_INT_3_bp  /* This define is deprecated and should not be used */
+
+/* CCL.LUT0CTRLA  bit masks and bit positions */
+/* CCL_ENABLE  is already defined. */
+#define CCL_CLKSRC_gm  0x0E  /* Clock Source Selection group mask. */
+#define CCL_CLKSRC_gp  1  /* Clock Source Selection group position. */
+#define CCL_CLKSRC_0_bm  (1<<1)  /* Clock Source Selection bit 0 mask. */
+#define CCL_CLKSRC_0_bp  1  /* Clock Source Selection bit 0 position. */
+#define CCL_CLKSRC_1_bm  (1<<2)  /* Clock Source Selection bit 1 mask. */
+#define CCL_CLKSRC_1_bp  2  /* Clock Source Selection bit 1 position. */
+#define CCL_CLKSRC_2_bm  (1<<3)  /* Clock Source Selection bit 2 mask. */
+#define CCL_CLKSRC_2_bp  3  /* Clock Source Selection bit 2 position. */
+#define CCL_FILTSEL_gm  0x30  /* Filter Selection group mask. */
+#define CCL_FILTSEL_gp  4  /* Filter Selection group position. */
+#define CCL_FILTSEL_0_bm  (1<<4)  /* Filter Selection bit 0 mask. */
+#define CCL_FILTSEL_0_bp  4  /* Filter Selection bit 0 position. */
+#define CCL_FILTSEL_1_bm  (1<<5)  /* Filter Selection bit 1 mask. */
+#define CCL_FILTSEL_1_bp  5  /* Filter Selection bit 1 position. */
+#define CCL_OUTEN_bm  0x40  /* Output Enable bit mask. */
+#define CCL_OUTEN_bp  6  /* Output Enable bit position. */
+#define CCL_EDGEDET_bm  0x80  /* Edge Detection Enable bit mask. */
+#define CCL_EDGEDET_bp  7  /* Edge Detection Enable bit position. */
+
+/* CCL.LUT0CTRLB  bit masks and bit positions */
+#define CCL_INSEL0_gm  0x0F  /* LUT Input 0 Source Selection group mask. */
+#define CCL_INSEL0_gp  0  /* LUT Input 0 Source Selection group position. */
+#define CCL_INSEL0_0_bm  (1<<0)  /* LUT Input 0 Source Selection bit 0 mask. */
+#define CCL_INSEL0_0_bp  0  /* LUT Input 0 Source Selection bit 0 position. */
+#define CCL_INSEL0_1_bm  (1<<1)  /* LUT Input 0 Source Selection bit 1 mask. */
+#define CCL_INSEL0_1_bp  1  /* LUT Input 0 Source Selection bit 1 position. */
+#define CCL_INSEL0_2_bm  (1<<2)  /* LUT Input 0 Source Selection bit 2 mask. */
+#define CCL_INSEL0_2_bp  2  /* LUT Input 0 Source Selection bit 2 position. */
+#define CCL_INSEL0_3_bm  (1<<3)  /* LUT Input 0 Source Selection bit 3 mask. */
+#define CCL_INSEL0_3_bp  3  /* LUT Input 0 Source Selection bit 3 position. */
+#define CCL_INSEL1_gm  0xF0  /* LUT Input 1 Source Selection group mask. */
+#define CCL_INSEL1_gp  4  /* LUT Input 1 Source Selection group position. */
+#define CCL_INSEL1_0_bm  (1<<4)  /* LUT Input 1 Source Selection bit 0 mask. */
+#define CCL_INSEL1_0_bp  4  /* LUT Input 1 Source Selection bit 0 position. */
+#define CCL_INSEL1_1_bm  (1<<5)  /* LUT Input 1 Source Selection bit 1 mask. */
+#define CCL_INSEL1_1_bp  5  /* LUT Input 1 Source Selection bit 1 position. */
+#define CCL_INSEL1_2_bm  (1<<6)  /* LUT Input 1 Source Selection bit 2 mask. */
+#define CCL_INSEL1_2_bp  6  /* LUT Input 1 Source Selection bit 2 position. */
+#define CCL_INSEL1_3_bm  (1<<7)  /* LUT Input 1 Source Selection bit 3 mask. */
+#define CCL_INSEL1_3_bp  7  /* LUT Input 1 Source Selection bit 3 position. */
+
+/* CCL.LUT0CTRLC  bit masks and bit positions */
+#define CCL_INSEL2_gm  0x0F  /* LUT Input 2 Source Selection group mask. */
+#define CCL_INSEL2_gp  0  /* LUT Input 2 Source Selection group position. */
+#define CCL_INSEL2_0_bm  (1<<0)  /* LUT Input 2 Source Selection bit 0 mask. */
+#define CCL_INSEL2_0_bp  0  /* LUT Input 2 Source Selection bit 0 position. */
+#define CCL_INSEL2_1_bm  (1<<1)  /* LUT Input 2 Source Selection bit 1 mask. */
+#define CCL_INSEL2_1_bp  1  /* LUT Input 2 Source Selection bit 1 position. */
+#define CCL_INSEL2_2_bm  (1<<2)  /* LUT Input 2 Source Selection bit 2 mask. */
+#define CCL_INSEL2_2_bp  2  /* LUT Input 2 Source Selection bit 2 position. */
+#define CCL_INSEL2_3_bm  (1<<3)  /* LUT Input 2 Source Selection bit 3 mask. */
+#define CCL_INSEL2_3_bp  3  /* LUT Input 2 Source Selection bit 3 position. */
+
+/* CCL.TRUTH0  bit masks and bit positions */
+#define CCL_TRUTH_gm  0xFF  /* Truth Table group mask. */
+#define CCL_TRUTH_gp  0  /* Truth Table group position. */
+#define CCL_TRUTH_0_bm  (1<<0)  /* Truth Table bit 0 mask. */
+#define CCL_TRUTH_0_bp  0  /* Truth Table bit 0 position. */
+#define CCL_TRUTH_1_bm  (1<<1)  /* Truth Table bit 1 mask. */
+#define CCL_TRUTH_1_bp  1  /* Truth Table bit 1 position. */
+#define CCL_TRUTH_2_bm  (1<<2)  /* Truth Table bit 2 mask. */
+#define CCL_TRUTH_2_bp  2  /* Truth Table bit 2 position. */
+#define CCL_TRUTH_3_bm  (1<<3)  /* Truth Table bit 3 mask. */
+#define CCL_TRUTH_3_bp  3  /* Truth Table bit 3 position. */
+#define CCL_TRUTH_4_bm  (1<<4)  /* Truth Table bit 4 mask. */
+#define CCL_TRUTH_4_bp  4  /* Truth Table bit 4 position. */
+#define CCL_TRUTH_5_bm  (1<<5)  /* Truth Table bit 5 mask. */
+#define CCL_TRUTH_5_bp  5  /* Truth Table bit 5 position. */
+#define CCL_TRUTH_6_bm  (1<<6)  /* Truth Table bit 6 mask. */
+#define CCL_TRUTH_6_bp  6  /* Truth Table bit 6 position. */
+#define CCL_TRUTH_7_bm  (1<<7)  /* Truth Table bit 7 mask. */
+#define CCL_TRUTH_7_bp  7  /* Truth Table bit 7 position. */
+
+/* CCL.LUT1CTRLA  bit masks and bit positions */
+/* CCL_ENABLE  is already defined. */
+/* CCL_CLKSRC  is already defined. */
+/* CCL_FILTSEL  is already defined. */
+/* CCL_OUTEN  is already defined. */
+/* CCL_EDGEDET  is already defined. */
+
+/* CCL.LUT1CTRLB  bit masks and bit positions */
+/* CCL_INSEL0  is already defined. */
+/* CCL_INSEL1  is already defined. */
+
+/* CCL.LUT1CTRLC  bit masks and bit positions */
+/* CCL_INSEL2  is already defined. */
+
+/* CCL.TRUTH1  bit masks and bit positions */
+/* CCL_TRUTH  is already defined. */
+
+/* CCL.LUT2CTRLA  bit masks and bit positions */
+/* CCL_ENABLE  is already defined. */
+/* CCL_CLKSRC  is already defined. */
+/* CCL_FILTSEL  is already defined. */
+/* CCL_OUTEN  is already defined. */
+/* CCL_EDGEDET  is already defined. */
+
+/* CCL.LUT2CTRLB  bit masks and bit positions */
+/* CCL_INSEL0  is already defined. */
+/* CCL_INSEL1  is already defined. */
+
+/* CCL.LUT2CTRLC  bit masks and bit positions */
+/* CCL_INSEL2  is already defined. */
+
+/* CCL.TRUTH2  bit masks and bit positions */
+/* CCL_TRUTH  is already defined. */
+
+/* CCL.LUT3CTRLA  bit masks and bit positions */
+/* CCL_ENABLE  is already defined. */
+/* CCL_CLKSRC  is already defined. */
+/* CCL_FILTSEL  is already defined. */
+/* CCL_OUTEN  is already defined. */
+/* CCL_EDGEDET  is already defined. */
+
+/* CCL.LUT3CTRLB  bit masks and bit positions */
+/* CCL_INSEL0  is already defined. */
+/* CCL_INSEL1  is already defined. */
+
+/* CCL.LUT3CTRLC  bit masks and bit positions */
+/* CCL_INSEL2  is already defined. */
+
+/* CCL.TRUTH3  bit masks and bit positions */
+/* CCL_TRUTH  is already defined. */
+
+
+/* CLKCTRL - Clock controller */
+/* CLKCTRL.MCLKCTRLA  bit masks and bit positions */
+#define CLKCTRL_CLKSEL_gm  0x07  /* Clock select group mask. */
+#define CLKCTRL_CLKSEL_gp  0  /* Clock select group position. */
+#define CLKCTRL_CLKSEL_0_bm  (1<<0)  /* Clock select bit 0 mask. */
+#define CLKCTRL_CLKSEL_0_bp  0  /* Clock select bit 0 position. */
+#define CLKCTRL_CLKSEL_1_bm  (1<<1)  /* Clock select bit 1 mask. */
+#define CLKCTRL_CLKSEL_1_bp  1  /* Clock select bit 1 position. */
+#define CLKCTRL_CLKSEL_2_bm  (1<<2)  /* Clock select bit 2 mask. */
+#define CLKCTRL_CLKSEL_2_bp  2  /* Clock select bit 2 position. */
+#define CLKCTRL_CLKOUT_bm  0x80  /* System clock out bit mask. */
+#define CLKCTRL_CLKOUT_bp  7  /* System clock out bit position. */
+
+/* CLKCTRL.MCLKCTRLB  bit masks and bit positions */
+#define CLKCTRL_PEN_bm  0x01  /* Prescaler enable bit mask. */
+#define CLKCTRL_PEN_bp  0  /* Prescaler enable bit position. */
+#define CLKCTRL_PDIV_gm  0x1E  /* Prescaler division group mask. */
+#define CLKCTRL_PDIV_gp  1  /* Prescaler division group position. */
+#define CLKCTRL_PDIV_0_bm  (1<<1)  /* Prescaler division bit 0 mask. */
+#define CLKCTRL_PDIV_0_bp  1  /* Prescaler division bit 0 position. */
+#define CLKCTRL_PDIV_1_bm  (1<<2)  /* Prescaler division bit 1 mask. */
+#define CLKCTRL_PDIV_1_bp  2  /* Prescaler division bit 1 position. */
+#define CLKCTRL_PDIV_2_bm  (1<<3)  /* Prescaler division bit 2 mask. */
+#define CLKCTRL_PDIV_2_bp  3  /* Prescaler division bit 2 position. */
+#define CLKCTRL_PDIV_3_bm  (1<<4)  /* Prescaler division bit 3 mask. */
+#define CLKCTRL_PDIV_3_bp  4  /* Prescaler division bit 3 position. */
+
+/* CLKCTRL.MCLKCTRLC  bit masks and bit positions */
+#define CLKCTRL_CFDEN_bm  0x01  /* Clock Failure Detect Enable bit mask. */
+#define CLKCTRL_CFDEN_bp  0  /* Clock Failure Detect Enable bit position. */
+#define CLKCTRL_CFDTST_bm  0x02  /* CFD Test bit mask. */
+#define CLKCTRL_CFDTST_bp  1  /* CFD Test bit position. */
+#define CLKCTRL_CFDSRC_gm  0x0C  /* CFD Source group mask. */
+#define CLKCTRL_CFDSRC_gp  2  /* CFD Source group position. */
+#define CLKCTRL_CFDSRC_0_bm  (1<<2)  /* CFD Source bit 0 mask. */
+#define CLKCTRL_CFDSRC_0_bp  2  /* CFD Source bit 0 position. */
+#define CLKCTRL_CFDSRC_1_bm  (1<<3)  /* CFD Source bit 1 mask. */
+#define CLKCTRL_CFDSRC_1_bp  3  /* CFD Source bit 1 position. */
+
+/* CLKCTRL.MCLKINTCTRL  bit masks and bit positions */
+#define CLKCTRL_CFD_bm  0x01  /* Interrupt Enable bit mask. */
+#define CLKCTRL_CFD_bp  0  /* Interrupt Enable bit position. */
+#define CLKCTRL_INTTYPE_bm  0x80  /* Interrupt Type bit mask. */
+#define CLKCTRL_INTTYPE_bp  7  /* Interrupt Type bit position. */
+
+/* CLKCTRL.MCLKINTFLAGS  bit masks and bit positions */
+/* CLKCTRL_CFD  is already defined. */
+
+/* CLKCTRL.MCLKSTATUS  bit masks and bit positions */
+#define CLKCTRL_SOSC_bm  0x01  /* System Oscillator changing bit mask. */
+#define CLKCTRL_SOSC_bp  0  /* System Oscillator changing bit position. */
+#define CLKCTRL_OSCHFS_bm  0x02  /* High frequency oscillator status bit mask. */
+#define CLKCTRL_OSCHFS_bp  1  /* High frequency oscillator status bit position. */
+#define CLKCTRL_OSC32KS_bm  0x04  /* 32KHz oscillator status bit mask. */
+#define CLKCTRL_OSC32KS_bp  2  /* 32KHz oscillator status bit position. */
+#define CLKCTRL_XOSC32KS_bm  0x08  /* 32.768 kHz Crystal Oscillator status bit mask. */
+#define CLKCTRL_XOSC32KS_bp  3  /* 32.768 kHz Crystal Oscillator status bit position. */
+#define CLKCTRL_EXTS_bm  0x10  /* External Clock status / XOSCHF status bit mask. */
+#define CLKCTRL_EXTS_bp  4  /* External Clock status / XOSCHF status bit position. */
+
+/* CLKCTRL.MCLKTIMEBASE  bit masks and bit positions */
+#define CLKCTRL_TIMEBASE_gm  0x1F  /* Timebase group mask. */
+#define CLKCTRL_TIMEBASE_gp  0  /* Timebase group position. */
+#define CLKCTRL_TIMEBASE_0_bm  (1<<0)  /* Timebase bit 0 mask. */
+#define CLKCTRL_TIMEBASE_0_bp  0  /* Timebase bit 0 position. */
+#define CLKCTRL_TIMEBASE_1_bm  (1<<1)  /* Timebase bit 1 mask. */
+#define CLKCTRL_TIMEBASE_1_bp  1  /* Timebase bit 1 position. */
+#define CLKCTRL_TIMEBASE_2_bm  (1<<2)  /* Timebase bit 2 mask. */
+#define CLKCTRL_TIMEBASE_2_bp  2  /* Timebase bit 2 position. */
+#define CLKCTRL_TIMEBASE_3_bm  (1<<3)  /* Timebase bit 3 mask. */
+#define CLKCTRL_TIMEBASE_3_bp  3  /* Timebase bit 3 position. */
+#define CLKCTRL_TIMEBASE_4_bm  (1<<4)  /* Timebase bit 4 mask. */
+#define CLKCTRL_TIMEBASE_4_bp  4  /* Timebase bit 4 position. */
+
+/* CLKCTRL.OSCHFCTRLA  bit masks and bit positions */
+#define CLKCTRL_AUTOTUNE_gm  0x03  /* Automatic Oscillator Tune group mask. */
+#define CLKCTRL_AUTOTUNE_gp  0  /* Automatic Oscillator Tune group position. */
+#define CLKCTRL_AUTOTUNE_0_bm  (1<<0)  /* Automatic Oscillator Tune bit 0 mask. */
+#define CLKCTRL_AUTOTUNE_0_bp  0  /* Automatic Oscillator Tune bit 0 position. */
+#define CLKCTRL_AUTOTUNE_1_bm  (1<<1)  /* Automatic Oscillator Tune bit 1 mask. */
+#define CLKCTRL_AUTOTUNE_1_bp  1  /* Automatic Oscillator Tune bit 1 position. */
+#define CLKCTRL_RUNSTDBY_bm  0x80  /* Run in standby bit mask. */
+#define CLKCTRL_RUNSTDBY_bp  7  /* Run in standby bit position. */
+
+/* CLKCTRL.OSCHFTUNE  bit masks and bit positions */
+#define CLKCTRL_TUNE_gm  0xFF  /* Oscillator Tune group mask. */
+#define CLKCTRL_TUNE_gp  0  /* Oscillator Tune group position. */
+#define CLKCTRL_TUNE_0_bm  (1<<0)  /* Oscillator Tune bit 0 mask. */
+#define CLKCTRL_TUNE_0_bp  0  /* Oscillator Tune bit 0 position. */
+#define CLKCTRL_TUNE_1_bm  (1<<1)  /* Oscillator Tune bit 1 mask. */
+#define CLKCTRL_TUNE_1_bp  1  /* Oscillator Tune bit 1 position. */
+#define CLKCTRL_TUNE_2_bm  (1<<2)  /* Oscillator Tune bit 2 mask. */
+#define CLKCTRL_TUNE_2_bp  2  /* Oscillator Tune bit 2 position. */
+#define CLKCTRL_TUNE_3_bm  (1<<3)  /* Oscillator Tune bit 3 mask. */
+#define CLKCTRL_TUNE_3_bp  3  /* Oscillator Tune bit 3 position. */
+#define CLKCTRL_TUNE_4_bm  (1<<4)  /* Oscillator Tune bit 4 mask. */
+#define CLKCTRL_TUNE_4_bp  4  /* Oscillator Tune bit 4 position. */
+#define CLKCTRL_TUNE_5_bm  (1<<5)  /* Oscillator Tune bit 5 mask. */
+#define CLKCTRL_TUNE_5_bp  5  /* Oscillator Tune bit 5 position. */
+#define CLKCTRL_TUNE_6_bm  (1<<6)  /* Oscillator Tune bit 6 mask. */
+#define CLKCTRL_TUNE_6_bp  6  /* Oscillator Tune bit 6 position. */
+#define CLKCTRL_TUNE_7_bm  (1<<7)  /* Oscillator Tune bit 7 mask. */
+#define CLKCTRL_TUNE_7_bp  7  /* Oscillator Tune bit 7 position. */
+
+/* CLKCTRL.OSC32KCTRLA  bit masks and bit positions */
+/* CLKCTRL_RUNSTDBY  is already defined. */
+
+/* CLKCTRL.XOSC32KCTRLA  bit masks and bit positions */
+#define CLKCTRL_ENABLE_bm  0x01  /* Enable bit mask. */
+#define CLKCTRL_ENABLE_bp  0  /* Enable bit position. */
+#define CLKCTRL_LPMODE_bm  0x02  /* Low power mode bit mask. */
+#define CLKCTRL_LPMODE_bp  1  /* Low power mode bit position. */
+#define CLKCTRL_SEL_bm  0x04  /* Select bit mask. */
+#define CLKCTRL_SEL_bp  2  /* Select bit position. */
+#define CLKCTRL_CSUT_gm  0x30  /* Crystal startup time group mask. */
+#define CLKCTRL_CSUT_gp  4  /* Crystal startup time group position. */
+#define CLKCTRL_CSUT_0_bm  (1<<4)  /* Crystal startup time bit 0 mask. */
+#define CLKCTRL_CSUT_0_bp  4  /* Crystal startup time bit 0 position. */
+#define CLKCTRL_CSUT_1_bm  (1<<5)  /* Crystal startup time bit 1 mask. */
+#define CLKCTRL_CSUT_1_bp  5  /* Crystal startup time bit 1 position. */
+/* CLKCTRL_RUNSTDBY  is already defined. */
+
+/* CLKCTRL.XOSCHFCTRLA  bit masks and bit positions */
+/* CLKCTRL_ENABLE  is already defined. */
+#define CLKCTRL_SELHF_bm  0x02  /* Source Select bit mask. */
+#define CLKCTRL_SELHF_bp  1  /* Source Select bit position. */
+#define CLKCTRL_CSUTHF_gm  0x30  /* Start-Up Time group mask. */
+#define CLKCTRL_CSUTHF_gp  4  /* Start-Up Time group position. */
+#define CLKCTRL_CSUTHF_0_bm  (1<<4)  /* Start-Up Time bit 0 mask. */
+#define CLKCTRL_CSUTHF_0_bp  4  /* Start-Up Time bit 0 position. */
+#define CLKCTRL_CSUTHF_1_bm  (1<<5)  /* Start-Up Time bit 1 mask. */
+#define CLKCTRL_CSUTHF_1_bp  5  /* Start-Up Time bit 1 position. */
+/* CLKCTRL_RUNSTDBY  is already defined. */
+
+
+/* CPU - CPU */
+/* CPU.CCP  bit masks and bit positions */
+#define CPU_CCP_gm  0xFF  /* CCP signature group mask. */
+#define CPU_CCP_gp  0  /* CCP signature group position. */
+#define CPU_CCP_0_bm  (1<<0)  /* CCP signature bit 0 mask. */
+#define CPU_CCP_0_bp  0  /* CCP signature bit 0 position. */
+#define CPU_CCP_1_bm  (1<<1)  /* CCP signature bit 1 mask. */
+#define CPU_CCP_1_bp  1  /* CCP signature bit 1 position. */
+#define CPU_CCP_2_bm  (1<<2)  /* CCP signature bit 2 mask. */
+#define CPU_CCP_2_bp  2  /* CCP signature bit 2 position. */
+#define CPU_CCP_3_bm  (1<<3)  /* CCP signature bit 3 mask. */
+#define CPU_CCP_3_bp  3  /* CCP signature bit 3 position. */
+#define CPU_CCP_4_bm  (1<<4)  /* CCP signature bit 4 mask. */
+#define CPU_CCP_4_bp  4  /* CCP signature bit 4 position. */
+#define CPU_CCP_5_bm  (1<<5)  /* CCP signature bit 5 mask. */
+#define CPU_CCP_5_bp  5  /* CCP signature bit 5 position. */
+#define CPU_CCP_6_bm  (1<<6)  /* CCP signature bit 6 mask. */
+#define CPU_CCP_6_bp  6  /* CCP signature bit 6 position. */
+#define CPU_CCP_7_bm  (1<<7)  /* CCP signature bit 7 mask. */
+#define CPU_CCP_7_bp  7  /* CCP signature bit 7 position. */
+
+/* CPU.SREG  bit masks and bit positions */
+#define CPU_C_bm  0x01  /* Carry Flag bit mask. */
+#define CPU_C_bp  0  /* Carry Flag bit position. */
+#define CPU_Z_bm  0x02  /* Zero Flag bit mask. */
+#define CPU_Z_bp  1  /* Zero Flag bit position. */
+#define CPU_N_bm  0x04  /* Negative Flag bit mask. */
+#define CPU_N_bp  2  /* Negative Flag bit position. */
+#define CPU_V_bm  0x08  /* Two's Complement Overflow Flag bit mask. */
+#define CPU_V_bp  3  /* Two's Complement Overflow Flag bit position. */
+#define CPU_S_bm  0x10  /* N Exclusive Or V Flag bit mask. */
+#define CPU_S_bp  4  /* N Exclusive Or V Flag bit position. */
+#define CPU_H_bm  0x20  /* Half Carry Flag bit mask. */
+#define CPU_H_bp  5  /* Half Carry Flag bit position. */
+#define CPU_T_bm  0x40  /* Transfer Bit bit mask. */
+#define CPU_T_bp  6  /* Transfer Bit bit position. */
+#define CPU_I_bm  0x80  /* Global Interrupt Enable Flag bit mask. */
+#define CPU_I_bp  7  /* Global Interrupt Enable Flag bit position. */
+
+
+/* CPUINT - Interrupt Controller */
+/* CPUINT.CTRLA  bit masks and bit positions */
+#define CPUINT_LVL0RR_bm  0x01  /* Round-robin Scheduling Enable bit mask. */
+#define CPUINT_LVL0RR_bp  0  /* Round-robin Scheduling Enable bit position. */
+#define CPUINT_CVT_bm  0x20  /* Compact Vector Table bit mask. */
+#define CPUINT_CVT_bp  5  /* Compact Vector Table bit position. */
+#define CPUINT_IVSEL_bm  0x40  /* Interrupt Vector Select bit mask. */
+#define CPUINT_IVSEL_bp  6  /* Interrupt Vector Select bit position. */
+
+/* CPUINT.STATUS  bit masks and bit positions */
+#define CPUINT_LVL0EX_bm  0x01  /* Level 0 Interrupt Executing bit mask. */
+#define CPUINT_LVL0EX_bp  0  /* Level 0 Interrupt Executing bit position. */
+#define CPUINT_LVL1EX_bm  0x02  /* Level 1 Interrupt Executing bit mask. */
+#define CPUINT_LVL1EX_bp  1  /* Level 1 Interrupt Executing bit position. */
+#define CPUINT_NMIEX_bm  0x80  /* Non-maskable Interrupt Executing bit mask. */
+#define CPUINT_NMIEX_bp  7  /* Non-maskable Interrupt Executing bit position. */
+
+/* CPUINT.LVL0PRI  bit masks and bit positions */
+#define CPUINT_LVL0PRI_gm  0xFF  /* Interrupt Level Priority group mask. */
+#define CPUINT_LVL0PRI_gp  0  /* Interrupt Level Priority group position. */
+#define CPUINT_LVL0PRI_0_bm  (1<<0)  /* Interrupt Level Priority bit 0 mask. */
+#define CPUINT_LVL0PRI_0_bp  0  /* Interrupt Level Priority bit 0 position. */
+#define CPUINT_LVL0PRI_1_bm  (1<<1)  /* Interrupt Level Priority bit 1 mask. */
+#define CPUINT_LVL0PRI_1_bp  1  /* Interrupt Level Priority bit 1 position. */
+#define CPUINT_LVL0PRI_2_bm  (1<<2)  /* Interrupt Level Priority bit 2 mask. */
+#define CPUINT_LVL0PRI_2_bp  2  /* Interrupt Level Priority bit 2 position. */
+#define CPUINT_LVL0PRI_3_bm  (1<<3)  /* Interrupt Level Priority bit 3 mask. */
+#define CPUINT_LVL0PRI_3_bp  3  /* Interrupt Level Priority bit 3 position. */
+#define CPUINT_LVL0PRI_4_bm  (1<<4)  /* Interrupt Level Priority bit 4 mask. */
+#define CPUINT_LVL0PRI_4_bp  4  /* Interrupt Level Priority bit 4 position. */
+#define CPUINT_LVL0PRI_5_bm  (1<<5)  /* Interrupt Level Priority bit 5 mask. */
+#define CPUINT_LVL0PRI_5_bp  5  /* Interrupt Level Priority bit 5 position. */
+#define CPUINT_LVL0PRI_6_bm  (1<<6)  /* Interrupt Level Priority bit 6 mask. */
+#define CPUINT_LVL0PRI_6_bp  6  /* Interrupt Level Priority bit 6 position. */
+#define CPUINT_LVL0PRI_7_bm  (1<<7)  /* Interrupt Level Priority bit 7 mask. */
+#define CPUINT_LVL0PRI_7_bp  7  /* Interrupt Level Priority bit 7 position. */
+
+/* CPUINT.LVL1VEC  bit masks and bit positions */
+#define CPUINT_LVL1VEC_gm  0xFF  /* Interrupt Vector with High Priority group mask. */
+#define CPUINT_LVL1VEC_gp  0  /* Interrupt Vector with High Priority group position. */
+#define CPUINT_LVL1VEC_0_bm  (1<<0)  /* Interrupt Vector with High Priority bit 0 mask. */
+#define CPUINT_LVL1VEC_0_bp  0  /* Interrupt Vector with High Priority bit 0 position. */
+#define CPUINT_LVL1VEC_1_bm  (1<<1)  /* Interrupt Vector with High Priority bit 1 mask. */
+#define CPUINT_LVL1VEC_1_bp  1  /* Interrupt Vector with High Priority bit 1 position. */
+#define CPUINT_LVL1VEC_2_bm  (1<<2)  /* Interrupt Vector with High Priority bit 2 mask. */
+#define CPUINT_LVL1VEC_2_bp  2  /* Interrupt Vector with High Priority bit 2 position. */
+#define CPUINT_LVL1VEC_3_bm  (1<<3)  /* Interrupt Vector with High Priority bit 3 mask. */
+#define CPUINT_LVL1VEC_3_bp  3  /* Interrupt Vector with High Priority bit 3 position. */
+#define CPUINT_LVL1VEC_4_bm  (1<<4)  /* Interrupt Vector with High Priority bit 4 mask. */
+#define CPUINT_LVL1VEC_4_bp  4  /* Interrupt Vector with High Priority bit 4 position. */
+#define CPUINT_LVL1VEC_5_bm  (1<<5)  /* Interrupt Vector with High Priority bit 5 mask. */
+#define CPUINT_LVL1VEC_5_bp  5  /* Interrupt Vector with High Priority bit 5 position. */
+#define CPUINT_LVL1VEC_6_bm  (1<<6)  /* Interrupt Vector with High Priority bit 6 mask. */
+#define CPUINT_LVL1VEC_6_bp  6  /* Interrupt Vector with High Priority bit 6 position. */
+#define CPUINT_LVL1VEC_7_bm  (1<<7)  /* Interrupt Vector with High Priority bit 7 mask. */
+#define CPUINT_LVL1VEC_7_bp  7  /* Interrupt Vector with High Priority bit 7 position. */
+
+
+/* CRCSCAN - CRCSCAN */
+/* CRCSCAN.CTRLA  bit masks and bit positions */
+#define CRCSCAN_ENABLE_bm  0x01  /* Enable CRC scan bit mask. */
+#define CRCSCAN_ENABLE_bp  0  /* Enable CRC scan bit position. */
+#define CRCSCAN_NMIEN_bm  0x02  /* Enable NMI Trigger bit mask. */
+#define CRCSCAN_NMIEN_bp  1  /* Enable NMI Trigger bit position. */
+#define CRCSCAN_RESET_bm  0x80  /* Reset CRC scan bit mask. */
+#define CRCSCAN_RESET_bp  7  /* Reset CRC scan bit position. */
+
+/* CRCSCAN.CTRLB  bit masks and bit positions */
+#define CRCSCAN_SRC_gm  0x03  /* CRC Source group mask. */
+#define CRCSCAN_SRC_gp  0  /* CRC Source group position. */
+#define CRCSCAN_SRC_0_bm  (1<<0)  /* CRC Source bit 0 mask. */
+#define CRCSCAN_SRC_0_bp  0  /* CRC Source bit 0 position. */
+#define CRCSCAN_SRC_1_bm  (1<<1)  /* CRC Source bit 1 mask. */
+#define CRCSCAN_SRC_1_bp  1  /* CRC Source bit 1 position. */
+
+/* CRCSCAN.STATUS  bit masks and bit positions */
+#define CRCSCAN_BUSY_bm  0x01  /* CRC Busy bit mask. */
+#define CRCSCAN_BUSY_bp  0  /* CRC Busy bit position. */
+#define CRCSCAN_OK_bm  0x02  /* CRC Ok bit mask. */
+#define CRCSCAN_OK_bp  1  /* CRC Ok bit position. */
+
+
+/* DAC - Digital to Analog Converter */
+/* DAC.CTRLA  bit masks and bit positions */
+#define DAC_ENABLE_bm  0x01  /* DAC Enable bit mask. */
+#define DAC_ENABLE_bp  0  /* DAC Enable bit position. */
+#define DAC_OUTRANGE_gm  0x30  /* Output Buffer Range group mask. */
+#define DAC_OUTRANGE_gp  4  /* Output Buffer Range group position. */
+#define DAC_OUTRANGE_0_bm  (1<<4)  /* Output Buffer Range bit 0 mask. */
+#define DAC_OUTRANGE_0_bp  4  /* Output Buffer Range bit 0 position. */
+#define DAC_OUTRANGE_1_bm  (1<<5)  /* Output Buffer Range bit 1 mask. */
+#define DAC_OUTRANGE_1_bp  5  /* Output Buffer Range bit 1 position. */
+#define DAC_OUTEN_bm  0x40  /* Output Buffer Enable bit mask. */
+#define DAC_OUTEN_bp  6  /* Output Buffer Enable bit position. */
+#define DAC_RUNSTDBY_bm  0x80  /* Run in Standby Mode bit mask. */
+#define DAC_RUNSTDBY_bp  7  /* Run in Standby Mode bit position. */
+
+/* DAC.DATA  bit masks and bit positions */
+#define DAC_DATA_gm  0xFFC0  /* Data group mask. */
+#define DAC_DATA_gp  6  /* Data group position. */
+#define DAC_DATA_0_bm  (1<<6)  /* Data bit 0 mask. */
+#define DAC_DATA_0_bp  6  /* Data bit 0 position. */
+#define DAC_DATA_1_bm  (1<<7)  /* Data bit 1 mask. */
+#define DAC_DATA_1_bp  7  /* Data bit 1 position. */
+#define DAC_DATA_2_bm  (1<<8)  /* Data bit 2 mask. */
+#define DAC_DATA_2_bp  8  /* Data bit 2 position. */
+#define DAC_DATA_3_bm  (1<<9)  /* Data bit 3 mask. */
+#define DAC_DATA_3_bp  9  /* Data bit 3 position. */
+#define DAC_DATA_4_bm  (1<<10)  /* Data bit 4 mask. */
+#define DAC_DATA_4_bp  10  /* Data bit 4 position. */
+#define DAC_DATA_5_bm  (1<<11)  /* Data bit 5 mask. */
+#define DAC_DATA_5_bp  11  /* Data bit 5 position. */
+#define DAC_DATA_6_bm  (1<<12)  /* Data bit 6 mask. */
+#define DAC_DATA_6_bp  12  /* Data bit 6 position. */
+#define DAC_DATA_7_bm  (1<<13)  /* Data bit 7 mask. */
+#define DAC_DATA_7_bp  13  /* Data bit 7 position. */
+#define DAC_DATA_8_bm  (1<<14)  /* Data bit 8 mask. */
+#define DAC_DATA_8_bp  14  /* Data bit 8 position. */
+#define DAC_DATA_9_bm  (1<<15)  /* Data bit 9 mask. */
+#define DAC_DATA_9_bp  15  /* Data bit 9 position. */
+
+
+/* EVSYS - Event System */
+/* EVSYS.SWEVENTA  bit masks and bit positions */
+#define EVSYS_SWEVENTA_gm  0xFF  /* Software event on channel select group mask. */
+#define EVSYS_SWEVENTA_gp  0  /* Software event on channel select group position. */
+#define EVSYS_SWEVENTA_0_bm  (1<<0)  /* Software event on channel select bit 0 mask. */
+#define EVSYS_SWEVENTA_0_bp  0  /* Software event on channel select bit 0 position. */
+#define EVSYS_SWEVENTA_1_bm  (1<<1)  /* Software event on channel select bit 1 mask. */
+#define EVSYS_SWEVENTA_1_bp  1  /* Software event on channel select bit 1 position. */
+#define EVSYS_SWEVENTA_2_bm  (1<<2)  /* Software event on channel select bit 2 mask. */
+#define EVSYS_SWEVENTA_2_bp  2  /* Software event on channel select bit 2 position. */
+#define EVSYS_SWEVENTA_3_bm  (1<<3)  /* Software event on channel select bit 3 mask. */
+#define EVSYS_SWEVENTA_3_bp  3  /* Software event on channel select bit 3 position. */
+#define EVSYS_SWEVENTA_4_bm  (1<<4)  /* Software event on channel select bit 4 mask. */
+#define EVSYS_SWEVENTA_4_bp  4  /* Software event on channel select bit 4 position. */
+#define EVSYS_SWEVENTA_5_bm  (1<<5)  /* Software event on channel select bit 5 mask. */
+#define EVSYS_SWEVENTA_5_bp  5  /* Software event on channel select bit 5 position. */
+#define EVSYS_SWEVENTA_6_bm  (1<<6)  /* Software event on channel select bit 6 mask. */
+#define EVSYS_SWEVENTA_6_bp  6  /* Software event on channel select bit 6 position. */
+#define EVSYS_SWEVENTA_7_bm  (1<<7)  /* Software event on channel select bit 7 mask. */
+#define EVSYS_SWEVENTA_7_bp  7  /* Software event on channel select bit 7 position. */
+
+/* EVSYS.CHANNEL0  bit masks and bit positions */
+#define EVSYS_CHANNEL_gm  0xFF  /* Channel generator select group mask. */
+#define EVSYS_CHANNEL_gp  0  /* Channel generator select group position. */
+#define EVSYS_CHANNEL_0_bm  (1<<0)  /* Channel generator select bit 0 mask. */
+#define EVSYS_CHANNEL_0_bp  0  /* Channel generator select bit 0 position. */
+#define EVSYS_CHANNEL_1_bm  (1<<1)  /* Channel generator select bit 1 mask. */
+#define EVSYS_CHANNEL_1_bp  1  /* Channel generator select bit 1 position. */
+#define EVSYS_CHANNEL_2_bm  (1<<2)  /* Channel generator select bit 2 mask. */
+#define EVSYS_CHANNEL_2_bp  2  /* Channel generator select bit 2 position. */
+#define EVSYS_CHANNEL_3_bm  (1<<3)  /* Channel generator select bit 3 mask. */
+#define EVSYS_CHANNEL_3_bp  3  /* Channel generator select bit 3 position. */
+#define EVSYS_CHANNEL_4_bm  (1<<4)  /* Channel generator select bit 4 mask. */
+#define EVSYS_CHANNEL_4_bp  4  /* Channel generator select bit 4 position. */
+#define EVSYS_CHANNEL_5_bm  (1<<5)  /* Channel generator select bit 5 mask. */
+#define EVSYS_CHANNEL_5_bp  5  /* Channel generator select bit 5 position. */
+#define EVSYS_CHANNEL_6_bm  (1<<6)  /* Channel generator select bit 6 mask. */
+#define EVSYS_CHANNEL_6_bp  6  /* Channel generator select bit 6 position. */
+#define EVSYS_CHANNEL_7_bm  (1<<7)  /* Channel generator select bit 7 mask. */
+#define EVSYS_CHANNEL_7_bp  7  /* Channel generator select bit 7 position. */
+
+/* EVSYS.CHANNEL1  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.CHANNEL2  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.CHANNEL3  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.CHANNEL4  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.CHANNEL5  bit masks and bit positions */
+/* EVSYS_CHANNEL  is already defined. */
+
+/* EVSYS.USERCCLLUT0A  bit masks and bit positions */
+#define EVSYS_USER_gm  0xFF  /* User channel select group mask. */
+#define EVSYS_USER_gp  0  /* User channel select group position. */
+#define EVSYS_USER_0_bm  (1<<0)  /* User channel select bit 0 mask. */
+#define EVSYS_USER_0_bp  0  /* User channel select bit 0 position. */
+#define EVSYS_USER_1_bm  (1<<1)  /* User channel select bit 1 mask. */
+#define EVSYS_USER_1_bp  1  /* User channel select bit 1 position. */
+#define EVSYS_USER_2_bm  (1<<2)  /* User channel select bit 2 mask. */
+#define EVSYS_USER_2_bp  2  /* User channel select bit 2 position. */
+#define EVSYS_USER_3_bm  (1<<3)  /* User channel select bit 3 mask. */
+#define EVSYS_USER_3_bp  3  /* User channel select bit 3 position. */
+#define EVSYS_USER_4_bm  (1<<4)  /* User channel select bit 4 mask. */
+#define EVSYS_USER_4_bp  4  /* User channel select bit 4 position. */
+#define EVSYS_USER_5_bm  (1<<5)  /* User channel select bit 5 mask. */
+#define EVSYS_USER_5_bp  5  /* User channel select bit 5 position. */
+#define EVSYS_USER_6_bm  (1<<6)  /* User channel select bit 6 mask. */
+#define EVSYS_USER_6_bp  6  /* User channel select bit 6 position. */
+#define EVSYS_USER_7_bm  (1<<7)  /* User channel select bit 7 mask. */
+#define EVSYS_USER_7_bp  7  /* User channel select bit 7 position. */
+
+/* EVSYS.USERCCLLUT0B  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT1A  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT1B  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT2A  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT2B  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT3A  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERCCLLUT3B  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERADC0START  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTB  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTC  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTD  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTE  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USEREVSYSEVOUTF  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERUSART0IRDA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERUSART1IRDA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERUSART2IRDA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCA0CNTA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCA0CNTB  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCA1CNTA  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCA1CNTB  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB0CAPT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB0COUNT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB1CAPT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB1COUNT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB2CAPT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB2COUNT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB3CAPT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+/* EVSYS.USERTCB3COUNT  bit masks and bit positions */
+/* EVSYS_USER  is already defined. */
+
+
+/* FUSE - Fuses */
+/* FUSE.WDTCFG  bit masks and bit positions */
+#define FUSE_PERIOD_gm  0x0F  /* Watchdog Timeout Period group mask. */
+#define FUSE_PERIOD_gp  0  /* Watchdog Timeout Period group position. */
+#define FUSE_PERIOD_0_bm  (1<<0)  /* Watchdog Timeout Period bit 0 mask. */
+#define FUSE_PERIOD_0_bp  0  /* Watchdog Timeout Period bit 0 position. */
+#define FUSE_PERIOD_1_bm  (1<<1)  /* Watchdog Timeout Period bit 1 mask. */
+#define FUSE_PERIOD_1_bp  1  /* Watchdog Timeout Period bit 1 position. */
+#define FUSE_PERIOD_2_bm  (1<<2)  /* Watchdog Timeout Period bit 2 mask. */
+#define FUSE_PERIOD_2_bp  2  /* Watchdog Timeout Period bit 2 position. */
+#define FUSE_PERIOD_3_bm  (1<<3)  /* Watchdog Timeout Period bit 3 mask. */
+#define FUSE_PERIOD_3_bp  3  /* Watchdog Timeout Period bit 3 position. */
+#define FUSE_WINDOW_gm  0xF0  /* Watchdog Window Timeout Period group mask. */
+#define FUSE_WINDOW_gp  4  /* Watchdog Window Timeout Period group position. */
+#define FUSE_WINDOW_0_bm  (1<<4)  /* Watchdog Window Timeout Period bit 0 mask. */
+#define FUSE_WINDOW_0_bp  4  /* Watchdog Window Timeout Period bit 0 position. */
+#define FUSE_WINDOW_1_bm  (1<<5)  /* Watchdog Window Timeout Period bit 1 mask. */
+#define FUSE_WINDOW_1_bp  5  /* Watchdog Window Timeout Period bit 1 position. */
+#define FUSE_WINDOW_2_bm  (1<<6)  /* Watchdog Window Timeout Period bit 2 mask. */
+#define FUSE_WINDOW_2_bp  6  /* Watchdog Window Timeout Period bit 2 position. */
+#define FUSE_WINDOW_3_bm  (1<<7)  /* Watchdog Window Timeout Period bit 3 mask. */
+#define FUSE_WINDOW_3_bp  7  /* Watchdog Window Timeout Period bit 3 position. */
+
+/* FUSE.BODCFG  bit masks and bit positions */
+#define FUSE_SLEEP_gm  0x03  /* BOD Operation in Sleep Mode group mask. */
+#define FUSE_SLEEP_gp  0  /* BOD Operation in Sleep Mode group position. */
+#define FUSE_SLEEP_0_bm  (1<<0)  /* BOD Operation in Sleep Mode bit 0 mask. */
+#define FUSE_SLEEP_0_bp  0  /* BOD Operation in Sleep Mode bit 0 position. */
+#define FUSE_SLEEP_1_bm  (1<<1)  /* BOD Operation in Sleep Mode bit 1 mask. */
+#define FUSE_SLEEP_1_bp  1  /* BOD Operation in Sleep Mode bit 1 position. */
+#define FUSE_ACTIVE_gm  0x0C  /* BOD Operation in Active Mode group mask. */
+#define FUSE_ACTIVE_gp  2  /* BOD Operation in Active Mode group position. */
+#define FUSE_ACTIVE_0_bm  (1<<2)  /* BOD Operation in Active Mode bit 0 mask. */
+#define FUSE_ACTIVE_0_bp  2  /* BOD Operation in Active Mode bit 0 position. */
+#define FUSE_ACTIVE_1_bm  (1<<3)  /* BOD Operation in Active Mode bit 1 mask. */
+#define FUSE_ACTIVE_1_bp  3  /* BOD Operation in Active Mode bit 1 position. */
+#define FUSE_SAMPFREQ_bm  0x10  /* BOD Sample Frequency bit mask. */
+#define FUSE_SAMPFREQ_bp  4  /* BOD Sample Frequency bit position. */
+#define FUSE_LVL_gm  0xE0  /* BOD Level group mask. */
+#define FUSE_LVL_gp  5  /* BOD Level group position. */
+#define FUSE_LVL_0_bm  (1<<5)  /* BOD Level bit 0 mask. */
+#define FUSE_LVL_0_bp  5  /* BOD Level bit 0 position. */
+#define FUSE_LVL_1_bm  (1<<6)  /* BOD Level bit 1 mask. */
+#define FUSE_LVL_1_bp  6  /* BOD Level bit 1 position. */
+#define FUSE_LVL_2_bm  (1<<7)  /* BOD Level bit 2 mask. */
+#define FUSE_LVL_2_bp  7  /* BOD Level bit 2 position. */
+
+/* FUSE.OSCCFG  bit masks and bit positions */
+#define FUSE_OSCHFFRQ_bm  0x08  /* High-frequency Oscillator Frequency bit mask. */
+#define FUSE_OSCHFFRQ_bp  3  /* High-frequency Oscillator Frequency bit position. */
+
+/* FUSE.SYSCFG0  bit masks and bit positions */
+#define FUSE_EESAVE_bm  0x01  /* EEPROM Save bit mask. */
+#define FUSE_EESAVE_bp  0  /* EEPROM Save bit position. */
+#define FUSE_RSTPINCFG_bm  0x08  /* Reset Pin Configuration bit mask. */
+#define FUSE_RSTPINCFG_bp  3  /* Reset Pin Configuration bit position. */
+#define FUSE_UPDIPINCFG_bm  0x10  /* UPDI Pin Configuration bit mask. */
+#define FUSE_UPDIPINCFG_bp  4  /* UPDI Pin Configuration bit position. */
+#define FUSE_CRCSEL_bm  0x20  /* CRC Select bit mask. */
+#define FUSE_CRCSEL_bp  5  /* CRC Select bit position. */
+#define FUSE_CRCSRC_gm  0xC0  /* CRC Source group mask. */
+#define FUSE_CRCSRC_gp  6  /* CRC Source group position. */
+#define FUSE_CRCSRC_0_bm  (1<<6)  /* CRC Source bit 0 mask. */
+#define FUSE_CRCSRC_0_bp  6  /* CRC Source bit 0 position. */
+#define FUSE_CRCSRC_1_bm  (1<<7)  /* CRC Source bit 1 mask. */
+#define FUSE_CRCSRC_1_bp  7  /* CRC Source bit 1 position. */
+
+/* FUSE.SYSCFG1  bit masks and bit positions */
+#define FUSE_SUT_gm  0x07  /* Startup Time group mask. */
+#define FUSE_SUT_gp  0  /* Startup Time group position. */
+#define FUSE_SUT_0_bm  (1<<0)  /* Startup Time bit 0 mask. */
+#define FUSE_SUT_0_bp  0  /* Startup Time bit 0 position. */
+#define FUSE_SUT_1_bm  (1<<1)  /* Startup Time bit 1 mask. */
+#define FUSE_SUT_1_bp  1  /* Startup Time bit 1 position. */
+#define FUSE_SUT_2_bm  (1<<2)  /* Startup Time bit 2 mask. */
+#define FUSE_SUT_2_bp  2  /* Startup Time bit 2 position. */
+
+
+
+/* LOCK - Lockbits */
+/* LOCK.KEY  bit masks and bit positions */
+#define LOCK_KEY_gm  0xFFFFFFFF  /* Lock Key group mask. */
+#define LOCK_KEY_gp  0  /* Lock Key group position. */
+#define LOCK_KEY_0_bm  (1<<0)  /* Lock Key bit 0 mask. */
+#define LOCK_KEY_0_bp  0  /* Lock Key bit 0 position. */
+#define LOCK_KEY_1_bm  (1<<1)  /* Lock Key bit 1 mask. */
+#define LOCK_KEY_1_bp  1  /* Lock Key bit 1 position. */
+#define LOCK_KEY_2_bm  (1<<2)  /* Lock Key bit 2 mask. */
+#define LOCK_KEY_2_bp  2  /* Lock Key bit 2 position. */
+#define LOCK_KEY_3_bm  (1<<3)  /* Lock Key bit 3 mask. */
+#define LOCK_KEY_3_bp  3  /* Lock Key bit 3 position. */
+#define LOCK_KEY_4_bm  (1<<4)  /* Lock Key bit 4 mask. */
+#define LOCK_KEY_4_bp  4  /* Lock Key bit 4 position. */
+#define LOCK_KEY_5_bm  (1<<5)  /* Lock Key bit 5 mask. */
+#define LOCK_KEY_5_bp  5  /* Lock Key bit 5 position. */
+#define LOCK_KEY_6_bm  (1<<6)  /* Lock Key bit 6 mask. */
+#define LOCK_KEY_6_bp  6  /* Lock Key bit 6 position. */
+#define LOCK_KEY_7_bm  (1<<7)  /* Lock Key bit 7 mask. */
+#define LOCK_KEY_7_bp  7  /* Lock Key bit 7 position. */
+#define LOCK_KEY_8_bm  (1<<8)  /* Lock Key bit 8 mask. */
+#define LOCK_KEY_8_bp  8  /* Lock Key bit 8 position. */
+#define LOCK_KEY_9_bm  (1<<9)  /* Lock Key bit 9 mask. */
+#define LOCK_KEY_9_bp  9  /* Lock Key bit 9 position. */
+#define LOCK_KEY_10_bm  (1<<10)  /* Lock Key bit 10 mask. */
+#define LOCK_KEY_10_bp  10  /* Lock Key bit 10 position. */
+#define LOCK_KEY_11_bm  (1<<11)  /* Lock Key bit 11 mask. */
+#define LOCK_KEY_11_bp  11  /* Lock Key bit 11 position. */
+#define LOCK_KEY_12_bm  (1<<12)  /* Lock Key bit 12 mask. */
+#define LOCK_KEY_12_bp  12  /* Lock Key bit 12 position. */
+#define LOCK_KEY_13_bm  (1<<13)  /* Lock Key bit 13 mask. */
+#define LOCK_KEY_13_bp  13  /* Lock Key bit 13 position. */
+#define LOCK_KEY_14_bm  (1<<14)  /* Lock Key bit 14 mask. */
+#define LOCK_KEY_14_bp  14  /* Lock Key bit 14 position. */
+#define LOCK_KEY_15_bm  (1<<15)  /* Lock Key bit 15 mask. */
+#define LOCK_KEY_15_bp  15  /* Lock Key bit 15 position. */
+#define LOCK_KEY_16_bm  (1<<16)  /* Lock Key bit 16 mask. */
+#define LOCK_KEY_16_bp  16  /* Lock Key bit 16 position. */
+#define LOCK_KEY_17_bm  (1<<17)  /* Lock Key bit 17 mask. */
+#define LOCK_KEY_17_bp  17  /* Lock Key bit 17 position. */
+#define LOCK_KEY_18_bm  (1<<18)  /* Lock Key bit 18 mask. */
+#define LOCK_KEY_18_bp  18  /* Lock Key bit 18 position. */
+#define LOCK_KEY_19_bm  (1<<19)  /* Lock Key bit 19 mask. */
+#define LOCK_KEY_19_bp  19  /* Lock Key bit 19 position. */
+#define LOCK_KEY_20_bm  (1<<20)  /* Lock Key bit 20 mask. */
+#define LOCK_KEY_20_bp  20  /* Lock Key bit 20 position. */
+#define LOCK_KEY_21_bm  (1<<21)  /* Lock Key bit 21 mask. */
+#define LOCK_KEY_21_bp  21  /* Lock Key bit 21 position. */
+#define LOCK_KEY_22_bm  (1<<22)  /* Lock Key bit 22 mask. */
+#define LOCK_KEY_22_bp  22  /* Lock Key bit 22 position. */
+#define LOCK_KEY_23_bm  (1<<23)  /* Lock Key bit 23 mask. */
+#define LOCK_KEY_23_bp  23  /* Lock Key bit 23 position. */
+#define LOCK_KEY_24_bm  (1<<24)  /* Lock Key bit 24 mask. */
+#define LOCK_KEY_24_bp  24  /* Lock Key bit 24 position. */
+#define LOCK_KEY_25_bm  (1<<25)  /* Lock Key bit 25 mask. */
+#define LOCK_KEY_25_bp  25  /* Lock Key bit 25 position. */
+#define LOCK_KEY_26_bm  (1<<26)  /* Lock Key bit 26 mask. */
+#define LOCK_KEY_26_bp  26  /* Lock Key bit 26 position. */
+#define LOCK_KEY_27_bm  (1<<27)  /* Lock Key bit 27 mask. */
+#define LOCK_KEY_27_bp  27  /* Lock Key bit 27 position. */
+#define LOCK_KEY_28_bm  (1<<28)  /* Lock Key bit 28 mask. */
+#define LOCK_KEY_28_bp  28  /* Lock Key bit 28 position. */
+#define LOCK_KEY_29_bm  (1<<29)  /* Lock Key bit 29 mask. */
+#define LOCK_KEY_29_bp  29  /* Lock Key bit 29 position. */
+#define LOCK_KEY_30_bm  (1<<30)  /* Lock Key bit 30 mask. */
+#define LOCK_KEY_30_bp  30  /* Lock Key bit 30 position. */
+#define LOCK_KEY_31_bm  (1<<31)  /* Lock Key bit 31 mask. */
+#define LOCK_KEY_31_bp  31  /* Lock Key bit 31 position. */
+
+
+/* NVMCTRL - Non-volatile Memory Controller */
+/* NVMCTRL.CTRLA  bit masks and bit positions */
+#define NVMCTRL_CMD_gm  0x7F  /* Command group mask. */
+#define NVMCTRL_CMD_gp  0  /* Command group position. */
+#define NVMCTRL_CMD_0_bm  (1<<0)  /* Command bit 0 mask. */
+#define NVMCTRL_CMD_0_bp  0  /* Command bit 0 position. */
+#define NVMCTRL_CMD_1_bm  (1<<1)  /* Command bit 1 mask. */
+#define NVMCTRL_CMD_1_bp  1  /* Command bit 1 position. */
+#define NVMCTRL_CMD_2_bm  (1<<2)  /* Command bit 2 mask. */
+#define NVMCTRL_CMD_2_bp  2  /* Command bit 2 position. */
+#define NVMCTRL_CMD_3_bm  (1<<3)  /* Command bit 3 mask. */
+#define NVMCTRL_CMD_3_bp  3  /* Command bit 3 position. */
+#define NVMCTRL_CMD_4_bm  (1<<4)  /* Command bit 4 mask. */
+#define NVMCTRL_CMD_4_bp  4  /* Command bit 4 position. */
+#define NVMCTRL_CMD_5_bm  (1<<5)  /* Command bit 5 mask. */
+#define NVMCTRL_CMD_5_bp  5  /* Command bit 5 position. */
+#define NVMCTRL_CMD_6_bm  (1<<6)  /* Command bit 6 mask. */
+#define NVMCTRL_CMD_6_bp  6  /* Command bit 6 position. */
+
+/* NVMCTRL.CTRLB  bit masks and bit positions */
+#define NVMCTRL_APPCODEWP_bm  0x01  /* Application Code Write Protect bit mask. */
+#define NVMCTRL_APPCODEWP_bp  0  /* Application Code Write Protect bit position. */
+#define NVMCTRL_BOOTRP_bm  0x02  /* Boot Read Protect bit mask. */
+#define NVMCTRL_BOOTRP_bp  1  /* Boot Read Protect bit position. */
+#define NVMCTRL_APPDATAWP_bm  0x04  /* Application Data Write Protect bit mask. */
+#define NVMCTRL_APPDATAWP_bp  2  /* Application Data Write Protect bit position. */
+#define NVMCTRL_EEWP_bm  0x08  /* EEPROM Write Protect bit mask. */
+#define NVMCTRL_EEWP_bp  3  /* EEPROM Write Protect bit position. */
+#define NVMCTRL_FLMAP_gm  0x30  /* Flash Mapping in Data space group mask. */
+#define NVMCTRL_FLMAP_gp  4  /* Flash Mapping in Data space group position. */
+#define NVMCTRL_FLMAP_0_bm  (1<<4)  /* Flash Mapping in Data space bit 0 mask. */
+#define NVMCTRL_FLMAP_0_bp  4  /* Flash Mapping in Data space bit 0 position. */
+#define NVMCTRL_FLMAP_1_bm  (1<<5)  /* Flash Mapping in Data space bit 1 mask. */
+#define NVMCTRL_FLMAP_1_bp  5  /* Flash Mapping in Data space bit 1 position. */
+#define NVMCTRL_FLMAPLOCK_bm  0x80  /* Flash Mapping Lock bit mask. */
+#define NVMCTRL_FLMAPLOCK_bp  7  /* Flash Mapping Lock bit position. */
+
+/* NVMCTRL.INTCTRL  bit masks and bit positions */
+#define NVMCTRL_EEREADY_bm  0x01  /* EEPROM Ready bit mask. */
+#define NVMCTRL_EEREADY_bp  0  /* EEPROM Ready bit position. */
+#define NVMCTRL_FLREADY_bm  0x02  /* Flash Ready bit mask. */
+#define NVMCTRL_FLREADY_bp  1  /* Flash Ready bit position. */
+
+/* NVMCTRL.INTFLAGS  bit masks and bit positions */
+/* NVMCTRL_EEREADY  is already defined. */
+/* NVMCTRL_FLREADY  is already defined. */
+
+/* NVMCTRL.STATUS  bit masks and bit positions */
+#define NVMCTRL_EEBUSY_bm  0x01  /* EEPROM busy bit mask. */
+#define NVMCTRL_EEBUSY_bp  0  /* EEPROM busy bit position. */
+#define NVMCTRL_FLBUSY_bm  0x02  /* Flash busy bit mask. */
+#define NVMCTRL_FLBUSY_bp  1  /* Flash busy bit position. */
+#define NVMCTRL_ERROR_gm  0x70  /* Write error group mask. */
+#define NVMCTRL_ERROR_gp  4  /* Write error group position. */
+#define NVMCTRL_ERROR_0_bm  (1<<4)  /* Write error bit 0 mask. */
+#define NVMCTRL_ERROR_0_bp  4  /* Write error bit 0 position. */
+#define NVMCTRL_ERROR_1_bm  (1<<5)  /* Write error bit 1 mask. */
+#define NVMCTRL_ERROR_1_bp  5  /* Write error bit 1 position. */
+#define NVMCTRL_ERROR_2_bm  (1<<6)  /* Write error bit 2 mask. */
+#define NVMCTRL_ERROR_2_bp  6  /* Write error bit 2 position. */
+
+
+/* PORT - I/O Ports */
+/* PORT.INTFLAGS  bit masks and bit positions */
+#define PORT_INT_gm  0xFF  /* Pin Interrupt Flag group mask. */
+#define PORT_INT_gp  0  /* Pin Interrupt Flag group position. */
+#define PORT_INT_0_bm  (1<<0)  /* Pin Interrupt Flag bit 0 mask. */
+#define PORT_INT_0_bp  0  /* Pin Interrupt Flag bit 0 position. */
+#define PORT_INT0_bm  PORT_INT_0_bm  /* This define is deprecated and should not be used */
+#define PORT_INT0_bp  PORT_INT_0_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_1_bm  (1<<1)  /* Pin Interrupt Flag bit 1 mask. */
+#define PORT_INT_1_bp  1  /* Pin Interrupt Flag bit 1 position. */
+#define PORT_INT1_bm  PORT_INT_1_bm  /* This define is deprecated and should not be used */
+#define PORT_INT1_bp  PORT_INT_1_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_2_bm  (1<<2)  /* Pin Interrupt Flag bit 2 mask. */
+#define PORT_INT_2_bp  2  /* Pin Interrupt Flag bit 2 position. */
+#define PORT_INT2_bm  PORT_INT_2_bm  /* This define is deprecated and should not be used */
+#define PORT_INT2_bp  PORT_INT_2_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_3_bm  (1<<3)  /* Pin Interrupt Flag bit 3 mask. */
+#define PORT_INT_3_bp  3  /* Pin Interrupt Flag bit 3 position. */
+#define PORT_INT3_bm  PORT_INT_3_bm  /* This define is deprecated and should not be used */
+#define PORT_INT3_bp  PORT_INT_3_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_4_bm  (1<<4)  /* Pin Interrupt Flag bit 4 mask. */
+#define PORT_INT_4_bp  4  /* Pin Interrupt Flag bit 4 position. */
+#define PORT_INT4_bm  PORT_INT_4_bm  /* This define is deprecated and should not be used */
+#define PORT_INT4_bp  PORT_INT_4_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_5_bm  (1<<5)  /* Pin Interrupt Flag bit 5 mask. */
+#define PORT_INT_5_bp  5  /* Pin Interrupt Flag bit 5 position. */
+#define PORT_INT5_bm  PORT_INT_5_bm  /* This define is deprecated and should not be used */
+#define PORT_INT5_bp  PORT_INT_5_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_6_bm  (1<<6)  /* Pin Interrupt Flag bit 6 mask. */
+#define PORT_INT_6_bp  6  /* Pin Interrupt Flag bit 6 position. */
+#define PORT_INT6_bm  PORT_INT_6_bm  /* This define is deprecated and should not be used */
+#define PORT_INT6_bp  PORT_INT_6_bp  /* This define is deprecated and should not be used */
+#define PORT_INT_7_bm  (1<<7)  /* Pin Interrupt Flag bit 7 mask. */
+#define PORT_INT_7_bp  7  /* Pin Interrupt Flag bit 7 position. */
+#define PORT_INT7_bm  PORT_INT_7_bm  /* This define is deprecated and should not be used */
+#define PORT_INT7_bp  PORT_INT_7_bp  /* This define is deprecated and should not be used */
+
+/* PORT.PORTCTRL  bit masks and bit positions */
+#define PORT_SRL_bm  0x01  /* Slew Rate Limit Enable bit mask. */
+#define PORT_SRL_bp  0  /* Slew Rate Limit Enable bit position. */
+
+/* PORT.PINCONFIG  bit masks and bit positions */
+#define PORT_ISC_gm  0x07  /* Input/Sense Configuration group mask. */
+#define PORT_ISC_gp  0  /* Input/Sense Configuration group position. */
+#define PORT_ISC_0_bm  (1<<0)  /* Input/Sense Configuration bit 0 mask. */
+#define PORT_ISC_0_bp  0  /* Input/Sense Configuration bit 0 position. */
+#define PORT_ISC_1_bm  (1<<1)  /* Input/Sense Configuration bit 1 mask. */
+#define PORT_ISC_1_bp  1  /* Input/Sense Configuration bit 1 position. */
+#define PORT_ISC_2_bm  (1<<2)  /* Input/Sense Configuration bit 2 mask. */
+#define PORT_ISC_2_bp  2  /* Input/Sense Configuration bit 2 position. */
+#define PORT_PULLUPEN_bm  0x08  /* Pullup enable bit mask. */
+#define PORT_PULLUPEN_bp  3  /* Pullup enable bit position. */
+#define PORT_INLVL_bm  0x40  /* Input Level Select bit mask. */
+#define PORT_INLVL_bp  6  /* Input Level Select bit position. */
+#define PORT_INVEN_bm  0x80  /* Inverted I/O Enable bit mask. */
+#define PORT_INVEN_bp  7  /* Inverted I/O Enable bit position. */
+
+/* PORT.PIN0CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN1CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN2CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN3CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN4CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN5CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN6CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.PIN7CTRL  bit masks and bit positions */
+/* PORT_ISC  is already defined. */
+/* PORT_PULLUPEN  is already defined. */
+/* PORT_INLVL  is already defined. */
+/* PORT_INVEN  is already defined. */
+
+/* PORT.EVGENCTRL  bit masks and bit positions */
+#define PORT_EVGEN0SEL_gm  0x07  /* Event Generator 0 Select group mask. */
+#define PORT_EVGEN0SEL_gp  0  /* Event Generator 0 Select group position. */
+#define PORT_EVGEN0SEL_0_bm  (1<<0)  /* Event Generator 0 Select bit 0 mask. */
+#define PORT_EVGEN0SEL_0_bp  0  /* Event Generator 0 Select bit 0 position. */
+#define PORT_EVGEN0SEL_1_bm  (1<<1)  /* Event Generator 0 Select bit 1 mask. */
+#define PORT_EVGEN0SEL_1_bp  1  /* Event Generator 0 Select bit 1 position. */
+#define PORT_EVGEN0SEL_2_bm  (1<<2)  /* Event Generator 0 Select bit 2 mask. */
+#define PORT_EVGEN0SEL_2_bp  2  /* Event Generator 0 Select bit 2 position. */
+#define PORT_EVGEN1SEL_gm  0x70  /* Event Generator 1 Select group mask. */
+#define PORT_EVGEN1SEL_gp  4  /* Event Generator 1 Select group position. */
+#define PORT_EVGEN1SEL_0_bm  (1<<4)  /* Event Generator 1 Select bit 0 mask. */
+#define PORT_EVGEN1SEL_0_bp  4  /* Event Generator 1 Select bit 0 position. */
+#define PORT_EVGEN1SEL_1_bm  (1<<5)  /* Event Generator 1 Select bit 1 mask. */
+#define PORT_EVGEN1SEL_1_bp  5  /* Event Generator 1 Select bit 1 position. */
+#define PORT_EVGEN1SEL_2_bm  (1<<6)  /* Event Generator 1 Select bit 2 mask. */
+#define PORT_EVGEN1SEL_2_bp  6  /* Event Generator 1 Select bit 2 position. */
+
+
+/* PORTMUX - Port Multiplexer */
+/* PORTMUX.EVSYSROUTEA  bit masks and bit positions */
+#define PORTMUX_EVOUTA_bm  0x01  /* Event Output A bit mask. */
+#define PORTMUX_EVOUTA_bp  0  /* Event Output A bit position. */
+#define PORTMUX_EVOUTB_bm  0x02  /* Event Output B bit mask. */
+#define PORTMUX_EVOUTB_bp  1  /* Event Output B bit position. */
+#define PORTMUX_EVOUTC_bm  0x04  /* Event Output C bit mask. */
+#define PORTMUX_EVOUTC_bp  2  /* Event Output C bit position. */
+#define PORTMUX_EVOUTD_bm  0x08  /* Event Output D bit mask. */
+#define PORTMUX_EVOUTD_bp  3  /* Event Output D bit position. */
+#define PORTMUX_EVOUTE_bm  0x10  /* Event Output E bit mask. */
+#define PORTMUX_EVOUTE_bp  4  /* Event Output E bit position. */
+#define PORTMUX_EVOUTF_bm  0x20  /* Event Output F bit mask. */
+#define PORTMUX_EVOUTF_bp  5  /* Event Output F bit position. */
+
+/* PORTMUX.CCLROUTEA  bit masks and bit positions */
+#define PORTMUX_LUT0_bm  0x01  /* CCL Look-Up Table 0 Signals bit mask. */
+#define PORTMUX_LUT0_bp  0  /* CCL Look-Up Table 0 Signals bit position. */
+#define PORTMUX_LUT1_bm  0x02  /* CCL Look-Up Table 1 Signals bit mask. */
+#define PORTMUX_LUT1_bp  1  /* CCL Look-Up Table 1 Signals bit position. */
+#define PORTMUX_LUT2_bm  0x04  /* CCL Look-Up Table 2 Signals bit mask. */
+#define PORTMUX_LUT2_bp  2  /* CCL Look-Up Table 2 Signals bit position. */
+
+/* PORTMUX.USARTROUTEA  bit masks and bit positions */
+#define PORTMUX_USART0_gm  0x07  /* USART0 Routing group mask. */
+#define PORTMUX_USART0_gp  0  /* USART0 Routing group position. */
+#define PORTMUX_USART0_0_bm  (1<<0)  /* USART0 Routing bit 0 mask. */
+#define PORTMUX_USART0_0_bp  0  /* USART0 Routing bit 0 position. */
+#define PORTMUX_USART0_1_bm  (1<<1)  /* USART0 Routing bit 1 mask. */
+#define PORTMUX_USART0_1_bp  1  /* USART0 Routing bit 1 position. */
+#define PORTMUX_USART0_2_bm  (1<<2)  /* USART0 Routing bit 2 mask. */
+#define PORTMUX_USART0_2_bp  2  /* USART0 Routing bit 2 position. */
+#define PORTMUX_USART1_gm  0x18  /* USART1 Routing group mask. */
+#define PORTMUX_USART1_gp  3  /* USART1 Routing group position. */
+#define PORTMUX_USART1_0_bm  (1<<3)  /* USART1 Routing bit 0 mask. */
+#define PORTMUX_USART1_0_bp  3  /* USART1 Routing bit 0 position. */
+#define PORTMUX_USART1_1_bm  (1<<4)  /* USART1 Routing bit 1 mask. */
+#define PORTMUX_USART1_1_bp  4  /* USART1 Routing bit 1 position. */
+
+/* PORTMUX.USARTROUTEB  bit masks and bit positions */
+#define PORTMUX_USART2_gm  0x03  /* USART2 Routing group mask. */
+#define PORTMUX_USART2_gp  0  /* USART2 Routing group position. */
+#define PORTMUX_USART2_0_bm  (1<<0)  /* USART2 Routing bit 0 mask. */
+#define PORTMUX_USART2_0_bp  0  /* USART2 Routing bit 0 position. */
+#define PORTMUX_USART2_1_bm  (1<<1)  /* USART2 Routing bit 1 mask. */
+#define PORTMUX_USART2_1_bp  1  /* USART2 Routing bit 1 position. */
+
+/* PORTMUX.SPIROUTEA  bit masks and bit positions */
+#define PORTMUX_SPI0_gm  0x07  /* SPI0 Signals group mask. */
+#define PORTMUX_SPI0_gp  0  /* SPI0 Signals group position. */
+#define PORTMUX_SPI0_0_bm  (1<<0)  /* SPI0 Signals bit 0 mask. */
+#define PORTMUX_SPI0_0_bp  0  /* SPI0 Signals bit 0 position. */
+#define PORTMUX_SPI0_1_bm  (1<<1)  /* SPI0 Signals bit 1 mask. */
+#define PORTMUX_SPI0_1_bp  1  /* SPI0 Signals bit 1 position. */
+#define PORTMUX_SPI0_2_bm  (1<<2)  /* SPI0 Signals bit 2 mask. */
+#define PORTMUX_SPI0_2_bp  2  /* SPI0 Signals bit 2 position. */
+
+/* PORTMUX.TWIROUTEA  bit masks and bit positions */
+#define PORTMUX_TWI0_gm  0x03  /* TWI0 Signals group mask. */
+#define PORTMUX_TWI0_gp  0  /* TWI0 Signals group position. */
+#define PORTMUX_TWI0_0_bm  (1<<0)  /* TWI0 Signals bit 0 mask. */
+#define PORTMUX_TWI0_0_bp  0  /* TWI0 Signals bit 0 position. */
+#define PORTMUX_TWI0_1_bm  (1<<1)  /* TWI0 Signals bit 1 mask. */
+#define PORTMUX_TWI0_1_bp  1  /* TWI0 Signals bit 1 position. */
+
+/* PORTMUX.TCAROUTEA  bit masks and bit positions */
+#define PORTMUX_TCA0_gm  0x07  /* TCA0 Signals group mask. */
+#define PORTMUX_TCA0_gp  0  /* TCA0 Signals group position. */
+#define PORTMUX_TCA0_0_bm  (1<<0)  /* TCA0 Signals bit 0 mask. */
+#define PORTMUX_TCA0_0_bp  0  /* TCA0 Signals bit 0 position. */
+#define PORTMUX_TCA0_1_bm  (1<<1)  /* TCA0 Signals bit 1 mask. */
+#define PORTMUX_TCA0_1_bp  1  /* TCA0 Signals bit 1 position. */
+#define PORTMUX_TCA0_2_bm  (1<<2)  /* TCA0 Signals bit 2 mask. */
+#define PORTMUX_TCA0_2_bp  2  /* TCA0 Signals bit 2 position. */
+#define PORTMUX_TCA1_gm  0x38  /* TCA1 Signals group mask. */
+#define PORTMUX_TCA1_gp  3  /* TCA1 Signals group position. */
+#define PORTMUX_TCA1_0_bm  (1<<3)  /* TCA1 Signals bit 0 mask. */
+#define PORTMUX_TCA1_0_bp  3  /* TCA1 Signals bit 0 position. */
+#define PORTMUX_TCA1_1_bm  (1<<4)  /* TCA1 Signals bit 1 mask. */
+#define PORTMUX_TCA1_1_bp  4  /* TCA1 Signals bit 1 position. */
+#define PORTMUX_TCA1_2_bm  (1<<5)  /* TCA1 Signals bit 2 mask. */
+#define PORTMUX_TCA1_2_bp  5  /* TCA1 Signals bit 2 position. */
+
+/* PORTMUX.TCBROUTEA  bit masks and bit positions */
+#define PORTMUX_TCB0_bm  0x01  /* TCB0 Output bit mask. */
+#define PORTMUX_TCB0_bp  0  /* TCB0 Output bit position. */
+#define PORTMUX_TCB1_bm  0x02  /* TCB1 Output bit mask. */
+#define PORTMUX_TCB1_bp  1  /* TCB1 Output bit position. */
+#define PORTMUX_TCB2_bm  0x04  /* TCB2 Output bit mask. */
+#define PORTMUX_TCB2_bp  2  /* TCB2 Output bit position. */
+#define PORTMUX_TCB3_bm  0x08  /* TCB3 Output bit mask. */
+#define PORTMUX_TCB3_bp  3  /* TCB3 Output bit position. */
+
+/* PORTMUX.ACROUTEA  bit masks and bit positions */
+#define PORTMUX_AC0_bm  0x01  /* Analog Comparator 0 Output bit mask. */
+#define PORTMUX_AC0_bp  0  /* Analog Comparator 0 Output bit position. */
+#define PORTMUX_AC1_bm  0x02  /* Analog Comparator 1 Output bit mask. */
+#define PORTMUX_AC1_bp  1  /* Analog Comparator 1 Output bit position. */
+
+
+/* RSTCTRL - Reset controller */
+/* RSTCTRL.RSTFR  bit masks and bit positions */
+#define RSTCTRL_PORF_bm  0x01  /* Power on Reset flag bit mask. */
+#define RSTCTRL_PORF_bp  0  /* Power on Reset flag bit position. */
+#define RSTCTRL_BORF_bm  0x02  /* Brown out detector Reset flag bit mask. */
+#define RSTCTRL_BORF_bp  1  /* Brown out detector Reset flag bit position. */
+#define RSTCTRL_EXTRF_bm  0x04  /* External Reset flag bit mask. */
+#define RSTCTRL_EXTRF_bp  2  /* External Reset flag bit position. */
+#define RSTCTRL_WDRF_bm  0x08  /* Watch dog Reset flag bit mask. */
+#define RSTCTRL_WDRF_bp  3  /* Watch dog Reset flag bit position. */
+#define RSTCTRL_SWRF_bm  0x10  /* Software Reset flag bit mask. */
+#define RSTCTRL_SWRF_bp  4  /* Software Reset flag bit position. */
+#define RSTCTRL_UPDIRF_bm  0x20  /* UPDI Reset flag bit mask. */
+#define RSTCTRL_UPDIRF_bp  5  /* UPDI Reset flag bit position. */
+
+/* RSTCTRL.SWRR  bit masks and bit positions */
+#define RSTCTRL_SWRE_bm  0x01  /* Software Reset Enable bit mask. */
+#define RSTCTRL_SWRE_bp  0  /* Software Reset Enable bit position. */
+
+
+/* RTC - Real-Time Counter */
+/* RTC.CTRLA  bit masks and bit positions */
+#define RTC_RTCEN_bm  0x01  /* Enable bit mask. */
+#define RTC_RTCEN_bp  0  /* Enable bit position. */
+#define RTC_CORREN_bm  0x04  /* Correction enable bit mask. */
+#define RTC_CORREN_bp  2  /* Correction enable bit position. */
+#define RTC_PRESCALER_gm  0x78  /* Prescaling Factor group mask. */
+#define RTC_PRESCALER_gp  3  /* Prescaling Factor group position. */
+#define RTC_PRESCALER_0_bm  (1<<3)  /* Prescaling Factor bit 0 mask. */
+#define RTC_PRESCALER_0_bp  3  /* Prescaling Factor bit 0 position. */
+#define RTC_PRESCALER_1_bm  (1<<4)  /* Prescaling Factor bit 1 mask. */
+#define RTC_PRESCALER_1_bp  4  /* Prescaling Factor bit 1 position. */
+#define RTC_PRESCALER_2_bm  (1<<5)  /* Prescaling Factor bit 2 mask. */
+#define RTC_PRESCALER_2_bp  5  /* Prescaling Factor bit 2 position. */
+#define RTC_PRESCALER_3_bm  (1<<6)  /* Prescaling Factor bit 3 mask. */
+#define RTC_PRESCALER_3_bp  6  /* Prescaling Factor bit 3 position. */
+#define RTC_RUNSTDBY_bm  0x80  /* Run In Standby bit mask. */
+#define RTC_RUNSTDBY_bp  7  /* Run In Standby bit position. */
+
+/* RTC.STATUS  bit masks and bit positions */
+#define RTC_CTRLABUSY_bm  0x01  /* CTRLA Synchronization Busy Flag bit mask. */
+#define RTC_CTRLABUSY_bp  0  /* CTRLA Synchronization Busy Flag bit position. */
+#define RTC_CNTBUSY_bm  0x02  /* Count Synchronization Busy Flag bit mask. */
+#define RTC_CNTBUSY_bp  1  /* Count Synchronization Busy Flag bit position. */
+#define RTC_PERBUSY_bm  0x04  /* Period Synchronization Busy Flag bit mask. */
+#define RTC_PERBUSY_bp  2  /* Period Synchronization Busy Flag bit position. */
+#define RTC_CMPBUSY_bm  0x08  /* Comparator Synchronization Busy Flag bit mask. */
+#define RTC_CMPBUSY_bp  3  /* Comparator Synchronization Busy Flag bit position. */
+
+/* RTC.INTCTRL  bit masks and bit positions */
+#define RTC_OVF_bm  0x01  /* Overflow Interrupt enable bit mask. */
+#define RTC_OVF_bp  0  /* Overflow Interrupt enable bit position. */
+#define RTC_CMP_bm  0x02  /* Compare Match Interrupt enable bit mask. */
+#define RTC_CMP_bp  1  /* Compare Match Interrupt enable bit position. */
+
+/* RTC.INTFLAGS  bit masks and bit positions */
+/* RTC_OVF  is already defined. */
+/* RTC_CMP  is already defined. */
+
+/* RTC.DBGCTRL  bit masks and bit positions */
+#define RTC_DBGRUN_bm  0x01  /* Run in debug bit mask. */
+#define RTC_DBGRUN_bp  0  /* Run in debug bit position. */
+
+/* RTC.CALIB  bit masks and bit positions */
+#define RTC_ERROR_gm  0x7F  /* Error Correction Value group mask. */
+#define RTC_ERROR_gp  0  /* Error Correction Value group position. */
+#define RTC_ERROR_0_bm  (1<<0)  /* Error Correction Value bit 0 mask. */
+#define RTC_ERROR_0_bp  0  /* Error Correction Value bit 0 position. */
+#define RTC_ERROR_1_bm  (1<<1)  /* Error Correction Value bit 1 mask. */
+#define RTC_ERROR_1_bp  1  /* Error Correction Value bit 1 position. */
+#define RTC_ERROR_2_bm  (1<<2)  /* Error Correction Value bit 2 mask. */
+#define RTC_ERROR_2_bp  2  /* Error Correction Value bit 2 position. */
+#define RTC_ERROR_3_bm  (1<<3)  /* Error Correction Value bit 3 mask. */
+#define RTC_ERROR_3_bp  3  /* Error Correction Value bit 3 position. */
+#define RTC_ERROR_4_bm  (1<<4)  /* Error Correction Value bit 4 mask. */
+#define RTC_ERROR_4_bp  4  /* Error Correction Value bit 4 position. */
+#define RTC_ERROR_5_bm  (1<<5)  /* Error Correction Value bit 5 mask. */
+#define RTC_ERROR_5_bp  5  /* Error Correction Value bit 5 position. */
+#define RTC_ERROR_6_bm  (1<<6)  /* Error Correction Value bit 6 mask. */
+#define RTC_ERROR_6_bp  6  /* Error Correction Value bit 6 position. */
+#define RTC_SIGN_bm  0x80  /* Error Correction Sign Bit bit mask. */
+#define RTC_SIGN_bp  7  /* Error Correction Sign Bit bit position. */
+
+/* RTC.CLKSEL  bit masks and bit positions */
+#define RTC_CLKSEL_gm  0x03  /* Clock Select group mask. */
+#define RTC_CLKSEL_gp  0  /* Clock Select group position. */
+#define RTC_CLKSEL_0_bm  (1<<0)  /* Clock Select bit 0 mask. */
+#define RTC_CLKSEL_0_bp  0  /* Clock Select bit 0 position. */
+#define RTC_CLKSEL_1_bm  (1<<1)  /* Clock Select bit 1 mask. */
+#define RTC_CLKSEL_1_bp  1  /* Clock Select bit 1 position. */
+
+/* RTC.PITCTRLA  bit masks and bit positions */
+#define RTC_PITEN_bm  0x01  /* Enable bit mask. */
+#define RTC_PITEN_bp  0  /* Enable bit position. */
+#define RTC_PERIOD_gm  0x78  /* Period group mask. */
+#define RTC_PERIOD_gp  3  /* Period group position. */
+#define RTC_PERIOD_0_bm  (1<<3)  /* Period bit 0 mask. */
+#define RTC_PERIOD_0_bp  3  /* Period bit 0 position. */
+#define RTC_PERIOD_1_bm  (1<<4)  /* Period bit 1 mask. */
+#define RTC_PERIOD_1_bp  4  /* Period bit 1 position. */
+#define RTC_PERIOD_2_bm  (1<<5)  /* Period bit 2 mask. */
+#define RTC_PERIOD_2_bp  5  /* Period bit 2 position. */
+#define RTC_PERIOD_3_bm  (1<<6)  /* Period bit 3 mask. */
+#define RTC_PERIOD_3_bp  6  /* Period bit 3 position. */
+
+/* RTC.PITSTATUS  bit masks and bit positions */
+#define RTC_CTRLBUSY_bm  0x01  /* CTRLA Synchronization Busy Flag bit mask. */
+#define RTC_CTRLBUSY_bp  0  /* CTRLA Synchronization Busy Flag bit position. */
+
+/* RTC.PITINTCTRL  bit masks and bit positions */
+#define RTC_PI_bm  0x01  /* Periodic Interrupt bit mask. */
+#define RTC_PI_bp  0  /* Periodic Interrupt bit position. */
+
+/* RTC.PITINTFLAGS  bit masks and bit positions */
+/* RTC_PI  is already defined. */
+
+/* RTC.PITDBGCTRL  bit masks and bit positions */
+/* RTC_DBGRUN  is already defined. */
+
+/* RTC.PITEVGENCTRLA  bit masks and bit positions */
+#define RTC_EVGEN0SEL_gm  0x0F  /* Event Generation 0 Select group mask. */
+#define RTC_EVGEN0SEL_gp  0  /* Event Generation 0 Select group position. */
+#define RTC_EVGEN0SEL_0_bm  (1<<0)  /* Event Generation 0 Select bit 0 mask. */
+#define RTC_EVGEN0SEL_0_bp  0  /* Event Generation 0 Select bit 0 position. */
+#define RTC_EVGEN0SEL_1_bm  (1<<1)  /* Event Generation 0 Select bit 1 mask. */
+#define RTC_EVGEN0SEL_1_bp  1  /* Event Generation 0 Select bit 1 position. */
+#define RTC_EVGEN0SEL_2_bm  (1<<2)  /* Event Generation 0 Select bit 2 mask. */
+#define RTC_EVGEN0SEL_2_bp  2  /* Event Generation 0 Select bit 2 position. */
+#define RTC_EVGEN0SEL_3_bm  (1<<3)  /* Event Generation 0 Select bit 3 mask. */
+#define RTC_EVGEN0SEL_3_bp  3  /* Event Generation 0 Select bit 3 position. */
+#define RTC_EVGEN1SEL_gm  0xF0  /* Event Generation 1 Select group mask. */
+#define RTC_EVGEN1SEL_gp  4  /* Event Generation 1 Select group position. */
+#define RTC_EVGEN1SEL_0_bm  (1<<4)  /* Event Generation 1 Select bit 0 mask. */
+#define RTC_EVGEN1SEL_0_bp  4  /* Event Generation 1 Select bit 0 position. */
+#define RTC_EVGEN1SEL_1_bm  (1<<5)  /* Event Generation 1 Select bit 1 mask. */
+#define RTC_EVGEN1SEL_1_bp  5  /* Event Generation 1 Select bit 1 position. */
+#define RTC_EVGEN1SEL_2_bm  (1<<6)  /* Event Generation 1 Select bit 2 mask. */
+#define RTC_EVGEN1SEL_2_bp  6  /* Event Generation 1 Select bit 2 position. */
+#define RTC_EVGEN1SEL_3_bm  (1<<7)  /* Event Generation 1 Select bit 3 mask. */
+#define RTC_EVGEN1SEL_3_bp  7  /* Event Generation 1 Select bit 3 position. */
+
+
+
+/* SLPCTRL - Sleep Controller */
+/* SLPCTRL.CTRLA  bit masks and bit positions */
+#define SLPCTRL_SEN_bm  0x01  /* Sleep enable bit mask. */
+#define SLPCTRL_SEN_bp  0  /* Sleep enable bit position. */
+#define SLPCTRL_SMODE_gm  0x06  /* Sleep mode group mask. */
+#define SLPCTRL_SMODE_gp  1  /* Sleep mode group position. */
+#define SLPCTRL_SMODE_0_bm  (1<<1)  /* Sleep mode bit 0 mask. */
+#define SLPCTRL_SMODE_0_bp  1  /* Sleep mode bit 0 position. */
+#define SLPCTRL_SMODE_1_bm  (1<<2)  /* Sleep mode bit 1 mask. */
+#define SLPCTRL_SMODE_1_bp  2  /* Sleep mode bit 1 position. */
+
+
+/* SPI - Serial Peripheral Interface */
+/* SPI.CTRLA  bit masks and bit positions */
+#define SPI_ENABLE_bm  0x01  /* Enable Module bit mask. */
+#define SPI_ENABLE_bp  0  /* Enable Module bit position. */
+#define SPI_PRESC_gm  0x06  /* Prescaler group mask. */
+#define SPI_PRESC_gp  1  /* Prescaler group position. */
+#define SPI_PRESC_0_bm  (1<<1)  /* Prescaler bit 0 mask. */
+#define SPI_PRESC_0_bp  1  /* Prescaler bit 0 position. */
+#define SPI_PRESC_1_bm  (1<<2)  /* Prescaler bit 1 mask. */
+#define SPI_PRESC_1_bp  2  /* Prescaler bit 1 position. */
+#define SPI_CLK2X_bm  0x10  /* Enable Double Speed bit mask. */
+#define SPI_CLK2X_bp  4  /* Enable Double Speed bit position. */
+#define SPI_MASTER_bm  0x20  /* Host Operation Enable bit mask. */
+#define SPI_MASTER_bp  5  /* Host Operation Enable bit position. */
+#define SPI_DORD_bm  0x40  /* Data Order Setting bit mask. */
+#define SPI_DORD_bp  6  /* Data Order Setting bit position. */
+
+/* SPI.CTRLB  bit masks and bit positions */
+#define SPI_MODE_gm  0x03  /* SPI Mode group mask. */
+#define SPI_MODE_gp  0  /* SPI Mode group position. */
+#define SPI_MODE_0_bm  (1<<0)  /* SPI Mode bit 0 mask. */
+#define SPI_MODE_0_bp  0  /* SPI Mode bit 0 position. */
+#define SPI_MODE_1_bm  (1<<1)  /* SPI Mode bit 1 mask. */
+#define SPI_MODE_1_bp  1  /* SPI Mode bit 1 position. */
+#define SPI_SSD_bm  0x04  /* SPI Select Disable bit mask. */
+#define SPI_SSD_bp  2  /* SPI Select Disable bit position. */
+#define SPI_BUFWR_bm  0x40  /* Buffer Mode Wait for Receive bit mask. */
+#define SPI_BUFWR_bp  6  /* Buffer Mode Wait for Receive bit position. */
+#define SPI_BUFEN_bm  0x80  /* Buffer Mode Enable bit mask. */
+#define SPI_BUFEN_bp  7  /* Buffer Mode Enable bit position. */
+
+/* SPI.INTCTRL  bit masks and bit positions */
+#define SPI_IE_bm  0x01  /* Interrupt Enable bit mask. */
+#define SPI_IE_bp  0  /* Interrupt Enable bit position. */
+#define SPI_SSIE_bm  0x10  /* SPI Select Trigger Interrupt Enable bit mask. */
+#define SPI_SSIE_bp  4  /* SPI Select Trigger Interrupt Enable bit position. */
+#define SPI_DREIE_bm  0x20  /* Data Register Empty Interrupt Enable bit mask. */
+#define SPI_DREIE_bp  5  /* Data Register Empty Interrupt Enable bit position. */
+#define SPI_TXCIE_bm  0x40  /* Transfer Complete Interrupt Enable bit mask. */
+#define SPI_TXCIE_bp  6  /* Transfer Complete Interrupt Enable bit position. */
+#define SPI_RXCIE_bm  0x80  /* Receive Complete Interrupt Enable bit mask. */
+#define SPI_RXCIE_bp  7  /* Receive Complete Interrupt Enable bit position. */
+
+/* SPI.INTFLAGS  bit masks and bit positions */
+#define SPI_BUFOVF_bm  0x01  /* Buffer Overflow bit mask. */
+#define SPI_BUFOVF_bp  0  /* Buffer Overflow bit position. */
+#define SPI_SSIF_bm  0x10  /* SPI Select Trigger Interrupt Flag bit mask. */
+#define SPI_SSIF_bp  4  /* SPI Select Trigger Interrupt Flag bit position. */
+#define SPI_DREIF_bm  0x20  /* Data Register Empty Interrupt Flag bit mask. */
+#define SPI_DREIF_bp  5  /* Data Register Empty Interrupt Flag bit position. */
+#define SPI_TXCIF_bm  0x40  /* Transfer Complete Interrupt Flag bit mask. */
+#define SPI_TXCIF_bp  6  /* Transfer Complete Interrupt Flag bit position. */
+#define SPI_WRCOL_bm  0x40  /* Write Collision bit mask. */
+#define SPI_WRCOL_bp  6  /* Write Collision bit position. */
+#define SPI_RXCIF_bm  0x80  /* Receive Complete Interrupt Flag bit mask. */
+#define SPI_RXCIF_bp  7  /* Receive Complete Interrupt Flag bit position. */
+#define SPI_IF_bm  0x80  /* Interrupt Flag bit mask. */
+#define SPI_IF_bp  7  /* Interrupt Flag bit position. */
+
+
+/* SYSCFG - System Configuration Registers */
+/* SYSCFG.REVID  bit masks and bit positions */
+#define SYSCFG_MINOR_gm  0x0F  /* Minor Revision group mask. */
+#define SYSCFG_MINOR_gp  0  /* Minor Revision group position. */
+#define SYSCFG_MINOR_0_bm  (1<<0)  /* Minor Revision bit 0 mask. */
+#define SYSCFG_MINOR_0_bp  0  /* Minor Revision bit 0 position. */
+#define SYSCFG_MINOR_1_bm  (1<<1)  /* Minor Revision bit 1 mask. */
+#define SYSCFG_MINOR_1_bp  1  /* Minor Revision bit 1 position. */
+#define SYSCFG_MINOR_2_bm  (1<<2)  /* Minor Revision bit 2 mask. */
+#define SYSCFG_MINOR_2_bp  2  /* Minor Revision bit 2 position. */
+#define SYSCFG_MINOR_3_bm  (1<<3)  /* Minor Revision bit 3 mask. */
+#define SYSCFG_MINOR_3_bp  3  /* Minor Revision bit 3 position. */
+#define SYSCFG_MAJOR_gm  0xF0  /* Major Revision group mask. */
+#define SYSCFG_MAJOR_gp  4  /* Major Revision group position. */
+#define SYSCFG_MAJOR_0_bm  (1<<4)  /* Major Revision bit 0 mask. */
+#define SYSCFG_MAJOR_0_bp  4  /* Major Revision bit 0 position. */
+#define SYSCFG_MAJOR_1_bm  (1<<5)  /* Major Revision bit 1 mask. */
+#define SYSCFG_MAJOR_1_bp  5  /* Major Revision bit 1 position. */
+#define SYSCFG_MAJOR_2_bm  (1<<6)  /* Major Revision bit 2 mask. */
+#define SYSCFG_MAJOR_2_bp  6  /* Major Revision bit 2 position. */
+#define SYSCFG_MAJOR_3_bm  (1<<7)  /* Major Revision bit 3 mask. */
+#define SYSCFG_MAJOR_3_bp  7  /* Major Revision bit 3 position. */
+
+/* SYSCFG.OCDMCTRL  bit masks and bit positions */
+#define SYSCFG_OCDM_gm  0xFF  /* OCD Message group mask. */
+#define SYSCFG_OCDM_gp  0  /* OCD Message group position. */
+#define SYSCFG_OCDM_0_bm  (1<<0)  /* OCD Message bit 0 mask. */
+#define SYSCFG_OCDM_0_bp  0  /* OCD Message bit 0 position. */
+#define SYSCFG_OCDM_1_bm  (1<<1)  /* OCD Message bit 1 mask. */
+#define SYSCFG_OCDM_1_bp  1  /* OCD Message bit 1 position. */
+#define SYSCFG_OCDM_2_bm  (1<<2)  /* OCD Message bit 2 mask. */
+#define SYSCFG_OCDM_2_bp  2  /* OCD Message bit 2 position. */
+#define SYSCFG_OCDM_3_bm  (1<<3)  /* OCD Message bit 3 mask. */
+#define SYSCFG_OCDM_3_bp  3  /* OCD Message bit 3 position. */
+#define SYSCFG_OCDM_4_bm  (1<<4)  /* OCD Message bit 4 mask. */
+#define SYSCFG_OCDM_4_bp  4  /* OCD Message bit 4 position. */
+#define SYSCFG_OCDM_5_bm  (1<<5)  /* OCD Message bit 5 mask. */
+#define SYSCFG_OCDM_5_bp  5  /* OCD Message bit 5 position. */
+#define SYSCFG_OCDM_6_bm  (1<<6)  /* OCD Message bit 6 mask. */
+#define SYSCFG_OCDM_6_bp  6  /* OCD Message bit 6 position. */
+#define SYSCFG_OCDM_7_bm  (1<<7)  /* OCD Message bit 7 mask. */
+#define SYSCFG_OCDM_7_bp  7  /* OCD Message bit 7 position. */
+
+/* SYSCFG.OCDMSTATUS  bit masks and bit positions */
+#define SYSCFG_VALID_bm  0x01  /* OCD Message Valid bit mask. */
+#define SYSCFG_VALID_bp  0  /* OCD Message Valid bit position. */
+
+
+/* TCA - 16-bit Timer/Counter Type A */
+/* TCA_SINGLE.CTRLA  bit masks and bit positions */
+#define TCA_SINGLE_ENABLE_bm  0x01  /* Module Enable bit mask. */
+#define TCA_SINGLE_ENABLE_bp  0  /* Module Enable bit position. */
+#define TCA_SINGLE_CLKSEL_gm  0x0E  /* Clock Selection group mask. */
+#define TCA_SINGLE_CLKSEL_gp  1  /* Clock Selection group position. */
+#define TCA_SINGLE_CLKSEL_0_bm  (1<<1)  /* Clock Selection bit 0 mask. */
+#define TCA_SINGLE_CLKSEL_0_bp  1  /* Clock Selection bit 0 position. */
+#define TCA_SINGLE_CLKSEL_1_bm  (1<<2)  /* Clock Selection bit 1 mask. */
+#define TCA_SINGLE_CLKSEL_1_bp  2  /* Clock Selection bit 1 position. */
+#define TCA_SINGLE_CLKSEL_2_bm  (1<<3)  /* Clock Selection bit 2 mask. */
+#define TCA_SINGLE_CLKSEL_2_bp  3  /* Clock Selection bit 2 position. */
+#define TCA_SINGLE_RUNSTDBY_bm  0x80  /* Run in Standby bit mask. */
+#define TCA_SINGLE_RUNSTDBY_bp  7  /* Run in Standby bit position. */
+
+/* TCA_SINGLE.CTRLB  bit masks and bit positions */
+#define TCA_SINGLE_WGMODE_gm  0x07  /* Waveform generation mode group mask. */
+#define TCA_SINGLE_WGMODE_gp  0  /* Waveform generation mode group position. */
+#define TCA_SINGLE_WGMODE_0_bm  (1<<0)  /* Waveform generation mode bit 0 mask. */
+#define TCA_SINGLE_WGMODE_0_bp  0  /* Waveform generation mode bit 0 position. */
+#define TCA_SINGLE_WGMODE_1_bm  (1<<1)  /* Waveform generation mode bit 1 mask. */
+#define TCA_SINGLE_WGMODE_1_bp  1  /* Waveform generation mode bit 1 position. */
+#define TCA_SINGLE_WGMODE_2_bm  (1<<2)  /* Waveform generation mode bit 2 mask. */
+#define TCA_SINGLE_WGMODE_2_bp  2  /* Waveform generation mode bit 2 position. */
+#define TCA_SINGLE_ALUPD_bm  0x08  /* Auto Lock Update bit mask. */
+#define TCA_SINGLE_ALUPD_bp  3  /* Auto Lock Update bit position. */
+#define TCA_SINGLE_CMP0EN_bm  0x10  /* Compare 0 Enable bit mask. */
+#define TCA_SINGLE_CMP0EN_bp  4  /* Compare 0 Enable bit position. */
+#define TCA_SINGLE_CMP1EN_bm  0x20  /* Compare 1 Enable bit mask. */
+#define TCA_SINGLE_CMP1EN_bp  5  /* Compare 1 Enable bit position. */
+#define TCA_SINGLE_CMP2EN_bm  0x40  /* Compare 2 Enable bit mask. */
+#define TCA_SINGLE_CMP2EN_bp  6  /* Compare 2 Enable bit position. */
+
+/* TCA_SINGLE.CTRLC  bit masks and bit positions */
+#define TCA_SINGLE_CMP0OV_bm  0x01  /* Compare 0 Waveform Output Value bit mask. */
+#define TCA_SINGLE_CMP0OV_bp  0  /* Compare 0 Waveform Output Value bit position. */
+#define TCA_SINGLE_CMP1OV_bm  0x02  /* Compare 1 Waveform Output Value bit mask. */
+#define TCA_SINGLE_CMP1OV_bp  1  /* Compare 1 Waveform Output Value bit position. */
+#define TCA_SINGLE_CMP2OV_bm  0x04  /* Compare 2 Waveform Output Value bit mask. */
+#define TCA_SINGLE_CMP2OV_bp  2  /* Compare 2 Waveform Output Value bit position. */
+
+/* TCA_SINGLE.CTRLD  bit masks and bit positions */
+#define TCA_SINGLE_SPLITM_bm  0x01  /* Split Mode Enable bit mask. */
+#define TCA_SINGLE_SPLITM_bp  0  /* Split Mode Enable bit position. */
+
+/* TCA_SINGLE.CTRLECLR  bit masks and bit positions */
+#define TCA_SINGLE_DIR_bm  0x01  /* Direction bit mask. */
+#define TCA_SINGLE_DIR_bp  0  /* Direction bit position. */
+#define TCA_SINGLE_LUPD_bm  0x02  /* Lock Update bit mask. */
+#define TCA_SINGLE_LUPD_bp  1  /* Lock Update bit position. */
+#define TCA_SINGLE_CMD_gm  0x0C  /* Command group mask. */
+#define TCA_SINGLE_CMD_gp  2  /* Command group position. */
+#define TCA_SINGLE_CMD_0_bm  (1<<2)  /* Command bit 0 mask. */
+#define TCA_SINGLE_CMD_0_bp  2  /* Command bit 0 position. */
+#define TCA_SINGLE_CMD_1_bm  (1<<3)  /* Command bit 1 mask. */
+#define TCA_SINGLE_CMD_1_bp  3  /* Command bit 1 position. */
+
+/* TCA_SINGLE.CTRLESET  bit masks and bit positions */
+/* TCA_SINGLE_DIR  is already defined. */
+/* TCA_SINGLE_LUPD  is already defined. */
+/* TCA_SINGLE_CMD  is already defined. */
+
+/* TCA_SINGLE.CTRLFCLR  bit masks and bit positions */
+#define TCA_SINGLE_PERBV_bm  0x01  /* Period Buffer Valid bit mask. */
+#define TCA_SINGLE_PERBV_bp  0  /* Period Buffer Valid bit position. */
+#define TCA_SINGLE_CMP0BV_bm  0x02  /* Compare 0 Buffer Valid bit mask. */
+#define TCA_SINGLE_CMP0BV_bp  1  /* Compare 0 Buffer Valid bit position. */
+#define TCA_SINGLE_CMP1BV_bm  0x04  /* Compare 1 Buffer Valid bit mask. */
+#define TCA_SINGLE_CMP1BV_bp  2  /* Compare 1 Buffer Valid bit position. */
+#define TCA_SINGLE_CMP2BV_bm  0x08  /* Compare 2 Buffer Valid bit mask. */
+#define TCA_SINGLE_CMP2BV_bp  3  /* Compare 2 Buffer Valid bit position. */
+
+/* TCA_SINGLE.CTRLFSET  bit masks and bit positions */
+/* TCA_SINGLE_PERBV  is already defined. */
+/* TCA_SINGLE_CMP0BV  is already defined. */
+/* TCA_SINGLE_CMP1BV  is already defined. */
+/* TCA_SINGLE_CMP2BV  is already defined. */
+
+/* TCA_SINGLE.EVCTRL  bit masks and bit positions */
+#define TCA_SINGLE_CNTAEI_bm  0x01  /* Count on Event Input A bit mask. */
+#define TCA_SINGLE_CNTAEI_bp  0  /* Count on Event Input A bit position. */
+#define TCA_SINGLE_EVACTA_gm  0x0E  /* Event Action A group mask. */
+#define TCA_SINGLE_EVACTA_gp  1  /* Event Action A group position. */
+#define TCA_SINGLE_EVACTA_0_bm  (1<<1)  /* Event Action A bit 0 mask. */
+#define TCA_SINGLE_EVACTA_0_bp  1  /* Event Action A bit 0 position. */
+#define TCA_SINGLE_EVACTA_1_bm  (1<<2)  /* Event Action A bit 1 mask. */
+#define TCA_SINGLE_EVACTA_1_bp  2  /* Event Action A bit 1 position. */
+#define TCA_SINGLE_EVACTA_2_bm  (1<<3)  /* Event Action A bit 2 mask. */
+#define TCA_SINGLE_EVACTA_2_bp  3  /* Event Action A bit 2 position. */
+#define TCA_SINGLE_CNTBEI_bm  0x10  /* Count on Event Input B bit mask. */
+#define TCA_SINGLE_CNTBEI_bp  4  /* Count on Event Input B bit position. */
+#define TCA_SINGLE_EVACTB_gm  0xE0  /* Event Action B group mask. */
+#define TCA_SINGLE_EVACTB_gp  5  /* Event Action B group position. */
+#define TCA_SINGLE_EVACTB_0_bm  (1<<5)  /* Event Action B bit 0 mask. */
+#define TCA_SINGLE_EVACTB_0_bp  5  /* Event Action B bit 0 position. */
+#define TCA_SINGLE_EVACTB_1_bm  (1<<6)  /* Event Action B bit 1 mask. */
+#define TCA_SINGLE_EVACTB_1_bp  6  /* Event Action B bit 1 position. */
+#define TCA_SINGLE_EVACTB_2_bm  (1<<7)  /* Event Action B bit 2 mask. */
+#define TCA_SINGLE_EVACTB_2_bp  7  /* Event Action B bit 2 position. */
+
+/* TCA_SINGLE.INTCTRL  bit masks and bit positions */
+#define TCA_SINGLE_OVF_bm  0x01  /* Overflow Interrupt bit mask. */
+#define TCA_SINGLE_OVF_bp  0  /* Overflow Interrupt bit position. */
+#define TCA_SINGLE_CMP0_bm  0x10  /* Compare 0 Interrupt bit mask. */
+#define TCA_SINGLE_CMP0_bp  4  /* Compare 0 Interrupt bit position. */
+#define TCA_SINGLE_CMP1_bm  0x20  /* Compare 1 Interrupt bit mask. */
+#define TCA_SINGLE_CMP1_bp  5  /* Compare 1 Interrupt bit position. */
+#define TCA_SINGLE_CMP2_bm  0x40  /* Compare 2 Interrupt bit mask. */
+#define TCA_SINGLE_CMP2_bp  6  /* Compare 2 Interrupt bit position. */
+
+/* TCA_SINGLE.INTFLAGS  bit masks and bit positions */
+/* TCA_SINGLE_OVF  is already defined. */
+/* TCA_SINGLE_CMP0  is already defined. */
+/* TCA_SINGLE_CMP1  is already defined. */
+/* TCA_SINGLE_CMP2  is already defined. */
+
+/* TCA_SINGLE.DBGCTRL  bit masks and bit positions */
+#define TCA_SINGLE_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define TCA_SINGLE_DBGRUN_bp  0  /* Debug Run bit position. */
+
+/* TCA_SPLIT.CTRLA  bit masks and bit positions */
+#define TCA_SPLIT_ENABLE_bm  0x01  /* Module Enable bit mask. */
+#define TCA_SPLIT_ENABLE_bp  0  /* Module Enable bit position. */
+#define TCA_SPLIT_CLKSEL_gm  0x0E  /* Clock Selection group mask. */
+#define TCA_SPLIT_CLKSEL_gp  1  /* Clock Selection group position. */
+#define TCA_SPLIT_CLKSEL_0_bm  (1<<1)  /* Clock Selection bit 0 mask. */
+#define TCA_SPLIT_CLKSEL_0_bp  1  /* Clock Selection bit 0 position. */
+#define TCA_SPLIT_CLKSEL_1_bm  (1<<2)  /* Clock Selection bit 1 mask. */
+#define TCA_SPLIT_CLKSEL_1_bp  2  /* Clock Selection bit 1 position. */
+#define TCA_SPLIT_CLKSEL_2_bm  (1<<3)  /* Clock Selection bit 2 mask. */
+#define TCA_SPLIT_CLKSEL_2_bp  3  /* Clock Selection bit 2 position. */
+#define TCA_SPLIT_RUNSTDBY_bm  0x80  /* Run in Standby bit mask. */
+#define TCA_SPLIT_RUNSTDBY_bp  7  /* Run in Standby bit position. */
+
+/* TCA_SPLIT.CTRLB  bit masks and bit positions */
+#define TCA_SPLIT_LCMP0EN_bm  0x01  /* Low Compare 0 Enable bit mask. */
+#define TCA_SPLIT_LCMP0EN_bp  0  /* Low Compare 0 Enable bit position. */
+#define TCA_SPLIT_LCMP1EN_bm  0x02  /* Low Compare 1 Enable bit mask. */
+#define TCA_SPLIT_LCMP1EN_bp  1  /* Low Compare 1 Enable bit position. */
+#define TCA_SPLIT_LCMP2EN_bm  0x04  /* Low Compare 2 Enable bit mask. */
+#define TCA_SPLIT_LCMP2EN_bp  2  /* Low Compare 2 Enable bit position. */
+#define TCA_SPLIT_HCMP0EN_bm  0x10  /* High Compare 0 Enable bit mask. */
+#define TCA_SPLIT_HCMP0EN_bp  4  /* High Compare 0 Enable bit position. */
+#define TCA_SPLIT_HCMP1EN_bm  0x20  /* High Compare 1 Enable bit mask. */
+#define TCA_SPLIT_HCMP1EN_bp  5  /* High Compare 1 Enable bit position. */
+#define TCA_SPLIT_HCMP2EN_bm  0x40  /* High Compare 2 Enable bit mask. */
+#define TCA_SPLIT_HCMP2EN_bp  6  /* High Compare 2 Enable bit position. */
+
+/* TCA_SPLIT.CTRLC  bit masks and bit positions */
+#define TCA_SPLIT_LCMP0OV_bm  0x01  /* Low Compare 0 Output Value bit mask. */
+#define TCA_SPLIT_LCMP0OV_bp  0  /* Low Compare 0 Output Value bit position. */
+#define TCA_SPLIT_LCMP1OV_bm  0x02  /* Low Compare 1 Output Value bit mask. */
+#define TCA_SPLIT_LCMP1OV_bp  1  /* Low Compare 1 Output Value bit position. */
+#define TCA_SPLIT_LCMP2OV_bm  0x04  /* Low Compare 2 Output Value bit mask. */
+#define TCA_SPLIT_LCMP2OV_bp  2  /* Low Compare 2 Output Value bit position. */
+#define TCA_SPLIT_HCMP0OV_bm  0x10  /* High Compare 0 Output Value bit mask. */
+#define TCA_SPLIT_HCMP0OV_bp  4  /* High Compare 0 Output Value bit position. */
+#define TCA_SPLIT_HCMP1OV_bm  0x20  /* High Compare 1 Output Value bit mask. */
+#define TCA_SPLIT_HCMP1OV_bp  5  /* High Compare 1 Output Value bit position. */
+#define TCA_SPLIT_HCMP2OV_bm  0x40  /* High Compare 2 Output Value bit mask. */
+#define TCA_SPLIT_HCMP2OV_bp  6  /* High Compare 2 Output Value bit position. */
+
+/* TCA_SPLIT.CTRLD  bit masks and bit positions */
+#define TCA_SPLIT_SPLITM_bm  0x01  /* Split Mode Enable bit mask. */
+#define TCA_SPLIT_SPLITM_bp  0  /* Split Mode Enable bit position. */
+
+/* TCA_SPLIT.CTRLECLR  bit masks and bit positions */
+#define TCA_SPLIT_CMDEN_gm  0x03  /* Command Enable group mask. */
+#define TCA_SPLIT_CMDEN_gp  0  /* Command Enable group position. */
+#define TCA_SPLIT_CMDEN_0_bm  (1<<0)  /* Command Enable bit 0 mask. */
+#define TCA_SPLIT_CMDEN_0_bp  0  /* Command Enable bit 0 position. */
+#define TCA_SPLIT_CMDEN_1_bm  (1<<1)  /* Command Enable bit 1 mask. */
+#define TCA_SPLIT_CMDEN_1_bp  1  /* Command Enable bit 1 position. */
+#define TCA_SPLIT_CMD_gm  0x0C  /* Command group mask. */
+#define TCA_SPLIT_CMD_gp  2  /* Command group position. */
+#define TCA_SPLIT_CMD_0_bm  (1<<2)  /* Command bit 0 mask. */
+#define TCA_SPLIT_CMD_0_bp  2  /* Command bit 0 position. */
+#define TCA_SPLIT_CMD_1_bm  (1<<3)  /* Command bit 1 mask. */
+#define TCA_SPLIT_CMD_1_bp  3  /* Command bit 1 position. */
+
+/* TCA_SPLIT.CTRLESET  bit masks and bit positions */
+/* TCA_SPLIT_CMDEN  is already defined. */
+/* TCA_SPLIT_CMD  is already defined. */
+
+/* TCA_SPLIT.INTCTRL  bit masks and bit positions */
+#define TCA_SPLIT_LUNF_bm  0x01  /* Low Underflow Interrupt Enable bit mask. */
+#define TCA_SPLIT_LUNF_bp  0  /* Low Underflow Interrupt Enable bit position. */
+#define TCA_SPLIT_HUNF_bm  0x02  /* High Underflow Interrupt Enable bit mask. */
+#define TCA_SPLIT_HUNF_bp  1  /* High Underflow Interrupt Enable bit position. */
+#define TCA_SPLIT_LCMP0_bm  0x10  /* Low Compare 0 Interrupt Enable bit mask. */
+#define TCA_SPLIT_LCMP0_bp  4  /* Low Compare 0 Interrupt Enable bit position. */
+#define TCA_SPLIT_LCMP1_bm  0x20  /* Low Compare 1 Interrupt Enable bit mask. */
+#define TCA_SPLIT_LCMP1_bp  5  /* Low Compare 1 Interrupt Enable bit position. */
+#define TCA_SPLIT_LCMP2_bm  0x40  /* Low Compare 2 Interrupt Enable bit mask. */
+#define TCA_SPLIT_LCMP2_bp  6  /* Low Compare 2 Interrupt Enable bit position. */
+
+/* TCA_SPLIT.INTFLAGS  bit masks and bit positions */
+/* TCA_SPLIT_LUNF  is already defined. */
+/* TCA_SPLIT_HUNF  is already defined. */
+/* TCA_SPLIT_LCMP0  is already defined. */
+/* TCA_SPLIT_LCMP1  is already defined. */
+/* TCA_SPLIT_LCMP2  is already defined. */
+
+/* TCA_SPLIT.DBGCTRL  bit masks and bit positions */
+#define TCA_SPLIT_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define TCA_SPLIT_DBGRUN_bp  0  /* Debug Run bit position. */
+
+
+/* TCB - 16-bit Timer Type B */
+/* TCB.CTRLA  bit masks and bit positions */
+#define TCB_ENABLE_bm  0x01  /* Enable bit mask. */
+#define TCB_ENABLE_bp  0  /* Enable bit position. */
+#define TCB_CLKSEL_gm  0x0E  /* Clock Select group mask. */
+#define TCB_CLKSEL_gp  1  /* Clock Select group position. */
+#define TCB_CLKSEL_0_bm  (1<<1)  /* Clock Select bit 0 mask. */
+#define TCB_CLKSEL_0_bp  1  /* Clock Select bit 0 position. */
+#define TCB_CLKSEL_1_bm  (1<<2)  /* Clock Select bit 1 mask. */
+#define TCB_CLKSEL_1_bp  2  /* Clock Select bit 1 position. */
+#define TCB_CLKSEL_2_bm  (1<<3)  /* Clock Select bit 2 mask. */
+#define TCB_CLKSEL_2_bp  3  /* Clock Select bit 2 position. */
+#define TCB_SYNCUPD_bm  0x10  /* Synchronize Update bit mask. */
+#define TCB_SYNCUPD_bp  4  /* Synchronize Update bit position. */
+#define TCB_CASCADE_bm  0x20  /* Cascade two timers bit mask. */
+#define TCB_CASCADE_bp  5  /* Cascade two timers bit position. */
+#define TCB_RUNSTDBY_bm  0x40  /* Run Standby bit mask. */
+#define TCB_RUNSTDBY_bp  6  /* Run Standby bit position. */
+
+/* TCB.CTRLB  bit masks and bit positions */
+#define TCB_CNTMODE_gm  0x07  /* Timer Mode group mask. */
+#define TCB_CNTMODE_gp  0  /* Timer Mode group position. */
+#define TCB_CNTMODE_0_bm  (1<<0)  /* Timer Mode bit 0 mask. */
+#define TCB_CNTMODE_0_bp  0  /* Timer Mode bit 0 position. */
+#define TCB_CNTMODE_1_bm  (1<<1)  /* Timer Mode bit 1 mask. */
+#define TCB_CNTMODE_1_bp  1  /* Timer Mode bit 1 position. */
+#define TCB_CNTMODE_2_bm  (1<<2)  /* Timer Mode bit 2 mask. */
+#define TCB_CNTMODE_2_bp  2  /* Timer Mode bit 2 position. */
+#define TCB_CCMPEN_bm  0x10  /* Pin Output Enable bit mask. */
+#define TCB_CCMPEN_bp  4  /* Pin Output Enable bit position. */
+#define TCB_CCMPINIT_bm  0x20  /* Pin Initial State bit mask. */
+#define TCB_CCMPINIT_bp  5  /* Pin Initial State bit position. */
+#define TCB_ASYNC_bm  0x40  /* Asynchronous Enable bit mask. */
+#define TCB_ASYNC_bp  6  /* Asynchronous Enable bit position. */
+
+/* TCB.EVCTRL  bit masks and bit positions */
+#define TCB_CAPTEI_bm  0x01  /* Event Input Enable bit mask. */
+#define TCB_CAPTEI_bp  0  /* Event Input Enable bit position. */
+#define TCB_EDGE_bm  0x10  /* Event Edge bit mask. */
+#define TCB_EDGE_bp  4  /* Event Edge bit position. */
+#define TCB_FILTER_bm  0x40  /* Input Capture Noise Cancellation Filter bit mask. */
+#define TCB_FILTER_bp  6  /* Input Capture Noise Cancellation Filter bit position. */
+
+/* TCB.INTCTRL  bit masks and bit positions */
+#define TCB_CAPT_bm  0x01  /* Capture or Timeout bit mask. */
+#define TCB_CAPT_bp  0  /* Capture or Timeout bit position. */
+#define TCB_OVF_bm  0x02  /* Overflow bit mask. */
+#define TCB_OVF_bp  1  /* Overflow bit position. */
+
+/* TCB.INTFLAGS  bit masks and bit positions */
+/* TCB_CAPT  is already defined. */
+/* TCB_OVF  is already defined. */
+
+/* TCB.STATUS  bit masks and bit positions */
+#define TCB_RUN_bm  0x01  /* Run bit mask. */
+#define TCB_RUN_bp  0  /* Run bit position. */
+
+/* TCB.DBGCTRL  bit masks and bit positions */
+#define TCB_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define TCB_DBGRUN_bp  0  /* Debug Run bit position. */
+
+
+/* TWI - Two-Wire Interface */
+/* TWI.CTRLA  bit masks and bit positions */
+#define TWI_FMEN_bm  0x01  /* Fast-mode Enable bit mask. */
+#define TWI_FMEN_bp  0  /* Fast-mode Enable bit position. */
+#define TWI_FMPEN_bm  0x02  /* Fast-mode Plus Enable bit mask. */
+#define TWI_FMPEN_bp  1  /* Fast-mode Plus Enable bit position. */
+#define TWI_SDAHOLD_gm  0x0C  /* SDA Hold Time group mask. */
+#define TWI_SDAHOLD_gp  2  /* SDA Hold Time group position. */
+#define TWI_SDAHOLD_0_bm  (1<<2)  /* SDA Hold Time bit 0 mask. */
+#define TWI_SDAHOLD_0_bp  2  /* SDA Hold Time bit 0 position. */
+#define TWI_SDAHOLD_1_bm  (1<<3)  /* SDA Hold Time bit 1 mask. */
+#define TWI_SDAHOLD_1_bp  3  /* SDA Hold Time bit 1 position. */
+#define TWI_SDASETUP_bm  0x10  /* SDA Setup Time bit mask. */
+#define TWI_SDASETUP_bp  4  /* SDA Setup Time bit position. */
+#define TWI_INPUTLVL_bm  0x40  /* Input voltage transition level bit mask. */
+#define TWI_INPUTLVL_bp  6  /* Input voltage transition level bit position. */
+
+/* TWI.DUALCTRL  bit masks and bit positions */
+#define TWI_ENABLE_bm  0x01  /* Enable bit mask. */
+#define TWI_ENABLE_bp  0  /* Enable bit position. */
+/* TWI_FMPEN  is already defined. */
+/* TWI_SDAHOLD  is already defined. */
+/* TWI_INPUTLVL  is already defined. */
+
+/* TWI.DBGCTRL  bit masks and bit positions */
+#define TWI_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define TWI_DBGRUN_bp  0  /* Debug Run bit position. */
+
+/* TWI.MCTRLA  bit masks and bit positions */
+/* TWI_ENABLE  is already defined. */
+#define TWI_SMEN_bm  0x02  /* Smart Mode Enable bit mask. */
+#define TWI_SMEN_bp  1  /* Smart Mode Enable bit position. */
+#define TWI_TIMEOUT_gm  0x0C  /* Inactive Bus Time-Out group mask. */
+#define TWI_TIMEOUT_gp  2  /* Inactive Bus Time-Out group position. */
+#define TWI_TIMEOUT_0_bm  (1<<2)  /* Inactive Bus Time-Out bit 0 mask. */
+#define TWI_TIMEOUT_0_bp  2  /* Inactive Bus Time-Out bit 0 position. */
+#define TWI_TIMEOUT_1_bm  (1<<3)  /* Inactive Bus Time-Out bit 1 mask. */
+#define TWI_TIMEOUT_1_bp  3  /* Inactive Bus Time-Out bit 1 position. */
+#define TWI_QCEN_bm  0x10  /* Quick Command Enable bit mask. */
+#define TWI_QCEN_bp  4  /* Quick Command Enable bit position. */
+#define TWI_WIEN_bm  0x40  /* Write Interrupt Enable bit mask. */
+#define TWI_WIEN_bp  6  /* Write Interrupt Enable bit position. */
+#define TWI_RIEN_bm  0x80  /* Read Interrupt Enable bit mask. */
+#define TWI_RIEN_bp  7  /* Read Interrupt Enable bit position. */
+
+/* TWI.MCTRLB  bit masks and bit positions */
+#define TWI_MCMD_gm  0x03  /* Command group mask. */
+#define TWI_MCMD_gp  0  /* Command group position. */
+#define TWI_MCMD_0_bm  (1<<0)  /* Command bit 0 mask. */
+#define TWI_MCMD_0_bp  0  /* Command bit 0 position. */
+#define TWI_MCMD_1_bm  (1<<1)  /* Command bit 1 mask. */
+#define TWI_MCMD_1_bp  1  /* Command bit 1 position. */
+#define TWI_ACKACT_bm  0x04  /* Acknowledge Action bit mask. */
+#define TWI_ACKACT_bp  2  /* Acknowledge Action bit position. */
+#define TWI_FLUSH_bm  0x08  /* Flush bit mask. */
+#define TWI_FLUSH_bp  3  /* Flush bit position. */
+
+/* TWI.MSTATUS  bit masks and bit positions */
+#define TWI_BUSSTATE_gm  0x03  /* Bus State group mask. */
+#define TWI_BUSSTATE_gp  0  /* Bus State group position. */
+#define TWI_BUSSTATE_0_bm  (1<<0)  /* Bus State bit 0 mask. */
+#define TWI_BUSSTATE_0_bp  0  /* Bus State bit 0 position. */
+#define TWI_BUSSTATE_1_bm  (1<<1)  /* Bus State bit 1 mask. */
+#define TWI_BUSSTATE_1_bp  1  /* Bus State bit 1 position. */
+#define TWI_BUSERR_bm  0x04  /* Bus Error bit mask. */
+#define TWI_BUSERR_bp  2  /* Bus Error bit position. */
+#define TWI_ARBLOST_bm  0x08  /* Arbitration Lost bit mask. */
+#define TWI_ARBLOST_bp  3  /* Arbitration Lost bit position. */
+#define TWI_RXACK_bm  0x10  /* Received Acknowledge bit mask. */
+#define TWI_RXACK_bp  4  /* Received Acknowledge bit position. */
+#define TWI_CLKHOLD_bm  0x20  /* Clock Hold bit mask. */
+#define TWI_CLKHOLD_bp  5  /* Clock Hold bit position. */
+#define TWI_WIF_bm  0x40  /* Write Interrupt Flag bit mask. */
+#define TWI_WIF_bp  6  /* Write Interrupt Flag bit position. */
+#define TWI_RIF_bm  0x80  /* Read Interrupt Flag bit mask. */
+#define TWI_RIF_bp  7  /* Read Interrupt Flag bit position. */
+
+/* TWI.MBAUD  bit masks and bit positions */
+#define TWI_BAUD_gm  0xFF  /* Baud Rate group mask. */
+#define TWI_BAUD_gp  0  /* Baud Rate group position. */
+#define TWI_BAUD_0_bm  (1<<0)  /* Baud Rate bit 0 mask. */
+#define TWI_BAUD_0_bp  0  /* Baud Rate bit 0 position. */
+#define TWI_BAUD_1_bm  (1<<1)  /* Baud Rate bit 1 mask. */
+#define TWI_BAUD_1_bp  1  /* Baud Rate bit 1 position. */
+#define TWI_BAUD_2_bm  (1<<2)  /* Baud Rate bit 2 mask. */
+#define TWI_BAUD_2_bp  2  /* Baud Rate bit 2 position. */
+#define TWI_BAUD_3_bm  (1<<3)  /* Baud Rate bit 3 mask. */
+#define TWI_BAUD_3_bp  3  /* Baud Rate bit 3 position. */
+#define TWI_BAUD_4_bm  (1<<4)  /* Baud Rate bit 4 mask. */
+#define TWI_BAUD_4_bp  4  /* Baud Rate bit 4 position. */
+#define TWI_BAUD_5_bm  (1<<5)  /* Baud Rate bit 5 mask. */
+#define TWI_BAUD_5_bp  5  /* Baud Rate bit 5 position. */
+#define TWI_BAUD_6_bm  (1<<6)  /* Baud Rate bit 6 mask. */
+#define TWI_BAUD_6_bp  6  /* Baud Rate bit 6 position. */
+#define TWI_BAUD_7_bm  (1<<7)  /* Baud Rate bit 7 mask. */
+#define TWI_BAUD_7_bp  7  /* Baud Rate bit 7 position. */
+
+/* TWI.MADDR  bit masks and bit positions */
+#define TWI_ADDR_gm  0xFF  /* Address group mask. */
+#define TWI_ADDR_gp  0  /* Address group position. */
+#define TWI_ADDR_0_bm  (1<<0)  /* Address bit 0 mask. */
+#define TWI_ADDR_0_bp  0  /* Address bit 0 position. */
+#define TWI_ADDR_1_bm  (1<<1)  /* Address bit 1 mask. */
+#define TWI_ADDR_1_bp  1  /* Address bit 1 position. */
+#define TWI_ADDR_2_bm  (1<<2)  /* Address bit 2 mask. */
+#define TWI_ADDR_2_bp  2  /* Address bit 2 position. */
+#define TWI_ADDR_3_bm  (1<<3)  /* Address bit 3 mask. */
+#define TWI_ADDR_3_bp  3  /* Address bit 3 position. */
+#define TWI_ADDR_4_bm  (1<<4)  /* Address bit 4 mask. */
+#define TWI_ADDR_4_bp  4  /* Address bit 4 position. */
+#define TWI_ADDR_5_bm  (1<<5)  /* Address bit 5 mask. */
+#define TWI_ADDR_5_bp  5  /* Address bit 5 position. */
+#define TWI_ADDR_6_bm  (1<<6)  /* Address bit 6 mask. */
+#define TWI_ADDR_6_bp  6  /* Address bit 6 position. */
+#define TWI_ADDR_7_bm  (1<<7)  /* Address bit 7 mask. */
+#define TWI_ADDR_7_bp  7  /* Address bit 7 position. */
+
+/* TWI.MDATA  bit masks and bit positions */
+#define TWI_DATA_gm  0xFF  /* Data group mask. */
+#define TWI_DATA_gp  0  /* Data group position. */
+#define TWI_DATA_0_bm  (1<<0)  /* Data bit 0 mask. */
+#define TWI_DATA_0_bp  0  /* Data bit 0 position. */
+#define TWI_DATA_1_bm  (1<<1)  /* Data bit 1 mask. */
+#define TWI_DATA_1_bp  1  /* Data bit 1 position. */
+#define TWI_DATA_2_bm  (1<<2)  /* Data bit 2 mask. */
+#define TWI_DATA_2_bp  2  /* Data bit 2 position. */
+#define TWI_DATA_3_bm  (1<<3)  /* Data bit 3 mask. */
+#define TWI_DATA_3_bp  3  /* Data bit 3 position. */
+#define TWI_DATA_4_bm  (1<<4)  /* Data bit 4 mask. */
+#define TWI_DATA_4_bp  4  /* Data bit 4 position. */
+#define TWI_DATA_5_bm  (1<<5)  /* Data bit 5 mask. */
+#define TWI_DATA_5_bp  5  /* Data bit 5 position. */
+#define TWI_DATA_6_bm  (1<<6)  /* Data bit 6 mask. */
+#define TWI_DATA_6_bp  6  /* Data bit 6 position. */
+#define TWI_DATA_7_bm  (1<<7)  /* Data bit 7 mask. */
+#define TWI_DATA_7_bp  7  /* Data bit 7 position. */
+
+/* TWI.SCTRLA  bit masks and bit positions */
+/* TWI_ENABLE  is already defined. */
+/* TWI_SMEN  is already defined. */
+#define TWI_PMEN_bm  0x04  /* Address Recognition Mode bit mask. */
+#define TWI_PMEN_bp  2  /* Address Recognition Mode bit position. */
+#define TWI_PIEN_bm  0x20  /* Stop Interrupt Enable bit mask. */
+#define TWI_PIEN_bp  5  /* Stop Interrupt Enable bit position. */
+#define TWI_APIEN_bm  0x40  /* Address or Stop Interrupt Enable bit mask. */
+#define TWI_APIEN_bp  6  /* Address or Stop Interrupt Enable bit position. */
+#define TWI_DIEN_bm  0x80  /* Data Interrupt Enable bit mask. */
+#define TWI_DIEN_bp  7  /* Data Interrupt Enable bit position. */
+
+/* TWI.SCTRLB  bit masks and bit positions */
+#define TWI_SCMD_gm  0x03  /* Command group mask. */
+#define TWI_SCMD_gp  0  /* Command group position. */
+#define TWI_SCMD_0_bm  (1<<0)  /* Command bit 0 mask. */
+#define TWI_SCMD_0_bp  0  /* Command bit 0 position. */
+#define TWI_SCMD_1_bm  (1<<1)  /* Command bit 1 mask. */
+#define TWI_SCMD_1_bp  1  /* Command bit 1 position. */
+/* TWI_ACKACT  is already defined. */
+
+/* TWI.SSTATUS  bit masks and bit positions */
+#define TWI_AP_bm  0x01  /* Address or Stop bit mask. */
+#define TWI_AP_bp  0  /* Address or Stop bit position. */
+#define TWI_DIR_bm  0x02  /* Read/Write Direction bit mask. */
+#define TWI_DIR_bp  1  /* Read/Write Direction bit position. */
+/* TWI_BUSERR  is already defined. */
+#define TWI_COLL_bm  0x08  /* Collision bit mask. */
+#define TWI_COLL_bp  3  /* Collision bit position. */
+/* TWI_RXACK  is already defined. */
+/* TWI_CLKHOLD  is already defined. */
+#define TWI_APIF_bm  0x40  /* Address or Stop Interrupt Flag bit mask. */
+#define TWI_APIF_bp  6  /* Address or Stop Interrupt Flag bit position. */
+#define TWI_DIF_bm  0x80  /* Data Interrupt Flag bit mask. */
+#define TWI_DIF_bp  7  /* Data Interrupt Flag bit position. */
+
+/* TWI.SADDR  bit masks and bit positions */
+/* TWI_ADDR  is already defined. */
+
+/* TWI.SDATA  bit masks and bit positions */
+/* TWI_DATA  is already defined. */
+
+/* TWI.SADDRMASK  bit masks and bit positions */
+#define TWI_ADDREN_bm  0x01  /* Address Mask Enable bit mask. */
+#define TWI_ADDREN_bp  0  /* Address Mask Enable bit position. */
+#define TWI_ADDRMASK_gm  0xFE  /* Address Mask group mask. */
+#define TWI_ADDRMASK_gp  1  /* Address Mask group position. */
+#define TWI_ADDRMASK_0_bm  (1<<1)  /* Address Mask bit 0 mask. */
+#define TWI_ADDRMASK_0_bp  1  /* Address Mask bit 0 position. */
+#define TWI_ADDRMASK_1_bm  (1<<2)  /* Address Mask bit 1 mask. */
+#define TWI_ADDRMASK_1_bp  2  /* Address Mask bit 1 position. */
+#define TWI_ADDRMASK_2_bm  (1<<3)  /* Address Mask bit 2 mask. */
+#define TWI_ADDRMASK_2_bp  3  /* Address Mask bit 2 position. */
+#define TWI_ADDRMASK_3_bm  (1<<4)  /* Address Mask bit 3 mask. */
+#define TWI_ADDRMASK_3_bp  4  /* Address Mask bit 3 position. */
+#define TWI_ADDRMASK_4_bm  (1<<5)  /* Address Mask bit 4 mask. */
+#define TWI_ADDRMASK_4_bp  5  /* Address Mask bit 4 position. */
+#define TWI_ADDRMASK_5_bm  (1<<6)  /* Address Mask bit 5 mask. */
+#define TWI_ADDRMASK_5_bp  6  /* Address Mask bit 5 position. */
+#define TWI_ADDRMASK_6_bm  (1<<7)  /* Address Mask bit 6 mask. */
+#define TWI_ADDRMASK_6_bp  7  /* Address Mask bit 6 position. */
+
+
+/* USART - Universal Synchronous and Asynchronous Receiver and Transmitter */
+/* USART.RXDATAL  bit masks and bit positions */
+#define USART_DATA_gm  0xFF  /* RX Data group mask. */
+#define USART_DATA_gp  0  /* RX Data group position. */
+#define USART_DATA_0_bm  (1<<0)  /* RX Data bit 0 mask. */
+#define USART_DATA_0_bp  0  /* RX Data bit 0 position. */
+#define USART_DATA_1_bm  (1<<1)  /* RX Data bit 1 mask. */
+#define USART_DATA_1_bp  1  /* RX Data bit 1 position. */
+#define USART_DATA_2_bm  (1<<2)  /* RX Data bit 2 mask. */
+#define USART_DATA_2_bp  2  /* RX Data bit 2 position. */
+#define USART_DATA_3_bm  (1<<3)  /* RX Data bit 3 mask. */
+#define USART_DATA_3_bp  3  /* RX Data bit 3 position. */
+#define USART_DATA_4_bm  (1<<4)  /* RX Data bit 4 mask. */
+#define USART_DATA_4_bp  4  /* RX Data bit 4 position. */
+#define USART_DATA_5_bm  (1<<5)  /* RX Data bit 5 mask. */
+#define USART_DATA_5_bp  5  /* RX Data bit 5 position. */
+#define USART_DATA_6_bm  (1<<6)  /* RX Data bit 6 mask. */
+#define USART_DATA_6_bp  6  /* RX Data bit 6 position. */
+#define USART_DATA_7_bm  (1<<7)  /* RX Data bit 7 mask. */
+#define USART_DATA_7_bp  7  /* RX Data bit 7 position. */
+
+/* USART.RXDATAH  bit masks and bit positions */
+#define USART_DATA8_bm  0x01  /* Receiver Data Register bit mask. */
+#define USART_DATA8_bp  0  /* Receiver Data Register bit position. */
+#define USART_PERR_bm  0x02  /* Parity Error bit mask. */
+#define USART_PERR_bp  1  /* Parity Error bit position. */
+#define USART_FERR_bm  0x04  /* Frame Error bit mask. */
+#define USART_FERR_bp  2  /* Frame Error bit position. */
+#define USART_BUFOVF_bm  0x40  /* Buffer Overflow bit mask. */
+#define USART_BUFOVF_bp  6  /* Buffer Overflow bit position. */
+#define USART_RXCIF_bm  0x80  /* Receive Complete Interrupt Flag bit mask. */
+#define USART_RXCIF_bp  7  /* Receive Complete Interrupt Flag bit position. */
+
+/* USART.TXDATAL  bit masks and bit positions */
+/* USART_DATA  is already defined. */
+
+/* USART.TXDATAH  bit masks and bit positions */
+/* USART_DATA8  is already defined. */
+
+/* USART.STATUS  bit masks and bit positions */
+#define USART_WFB_bm  0x01  /* Wait For Break bit mask. */
+#define USART_WFB_bp  0  /* Wait For Break bit position. */
+#define USART_BDF_bm  0x02  /* Break Detected Flag bit mask. */
+#define USART_BDF_bp  1  /* Break Detected Flag bit position. */
+#define USART_ISFIF_bm  0x08  /* Inconsistent Sync Field Interrupt Flag bit mask. */
+#define USART_ISFIF_bp  3  /* Inconsistent Sync Field Interrupt Flag bit position. */
+#define USART_RXSIF_bm  0x10  /* Receive Start Interrupt bit mask. */
+#define USART_RXSIF_bp  4  /* Receive Start Interrupt bit position. */
+#define USART_DREIF_bm  0x20  /* Data Register Empty Flag bit mask. */
+#define USART_DREIF_bp  5  /* Data Register Empty Flag bit position. */
+#define USART_TXCIF_bm  0x40  /* Transmit Interrupt Flag bit mask. */
+#define USART_TXCIF_bp  6  /* Transmit Interrupt Flag bit position. */
+/* USART_RXCIF  is already defined. */
+
+/* USART.CTRLA  bit masks and bit positions */
+#define USART_RS485_bm  0x01  /* RS485 Mode internal transmitter bit mask. */
+#define USART_RS485_bp  0  /* RS485 Mode internal transmitter bit position. */
+#define USART_ABEIE_bm  0x04  /* Auto-baud Error Interrupt Enable bit mask. */
+#define USART_ABEIE_bp  2  /* Auto-baud Error Interrupt Enable bit position. */
+#define USART_LBME_bm  0x08  /* Loop-back Mode Enable bit mask. */
+#define USART_LBME_bp  3  /* Loop-back Mode Enable bit position. */
+#define USART_RXSIE_bm  0x10  /* Receiver Start Frame Interrupt Enable bit mask. */
+#define USART_RXSIE_bp  4  /* Receiver Start Frame Interrupt Enable bit position. */
+#define USART_DREIE_bm  0x20  /* Data Register Empty Interrupt Enable bit mask. */
+#define USART_DREIE_bp  5  /* Data Register Empty Interrupt Enable bit position. */
+#define USART_TXCIE_bm  0x40  /* Transmit Complete Interrupt Enable bit mask. */
+#define USART_TXCIE_bp  6  /* Transmit Complete Interrupt Enable bit position. */
+#define USART_RXCIE_bm  0x80  /* Receive Complete Interrupt Enable bit mask. */
+#define USART_RXCIE_bp  7  /* Receive Complete Interrupt Enable bit position. */
+
+/* USART.CTRLB  bit masks and bit positions */
+#define USART_MPCM_bm  0x01  /* Multi-processor Communication Mode bit mask. */
+#define USART_MPCM_bp  0  /* Multi-processor Communication Mode bit position. */
+#define USART_RXMODE_gm  0x06  /* Receiver Mode group mask. */
+#define USART_RXMODE_gp  1  /* Receiver Mode group position. */
+#define USART_RXMODE_0_bm  (1<<1)  /* Receiver Mode bit 0 mask. */
+#define USART_RXMODE_0_bp  1  /* Receiver Mode bit 0 position. */
+#define USART_RXMODE_1_bm  (1<<2)  /* Receiver Mode bit 1 mask. */
+#define USART_RXMODE_1_bp  2  /* Receiver Mode bit 1 position. */
+#define USART_ODME_bm  0x08  /* Open Drain Mode Enable bit mask. */
+#define USART_ODME_bp  3  /* Open Drain Mode Enable bit position. */
+#define USART_SFDEN_bm  0x10  /* Start Frame Detection Enable bit mask. */
+#define USART_SFDEN_bp  4  /* Start Frame Detection Enable bit position. */
+#define USART_TXEN_bm  0x40  /* Transmitter Enable bit mask. */
+#define USART_TXEN_bp  6  /* Transmitter Enable bit position. */
+#define USART_RXEN_bm  0x80  /* Reciever enable bit mask. */
+#define USART_RXEN_bp  7  /* Reciever enable bit position. */
+
+/* USART.CTRLC  bit masks and bit positions */
+#define USART_UCPHA_bm  0x02  /* SPI Host Mode, Clock Phase bit mask. */
+#define USART_UCPHA_bp  1  /* SPI Host Mode, Clock Phase bit position. */
+#define USART_UDORD_bm  0x04  /* SPI Host Mode, Data Order bit mask. */
+#define USART_UDORD_bp  2  /* SPI Host Mode, Data Order bit position. */
+#define USART_CHSIZE_gm  0x07  /* Character Size group mask. */
+#define USART_CHSIZE_gp  0  /* Character Size group position. */
+#define USART_CHSIZE_0_bm  (1<<0)  /* Character Size bit 0 mask. */
+#define USART_CHSIZE_0_bp  0  /* Character Size bit 0 position. */
+#define USART_CHSIZE_1_bm  (1<<1)  /* Character Size bit 1 mask. */
+#define USART_CHSIZE_1_bp  1  /* Character Size bit 1 position. */
+#define USART_CHSIZE_2_bm  (1<<2)  /* Character Size bit 2 mask. */
+#define USART_CHSIZE_2_bp  2  /* Character Size bit 2 position. */
+#define USART_SBMODE_bm  0x08  /* Stop Bit Mode bit mask. */
+#define USART_SBMODE_bp  3  /* Stop Bit Mode bit position. */
+#define USART_PMODE_gm  0x30  /* Parity Mode group mask. */
+#define USART_PMODE_gp  4  /* Parity Mode group position. */
+#define USART_PMODE_0_bm  (1<<4)  /* Parity Mode bit 0 mask. */
+#define USART_PMODE_0_bp  4  /* Parity Mode bit 0 position. */
+#define USART_PMODE_1_bm  (1<<5)  /* Parity Mode bit 1 mask. */
+#define USART_PMODE_1_bp  5  /* Parity Mode bit 1 position. */
+#define USART_CMODE_gm  0xC0  /* Communication Mode group mask. */
+#define USART_CMODE_gp  6  /* Communication Mode group position. */
+#define USART_CMODE_0_bm  (1<<6)  /* Communication Mode bit 0 mask. */
+#define USART_CMODE_0_bp  6  /* Communication Mode bit 0 position. */
+#define USART_CMODE_1_bm  (1<<7)  /* Communication Mode bit 1 mask. */
+#define USART_CMODE_1_bp  7  /* Communication Mode bit 1 position. */
+
+/* USART.CTRLD  bit masks and bit positions */
+#define USART_ABW_gm  0xC0  /* Auto Baud Window group mask. */
+#define USART_ABW_gp  6  /* Auto Baud Window group position. */
+#define USART_ABW_0_bm  (1<<6)  /* Auto Baud Window bit 0 mask. */
+#define USART_ABW_0_bp  6  /* Auto Baud Window bit 0 position. */
+#define USART_ABW_1_bm  (1<<7)  /* Auto Baud Window bit 1 mask. */
+#define USART_ABW_1_bp  7  /* Auto Baud Window bit 1 position. */
+
+/* USART.DBGCTRL  bit masks and bit positions */
+#define USART_DBGRUN_bm  0x01  /* Debug Run bit mask. */
+#define USART_DBGRUN_bp  0  /* Debug Run bit position. */
+
+/* USART.EVCTRL  bit masks and bit positions */
+#define USART_IREI_bm  0x01  /* IrDA Event Input Enable bit mask. */
+#define USART_IREI_bp  0  /* IrDA Event Input Enable bit position. */
+
+/* USART.TXPLCTRL  bit masks and bit positions */
+#define USART_TXPL_gm  0xFF  /* Transmit pulse length group mask. */
+#define USART_TXPL_gp  0  /* Transmit pulse length group position. */
+#define USART_TXPL_0_bm  (1<<0)  /* Transmit pulse length bit 0 mask. */
+#define USART_TXPL_0_bp  0  /* Transmit pulse length bit 0 position. */
+#define USART_TXPL_1_bm  (1<<1)  /* Transmit pulse length bit 1 mask. */
+#define USART_TXPL_1_bp  1  /* Transmit pulse length bit 1 position. */
+#define USART_TXPL_2_bm  (1<<2)  /* Transmit pulse length bit 2 mask. */
+#define USART_TXPL_2_bp  2  /* Transmit pulse length bit 2 position. */
+#define USART_TXPL_3_bm  (1<<3)  /* Transmit pulse length bit 3 mask. */
+#define USART_TXPL_3_bp  3  /* Transmit pulse length bit 3 position. */
+#define USART_TXPL_4_bm  (1<<4)  /* Transmit pulse length bit 4 mask. */
+#define USART_TXPL_4_bp  4  /* Transmit pulse length bit 4 position. */
+#define USART_TXPL_5_bm  (1<<5)  /* Transmit pulse length bit 5 mask. */
+#define USART_TXPL_5_bp  5  /* Transmit pulse length bit 5 position. */
+#define USART_TXPL_6_bm  (1<<6)  /* Transmit pulse length bit 6 mask. */
+#define USART_TXPL_6_bp  6  /* Transmit pulse length bit 6 position. */
+#define USART_TXPL_7_bm  (1<<7)  /* Transmit pulse length bit 7 mask. */
+#define USART_TXPL_7_bp  7  /* Transmit pulse length bit 7 position. */
+
+/* USART.RXPLCTRL  bit masks and bit positions */
+#define USART_RXPL_gm  0x7F  /* Receiver Pulse Lenght group mask. */
+#define USART_RXPL_gp  0  /* Receiver Pulse Lenght group position. */
+#define USART_RXPL_0_bm  (1<<0)  /* Receiver Pulse Lenght bit 0 mask. */
+#define USART_RXPL_0_bp  0  /* Receiver Pulse Lenght bit 0 position. */
+#define USART_RXPL_1_bm  (1<<1)  /* Receiver Pulse Lenght bit 1 mask. */
+#define USART_RXPL_1_bp  1  /* Receiver Pulse Lenght bit 1 position. */
+#define USART_RXPL_2_bm  (1<<2)  /* Receiver Pulse Lenght bit 2 mask. */
+#define USART_RXPL_2_bp  2  /* Receiver Pulse Lenght bit 2 position. */
+#define USART_RXPL_3_bm  (1<<3)  /* Receiver Pulse Lenght bit 3 mask. */
+#define USART_RXPL_3_bp  3  /* Receiver Pulse Lenght bit 3 position. */
+#define USART_RXPL_4_bm  (1<<4)  /* Receiver Pulse Lenght bit 4 mask. */
+#define USART_RXPL_4_bp  4  /* Receiver Pulse Lenght bit 4 position. */
+#define USART_RXPL_5_bm  (1<<5)  /* Receiver Pulse Lenght bit 5 mask. */
+#define USART_RXPL_5_bp  5  /* Receiver Pulse Lenght bit 5 position. */
+#define USART_RXPL_6_bm  (1<<6)  /* Receiver Pulse Lenght bit 6 mask. */
+#define USART_RXPL_6_bp  6  /* Receiver Pulse Lenght bit 6 position. */
+
+
+
+/* VPORT - Virtual Ports */
+/* VPORT.INTFLAGS  bit masks and bit positions */
+#define VPORT_INT_gm  0xFF  /* Pin Interrupt Flag group mask. */
+#define VPORT_INT_gp  0  /* Pin Interrupt Flag group position. */
+#define VPORT_INT_0_bm  (1<<0)  /* Pin Interrupt Flag bit 0 mask. */
+#define VPORT_INT_0_bp  0  /* Pin Interrupt Flag bit 0 position. */
+#define VPORT_INT_1_bm  (1<<1)  /* Pin Interrupt Flag bit 1 mask. */
+#define VPORT_INT_1_bp  1  /* Pin Interrupt Flag bit 1 position. */
+#define VPORT_INT_2_bm  (1<<2)  /* Pin Interrupt Flag bit 2 mask. */
+#define VPORT_INT_2_bp  2  /* Pin Interrupt Flag bit 2 position. */
+#define VPORT_INT_3_bm  (1<<3)  /* Pin Interrupt Flag bit 3 mask. */
+#define VPORT_INT_3_bp  3  /* Pin Interrupt Flag bit 3 position. */
+#define VPORT_INT_4_bm  (1<<4)  /* Pin Interrupt Flag bit 4 mask. */
+#define VPORT_INT_4_bp  4  /* Pin Interrupt Flag bit 4 position. */
+#define VPORT_INT_5_bm  (1<<5)  /* Pin Interrupt Flag bit 5 mask. */
+#define VPORT_INT_5_bp  5  /* Pin Interrupt Flag bit 5 position. */
+#define VPORT_INT_6_bm  (1<<6)  /* Pin Interrupt Flag bit 6 mask. */
+#define VPORT_INT_6_bp  6  /* Pin Interrupt Flag bit 6 position. */
+#define VPORT_INT_7_bm  (1<<7)  /* Pin Interrupt Flag bit 7 mask. */
+#define VPORT_INT_7_bp  7  /* Pin Interrupt Flag bit 7 position. */
+
+
+/* VREF - Voltage reference */
+/* VREF.DAC0REF  bit masks and bit positions */
+#define VREF_REFSEL_gm  0x07  /* Reference select group mask. */
+#define VREF_REFSEL_gp  0  /* Reference select group position. */
+#define VREF_REFSEL_0_bm  (1<<0)  /* Reference select bit 0 mask. */
+#define VREF_REFSEL_0_bp  0  /* Reference select bit 0 position. */
+#define VREF_REFSEL_1_bm  (1<<1)  /* Reference select bit 1 mask. */
+#define VREF_REFSEL_1_bp  1  /* Reference select bit 1 position. */
+#define VREF_REFSEL_2_bm  (1<<2)  /* Reference select bit 2 mask. */
+#define VREF_REFSEL_2_bp  2  /* Reference select bit 2 position. */
+#define VREF_ALWAYSON_bm  0x80  /* Always on bit mask. */
+#define VREF_ALWAYSON_bp  7  /* Always on bit position. */
+
+/* VREF.ACREF  bit masks and bit positions */
+/* VREF_REFSEL  is already defined. */
+/* VREF_ALWAYSON  is already defined. */
+
+
+/* WDT - Watch-Dog Timer */
+/* WDT.CTRLA  bit masks and bit positions */
+#define WDT_PERIOD_gm  0x0F  /* Period group mask. */
+#define WDT_PERIOD_gp  0  /* Period group position. */
+#define WDT_PERIOD_0_bm  (1<<0)  /* Period bit 0 mask. */
+#define WDT_PERIOD_0_bp  0  /* Period bit 0 position. */
+#define WDT_PERIOD_1_bm  (1<<1)  /* Period bit 1 mask. */
+#define WDT_PERIOD_1_bp  1  /* Period bit 1 position. */
+#define WDT_PERIOD_2_bm  (1<<2)  /* Period bit 2 mask. */
+#define WDT_PERIOD_2_bp  2  /* Period bit 2 position. */
+#define WDT_PERIOD_3_bm  (1<<3)  /* Period bit 3 mask. */
+#define WDT_PERIOD_3_bp  3  /* Period bit 3 position. */
+#define WDT_WINDOW_gm  0xF0  /* Window group mask. */
+#define WDT_WINDOW_gp  4  /* Window group position. */
+#define WDT_WINDOW_0_bm  (1<<4)  /* Window bit 0 mask. */
+#define WDT_WINDOW_0_bp  4  /* Window bit 0 position. */
+#define WDT_WINDOW_1_bm  (1<<5)  /* Window bit 1 mask. */
+#define WDT_WINDOW_1_bp  5  /* Window bit 1 position. */
+#define WDT_WINDOW_2_bm  (1<<6)  /* Window bit 2 mask. */
+#define WDT_WINDOW_2_bp  6  /* Window bit 2 position. */
+#define WDT_WINDOW_3_bm  (1<<7)  /* Window bit 3 mask. */
+#define WDT_WINDOW_3_bp  7  /* Window bit 3 position. */
+
+/* WDT.STATUS  bit masks and bit positions */
+#define WDT_SYNCBUSY_bm  0x01  /* Syncronization busy bit mask. */
+#define WDT_SYNCBUSY_bp  0  /* Syncronization busy bit position. */
+#define WDT_LOCK_bm  0x80  /* Lock enable bit mask. */
+#define WDT_LOCK_bp  7  /* Lock enable bit position. */
+
+
+/* ========== Generic Port Pins ========== */
+#define PIN0_bm 0x01
+#define PIN0_bp 0
+#define PIN1_bm 0x02
+#define PIN1_bp 1
+#define PIN2_bm 0x04
+#define PIN2_bp 2
+#define PIN3_bm 0x08
+#define PIN3_bp 3
+#define PIN4_bm 0x10
+#define PIN4_bp 4
+#define PIN5_bm 0x20
+#define PIN5_bp 5
+#define PIN6_bm 0x40
+#define PIN6_bp 6
+#define PIN7_bm 0x80
+#define PIN7_bp 7
+
+/* ========== Interrupt Vector Definitions ========== */
+/* Vector 0 is the reset vector */
+
+/* NMI interrupt vectors */
+#define NMI_vect_num  1
+#define NMI_vect      _VECTOR(1)  /*  */
+
+/* BOD interrupt vectors */
+#define BOD_VLM_vect_num  2
+#define BOD_VLM_vect      _VECTOR(2)  /*  */
+
+/* CLKCTRL interrupt vectors */
+#define CLKCTRL_CFD_vect_num  3
+#define CLKCTRL_CFD_vect      _VECTOR(3)  /*  */
+
+/* RTC interrupt vectors */
+#define RTC_CNT_vect_num  4
+#define RTC_CNT_vect      _VECTOR(4)  /*  */
+#define RTC_PIT_vect_num  5
+#define RTC_PIT_vect      _VECTOR(5)  /*  */
+
+/* CCL interrupt vectors */
+#define CCL_CCL_vect_num  6
+#define CCL_CCL_vect      _VECTOR(6)  /*  */
+
+/* PORTA interrupt vectors */
+#define PORTA_PORT_vect_num  7
+#define PORTA_PORT_vect      _VECTOR(7)  /*  */
+
+/* TCA0 interrupt vectors */
+#define TCA0_LUNF_vect_num  8
+#define TCA0_LUNF_vect      _VECTOR(8)  /*  */
+#define TCA0_OVF_vect_num  8
+#define TCA0_OVF_vect      _VECTOR(8)  /*  */
+#define TCA0_HUNF_vect_num  9
+#define TCA0_HUNF_vect      _VECTOR(9)  /*  */
+#define TCA0_CMP0_vect_num  10
+#define TCA0_CMP0_vect      _VECTOR(10)  /*  */
+#define TCA0_LCMP0_vect_num  10
+#define TCA0_LCMP0_vect      _VECTOR(10)  /*  */
+#define TCA0_CMP1_vect_num  11
+#define TCA0_CMP1_vect      _VECTOR(11)  /*  */
+#define TCA0_LCMP1_vect_num  11
+#define TCA0_LCMP1_vect      _VECTOR(11)  /*  */
+#define TCA0_CMP2_vect_num  12
+#define TCA0_CMP2_vect      _VECTOR(12)  /*  */
+#define TCA0_LCMP2_vect_num  12
+#define TCA0_LCMP2_vect      _VECTOR(12)  /*  */
+
+/* TCB0 interrupt vectors */
+#define TCB0_INT_vect_num  13
+#define TCB0_INT_vect      _VECTOR(13)  /*  */
+
+/* TCB1 interrupt vectors */
+#define TCB1_INT_vect_num  14
+#define TCB1_INT_vect      _VECTOR(14)  /*  */
+
+/* TWI0 interrupt vectors */
+#define TWI0_TWIS_vect_num  15
+#define TWI0_TWIS_vect      _VECTOR(15)  /*  */
+#define TWI0_TWIM_vect_num  16
+#define TWI0_TWIM_vect      _VECTOR(16)  /*  */
+
+/* SPI0 interrupt vectors */
+#define SPI0_INT_vect_num  17
+#define SPI0_INT_vect      _VECTOR(17)  /*  */
+
+/* USART0 interrupt vectors */
+#define USART0_RXC_vect_num  18
+#define USART0_RXC_vect      _VECTOR(18)  /*  */
+#define USART0_DRE_vect_num  19
+#define USART0_DRE_vect      _VECTOR(19)  /*  */
+#define USART0_TXC_vect_num  20
+#define USART0_TXC_vect      _VECTOR(20)  /*  */
+
+/* PORTD interrupt vectors */
+#define PORTD_PORT_vect_num  21
+#define PORTD_PORT_vect      _VECTOR(21)  /*  */
+
+/* AC0 interrupt vectors */
+#define AC0_AC_vect_num  22
+#define AC0_AC_vect      _VECTOR(22)  /*  */
+
+/* ADC0 interrupt vectors */
+#define ADC0_ERROR_vect_num  23
+#define ADC0_ERROR_vect      _VECTOR(23)  /*  */
+#define ADC0_RESRDY_vect_num  24
+#define ADC0_RESRDY_vect      _VECTOR(24)  /*  */
+#define ADC0_SAMPRDY_vect_num  25
+#define ADC0_SAMPRDY_vect      _VECTOR(25)  /*  */
+
+/* AC1 interrupt vectors */
+#define AC1_AC_vect_num  26
+#define AC1_AC_vect      _VECTOR(26)  /*  */
+
+/* PORTC interrupt vectors */
+#define PORTC_PORT_vect_num  27
+#define PORTC_PORT_vect      _VECTOR(27)  /*  */
+
+/* TCB2 interrupt vectors */
+#define TCB2_INT_vect_num  28
+#define TCB2_INT_vect      _VECTOR(28)  /*  */
+
+/* USART1 interrupt vectors */
+#define USART1_RXC_vect_num  29
+#define USART1_RXC_vect      _VECTOR(29)  /*  */
+#define USART1_DRE_vect_num  30
+#define USART1_DRE_vect      _VECTOR(30)  /*  */
+#define USART1_TXC_vect_num  31
+#define USART1_TXC_vect      _VECTOR(31)  /*  */
+
+/* PORTF interrupt vectors */
+#define PORTF_PORT_vect_num  32
+#define PORTF_PORT_vect      _VECTOR(32)  /*  */
+
+/* NVMCTRL interrupt vectors */
+#define NVMCTRL_EEREADY_vect_num  33
+#define NVMCTRL_EEREADY_vect      _VECTOR(33)  /*  */
+#define NVMCTRL_FLREADY_vect_num  33
+#define NVMCTRL_FLREADY_vect      _VECTOR(33)  /*  */
+#define NVMCTRL_NVMREADY_vect_num  33
+#define NVMCTRL_NVMREADY_vect      _VECTOR(33)  /*  */
+
+/* USART2 interrupt vectors */
+#define USART2_RXC_vect_num  34
+#define USART2_RXC_vect      _VECTOR(34)  /*  */
+#define USART2_DRE_vect_num  35
+#define USART2_DRE_vect      _VECTOR(35)  /*  */
+#define USART2_TXC_vect_num  36
+#define USART2_TXC_vect      _VECTOR(36)  /*  */
+
+/* TCB3 interrupt vectors */
+#define TCB3_INT_vect_num  37
+#define TCB3_INT_vect      _VECTOR(37)  /*  */
+
+/* TCA1 interrupt vectors */
+#define TCA1_LUNF_vect_num  38
+#define TCA1_LUNF_vect      _VECTOR(38)  /*  */
+#define TCA1_OVF_vect_num  38
+#define TCA1_OVF_vect      _VECTOR(38)  /*  */
+#define TCA1_HUNF_vect_num  39
+#define TCA1_HUNF_vect      _VECTOR(39)  /*  */
+#define TCA1_CMP0_vect_num  40
+#define TCA1_CMP0_vect      _VECTOR(40)  /*  */
+#define TCA1_LCMP0_vect_num  40
+#define TCA1_LCMP0_vect      _VECTOR(40)  /*  */
+#define TCA1_CMP1_vect_num  41
+#define TCA1_CMP1_vect      _VECTOR(41)  /*  */
+#define TCA1_LCMP1_vect_num  41
+#define TCA1_LCMP1_vect      _VECTOR(41)  /*  */
+#define TCA1_CMP2_vect_num  42
+#define TCA1_CMP2_vect      _VECTOR(42)  /*  */
+#define TCA1_LCMP2_vect_num  42
+#define TCA1_LCMP2_vect      _VECTOR(42)  /*  */
+
+/* PORTE interrupt vectors */
+#define PORTE_PORT_vect_num  43
+#define PORTE_PORT_vect      _VECTOR(43)  /*  */
+
+/* PORTB interrupt vectors */
+#define PORTB_PORT_vect_num  44
+#define PORTB_PORT_vect      _VECTOR(44)  /*  */
+
+#define _VECTOR_SIZE 4 /* Size of individual vector. */
+#define _VECTORS_SIZE (45 * _VECTOR_SIZE)
+
+
+/* ========== Constants ========== */
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define DATAMEM_START     (0x0000)
+#  define DATAMEM_SIZE      (65536)
+#else
+#  define DATAMEM_START     (0x0000U)
+#  define DATAMEM_SIZE      (65536U)
+#endif
+#define DATAMEM_END       (DATAMEM_START + DATAMEM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define IO_START     (0x0000)
+#  define IO_SIZE      (4159)
+#  define IO_PAGE_SIZE (0)
+#else
+#  define IO_START     (0x0000U)
+#  define IO_SIZE      (4159U)
+#  define IO_PAGE_SIZE (0U)
+#endif
+#define IO_END       (IO_START + IO_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define LOCKBITS_START     (0x1040)
+#  define LOCKBITS_SIZE      (4)
+#  define LOCKBITS_PAGE_SIZE (4)
+#else
+#  define LOCKBITS_START     (0x1040U)
+#  define LOCKBITS_SIZE      (4U)
+#  define LOCKBITS_PAGE_SIZE (4U)
+#endif
+#define LOCKBITS_END       (LOCKBITS_START + LOCKBITS_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define FUSES_START     (0x1050)
+#  define FUSES_SIZE      (16)
+#  define FUSES_PAGE_SIZE (8)
+#else
+#  define FUSES_START     (0x1050U)
+#  define FUSES_SIZE      (16U)
+#  define FUSES_PAGE_SIZE (8U)
+#endif
+#define FUSES_END       (FUSES_START + FUSES_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define USER_SIGNATURES_START     (0x1080)
+#  define USER_SIGNATURES_SIZE      (64)
+#  define USER_SIGNATURES_PAGE_SIZE (64)
+#else
+#  define USER_SIGNATURES_START     (0x1080U)
+#  define USER_SIGNATURES_SIZE      (64U)
+#  define USER_SIGNATURES_PAGE_SIZE (64U)
+#endif
+#define USER_SIGNATURES_END       (USER_SIGNATURES_START + USER_SIGNATURES_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define SIGNATURES_START     (0x1100)
+#  define SIGNATURES_SIZE      (3)
+#  define SIGNATURES_PAGE_SIZE (128)
+#else
+#  define SIGNATURES_START     (0x1100U)
+#  define SIGNATURES_SIZE      (3U)
+#  define SIGNATURES_PAGE_SIZE (128U)
+#endif
+#define SIGNATURES_END       (SIGNATURES_START + SIGNATURES_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define PROD_SIGNATURES_START     (0x1103)
+#  define PROD_SIGNATURES_SIZE      (125)
+#  define PROD_SIGNATURES_PAGE_SIZE (128)
+#else
+#  define PROD_SIGNATURES_START     (0x1103U)
+#  define PROD_SIGNATURES_SIZE      (125U)
+#  define PROD_SIGNATURES_PAGE_SIZE (128U)
+#endif
+#define PROD_SIGNATURES_END       (PROD_SIGNATURES_START + PROD_SIGNATURES_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define EEPROM_START     (0x1400)
+#  define EEPROM_SIZE      (512)
+#  define EEPROM_PAGE_SIZE (8)
+#else
+#  define EEPROM_START     (0x1400U)
+#  define EEPROM_SIZE      (512U)
+#  define EEPROM_PAGE_SIZE (8U)
+#endif
+#define EEPROM_END       (EEPROM_START + EEPROM_SIZE - 1)
+
+/* Added MAPPED_EEPROM segment names for avr-libc */
+#define MAPPED_EEPROM_START     (EEPROM_START)
+#define MAPPED_EEPROM_SIZE      (EEPROM_SIZE)
+#define MAPPED_EEPROM_PAGE_SIZE (EEPROM_PAGE_SIZE)
+#define MAPPED_EEPROM_END       (MAPPED_EEPROM_START + MAPPED_EEPROM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define INTERNAL_SRAM_START     (0x6800)
+#  define INTERNAL_SRAM_SIZE      (6144)
+#  define INTERNAL_SRAM_PAGE_SIZE (0)
+#else
+#  define INTERNAL_SRAM_START     (0x6800U)
+#  define INTERNAL_SRAM_SIZE      (6144U)
+#  define INTERNAL_SRAM_PAGE_SIZE (0U)
+#endif
+#define INTERNAL_SRAM_END       (INTERNAL_SRAM_START + INTERNAL_SRAM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define MAPPED_PROGMEM_START     (0x8000)
+#  define MAPPED_PROGMEM_SIZE      (32768)
+#  define MAPPED_PROGMEM_PAGE_SIZE (128)
+#else
+#  define MAPPED_PROGMEM_START     (0x8000U)
+#  define MAPPED_PROGMEM_SIZE      (32768U)
+#  define MAPPED_PROGMEM_PAGE_SIZE (128U)
+#endif
+#define MAPPED_PROGMEM_END       (MAPPED_PROGMEM_START + MAPPED_PROGMEM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define PROGMEM_START     (0x0000)
+#  define PROGMEM_SIZE      (65536)
+#  define PROGMEM_PAGE_SIZE (128)
+#else
+#  define PROGMEM_START     (0x0000U)
+#  define PROGMEM_SIZE      (65536U)
+#  define PROGMEM_PAGE_SIZE (128U)
+#endif
+#define PROGMEM_END       (PROGMEM_START + PROGMEM_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define PROGMEM_NRWW_START     (0x0000)
+#  define PROGMEM_NRWW_SIZE      (8192)
+#  define PROGMEM_NRWW_PAGE_SIZE (128)
+#else
+#  define PROGMEM_NRWW_START     (0x0000U)
+#  define PROGMEM_NRWW_SIZE      (8192U)
+#  define PROGMEM_NRWW_PAGE_SIZE (128U)
+#endif
+#define PROGMEM_NRWW_END       (PROGMEM_NRWW_START + PROGMEM_NRWW_SIZE - 1)
+
+#if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#  define PROGMEM_RWW_START     (0x2000)
+#  define PROGMEM_RWW_SIZE      (57344)
+#  define PROGMEM_RWW_PAGE_SIZE (128)
+#else
+#  define PROGMEM_RWW_START     (0x2000U)
+#  define PROGMEM_RWW_SIZE      (57344U)
+#  define PROGMEM_RWW_PAGE_SIZE (128U)
+#endif
+#define PROGMEM_RWW_END       (PROGMEM_RWW_START + PROGMEM_RWW_SIZE - 1)
+
+#define FLASHSTART   PROGMEM_START
+#define FLASHEND     PROGMEM_END
+#define RAMSTART     INTERNAL_SRAM_START
+#define RAMSIZE      INTERNAL_SRAM_SIZE
+#define RAMEND       INTERNAL_SRAM_END
+#define E2END        EEPROM_END
+#define E2PAGESIZE   EEPROM_PAGE_SIZE
+
+/* ========== Fuses ========== */
+#define FUSE_MEMORY_SIZE 16
+
+/* Fuse Byte 0 (WDTCFG) */
+#define FUSE_PERIOD0  (unsigned char)_BV(0)  /* Watchdog Timeout Period Bit 0 */
+#define FUSE_PERIOD1  (unsigned char)_BV(1)  /* Watchdog Timeout Period Bit 1 */
+#define FUSE_PERIOD2  (unsigned char)_BV(2)  /* Watchdog Timeout Period Bit 2 */
+#define FUSE_PERIOD3  (unsigned char)_BV(3)  /* Watchdog Timeout Period Bit 3 */
+#define FUSE_WINDOW0  (unsigned char)_BV(4)  /* Watchdog Window Timeout Period Bit 0 */
+#define FUSE_WINDOW1  (unsigned char)_BV(5)  /* Watchdog Window Timeout Period Bit 1 */
+#define FUSE_WINDOW2  (unsigned char)_BV(6)  /* Watchdog Window Timeout Period Bit 2 */
+#define FUSE_WINDOW3  (unsigned char)_BV(7)  /* Watchdog Window Timeout Period Bit 3 */
+#define FUSE0_DEFAULT  (0x0)
+#define FUSE_WDTCFG_DEFAULT  (0x0)
+
+/* Fuse Byte 1 (BODCFG) */
+#define FUSE_SLEEP0  (unsigned char)_BV(0)  /* BOD Operation in Sleep Mode Bit 0 */
+#define FUSE_SLEEP1  (unsigned char)_BV(1)  /* BOD Operation in Sleep Mode Bit 1 */
+#define FUSE_ACTIVE0  (unsigned char)_BV(2)  /* BOD Operation in Active Mode Bit 0 */
+#define FUSE_ACTIVE1  (unsigned char)_BV(3)  /* BOD Operation in Active Mode Bit 1 */
+#define FUSE_SAMPFREQ  (unsigned char)_BV(4)  /* BOD Sample Frequency */
+#define FUSE_LVL0  (unsigned char)_BV(5)  /* BOD Level Bit 0 */
+#define FUSE_LVL1  (unsigned char)_BV(6)  /* BOD Level Bit 1 */
+#define FUSE_LVL2  (unsigned char)_BV(7)  /* BOD Level Bit 2 */
+#define FUSE1_DEFAULT  (0x0)
+#define FUSE_BODCFG_DEFAULT  (0x0)
+
+/* Fuse Byte 2 (OSCCFG) */
+#define FUSE_OSCHFFRQ  (unsigned char)_BV(3)  /* High-frequency Oscillator Frequency */
+#define FUSE2_DEFAULT  (0x0)
+#define FUSE_OSCCFG_DEFAULT  (0x0)
+
+/* Fuse Byte 3 Reserved */
+
+/* Fuse Byte 4 Reserved */
+
+/* Fuse Byte 5 (SYSCFG0) */
+#define FUSE_EESAVE  (unsigned char)_BV(0)  /* EEPROM Save */
+#define FUSE_RSTPINCFG  (unsigned char)_BV(3)  /* Reset Pin Configuration */
+#define FUSE_UPDIPINCFG  (unsigned char)_BV(4)  /* UPDI Pin Configuration */
+#define FUSE_CRCSEL  (unsigned char)_BV(5)  /* CRC Select */
+#define FUSE_CRCSRC0  (unsigned char)_BV(6)  /* CRC Source Bit 0 */
+#define FUSE_CRCSRC1  (unsigned char)_BV(7)  /* CRC Source Bit 1 */
+#define FUSE5_DEFAULT  (0xD0)
+#define FUSE_SYSCFG0_DEFAULT  (0xD0)
+
+/* Fuse Byte 6 (SYSCFG1) */
+#define FUSE_SUT0  (unsigned char)_BV(0)  /* Startup Time Bit 0 */
+#define FUSE_SUT1  (unsigned char)_BV(1)  /* Startup Time Bit 1 */
+#define FUSE_SUT2  (unsigned char)_BV(2)  /* Startup Time Bit 2 */
+#define FUSE6_DEFAULT  (0x7)
+#define FUSE_SYSCFG1_DEFAULT  (0x7)
+
+/* Fuse Byte 7 (CODESIZE) */
+#define FUSE7_DEFAULT  (0x0)
+#define FUSE_CODESIZE_DEFAULT  (0x0)
+
+/* Fuse Byte 8 (BOOTSIZE) */
+#define FUSE8_DEFAULT  (0x0)
+#define FUSE_BOOTSIZE_DEFAULT  (0x0)
+
+/* ========== Lock Bits ========== */
+#define __LOCK_KEY_EXIST
+#ifdef LOCKBITS_DEFAULT
+#undef LOCKBITS_DEFAULT
+#endif //LOCKBITS_DEFAULT
+#define LOCKBITS_DEFAULT  (0x5CC5C55C)
+
+/* ========== Signature ========== */
+#define SIGNATURE_0 0x1E
+#define SIGNATURE_1 0x96
+#define SIGNATURE_2 0x1E
+
+#endif /* #ifdef _AVR_AVR64EA48_H_INCLUDED */
+

--- a/libc/misc/eewr_block_xmega.c
+++ b/libc/misc/eewr_block_xmega.c
@@ -55,7 +55,11 @@
 #if NVMCTRL_CMD_gm == 0x7
 #  define NVM_PAGEERASEWRITE_CMD NVMCTRL_CMD_PAGEERASEWRITE_gc
 #elif NVMCTRL_CMD_gm == 0x7F
-#  define NVM_PAGEERASEWRITE_CMD NVMCTRL_CMD_EEERWR_gc
+#  if defined (__AVR_AVR16EA28__) || defined (__AVR_AVR16EA32__) || defined (__AVR_AVR16EA48__) || defined (__AVR_AVR16EB14__) || defined (__AVR_AVR16EB20__) || defined (__AVR_AVR16EB28__) || defined (__AVR_AVR16EB32__) || defined (__AVR_AVR32EA28__) || defined (__AVR_AVR32EA32__) || defined (__AVR_AVR32EA48__) || defined (__AVR_AVR64EA28__) || defined (__AVR_AVR64EA32__) || defined (__AVR_AVR64EA48__)
+#    define NVM_PAGEERASEWRITE_CMD NVMCTRL_CMD_EEPERW_gc
+#  else
+#    define NVM_PAGEERASEWRITE_CMD NVMCTRL_CMD_EEERWR_gc
+#  endif
 #endif
 
 #endif /* NVM{CTRL} */


### PR DESCRIPTION
Adds support for the following devices:

- avr16ea28
- avr16ea32
- avr16ea48
- avr16eb14
- avr16eb20
- avr16eb28
- avr16eb32
- avr32ea28
- avr32ea32
- avr32ea48
- avr64ea28
- avr64ea32
- avr64ea48

ioavr*.h comes from Atmel.AVR-Ex_DFP.2.8.189.atpack (http://packs.download.atmel.com/).
avrd*.S were generated from .atdf files.